### PR TITLE
fixing regression in vm.nim... maybe?

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1127,7 +1127,12 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
     of dcEqOrDistinctOf:
       a = a.skipDistincts()
       if a.kind != b.kind: return false
-
+  
+  #[
+    The following code should not run in the case either side is an generic alias,
+    but it's not presently possible to distinguish the genericinsts from aliases of
+    objects ie `type A[T] = SomeObject`
+  ]#
   # this is required by tunique_type but makes no sense really:
   if tyDistinct notin {x.kind, y.kind} and x.kind == tyGenericInst and IgnoreTupleFields notin c.flags:
     let

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1045,8 +1045,8 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcSameNodeType:
       decodeBC(rkInt)
       let
-        aTyp = regs[rb].node.typ.skipTypes({tyGenericInst, tyAlias}) # Skip over generic aliases
-        bTyp = regs[rc].node.typ.skipTypes({tyGenericInst, tyAlias})
+        aTyp = regs[rb].node.typ.skipTypesOrNil({tyGenericInst, tyAlias}) # Skip over generic aliases
+        bTyp = regs[rc].node.typ.skipTypesOrNil({tyGenericInst, tyAlias})
       regs[ra].intVal = ord(aTyp.sameTypeOrNil(bTyp, {ExactTypeDescValues, ExactGenericParams}))
       # The types should exactly match which is why we pass `{ExactTypeDescValues, ExactGenericParams}`.
       # This solves checks with generics.

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -71,10 +71,11 @@ block: # SameType
   type
     A = int
     B = distinct int
+    C = object
     Generic[T, Y] = object
-    G[T] = T
   macro isSameType(a, b: typed): untyped =
     newLit(sameType(a, b))
+
   static:
     assert Generic[int, int].isSameType(Generic[int, int])
     assert Generic[A, string].isSameType(Generic[int, string])
@@ -86,10 +87,21 @@ block: # SameType
     assert not isSameType("Hello", cstring"world")
     assert not isSameType(int, B)
     assert not isSameType(int, Generic[int, int])
+    assert not isSameType(C, string)
+    assert not isSameType(C, int)
 
-    assert isSameType(float(1.0), G[float](1.0))
-    assert isSameType(G[float](1.0), float(1.0))
 
+  #[
+    # compiler sameType fails for the following, read more in `types.nim`'s `sameTypeAux`.
+    type
+      D[T] = C
+      G[T] = T
+    static:
+      assert isSameType(D[int], C)
+      assert isSameType(D[int], D[float])
+      assert isSameType(G[float](1.0), float(1.0))
+      assert isSameType(float(1.0), G[float](1.0))
+  ]#
 
   type Tensor[T] = object
     data: T
@@ -98,7 +110,7 @@ block: # SameType
     let
       tensorIntType = getTypeInst(Tensor[int])[1]
       xTyp = x.getTypeInst
-    
+
     newLit(xTyp.sameType(tensorIntType))
 
   var


### PR DESCRIPTION
I have no idea if this actually fixes the problem - I know it gets me passed the compiler error I described [here](https://github.com/alaviss/union/issues/16)

As far as what the implications / side effects of calling `skipTypes` vs `skipTypesOrNil` are, I have no clue... I have no experience really hacking on the Nim compiler and barely any with the VM. 

I know I was getting a sigsev and based on the stacktrace it was pretty easy to track down to this line. I looked at what `skipTypes` did and figured that if the `PNode`'s `type` field is assigned a nil value, it would bomb out, so I thought this might be the change. Lo and behold, it worked - or at least allowed my code to compile. 

I provided a simple example harness in that repo but you can probably just take the one nim file I provided `profile.nim` and run it against nimskull `HEAD` and get the error described in the issue.