### PR TITLE
turn test compilation errors into annotations

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -510,7 +510,7 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string, options: st
   let root = getCurrentDir()
 
   var args = @["c", "--nimCache:" & outDir, "-d:testing", "-d:nimMegatest", "--listCmd",
-              "--path:" & root]
+               "--listFullPaths:on", "--path:" & root]
   args.add options.parseCmdLine
   args.add megatestFile
   var (cmdLine, buf, exitCode) = execCmdEx2(command = compilerPrefix, args = args, input = "")

--- a/tools/ci_testresults.nim
+++ b/tools/ci_testresults.nim
@@ -3,27 +3,15 @@
 import os, json, sets, strformat, strutils
 
 const skip = toHashSet(["reDisabled", "reIgnored", "reSuccess", "reJoined"])
+let githubActions = existsEnv"GITHUB_ACTIONS"
 
-when isMainModule:
-  let githubActions = existsEnv"GITHUB_ACTIONS"
-
-  for fn in walkFiles("testresults/*.json"):
-    let entries = fn.readFile().parseJson()
-    for j in entries:
-      let res = j["result"].getStr()
-      if skip.contains(res):
-        continue
-
-      var msg = ""
-      if githubActions:
-        # Add error prefix so it shows up as annotations
-        msg.add fmt"""::error file={j["name"].getStr()}::"""
-
-      msg.add fmt"""
+func formatResult(j: JsonNode): string =
+  ## Turn test result `j` into a message
+  fmt"""
 Category: {j["category"].getStr()}
 Name: {j["name"].getStr()}
 Action: {j["action"].getStr()}
-Result: {res}
+Result: {j["result"].getStr()}
 -------- Expected -------
 {j["expected"].getStr()}
 --------- Given  --------
@@ -31,15 +19,56 @@ Result: {res}
 -------------------------
 """
 
-      if githubActions:
-        # Escape some characters so that Github Actions can read the full message
-        #
-        # The list is obtained from here: https://github.com/actions/toolkit/blob/e2eeb0a784f4067a75f0c6cd2cc9703f3cbc7744/packages/core/src/command.ts#L80-L85
-        msg = msg.multiReplace(
-          ("%", "%25"),
-          ("\r", "%0D"),
-          ("\n", "%0A")
-        )
+proc writeResult(j: JsonNode) =
+  ## Write test result `j` into stdout
+  
+  if githubActions:
+    func escape(s: string): string =
+      ## Escape the string `s` so that it can be used in Github Annotations
+      # The list is obtained from here:
+      # https://github.com/actions/toolkit/blob/e2eeb0a784f4067a75f0c6cd2cc9703f3cbc7744/packages/core/src/command.ts#L80-L85
+      s.multiReplace(
+        ("%", "%25"),
+        ("\r", "%0D"),
+        ("\n", "%0A")
+      )
 
-      # Print the error
-      echo msg
+    let res = j["result"].getStr()
+
+    let errorPrefix = fmt"""::error file={j["name"].getStr()}::"""
+
+    case res
+    of "reNimcCrash":
+      # Print a simple header, in case the test failure is not an error that is
+      # captured by the problem matcher.
+      stdout.writeLine errorPrefix & fmt"Test failed"
+
+      stdout.writeLine:
+        # Add the problem matcher
+        "::add-matcher::.github/nim-problem-matcher.json\n" &
+        # Print the result normally, hoping the matcher will catch the errors
+        formatResult(j) & '\n' &
+        # Remove the matcher afterwards
+        "::remove-matcher owner=nim::"
+
+    else:
+      # Concatenate the header and error message then print it.
+      #
+      # This makes the error result displayed in full on Github.
+      stdout.writeLine:
+        escape:
+          errorPrefix &
+          formatResult(j)
+
+  else:
+    stdout.writeLine formatResult(j)
+
+when isMainModule:
+  for fn in walkFiles("testresults/*.json"):
+    let entries = fn.readFile().parseJson()
+    for j in entries:
+      let res = j["result"].getStr()
+      if skip.contains(res):
+        continue
+
+      writeResult(j)


### PR DESCRIPTION
This lets the developer see which line in the test failed on Github
directly. Especially useful when dealing with megatest failures, as
those does not have coloring, making them hard to distinguish.