### PR TITLE
testament: remove stdlib isMainModule testing

### DIFF
--- a/lib/packages/docutils/highlite.nim
+++ b/lib/packages/docutils/highlite.nim
@@ -97,7 +97,7 @@ const
     "Other"]
 
   # The following list comes from doc/keywords.txt, make sure it is
-  # synchronized with this array by running the module itself as a test case.
+  # synchronized with this array -- a check exists within `koch/kochdocs`.
   nimKeywords = ["addr", "and", "as", "asm", "bind", "block",
     "break", "case", "cast", "concept", "const", "continue", "converter",
     "defer", "discard", "distinct", "div", "do",
@@ -1016,17 +1016,13 @@ proc tokenize*(text: string, lang: SourceLanguage): seq[(string, TokenClass)] =
     result.add (s, g.kind)
     prevPos = g.pos
 
-when isMainModule:
-  var keywords: seq[string]
-  # Try to work running in both the subdir or at the root.
-  for filename in ["doc/keywords.txt", "../../../doc/keywords.txt"]:
-    try:
-      let input = readFile(filename)
-      keywords = input.splitWhitespace()
-      break
-    except:
-      echo filename, " not found"
-  doAssert(keywords.len > 0, "Couldn't read any keywords.txt file!")
+proc nimKeywordsSynchronizationCheck*(keywordFileContent: string) =
+  ## used to ensure that keywords are synchronized between this module and
+  ## wherever the keywords content resides for docs.
+  ## 
+  ## at time of writing this was `docs/keywords.txt`
+  let keywords = keywordFileContent.splitWhitespace()
+  doAssert(keywords.len > 0, "Empty keywords content!")
   for i in 0..min(keywords.len, nimKeywords.len)-1:
     doAssert keywords[i] == nimKeywords[i], "Unexpected keyword"
   doAssert keywords.len == nimKeywords.len, "No matching lengths"

--- a/lib/pure/xmlparser.nim
+++ b/lib/pure/xmlparser.nim
@@ -147,27 +147,16 @@ proc loadXml*(path: string, options: set[XmlParseOption] = {reportComments}): Xm
   if errors.len > 0: raiseInvalidXml(errors)
 
 when isMainModule:
-  when not defined(testing):
-    import os
+  import os
 
-    var errors: seq[string] = @[]
-    var x = loadXml(paramStr(1), errors)
-    for e in items(errors): echo e
+  var
+    errors: seq[string] = @[]
+    x = loadXml(paramStr(1), errors)
+  for e in items(errors): echo e
 
-    var f: File
-    if open(f, "xmltest.txt", fmWrite):
-      f.write($x)
-      f.close()
-    else:
-      quit("cannot write test.txt")
+  var f: File
+  if open(f, "xmltest.txt", fmWrite):
+    f.write($x)
+    f.close()
   else:
-    block: # correctly parse ../../tests/testdata/doc1.xml
-      let filePath = "tests/testdata/doc1.xml"
-      var errors: seq[string] = @[]
-      var xml = loadXml(filePath, errors)
-      assert(errors.len == 0, "The file tests/testdata/doc1.xml should be parsed without errors.")
-
-    block bug1518:
-      var err: seq[string] = @[]
-      assert $parsexml(newStringStream"<tag>One &amp; two</tag>", "temp.xml",
-          err) == "<tag>One &amp; two</tag>"
+    quit("cannot write test.txt")

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -327,18 +327,8 @@ proc testStdlib(r: var TResults, pattern, options: string, cat: Category) =
 
   files.sort # reproducible order
   for testFile in files:
-    let contents = readFile(testFile)
     var testObj = makeTest(testFile, options, cat)
-    #[
-    todo:
-    this logic is fragile:
-    false positives (if appears in a comment), or false negatives, e.g.
-    `when defined(osx) and isMainModule`.
-    Instead of fixing this, see https://github.com/nim-lang/Nim/issues/10045
-    for a much better way.
-    ]#
-    if "when isMainModule" notin contents:
-      testObj.spec.action = actionCompile
+    testObj.spec.action = actionCompile
     testSpec r, testObj
 
 # ---------------- IC tests ---------------------------------------------
@@ -578,7 +568,6 @@ proc processCategory(r: var TResults, cat: Category,
       ioTests r, cat, options
     of "lib":
       testStdlib(r, "lib/pure/", options, cat)
-      testStdlib(r, "lib/packages/docutils/", options, cat)
     of "examples":
       compileExample(r, "examples/*.nim", options, cat)
       compileExample(r, "examples/gtk/*.nim", options, cat)

--- a/tests/stdlib/txmlparser.nim
+++ b/tests/stdlib/txmlparser.nim
@@ -1,0 +1,49 @@
+discard """
+description: '''
+Basic tests for the xmlparser module
+'''
+"""
+
+# note the module and tests might still be removed or heavily reworked, only
+# including here to remove the testament hack for testing std lib files
+
+let xmlData = r"""
+<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+  <tag>
+    <test arg="blah" arg2="test"/>
+    <test2>
+      bla ah absy hsh
+      hsh
+      &woohoo;
+      sjj
+    </test2>
+    <test><teh>bla</teh></test>
+  </tag>
+</root>
+
+
+"""
+
+import std/xmlparser
+from std/xmltree import `$`
+
+block parse_an_xml_string:
+  ## parse an xml string, should work without raising an invalid xml exception
+  try:
+    discard parseXml(xmlData)
+  except:
+    doAssert false, "Should not result in any errors, got: " &
+                    getCurrentExceptionMsg()
+
+block unescape_escaped_characters:
+  ## escape characters should preserve the spaces that follow
+  ## original regressions: https://github.com/nim-lang/Nim/issues/1518
+  let expected = "<tag>One &amp; two</tag>"
+  try:
+    doAssert $parseXml("<tag>One &amp; two</tag>") == expected,
+      "failed to handle escape characters"
+  except:
+    doAssert false, "unexpected error with test, got: " &
+                    getCurrentExceptionMsg()
+    


### PR DESCRIPTION
Presently testament will parse all modules under `pure/lib` and `lib/packages/docutils` then:
1. it would read the contents, looking for a string match of `when isMainModule`
  1. resulting in a compile action instead of run
2. then include these as "tests" within its run

There are only two modules that are making use of this:
* `lib/packages/docutils/highlite.nim`: which was piggybacking a build check
* `lib/pure/xmlparser.nim`: had a basic test case

For the former the build check was integrated into `tools/koch/kochDocs` and for the latter
a quick test was created with `tests/stdlib`. After which point the `lib/packages/docutils` was
removed from testament's stdlib category and now content parsing for `when isMainModule`
has been removed, this should speed up execution for slower disks. Also these are now
used as simple compiles tests instead of attempting a run.

After review I'll squash. The background motivation for this is it simplifies the testament
rework that I'm presently undertaking in: https://github.com/nim-works/nimskull/pull/135/files

<!--
## Finalizing a PR:

### title:
* reads like a short changelog line

### body:
* describe the current behaviour
* describe why this particular approach
* if it's breaking, migration steps
* note any follow-on work

### content:
* leave code better than you found it, add docs, tests, etc
-->