### PR TITLE
convert unittest.suite into a macro with structure

### DIFF
--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -27,13 +27,14 @@ import std/[unittest, sequtils]
 proc doThings(spuds: var int): int =
   spuds = 24
   return 99
+
 test "#964":
   var spuds = 0
   check doThings(spuds) == 99
   check spuds == 24
 
 
-from std/strutils import toUpperAscii
+from std/strutils import toUpperAscii, parseInt
 test "#1384":
   check(@["hello", "world"].map(toUpperAscii) == @["HELLO", "WORLD"])
 
@@ -50,7 +51,6 @@ test "unittest multiple requires":
 
 
 import std/random
-from std/strutils import parseInt
 proc defectiveRobot() =
   case rand(1..4)
   of 1: raise newException(OSError, "CANNOT COMPUTE!")

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -12,7 +12,7 @@ duplication (which always results in weaker test coverage in practice).
 ]#
 
 import std/unittest
-template test[T](a: T, expected: string) =
+template test(a, expected: untyped): untyped =
   check $a == expected
   var b = a
   check $b == expected


### PR DESCRIPTION
 * remove usage of macros.callsite()
 * add workaround for bug https://github.com/nim-works/nimskull/issues/193
 * add structural checks for unittest.suite
