### PR TITLE
move metadata retrivial from compiler source to koch

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -87,10 +87,11 @@ proc writeFullhelp(conf: ConfigRef; pass: TCmdLinePass) =
 
 proc getNimSourceData(): tuple[hash, date: string] {.compileTime.} =
   ## Retrieve metadata about the compiler source code.
-  let hashCall = gorgeEx("git rev-parse --verify HEAD")
-  let dateCall = gorgeEx("git log -1 --format=%cs HEAD")
-  if hashCall.exitCode == 0 and dateCall.exitCode == 0:
-    result = (hashCall.output.strip(), dateCall.output.strip())
+  const
+    # These are defined by koch
+    nimSourceHash {.strdefine.} = ""
+    nimSourceDate {.strdefine.} = ""
+  result = (nimSourceHash, nimSourceDate)
 
 proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
   if pass == passCmd1:


### PR DESCRIPTION
This metadata is only correct in the context of the compiler source. If the compiler is used as a library in an another location, then this information would be incorrect.

koch is a better location for this as it is guaranteed to run in the compiler source.