### PR TITLE
nimpretty/tester: always use built nimpretty

### DIFF
--- a/nimpretty/tester.nim
+++ b/nimpretty/tester.nim
@@ -10,12 +10,7 @@ const
 var
   failures = 0
 
-when defined(develop):
-  const nimp = "bin" / "nimpretty".addFileExt(ExeExt)
-  if execShellCmd("nim c -o:$# nimpretty/nimpretty.nim" % [nimp]) != 0:
-    quit("FAILURE: compilation of nimpretty failed")
-else:
-  const nimp = "nimpretty"
+const nimp = "bin" / "nimpretty".addFileExt(ExeExt)
 
 proc test(infile, ext: string) =
   if execShellCmd("$# -o:$# --backup:off $#" % [nimp, infile.changeFileExt(ext), infile]) != 0:


### PR DESCRIPTION
There are little reasons to use a nimpretty in PATH. The test suite
would only work for the nimpretty built from the same source.

This also removes the "feature" that automatically builds nimpretty
(which also depends on the nim in PATH, which might not be able to build
this at all). In the future this might return via koch.

Ref #89 