### PR TITLE
purge PATH dependency from main tester

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,7 @@ jobs:
           sudo apt-get install "${deps[@]}"
 
       - name: Run tester
-        run: |
-          # The tester requires `nim` to be in `PATH`
-          nim_bin_dir=$(python -c 'import os; print(os.path.abspath("bin"))')
-          export PATH=$nim_bin_dir:$PATH
-
-          ./koch.py test --batch:'${{ matrix.batch }}_${{ matrix.total_batch }}' all
+        run: ./koch.py test --batch:'${{ matrix.batch }}_${{ matrix.total_batch }}' all
 
       - name: Print all test errors
         if: failure()

--- a/readme.md
+++ b/readme.md
@@ -241,9 +241,8 @@ be used to run the Nim test suite.
 <details>
 <summary>Show</summary>
 
-Assuming that you added Nim's ``bin`` directory to your PATH, you may execute
-the tests using ``./koch.py tests``. The tests take a while to run, but you
-can run a subset of tests by specifying a category (for example
+You may execute the tests using ``./koch.py tests``. The tests take a while to
+run, but you can run a subset of tests by specifying a category (for example
 ``./koch.py tests cat async``).
 
 For more information on the ``koch`` build tool please see the documentation


### PR DESCRIPTION
With be6cd8a51e4d30cf67450468a6342ab1adecfcf8, this is now possible.