### PR TITLE
koch.py: add download bootstrap source command

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -62,17 +62,11 @@ jobs:
 
       - uses: actions/checkout@v2.4.0
 
-      - name: Bootstrap koch
-        run: |
-          # TODO: Add a special mode to koch.py so we don't have to do this
-          # dance
-          #
-          # Perform a bootstrapping run for koch so that we don't have to clone
-          # csources
-          ./koch.py --help
-          # Then remove artifacts so we can test build those, too
-          git clean -fdx --exclude=/build/csources/
-          git -C build/csources clean -fdx
+        # reprotest will manipulate the time which may cause bootstrapping
+        # source download to fail due to SSL errors. Download this beforehand
+        # as a workaround.
+      - name: Download bootstrapping source
+        run: ./koch.py fetch-bootstrap
 
       - name: Run reproducibility build
         run: |

--- a/koch.py
+++ b/koch.py
@@ -228,13 +228,29 @@ class Bootstrap:
 
 
 def main() -> None:
+    bootstrap = Bootstrap()
+
+    # Implements the fetch-bootstrap command. See koch.nim for more
+    # information.
+    if sys.argv[1] == "fetch-bootstrap":
+        bootstrap.fetch()
+        return
+
+    # In case --help is passed before the bootstrap compiler is built, warn the
+    # user about it.
+    if "-h" in sys.argv or "--help" in sys.argv:
+        if not bootstrap.is_built():
+            print(
+                "Warning: koch and its dependencies will be downloaded and built before --help is processed."
+            )
+
     print("Building koch.nim")
 
     # The path to koch's binary
     kochSourceDir = NimSource / "tools" / "koch"
     kochBinary = exe(kochSourceDir / "koch")
     kochSource = kochSourceDir / "koch.nim"
-    Bootstrap().run(
+    bootstrap.run(
         "c",
         "--hints:off",
         # (as of v1.0.11) This is required to silent "CC:" even with --hints:off.

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -61,6 +61,8 @@ Possible Commands:
   tools                    builds Nim related tools
   toolsNoExternal          builds Nim related tools (except external tools)
                            doesn't require network connectivity
+  fetch-bootstrap          download the bootstrap compiler; must be passed as
+                           the sole command without any options
 
 Boot options:
   -d:release               produce a release version of the compiler
@@ -726,6 +728,9 @@ when isMainModule:
       of "drnim": buildDrNim(op.cmdLineRest)
       of "ic": icTest(op.cmdLineRest)
       of "branchdone": branchDone()
+      of "fetch-bootstrap":
+        # This is handled by koch.py
+        quit()
       else: showHelp(success = false)
       break
     of cmdEnd:


### PR DESCRIPTION
This is used for reproducibility tests where the time might be
advanced far into the future, making download fails due to TLS
errors.

With this, the hack used in reproducibility CI can be dropped.

And as a QoL change, inform the user if they run `./koch.py` with
`--help` or `-h` before the bootstrap compiler was built as that step
might take a long time and that the user should be patient.