### PR TITLE
use improved range check of 128 for float64

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -182,10 +182,11 @@ proc checkConvertible(c: PContext, targetTyp: PType, src: PNode): TConvStatus =
       if src.kind in nkCharLit..nkUInt64Lit and
           src.getInt notin firstOrd(c.config, targetTyp)..lastOrd(c.config, targetTyp):
         result = convNotInRange
-      elif src.kind in nkFloatLit..nkFloat64Lit and
-          (classify(src.floatVal) in {fcNan, fcNegInf, fcInf} or
-            src.floatVal.int64 notin firstOrd(c.config, targetTyp)..lastOrd(c.config, targetTyp)):
-        result = convNotInRange
+      elif src.kind in nkFloatLit..nkFloat64Lit:
+        if not src.floatVal.inInt128Range:
+          result = convNotInRange
+        elif src.floatVal.toInt128 notin firstOrd(c.config, targetTyp)..lastOrd(c.config, targetTyp):
+          result = convNotInRange
     elif targetBaseTyp.kind in tyFloat..tyFloat64:
       if src.kind in nkFloatLit..nkFloat64Lit and
           not floatRangeCheck(src.floatVal, targetTyp):

--- a/tests/range/tcompiletime_range_checks.nim
+++ b/tests/range/tcompiletime_range_checks.nim
@@ -1,22 +1,23 @@
 discard """
   cmd: "nim check --hint:Processing:off --hint:Conf:off $file"
   errormsg: "18446744073709551615 can't be converted to int8"
-  nimout: '''tcompiletime_range_checks.nim(36, 21) Error: 2147483648 can't be converted to int32
-tcompiletime_range_checks.nim(37, 23) Error: -1 can't be converted to uint64
-tcompiletime_range_checks.nim(38, 34) Error: 255 can't be converted to FullNegativeRange
-tcompiletime_range_checks.nim(39, 34) Error: 18446744073709551615 can't be converted to HalfNegativeRange
-tcompiletime_range_checks.nim(40, 34) Error: 300 can't be converted to FullPositiveRange
-tcompiletime_range_checks.nim(41, 30) Error: 101 can't be converted to UnsignedRange
-tcompiletime_range_checks.nim(42, 32) Error: -9223372036854775808 can't be converted to SemiOutOfBounds
-tcompiletime_range_checks.nim(44, 22) Error: nan can't be converted to int32
-tcompiletime_range_checks.nim(46, 23) Error: 1e+100 can't be converted to uint64
-tcompiletime_range_checks.nim(49, 22) Error: 18446744073709551615 can't be converted to int64
-tcompiletime_range_checks.nim(50, 22) Error: 18446744073709551615 can't be converted to int32
-tcompiletime_range_checks.nim(51, 22) Error: 18446744073709551615 can't be converted to int16
-tcompiletime_range_checks.nim(52, 21) Error: 18446744073709551615 can't be converted to int8
+  nimout: '''
+tcompiletime_range_checks.nim(37, 21) Error: 2147483648 can't be converted to int32
+tcompiletime_range_checks.nim(38, 23) Error: -1 can't be converted to uint64
+tcompiletime_range_checks.nim(39, 34) Error: 255 can't be converted to FullNegativeRange
+tcompiletime_range_checks.nim(40, 34) Error: 18446744073709551615 can't be converted to HalfNegativeRange
+tcompiletime_range_checks.nim(41, 34) Error: 300 can't be converted to FullPositiveRange
+tcompiletime_range_checks.nim(42, 30) Error: 101 can't be converted to UnsignedRange
+tcompiletime_range_checks.nim(43, 32) Error: -9223372036854775808 can't be converted to SemiOutOfBounds
+tcompiletime_range_checks.nim(45, 22) Error: nan can't be converted to int32
+tcompiletime_range_checks.nim(46, 22) Error: 1e+100 can't be converted to int64
+tcompiletime_range_checks.nim(47, 23) Error: 1e+100 can't be converted to uint64
+tcompiletime_range_checks.nim(50, 22) Error: 18446744073709551615 can't be converted to int64
+tcompiletime_range_checks.nim(51, 22) Error: 18446744073709551615 can't be converted to int32
+tcompiletime_range_checks.nim(52, 22) Error: 18446744073709551615 can't be converted to int16
+tcompiletime_range_checks.nim(53, 21) Error: 18446744073709551615 can't be converted to int8
   '''
 """
-
 type
   UnsignedRange* = range[0'u64 .. 100'u64]
   SemiOutOfBounds* = range[0x7ffffffffffffe00'u64 .. 0x8000000000000100'u64]


### PR DESCRIPTION
 * Add a range check function to test if a float64 is in rage of the `int128` type.
 * Use that range check function for `semexpr.checkConvertible`
 * fixes #93

While this fixes the original issue mentioned above, it does not fix or implement the discussions in that issue. They need to be ported to their own issue.