### PR TITLE
store extra metadata in release archives

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -4,6 +4,8 @@
 [Project]
 Name: "Nim"
 Version: "$version"
+Commit: "$commit"
+CommitDate: "$commitdate"
 Platforms: """
   windows: i386;amd64
   linux: i386;hppa;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv32;riscv64


### PR DESCRIPTION
This allows koch to fill in commit/commit date data when compiling the compiler from a source archive.

A prerequisite for nightlies.

We are getting deep into the `niminst` is compiler-only territory with this. I hope that in the future I can make #123 happen and consolidate everything into koch.