### PR TITLE
implement new versioning scheme for the compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
 
       - name: Enable annotations
         run: echo "::add-matcher::.github/nim-problem-matcher.json"
@@ -135,6 +137,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/download-compiler
 
@@ -198,6 +202,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/download-compiler
 
@@ -221,6 +227,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/download-compiler
 
@@ -247,6 +255,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/download-compiler
 

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -61,6 +61,8 @@ jobs:
           sudo apt-get install -yqq reprotest
 
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
 
         # reprotest will manipulate the time which may cause bootstrapping
         # source download to fail due to SSL errors. Download this beforehand

--- a/compiler/nversion.nim
+++ b/compiler/nversion.nim
@@ -10,11 +10,44 @@
 # This module contains Nim's version. It is the only place where it needs
 # to be changed.
 
+import std/strscans
+
+type
+  Version* = object
+    ## An object describing the compiler version
+    suffix*: string ## Optional suffix
+    major*, minor*, patch*: int
+
+func `$`*(v: Version): string =
+  ## Return a string describing `v`.
+  result.addInt v.major
+  result.add '.'
+  result.addInt v.minor
+  result.add '.'
+  result.addInt v.patch
+  result.add v.suffix
+
+func parse*(s: string): Version =
+  ## Parse the string `s` to create `Version`.
+  if not scanf(
+    s, "$i.$i.$i$*$.",
+    result.major, result.minor, result.patch, result.suffix
+  ):
+    raise newException(ValueError):
+      "Invalid version string: " & s
+
 const
   MaxSetElements* = 1 shl 16  # (2^16) to support unicode character sets?
-  VersionAsString* = system.NimVersion
+  CompilerVersionSuffix* {.strdefine.} = ""
+    ## The suffix to attach to the compiler version. This is meant to be
+    ## declared by build tools to signify development version for example.
+  CompilerVersion* = Version(
+    major: 0, minor: 1, patch: 0,
+    suffix: CompilerVersionSuffix
+  )
+    ## The compiler version.
+  VersionAsString* = $CompilerVersion
   RodFileVersion* = "1223"       # modify this if the rod-format changes!
-
   NimCompilerApiVersion* = 3 ## Check for the existence of this before accessing it
                              ## as older versions of the compiler API do not
                              ## declare this.

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -308,7 +308,6 @@ running: v2
     let j = ret.parseJson
     # sanity checks
     doAssert "D20210428T161003" in j["defined_symbols"].to(seq[string])
-    doAssert j["version"].to(string) == NimVersion
     doAssert j["nimExe"].to(string) == getCurrentCompilerExe()
 
   block: # genscript


### PR DESCRIPTION
This commit implements the following scheme:

```
  <major>.<minor>.<patch>[-dev.<distance>][+dirty]
```

Where:

* `<major>.<minor>.<patch>` is the "base" version. This version is the
  compiler version being developed (ie. after 0.1.0, this will be bumped
  to 0.1.1 or 0.2.0).

* `-dev.<distance>` signifies a pre-release of the base version. Any
  version with this tag is considered to be older than the base version,
  and is not subjected to any stability requirements.

  The `<distance>` part specifies the number of commits since the last
  tag or the first commit if there are no tags.

* `+dirty` signifies that the compiler was built on modified source that
  was not committed.

With this commit, the compiler version is now rolled back to 0.1.0. The
advertised `NimVersion` remains at 1.6.0.

Implementation wise, this is done in two parts:

* The compiler maintains the base version and the `Version` structure
  with support for the suffix to be inputted by the build tool.

* Build tooling (koch specifically) maintains the addition of the
  version suffixes and ensure that the base version is correct with
  regards to the repository tags.

Known problems:

* There is no mechanism to obtain the compiler version from the code
  being compiled.

* Need a full clone with tags to compile with correct information.
  CI has been modified accordingly.

* The development status is embedded into the compiler, which makes transparent promotion impossible (ie. promoting `0.1.0-dev.100` -> `0.1.0` requires a rebuild).

Differences to https://github.com/nim-works/nimskull/discussions/150:

* `rc` is dropped.

* `dev` replaces `pre`, uses commit distance instead of commit date for
  easier comparision.

Closes https://github.com/nim-works/nimskull/issues/155