### PR TITLE
Fixed PrintRopeStats

### DIFF
--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -223,6 +223,9 @@ proc commandView(graph: ModuleGraph) =
 const
   PrintRopeCacheStats = false
 
+when PrintRopeCacheStats:
+  import utils/ropes
+
 proc hashMainCompilationParams*(conf: ConfigRef): string =
   ## doesn't have to be complete; worst case is a cache hit and recompilation.
   var state = newSha1State()


### PR DESCRIPTION
PrintRopeCacheStats is declared as a const false,
that acted as a guardian to a when block that references undeclared variables.
As such, setting it to true crashes the compiler.
Importing ropes.nim fixes the issue.
