### PR TITLE
Experiement: Data Oriented Design AST Sketch

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -34,7 +34,7 @@ type Gconfig = object
   ## we put comments in a side channel to avoid increasing `sizeof(TNode)`,
   ## which reduces memory usage given that `PNode` is the most allocated
   ## type by far.
-  comments: Table[int, string] # nodeId => comment
+  comments: Table[NodeId, string] # nodeId => comment
   useIc*: bool
 
 var gconfig {.threadvar.}: Gconfig
@@ -319,6 +319,7 @@ proc discardSons*(father: PNode)
 type Indexable = PNode | PType
 
 proc len*(n: Indexable): int {.inline.} =
+  ## number of children, unsafe if called on leaf nodes, see `safeLen`
   result = n.sons.len
 
 proc safeLen*(n: PNode): int {.inline.} =
@@ -326,15 +327,22 @@ proc safeLen*(n: PNode): int {.inline.} =
   if n.kind in {nkNone..nkNilLit}: result = 0
   else: result = n.len
 
-proc add*(father, son: Indexable) =
-  assert son != nil
-  father.sons.add(son)
+proc safeArrLen*(n: PNode): int {.inline.} =
+  ## works for array-like objects (strings passed as openArray in VM).
+  if n.kind in {nkStrLit..nkTripleStrLit}: result = n.strVal.len
+  elif n.kind in {nkNone..nkFloat128Lit}: result = 0
+  else: result = n.len
 
 proc addAllowNil*(father, son: Indexable) {.inline.} =
   father.sons.add(son)
 
+proc add*(father, son: Indexable) {.inline.} =
+  assert son != nil
+  addAllowNil(father, son)
+
 template `[]`*(n: Indexable, i: int): Indexable = n.sons[i]
-template `[]=`*(n: Indexable, i: int; x: Indexable) = n.sons[i] = x
+template `[]=`*(n: Indexable, i: int; x: Indexable) =
+  n.sons[i] = x
 
 template `[]`*(n: Indexable, i: BackwardsIndex): Indexable = n[n.len - i.int]
 template `[]=`*(n: Indexable, i: BackwardsIndex; x: Indexable) = n[n.len - i.int] = x
@@ -366,19 +374,46 @@ proc getDeclPragma*(n: PNode): PNode =
       result = n[0][1]
   else:
     # support as needed for `nkIdentDefs` etc.
-    result = nil
+    result = nilPNode
   if result != nil:
     assert result.kind == nkPragma, $(result.kind, n.kind)
 
-const invalidNodeId* = 0
-var gNodeId: int
-
 when defined(useNodeIds):
-  const nodeIdToDebug* = -1 # 2322968
+  const nodeIdToDebug* = NodeId -1 # 2322968
 
-template setNodeId() =
-  inc gNodeId
-  result.id = gNodeId
+template newNodeImpl(kind: TNodeKind, info2: TLineInfo) =
+  # result = PNode(kind: kind, info: info2)
+  {.cast(noSideEffect).}:
+    let
+      nodeId = state.nextNodeId()
+      nodeIdx = nodeId.idx
+    state.nodeList.add NodeData(kind: kind)
+    state.nodeInf.add info2
+    state.nodeFlag.add {}
+    case extraDataKind(kind):
+    of ExtraDataInt:
+      state.nodeInt.add 0
+      state.nodeList[nodeIdx].extra = ExtraDataId state.nodeInt.len
+    of ExtraDataFloat:
+      state.nodeFlt.add 0
+      state.nodeList[nodeIdx].extra = ExtraDataId state.nodeFlt.len
+    of ExtraDataString:
+      state.nodeStr.add ""
+      state.nodeList[nodeIdx].extra = ExtraDataId state.nodeStr.len
+    of ExtraDataSymbol:
+      state.nodeSym.add nil
+      state.nodeList[nodeIdx].extra = ExtraDataId state.nodeSym.len
+    of ExtraDataIdentifier:
+      state.nodeIdt.add nil
+      state.nodeList[nodeIdx].extra = ExtraDataId state.nodeIdt.len
+    of ExtraDataAst, ExtraDataNone:
+      state.astData.add @[]
+      state.nodeList[nodeIdx].extra = ExtraDataId state.astData.len
+      discard
+
+    result = PNode(id: nodeId)
+
+template checkNodeIdForDebug() =
   when defined(useNodeIds):
     if result.id == nodeIdToDebug:
       echo "KIND ", result.kind
@@ -386,16 +421,17 @@ template setNodeId() =
 
 func newNodeI*(kind: TNodeKind, info: TLineInfo): PNode =
   ## new node with line info, no type, and no children
-  result = PNode(kind: kind, info: info, reportId: emptyReportId)
+  newNodeImpl(kind, info)
   {.cast(noSideEffect).}:
-    setNodeId()
-  when false:
-    # this would add overhead, so we skip it; it results in a small amount of leaked entries
-    # for old PNode that gets re-allocated at the same address as a PNode that
-    # has `nfHasComment` set (and an entry in that table). Only `nfHasComment`
-    # should be used to test whether a PNode has a comment; gconfig.comments
-    # can contain extra entries for deleted PNode's with comments.
-    gconfig.comments.del(result.id)
+    checkNodeIdForDebug()
+    when defined(nimsuggest):
+      # this would add overhead, so we skip it; it results in a small amount of
+      # leaked entries for old PNode that gets re-allocated at the same address
+      # as a PNode that has `nfHasComment` set (and an entry in that table).
+      # Only `nfHasComment` should be used to test whether a PNode has a
+      # comment; gconfig.comments can contain extra entries for deleted PNode's
+      # with comments.
+      gconfig.comments.del(result.id)
 
 proc newNode*(kind: TNodeKind): PNode =
   ## new node with unknown line info, no type, and no children
@@ -417,6 +453,11 @@ proc newNodeIT*(kind: TNodeKind, info: TLineInfo, typ: PType, children: int): PN
   result = newNodeIT(kind, info, typ)
   if children > 0:
     newSeq(result.sons, children)
+
+proc newErrorNodeIT*(rep: ReportId, info: TLineInfo, typ: PType): PNode =
+  ## new node with line info, type, report, and no children
+  result = newNodeIT(nkError, info, typ)
+  result.reportId = rep
 
 proc newTree*(kind: TNodeKind; children: varargs[PNode]): PNode =
   result = newNode(kind)
@@ -802,14 +843,43 @@ proc delSon*(father: PNode, idx: int) =
   for i in idx..<father.len - 1: father[i] = father[i + 1]
   father.sons.setLen(father.len - 1)
 
+proc applyToNode*(src, dest: PNode) =
+  ## used for the VM when we pass nodes "by value"
+  # assert not dest.isNil
+  # assert not src.isNil
+  # assert dest.id != src.id, "applying to self, id: " & $src.id
+  state.nodeList[dest.idx] = state.nodeList[src.idx]
+  state.nodeFlag[dest.idx] = state.nodeFlag[src.idx]
+  state.nodeInf[dest.idx] = state.nodeInf[src.idx]
+  if state.nodeTyp.hasKey(src.id):
+    state.nodeTyp[dest.id] = state.nodeTyp[src.id]
+  if state.nodeRpt.hasKey(src.id):
+    state.nodeRpt[dest.id] = state.nodeRpt[src.id]
+  case src.kind.extraDataKind
+  of ExtraDataInt:
+    dest.intVal = src.intVal
+  of ExtraDataFloat:
+    dest.floatVal = src.floatVal
+  of ExtraDataString:
+    dest.strVal = src.strVal
+  of ExtraDataSymbol:
+    dest.sym = src.sym
+  of ExtraDataIdentifier:
+    dest.ident = src.ident
+  of ExtraDataAst, ExtraDataNone:
+    dest.sons = src.sons
+
 template copyNodeImpl(dst, src, processSonsStmt) =
-  if src == nil: return
+  # does not copy src's sons to dst
+  if src == nil:
+    return nilPNode
   dst = newNode(src.kind)
   dst.info = src.info
   dst.typ = src.typ
   dst.flags = src.flags * PersistentNodeFlags
   dst.comment = src.comment
-  dst.reportId = src.reportId
+  if src.kind == nkError:
+    dst.reportId = src.reportId
   when defined(useNodeIds):
     if dst.id == nodeIdToDebug:
       echo "COMES FROM ", src.id
@@ -826,22 +896,108 @@ proc copyNode*(src: PNode): PNode =
   copyNodeImpl(result, src):
     discard
 
-template transitionNodeKindCommon(k: TNodeKind) =
-  let obj {.inject.} = n[]
-  n[] = TNode(id: obj.id, kind: k, typ: obj.typ, info: obj.info,
-              flags: obj.flags)
-  # n.comment = obj.comment # shouldn't be needed, the address doesnt' change
+type
+  NodeDataToClear = enum
+    nodeClearAst,
+    nodeClearFlg,
+    nodeClearInf,
+    nodeClearSym,
+    nodeClearIdt,
+    nodeClearTyp,
+    nodeClearInt,
+    nodeClearFlt,
+    nodeClearStr,
+    nodeClearRpt,
+    nodeClearCmt
+
+func determineNodeDataToClear(k: TNodeKind): set[NodeDataToClear] {.inline.} =
+  case k
+  of nkCharLit..nkUInt64Lit:
+    {nodeClearAst, nodeClearSym, nodeClearIdt, nodeClearFlt, nodeClearStr, nodeClearRpt}
+  of nkFloatLit..nkFloat128Lit:
+    {nodeClearAst, nodeClearSym, nodeClearIdt, nodeClearInt, nodeClearStr, nodeClearRpt}
+  of nkStrLit..nkTripleStrLit:
+    {nodeClearAst, nodeClearSym, nodeClearIdt, nodeClearInt, nodeClearFlt, nodeClearRpt}
+  of nkSym:
+    {nodeClearAst, nodeClearIdt, nodeClearInt, nodeClearFlt, nodeClearStr, nodeClearRpt}
+  of nkIdent:
+    {nodeClearAst, nodeClearSym, nodeClearInt, nodeClearFlt, nodeClearStr, nodeClearRpt}
+  of nkError:
+    {nodeClearIdt, nodeClearSym, nodeClearInt, nodeClearFlt, nodeClearStr}
+  else:
+    {nodeClearIdt, nodeClearSym, nodeClearInt, nodeClearFlt, nodeClearStr, nodeClearRpt}
+    # xxx: this should handle empty and other special cases
+
+template transitionNodeKindCommon(k, old: TNodeKind) =
+  # xxx: this used to be a memory copy, but now we just change the kind
+  # xxx: trace the transition for lineage information
+
+  # clear old data: this was added as part of the data oriented design
+  #                 refactor; might be a source of bugs wrt to how legacy code
+  #                 expects things to work, try to favour fixing legacy code
+  let
+    kExtraDataKind = extraDataKind(k)
+    oldExtraDataKind = extraDataKind(old)
+    sameNodeVariety = kExtraDataKind == oldExtraDataKind ## kinds need equivalent storage
+    clears =
+      if sameNodeVariety: {}            # don't clear if the same
+      else: determineNodeDataToClear(k)
+    resetExtraDataId = clears != {} and oldExtraDataKind != ExtraDataNone
+
+  for clear in clears.items:
+    case clear
+    of nodeClearAst:
+      if oldExtraDataKind == ExtraDataAst:
+        state.astData[n.extraIdx].setLen(0)
+    of nodeClearFlg: state.nodeFlag[n.idx] = {}
+    of nodeClearInf: state.nodeInf[n.idx] = unknownLineInfo
+    of nodeClearTyp: state.nodeTyp.del(n.id)
+    of nodeClearRpt: state.nodeRpt.del(n.id)
+    of nodeClearSym:
+      if oldExtraDataKind == ExtraDataSymbol:
+        state.nodeSym[n.extraId.idx] = nil
+    of nodeClearIdt:
+      if oldExtraDataKind == ExtraDataIdentifier:
+        state.nodeIdt[n.extraId.idx] = nil
+    of nodeClearInt:
+      if oldExtraDataKind == ExtraDataInt:
+        state.nodeInt[n.extraId.idx] = 0
+    of nodeClearFlt:
+      if oldExtraDataKind == ExtraDataFloat:
+        state.nodeFlt[n.extraId.idx] = 0.0
+    of nodeClearStr:
+      if oldExtraDataKind == ExtraDataString:
+        state.nodeStr[n.extraId.idx] = ""
+    of nodeClearCmt: gconfig.comments.del(n.id)
+  
+  state.nodeList[n.idx].kind = k
+
+  # xxx: setup storage if we reset it
+  if resetExtraDataId:
+    state.nodeList[n.idx].extra = nilExtraDataId
+  
+  when defined(useNodeIds):
+    if n.id == nodeIdToDebug:
+      echo "KIND ", n.kind
+      writeStackTrace()
 
 proc transitionSonsKind*(n: PNode, kind: range[nkDotCall..nkTupleConstr]) =
-  transitionNodeKindCommon(kind)
-  n.sons = obj.sons
+  # xxx: just change the kind now, might need clearing/validation here
+  transitionNodeKindCommon(kind, n.kind)
+  # xxx: this used to copy sons, not sure if that's still needed.
 
 proc transitionIntKind*(n: PNode, kind: range[nkCharLit..nkUInt64Lit]) =
-  transitionNodeKindCommon(kind)
-  n.intVal = obj.intVal
+  # xxx: just change the kind now, might need clearing/validation here
+  transitionNodeKindCommon(kind, n.kind)
+
+proc transitionToNilLit*(n: PNode) =
+  ## used to reset a node to a nil literal
+  transitionNodeKindCommon(nkNilLit, n.kind)
 
 proc transitionNoneToSym*(n: PNode) =
-  transitionNodeKindCommon(nkSym)
+  # xxx: just change the kind now, might need clearing/validation here
+  #      see the hack in `semtypes.semTypeIdent`
+  transitionNodeKindCommon(nkSym, n.kind)
 
 template transitionSymKindCommon*(k: TSymKind) =
   let obj {.inject.} = s[]
@@ -1175,7 +1331,7 @@ proc findUnresolvedStatic*(n: PNode): PNode =
     let n = son.findUnresolvedStatic
     if n != nil: return n
 
-  return nil
+  return nilPNode
 
 when false:
   proc containsNil*(n: PNode): bool =

--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -89,7 +89,7 @@ proc sameValue*(a, b: PNode): bool =
     #InternalError(a.info, "SameValue")
     discard
 
-proc leValue*(a, b: PNode): bool =
+func leValue*(a, b: PNode): bool =
   # a <= b?
   result = false
   case a.kind
@@ -501,7 +501,7 @@ proc idNodeTableGet(t: TIdNodeTable, key: PIdObj): PNode =
   var index: int
   index = idNodeTableRawGet(t, key)
   if index >= 0: result = t.data[index].val
-  else: result = nil
+  else: result = nilPNode
 
 proc idNodeTableRawInsert(data: var TIdNodePairSeq, key: PIdObj, val: PNode) =
   var h: Hash

--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -52,7 +52,7 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
 proc searchObjCaseImpl(obj: PNode; field: PSym): PNode =
   case obj.kind
   of nkSym:
-    result = nil
+    result = nilPNode
   of nkElse, nkOfBranch:
     result = searchObjCaseImpl(obj.lastSon, field)
   else:

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -49,11 +49,11 @@ proc errorSubNode*(n: PNode): PNode =
   ## find the first error node, or nil, under `n` using a depth first traversal
   case n.kind
   of nkEmpty..nkNilLit:
-    result = nil
+    result = nilPNode
   of nkError:
     result = n
   else:
-    result = nil
+    result = nilPNode
     for s in n.items:
       if s.isNil: continue
       result = errorSubNode(s)
@@ -85,11 +85,10 @@ proc newError*(
   assert wrongNode != nil, "can't have a nil node for `wrongNode`"
   assert not report.isEmpty(), $report
 
-  result = PNode(
-    kind: nkError,
-    info: wrongNode.info,
-    typ: newType(tyError, ItemId(module: -2, item: -1), nil),
-    reportId: report
+  result = newErrorNodeIT(
+    report,
+    wrongNode.info,
+    newType(tyError, ItemId(module: -2, item: -1), nil)
   )
 
   addInNimDebugUtilsError(conf, wrongNode, result)

--- a/compiler/ast/filters.nim
+++ b/compiler/ast/filters.nim
@@ -32,7 +32,7 @@ proc invalidPragma(conf: ConfigRef; n: PNode) =
   conf.localReport(n.info, reportAst(rsemNodeNotAllowed, n))
 
 proc getArg(conf: ConfigRef; n: PNode, name: string, pos: int): PNode =
-  result = nil
+  result = nilPNode
   if n.kind in {nkEmpty..nkNilLit}: return
   for i in 1..<n.len:
     if n[i].kind == nkExprEqExpr:

--- a/compiler/ast/nimsets.nim
+++ b/compiler/ast/nimsets.nim
@@ -33,7 +33,7 @@ proc inSet*(s: PNode, elem: PNode): bool =
         return true
   result = false
 
-proc overlap*(a, b: PNode): bool =
+func overlap*(a, b: PNode): bool =
   if a.kind == nkRange:
     if b.kind == nkRange:
       # X..Y and C..D overlap iff (X <= D and C <= Y)

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -448,7 +448,7 @@ proc exprList(p: var Parser, endTok: TokType, result: PNode) =
   when defined(nimpretty):
     dec p.em.doIndentMore
 
-proc exprColonEqExprListAux(p: var Parser, endTok: TokType, result: PNode) =
+proc exprColonEqExprListAux(p: var Parser, endTok: TokType, result: var PNode) =
   assert(endTok in {tkCurlyRi, tkCurlyDotRi, tkBracketRi, tkParRi})
   getTok(p)
   flexComment(p, result)
@@ -518,7 +518,8 @@ proc setOrTableConstr(p: var Parser): PNode =
     # progress guaranteed
     while p.tok.tokType notin {tkCurlyRi, tkEof}:
       var a = exprColonEqExpr(p)
-      if a.kind == nkExprColonExpr: result.transitionSonsKind(nkTableConstr)
+      if a.kind == nkExprColonExpr:
+        result.transitionSonsKind(nkTableConstr)
       result.add(a)
       if p.tok.tokType != tkComma: break
       getTok(p)
@@ -1709,7 +1710,7 @@ proc parseTry(p: var Parser; isExpr: bool): PNode =
   getTok(p)
   colcom(p, result)
   result.add(parseStmt(p))
-  var b: PNode = nil
+  var b: PNode = nilPNode
   while sameOrNoInd(p) or isExpr:
     case p.tok.tokType
     of tkExcept:

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -408,7 +408,9 @@ proc atom(g: TSrcGen; n: PNode): string =
   of nkUInt64Lit: result = ulitAux(g, n, n.intVal, 8) & "\'u64"
   of nkFloatLit:
     if n.flags * {nfBase2, nfBase8, nfBase16} == {}: result = $(n.floatVal)
-    else: result = litAux(g, n, (cast[PInt64](addr(n.floatVal)))[] , 8)
+    else:
+      f = n.floatVal
+      result = litAux(g, n, (cast[PInt64](addr(f)))[] , 8)
   of nkFloat32Lit:
     if n.flags * {nfBase2, nfBase8, nfBase16} == {}:
       result = $n.floatVal & "\'f32"
@@ -419,7 +421,8 @@ proc atom(g: TSrcGen; n: PNode): string =
     if n.flags * {nfBase2, nfBase8, nfBase16} == {}:
       result = $n.floatVal & "\'f64"
     else:
-      result = litAux(g, n, (cast[PInt64](addr(n.floatVal)))[], 8) & "\'f64"
+      f = n.floatVal
+      result = litAux(g, n, (cast[PInt64](addr(f)))[], 8) & "\'f64"
   of nkNilLit: result = "nil"
   of nkType:
     if (n.typ != nil) and (n.typ.sym != nil): result = n.typ.sym.name.s

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -369,7 +369,7 @@ proc reportSymbols*(
     kind: ReportKind,
     symbols: seq[PSym],
     typ: PType = nil,
-    ast: PNode = nil
+    ast: PNode = nilPNode
   ): SemReport =
   case kind:
     of rsemReportTwoSym: assert symbols.len == 2
@@ -392,20 +392,20 @@ func reportAst*(
 
 func reportTyp*(
     kind: ReportKind,
-    typ: PType, ast: PNode = nil, sym: PSym = nil, str: string = ""
+    typ: PType, ast: PNode = nilPNode, sym: PSym = nil, str: string = ""
   ): SemReport =
   SemReport(kind: kind, typ: typ, ast: ast, sym: sym, str: str)
 
 func reportStr*(
     kind: ReportKind,
-    str: string, ast: PNode = nil, typ: PType = nil, sym: PSym = nil
+    str: string, ast: PNode = nilPNode, typ: PType = nil, sym: PSym = nil
   ): SemReport =
 
   SemReport(kind: kind, ast: ast, str: str, typ: typ, sym: sym)
 
 func reportSym*(
     kind: ReportKind,
-    sym: PSym, ast: PNode = nil, str: string = "", typ: PType = nil,
+    sym: PSym, ast: PNode = nilPNode, str: string = "", typ: PType = nil,
   ): SemReport =
 
   SemReport(kind: kind, ast: ast, str: str, typ: typ, sym: sym)

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -372,7 +372,7 @@ proc mutateTypeAux(marker: var IntSet, t: PType, iter: TTypeMutator,
                    closure: RootRef): PType
 proc mutateNode(marker: var IntSet, n: PNode, iter: TTypeMutator,
                 closure: RootRef): PNode =
-  result = nil
+  result = nilPNode
   if n != nil:
     result = copyNode(n)
     result.typ = mutateTypeAux(marker, n.typ, iter, closure)

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -829,4 +829,4 @@ proc genAsgnCall(p: BProc, le, ri: PNode, d: var TLoc) =
   else:
     genPrefixCall(p, le, ri, d)
 
-proc genCall(p: BProc, e: PNode, d: var TLoc) = genAsgnCall(p, nil, e, d)
+proc genCall(p: BProc, e: PNode, d: var TLoc) = genAsgnCall(p, nilPNode, e, d)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2593,7 +2593,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
       p.config.quitOrRaise "compiler built without support for the 'spawn' statement"
     else:
       let n = spawn.wrapProcForSpawn(
-        p.module.g.graph, p.module.idgen, p.module.module, e, e.typ, nil, nil)
+        p.module.g.graph, p.module.idgen, p.module.module, e, e.typ, nilPNode, nilPNode)
       expr(p, n, d)
   of mParallel:
     when defined(leanCompiler):
@@ -3129,7 +3129,7 @@ proc getDefaultValue(p: BProc; typ: PType; info: TLineInfo): Rope =
   of tyObject:
     var count = 0
     result.add "{"
-    getNullValueAuxT(p, t, t, t.n, nil, result, count, true, info)
+    getNullValueAuxT(p, t, t, t.n, nilPNode, result, count, true, info)
     result.add "}"
   of tyTuple:
     result = rope"{"

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -1007,7 +1007,7 @@ proc genTryCpp(p: BProc, t: PNode, d: var TLoc) =
 
   p.procSec(cpsInit).add(ropecg(p.module, "\tstd::exception_ptr T$1_ = nullptr;", [etmp]))
 
-  let fin = if t[^1].kind == nkFinally: t[^1] else: nil
+  let fin = if t[^1].kind == nkFinally: t[^1] else: nilPNode
   p.nestedTryStmts.add((fin, false, 0.Natural))
 
   if t.kind == nkHiddenTryStmt:
@@ -1045,7 +1045,7 @@ proc genTryCpp(p: BProc, t: PNode, d: var TLoc) =
       endBlock(p)
     else:
       var orExpr = Rope(nil)
-      var exvar = PNode(nil)
+      var exvar = nilPNode
       for j in 0..<t[i].len - 1:
         var typeNode = t[i][j]
         if t[i][j].isInfixAs():
@@ -1165,7 +1165,7 @@ proc genTryCppOld(p: BProc, t: PNode, d: var TLoc) =
     getTemp(p, t.typ, d)
   genLineDir(p, t)
   discard cgsym(p.module, "popCurrentExceptionEx")
-  let fin = if t[^1].kind == nkFinally: t[^1] else: nil
+  let fin = if t[^1].kind == nkFinally: t[^1] else: nilPNode
   p.nestedTryStmts.add((fin, false, 0.Natural))
   startBlock(p, "try {$n")
   expr(p, t[0], d)
@@ -1229,7 +1229,7 @@ proc bodyCanRaise(p: BProc; n: PNode): bool =
     result = false
 
 proc genTryGoto(p: BProc; t: PNode; d: var TLoc) =
-  let fin = if t[^1].kind == nkFinally: t[^1] else: nil
+  let fin = if t[^1].kind == nkFinally: t[^1] else: nilPNode
   inc p.labels
   let lab = p.labels
   let hasExcept = t[1].kind == nkExceptBranch
@@ -1378,7 +1378,7 @@ proc genTrySetjmp(p: BProc, t: PNode, d: var TLoc) =
     else:
       linefmt(p, cpsStmts, "$1.status = setjmp($1.context);$n", [safePoint])
     lineCg(p, cpsStmts, "if ($1.status == 0) {$n", [safePoint])
-  let fin = if t[^1].kind == nkFinally: t[^1] else: nil
+  let fin = if t[^1].kind == nkFinally: t[^1] else: nilPNode
   p.nestedTryStmts.add((fin, quirkyExceptions, 0.Natural))
   expr(p, t[0], d)
   if not quirkyExceptions:

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -268,7 +268,7 @@ proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet): PS
             newSymNode(getCompilerProc(g, "chckNilDisp")), newSymNode(param))
   for meth in 0..high(methods):
     var curr = methods[meth]      # generate condition:
-    var cond: PNode = nil
+    var cond: PNode = nilPNode
     for col in 1..<paramLen:
       if contains(relevantCols, col):
         var isn = newNodeIT(nkCall, base.info, boolType)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -206,7 +206,7 @@ proc initProcOptions(module: BModule): TOptions =
     result.excl(optStackTrace)
 
 proc newInitProc(globals: PGlobals, module: BModule): PProc =
-  result = newProc(globals, module, nil, initProcOptions(module))
+  result = newProc(globals, module, nilPNode, initProcOptions(module))
 
 proc declareGlobal(p: PProc; id: int; r: Rope) =
   if p.prc != nil and not p.declaredGlobals.containsOrIncl(id):
@@ -835,7 +835,7 @@ proc genTry(p: PProc, n: PNode, r: var TCompRes) =
       if i > 1: lineF(p, "}$n", [])
     else:
       var orExpr: Rope = nil
-      var excAlias: PNode = nil
+      var excAlias: PNode = nilPNode
 
       useMagic(p, "isObj")
       for j in 0..<n[i].len - 1:
@@ -1574,7 +1574,7 @@ proc genArgs(p: PProc, n: PNode, r: var TCompRes; start=1) =
 
   for i in start..<n.len:
     let it = n[i]
-    var paramType: PNode = nil
+    var paramType: PNode = nilPNode
     if i < typ.len:
       assert(typ.n[i].kind == nkSym)
       paramType = typ.n[i]
@@ -1606,7 +1606,7 @@ proc genOtherArg(p: PProc; n: PNode; i: int; typ: PType;
       node = n))
 
   let it = n[i]
-  var paramType: PNode = nil
+  var paramType: PNode = nilPNode
   if i < typ.len:
     assert(typ.n[i].kind == nkSym)
     paramType = typ.n[i]

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -567,7 +567,7 @@ template localReport*(conf: ConfigRef, report: Report) =
 proc semReportCountMismatch*(
     kind: ReportKind,
     expected, got: distinct SomeInteger,
-    node: PNode = nil,
+    node: PNode = nilPNode,
   ): SemReport =
   result = SemReport(kind: kind, ast: node)
   result.countMismatch = (toInt128(expected), toInt128(got))

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -499,7 +499,7 @@ proc canReport*(conf: ConfigRef, id: ReportId): bool =
   ## Check whether report with given ID can actually be written out, or it
   ## has already been seen. This check is used to prevent multiple reports
   ## from the `nkError` node.
-  id notin conf.m.writtenSemReports
+  true or id notin conf.m.writtenSemReports
 
 proc canReport*(conf: ConfigRef, node: PNode): bool =
   ## Check whether `nkError` node can be reported

--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -61,7 +61,7 @@ proc followLater(c: var AliveContext; g: PackedModuleGraph; module: int; item: i
     if body != emptyNodeId:
       let opt = g[module].fromDisk.syms[item].options
       if g[module].fromDisk.syms[item].kind in routineKinds:
-        body = NodeId ithSon(g[module].fromDisk.bodies, NodePos body, bodyPos)
+        body = packed_ast.NodeId ithSon(g[module].fromDisk.bodies, NodePos body, bodyPos)
       c.stack.add((module, opt, NodePos(body)))
 
     when false:

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -758,7 +758,7 @@ proc loadNodes*(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;
                 tree: PackedTree; n: NodePos): PNode =
   let k = n.kind
   if k == nkNilRodNode:
-    return nil
+    return nilPNode
   when false:
     echo "loading node ", c.config $ translateLineInfo(c, g, thisModule, n.info)
   result = newNodeIT(k, translateLineInfo(c, g, thisModule, n.info),
@@ -784,7 +784,7 @@ proc loadNodes*(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;
     let (n1, n2) = sons2(tree, n)
     assert n1.kind == nkInt32Lit
     assert n2.kind == nkInt32Lit
-    transitionNoneToSym(result)
+    result.transitionNoneToSym()
     result.sym = loadSym(c, g, thisModule, PackedItemId(module: n1.litId, item: tree.nodes[n2.int].operand))
   else:
     for n0 in sonsReadonly(tree, n):
@@ -812,7 +812,7 @@ proc loadProcHeader(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: 
     if i != bodyPos:
       result.add loadNodes(c, g, thisModule, tree, n0)
     else:
-      result.addAllowNil nil
+      result.addAllowNil nilPNode
     inc i
 
 proc loadProcBody(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -122,7 +122,7 @@ proc getFloatLitType*(g: ModuleGraph; literal: PNode): PType =
 proc skipIntLit*(t: PType; id: IdGenerator): PType {.inline.} =
   if t.n != nil and t.kind in {tyInt, tyFloat}:
     result = copyType(t, nextTypeId(id), t.owner)
-    result.n = nil
+    result.n = nilPNode
   else:
     result = t
 

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -147,7 +147,7 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags, fr
     result.flags.excl sfDirty
     # reset module fields:
     initStrTables(graph, result)
-    result.ast = nil
+    result.ast = nilPNode
     processModuleAux("import(dirty)")
     graph.markClientsDirty(fileIdx)
 

--- a/compiler/sem/closureiters.nim
+++ b/compiler/sem/closureiters.nim
@@ -473,7 +473,7 @@ proc newNotCall(g: ModuleGraph; e: PNode): PNode =
   result = newTree(nkCall, newSymNode(g.getSysMagic(e.info, "not", mNot), e.info), e)
   result.typ = g.getSysType(e.info, tyBool)
 
-proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
+proc lowerStmtListExprs(ctx: var Ctx, n: var PNode, needsSplit: var bool): PNode =
   result = n
   case n.kind
   of nkSkip:
@@ -995,7 +995,7 @@ proc transformClosureIteratorBody(ctx: var Ctx, n: PNode, gotoOut: PNode): PNode
 
       if exceptBody.kind != nkEmpty:
         ctx.curExcHandlingState = finallyIdx
-        let realExceptIdx = ctx.newState(exceptBody, nil)
+        let realExceptIdx = ctx.newState(exceptBody, nilPNode)
         assert(realExceptIdx == -exceptIdx)
 
       ctx.curExcHandlingState = oldExcHandlingState
@@ -1279,7 +1279,7 @@ proc wrapIntoStateLoop(ctx: var Ctx, n: PNode): PNode =
 
 proc deleteEmptyStates(ctx: var Ctx) =
   let goOut = newTree(nkGotoState, ctx.g.newIntLit(TLineInfo(), -1))
-  ctx.exitStateIdx = ctx.newState(goOut, nil)
+  ctx.exitStateIdx = ctx.newState(goOut, nilPNode)
 
   # Apply new state indexes and mark unused states with -1
   var iValid = 0
@@ -1429,7 +1429,7 @@ proc transformClosureIterator*(g: ModuleGraph; idgen: IdGenerator; fn: PSym, n: 
   #echo "transformed into ", n
   #var n = n.toStmtList
 
-  discard ctx.newState(n, nil)
+  discard ctx.newState(n, nilPNode)
   let gotoOut = newTree(nkGotoState, g.newIntLit(n.info, -1))
 
   var ns = false

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -113,7 +113,7 @@ proc swapArgs(fact: PNode, newOp: PSym): PNode =
   result[2] = fact[1]
 
 proc neg(n: PNode; o: Operators): PNode =
-  if n == nil: return nil
+  if n == nil: return nilPNode
   case n.getMagic
   of mNot:
     result = n[1]
@@ -123,7 +123,7 @@ proc neg(n: PNode; o: Operators): PNode =
   of someLe:
     result = swapArgs(n, o.opLt)
   of mInSet:
-    if n[1].kind != nkCurly: return nil
+    if n[1].kind != nkCurly: return nilPNode
     let t = n[2].typ.skipTypes(abstractInst)
     result = newNodeI(nkCall, n.info, 3)
     result[0] = n[0]
@@ -139,7 +139,7 @@ proc neg(n: PNode; o: Operators): PNode =
     else:
       # not ({2, 3, 4}.contains(x))   x != 2 and x != 3 and x != 4
       # XXX todo
-      result = nil
+      result = nilPNode
   of mOr:
     # not (a or b) --> not a and not b
     let
@@ -304,7 +304,7 @@ proc canon*(n: PNode; o: Operators): PNode =
                            reassociation(o.opAdd.buildCall(y, x[2]), o))
       of someAdd:
         # Rule A:
-        let plus = negate(y, x[2], nil, o).reassociation(o)
+        let plus = negate(y, x[2], nilPNode, o).reassociation(o)
         if plus != nil: result = buildCall(result[0].sym, x[1], plus)
       else: discard
     elif y.kind in nkCallKinds and y.len == 3 and y[2].isValue and
@@ -315,7 +315,7 @@ proc canon*(n: PNode; o: Operators): PNode =
         result = buildCall(result[0].sym, y[1],
                            reassociation(o.opAdd.buildCall(x, y[2]), o))
       of someAdd:
-        let plus = negate(x, y[2], nil, o).reassociation(o)
+        let plus = negate(x, y[2], nilPNode, o).reassociation(o)
         # ensure that Rule A will not trigger afterwards with the
         # additional 'not isLetLocation' constraint:
         if plus != nil and not isLetLocation(x, true):
@@ -898,7 +898,7 @@ proc pleViaModelRec(m: var TModel; a, b: PNode): TImplication =
     let fact = m.s[i]
     if fact != nil and fact.getMagic in someLe:
       # mark as used:
-      m.s[i] = nil
+      m.s[i] = nilPNode
       # i <= len-100
       # i <=? len-1
       # --> true  if  (len-100) <= (len-1)

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -104,7 +104,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope; isDecl = false): PNod
 
 import sets, hashes
 
-proc hash(n: PNode): Hash = hash(cast[pointer](n))
+proc hash(n: PNode): Hash = hash(n.id)
 
 proc aliasesCached(cache: var Table[(PNode, PNode), AliasKind], obj, field: PNode): AliasKind =
   let key = (obj, field)
@@ -327,7 +327,7 @@ proc genOp(c: var Con; t: PType; kind: TTypeAttachedOp; dest, ri: PNode): PNode 
 
 proc genDestroy(c: var Con; dest: PNode): PNode =
   let t = dest.typ.skipTypes({tyGenericInst, tyAlias, tySink})
-  result = c.genOp(t, attachedDestructor, dest, nil)
+  result = c.genOp(t, attachedDestructor, dest, nilPNode)
 
 proc canBeMoved(c: Con; t: PType): bool {.inline.} =
   let t = t.skipTypes({tyGenericInst, tyAlias, tySink})
@@ -545,7 +545,7 @@ proc cycleCheck(n: PNode; c: var Con) =
     return
 
   var x = n[0]
-  var field: PNode = nil
+  var field: PNode = nilPNode
   while true:
     if x.kind == nkDotExpr:
       field = x[1]

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -68,8 +68,8 @@ proc considerQuotedIdent2*(c: PContext; n: PNode): PIdentResult =
 
   result =
     case n.kind
-    of nkIdent: (ident: n.ident, errNode: nil)
-    of nkSym: (ident: n.sym.name, errNode: nil)
+    of nkIdent: (ident: n.ident, errNode: nilPNode)
+    of nkSym: (ident: n.sym.name, errNode: nilPNode)
     of nkAccQuoted:
       case n.len
       of 0: (ident: ic.getNotFoundIdent(), errNode: n)
@@ -90,10 +90,10 @@ proc considerQuotedIdent2*(c: PContext; n: PNode): PIdentResult =
         if error:
           (ident: ic.getNotFoundIdent(), errNode: n)
         else:
-          (ident: getIdent(c.cache, id), errNode: nil)
+          (ident: getIdent(c.cache, id), errNode: nilPNode)
     of nkOpenSymChoice, nkClosedSymChoice:
       if n[0].kind == nkSym:
-        (ident: n[0].sym.name, errNode: nil)
+        (ident: n[0].sym.name, errNode: nilPNode)
       else:
         (ident: ic.getNotFoundIdent(), errNode: n)
     else:
@@ -110,7 +110,7 @@ proc noidentError(conf: ConfigRef; n, origin: PNode) =
     wrongNode: origin
   ))
 
-proc considerQuotedIdent*(c: PContext; n: PNode, origin: PNode = nil): PIdent =
+proc considerQuotedIdent*(c: PContext; n: PNode, origin: PNode = nilPNode): PIdent =
   ## Retrieve a PIdent from a PNode, taking into account accent nodes.
   ## ``origin`` can be nil. If it is not nil, it is used for a better
   ## error message.
@@ -642,7 +642,7 @@ proc newQualifiedLookUpError(c: PContext, ident: PIdent, info: TLineInfo, err: P
   result.ast = err
 
 proc errorExpectedIdentifier(
-    c: PContext, ident: PIdent, n: PNode, exp: PNode = nil
+    c: PContext, ident: PIdent, n: PNode, exp: PNode = nilPNode
   ): PSym {.inline.} =
   ## create an error symbol for non-identifier in identifier position within an
   ## expression (`exp`). non-nil `exp` leads to better error messages.
@@ -748,7 +748,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
       amb = false
       (ident, errNode) = considerQuotedIdent2(c, n)
     if isNotFound(c.cache, ident):
-      let errExprCtx = if errNode != n: n else: nil
+      let errExprCtx = if errNode != n: n else: nilPNode
         ## expression within which the error occurred
       result = errorExpectedIdentifier(c, ident, errNode, errExprCtx)
     elif checkModule in flags:
@@ -816,7 +816,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
     if m != nil and m.kind == skModule:
       var
         ident: PIdent = nil
-        errNode: PNode = nil
+        errNode: PNode = nilPNode
       if n[1].kind == nkIdent:
         ident = n[1].ident
       elif n[1].kind == nkAccQuoted:

--- a/compiler/sem/lowerings.nim
+++ b/compiler/sem/lowerings.nim
@@ -300,7 +300,7 @@ proc genDeref*(n: PNode; k = nkHiddenDeref): PNode =
 
 proc callCodegenProc*(g: ModuleGraph; name: string;
                       info: TLineInfo = unknownLineInfo;
-                      arg1, arg2, arg3, optionalArgs: PNode = nil): PNode =
+                      arg1, arg2, arg3, optionalArgs: PNode = nilPNode): PNode =
   result = newNodeI(nkCall, info)
   let sym = magicsys.getCompilerProc(g, name)
   if sym == nil:

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -392,7 +392,6 @@ proc aliasSet(ctx: NilCheckerContext, map: NilMap, index: ExprIndex): IntSet =
   result = map.sets[map.setIndices[index]]
 
 
-
 proc store(
     map: NilMap,
     ctx: NilCheckerContext,
@@ -400,9 +399,8 @@ proc store(
     value: Nilability,
     kind: NilTransition,
     info: TLineInfo,
-    node: PNode = nil
+    node: PNode = nilPNode
   ) =
-
   if index == noExprIndex:
     return
   map.expressions[index] = value

--- a/compiler/sem/passes.nim
+++ b/compiler/sem/passes.nim
@@ -78,7 +78,7 @@ proc openPasses(g: ModuleGraph; a: var TPassContextArray;
     else: a[i] = nil
 
 proc closePasses(graph: ModuleGraph; a: var TPassContextArray) =
-  var m: PNode = nil
+  var m: PNode = nilPNode
   for i in 0..<graph.passes.len:
     if not isNil(graph.passes[i].close):
       m = graph.passes[i].close(graph, a[i], m)
@@ -188,7 +188,7 @@ proc processModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator;
         # read everything until the next proc declaration etc.
         var sl = newNodeI(nkStmtList, n.info)
         sl.add n
-        var rest: PNode = nil
+        var rest: PNode = nilPNode
         while true:
           var n = parseTopLevelStmt(p)
           if n.kind == nkEmpty or n.kind notin imperativeCode:

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -258,7 +258,7 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
   ctx.c = c
   ctx.formals = s.typ.len-1
   var m = matchStmtList(ctx, s.ast[patternPos], n)
-  if isNil(m): return nil
+  if isNil(m): return nilPNode
   # each parameter should have been bound; we simply setup a call and
   # let semantic checking deal with the rest :-)
   result = newNodeI(nkCall, n.info)
@@ -272,7 +272,7 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
     let param = params[i].sym
     let x = getLazy(ctx, param)
     # couldn't bind parameter:
-    if isNil(x): return nil
+    if isNil(x): return nilPNode
     result.add(x)
     if requiresAA: addToArgList(args, x)
   # perform alias analysis here:
@@ -290,7 +290,7 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
             ok = true
             break
         # constraint not fulfilled:
-        if not ok: return nil
+        if not ok: return nilPNode
       of aqNoAlias:
         # it MUST not alias with any other param:
         var ok = true
@@ -299,7 +299,7 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
             ok = false
             break
         # constraint not fulfilled:
-        if not ok: return nil
+        if not ok: return nilPNode
 
   markUsed(c, n.info, s)
   if ctx.subMatch:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -447,7 +447,7 @@ proc tryConstExpr(c: PContext, n: PNode): PNode =
 
   result = evalConstExpr(c.module, c.idgen, c.graph, e)
   if result == nil or result.kind in {nkEmpty, nkError}:
-    result = nil
+    result = nilPNode
   else:
     result = fixupTypeAfterEval(c, result, e)
 
@@ -781,7 +781,7 @@ proc myProcess(context: PPassContext, n: PNode): PNode {.nosinks.} =
       msgs.setInfoContextLen(c.config, oldContextLen)
       if getCurrentException() of ESuggestDone:
         c.suggestionsMade = true
-        result = nil
+        result = nilPNode
       else:
         result = newNodeI(nkEmpty, n.info)
   storeRodNode(c, result)

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -280,7 +280,7 @@ proc resolveOverloads(c: PContext, n: PNode,
     else:
       f = f[0]
   else:
-    initialBinding = nil
+    initialBinding = nilPNode
 
   if f.isError:
     n[0] = f
@@ -319,7 +319,7 @@ proc resolveOverloads(c: PContext, n: PNode,
       if f.ident.s notin [".", ".()"]: # a dot call on a dot call is invalid
         # leave the op head symbol empty,
         # we are going to try multiple variants
-        n.sons[0..1] = [nil, n[1], f]
+        n.sons[0..1] = [nilPNode, n[1], f]
 
         if nfExplicitCall in n.flags:
           tryOp ".()"
@@ -330,7 +330,7 @@ proc resolveOverloads(c: PContext, n: PNode,
     elif nfDotSetter in n.flags and f.kind == nkIdent and n.len == 3:
       # we need to strip away the trailing '=' here:
       let calleeName = newIdentNode(getIdent(c.cache, f.ident.s[0..^2]), f.info)
-      n.sons[0..1] = [nil, n[1], calleeName]
+      n.sons[0..1] = [nilPNode, n[1], calleeName]
       tryOp ".="
 
     if overloadsState == csEmpty and result.state == csEmpty:
@@ -552,7 +552,7 @@ proc explicitGenericInstError(c: PContext; n: PNode): PNode =
 
 proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   # binding has to stay 'nil' for this to work!
-  var m = newCandidate(c, s, nil)
+  var m = newCandidate(c, s, nilPNode)
 
   for i in 1..<n.len:
     let formal = s.ast[genericParamsPos][i-1].typ
@@ -566,7 +566,7 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
         arg.sons = @[evaluated.typ]
         arg.n = evaluated
     let tm = typeRel(m, formal, arg)
-    if tm in {isNone, isConvertible}: return nil
+    if tm in {isNone, isConvertible}: return nilPNode
   var newInst = generateInstance(c, s, m.bindings, n.info)
   newInst.typ.flags.excl tfUnresolved
   let info = getCallLineInfo(n)

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -145,7 +145,7 @@ proc isIntRangeOrLit(t: PType): bool =
 
 proc evalOp(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
   # b and c may be nil
-  result = nil
+  result = nilPNode
   case m
   of mOrd: result = newIntNodeT(getOrdValue(a), n, idgen, g)
   of mChr: result = newIntNodeT(getInt(a), n, idgen, g)
@@ -333,12 +333,12 @@ proc evalOp(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): P
   else: discard
 
 proc getConstIfExpr(c: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
-  result = nil
+  result = nilPNode
   for i in 0..<n.len:
     var it = n[i]
     if it.len == 2:
       var e = getConstExpr(c, it[0], idgen, g)
-      if e == nil: return nil
+      if e == nil: return nilPNode
       if getOrdValue(e) != 0:
         if result == nil:
           result = getConstExpr(c, it[1], idgen, g)
@@ -519,7 +519,7 @@ proc foldConStrStr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode
   result.strVal = ""
   for i in 1..<n.len:
     let a = getConstExpr(m, n[i], idgen, g)
-    if a == nil: return nil
+    if a == nil: return nilPNode
     result.strVal.add(getStrOrChar(a))
 
 proc newSymNodeTypeDesc*(s: PSym; idgen: IdGenerator; info: TLineInfo): PNode =
@@ -531,7 +531,7 @@ proc newSymNodeTypeDesc*(s: PSym; idgen: IdGenerator; info: TLineInfo): PNode =
     result.typ = s.typ
 
 proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
-  result = nil
+  result = nilPNode
   case n.kind
   of nkSym:
     var s = n.sym
@@ -638,11 +638,11 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
         # This fixes bug #544.
         result = newIntNodeT(lengthOrd(g.config, n[1].typ), n, idgen, g)
       of mSizeOf:
-        result = foldSizeOf(g.config, n, nil)
+        result = foldSizeOf(g.config, n, nilPNode)
       of mAlignOf:
-        result = foldAlignOf(g.config, n, nil)
+        result = foldAlignOf(g.config, n, nilPNode)
       of mOffsetOf:
-        result = foldOffsetOf(g.config, n, nil)
+        result = foldOffsetOf(g.config, n, nilPNode)
       of mAstToStr:
         result = newStrNodeT(renderTree(n[1], {renderNoComments}), n, g)
       of mConStrStr:
@@ -666,7 +666,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
     result = copyNode(n)
     for i, son in n.pairs:
       var a = getConstExpr(m, son, idgen, g)
-      if a == nil: return nil
+      if a == nil: return nilPNode
       result.add a
     incl(result.flags, nfAllConst)
   of nkRange:
@@ -692,13 +692,13 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
         let exprNew = copyNode(expr) # nkExprColonExpr
         exprNew.add expr[0]
         let a = getConstExpr(m, expr[1], idgen, g)
-        if a == nil: return nil
+        if a == nil: return nilPNode
         exprNew.add a
         result.add exprNew
     else:
       for i, expr in n.pairs:
         let a = getConstExpr(m, expr, idgen, g)
-        if a == nil: return nil
+        if a == nil: return nilPNode
         result.add a
     incl(result.flags, nfAllConst)
   of nkChckRangeF, nkChckRange64, nkChckRange:
@@ -724,7 +724,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
   of nkDerefExpr, nkHiddenDeref:
     let a = getConstExpr(m, n[0], idgen, g)
     if a != nil and a.kind == nkNilLit:
-      result = nil
+      result = nilPNode
       #localReport(g.config, n.info, "nil dereference is not allowed")
   of nkCast:
     var a = getConstExpr(m, n[1], idgen, g)

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -286,7 +286,7 @@ proc semConstructFields(c: PContext, n: PNode,
       if discrimAssign != nil and discrimAssign.kind == nkError:
         mergeInitStatus(result, initError)
         return
-      var discriminatorVal = if discrimAssign.isNil: nil else: discrimAssign[1]
+      var discriminatorVal = if discrimAssign.isNil: nilPNode else: discrimAssign[1]
 
       if discriminatorVal != nil:
         discriminatorVal = discriminatorVal.skipHidden
@@ -362,7 +362,7 @@ proc semConstructFields(c: PContext, n: PNode,
         mergeInitStatus(result, initError)
         return
 
-      let discriminatorVal = if discrimAssign.isNil: nil else: discrimAssign[1]
+      let discriminatorVal = if discrimAssign.isNil: nilPNode else: discrimAssign[1]
       if discriminatorVal == nil:
         # None of the branches were explicitly selected by the user and no
         # value was given to the discrimator. We can assume that it will be

--- a/compiler/sem/semparallel.nim
+++ b/compiler/sem/semparallel.nim
@@ -468,7 +468,7 @@ proc transformSpawnSons(g: ModuleGraph; idgen: IdGenerator; owner: PSym; n, barr
 proc transformSpawn(g: ModuleGraph; idgen: IdGenerator; owner: PSym; n, barrier: PNode): PNode =
   case n.kind
   of nkVarSection, nkLetSection:
-    result = nil
+    result = nilPNode
     for it in n:
       let b = it.lastSon
       if getMagic(b) == mSpawn:
@@ -484,7 +484,7 @@ proc transformSpawn(g: ModuleGraph; idgen: IdGenerator; owner: PSym; n, barrier:
           result.add wrapProcForSpawn(g, idgen, owner, m, b.typ, barrier, it[0])
           it[^1] = newNodeI(nkEmpty, it.info)
         else:
-          it[^1] = wrapProcForSpawn(g, idgen, owner, m, b.typ, barrier, nil)
+          it[^1] = wrapProcForSpawn(g, idgen, owner, m, b.typ, barrier, nilPNode)
     if result.isNil: result = n
   of nkAsgn, nkFastAsgn:
     let b = n[1]
@@ -496,7 +496,7 @@ proc transformSpawn(g: ModuleGraph; idgen: IdGenerator; owner: PSym; n, barrier:
   of nkCallKinds:
     if getMagic(n) == mSpawn:
       result = transformSlices(g, idgen, n)
-      return wrapProcForSpawn(g, idgen, owner, result, n.typ, barrier, nil)
+      return wrapProcForSpawn(g, idgen, owner, result, n.typ, barrier, nilPNode)
     result = transformSpawnSons(g, idgen, owner, n, barrier)
   elif n.safeLen > 0:
     result = transformSpawnSons(g, idgen, owner, n, barrier)

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -671,8 +671,8 @@ proc notNilCheck(tracked: PEffects, n: PNode, paramType: PType) =
         discard
 
 proc assumeTheWorst(tracked: PEffects; n: PNode; op: PType) =
-  addRaiseEffect(tracked, createRaise(tracked.graph, n), nil)
-  addTag(tracked, createTag(tracked.graph, n), nil)
+  addRaiseEffect(tracked, createRaise(tracked.graph, n), nilPNode)
+  addTag(tracked, createTag(tracked.graph, n), nilPNode)
   let lockLevel = if op.lockLevel == UnspecifiedLockLevel: UnknownLockLevel
                   else: op.lockLevel
   #if lockLevel == UnknownLockLevel:
@@ -1092,7 +1092,7 @@ proc track(tracked: PEffects, n: PNode) =
       # A `raise` with no arguments means we're going to re-raise the exception
       # being handled or, if outside of an `except` block, a `ReraiseDefect`.
       # Here we add a `Exception` tag in order to cover both the cases.
-      addRaiseEffect(tracked, createRaise(tracked.graph, n), nil)
+      addRaiseEffect(tracked, createRaise(tracked.graph, n), nilPNode)
   of nkCallKinds:
     trackCall(tracked, n)
   of nkDotExpr:
@@ -1339,7 +1339,7 @@ proc checkRaisesSpec(
     spec, real: PNode,
     hints: bool,
     effectPredicate: proc (g: ModuleGraph; a, b: PNode): bool {.nimcall.},
-    hintsArg: PNode = nil
+    hintsArg: PNode = nilPNode
   ) =
   # check that any real exception is listed in 'spec'; mark those as used;
   # report any unused exception

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -897,7 +897,7 @@ proc handleStmtMacro(c: PContext; n, selector: PNode; magicType: string;
     case match.kind
     of skMacro: result = semMacroExpr(c, callExpr, match, flags)
     of skTemplate: result = semTemplateExpr(c, callExpr, match, flags)
-    else: result = nil
+    else: result = nilPNode
 
 proc handleForLoopMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
   result = handleStmtMacro(c, n, n[^2], "ForLoopStmt", flags)
@@ -923,7 +923,7 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
     case match.kind
     of skMacro: result = semMacroExpr(c, toExpand, match, flags)
     of skTemplate: result = semTemplateExpr(c, toExpand, match, flags)
-    else: result = nil
+    else: result = nilPNode
   else:
     assert r.call.kind == nkError
     result = r.call # xxx: hope this is nkError
@@ -2136,6 +2136,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
         maybeAddResult(c, s, n)
         # semantic checking also needed with importc in case used in VM
         s.ast[bodyPos] = hloBody(c, semProcBody(c, n[bodyPos]))
+
         # unfortunately we cannot skip this step when in 'system.compiles'
         # context as it may even be evaluated in 'system.compiles':
         trackProc(c, s, s.ast[bodyPos])

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -66,7 +66,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
         identToReplace = addr n[i][0]
 
       var v = semConstExpr(c, n[i][1])
-      var strVal: PNode = nil
+      var strVal: PNode = nilPNode
       case skipTypes(v.typ, abstractInst-{tyTypeDesc}).kind
       of tyTuple:
         if v.len == 2:
@@ -482,9 +482,7 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
       if result.typ.kind != tyGenericParam:
         # XXX get rid of this hack!
         var oldInfo = n.info
-        let oldId = n.id
-        reset(n[])
-        n.id = oldId
+        n.flags = {}
         n.transitionNoneToSym()
         n.sym = result
         n.info = oldInfo
@@ -539,7 +537,7 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
       styleCheckDef(c.config, a[j].info, field)
       onDef(field.info, field)
 
-  if result.n.len == 0: result.n = nil
+  if result.n.len == 0: result.n = nilPNode
   if isTupleRecursive(result):
     localReport(c.config, n.info, reportTyp(
       rsemIllegalRecursion, result))
@@ -835,7 +833,7 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
   if n == nil: return
   case n.kind
   of nkRecWhen:
-    var branch: PNode = nil   # the branch to take
+    var branch: PNode = nilPNode   # the branch to take
     for i in 0..<n.len:
       var it = n[i]
       if it == nil:
@@ -1370,8 +1368,8 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
     checkMinSonsLen(a, 3, c.config)
     var
       typ: PType = nil
-      def: PNode = nil
-      constraint: PNode = nil
+      def: PNode = nilPNode
+      constraint: PNode = nilPNode
       hasType = a[^2].kind != nkEmpty
       hasDefault = a[^1].kind != nkEmpty
 
@@ -1530,13 +1528,13 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       result.n.typ = r
 
   if genericParams.isGenericParams:
-    for n in genericParams:
-      if {sfUsed, sfAnon} * n.sym.flags == {}:
+    for gp in genericParams:
+      if {sfUsed, sfAnon} * gp.sym.flags == {}:
         result.flags.incl tfUnresolved
 
-      if tfWildcard in n.sym.typ.flags:
-        n.sym.transitionGenericParamToType()
-        n.sym.typ.flags.excl tfWildcard
+      if tfWildcard in gp.sym.typ.flags:
+        gp.sym.transitionGenericParamToType()
+        gp.sym.typ.flags.excl tfWildcard
 
 proc semStmtListType(c: PContext, n: PNode, prev: PType): PType =
   checkMinSonsLen(n, 1, c.config)
@@ -1832,7 +1830,7 @@ proc semProcTypeWithScope(c: PContext, n: PNode,
       return semTypeNode(c, macroEval, prev)
 
   openScope(c)
-  result = semProcTypeNode(c, n[0], nil, prev, kind, isType=true)
+  result = semProcTypeNode(c, n[0], nilPNode, prev, kind, isType=true)
   # start with 'ccClosure', but of course pragmas can overwrite this:
   result.callConv = ccClosure
   # dummy symbol for `pragma`:

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -194,8 +194,8 @@ proc replaceObjBranches(cl: TReplTypeVars, n: PNode): PNode =
   of nkNone..nkNilLit:
     discard
   of nkRecWhen:
-    var branch: PNode = nil              # the branch to take
-    for i in 0 ..< n.len:
+    var branch: PNode = nilPNode         # the branch to take
+    for i in 0..<n.len:
       var it = n[i]
       if it == nil:
         cl.c.config.globalReport(reportAst(
@@ -243,7 +243,7 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
       # don't add the 'void' field
       result = newNodeI(nkRecList, n.info)
   of nkRecWhen:
-    var branch: PNode = nil              # the branch to take
+    var branch: PNode = nilPNode         # the branch to take
     for i in 0..<n.len:
       var it = n[i]
       if it == nil:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -99,6 +99,27 @@ proc markOwnerModuleAsUsed*(c: PContext; s: PSym)
 
 template hasFauxMatch*(c: TCandidate): bool = c.fauxMatch != tyNone
 
+proc initCandidateAux(ctx: PContext,
+                      c: var TCandidate, callee: PType) {.inline.} =
+  c.c = ctx
+  c.exactMatches = 0
+  c.subtypeMatches = 0
+  c.convMatches = 0
+  c.intConvMatches = 0
+  c.genericMatches = 0
+  c.state = csEmpty
+  c.callee = callee
+  c.call = nilPNode
+  c.baseTypeMatch = false
+  c.genericConverter = false
+  c.inheritancePenalty = 0
+  c.error = SemCallMismatch()
+
+proc initCandidate*(ctx: PContext, c: var TCandidate, callee: PType) =
+  initCandidateAux(ctx, c, callee)
+  c.calleeSym = nil
+  initIdTable(c.bindings)
+
 proc put(c: var TCandidate, key, val: PType) {.inline.} =
   ## Given: proc foo[T](x: T); foo(4)
   ## key: 'T'
@@ -112,23 +133,6 @@ proc put(c: var TCandidate, key, val: PType) {.inline.} =
     if c.c.module.name.s == "temp3":
       echo "binding ", key, " -> ", val
   idTablePut(c.bindings, key, val.skipIntLit(c.c.idgen))
-
-proc initCandidate*(ctx: PContext, c: var TCandidate, callee: PType) =
-  c.c = ctx
-  c.exactMatches = 0
-  c.subtypeMatches = 0
-  c.convMatches = 0
-  c.intConvMatches = 0
-  c.genericMatches = 0
-  c.state = csEmpty
-  c.callee = callee
-  c.calleeSym = nil
-  c.call = nil
-  c.baseTypeMatch = false
-  c.genericConverter = false
-  c.inheritancePenalty = 0
-  c.error = SemCallMismatch()
-  initIdTable(c.bindings)
 
 proc initCandidate*(ctx: PContext, c: var TCandidate, callee: PSym,
                     binding: PNode, calleeScope = -1) =
@@ -1899,7 +1903,7 @@ proc isLValue(c: PContext; n: PNode): bool {.inline.} =
 
 proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
                    arg: PNode): PNode =
-  result = nil
+  result = nilPNode
   for i in 0..<c.converters.len:
     var src = c.converters[i].typ[1]
     var dest = c.converters[i].typ[0]
@@ -1930,7 +1934,7 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
       # We build the call expression by ourselves in order to avoid passing this
       # expression trough the semantic check phase once again so let's make sure
       # it is correct
-      var param: PNode = nil
+      var param: PNode = nilPNode
       if srca == isSubtype:
         param = implicitConv(nkHiddenSubConv, src, copyTree(arg), m, c)
       elif src.kind in {tyVar}:
@@ -1953,7 +1957,7 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
 proc localConvMatch(c: PContext, m: var TCandidate, f, a: PType,
                     arg: PNode): PNode =
   # arg.typ can be nil in 'suggest':
-  if isNil(arg.typ): return nil
+  if isNil(arg.typ): return nilPNode
 
   # sem'checking for 'echo' needs to be re-entrant:
   # XXX we will revisit this issue after 0.10.2 is released
@@ -1967,13 +1971,14 @@ proc localConvMatch(c: PContext, m: var TCandidate, f, a: PType,
   result = c.semTryExpr(c, call, {efNoSem2Check})
 
   if result != nil:
-    if result.typ == nil: return nil
+    if result.typ == nil: return nilPNode
     # bug #13378, ensure we produce a real generic instantiation:
     result = c.semExpr(c, call)
     # resulting type must be consistent with the other arguments:
     var r = typeRel(m, f[0], result.typ)
-    if r < isGeneric: return nil
-    if result.kind == nkCall: result.transitionSonsKind(nkHiddenCallConv)
+    if r < isGeneric: return nilPNode
+    if result.kind == nkCall:
+      result.transitionSonsKind(nkHiddenCallConv)
     inc(m.convMatches)
     if r == isGeneric:
       result.typ = getInstantiatedType(c, arg, m, base(f))
@@ -2079,7 +2084,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     if arg.kind in {nkProcDef, nkFuncDef, nkIteratorDef} + nkLambdaKinds:
       result = c.semInferredLambda(c, m.bindings, arg)
     elif arg.kind != nkSym:
-      result = nil
+      result = nilPNode
       return
     else:
       let inferred = c.semGenerateInstance(c, arg.sym, m.bindings, arg.info)
@@ -2113,7 +2118,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     if arg.kind in {nkProcDef, nkFuncDef, nkIteratorDef} + nkLambdaKinds:
       result = c.semInferredLambda(c, m.bindings, arg)
     elif arg.kind != nkSym:
-      result = nil
+      result = nilPNode
       return
     else:
       let inferred = c.semGenerateInstance(c, arg.sym, m.bindings, arg.info)
@@ -2137,7 +2142,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
       result = arg
   of isBothMetaConvertible:
     # This is the result for the 101th time.
-    result = nil
+    result = nilPNode
   of isFromIntLit:
     # too lazy to introduce another ``*matches`` field, so we conflate
     # ``isIntConv`` and ``isIntLit`` here:
@@ -2247,14 +2252,14 @@ proc paramTypesMatch*(m: var TCandidate, f, a: PType,
               y = z           # z is as good as x
 
     if x.state == csEmpty:
-      result = nil
+      result = nilPNode
     elif y.state == csMatch and cmpCandidates(x, y) == 0:
       m.c.graph.config.internalAssert(x.state == csMatch, arg.info, "x.state is not csMatch")
       # ambiguous: more than one symbol fits!
       # See tsymchoice_for_expr as an example. 'f.kind == tyUntyped' should match
       # anyway:
       if f.kind in {tyUntyped, tyTyped}: result = arg
-      else: result = nil
+      else: result = nilPNode
     else:
       # only one valid interpretation found:
       markUsed(m.c, arg.info, arg[best].sym)
@@ -2400,7 +2405,7 @@ proc matchesAux(c: PContext, n: PNode, m: var TCandidate, marker: var IntSet) =
     arg: PNode # current prepared argument
     formalLen = m.callee.n.len
     formal = if formalLen > 1: m.callee.n[1].sym else: nil # current routine parameter
-    container: PNode = nil # constructed container
+    container: PNode = nilPNode # constructed container
   let firstArgBlock = findFirstArgBlock(m, n)
   while a < n.len:
     c.openShadowScope
@@ -2461,7 +2466,7 @@ proc matchesAux(c: PContext, n: PNode, m: var TCandidate, marker: var IntSet) =
         container = newNodeIT(nkBracket, n[a].info, arrayConstr(c, arg))
         container.add arg
         setSon(m.call, formal.position + 1, container)
-        if f != formalLen - 1: container = nil
+        if f != formalLen - 1: container = nilPNode
       else:
         setSon(m.call, formal.position + 1, arg)
       inc f
@@ -2547,7 +2552,7 @@ proc matchesAux(c: PContext, n: PNode, m: var TCandidate, marker: var IntSet) =
           elif formal.typ.kind != tyVarargs or container == nil:
             setSon(m.call, formal.position + 1, arg)
             inc f
-            container = nil
+            container = nilPNode
           else:
             # we end up here if the argument can be converted into the varargs
             # formal (e.g. seq[T] -> varargs[T]) but we have already instantiated

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -114,7 +114,7 @@ proc transformSymAux(c: PTransf, n: PNode): PNode =
       else: return liftIterSym(c.graph, n, c.idgen, getCurrOwner(c))
     elif s.kind in {skProc, skFunc, skConverter, skMethod} and not c.tooEarly:
       # top level .closure procs are still somewhat supported for 'Nake':
-      return makeClosure(c.graph, c.idgen, s, nil, n.info)
+      return makeClosure(c.graph, c.idgen, s, nilPNode, n.info)
   #elif n.sym.kind in {skVar, skLet} and n.sym.typ.callConv == ccClosure:
   #  echo n.info, " come heer for ", c.tooEarly
   #  if not c.tooEarly:
@@ -748,7 +748,7 @@ proc transformCase(c: PTransf, n: PNode): PNode =
   # removes `elif` branches of a case stmt
   # adds ``else: nil`` if needed for the code generator
   result = newNodeIT(nkCaseStmt, n.info, n.typ)
-  var ifs: PNode = nil
+  var ifs: PNode = nilPNode
   for it in n:
     var e = transform(c, it)
     case it.kind
@@ -823,7 +823,7 @@ proc transformCall(c: PTransf, n: PNode): PNode =
         while (j < n.len):
           let b = transform(c, n[j])
           if not isConstExpr(b): break
-          a = evalOp(op.magic, n, a, b, nil, c.idgen, c.graph)
+          a = evalOp(op.magic, n, a, b, nilPNode, c.idgen, c.graph)
           inc(j)
       result.add(a)
     if result.len == 2: result = result[1]
@@ -893,7 +893,7 @@ proc commonOptimizations*(g: ModuleGraph; idgen: IdGenerator; c: PSym, n: PNode)
         while j < args.len:
           let b = args[j]
           if not isConstExpr(b): break
-          a = evalOp(op.magic, result, a, b, nil, idgen, g)
+          a = evalOp(op.magic, result, a, b, nilPNode, idgen, g)
           inc(j)
       result.add(a)
     if result.len == 2: result = result[1]
@@ -1132,7 +1132,7 @@ proc transformBody*(g: ModuleGraph; idgen: IdGenerator; prc: PSym; cache: bool):
       # it is important to transform exactly once to get sym ids and locations right
       prc.transformedBody = result
     else:
-      prc.transformedBody = nil
+      prc.transformedBody = nilPNode
     # XXX Rodfile support for transformedBody!
 
 proc transformStmt*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode): PNode =

--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -324,7 +324,7 @@ proc pathExpr(node: PNode; owner: PSym): PNode =
   if it is not a valid path expression.
   ]#
   var n = node
-  result = nil
+  result = nilPNode
   while true:
     case n.kind
     of nkSym:

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -59,7 +59,7 @@ const
 template origModuleName(m: PSym): string = m.name.s
 
 proc findDocComment(n: PNode): PNode =
-  if n == nil: return nil
+  if n == nil: return nilPNode
   if n.comment.len > 0: return n
   if n.kind in {nkStmtList, nkStmtListExpr, nkObjectTy, nkRecList} and n.len > 0:
     result = findDocComment(n[0])
@@ -334,7 +334,7 @@ proc nameFits(c: PContext, s: PSym, n: PNode): bool =
 proc argsFit(c: PContext, candidate: PSym, n: PNode): bool =
   case candidate.kind
   of OverloadableSyms:
-    var m = newCandidate(c, candidate, nil)
+    var m = newCandidate(c, candidate, nilPNode)
     sigmatch.partialMatch(c, n, m)
     result = m.state != csNoMatch
   else:
@@ -342,7 +342,7 @@ proc argsFit(c: PContext, candidate: PSym, n: PNode): bool =
 
 proc suggestCall(c: PContext, n: PNode, outputs: var Suggestions) =
   let info = n.info
-  wholeSymTab(filterSym(it, nil, pm) and nameFits(c, it, n) and argsFit(c, it, n),
+  wholeSymTab(filterSym(it, nilPNode, pm) and nameFits(c, it, n) and argsFit(c, it, n),
               ideCon)
 
 proc suggestVar(c: PContext, n: PNode, outputs: var Suggestions) =
@@ -625,7 +625,7 @@ proc sugExpr(c: PContext, n: PNode, outputs: var Suggestions) =
     # of the next line, so we check the 'field' is actually on the same
     # line as the object to prevent this from happening:
     let prefix = if n.len == 2 and n[1].info.line == n[0].info.line and
-       not c.config.m.trackPosAttached: n[1] else: nil
+       not c.config.m.trackPosAttached: n[1] else: nilPNode
     suggestFieldAccess(c, obj, prefix, outputs)
 
     #if optIdeDebug in gGlobalOptions:
@@ -633,11 +633,11 @@ proc sugExpr(c: PContext, n: PNode, outputs: var Suggestions) =
     #writeStackTrace()
   elif n.kind == nkIdent:
     let
-      prefix = if c.config.m.trackPosAttached: nil else: n
+      prefix = if c.config.m.trackPosAttached: nilPNode else: n
       info = n.info
     wholeSymTab(filterSym(it, prefix, pm), ideSug)
   else:
-    let prefix = if c.config.m.trackPosAttached: nil else: n
+    let prefix = if c.config.m.trackPosAttached: nilPNode else: n
     suggestEverything(c, n, prefix, outputs)
 
 proc suggestExprNoCheck*(c: PContext, n: PNode) =
@@ -684,7 +684,7 @@ proc suggestStmt*(c: PContext, n: PNode) =
 
 proc suggestEnum*(c: PContext; n: PNode; t: PType) =
   var outputs: Suggestions = @[]
-  suggestSymList(c, t.n, nil, n.info, outputs)
+  suggestSymList(c, t.n, nilPNode, n.info, outputs)
   produceOutput(outputs, c.config)
   if outputs.len > 0: suggestQuit()
 
@@ -696,7 +696,7 @@ proc suggestSentinel*(c: PContext) =
   # suggest everything:
   for (it, scopeN, isLocal) in allSyms(c):
     var pm: PrefixMatch
-    if filterSymNoOpr(it, nil, pm):
+    if filterSymNoOpr(it, nilPNode, pm):
       outputs.add(symToSuggest(c.graph, it, isLocal = isLocal, ideSug,
           newLineInfo(c.config.m.trackPos.fileIndex, 0, -1), it.getQuality,
           PrefixMatch.None, false, scopeN))

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -140,6 +140,19 @@ const treeReprAllFields* = { trfShowSymFlags .. trfShowNodeTypes } ## Set
                            ## of flags to print all fields in all tree
                            ## reprs
 
+const defaultTreeReprFlags* = {
+  trfShowNodeIds,
+  trfShowNodeFlags,
+  trfReportInfo,
+  trfSkipAuxError
+} + treeReprAllFields - {
+  trfShowNodeLineInfo,
+  trfShowSymLineInfo,
+  trfShowSymOptions,
+}
+
+const treeReprCompact* = defaultTreeReprFlags + {trfPackedFields}
+
 const style = (
   kind: fgBlue,
   nilIt: fgRed,
@@ -211,7 +224,6 @@ var implicitTReprConf*: TReprConf = defaultTReprConf ## global
   ## `debugType`. Can be used in order to configure behaviour of the
   ## debugging functions that could later be called from `gdb` environment
   ## (`debugAst`, `debugType`, `debugSym`), or sem execution tracer
-
 
 const IntTypes = {
   tyInt, tyInt8, tyInt16,

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -130,6 +130,8 @@ type
     akObject # currently also includes tuple types
     akArray
 
+  # NodeAddr* = distinct int    ## index/identifier into `TCtx.nodeAddrs`
+  NodeAddr* = distinct PNode ## a PNode, but used an address in the VM
 
   # XXX: will be replaced with integer IDs
   PVmType* = ref VmType
@@ -512,6 +514,8 @@ type
     templInstCounter*: ref int # gives every template instantiation a unique ID, needed here for getAst
     vmstateDiff*: seq[(PSym, PNode)] # we remember the "diff" to global state here (feature for IC)
     procToCodePos*: Table[int, int]
+    # nodeAddrs*: seq[NodeId] ## maintain "references" to PNodes, so we can alter
+    #                          ## which PNode we're referring to
 
   StackFrameIndex* = int
 
@@ -695,6 +699,7 @@ const realAtomKinds* = {low(AtomKind)..high(AtomKind)} - pseudoAtomKinds
 
 const
   slotSomeTemp* = slotTempUnknown
+  # nilNodeAddr* = NodeAddr 0
 
 # flag is used to signal opcSeqLen if node is NimNode.
 const nimNodeFlag* = 16

--- a/tests/vm/tnimnode.nim
+++ b/tests/vm/tnimnode.nim
@@ -3,7 +3,6 @@ import macros
 proc assertEq(arg0,arg1: string): void =
   if arg0 != arg1:
     raiseAssert("strings not equal:\n" & arg0 & "\n" & arg1)
-
 # a simple assignment of stmtList to another variable
 var node {.compileTime.}: NimNode
 # an assignment of stmtList into an array


### PR DESCRIPTION
First pass attempt at drafting a DOD AST based on this discussion:
https://github.com/nim-works/nimskull/discussions/139

Breaks/Issues:
- `ast.transitionX` procs now return a new node
- no more nil means have to use a sentinel value

signature change for transition procs mean we're creating new node
this could well break assumptions that pervade the compiler. Worst case
will need to supprot the mutability for now to get the first port, then
figure out how to start changing up the compiler based on
fork/join/mutation observations.

Blocker(s):
The VM takes address of nodes, but now transitions might mean those are
no longer valid. Even if we rely on id as address, this is likely not
the right semantics, as we want to point to the AST "position", for
example when we're doing constant expression evaluation incrementally

Reviewers:
- meant as an example and discussion point for now in the discussion thread
- It doesn't compile because of VM breakages elaborated above
- ast.nim contains all the real content 
  - other changes are to satisfy the compiler
- **do not merge**