### PR TITLE
add string fields for target command and extension

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -111,11 +111,23 @@ proc getCmd*(s: TSpec): string =
   else:
     result = s.cmd
 
-const
-  targetToExt*: array[TTarget, string] = ["nim.c", "nim.cpp", "nim.m", "js"]
-  targetToCmd*: array[TTarget, string] = ["c", "cpp", "objc", "js"]
+func ext*(t: TTarget): string {.inline.} =
+  ## read-only field providing the extension string for the given target
+  case t:
+    of targetC:    "nim.c"
+    of targetCpp:  "nim.cpp"
+    of targetObjC: "nim.m"
+    of targetJS:   "js"
 
-proc defaultOptions*(a: TTarget): string =
+func cmd*(t: TTarget): string {.inline.} =
+  ## read-only field providing the command string for the given target
+  case t:
+    of targetC:    "c"
+    of targetCpp:  "cpp"
+    of targetObjC: "objc"
+    of targetJS:   "js"
+
+func defaultOptions*(a: TTarget): string {.inline.} =
   case a
   of targetJS: "-d:nodejs"
     # once we start testing for `nim js -d:nimbrowser` (eg selenium or similar),
@@ -263,10 +275,10 @@ proc parseSpec*(filename: string): TSpec =
     case e.kind
     of cfgKeyValuePair:
       let key = e.key.normalize
-      const whiteListMulti = ["disabled", "ccodecheck"]
+      const allowMultipleOccurences = ["disabled", "ccodecheck"]
         ## list of flags that are correctly handled when passed multiple times
         ## (instead of being overwritten)
-      if key notin whiteListMulti:
+      if key notin allowMultipleOccurences:
         doAssert key notin flags, $(key, filename)
       flags.incl key
       case key

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -79,10 +79,12 @@ proc isNimRepoTests(): bool =
 
 type
   Category = distinct string
+  
   TResults = object
     total, passed, failedButAllowed, skipped: int
       ## xxx rename passed to passedOrAllowedFailure
     data: string
+  
   TTest = object
     name: string
     cat: Category
@@ -161,7 +163,7 @@ proc prepareTestCmd(cmdTemplate, filename, options, nimcache: string,
   if nimcache.len > 0: options.add(" --nimCache:$#" % nimcache.quoteShell)
   options.add ' ' & extraOptions
   # we avoid using `parseCmdLine` which is buggy, refs bug #14343
-  result = cmdTemplate % ["target", targetToCmd[target],
+  result = cmdTemplate % ["target", target.cmd,
                       "options", options, "file", filename.quoteShell,
                       "filedir", filename.getFileDir(), "nim", compilerPrefix]
 
@@ -405,7 +407,7 @@ proc generatedFile(test: TTest, target: TTarget): string =
     result = test.name.changeFileExt("js")
   else:
     let (_, name, _) = test.name.splitFile
-    let ext = targetToExt[target]
+    let ext = target.ext
     result = nimcacheDir(test.name, test.options, target) / "@m" & name.changeFileExt(ext)
 
 proc needsCodegenCheck(spec: TSpec): bool =


### PR DESCRIPTION
- previously the were consts, and undocumtented, now they're funcs
  and marked for inlining
- changed whitelist to
- minor formatting to something less archaic

minor items while looking into #61.