### PR TITLE
Remove the nOrig from all over the compiler

### DIFF
--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1098,7 +1098,7 @@ proc semCustomPragma(c: PContext, n: PNode): PNode =
     # invalidPragma(c, n)
     # return n
 
-  let r = c.semOverloadedCall(c, callNode, n, {skTemplate}, {efNoUndeclared})
+  let r = c.semOverloadedCall(c, callNode, {skTemplate}, {efNoUndeclared})
   if r.isNil or sfCustomPragma notin r[0].sym.flags:
     result = c.config.newError(n, reportAst(rsemInvalidPragma, n))
     return

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -373,7 +373,7 @@ proc semDirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode
 proc semWhen(c: PContext, n: PNode, semCheck: bool = true): PNode
 proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
                      flags: TExprFlags = {}): PNode
-proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
+proc semMacroExpr(c: PContext, n: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode
 
 proc symFromType(c: PContext; t: PType, info: TLineInfo): PSym =
@@ -570,10 +570,10 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
   dec(c.config.evalTemplateCounter)
   discard c.friendModules.pop()
 
-proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
+proc semMacroExpr(c: PContext, n: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode =
-  rememberExpansion(c, nOrig.info, sym)
-  pushInfoContext(c.config, nOrig.info, sym)
+  rememberExpansion(c, n.info, sym)
+  pushInfoContext(c.config, n.info, sym)
 
   let info = getCallLineInfo(n)
   markUsed(c, info, sym)
@@ -595,19 +595,19 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
     original = n
 
   result = evalMacroCall(
-    c.module, c.idgen, c.graph, c.templInstCounter, n, nOrig, sym)
+    c.module, c.idgen, c.graph, c.templInstCounter, n, sym)
 
   if efNoSemCheck notin flags:
     result = semAfterMacroCall(c, n, result, sym, flags)
 
   if reportTraceExpand:
-    c.config.localReport(nOrig.info, SemReport(
+    c.config.localReport(n.info, SemReport(
       sym: sym,
       kind: rsemExpandMacro,
-      ast: original,
+      ast: n,
       expandedAst: result))
 
-  result = wrapInComesFrom(nOrig.info, sym, result)
+  result = wrapInComesFrom(n.info, sym, result)
   popInfoContext(c.config)
 
 proc forceBool(c: PContext, n: PNode): PNode =

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -133,7 +133,7 @@ type
 
     semOperand*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
     semConstBoolExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # XXX bite the bullet
-    semOverloadedCall*: proc (c: PContext, n, nOrig: PNode,
+    semOverloadedCall*: proc (c: PContext, n: PNode,
                               filter: TSymKinds, flags: TExprFlags): PNode {.nimcall.}
     semTypeNode*: proc(c: PContext, n: PNode, prev: PType): PType {.nimcall.}
     semInferredLambda*: proc(c: PContext, pt: TIdTable, n: PNode): PNode

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -86,7 +86,7 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
   of skMacro:
     if macroToExpandSym(s):
       onUse(n.info, s)
-      result = semMacroExpr(c, n, n, s, {efNoSemCheck})
+      result = semMacroExpr(c, n, s, {efNoSemCheck})
       result = semGenericStmt(c, result, {}, ctx)
     else:
       result = symChoice(c, n, s, scOpen)
@@ -252,7 +252,7 @@ proc semGenericStmt(c: PContext, n: PNode,
       of skMacro:
         if macroToExpand(s) and sc.safeLen <= 1:
           onUse(fn.info, s)
-          result = semMacroExpr(c, n, n, s, {efNoSemCheck})
+          result = semMacroExpr(c, n, s, {efNoSemCheck})
           result = semGenericStmt(c, result, flags, ctx)
         else:
           n[0] = sc

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -896,7 +896,7 @@ proc handleStmtMacro(c: PContext; n, selector: PNode; magicType: string;
     callExpr.add newSymNode(match)
     callExpr.add n
     case match.kind
-    of skMacro: result = semMacroExpr(c, callExpr, callExpr, match, flags)
+    of skMacro: result = semMacroExpr(c, callExpr, match, flags)
     of skTemplate: result = semTemplateExpr(c, callExpr, match, flags)
     else: result = nil
 
@@ -912,7 +912,7 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
   toResolve.add n[0]
 
   var errors: CandidateErrors
-  var r = resolveOverloads(c, toResolve, toResolve, {skTemplate, skMacro}, {},
+  var r = resolveOverloads(c, toResolve, {skTemplate, skMacro}, {},
                            errors, false)
   if r.state == csMatch:
     var match = r.calleeSym
@@ -923,7 +923,7 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
     r.call[1] = n
     let toExpand = semResolvedCall(c, r, r.call, {})
     case match.kind
-    of skMacro: result = semMacroExpr(c, toExpand, toExpand, match, flags)
+    of skMacro: result = semMacroExpr(c, toExpand, match, flags)
     of skTemplate: result = semTemplateExpr(c, toExpand, match, flags)
     else: result = nil
   else:
@@ -1623,7 +1623,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
     x.add(prc)
 
     # recursion assures that this works for multiple macro annotations too:
-    var r = semOverloadedCall(c, x, x, {skMacro, skTemplate}, {efNoUndeclared})
+    var r = semOverloadedCall(c, x, {skMacro, skTemplate}, {efNoUndeclared})
     if r == nil:
       # Restore the old list of pragmas since we couldn't process this
       prc[pragmasPos] = n
@@ -1640,7 +1640,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
     doAssert r[0].kind == nkSym
     let m = r[0].sym
     case m.kind
-    of skMacro: result = semMacroExpr(c, r, r, m, {})
+    of skMacro: result = semMacroExpr(c, r, m, {})
     of skTemplate: result = semTemplateExpr(c, r, m, {})
     else:
       prc[pragmasPos] = n

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1624,7 +1624,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   else:
     var m = newCandidate(c, t)
     m.isNoCall = true
-    matches(c, n, copyTree(n), m)
+    matches(c, n, m)
 
     if m.state != csMatch:
       localReport(c.config, n.info):
@@ -1815,7 +1815,7 @@ proc applyTypeSectionPragmas(c: PContext; pragmas, operand: PNode): PNode =
           # Also pass the node the pragma has been applied to
           x.add(operand.copyTreeWithoutNode(p))
           # recursion assures that this works for multiple macro annotations too:
-          var r = semOverloadedCall(c, x, x, {skMacro, skTemplate}, {efNoUndeclared})
+          var r = semOverloadedCall(c, x, {skMacro, skTemplate}, {efNoUndeclared})
           if r != nil:
             if r.kind == nkError:
               localReport(c.config, r)
@@ -1824,7 +1824,7 @@ proc applyTypeSectionPragmas(c: PContext; pragmas, operand: PNode): PNode =
             doAssert r[0].kind == nkSym
             let m = r[0].sym
             case m.kind
-            of skMacro: return semMacroExpr(c, r, r, m, {efNoSemCheck})
+            of skMacro: return semMacroExpr(c, r, m, {efNoSemCheck})
             of skTemplate: return semTemplateExpr(c, r, m, {efNoSemCheck})
             else: doAssert(false, "cannot happen")
 

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -178,7 +178,7 @@ proc reResolveCallsWithTypedescParams(cl: var TReplTypeVars, n: PNode): PNode =
       if isTypeParam(n[i]): needsFixing = true
     if needsFixing:
       n[0] = newSymNode(n[0].sym.owner)
-      return cl.c.semOverloadedCall(cl.c, n, n, {skProc, skFunc}, {})
+      return cl.c.semOverloadedCall(cl.c, n, {skProc, skFunc}, {})
 
   for i in 0..<n.safeLen:
     n[i] = reResolveCallsWithTypedescParams(cl, n[i])

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -331,18 +331,18 @@ proc nameFits(c: PContext, s: PSym, n: PNode): bool =
   else: return false
   result = opr.id == s.name.id
 
-proc argsFit(c: PContext, candidate: PSym, n, nOrig: PNode): bool =
+proc argsFit(c: PContext, candidate: PSym, n: PNode): bool =
   case candidate.kind
   of OverloadableSyms:
     var m = newCandidate(c, candidate, nil)
-    sigmatch.partialMatch(c, n, nOrig, m)
+    sigmatch.partialMatch(c, n, m)
     result = m.state != csNoMatch
   else:
     result = false
 
-proc suggestCall(c: PContext, n, nOrig: PNode, outputs: var Suggestions) =
+proc suggestCall(c: PContext, n: PNode, outputs: var Suggestions) =
   let info = n.info
-  wholeSymTab(filterSym(it, nil, pm) and nameFits(c, it, n) and argsFit(c, it, n, nOrig),
+  wholeSymTab(filterSym(it, nil, pm) and nameFits(c, it, n) and argsFit(c, it, n),
               ideCon)
 
 proc suggestVar(c: PContext, n: PNode, outputs: var Suggestions) =
@@ -658,7 +658,7 @@ proc suggestExprNoCheck*(c: PContext, n: PNode) =
         var x = safeSemExpr(c, n[i])
         if x.kind == nkEmpty or x.typ == nil or x.isErrorLike: break
         a.add x
-      suggestCall(c, a, n, outputs)
+      suggestCall(c, a, outputs)
     elif n.kind in nkIdentKinds:
       var x = safeSemExpr(c, n)
       if x.kind == nkEmpty or x.typ == nil or x.isErrorLike: x = n

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -17,7 +17,6 @@ import
     parseutils
   ],
   ast/[
-    astalgo,
     lineinfos,
     renderer, # toStrLit implementation
     trees,
@@ -2503,7 +2502,7 @@ const evalMacroLimit = 1000
 #  result.typ.flags.incl tfCheckedForDestructor
 
 proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph; templInstCounter: ref int;
-                    n, nOrig: PNode, sym: PSym): PNode =
+                    n: PNode, sym: PSym): PNode =
   #if g.config.errorCounter > 0: return errorNode(idgen, module, n)
 
   # XXX globalReport() is ugly here, but I don't know a better solution for now
@@ -2527,7 +2526,7 @@ proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph; templInstC
   let oldMode = c.mode
   c.mode = emStaticStmt
   c.comesFromHeuristic.line = 0'u16
-  c.callsite = nOrig
+  c.callsite = n
   c.templInstCounter = templInstCounter
   let start = genProc(c, sym)
 

--- a/tests/macros/tdumpast2.nim
+++ b/tests/macros/tdumpast2.nim
@@ -11,8 +11,8 @@ proc dumpit(n: NimNode): string {.compileTime.} =
   of nnkNilLit:                  add(result, "nil")
   of nnkCharLit..nnkInt64Lit:    add(result, $n.intVal)
   of nnkFloatLit..nnkFloat64Lit: add(result, $n.floatVal)
-  of nnkStrLit..nnkTripleStrLit: add(result, $n.strVal)
-  of nnkIdent:                   add(result, $n.ident)
+  of nnkStrLit..nnkTripleStrLit: add(result, n.strVal)
+  of nnkIdent:                   add(result, n.strVal)
   of nnkSym, nnkNone:            assert false
   else:
     add(result, dumpit(n[0]))
@@ -21,11 +21,10 @@ proc dumpit(n: NimNode): string {.compileTime.} =
       add(result, dumpit(n[j]))
   add(result, ")")
 
-macro dumpAST(n): untyped =
+macro dumpAST(n: untyped): untyped =
   # dump AST as a side-effect and return the inner node
-  let n = callsite()
   echo dumpit(n)
-  result = n[1]
+  result = n
 
 dumpAST:
   proc add(x, y: int): int =

--- a/tests/macros/tquotewords.nim
+++ b/tests/macros/tquotewords.nim
@@ -6,9 +6,8 @@ discard """
 import macros
 
 macro quoteWords(n: varargs[untyped]): untyped =
-  let n = callsite()
-  result = newNimNode(nnkBracket, n)
-  for i in 1..n.len-1:
+  result = newNimNode(nnkBracket)
+  for i in 0 ..< n.len:
     expectKind(n[i], nnkIdent)
     result.add(toStrLit(n[i]))
 

--- a/tests/misc/thallo.nim
+++ b/tests/misc/thallo.nim
@@ -19,14 +19,12 @@ proc fac[T](x: T): T =
   if x <= 1: return 1
   else: return x.`*`(fac(x-1))
 
-macro macrotest(n: varargs[untyped]): untyped =
-  let n = callsite()
-  expectKind(n, nnkCall)
-  expectMinLen(n, 2)
-  result = newNimNode(nnkStmtList, n)
-  for i in 2..n.len-1:
-    result.add(newCall("write", n[1], n[i]))
-  result.add(newCall("writeLine", n[1], newStrLitNode("")))
+macro macrotest(file: File; n: varargs[untyped]): untyped =
+  expectKind(n, nnkArgList)
+  result = newStmtList()
+  for arg in n:
+    result.add(newCall("write", file, arg))
+  result.add(newCall("writeLine", file, newStrLitNode("")))
 
 macro debug(n: untyped): untyped =
   let n = callsite()

--- a/tests/objects/toop1.nim
+++ b/tests/objects/toop1.nim
@@ -34,25 +34,30 @@ proc init(my: var TRectangle) =
   my.height = 10
   my.draw = cast[proc (my: var TFigure) {.nimcall.}](drawRectangle)
 
-macro `!` (n: varargs[untyped]): typed =
-  let n = callsite()
-  result = newNimNode(nnkCall, n)
-  var dot = newNimNode(nnkDotExpr, n)
-  dot.add(n[1])    # obj
-  if n[2].kind == nnkCall:
+macro `!` (args: varargs[untyped]): typed =
+  args.expectLen 2
+  let arg1 = args[0]
+  let arg2 = args[1]
+  for i, arg in args:
+    echo "arg", i, " ", arg.lispRepr
+
+  result = newNimNode(nnkCall)
+  var dot = newNimNode(nnkDotExpr)
+  dot.add(arg1)    # obj
+  if arg2.kind == nnkCall:
     # transforms ``obj!method(arg1, arg2, ...)`` to
     # ``(obj.method)(obj, arg1, arg2, ...)``
-    dot.add(n[2][0]) # method
+    dot.add(arg2[0]) # method
     result.add(dot)
-    result.add(n[1]) # obj
-    for i in 1..n[2].len-1:
-      result.add(n[2][i])
+    result.add(arg1) # obj
+    for i in 1..arg2.len-1:
+      result.add(arg2[i])
   else:
     # transforms ``obj!method`` to
     # ``(obj.method)(obj)``
-    dot.add(n[2]) # method
+    dot.add(arg2) # method
     result.add(dot)
-    result.add(n[1]) # obj
+    result.add(arg1) # obj
 
 type
   TSocket* = object of RootObj

--- a/tests/usingstmt/tusingstatement.nim
+++ b/tests/usingstmt/tusingstatement.nim
@@ -12,22 +12,14 @@ import
 # disposal of resources.
 #
 macro autoClose(args: varargs[untyped]): untyped =
-  let e = callsite()
-  if e.len != 3:
-    error "Using statement: unexpected number of arguments. Got " &
-      $e.len & ", expected: 1 or more variable assignments and a block"
-
-  var args = e
-  var body = e[2]
+  # lazy fix for callsite usage
+  let body = args.last
 
   var
     variables : seq[NimNode]
     closingCalls : seq[NimNode]
 
-  newSeq(variables, 0)
-  newSeq(closingCalls, 0)
-
-  for i in countup(1, args.len-2):
+  for i in 0 ..< args.len-1:
     if args[i].kind == nnkExprEqExpr:
       var varName = args[i][0]
       var varValue = args[i][1]


### PR DESCRIPTION
`nOrig` is pretty much only used for `macros.callsite` which is
deprecated/redundant since Nim has `untyped` as macro arguments. Since
then it has huge negative value on both developers as well as the
computer because all of this copyTree that is happening to preserve it.

Before this change, callsite returned an AST like it got spit out by
the parser. But overload resolution does modify the ast. arguments get
converted into nkArgList for varargs for example. To actually preserve
the unchanged AST, there is this `nOrig` parameter all over the
compiler. The idea is, befere a change is applied to the ast, deep copy
the tree and store it as `nOrig` and pass that down along `n`. But it
this strict AST preservation isn't tested, so I wouldn't assume that it
actually work.
 
Now I am passing down the node `n` instead of `nOrig` to callsite. So
when the macro expects typed arguments, the corresponding children in
the call node are also sem checked. Varargs are grouped to
`nkArgsList`.

So callsite in `myMacro(a,b)` is now often
`(nnkCall (ident "mymacro") (nnkArgsList (ident "a") (ident "b")))`
instead of `(nnkCall (ident "mymacro") (ident "a") (ident "b"))` which
causes indices to be wrong and the macro crashes or generates an
invalid ast.

The one thing to preserve callsite for, that can't be done with simply
reading the argument (which should have been done for years now), is to
get line information of the actual macro invocation. But for this it
might be better to just pass the the first child of call, the `symbol`
of the macro down to callsite.
