### PR TITLE
bors: cut PR description at the first thematic break

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,3 +7,7 @@ status = [
 pr_status = [
   "PR has only one commit"
 ]
+
+# When turning PR into commit message, consider the body ends at the first
+# thematic break.
+cut_body_after = "---"


### PR DESCRIPTION
After the thematic break, the information typically stops being related
to the PR itself (for example, dependabot command lists). Thus cut the
body there to avoid introducing junk into the merge commit.