### PR TITLE
niminst: let the nim compiler be specified by koch

### DIFF
--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -141,8 +141,8 @@ const
 
 proc csource(args: string) =
   nimexec(("cc $1 -r $3 --var:version=$2 --var:mingw=none csource " &
-           "--main:compiler/nim.nim compiler/installer.ini $1") %
-       [args, VersionAsString, compileNimInst])
+           "--main:compiler/nim.nim $4 compiler/installer.ini $1") %
+       [args, VersionAsString, compileNimInst, quoteShell("--nim:" & findNim())])
 
 proc bundleC2nim(args: string) =
   cloneDependency(distDir, "https://github.com/nim-lang/c2nim.git")


### PR DESCRIPTION
By default `niminst` uses the compiler in `PATH`, which might not be compatible with the source it is compiling. This causes csources generation to fail for nimskull as the compiler was incompatible.

This commit enable the exact compiler to be specified by koch, solving this issue.