### PR TITLE
[REPO] Remove links to nim from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,4 @@
 contact_links:
-  - name: Forum
-    url: https://forum.nim-lang.org
-    about: Please ask and answer questions here.
-  - name: Discord
-    url: https://discord.gg/nim
-    about: Please ask and answer questions here.
-  - name: Stack Overflow
-    url: https://stackoverflow.com/questions/tagged/nim-lang
+  - name: Github Discussions
+    url: https://github.com/nim-works/nimskull/discussions
     about: Please ask and answer questions here.


### PR DESCRIPTION
Remove links to discord, stack overflow and forum. Redirect to GitHub discussions for now - should be updated later when we finalize community design.