### PR TITLE
debug: add debug(), debugAst() etc. to astrepr

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -20,7 +20,8 @@ import
     tables,
     intsets,
     json,
-    strtabs
+    strtabs,
+    os
   ],
   experimental/[
     colortext
@@ -95,33 +96,6 @@ func wrap*(
 func wrap(conf: ConfigRef, text: ColText): string =
   toString(text, conf.useColor())
 
-
-import std/[os]
-
-proc formatPath(conf: ConfigRef, path: string): string =
-  ## Format absolute path for reporting
-  if path in conf.m.filenameToIndexTbl:
-    # Check if path is registered in filename table index - in that case
-    # formatting is done using `FileInfo` data from the config.
-    let id = conf.m.filenameToIndexTbl[path]
-    result = toFilenameOption(conf, id, conf.filenameOption)
-
-  else:
-    # Path not registered in the filename table - most likely an
-    # instantiation info report location
-    when compileOption"excessiveStackTrace":
-      # instLoc(), when `--excessiveStackTrace` is used, generates full
-      # paths that /might/ need to be filtered if `--filenames:canonical`.
-      const compilerRoot = currentSourcePath().parentDir().parentDir()
-      if conf.filenameOption == foCanonical and
-         path.startsWith(compilerRoot):
-        result = path[(compilerRoot.len + 1) .. ^1]
-
-      else:
-        result = path
-
-    else:
-      result = path
 
 proc formatTrace*(conf: ConfigRef, trace: seq[StackTraceEntry]): string =
   ## Format stack trace entries for reporting

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -284,6 +284,38 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
     else:
       result = toFilenameOption(conf, fileIdx, foName)
 
+proc formatPath*(conf: ConfigRef, path: string): string =
+  ## Format absolute file path for error message reporting. If path is not
+  ## registered in the `filenameToIndexTbl` and is not a path to the
+  ## compiler source, return it unchanged. If configuration is nil also
+  ## return path unchanged.
+  if isNil(conf):
+    return path
+
+  if path in conf.m.filenameToIndexTbl:
+    # Check if path is registered in filename table index - in that case
+    # formatting is done using `FileInfo` data from the config.
+    let id = conf.m.filenameToIndexTbl[path]
+    result = toFilenameOption(conf, id, conf.filenameOption)
+
+  else:
+    # Path not registered in the filename table - most likely an
+    # instantiation info report location
+    when compileOption"excessiveStackTrace":
+      # instLoc(), when `--excessiveStackTrace` is used, generates full
+      # paths that /might/ need to be filtered if `--filenames:canonical`.
+      const compilerRoot = currentSourcePath().parentDir().parentDir()
+      if conf.filenameOption == foCanonical and
+         path.startsWith(compilerRoot):
+        result = path[(compilerRoot.len + 1) .. ^1]
+
+      else:
+        result = path
+
+    else:
+      result = path
+
+
 proc toMsgFilename*(conf: ConfigRef; fileIdx: FileIndex): string =
   toFilenameOption(conf, fileIdx, conf.filenameOption)
 

--- a/lib/experimental/colortext.nim
+++ b/lib/experimental/colortext.nim
@@ -714,7 +714,8 @@ template coloredResult*(indentationStep: int = 2): untyped =
 
   template add(arg: untyped): untyped {.used.} = outPtr[].add arg
   template add(arg1, arg2: untyped): untyped {.used.} =
-    outPtr[].add(arg1, arg2)
+    outPtr[].add(arg1)
+    outPtr[].add(arg2)
 
   template addIndent(level: int, sep: int = indentationStep): untyped {.used.} =
     outPtr[].addIndent(level, sep)


### PR DESCRIPTION
Closes https://github.com/nim-works/nimskull/issues/203 - adds missing
debug procedures to the `astrepr` module, returning the old API for
debugging.
