### PR TITLE
rework release archive creation

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -36,6 +36,7 @@ App: Console
 License: "copying.txt"
 
 [Config]
+Files: "config/build_config.txt"
 Files: "config/*.cfg"
 Files: "config/config.nims"
 
@@ -56,10 +57,6 @@ Files: "icons/nim.ico"
 Files: "icons/nim.rc"
 Files: "icons/nim.res"
 Files: "icons/nim_icon.o"
-Files: "icons/koch.ico"
-Files: "icons/koch.rc"
-Files: "icons/koch.res"
-Files: "icons/koch_icon.o"
 
 Files: "compiler"
 Files: "doc"
@@ -81,32 +78,21 @@ Files: "dist/nimble"
 Files: "tests"
 
 [Windows]
-Files: "bin/nim.exe"
-Files: "bin/nimgrep.exe"
-Files: "bin/nimsuggest.exe"
-Files: "bin/nimble.exe"
-Files: "bin/vccexe.exe"
-Files: "bin/nimgrab.exe"
-Files: "bin/nimpretty.exe"
-Files: "bin/testament.exe"
 Files: "bin/nim-gdb.bat"
 
-Files: "koch.exe"
-Files: "finish.exe"
-; Files: "bin/downloader.exe"
-
-; Files: "dist/mingw"
-Files: r"tools\start.bat"
-BinPath: r"bin;dist\mingw\bin;dist"
-
-;           Section | dir | zipFile | size hint (in KB) | url | exe start menu entry
-Download: r"Documentation|doc|docs.zip|13824|https://nim-lang.org/download/docs-${version}.zip|overview.html"
-Download: r"C Compiler (MingW)|dist|mingw.zip|82944|https://nim-lang.org/download/${mingw}.zip"
-Download: r"Support DLLs|bin|nim_dlls.zip|479|https://nim-lang.org/download/dlls.zip"
-Download: r"Aporia Text Editor|dist|aporia.zip|97997|https://nim-lang.org/download/aporia-0.4.0.zip|aporia-0.4.0\bin\aporia.exe"
-; for now only NSIS supports optional downloads
-
 [WinBin]
+Files: "bin/nim.exe"
+Files: "bin/nim_dbg.exe"
+Files: "bin/nimble.exe"
+Files: "bin/nimgrab.exe"
+Files: "bin/nimgrep.exe"
+Files: "bin/nimpretty.exe"
+Files: "bin/nimsuggest.exe"
+Files: "bin/testament.exe"
+Files: "bin/vccexe.exe"
+
+Files: "finish.exe"
+
 Files: "bin/makelink.exe"
 Files: "bin/7zG.exe"
 Files: "bin/*.dll"
@@ -114,7 +100,11 @@ Files: "bin/cacert.pem"
 
 [UnixBin]
 Files: "bin/nim"
-
+Files: "bin/nim_dbg"
+Files: "bin/nimgrep"
+Files: "bin/nimpretty"
+Files: "bin/nimsuggest"
+Files: "bin/testament"
 
 [Unix]
 InstallScript: "yes"


### PR DESCRIPTION
This is a big change, but most of it circles around the model of archive
creation embedded in niminst.

Previously niminst have two modes of operations: either it creates a
binary zip archive for Windows, or it creates a source tar.xz archive
for Unix.

This commit refactored that into three new pieces:

- `archive`: The main command to create a release archive. By default
             this archive contains only source code, and the source
             archive can be used to create binary archives.
- `--format`: A switch allowing selection of the release archive format.
- `--binaries`: A switch that set archive build mode to "binary
                archive", where either windows or unix (or both)
                binaries will be included in the archive. In this mode,
                files not relevant to the target platforms will also be
                omitted.

With these, koch is now equipped with some "new" commands:

- `archive`: Create a source archive
- `winrelease`: Create a binary zip archive for Windows
- `unixrelease`: Create a binary tarball for Unix-like

Some are removed:

- `testinstall`: Automated test to see if Unix binaries can be built
                 from sources. Currently have too many assumptions on
                 the way the old architecture work, so it is axed for
                 now.
- `zip`: superseded by `winrelease`
- `xz`: superseded by `archive`

And finally, `installer.ini` is updated to synchronize the binary list
with what is actually built.

Depends on #117