### PR TITLE
disable CI skipping for duplicated runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
           #
           # Only CI in upstream has docs publishing rights.
           skip_after_successful_duplicate: false
-          # Skip newer runs with the same content
-          concurrent_skipping: same_content_newer
           # Do not skip on push, dispatched or cron
           do_not_skip: '["push", "workflow_dispatch", "schedule"]'
 


### PR DESCRIPTION
This feature, while useful, is very confusing to developers and
tools since it will trigger while a previous PR run is being done.
Causing the change to attain a CI pass even when the previous duplicated
run is not finished.