### PR TITLE
Make release compiler builds reproducible

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -13,7 +13,7 @@ import
   options, ropes, lineinfos, pathutils, strutils2
 
 type InstantiationInfo* = typeof(instantiationInfo())
-template instLoc*(): InstantiationInfo = instantiationInfo(-2, fullPaths = true)
+template instLoc*(): InstantiationInfo = instantiationInfo(-2, fullPaths = compileOption"excessiveStackTrace")
 
 template toStdOrrKind(stdOrr): untyped =
   if stdOrr == stdout: stdOrrStdout else: stdOrrStderr

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -74,7 +74,7 @@ proc stackTraceImpl(c: PCtx, tos: PStackFrame, pc: int,
 
 template stackTrace(c: PCtx, tos: PStackFrame, pc: int,
                     msg: string, lineInfo: TLineInfo = TLineInfo.default) =
-  stackTraceImpl(c, tos, pc, msg, lineInfo, instantiationInfo(-2, fullPaths = true))
+  stackTraceImpl(c, tos, pc, msg, lineInfo, instantiationInfo(-2, fullPaths = compileOption"excessiveStackTrace"))
   return
 
 proc bailOut(c: PCtx; tos: PStackFrame) =

--- a/koch.nim
+++ b/koch.nim
@@ -207,7 +207,7 @@ proc buildTools(args: string = "") =
   # `-d:debug` should be changed to a flag that doesn't require re-compiling nim
   # `--opt:speed` is a sensible default even for a debug build, it doesn't affect nim stacktraces
   nimCompileFold("Compile nim_dbg", "compiler/nim.nim", options =
-      "--opt:speed --stacktrace -d:debug --stacktraceMsgs -d:nimCompilerStacktraceHints " & args,
+      "--opt:speed --stacktrace -d:debug --stacktraceMsgs -d:nimCompilerStacktraceHints --excessiveStackTrace:off " & args,
       outputName = "nim_dbg")
 
   nimCompileFold("Compile atlas", "tools/atlas/atlas.nim", options = "-d:release " & args,


### PR DESCRIPTION
This pull focuses on making compiler builds reproducible for release versions.

Problems:
- [x] Full paths embedded in executables
  - [x] `nim`
  - [x] `nimsuggest`
  - [x] `nimgrep`
  - [x] `nimpretty`
  - [x] `testament`
  - [x] `nim_dbg` (why do we ship this again?)
  - [x] `atlas` (candidate for removal)

- [x] Build date/time embedded in executables

Todo (in future PRs):

- CI to catch reproducibility issues (might become a part of nightlies)