### PR TITLE
make cancelled CI a failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
   passed:
     name: All check passed
     needs: [bootstrap, test, tooling, doc, orc]
-    if: always() && !cancelled()
+    if: always()
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
#65 managed to skip through bors by having its CI cancelled. This is not optimal and has to be fixed.