### PR TITLE
runs PR requirement CI on conversion to/from draft

### DIFF
--- a/.github/workflows/pr-req.yml
+++ b/.github/workflows/pr-req.yml
@@ -4,6 +4,12 @@ on:
     # Only take PRs to devel
     branches:
       - devel
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - converted_to_draft
+      - ready_for_review
 
 # Run every script actions in bash
 defaults:


### PR DESCRIPTION
Otherwise it would be possible to bypass this requirement by starting
off as a draft then switch to "ready for review".