### PR TITLE
don't skip duplicated runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
         with:
           # Cancel CI on outdated commits
           cancel_others: true
-          # Skip when a duplicated run (ie. from a PR) is done
-          skip_after_successful_duplicate: true
+          # Don't skip when a duplicated run (ie. from a PR) is done.
+          #
+          # Only CI in upstream has docs publishing rights.
+          skip_after_successful_duplicate: false
           # Skip newer runs with the same content
           concurrent_skipping: same_content_newer
 


### PR DESCRIPTION
While it would be nice to skip re-checking our tests, there is the unfortunate detail of not having access to docs publishing outside of devel.