### PR TITLE
tgetprotobyname: remove "ip" test query

### DIFF
--- a/tests/stdlib/tgetprotobyname.nim
+++ b/tests/stdlib/tgetprotobyname.nim
@@ -1,9 +1,5 @@
 import nativesockets
 
-when not defined(netbsd):
-  # Ref: https://github.com/nim-lang/Nim/issues/15452 - NetBSD doesn't define an `ip` protocol
-  doAssert getProtoByName("ip") == 0
-
 doAssert getProtoByName("ipv6") == 41
 doAssert getProtoByName("tcp") == 6
 doAssert getProtoByName("udp") == 17


### PR DESCRIPTION
getProtoByName aparently fails on NetBSD. It also fails on my Arch
machine and my Manjaro machine. Removing this test is probably a good
idea.
