### PR TITLE
Added knownIssue as key for testament spec

### DIFF
--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -1,5 +1,5 @@
 discard """
-disabled: "true"
+knownIssue: "https://github.com/nim-works/nimskull/pull/27"
 description: "explain reporting isn't working during the transition to nkError; revise and ressurrect once fixed"
 errormsg: "type mismatch: got <Bar[system.int]>"
 nimout: '''

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -1,6 +1,6 @@
 discard """
   cmd: "nim c --verbosity:0 --colors:off $file"
-  disabled: "true"
+  knownIssue: "https://github.com/nim-works/nimskull/pull/27"
   description: "explain reporting isn't working during the transition to nkError; revise and ressurrect once fixed"
   nimout: '''
 texplain.nim(144, 10) Hint: Non-matching candidates for e(y)

--- a/tests/concepts/tswizzle.nim
+++ b/tests/concepts/tswizzle.nim
@@ -3,7 +3,7 @@ discard """
 [1, 3]
 [2, 1, 2]
 '''
-  disabled: "true"
+  knownIssue: "https://github.com/nim-lang/Nim/issues/2346"
 """
 
 import macros, strutils

--- a/tests/concepts/twrapconcept.nim
+++ b/tests/concepts/twrapconcept.nim
@@ -1,5 +1,5 @@
 discard """
-  disabled: "true"
+  knownIssue: "https://github.com/nim-works/nimskull/pull/27"
   description: "concept error reporting isn't working during the transition to nkError; revise and ressurrect once fixed"
   errormsg: "type mismatch: got <string>"
   nimout: "twrapconcept.nim(11, 5) Foo: concept predicate failed"

--- a/tests/cpp/tterminate_handler.nim
+++ b/tests/cpp/tterminate_handler.nim
@@ -2,7 +2,7 @@ discard """
   targets: "cpp"
   outputsub: "Error: unhandled unknown cpp exception"
   exitcode: 1
-  disabled: true
+  knownIssue: "https://github.com/nim-lang/Nim/issues/13695"
 """
 type Crap {.importcpp: "int".} = object
 

--- a/tests/cpp/tvectorseq.nim
+++ b/tests/cpp/tvectorseq.nim
@@ -2,7 +2,7 @@ discard """
   targets: "cpp"
   output: '''(x: 1.0)
 (x: 0.0)'''
-  disabled: "true"
+  knownIssue: "https://github.com/nim-lang/Nim/issues/2536"
 """
 
 # This cannot work yet because we omit type information for importcpp'ed types.

--- a/tests/dll/nimhcr_integration.nim
+++ b/tests/dll/nimhcr_integration.nim
@@ -1,5 +1,7 @@
 discard """
-  disabled: "true"
+  knownIssue: "https://github.com/nim-lang/Nim/pull/12105"
+  knownIssue: "https://github.com/nim-lang/Nim/pull/17311"
+  knownIssue: "https://github.com/nim-lang/Nim/pull/15458"
   output: '''
 main: HELLO!
 main: hasAnyModuleChanged? true

--- a/tests/errmsgs/tundeclared_field.nim
+++ b/tests/errmsgs/tundeclared_field.nim
@@ -1,5 +1,5 @@
 discard """
-disabled: "true"
+knownIssue: "https://github.com/nim-works/nimskull/pull/27"
 description: '''
 disabled this test because the ast is being screwed up and we get gensyms when we shouldn't
 

--- a/tests/fragmentation/tfragment_alloc.nim
+++ b/tests/fragmentation/tfragment_alloc.nim
@@ -2,7 +2,9 @@
 discard """
   output: '''occupied ok: true
 total ok: true'''
-  disabled: "true"
+knownIssue: "https://github.com/nim-lang/Nim/issues/8509"
+knownIssue: "https://github.com/nim-lang/Nim/issues/7120"
+knownIssue: "https://github.com/nim-lang/Nim/issues/9421"
 """
 
 import strutils, data

--- a/tests/fragmentation/tfragment_gc.nim
+++ b/tests/fragmentation/tfragment_gc.nim
@@ -1,7 +1,9 @@
 discard """
   output: '''occupied ok: true
 total ok: true'''
-  disabled: "true"
+knownIssue: "https://github.com/nim-lang/Nim/issues/8509"
+knownIssue: "https://github.com/nim-lang/Nim/issues/7120"
+knownIssue: "https://github.com/nim-lang/Nim/issues/9421"
 """
 
 import strutils, data

--- a/tests/iter/tchainediterators.nim
+++ b/tests/iter/tchainediterators.nim
@@ -6,7 +6,7 @@ discard """
 128
 192
 '''
-  disabled: "true"
+  knownIssue: "https://github.com/nim-lang/Nim/issues/1838"
 """
 
 # This all relies on non-documented and questionable features.

--- a/tests/lang/s01_basics/s05_data_types/t4_char.nim
+++ b/tests/lang/s01_basics/s05_data_types/t4_char.nim
@@ -1,6 +1,0 @@
-discard """
-disabled: true
-description: '''
-Placeholder file just in case, covered elsehwere
-'''
-"""

--- a/tests/macros/tmacro7.nim
+++ b/tests/macros/tmacro7.nim
@@ -3,7 +3,7 @@ output: '''
 calling!stuff
 calling!stuff
 '''
-disabled: true
+knownIssue: "https://github.com/nim-lang/Nim/issues/11883"
 """
 
 # this test modifies an already semchecked ast (bad things happen)

--- a/tests/misc/tnoinst.nim
+++ b/tests/misc/tnoinst.nim
@@ -1,7 +1,8 @@
 discard """
   errormsg: "instantiate 'notConcrete' explicitly"
   line: 12
-  disabled: "true"
+  knownIssue: "https://github.com/nim-lang/Nim/issues/1708"
+  knownIssue: "https://github.com/nim-lang/Nim/issues/871"
 """
 
 proc wrap[T]() =

--- a/tests/objvariant/tfloatrangeobj.nim
+++ b/tests/objvariant/tfloatrangeobj.nim
@@ -2,7 +2,8 @@ discard """
   output: '''(kind: 2.0, twoStr: "TWO STR")
 (kind: 1.0)
 '''
-disabled: "true"
+knownIssue: "https://github.com/nim-lang/Nim/issues/12379"
+knownIssue: "https://github.com/nim-lang/Nim/issues/12591"
 """
 type
   FloatRange = range[1.0..3.0]

--- a/tests/proc/t17157.nim
+++ b/tests/proc/t17157.nim
@@ -1,6 +1,7 @@
 discard """
   errormsg: "'untyped' is only allowed in templates and macros or magic procs"
-  disabled: true
+  knownIssue: "https://github.com/nim-lang/Nim/issues/18113"
+  knownIssue: "https://github.com/nim-lang/Nim/issues/18124"
 """
 
 template something(op: proc (v: untyped): void): void =


### PR DESCRIPTION
This references issue [61]( https://github.com/nim-works/nimskull/issues/61 )

- added 'knownIssue' as key for spec.
- 'disabled' is now interpreted as a semicolon separated list of (platform names or truthy values).


KnowIssues is allowed to be mentioned multiple times;
The proposal of no longer accepting boolean values seems to be more intricate, since various tests rely on this option.
Still not handling the case of knownIssue for specific platforms.