### PR TITLE
put links 'for developers' on the top

### DIFF
--- a/doc/docs.rst
+++ b/doc/docs.rst
@@ -1,5 +1,22 @@
 The documentation consists of several documents:
 
+For developers and contributors
+===============================
+
+- | `Internal documentation <intern.html>`_
+  | The internal documentation describes how the compiler is implemented. Read
+    this if you want to hack the compiler.
+
+- | `Contribution guide <contributing.html>`_
+  | Contribution guide for |nimskull| projects
+
+- | `Moderation guidelines <moderation.html>`_
+  | Rules of moderation for |nimskull| projects.
+
+- | `Style guide <style_guide.html>`_
+  | Stanard library and compiler style guide
+
+
 For users
 =========
 
@@ -39,18 +56,3 @@ For users
 - | `Index <theindex.html>`_
   | The generated index.
 
-For developers and contributors
-===============================
-
-- | `Internal documentation <intern.html>`_
-  | The internal documentation describes how the compiler is implemented. Read
-    this if you want to hack the compiler.
-
-- | `Contribution guide <contributing.html>`_
-  | Contribution guide for |nimskull| projects
-
-- | `Moderation guidelines <moderation.html>`_
-  | Rules of moderation for |nimskull| projects.
-
-- | `Style guide <style_guide.html>`_
-  | Stanard library and compiler style guide

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -2,8 +2,5 @@
 Nim Documentation Overview
 =============================
 
-:Author: Andreas Rumpf
-:Version: |nimversion|
-
 .. include:: docs.rst
 


### PR DESCRIPTION
In documentation overview, put links 'for developers' on the
top of the page

<!--
## Tips for pull requests
* use chat, discussions, etc... to refine an idea for big and/or impactful changes
* open them relatively early in draft mode and get regular feedback
* add notes for reviewers and yourself as you go, so it's easy to maintain context
* refine the pull request message over time
-->

<!--
## Finalizing a PR:

### title:
* reads like a short changelog line

### body:
* describe the current behaviour
* describe why this particular approach
* if it's breaking, migration steps
* note any follow-on work

### content:
* leave code better than you found it, add docs, tests, etc
-->


<!--
* note any issues that this fixes entirely
* use `fixes #123 .` to auto-close issues
-->