### PR TITLE
tosproc: completely remove compiler execution

### DIFF
--- a/tests/stdlib/osproctest.nim
+++ b/tests/stdlib/osproctest.nim
@@ -1,8 +1,0 @@
-# This is test program for the osproc module.
-
-import os
-
-echo getCurrentDir()
-
-for i in 1..paramCount():
-  echo paramStr(i)


### PR DESCRIPTION
Previously this test would depend on the compiler being available to execute to recompile itself.

Not only is this hugely inefficient, but it also produce a dependency on the compiler being in `PATH`.

Instead this pull request:

- Fold external runners into the same test binary. This removes the need of recompilation altogether.
- Replaced `nim r` in tests with much simpler "consume all" runner that allow testing the same thing. This prevents compiler bugs from tripping this test up.

Done as part of #89 to remove `PATH` dependency from test suite.