### PR TITLE
separate documentation publishing from building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
   push:
     # Empty configuration means use default (ie. test all branches)
     branches-ignore:
+      # Everything would have passed bors before going into devel
+      - devel
+      # Bors temporary branches
       - staging.tmp
       - trying.tmp
       - staging-squash-merge.tmp
@@ -265,24 +268,22 @@ jobs:
 
       - name: Build docs
         run: |
-          branch=${{ github.ref }}
-          # Remove refs/heads/ prefix
-          branch=${branch##*/}
-
           ./koch.py doc \
             --git.url:'https://github.com/${{ github.repository }}' \
             --git.commit:'${{ github.sha }}' \
-            --git.devel:"$branch"
+            --git.devel:devel
 
-      - name: Publish
-        if: |
-          github.event_name == 'push' && github.ref == 'refs/heads/devel' &&
-          matrix.target.publish_docs
-        uses: crazy-max/ghaction-github-pages@v2.6.0
+          # Remove leftover nimcache
+          rm -rf doc/html/nimcache
+
+      - name: Publish to artifacts
+        if: matrix.target.publish_docs
+        uses: actions/upload-artifact@v2.3.1
         with:
-          build_dir: doc/html
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # If this name is updated, tweak publisher.yml
+          name: Generated docs
+          path: doc/html/
+          if-no-files-found: error
 
   passed:
     name: All check passed

--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -1,0 +1,39 @@
+name: Publish built artifacts
+on:
+  push:
+    branches:
+      - devel
+
+# Run every script actions in bash
+defaults:
+  run:
+    shell: bash
+
+# Since we will be pushing, make sure that only one instance can run at a time.
+concurrency: publisher
+
+jobs:
+  publisher:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Publish action needs a checkout
+      - uses: actions/checkout@v2.4.0
+
+      # Download the latest instance of generated documentation from the build
+      # during bors staging.
+      - name: Download generated docs
+        uses: dawidd6/action-download-artifact@v2.16.0
+        with:
+          workflow: ci.yml
+          workflow_conclusion: completed
+          commit: ${{ github.event.after }}
+          # Keep up-to-date with ci.yml
+          name: Generated docs
+          path: doc/html
+
+      - name: Publish docs
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: gh-pages
+          folder: doc/html


### PR DESCRIPTION
Since docs were published as a part of the main CI run, we were forced
to re-run CI on devel even though bors has performed the check and built
the documentation. This wastes resources especially since our test
matrix is expanding.

This commit implemented a separate publisher that publishes artifacts
built during staging (currently docs). The publisher uses a pull
architecture, that is, to query producers and obtain necessary artifacts
from them.

Main CI will now always build and upload generated documentation, which
has a nice bonus of allowing us to review docgen changes more throughly
in PRs.

An another adjustment made is that the "Edit" link will now be
hard-coded to the `devel` branch instead of being inferred from the
branch being built on. This lets us reuse docs built during the time
spent in staging branch.

Closes #182 