### PR TITLE
enable squash commits for bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,3 +7,6 @@ status = [
 #
 # Ideally we set this to some light checks. Is not set for now.
 # pr_status = []
+
+# Produce squash commits instead of merge commits
+use_squash_commits = true


### PR DESCRIPTION
Known issues:

https://github.com/bors-ng/bors-ng/issues/1217

https://github.com/bors-ng/bors-ng/issues/987

We should consider trying Github's merge queue, which seems to work like bors, but its in limited beta atm: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/using-a-merge-queue