### PR TITLE
koch.py: support csources in release archives

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -50,7 +50,7 @@ Start: "doc/html/overview.html"
 
 [Other]
 Files: "copying.txt"
-Files: "koch.nim"
+Files: "koch.py"
 
 Files: "icons/nim.ico"
 Files: "icons/nim.rc"


### PR DESCRIPTION
This pull enables `koch.py` to build a bootstrap compiler from bundled csources in release archives.

This allow a build from the source archive to be network-less.

Included is a small fix to ensure that `koch.py` is packaged in release archives.

This pull also changes the source archive layout a fair bit, with all of `csources` being placed in `/build/csources` instead of `/`.