### PR TITLE
debug: refactor debugutils tracer templates

### DIFF
--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -1,3 +1,9 @@
+.. include:: rstcommon.rst
+
+========================
+Compiler debugging guide
+========================
+
 .. raw:: html
   <blockquote><p>
   The process of identifying and removing errors from computer hardware or software.


### PR DESCRIPTION
- REFACTOR implementation of the debug tracer templates from `debugutils`.
  Add generalized template that allows modifiying remaining bits that are
  needed to produce full debug step information.
- FIX debug trace segfault/out-of-bounds error for `--stacktrace=off`. This
  commit closes https://github.com/nim-works/nimskull/issues/194

