### PR TITLE
introduce compiler build reproducibility test to CI

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -1,0 +1,73 @@
+name: Test compiler build reproducibility
+
+on:
+  push:
+    # Only run on bors branches
+    branches:
+      - staging
+      - trying
+
+jobs:
+  reprotest:
+    # This job is meant for testing whether the compiler can be built
+    # reproducibly given the same build environment.
+    #
+    # There are two tools used for this test:
+    #
+    # - reprotest: This tool varies the environment in multiple ways, like
+    #              adjusting time, build user, locale, etc. then run the build.
+    #              If the binary matches the control build (build without any
+    #              variations), then it's a pass. Otherwise, diffoscope is
+    #              employed to show the differences.
+    #
+    # - diffoscope: This tool visualize differences in binaries in a
+    #               human-readable fashion. This would allow developers to
+    #               figure out what of their changes caused the build to
+    #               varies based on outside environment.
+
+    name: Reproducibility tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install reprotest
+        run: |
+          sudo apt-get update -qq
+          # Diffoscope have a /lot/ of optional dependencies, but we don't need
+          # all of them
+          sudo apt-get install -yqq --no-install-recommends diffoscope
+          # On the contrary, reprotest needs all of those deps to work
+          sudo apt-get install -yqq reprotest
+
+      - uses: actions/checkout@v2.4.0
+
+      - name: Bootstrap koch
+        run: |
+          # TODO: Add a special mode to koch.py so we don't have to do this
+          # dance
+          #
+          # Perform a bootstrapping run for koch so that we don't have to clone
+          # csources
+          ./koch.py --help
+          # Then remove artifacts so we can test build those, too
+          git clean -fdx --exclude=/build/csources/
+          git -C build/csources clean -fdx
+
+      - name: Run reproducibility build
+        run: |
+          # Add a guest user for reprotest
+          sudo useradd -m guest-builder
+
+          # Disabled kernel variation as it messes with csources architecture
+          # detection.
+          #
+          # Can be re-enabled once reprotest is >= 0.7.18, where a fix is added
+          # to prevent 32-bit architectures from being selected.
+          reprotest \
+            --vary=domain_host.use_sudo=1 \
+            --vary=user_group.available+=guest-builder:guest-builder \
+            --vary=-kernel \
+            'export XDG_CACHE_HOME=$PWD/build/nimcache \
+              && ./koch.py boot -d:release \
+              && ./koch.py tools -d:release' \
+            'bin/*'

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,7 @@
 # Checks that has to pass before merge to devel can be done
 status = [
-  "All check passed"
+  "All check passed",
+  "Reproducibility tests"
 ]
 
 # Checks that has to pass before bors will process the PR


### PR DESCRIPTION
This check makes sure that the compiler can be built reproducibly on the same environment.

To save time, this check is only run on merge via bors.