### PR TITLE
nkerror remove legacy lookups and concept fixes

### DIFF
--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -186,9 +186,9 @@ iterator walkErrors*(config: ConfigRef; n: PNode): PNode =
   buildErrorList(config, n, errNodes)
 
   # report from last to first (deepest in tree to highest)
-  for i in 1..errNodes.len:
+  for i in countdown(errNodes.len - 1, 0):
     # reverse index so we go from the innermost to outermost
-    let e = errNodes[^i]
+    let e = errNodes[i]
     if e.errorKind == rsemWrappedError:
       continue
 

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1032,7 +1032,7 @@ proc deprecatedStmt(c: PContext; outerPragma: PNode): PNode =
     return
   for n in pragma:
     if n.kind in nkPragmaCallKinds and n.len == 2:
-      let dest = qualifiedLookUp2(c, n[1], {checkUndeclared})
+      let dest = qualifiedLookUp(c, n[1], {checkUndeclared})
       if dest == nil or dest.kind in routineKinds or dest.kind == skError:
         # xxx: warnings need to be figured out, also this is just silly, why
         #      are they unreliable?
@@ -1067,7 +1067,7 @@ proc pragmaGuard(c: PContext; it: PNode; kind: TSymKind): PSym =
     result = n.sym
   elif kind == skField:
     # First check if the guard is a global variable:
-    result = qualifiedLookUp2(c, n, {})
+    result = qualifiedLookUp(c, n, {})
     if result.isError:
       # this is an error propagate it
       return
@@ -1079,7 +1079,7 @@ proc pragmaGuard(c: PContext; it: PNode; kind: TSymKind): PSym =
       result = newSym(skUnknown, considerQuotedIdent(c, n), nextSymId(c.idgen), nil, n.info,
         c.config.options)
   else:
-    result = qualifiedLookUp2(c, n, {checkUndeclared})
+    result = qualifiedLookUp(c, n, {checkUndeclared})
 
 proc semCustomPragma(c: PContext, n: PNode): PNode =
   var callNode: PNode

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -368,7 +368,6 @@ proc typeAllowedCheck(c: PContext; info: TLineInfo; typ: PType; kind: TSymKind;
 proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
   typeAllowedCheck(c, typ.n.info, typ, skProc)
 
-proc expectMacroOrTemplateCall(c: PContext, n: PNode): PSym
 proc semDirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode
 proc semWhen(c: PContext, n: PNode, semCheck: bool = true): PNode
 proc semTemplateExpr(c: PContext, n: PNode, s: PSym,

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -72,6 +72,7 @@ proc semExprCheck(c: PContext, n: PNode, flags: TExprFlags): PNode =
     localReport(c.config, n, reportSem rsemExpressionHasNoType)
 
   if isError and isTypeError:
+    # XXX: Error message should mention that it's an error node/type
     # newer code paths propagate nkError nodes
     result = c.config.newError(result, reportSem rsemExpressionHasNoType, args = @[n])
 
@@ -91,8 +92,8 @@ proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   elif result.typ.kind == tyError:
     # associates the type error to the current owner
     result.typ = errorType(c)
-  else:
-    if result.typ.kind in {tyVar, tyLent}: result = newDeref(result)
+  elif result.typ.kind in {tyVar, tyLent}:
+    result = newDeref(result)
 
 proc semExprNoDeref(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   result = semExprCheck(c, n, flags)
@@ -266,8 +267,15 @@ proc maybeLiftType(t: var PType, c: PContext, info: TLineInfo) =
   if lifted != nil: t = lifted
 
 proc isOwnedSym(c: PContext; n: PNode): bool =
+  ## checks to see if the `n`ode is the "owned" sym node
   let s = qualifiedLookUp(c, n, {})
-  result = s != nil and sfSystemModule in s.owner.flags and s.name.s == "owned"
+  result =
+    if s.isError:
+      # XXX: move to propagating nkError, skError, and tyError
+      localReport(c.config, s.ast)
+      false
+    else:
+      s != nil and sfSystemModule in s.owner.flags and s.name.s == "owned"
 
 proc semConv(c: PContext, n: PNode): PNode =
   if n.len != 2:
@@ -477,13 +485,20 @@ proc isOpImpl(c: PContext, n: PNode, flags: TExprFlags): PNode =
       discard
     var m = newCandidate(c, t2)
     if efExplain in flags:
-      m.diagnostics = @[]
-      m.diagnosticsEnabled = true
+      m.error.diagnosticsEnabled = true
     res = typeRel(m, t2, t1) >= isSubtype # isNone
+    if m.error.diagnosticsEnabled and m.error.diag.reports.len > 0:
+      localReport(c.config, n.info, SemReport(
+        ast: n,
+        kind: rsemDiagnostics,
+        diag: m.error.diag
+      ))
+
     # `res = sameType(t1, t2)` would be wrong, e.g. for `int is (int|float)`
 
   result = newIntNode(nkIntLit, ord(res))
   result.typ = n.typ
+  result.info = n.info
 
 proc semIs(c: PContext, n: PNode, flags: TExprFlags): PNode =
   if n.len != 3:
@@ -491,12 +506,14 @@ proc semIs(c: PContext, n: PNode, flags: TExprFlags): PNode =
       rsemWrongNumberOfArguments, 1, 2, n))
 
   let boolType = getSysType(c.graph, n.info, tyBool)
-  result = n
   n.typ = boolType
   var liftLhs = true
 
-  n[1] = semExprWithType(c, n[1], {efDetermineType, efWantIterator})
-  if n[2].kind notin {nkStrLit..nkTripleStrLit}:
+  n[1] = semExprWithType(c, n[1], flags + {efDetermineType, efWantIterator})
+
+  if n[2].kind in {nkStrLit..nkTripleStrLit}:
+    n[2] = semExpr(c, n[2])
+  else:
     let t2 = semTypeNode(c, n[2], nil)
     n[2] = newNodeIT(nkType, n[2].info, t2)
     if t2.kind == tyStatic:
@@ -507,27 +524,25 @@ proc semIs(c: PContext, n: PNode, flags: TExprFlags): PNode =
       else:
         result = newIntNode(nkIntLit, 0)
         result.typ = boolType
+        result.info = n.info
         return
     elif t2.kind == tyTypeDesc and
         (t2.base.kind == tyNone or tfExplicit in t2.flags):
       # When the right-hand side is an explicit type, we must
       # not allow regular values to be matched against the type:
       liftLhs = false
-  else:
-    n[2] = semExpr(c, n[2])
 
   var lhsType = n[1].typ
-  if lhsType.kind != tyTypeDesc:
-    if liftLhs:
-      n[1] = makeTypeSymNode(c, lhsType, n[1].info)
-      lhsType = n[1].typ
+  if n[1].isError:
+    result = wrapErrorInSubTree(c.config, n)
+  elif lhsType.kind == tyTypeDesc and (lhsType.base.kind == tyNone or
+     (c.inGenericContext > 0 and lhsType.base.containsGenericType)):
+    # BUGFIX: don't evaluate this too early: ``T is void``
+    result = n
   else:
-    if lhsType.base.kind == tyNone or
-        (c.inGenericContext > 0 and lhsType.base.containsGenericType):
-      # BUGFIX: don't evaluate this too early: ``T is void``
-      return
-
-  result = isOpImpl(c, n, flags)
+    if lhsType.kind != tyTypeDesc and liftLhs:
+      n[1] = makeTypeSymNode(c, lhsType, n[1].info)
+    result = isOpImpl(c, n, flags)
 
 proc semOpAux(c: PContext, n: PNode) =
   const flags = {efDetermineType}
@@ -1407,7 +1422,7 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
     result = newSymNode(s, n.info)
   else:
     if s.kind == skError and not s.ast.isNil and s.ast.kind == nkError:
-      # XXX: at the time or writing only `lookups.qualifiedLookUp2` sets up the
+      # XXX: at the time or writing only `lookups.qualifiedlookup` sets up the
       #      PSym so the error is in the ast field
       result = s.ast
     else:
@@ -1477,7 +1492,10 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
       if exactEquals(c.config.m.trackPos, n[1].info): suggestExprNoCheck(c, n)
 
   var s = qualifiedLookUp(c, n, {checkAmbiguity, checkUndeclared, checkModule})
-  if s != nil:
+  if s.isError:
+    # XXX: move to propagating nkError, skError, and tyError
+    localReport(c.config, s.ast)
+  elif s != nil:
     if s.kind in OverloadableSyms:
       result = symChoice(c, n, s, scClosed)
       if result.kind == nkSym: result = semSym(c, n, s, flags)
@@ -2095,27 +2113,6 @@ proc semDeclared(c: PContext, n: PNode, onlyCurrentScope: bool): PNode =
   result.info = n.info
   result.typ = getSysType(c.graph, n.info, tyBool)
 
-proc expectMacroOrTemplateCall(c: PContext, n: PNode): PSym =
-  ## The argument to the proc should be nkCall(...) or similar
-  ## Returns the macro/template symbol
-  if isCallExpr(n):
-    var expandedSym = qualifiedLookUp(c, n[0], {checkUndeclared})
-    if expandedSym == nil:
-      errorUndeclaredIdentifier(c, n.info, n[0].renderTree)
-      return errorSym(c, n[0])
-
-    if expandedSym.kind notin {skMacro, skTemplate}:
-      localReport(c.config, n.info, reportSym(
-        rsemExpectedMacroOrTemplate, expandedSym))
-
-      return errorSym(c, n[0])
-
-    result = expandedSym
-  else:
-    localReport(c.config, n, reportSem rsemExpectedMacroOrTemplate)
-
-    result = errorSym(c, n)
-
 proc expectString(c: PContext, n: PNode): string =
   var n = semConstExpr(c, n)
   if n.kind in nkStrKinds:
@@ -2128,14 +2125,6 @@ proc newAnonSym(c: PContext; kind: TSymKind, info: TLineInfo): PSym =
 
 proc semExpandToAst(c: PContext, n: PNode): PNode =
   let macroCall = n[1]
-
-  when false:
-    let expandedSym = expectMacroOrTemplateCall(c, macroCall)
-    if expandedSym.kind == skError: return n
-
-    macroCall[0] = newSymNode(expandedSym, macroCall.info)
-    markUsed(c, n.info, expandedSym)
-    onUse(n.info, expandedSym)
 
   if isCallExpr(macroCall):
     for i in 1..<macroCall.len:
@@ -2848,7 +2837,12 @@ proc asBracketExpr(c: PContext; n: PNode): PNode =
   proc isGeneric(c: PContext; n: PNode): bool =
     if n.kind in {nkIdent, nkAccQuoted}:
       let s = qualifiedLookUp(c, n, {})
-      result = s != nil and isGenericRoutineStrict(s)
+      if s.isError:
+        # XXX: move to propagating nkError, skError, and tyError
+        localReport(c.config, s.ast)
+        result = false
+      else:
+        result = s != nil and isGenericRoutineStrict(s)
 
   assert n.kind in nkCallKinds
   if n.len > 1 and isGeneric(c, n[1]):
@@ -2964,7 +2958,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
         {checkUndeclared, checkPureEnumFields, checkModule}
       else:
         {checkUndeclared, checkPureEnumFields, checkModule, checkAmbiguity}
-    var s = qualifiedLookUp2(c, n, checks) # query & production (errors)
+    var s = qualifiedLookUp(c, n, checks) # query & production (errors)
 
     # production (outside of errors above)
     case s.kind
@@ -3060,9 +3054,9 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     #  if gIdeCmd == ideCon and c.config.m.trackPos == n.info: suggestExprNoCheck(c, n)
     let mode = if nfDotField in n.flags: {} else: {checkUndeclared}
     c.isAmbiguous = false
-    var s = qualifiedLookUp2(c, n[0], mode)
+    var s = qualifiedLookUp(c, n[0], mode)
     if s != nil and not s.isError:
-      # xxx: currently `qualifiedLookup2` will set the s.ast field to nkError
+      # xxx: currently `qualifiedLookUp` will set the s.ast field to nkError
       #      if there was an nkError reported instead of the legacy localReport
       #      based flows we need to halt progress. This also needs to do a
       #      better job of raising/handling the fact that we just got an error.

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1320,8 +1320,7 @@ proc track(tracked: PEffects, n: PNode) =
 
     inc tracked.leftPartOfAsgn
   of nkError:
-    for e in walkErrors(tracked.config, n):
-      localReport(tracked.config, e)
+    localReport(tracked.config, n)
   else:
     for i in 0 ..< n.safeLen:
       track(tracked, n[i])

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -1,5 +1,4 @@
 discard """
-knownIssue: "https://github.com/nim-works/nimskull/pull/27"
 description: "explain reporting isn't working during the transition to nkError; revise and ressurrect once fixed"
 errormsg: "type mismatch: got <Bar[system.int]>"
 nimout: '''

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -1,34 +1,36 @@
 discard """
-  cmd: "nim c --verbosity:0 --colors:off $file"
-  knownIssue: "https://github.com/nim-works/nimskull/pull/27"
-  description: "explain reporting isn't working during the transition to nkError; revise and ressurrect once fixed"
+  description: "Tests {.explain.} attached to concept types, to expressions, and diagnostics reporting on failed overload resolution"
   nimout: '''
 texplain.nim(144, 10) Hint: Non-matching candidates for e(y)
 proc e(i: int): int
   first type mismatch at position: 1
   required type for i: int
   but expression 'y' is of type: MatchingType
-
+ [rsemNonMatchingCandidates]
 texplain.nim(147, 7) Hint: Non-matching candidates for e(10)
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
   required type for o: ExplainedConcept
   but expression '10' is of type: int literal(10)
 texplain.nim(110, 6) ExplainedConcept: undeclared field: 'foo'
-texplain.nim(110, 5) ExplainedConcept: concept predicate failed
+texplain.nim(110, 6) ExplainedConcept: expression has no type: `.`(o, foo)
+texplain.nim(110, 11) ExplainedConcept: concept predicate failed
 texplain.nim(111, 6) ExplainedConcept: undeclared field: 'bar'
-texplain.nim(110, 5) ExplainedConcept: concept predicate failed
-
+texplain.nim(111, 6) ExplainedConcept: expression has no type: `.`(o, bar)
+texplain.nim(111, 11) ExplainedConcept: concept predicate failed
+ [rsemNonMatchingCandidates]
 texplain.nim(150, 10) Hint: Non-matching candidates for e(10)
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
   required type for o: ExplainedConcept
   but expression '10' is of type: int literal(10)
 texplain.nim(110, 6) ExplainedConcept: undeclared field: 'foo'
-texplain.nim(110, 5) ExplainedConcept: concept predicate failed
+texplain.nim(110, 6) ExplainedConcept: expression has no type: `.`(o, foo)
+texplain.nim(110, 11) ExplainedConcept: concept predicate failed
 texplain.nim(111, 6) ExplainedConcept: undeclared field: 'bar'
-texplain.nim(110, 5) ExplainedConcept: concept predicate failed
-
+texplain.nim(111, 6) ExplainedConcept: expression has no type: `.`(o, bar)
+texplain.nim(111, 11) ExplainedConcept: concept predicate failed
+ [rsemNonMatchingCandidates]
 texplain.nim(154, 20) Error: type mismatch: got <NonMatchingType>
 but expected one of:
 proc e(i: int): int
@@ -40,7 +42,7 @@ proc e(o: ExplainedConcept): int
   required type for o: ExplainedConcept
   but expression 'n' is of type: NonMatchingType
 texplain.nim(154, 9) template/generic instantiation of `assert` from here
-texplain.nim(110, 5) ExplainedConcept: concept predicate failed
+texplain.nim(111, 11) ExplainedConcept: concept predicate failed
 
 expression: e(n)
 texplain.nim(155, 20) Error: type mismatch: got <NonMatchingType>
@@ -54,7 +56,7 @@ proc r(o: RegularConcept): int
   required type for o: RegularConcept
   but expression 'n' is of type: NonMatchingType
 texplain.nim(155, 9) template/generic instantiation of `assert` from here
-texplain.nim(114, 5) RegularConcept: concept predicate failed
+texplain.nim(115, 11) RegularConcept: concept predicate failed
 proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1
   required type for a: SomeNumber
@@ -70,7 +72,7 @@ proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1
   required type for a: SomeNumber
   but expression 'y' is of type: MatchingType
-
+ [rsemNonMatchingCandidates]
 texplain.nim(164, 2) Error: type mismatch: got <MatchingType>
 but expected one of:
 proc f(o: NestedConcept)
@@ -78,10 +80,12 @@ proc f(o: NestedConcept)
   required type for o: NestedConcept
   but expression 'y' is of type: MatchingType
 texplain.nim(114, 6) RegularConcept: undeclared field: 'foo'
-texplain.nim(114, 5) RegularConcept: concept predicate failed
+texplain.nim(114, 6) RegularConcept: expression has no type: `.`(o, foo)
+texplain.nim(114, 11) RegularConcept: concept predicate failed
 texplain.nim(115, 6) RegularConcept: undeclared field: 'bar'
-texplain.nim(114, 5) RegularConcept: concept predicate failed
-texplain.nim(118, 5) NestedConcept: concept predicate failed
+texplain.nim(115, 6) RegularConcept: expression has no type: `.`(o, bar)
+texplain.nim(115, 11) RegularConcept: concept predicate failed
+texplain.nim(118, 11) NestedConcept: concept predicate failed
 
 expression: f(y)'''
   errormsg: "type mismatch: got <MatchingType>"
@@ -89,17 +93,11 @@ expression: f(y)'''
 
 
 
+
+
 # proc r[T](a: SomeNumber; b: T; c: auto)
 # proc r(i: string): int
 # proc r(o: RegularConcept): int
-
-
-
-
-
-
-
-
 
 
 
@@ -139,7 +137,7 @@ proc f(o: NestedConcept) = discard
 var n = NonMatchingType(foo: 10, bar: 20)
 var y = MatchingType(foo: 10, bar: "bar")
 
-# no diagnostic here:
+# no diagnostic here (because the {.explain.} tagged concept *does* match)
 discard e(y)
 
 # explain that e(int) doesn't match

--- a/tests/concepts/twrapconcept.nim
+++ b/tests/concepts/twrapconcept.nim
@@ -1,8 +1,6 @@
 discard """
-  knownIssue: "https://github.com/nim-works/nimskull/pull/27"
-  description: "concept error reporting isn't working during the transition to nkError; revise and ressurrect once fixed"
   errormsg: "type mismatch: got <string>"
-  nimout: "twrapconcept.nim(11, 5) Foo: concept predicate failed"
+  nimout: "twrapconcept.nim(10, 8) Foo: expression has no type: get(foo)"
 """
 
 # https://github.com/nim-lang/Nim/issues/5127

--- a/tests/errmsgs/tundeclared_field.nim
+++ b/tests/errmsgs/tundeclared_field.nim
@@ -39,7 +39,7 @@ tundeclared_field.nim(65, 14) Error: expression 'Bi(bad7: 0)' has no type (or is
 xxx in future work, generic instantiations (e.g. `B[int]`) should be shown with their instantiation instead of `tundeclared_field.B`,
 maybe using TPreferedDesc.preferResolved or preferMixed
 ]#
-# line 20
+# line 39
 block:
   type A = object
     a0: int


### PR DESCRIPTION
replace the legacy `qualifiedLookUp`  with the implementation from `qualifiedLookUp2`.

Also fixed some issues with sigmatch/semcall such that concept error reporting is almost back to normal.