### PR TITLE
debug: clean up formatting for the vmgen debugging

### DIFF
--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -58,9 +58,13 @@ proc computeNotesVerbosity(): tuple[
     # debug report for transition of the configuration options
     result.base.incl {rdbgOptionsPush, rdbgOptionsPop}
 
-  when defined(nimVMDebug):
+  when defined(nimVMDebugExecute):
     result.base.incl {
-      rdbgVmExecTraceFull, # execution of the generated code listings
+      rdbgVmExecTraceFull # execution of the generated code listings
+    }
+
+  when defined(nimVMDebugGenerate):
+    result.base.incl {
       rdbgVmCodeListing    # immediately generated code listings
     }
 

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -63,7 +63,7 @@ import ast/ast except getstr
 
 
 const
-  traceCode = defined(nimVMDebug)
+  traceCode = defined(nimVMDebugExecute)
 
 when hasFFI:
   import evalffi

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -64,7 +64,7 @@ when defined(nimCompilerStacktraceHints):
   import std/stackframes
 
 const
-  debugEchoCode* = defined(nimVMDebug)
+  debugEchoCode* = defined(nimVMDebugGenerate)
 
 when hasFFI:
   import vm/evalffi

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -212,6 +212,131 @@ You can also bisect using custom options to build the compiler, for example if
 you don't need a debug version of the compiler (which runs slower), you can replace
 `./koch.py temp`:cmd: by explicit compilation command, see `Rebuilding the compiler`_.
 
+Debugging the compiler
+======================
+
+How to debug different subsystems of the compiler using built-in tooling.
+
+Special defines
+---------------
+
+Debugging functionality can usually be accessed only when compiler itself
+has been built with special defines - this is made to avoid runtime
+overhead, because some debugging tools are not exactly cheap to run.
+
+==================== =======
+Define               Enables
+-------------------- -------
+nimVMDebugExecute    Print out every instruction executed by the VM
+nimVMDebugGenerate   List VM code generated for every procedure called at compile-time
+nimDebugUtils        Enable semantic analysis execution tracer
+
+==================== =======
+
+
+Semantic analysis
+-----------------
+
+When `nimDebugUtils` is enabled you can annotate section of the code to
+trace how semantic analysis is performed on this block of code. Each
+procedure that is annotated with one of the `addInNimDebugUtils()`
+overloads is going to be traced in the execution tree. For example -
+`sem.semOverloadedCall`, triggered when it is necessary to analyze call to
+overloaded procedure.
+
+.. code-block:: nim
+
+    proc semOverloadedCall(c: PContext, n, nOrig: PNode,
+                           filter: TSymKinds, flags: TExprFlags): PNode {.nosinks.} =
+      addInNimDebugUtils(c.config, "semOverloadedCall")
+      # Other implementaion parts ...
+
+If you compile your test file with `nim c -d:nimDebugUtils
+--filenames:canonical file.nim` and annotate code block with the
+
+.. code-block:: nim
+
+    {.define(nimCompilerDebug).}
+    vmTarget(Obj())
+    {.undef(nimCompilerDebug).}
+
+You will get all the call entries traced
+
+.. code-block:: literal
+
+    >>] trace start
+    #0]> semExpr @ sem/semexprs.nim(2948, 21) from sem/semstmts.nim(2446, 1)
+    #1]  > semOverloadedCallAnalyseEffects @ sem/semexprs.nim(941, 21) from sem/semexprs.nim(1133, 1)
+    #2]    > semOverloadedCall @ sem/semcall.nim(569, 21) from sem/semexprs.nim(950, 1)
+    #3]      > semExpr @ sem/semexprs.nim(2948, 21) from sem/semexprs.nim(43, 1)
+    #4]        > semTypeNode @ sem/semtypes.nim(1903, 21) from sem/semobjconstr.nim(469, 1)
+    #4]        < semTypeNode @ sem/semtypes.nim(1903, 21) from sem/semobjconstr.nim(469, 1)
+    #3]      < semExpr @ sem/semexprs.nim(2948, 21) from sem/semexprs.nim(43, 1)
+    #2]    < semOverloadedCall @ sem/semcall.nim(569, 21) from sem/semexprs.nim(950, 1)
+    #1]  < semOverloadedCallAnalyseEffects @ sem/semexprs.nim(941, 21) from sem/semexprs.nim(1133, 1)
+    #0]< semExpr @ sem/semexprs.nim(2948, 21) from sem/semstmts.nim(2446, 1)
+    #0]> semExpr @ sem/semexprs.nim(2948, 21) from sem/semstmts.nim(2446, 1)
+    <<] trace end
+
+Formatting of the report is implemented in the `cli_reporter.nim` as well
+(all debug reports are also transferred using regular reporting pipeline).
+It has a lot of information, but general parts for each call parts are:
+
+.. code-block:: literal
+
+   #2]    < semOverloadedCall @ sem/semcall.nim(569, 21) from sem/semexprs.nim(950, 1)
+   ^      ^ ^                   ^                             ^
+   |      | |                   |                             Where proc has been called from
+   |      | |                   Location of the `addInNimDebugUtils()` - the proc itsemf
+   |      | Name of the proc
+   |      Whether proc has been entered or exited
+   Depth of the traced call tree
+
+
+
+VM codegen and execution
+------------------------
+
+VM code generation prints all of the generated procedures. If this is not
+needed (which would be the majority of use cases) you can add
+`--define:expandVmListing=vmTarget` and only code for the specific proc
+would be printed. For example (generated listing might not match exactly)
+
+.. code-block:: nim
+
+    type
+      Obj = object
+        charField: char
+        intField: int
+
+    proc vmTarget(arg: Obj) =
+      echo arg.charField.int + arg.intField
+
+    static:
+      vmTarget(Obj())
+
+
+.. code-block:: cmd
+
+  nim c --filenames:canonical --define:expandVmListing=vmTarget file.nim
+
+
+.. code-block:: literal
+
+    Code listing for the 'vmTarget' file.nim(6, 6)
+
+      LdConst      r3     $     1279                system.nim(2005, 30)
+      LdObj        r6     r1     r0                 file.nim(7, 11)
+      NodeToReg    r5     r6     r0                 file.nim(7, 11)
+      Conv         r6     r5     int   char         file.nim(7, 21)
+      LdObj        r7     r1     r1                 file.nim(7, 31)
+      NodeToReg    r5     r7     r0                 file.nim(7, 31)
+      AddInt       r4     r6     r5                 file.nim(7, 26)
+      IndCallAsgn  r2     r3     #2                 file.nim(7, 26)
+      Echo         r2     r1     r0                 file.nim(7, 26)
+      Ret          r0     r0     r0                 file.nim(7, 8)
+      Eof          r0     r0     r0                 file.nim(7, 8)
+
 
 Runtimes
 ========


### PR DESCRIPTION
- Improve formatting for the vmgen code listing reports
- Split VM debuggint defines in two - `nimVMDebugExecute` to trace actually
  executed vm opcodes, and `nimVMDebugGenerate` to see generated code.
- Allow filtering out generated code by proc name, using
  `--define:expandVmListing=vmTarget`
```nim
type
  Obj = object
    charField: char
    intField: int

proc vmTarget(arg: Obj) =
  echo arg.charField.int + arg.intField

static:
  vmTarget(Obj())

```

```
nim c --filenames:canonical --define:expandVmListing=vmTarget file.nim
```

```
Code listing for vmTarget
  LdConst      r3     $     1279                system.nim(2005, 30)
  LdObj        r6     r1     r0                 file.nim(7, 11)
  NodeToReg    r5     r6     r0                 file.nim(7, 11)
  Conv         r6     r5     int   char         file.nim(7, 21)
  LdObj        r7     r1     r1                 file.nim(7, 31)
  NodeToReg    r5     r7     r0                 file.nim(7, 31)
  AddInt       r4     r6     r5                 file.nim(7, 26)
  IndCallAsgn  r2     r3     #2                 file.nim(7, 26)
  Echo         r2     r1     r0                 file.nim(7, 26)
  Ret          r0     r0     r0                 file.nim(7, 8)
  Eof          r0     r0     r0                 file.nim(7, 8)
```