### PR TITLE
Static object fields can now be accessed in generics

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1442,7 +1442,7 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
 
   if ty.kind in tyUserTypeClasses and ty.isResolvedUserTypeClass:
     ty = ty.lastSon
-  ty = skipTypes(ty, {tyGenericInst, tyVar, tyLent, tyPtr, tyRef, tyOwned, tyAlias, tySink})
+  ty = skipTypes(ty, {tyGenericInst, tyVar, tyLent, tyPtr, tyRef, tyOwned, tyAlias, tySink, tyStatic})
   while tfBorrowDot in ty.flags: ty = ty.skipTypes({tyDistinct, tyGenericInst, tyAlias})
   var check: PNode = nil
   if ty.kind == tyObject:

--- a/tests/system/tstatic.nim
+++ b/tests/system/tstatic.nim
@@ -45,6 +45,15 @@ template main() =
 
       doAssert "123".parseInt == 123
 
+    block:
+      type
+        MyType = object
+          field: float32
+        AType[T: static MyType] = distinct range[0f32 .. T.field]
+      var a: AType[MyType(field: 5f32)]
+      proc n(S: static Slice[int]): range[S.a..S.b] = discard
+      assert typeof(n 1..2) is range[1..2]
+
 
 static: main()
 main()


### PR DESCRIPTION
Accessing static object fields  in generics such as `type DoThing[T: static Hslice[int]] = distinct array[T.a..T.b, int]` now compiles. Previously `tyStatic` was not handled during field access, this fixes that.