### PR TITLE
remove some when compiles calls from tables/deques

### DIFF
--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -71,9 +71,8 @@ template initImpl(result: typed, initialSize: int) =
   newSeq(result.data, correctSize)
 
 template checkIfInitialized(deq: typed) =
-  when compiles(defaultInitialSize):
-    if deq.mask == 0:
-      initImpl(deq, defaultInitialSize)
+  if deq.mask == 0:
+    initImpl(deq, defaultInitialSize)
 
 proc initDeque*[T](initialSize: int = defaultInitialSize): Deque[T] =
   ## Creates a new empty deque.

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -27,6 +27,9 @@ type
 
 template maxHash(t): untyped = t.dataLen-1
 
+template checkIfInitialized() =
+  assert t.data != nil, "shared table use before initialization"
+
 include tableimpl
 
 template st_maybeRehashPutImpl(enlarge) {.dirty.} =

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -227,6 +227,10 @@ const
 template maxHash(t): untyped = high(t.data)
 template dataLen(t): untyped = len(t.data)
 
+template checkIfInitialized() =
+  if t.dataLen == 0:
+    initImpl(t, defaultInitialSize)
+
 include tableimpl
 
 proc raiseKeyError[T](key: T) {.noinline, noreturn.} =
@@ -1320,6 +1324,8 @@ proc initOrderedTable*[A, B](initialSize = defaultInitialSize): OrderedTable[A, 
       a = initOrderedTable[int, string]()
       b = initOrderedTable[char, seq[int]]()
   initImpl(result, initialSize)
+  result.first = -1
+  result.last = -1
 
 proc `[]=`*[A, B](t: var OrderedTable[A, B], key: A, val: sink B) =
   ## Inserts a `(key, value)` pair into `t`.


### PR DESCRIPTION
using when compiles is considered a bad practice. With this change, nimskull uses less of it.

 *   `checkIfInitialized` tableimpl is moved down to `tables` and `sharedtables`
 * `deques.defaultInitialSize` just exists. No point to check for it.

## Opinion

I think the file `tablesimpl` should be eleminated entirely. It provides little dryness of code, but really hurts code readability. Not in this PR though.