### PR TITLE
Fix vm's sametype implementation to properly handle generics/typedescs

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1044,7 +1044,12 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
                                      strictSymEquality=true))
     of opcSameNodeType:
       decodeBC(rkInt)
-      regs[ra].intVal = ord(regs[rb].node.typ.sameTypeOrNil regs[rc].node.typ)
+      let
+        aTyp = regs[rb].node.typ.skipTypes({tyGenericInst, tyAlias}) # Skip over generic aliases
+        bTyp = regs[rc].node.typ.skipTypes({tyGenericInst, tyAlias})
+      regs[ra].intVal = ord(aTyp.sameTypeOrNil(bTyp, {ExactTypeDescValues, ExactGenericParams}))
+      # The types should exactly match which is why we pass `{ExactTypeDescValues, ExactGenericParams}`.
+      # This solves checks with generics.
     of opcXor:
       decodeBC(rkInt)
       regs[ra].intVal = ord(regs[rb].intVal != regs[rc].intVal)

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -66,3 +66,49 @@ block: # unpackVarargs
     doAssert call1(toString) == ""
     doAssert call1(toString, 10) == "10"
     doAssert call1(toString, 10, 11) == "1011"
+
+block: # SameType
+  type
+    A = int
+    B = distinct int
+    Generic[T, Y] = object
+    G[T] = T
+  macro isSameType(a, b: typed): untyped =
+    newLit(sameType(a, b))
+  static:
+    assert Generic[int, int].isSameType(Generic[int, int])
+    assert Generic[A, string].isSameType(Generic[int, string])
+    assert not Generic[A, string].isSameType(Generic[B, string])
+    assert not Generic[int, string].isSameType(Generic[int, int])
+    assert isSameType(int, A)
+    assert isSameType(10, 20)
+    assert isSameType("Hello", "world")
+    assert not isSameType("Hello", cstring"world")
+    assert not isSameType(int, B)
+    assert not isSameType(int, Generic[int, int])
+
+    assert isSameType(float(1.0), G[float](1.0))
+    assert isSameType(G[float](1.0), float(1.0))
+
+
+  type Tensor[T] = object
+    data: T
+
+  macro testTensorInt(x: typed): untyped =
+    let
+      tensorIntType = getTypeInst(Tensor[int])[1]
+      xTyp = x.getTypeInst
+    
+    newLit(xTyp.sameType(tensorIntType))
+
+  var
+    x: Tensor[int]
+    x1 = Tensor[float]()
+    x2 = Tensor[A]()
+    x3 = Tensor[B]()
+
+  static: 
+    assert testTensorInt(x)
+    assert not testTensorInt(x1)
+    assert testTensorInt(x2)
+    assert not testTensorInt(x3)


### PR DESCRIPTION
When calling `sameType(a, b)` in macros the expected result now happens for typedescs and generics.