### PR TITLE
remove PATH edits from tooling tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,12 +171,7 @@ jobs:
         run: ./koch.py tools -d:release
 
       - name: Test tooling
-        run: |
-          # The tester requires `bin` to be in `PATH`
-          nim_bin_dir=$(python -c 'import os; print(os.path.abspath("bin"))')
-          export PATH=$nim_bin_dir:$PATH
-
-          ./koch.py testTools
+        run: ./koch.py testTools
 
   doc:
     name: Build HTML documentation


### PR DESCRIPTION
With c31b5fc523e46cc815b22e95f5a3c2fb8930c3ec, we no longer have a PATH
dependency on tooling tests.