### PR TITLE
koch: set SOURCE_DATE_EPOCH for docgen

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -35,14 +35,14 @@ jobs:
             pattern: 'build/*.tar.zst'
 
           - name: Unix binary archive
-            command: './koch.py unixrelease'
+            command: './koch.py boot -d:danger && ./koch.py docs --docCmd:skip && ./koch.py unixrelease'
             pattern: 'build/*.tar.zst'
 
           # Note: this tests the zip generation and not exe generation determinism.
           #
           # Testing exe generation will be done when cross-bootstrap is possible.
           - name: Windows binary archive
-            command: './koch.py winrelease'
+            command: './koch.py boot -d:danger && ./koch.py docs --docCmd:skip && ./koch.py winrelease'
             pattern: 'build/*.zip'
 
     name: '${{ matrix.test.name }} reproducibility tests'

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -24,7 +24,7 @@ when defined(amd64) and defined(windows) and defined(vcc):
 when defined(i386) and defined(windows) and defined(vcc):
   {.link: "icons/koch-i386-windows-vcc.res".}
 
-import std/[json, os, strutils, parseopt, osproc]
+import std/[json, os, strutils, parseopt, osproc, times]
   # Using `std/os` instead of `os` to fail early if config isn't set up properly.
   # If this fails with: `Error: cannot open file: std/os`, see
   # https://github.com/nim-lang/Nim/pull/14291 for explanation + how to fix.
@@ -652,6 +652,14 @@ when isMainModule:
     latest = false
     localDocsOnly = false
     localDocsOut = ""
+
+  # Set SOURCE_DATE_EPOCH to cover other tooling that might make use of the
+  # current time. Currently these tools are known to use the current time:
+  #
+  # - nim doc
+  let epoch = getSourceMetadata().date.parse("yyyy-MM-dd", zone = utc())
+                                      .toTime.toUnix()
+  putEnv("SOURCE_DATE_EPOCH", $epoch)
   while true:
     op.next()
     case op.kind


### PR DESCRIPTION
Default generated docs embed the time at generation into its docs, which
is not reproducible.

Set SOURCE_DATE_EPOCH to the commit date to ensure the reproducibility
of generated docs.

Added docs building to reproducibility test. The generated documentation
will be picked up by the binary archive command.