### PR TITLE
niminst: create deterministic archives

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -25,14 +25,35 @@ jobs:
     #               figure out what of their changes caused the build to
     #               varies based on outside environment.
 
-    name: Reproducibility tests
+    strategy:
+      fail-fast: false
 
+      matrix:
+        test:
+          - name: Source archive
+            command: './koch.py boot -d:danger && ./koch.py csource -d:danger && ./koch.py archive'
+            pattern: 'build/*.tar.xz'
+
+          - name: Unix binary archive
+            command: './koch.py unixrelease'
+            pattern: 'build/*.tar.xz'
+
+          # Note: this tests the zip generation and not exe generation determinism.
+          #
+          # Testing exe generation will be done when cross-bootstrap is possible.
+          - name: Windows binary archive
+            command: './koch.py winrelease'
+            pattern: 'build/*.zip'
+
+    name: '${{ matrix.test.name }} reproducibility tests'
     runs-on: ubuntu-latest
 
     steps:
       - name: Install reprotest
         run: |
           sudo apt-get update -qq
+          # This tool is required for archive generation
+          sudo apt-get install -yqq libarchive-tools
           # Diffoscope have a /lot/ of optional dependencies, but we don't need
           # all of them
           sudo apt-get install -yqq --no-install-recommends diffoscope
@@ -68,6 +89,18 @@ jobs:
             --vary=user_group.available+=guest-builder:guest-builder \
             --vary=-kernel \
             'export XDG_CACHE_HOME=$PWD/build/nimcache \
-              && ./koch.py boot -d:release \
-              && ./koch.py tools -d:release' \
-            'bin/*'
+              && ${{ matrix.test.command }}' \
+            '${{ matrix.test.pattern }}'
+
+  passed:
+    name: All reproducibility tests passed
+    needs: [reprotest]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Raise failure
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::There are failing required jobs"
+          exit 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 # Checks that has to pass before merge to devel can be done
 status = [
   "All check passed",
-  "Reproducibility tests"
+  "All reproducibility tests passed"
 ]
 
 # Checks that has to pass before bors will process the PR


### PR DESCRIPTION
This pull makes niminst creates reproducible archives following the
recommendations at https://reproducible-builds.org/docs/archives/

In particular, these are the changes made:

- Make niminst outputs the commands being run and exit on failure if
  any of them fail to run.

- Procedures that walk directories will produce a sorted list to
  minimize undeterminism from OS ordering.

- Archived files have their timestamp set to the commit date if
  available or epoch 0 otherwise to minimize the effect of time on the
  build. The timezone used is always UTC.

- Archived files are stored in the archive in their alphabetical order,
  allowing them to be stored without regards to their ordering in the
  file system.

- Switched from 7-Zip to Info-Zip for creating zip files, as Info-Zip
  allow us to omit extra metadata from the archive that depends on
  undeterministic values.

- For tar archives, the user/group is set to 0 and use the GNU format to
  eliminate non-deterministic metadata. Since the options to perform
  this task is not standard, the `tar` utility support has been reduced
  to libarchive and GNU tar, the two most popular tar utilities.

- Modified reproducibility test to test source and release archive
  generation.