### PR TITLE
doc: reformat comments, add readmes in subdirs

### DIFF
--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -7,9 +7,9 @@
 #    distribution, for details about the copyright.
 #
 
-# Algorithms for the abstract syntax tree: hash tables, lists
-# and sets of nodes are supported. Efficiency is important as
-# the data structures here are used in various places of the compiler.
+## Algorithms for the abstract syntax tree: hash tables, lists
+## and sets of nodes are supported. Efficiency is important as
+## the data structures here are used in various places of the compiler.
 
 import
   ast/[

--- a/compiler/ast/nimlexbase.nim
+++ b/compiler/ast/nimlexbase.nim
@@ -7,10 +7,10 @@
 #    distribution, for details about the copyright.
 #
 
-# Base Object of a lexer with efficient buffer handling. In fact
-# I believe that this is the most efficient method of buffer
-# handling that exists! Only at line endings checks are necessary
-# if the buffer needs refilling.
+## Base Object of a lexer with efficient buffer handling. In fact
+## I believe that this is the most efficient method of buffer
+## handling that exists! Only at line endings checks are necessary
+## if the buffer needs refilling.
 
 import
   llstream, strutils
@@ -28,12 +28,17 @@ const
   VT* = '\x0B'
 
 const
-  EndOfFile* = '\0'           # end of file marker
-                              # A little picture makes everything clear :-)
-                              #  buf:
-                              #  "Example Text\n ha!"   bufLen = 17
-                              #   ^pos = 0     ^ sentinel = 12
-                              #
+  EndOfFile* = '\0' ##[
+end of file marker
+
+A little picture makes everything clear
+
+.. code-block:: nim
+
+  "Example Text\n ha!"   bufLen = 17
+    ^pos = 0     ^ sentinel = 12
+
+  ]##
   NewLines* = {CR, LF}
 
 type
@@ -42,12 +47,12 @@ type
     buf*: cstring
     bufStorage: string
     bufLen: int
-    stream*: PLLStream        # we read from this stream
-    lineNumber*: int          # the current line number
-                              # private data:
+    stream*: PLLStream        ## we read from this stream
+    lineNumber*: int          ## the current line number
+                              ## private data:
     sentinel*: int
-    lineStart*: int           # index of last line start in buffer
-    offsetBase*: int          # use ``offsetBase + bufpos`` to get the offset
+    lineStart*: int           ## index of last line start in buffer
+    offsetBase*: int          ## use ``offsetBase + bufpos`` to get the offset
 
 
 proc openBaseLexer*(L: var TBaseLexer, inputstream: PLLStream,
@@ -57,13 +62,13 @@ proc closeBaseLexer*(L: var TBaseLexer)
 proc getCurrentLine*(L: TBaseLexer, marker: bool = true): string
 proc getColNumber*(L: TBaseLexer, pos: int): int
 proc handleCR*(L: var TBaseLexer, pos: int): int
-  # Call this if you scanned over CR in the buffer; it returns the
-  # position to continue the scanning from. `pos` must be the position
-  # of the CR.
+  ## Call this if you scanned over CR in the buffer; it returns the
+  ## position to continue the scanning from. `pos` must be the position
+  ## of the CR.
 proc handleLF*(L: var TBaseLexer, pos: int): int
-  # Call this if you scanned over LF in the buffer; it returns the
-  # position to continue the scanning from. `pos` must be the position
-  # of the LF.
+  ## Call this if you scanned over LF in the buffer; it returns the
+  ## position to continue the scanning from. `pos` must be the position
+  ## of the LF.
 # implementation
 
 proc closeBaseLexer(L: var TBaseLexer) =

--- a/compiler/ast/nimsets.nim
+++ b/compiler/ast/nimsets.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# this unit handles Nim sets; it implements symbolic sets
+## this unit handles Nim sets; it implements symbolic sets
 
 import
   ast/[ast, astalgo, lineinfos, types],

--- a/compiler/ast/readme.rst
+++ b/compiler/ast/readme.rst
@@ -1,0 +1,2 @@
+Code lexer and parser as well as associated modules for working with
+generated trees.

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# tree helper routines
+## tree helper routines
 
 import
   ast, wordrecg, idents

--- a/compiler/ast/treetab.nim
+++ b/compiler/ast/treetab.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# Implements a table from trees to trees. Does structural equivalence checking.
+## Implements a table from trees to trees. Does structural equivalence checking.
 
 import
   hashes, ast, astalgo, types

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# this module contains routines for accessing and iterating over types
+## this module contains routines for accessing and iterating over types
 
 import
   std/[

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -7,7 +7,8 @@
 #    distribution, for details about the copyright.
 #
 #
-# included from cgen.nim
+
+## included from cgen.nim
 
 proc canRaiseDisp(p: BProc; n: PNode): bool =
   # we assume things like sysFatal cannot raise themselves

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -33,54 +33,54 @@ import
 
 
 type
-  TLabel* = Rope              # for the C generator a label is just a rope
-  TCFileSection* = enum       # the sections a generated C file consists of
-    cfsMergeInfo,             # section containing merge information
-    cfsHeaders,               # section for C include file headers
-    cfsFrameDefines           # section for nim frame macros
-    cfsForwardTypes,          # section for C forward typedefs
-    cfsTypes,                 # section for C typedefs
-    cfsSeqTypes,              # section for sequence types only
-                              # this is needed for strange type generation
-                              # reasons
-    cfsFieldInfo,             # section for field information
-    cfsTypeInfo,              # section for type information (ag ABI checks)
-    cfsProcHeaders,           # section for C procs prototypes
-    cfsData,                  # section for C constant data
-    cfsVars,                  # section for C variable declarations
-    cfsProcs,                 # section for C procs that are not inline
-    cfsInitProc,              # section for the C init proc
-    cfsDatInitProc,           # section for the C datInit proc
-    cfsTypeInit1,             # section 1 for declarations of type information
-    cfsTypeInit2,             # section 2 for init of type information
-    cfsTypeInit3,             # section 3 for init of type information
-    cfsDebugInit,             # section for init of debug information
-    cfsDynLibInit,            # section for init of dynamic library binding
-    cfsDynLibDeinit           # section for deinitialization of dynamic
-                              # libraries
-  TCTypeKind* = enum          # describes the type kind of a C type
+  TLabel* = Rope              ## for the C generator a label is just a rope
+  TCFileSection* = enum       ## the sections a generated C file consists of
+    cfsMergeInfo,             ## section containing merge information
+    cfsHeaders,               ## section for C include file headers
+    cfsFrameDefines           ## section for nim frame macros
+    cfsForwardTypes,          ## section for C forward typedefs
+    cfsTypes,                 ## section for C typedefs
+    cfsSeqTypes,              ## section for sequence types only
+                              ## this is needed for strange type generation
+                              ## reasons
+    cfsFieldInfo,             ## section for field information
+    cfsTypeInfo,              ## section for type information (ag ABI checks)
+    cfsProcHeaders,           ## section for C procs prototypes
+    cfsData,                  ## section for C constant data
+    cfsVars,                  ## section for C variable declarations
+    cfsProcs,                 ## section for C procs that are not inline
+    cfsInitProc,              ## section for the C init proc
+    cfsDatInitProc,           ## section for the C datInit proc
+    cfsTypeInit1,             ## section 1 for declarations of type information
+    cfsTypeInit2,             ## section 2 for init of type information
+    cfsTypeInit3,             ## section 3 for init of type information
+    cfsDebugInit,             ## section for init of debug information
+    cfsDynLibInit,            ## section for init of dynamic library binding
+    cfsDynLibDeinit           ## section for deinitialization of dynamic
+                              ## libraries
+  TCTypeKind* = enum          ## describes the type kind of a C type
     ctVoid, ctChar, ctBool,
     ctInt, ctInt8, ctInt16, ctInt32, ctInt64,
     ctFloat, ctFloat32, ctFloat64, ctFloat128,
     ctUInt, ctUInt8, ctUInt16, ctUInt32, ctUInt64,
     ctArray, ctPtrToArray, ctStruct, ctPtr, ctNimStr, ctNimSeq, ctProc,
     ctCString
-  TCFileSections* = array[TCFileSection, Rope] # represents a generated C file
-  TCProcSection* = enum       # the sections a generated C proc consists of
-    cpsLocals,                # section of local variables for C proc
-    cpsInit,                  # section for init of variables for C proc
-    cpsStmts                  # section of local statements for C proc
+  TCFileSections* = array[TCFileSection, Rope] ## represents a generated C file
+  TCProcSection* = enum       ## the sections a generated C proc consists of
+    cpsLocals,                ## section of local variables for C proc
+    cpsInit,                  ## section for init of variables for C proc
+    cpsStmts                  ## section of local statements for C proc
   TCProcSections* = array[TCProcSection, Rope] # represents a generated C proc
   BModule* = ref TCGen
   BProc* = ref TCProc
   TBlock* = object
-    id*: int                  # the ID of the label; positive means that it
-    label*: Rope              # generated text for the label
-                              # nil if label is not used
-    sections*: TCProcSections # the code belonging
-    isLoop*: bool             # whether block is a loop
-    nestedTryStmts*: int16    # how many try statements is it nested into
-    nestedExceptStmts*: int16 # how many except statements is it nested into
+    id*: int                  ## the ID of the label; positive means that it
+    label*: Rope              ## generated text for the label
+                              ## nil if label is not used
+    sections*: TCProcSections ## the code belonging
+    isLoop*: bool             ## whether block is a loop
+    nestedTryStmts*: int16    ## how many try statements is it nested into
+    nestedExceptStmts*: int16 ## how many except statements is it nested into
     frameLen*: int16
 
   TCProcFlag* = enum
@@ -92,31 +92,31 @@ type
     nimErrorFlagDeclared,
     nimErrorFlagDisabled
 
-  TCProc = object             # represents C proc that is currently generated
-    prc*: PSym                # the Nim proc that this C proc belongs to
+  TCProc = object             ## represents C proc that is currently generated
+    prc*: PSym                ## the Nim proc that this C proc belongs to
     flags*: set[TCProcFlag]
-    lastLineInfo*: TLineInfo  # to avoid generating excessive 'nimln' statements
-    currLineInfo*: TLineInfo  # AST codegen will make this superfluous
+    lastLineInfo*: TLineInfo  ## to avoid generating excessive 'nimln' statements
+    currLineInfo*: TLineInfo  ## AST codegen will make this superfluous
     nestedTryStmts*: seq[tuple[fin: PNode, inExcept: bool, label: Natural]]
-                              # in how many nested try statements we are
-                              # (the vars must be volatile then)
-                              # bool is true when are in the except part of a try block
-    finallySafePoints*: seq[Rope]  # For correctly cleaning up exceptions when
-                                   # using return in finally statements
-    labels*: Natural          # for generating unique labels in the C proc
-    blocks*: seq[TBlock]      # nested blocks
-    breakIdx*: int            # the block that will be exited
-                              # with a regular break
-    options*: TOptions        # options that should be used for code
-                              # generation; this is the same as prc.options
-                              # unless prc == nil
-    module*: BModule          # used to prevent excessive parameter passing
-    withinLoop*: int          # > 0 if we are within a loop
-    splitDecls*: int          # > 0 if we are in some context for C++ that
-                              # requires 'T x = T()' to become 'T x; x = T()'
-                              # (yes, C++ is weird like that)
-    withinTryWithExcept*: int # required for goto based exception handling
-    withinBlockLeaveActions*: int # complex to explain
+                              ## in how many nested try statements we are
+                              ## (the vars must be volatile then)
+                              ## bool is true when are in the except part of a try block
+    finallySafePoints*: seq[Rope]  ## For correctly cleaning up exceptions when
+                                   ## using return in finally statements
+    labels*: Natural          ## for generating unique labels in the C proc
+    blocks*: seq[TBlock]      ## nested blocks
+    breakIdx*: int            ## the block that will be exited
+                              ## with a regular break
+    options*: TOptions        ## options that should be used for code
+                              ## generation; this is the same as prc.options
+                              ## unless prc == nil
+    module*: BModule          ## used to prevent excessive parameter passing
+    withinLoop*: int          ## > 0 if we are within a loop
+    splitDecls*: int          ## > 0 if we are in some context for C++ that
+                              ## requires 'T x = T()' to become 'T x; x = T()'
+                              ## (yes, C++ is weird like that)
+    withinTryWithExcept*: int ## required for goto based exception handling
+    withinBlockLeaveActions*: int ## complex to explain
     sigConflicts*: CountTable[string]
 
   TTypeSeq* = seq[PType]
@@ -124,71 +124,71 @@ type
   TypeCacheWithOwner* = Table[SigHash, tuple[str: Rope, owner: int32]]
 
   CodegenFlag* = enum
-    preventStackTrace,  # true if stack traces need to be prevented
-    usesThreadVars,     # true if the module uses a thread var
-    frameDeclared,      # hack for ROD support so that we don't declare
-                        # a frame var twice in an init proc
-    isHeaderFile,       # C source file is the header file
-    includesStringh,    # C source file already includes ``<string.h>``
-    objHasKidsValid     # whether we can rely on tfObjHasKids
-    useAliveDataFromDce # use the `alive: IntSet` field instead of
-                        # computing alive data on our own.
+    preventStackTrace,  ## true if stack traces need to be prevented
+    usesThreadVars,     ## true if the module uses a thread var
+    frameDeclared,      ## hack for ROD support so that we don't declare
+                        ## a frame var twice in an init proc
+    isHeaderFile,       ## C source file is the header file
+    includesStringh,    ## C source file already includes ``<string.h>``
+    objHasKidsValid     ## whether we can rely on tfObjHasKids
+    useAliveDataFromDce ## use the `alive: IntSet` field instead of
+                        ## computing alive data on our own.
 
   BModuleList* = ref object of RootObj
     mainModProcs*, mainModInit*, otherModsInit*, mainDatInit*: Rope
-    mapping*: Rope             # the generated mapping file (if requested)
-    modules*: seq[BModule]     # list of all compiled modules
-    modulesClosed*: seq[BModule] # list of the same compiled modules, but in the order they were closed
-    forwardedProcs*: seq[PSym] # proc:s that did not yet have a body
+    mapping*: Rope             ## the generated mapping file (if requested)
+    modules*: seq[BModule]     ## list of all compiled modules
+    modulesClosed*: seq[BModule] ## list of the same compiled modules, but in the order they were closed
+    forwardedProcs*: seq[PSym] ## proc:s that did not yet have a body
     generatedHeader*: BModule
     typeInfoMarker*: TypeCacheWithOwner
     typeInfoMarkerV2*: TypeCacheWithOwner
     config*: ConfigRef
     graph*: ModuleGraph
-    strVersion*, seqVersion*: int # version of the string/seq implementation to use
+    strVersion*, seqVersion*: int ## version of the string/seq implementation to use
 
-    nimtv*: Rope            # Nim thread vars; the struct body
-    nimtvDeps*: seq[PType]  # type deps: every module needs whole struct
-    nimtvDeclared*: IntSet  # so that every var/field exists only once
-                            # in the struct
-                            # 'nimtv' is incredibly hard to modularize! Best
-                            # effort is to store all thread vars in a ROD
-                            # section and with their type deps and load them
-                            # unconditionally...
-                            # nimtvDeps is VERY hard to cache because it's
-                            # not a list of IDs nor can it be made to be one.
+    nimtv*: Rope            ## Nim thread vars; the struct body
+    nimtvDeps*: seq[PType]  ## type deps: every module needs whole struct
+    nimtvDeclared*: IntSet  ## so that every var/field exists only once
+                            ## in the struct
+                            ## 'nimtv' is incredibly hard to modularize! Best
+                            ## effort is to store all thread vars in a ROD
+                            ## section and with their type deps and load them
+                            ## unconditionally...
+                            ## nimtvDeps is VERY hard to cache because it's
+                            ## not a list of IDs nor can it be made to be one.
 
-  TCGen = object of PPassContext # represents a C source file
-    s*: TCFileSections        # sections of the C file
+  TCGen = object of PPassContext ## represents a C source file
+    s*: TCFileSections        ## sections of the C file
     flags*: set[CodegenFlag]
     module*: PSym
     filename*: AbsoluteFile
-    cfilename*: AbsoluteFile  # filename of the module (including path,
-                              # without extension)
-    tmpBase*: Rope            # base for temp identifier generation
-    typeCache*: TypeCache     # cache the generated types
-    typeABICache*: HashSet[SigHash] # cache for ABI checks; reusing typeCache
-                              # would be ideal but for some reason enums
-                              # don't seem to get cached so it'd generate
-                              # 1 ABI check per occurence in code
-    forwTypeCache*: TypeCache # cache for forward declarations of types
-    declaredThings*: IntSet   # things we have declared in this .c file
-    declaredProtos*: IntSet   # prototypes we have declared in this .c file
-    alive*: IntSet            # symbol IDs of alive data as computed by `dce.nim`
-    headerFiles*: seq[string] # needed headers to include
-    typeInfoMarker*: TypeCache # needed for generating type information
+    cfilename*: AbsoluteFile  ## filename of the module (including path,
+                              ## without extension)
+    tmpBase*: Rope            ## base for temp identifier generation
+    typeCache*: TypeCache     ## cache the generated types
+    typeABICache*: HashSet[SigHash] ## cache for ABI checks; reusing typeCache
+                              ## would be ideal but for some reason enums
+                              ## don't seem to get cached so it'd generate
+                              ## 1 ABI check per occurence in code
+    forwTypeCache*: TypeCache ## cache for forward declarations of types
+    declaredThings*: IntSet   ## things we have declared in this .c file
+    declaredProtos*: IntSet   ## prototypes we have declared in this .c file
+    alive*: IntSet            ## symbol IDs of alive data as computed by `dce.nim`
+    headerFiles*: seq[string] ## needed headers to include
+    typeInfoMarker*: TypeCache ## needed for generating type information
     typeInfoMarkerV2*: TypeCache
-    initProc*: BProc          # code for init procedure
-    preInitProc*: BProc       # code executed before the init proc
-    hcrCreateTypeInfosProc*: Rope # type info globals are in here when HCR=on
-    inHcrInitGuard*: bool     # We are currently within a HCR reloading guard.
-    typeStack*: TTypeSeq      # used for type generation
+    initProc*: BProc          ## code for init procedure
+    preInitProc*: BProc       ## code executed before the init proc
+    hcrCreateTypeInfosProc*: Rope ## type info globals are in here when HCR=on
+    inHcrInitGuard*: bool     ## We are currently within a HCR reloading guard.
+    typeStack*: TTypeSeq      ## used for type generation
     dataCache*: TNodeTable
-    typeNodes*, nimTypes*: int # used for type info generation
-    typeNodesName*, nimTypesName*: Rope # used for type info generation
-    labels*: Natural          # for generating unique module-scope names
-    extensionLoaders*: array['0'..'9', Rope] # special procs for the
-                                             # OpenGL wrapper
+    typeNodes*, nimTypes*: int ## used for type info generation
+    typeNodesName*, nimTypesName*: Rope ## used for type info generation
+    labels*: Natural          ## for generating unique module-scope names
+    extensionLoaders*: array['0'..'9', Rope] ## special procs for the
+                                             ## OpenGL wrapper
     sigConflicts*: CountTable[SigHash]
     g*: BModuleList
     ndi*: NdiFile

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# This is the JavaScript code generator.
+## This is the JavaScript code generator.
 
 discard """
 The JS code generator contains only 2 tricks:

--- a/compiler/backend/readme.rst
+++ b/compiler/backend/readme.rst
@@ -1,0 +1,1 @@
+Backend code generation for C, C++ and javascript targets

--- a/compiler/front/readme.rst
+++ b/compiler/front/readme.rst
@@ -1,0 +1,4 @@
+Frontend part of the compiler - configuration file reader, command-line
+option parser, `define()` configuration and error message formatting.
+All elements that allow user to either configure the compiler, or read
+compiler's output.

--- a/compiler/ic/bitabs.nim
+++ b/compiler/ic/bitabs.nim
@@ -7,8 +7,8 @@ type
   LitId* = distinct uint32
 
   BiTable*[T] = object
-    vals: seq[T] # indexed by LitId
-    keys: seq[LitId]  # indexed by hash(val)
+    vals: seq[T] ## indexed by LitId
+    keys: seq[LitId]  ## indexed by hash(val)
 
 proc nextTry(h, maxHash: Hash): Hash {.inline.} =
   result = (h + 1) and maxHash

--- a/compiler/modules/depends.nim
+++ b/compiler/modules/depends.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# This module implements a dependency file generator.
+## This module implements a dependency file generator.
 
 import
   ast/[

--- a/compiler/modules/readme.rst
+++ b/compiler/modules/readme.rst
@@ -1,0 +1,1 @@
+Module handling - import, project module graph, module paths, packages.

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -26,10 +26,10 @@ import
 type
   TemplCtx = object
     owner, genSymOwner: PSym
-    instLines: bool   # use the instantiation lines numbers
+    instLines: bool   ## use the instantiation lines numbers
     isDeclarative: bool
-    mapping: TIdTable # every gensym'ed symbol needs to be mapped to some
-                      # new symbol
+    mapping: TIdTable ## every gensym'ed symbol needs to be mapped to some
+                      ## new symbol
     config: ConfigRef
     ic: IdentCache
     instID: int

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# This file implements lambda lifting for the transformator.
+## This file implements lambda lifting for the transformator.
 
 import
   std/[

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# This module implements lookup helpers.
+## This module implements lookup helpers.
 
 import
   std/[
@@ -43,9 +43,9 @@ proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope)
 
 type
   PIdentResult* = tuple
-    ident: PIdent      # found ident, otherwise `IdentCache.notFoundIdent`
-    errNode: PNode     # if ident is notFoundIdent, node where error occurred
-                       # use with original PNode for better error reporting
+    ident: PIdent      ## found ident, otherwise `IdentCache.notFoundIdent`
+    errNode: PNode     ## if ident is notFoundIdent, node where error occurred
+                       ## use with original PNode for better error reporting
 
 proc noidentError2(conf: ConfigRef; n, origin: PNode): PNode =
   ## generate an error node when no ident was found in `n`, with `origin` being

--- a/compiler/sem/lowerings.nim
+++ b/compiler/sem/lowerings.nim
@@ -10,7 +10,7 @@
 ## This module implements common simple lowerings.
 
 const
-  genPrefix* = ":tmp"         # prefix for generated names
+  genPrefix* = ":tmp"         ## prefix for generated names
 
 import
   ast/[

--- a/compiler/sem/parampatterns.nim
+++ b/compiler/sem/parampatterns.nim
@@ -31,14 +31,14 @@ import
 # stack based VM :-) Why? Because it's fun; I did no benchmarks to see if that
 # actually improves performance.
 type
-  TAliasRequest* = enum # first byte of the bytecode determines alias checking
-    aqNone = 1,         # no alias analysis requested
-    aqShouldAlias,      # with some other param
-    aqNoAlias           # request noalias
+  TAliasRequest* = enum ## first byte of the bytecode determines alias checking
+    aqNone = 1,         ## no alias analysis requested
+    aqShouldAlias,      ## with some other param
+    aqNoAlias           ## request noalias
   TOpcode = enum
-    ppEof = 1, # end of compiled pattern
-    ppOr,      # we could short-cut the evaluation for 'and' and 'or',
-    ppAnd,     # but currently we don't
+    ppEof = 1, ## end of compiled pattern
+    ppOr,      ## we could short-cut the evaluation for 'and' and 'or',
+    ppAnd,     ## but currently we don't
     ppNot,
     ppSym,
     ppAtom,
@@ -197,13 +197,13 @@ proc checkForSideEffects*(n: PNode): TSideEffectAnalysis =
 
 type
   TAssignableResult* = enum
-    arNone,                   # no l-value and no discriminant
-    arLValue,                 # is an l-value
-    arLocalLValue,            # is an l-value, but local var; must not escape
-                              # its stack frame!
-    arDiscriminant,           # is a discriminant
-    arLentValue,              # lent value
-    arStrange                 # it is a strange beast like 'typedesc[var T]'
+    arNone,                   ## no l-value and no discriminant
+    arLValue,                 ## is an l-value
+    arLocalLValue,            ## is an l-value, but local var; must not escape
+                              ## its stack frame!
+    arDiscriminant,           ## is a discriminant
+    arLentValue,              ## lent value
+    arStrange                 ## it is a strange beast like 'typedesc[var T]'
 
 proc exprRoot*(n: PNode): PSym =
   var it = n

--- a/compiler/sem/passes.nim
+++ b/compiler/sem/passes.nim
@@ -35,23 +35,25 @@ import
 type
   TPassData* = tuple[input: PNode, closeOutput: PNode]
 
-# a pass is a tuple of procedure vars ``TPass.close`` may produce additional
-# nodes. These are passed to the other close procedures.
-# This mechanism used to be used for the instantiation of generics.
 
 proc makePass*(open: TPassOpen = nil,
                process: TPassProcess = nil,
                close: TPassClose = nil,
                isFrontend = false): TPass =
+
+  ## a pass is a tuple of procedure vars ``TPass.close`` may produce additional
+  ## nodes. These are passed to the other close procedures.
+  ## This mechanism used to be used for the instantiation of generics.
+
   result.open = open
   result.close = close
   result.process = process
   result.isFrontend = isFrontend
 
 proc skipCodegen*(config: ConfigRef; n: PNode): bool {.inline.} =
-  # can be used by codegen passes to determine whether they should do
-  # something with `n`. Currently, this ignores `n` and uses the global
-  # error count instead.
+  ## can be used by codegen passes to determine whether they should do
+  ## something with `n`. Currently, this ignores `n` and uses the global
+  ## error count instead.
   result = config.errorCounter > 0
 
 const

--- a/compiler/sem/procfind.nim
+++ b/compiler/sem/procfind.nim
@@ -7,8 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
-# This module implements the searching for procs and iterators.
-# This is needed for proper handling of forward declarations.
+## This module implements the searching for procs and iterators.
+## This is needed for proper handling of forward declarations.
 
 import
   ast/[

--- a/compiler/sem/readme.rst
+++ b/compiler/sem/readme.rst
@@ -1,0 +1,2 @@
+Semantic analysis part of the compiler - macro and template evaluation,
+call overload resolution, descructor injection and more.

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -8,7 +8,7 @@
 #
 
 ## This module implements semantic checking for calls.
-# included from sem.nim
+## included from sem.nim
 
 
 proc sameMethodDispatcher(a, b: PSym): bool =
@@ -679,10 +679,10 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
     result = explicitGenericInstError(c, n)
 
 proc searchForBorrowProc(c: PContext, startScope: PScope, fn: PSym): PSym =
-  # Searches for the fn in the symbol table. If the parameter lists are suitable
-  # for borrowing the sym in the symbol table is returned, else nil.
-  # New approach: generate fn(x, y, z) where x, y, z have the proper types
-  # and use the overloading resolution mechanism:
+  ## Searches for the fn in the symbol table. If the parameter lists are suitable
+  ## for borrowing the sym in the symbol table is returned, else nil.
+  ## New approach: generate fn(x, y, z) where x, y, z have the proper types
+  ## and use the overloading resolution mechanism:
   var call = newNodeI(nkCall, fn.info)
   var hasDistinct = false
   call.add(newIdentNode(fn.name, fn.info))

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -45,25 +45,25 @@ import
 export TExprFlag, TExprFlags
 
 type
-  TOptionEntry* = object      # entries to put on a stack for pragma parsing
+  TOptionEntry* = object      ## entries to put on a stack for pragma parsing
     options*: TOptions
     defaultCC*: TCallingConvention
     dynlib*: PLib
     notes*: ReportKinds
     features*: set[Feature]
-    otherPragmas*: PNode      # every pragma can be pushed
+    otherPragmas*: PNode      ## every pragma can be pushed
     warningAsErrors*: ReportKinds
 
   POptionEntry* = ref TOptionEntry
   PProcCon* = ref TProcCon
-  TProcCon* {.acyclic.} = object # procedure context; also used for top-level
-                                 # statements
-    owner*: PSym              # the symbol this context belongs to
-    resultSym*: PSym          # the result symbol (if we are in a proc)
-    selfSym*: PSym            # the 'self' symbol (if available)
-    nestedLoopCounter*: int   # whether we are in a loop or not
-    nestedBlockCounter*: int  # whether we are in a block or not
-    next*: PProcCon           # used for stacking procedure contexts
+  TProcCon* {.acyclic.} = object ## procedure context; also used for top-level
+                                 ## statements
+    owner*: PSym              ## the symbol this context belongs to
+    resultSym*: PSym          ## the result symbol (if we are in a proc)
+    selfSym*: PSym            ## the 'self' symbol (if available)
+    nestedLoopCounter*: int   ## whether we are in a loop or not
+    nestedBlockCounter*: int  ## whether we are in a block or not
+    next*: PProcCon           ## used for stacking procedure contexts
     mappingExists*: bool
     mapping*: TIdTable
     caseContext*: seq[tuple[n: PNode, idx: int]]
@@ -91,39 +91,39 @@ type
       exceptSet*: IntSet         # of PIdent.id
 
   PContext* = ref TContext
-  TContext* = object of TPassContext # a context represents the module
-                                     # that is currently being compiled
+  TContext* = object of TPassContext ## a context represents the module
+                                     ## that is currently being compiled
     enforceVoidContext*: PType
-      # for `if cond: stmt else: foo`, `foo` will be evaluated under
-      # enforceVoidContext != nil
+      ## for `if cond: stmt else: foo`, `foo` will be evaluated under
+      ## enforceVoidContext != nil
     voidType*: PType # for typeof(stmt)
-    module*: PSym              # the module sym belonging to the context
-    currentScope*: PScope      # current scope
-    moduleScope*: PScope       # scope for modules
-    imports*: seq[ImportedModule] # scope for all imported symbols
-    topLevelScope*: PScope     # scope for all top-level symbols
-    p*: PProcCon               # procedure context
-    intTypeCache*: array[-5..32, PType] # cache some common integer types
-                                        # to avoid type allocations
+    module*: PSym              ## the module sym belonging to the context
+    currentScope*: PScope      ## current scope
+    moduleScope*: PScope       ## scope for modules
+    imports*: seq[ImportedModule] ## scope for all imported symbols
+    topLevelScope*: PScope     ## scope for all top-level symbols
+    p*: PProcCon               ## procedure context
+    intTypeCache*: array[-5..32, PType] ## cache some common integer types
+                                        ## to avoid type allocations
     nilTypeCache*: PType
-    matchedConcept*: ptr TMatchedConcept # the current concept being matched
-    friendModules*: seq[PSym]  # friend modules; may access private data;
-                               # this is used so that generic instantiations
-                               # can access private object fields
-    instCounter*: int          # to prevent endless instantiations
-    templInstCounter*: ref int # gives every template instantiation a unique id
-    inGenericContext*: int     # > 0 if we are in a generic type
-    inStaticContext*: int      # > 0 if we are inside a static: block
-    inUnrolledContext*: int    # > 0 if we are unrolling a loop
-    compilesContextId*: int    # > 0 if we are in a ``compiles`` magic
+    matchedConcept*: ptr TMatchedConcept ## the current concept being matched
+    friendModules*: seq[PSym]  ## friend modules; may access private data;
+                               ## this is used so that generic instantiations
+                               ## can access private object fields
+    instCounter*: int          ## to prevent endless instantiations
+    templInstCounter*: ref int ## gives every template instantiation a unique id
+    inGenericContext*: int     ## > 0 if we are in a generic type
+    inStaticContext*: int      ## > 0 if we are inside a static: block
+    inUnrolledContext*: int    ## > 0 if we are unrolling a loop
+    compilesContextId*: int    ## > 0 if we are in a ``compiles`` magic
     compilesContextIdGenerator*: int
-    inGenericInst*: int        # > 0 if we are instantiating a generic
+    inGenericInst*: int        ## > 0 if we are instantiating a generic
     converters*: seq[PSym]
-    patterns*: seq[PSym]       # sequence of pattern matchers
+    patterns*: seq[PSym]       ## sequence of pattern matchers
     optionStack*: seq[POptionEntry]
-    symMapping*: TIdTable      # every gensym'ed symbol needs to be mapped
-                               # to some new symbol in a generic instantiation
-    libs*: seq[PLib]           # all libs used by this module
+    symMapping*: TIdTable      ## every gensym'ed symbol needs to be mapped
+                               ## to some new symbol in a generic instantiation
+    libs*: seq[PLib]           ## all libs used by this module
     semConstExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # for the pragmas
     semExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
     semTryExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
@@ -139,16 +139,16 @@ type
     semInferredLambda*: proc(c: PContext, pt: TIdTable, n: PNode): PNode
     semGenerateInstance*: proc (c: PContext, fn: PSym, pt: TIdTable,
                                 info: TLineInfo): PSym
-    includedFiles*: IntSet    # used to detect recursive include files
-    pureEnumFields*: TStrTable   # pure enum fields that can be used unambiguously
+    includedFiles*: IntSet    ## used to detect recursive include files
+    pureEnumFields*: TStrTable   ## pure enum fields that can be used unambiguously
     userPragmas*: TStrTable
     evalContext*: PEvalContext
-    unknownIdents*: IntSet     # ids of all unknown identifiers to prevent
-                               # naming it multiple times
-    generics*: seq[TInstantiationPair] # pending list of instantiated generics to compile
-    topStmts*: int # counts the number of encountered top level statements
-    lastGenericIdx*: int      # used for the generics stack
-    hloLoopDetector*: int     # used to prevent endless loops in the HLO
+    unknownIdents*: IntSet     ## ids of all unknown identifiers to prevent
+                               ## naming it multiple times
+    generics*: seq[TInstantiationPair] ## pending list of instantiated generics to compile
+    topStmts*: int ## counts the number of encountered top level statements
+    lastGenericIdx*: int      ## used for the generics stack
+    hloLoopDetector*: int     ## used to prevent endless loops in the HLO
     inParallelStmt*: int
     instTypeBoundOp*: proc (c: PContext; dc: PSym; t: PType; info: TLineInfo;
                             op: TTypeAttachedOp; col: int): PSym {.nimcall.}
@@ -162,10 +162,10 @@ type
     features*: set[Feature]
     inTypeContext*, inConceptDecl*: int
     unusedImports*: seq[(PSym, TLineInfo)]
-    exportIndirections*: HashSet[(int, int)] # (module.id, symbol.id)
-    importModuleMap*: Table[int, int] # (module.id, module.id)
+    exportIndirections*: HashSet[(int, int)] ## (module.id, symbol.id)
+    importModuleMap*: Table[int, int] ## (module.id, module.id)
     lastTLineInfo*: TLineInfo
-    sideEffects*: Table[int, seq[(TLineInfo, PSym)]] # symbol.id index
+    sideEffects*: Table[int, seq[(TLineInfo, PSym)]] ## symbol.id index
     inUncheckedAssignSection*: int
 
 template config*(c: PContext): ConfigRef = c.graph.config
@@ -233,10 +233,10 @@ proc scopeDepth*(c: PContext): int {.inline.} =
            else: 0
 
 proc getCurrOwner*(c: PContext): PSym =
-  # owner stack (used for initializing the
-  # owner field of syms)
-  # the documentation comment always gets
-  # assigned to the current owner
+  ## owner stack (used for initializing the
+  ## owner field of syms)
+  ## the documentation comment always gets
+  ## assigned to the current owner
   result = c.graph.owners[^1]
 
 proc pushOwner*(c: PContext; owner: PSym) =

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -7,8 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
-# this module does the semantic checking for expressions
-# included from sem.nim
+## this module does the semantic checking for expressions
+## included from sem.nim
 
 when defined(nimCompilerStacktraceHints):
   import std/stackframes

--- a/compiler/sem/semfields.nim
+++ b/compiler/sem/semfields.nim
@@ -8,7 +8,7 @@
 #
 
 ## This module does the semantic transformation of the fields* iterators.
-#  included from semstmts.nim
+##  included from semstmts.nim
 
 type
   TFieldInstCtx = object  # either 'tup[i]' or 'field' is valid

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -7,15 +7,15 @@
 #    distribution, for details about the copyright.
 #
 
-# This implements the first pass over the generic body; it resolves some
-# symbols. Thus for generics there is a two-phase symbol lookup just like
-# in C++.
-# A problem is that it cannot be detected if the symbol is introduced
-# as in ``var x = ...`` or used because macros/templates can hide this!
-# So we have to eval templates/macros right here so that symbol
-# lookup can be accurate.
+## This implements the first pass over the generic body; it resolves some
+## symbols. Thus for generics there is a two-phase symbol lookup just like
+## in C++.
+## A problem is that it cannot be detected if the symbol is introduced
+## as in ``var x = ...`` or used because macros/templates can hide this!
+## So we have to eval templates/macros right here so that symbol
+## lookup can be accurate.
 
-# included from sem.nim
+## included from sem.nim
 
 proc getIdentNode(c: PContext; n: PNode): PNode =
   case n.kind

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -7,8 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
-# This module implements the instantiation of generic procs.
-# included from sem.nim
+## This module implements the instantiation of generic procs.
+## included from sem.nim
 
 proc addObjFieldsToLocalScope(c: PContext; n: PNode) =
   template rec(n) = addObjFieldsToLocalScope(c, n)
@@ -241,11 +241,11 @@ proc referencesAnotherParam(n: PNode, p: PSym): bool =
 
 proc instantiateProcType(c: PContext, pt: TIdTable,
                          prc: PSym, info: TLineInfo) =
-  # XXX: Instantiates a generic proc signature, while at the same
-  # time adding the instantiated proc params into the current scope.
-  # This is necessary, because the instantiation process may refer to
-  # these params in situations like this:
-  # proc foo[Container](a: Container, b: a.type.Item): typeof(b.x)
+  ## Instantiates a generic proc signature, while at the same
+  ## time adding the instantiated proc params into the current scope.
+  ## This is necessary, because the instantiation process may refer to
+  ## these params in situations like this:
+  ## `proc foo[Container](a: Container, b: a.type.Item): typeof(b.x)`
   #
   # Alas, doing this here is probably not enough, because another
   # proc signature could appear in the params:

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -13,24 +13,24 @@
 ## * The return nil pattern leads to a lot of boilerplate, most of this is for
 ##   `PNode`s which can be converted to use nkEmpty and/or optional.
 
-# included from sem.nim
+## included from sem.nim
 
 type
   ObjConstrContext = object
-    typ: PType               # The constructed type
-    initExpr: PNode          # The init expression (nkObjConstr)
-    needsFullInit: bool      # A `requiresInit` derived type will
-                             # set this to true while visiting
-                             # parent types.
-    missingFields: seq[PSym] # Fields that the user failed to specify
+    typ: PType               ## The constructed type
+    initExpr: PNode          ## The init expression (nkObjConstr)
+    needsFullInit: bool      ## A `requiresInit` derived type will
+                             ## set this to true while visiting
+                             ## parent types.
+    missingFields: seq[PSym] ## Fields that the user failed to specify
 
-  InitStatus = enum # This indicates the result of object construction
+  InitStatus = enum ## This indicates the result of object construction
     initUnknown
-    initFull     # All  of the fields have been initialized
-    initPartial  # Some of the fields have been initialized
-    initNone     # None of the fields have been initialized
-    initConflict # Fields from different branches have been initialized
-    initError    # Some or all fields had errors during initialization
+    initFull     ## All  of the fields have been initialized
+    initPartial  ## Some of the fields have been initialized
+    initNone     ## None of the fields have been initialized
+    initConflict ## Fields from different branches have been initialized
+    initError    ## Some or all fields had errors during initialization
 
 proc mergeInitStatus(existing: var InitStatus, newStatus: InitStatus) =
   case newStatus

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -52,25 +52,28 @@ when defined(useDfa):
 import liftdestructors
 include sinkparameter_inference
 
-#[ Second semantic checking pass over the AST. Necessary because the old
-   way had some inherent problems. Performs:
+##[
 
-* effect+exception tracking
-* "usage before definition" checking
-* also now calls the "lift destructor logic" at strategic positions, this
+Second semantic checking pass over the AST. Necessary because the old
+way had some inherent problems. Performs:
+
+- effect+exception tracking
+- "usage before definition" checking
+- also now calls the "lift destructor logic" at strategic positions, this
   is about to be put into the spec:
 
 We treat assignment and sinks and destruction as identical.
 
-In the construct let/var x = expr() x's type is marked.
+In the construct `let/var x = expr()` x's type is marked.
 
-In x = y the type of x is marked.
+In `x = y` the type of `x` is marked.
 
-For every sink parameter of type T T is marked.
+For every sink parameter of type `T T` is marked.
 
-For every call f() the return type of f() is marked.
+For every call `f()` the return type of `f()` is marked.
 
-]#
+
+]##
 
 # ------------------------ exception and tag tracking -------------------------
 
@@ -95,14 +98,14 @@ discard """
 
 type
   TEffects = object
-    exc: PNode  # stack of exceptions
-    tags: PNode # list of tags
+    exc: PNode  ## stack of exceptions
+    tags: PNode ## list of tags
     bottom, inTryStmt, inExceptOrFinallyStmt, leftPartOfAsgn: int
     owner: PSym
     ownerModule: PSym
-    init: seq[int] # list of initialized variables
-    guards: TModel # nested guards
-    locked: seq[PNode] # locked locations
+    init: seq[int] ## list of initialized variables
+    guards: TModel ## nested guards
+    locked: seq[PNode] ## locked locations
     gcUnsafe, isRecursive, isTopLevel, hasSideEffect, inEnforcedGcSafe: bool
     hasDangerousAssign, isInnerProc: bool
     inEnforcedNoSideEffects: bool

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -8,7 +8,7 @@
 #
 
 ## this module does the semantic checking of statements
-#  included from sem.nim
+##  included from sem.nim
 
 proc semDiscard(c: PContext, n: PNode): PNode =
   result = n

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -7,8 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
-# this module does the semantic checking of type declarations
-# included from sem.nim
+## this module does the semantic checking of type declarations
+## included from sem.nim
 
 proc newOrPrevType(kind: TTypeKind, prev: PType, c: PContext): PType =
   if prev == nil:

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-# This module does the instantiation of generic types.
+## This module does the instantiation of generic types.
 
 import
   std/[

--- a/compiler/sem/spawn.nim
+++ b/compiler/sem/spawn.nim
@@ -44,9 +44,9 @@ type
   TSpawnResult* = enum
     srVoid, srFlowVar, srByVar
   TFlowVarKind = enum
-    fvInvalid # invalid type T for 'FlowVar[T]'
-    fvGC      # FlowVar of a GC'ed type
-    fvBlob    # FlowVar of a blob type
+    fvInvalid ## invalid type T for 'FlowVar[T]'
+    fvGC      ## FlowVar of a GC'ed type
+    fvBlob    ## FlowVar of a blob type
 
 proc spawnResult*(t: PType; inParallel: bool): TSpawnResult =
   if t.isEmptyType: srVoid

--- a/compiler/utils/readme.rst
+++ b/compiler/utils/readme.rst
@@ -1,0 +1,2 @@
+Miscelaneous helper modules used in different parts of the compiler - 128-bit
+integers, ropes, path handling etc.

--- a/compiler/vm/readme.rst
+++ b/compiler/vm/readme.rst
@@ -1,0 +1,2 @@
+Built-in VM evaluation. This directory contains modules that implement
+VM that runs code at compile-time and for nimscript targets.


### PR DESCRIPTION
Reformat comments to use double hash (to make them visible in
documentation), add readme.rst in compiler subsystem directories.

Mostly closes https://github.com/nim-works/nimskull/issues/180 although
there might be some bits and pieces that can be formatted better.
