### PR TITLE
add workflow to enforce one-commit PRs

### DIFF
--- a/.github/workflows/pr-req.yml
+++ b/.github/workflows/pr-req.yml
@@ -1,0 +1,23 @@
+name: Requirements for merging PR
+on:
+  pull_request:
+    # Only take PRs to devel
+    branches:
+      - devel
+
+# Run every script actions in bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  handle_pr:
+    name: PR has only one commit
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - if: github.event.pull_request.commits > 1
+        run: |
+          echo "::error::PR has more than one commit"
+          exit 1

--- a/bors.toml
+++ b/bors.toml
@@ -4,6 +4,6 @@ status = [
 ]
 
 # Checks that has to pass before bors will process the PR
-#
-# Ideally we set this to some light checks. Is not set for now.
-# pr_status = []
+pr_status = [
+  "PR has only one commit"
+]


### PR DESCRIPTION
An alternative for #21 where we require contributors to squash their commits.

Potential issue https://github.com/bors-ng/bors-ng/issues/390#issuecomment-398923658, but the test is short enough that it should never be a problem in practice.