### PR TITLE
disable MsgOrigin at default verbosity

### DIFF
--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -106,6 +106,7 @@ proc computeNotesVerbosity(): tuple[
     rsemHintLibDependency,
     rsemGlobalVar,
     rintGCStats,
+    rintMsgOrigin
   }
 
   result.main[0] = result.main[1] - {
@@ -115,7 +116,6 @@ proc computeNotesVerbosity(): tuple[
     rsemPattern,
     rcmdExecuting,
     rbackLinking,
-    rintMsgOrigin
   }
 
   result.foreign = result.base + {


### PR DESCRIPTION
This is very noisy and doesn't help anyone who is not developing the
compiler.