### PR TITLE
`genDepend` improvements

### DIFF
--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -75,8 +75,9 @@ proc writeDepsFile(g: ModuleGraph) =
   f.close()
 
 proc commandGenDepend(graph: ModuleGraph) =
+  registerPass(graph, genDependPreSemPass)
   semanticPasses(graph)
-  registerPass(graph, gendependPass)
+  registerPass(graph, genDependPostSemPass)
   compileProject(graph)
   let project = graph.config.projectFull
   writeDepsFile(graph)

--- a/compiler/modules/depends.nim
+++ b/compiler/modules/depends.nim
@@ -11,22 +11,38 @@
 
 import
   ast/[
-    ast
+    ast,
+    lineinfos,
+    renderer
   ],
   modules/[
     modulepaths,
     modulegraphs
   ],
   front/[
-    options
+    options,
+    msgs
   ],
   utils/[
     ropes,
-    pathutils
+    pathutils,
+    astrepr
   ],
   sem/[
     passes
+  ],
+  std/[
+    tables,
+    sets,
+    hashes,
+    sequtils,
+    strutils
   ]
+
+import std/options as std_options
+
+func hash(ps: PSym): Hash =
+  hash(ps.itemId.module) !& hash(ps.itemId.item)
 
 type
   TGen = object of PPassContext
@@ -35,47 +51,253 @@ type
     graph: ModuleGraph
   PGen = ref TGen
 
-  Backend = ref object of RootRef
+  DependData = ref object of RootRef
+    maybeImports, maybeIncludes: Table[FileIndex, seq[
+      tuple[context: seq[PNode], target: PNode]]]
+
+    foundImports: Table[PSym, seq[PSym]]
+
     dotGraph: Rope
 
-proc addDependencyAux(b: Backend; importing, imported: string) =
+proc addDependencyAux(b: DependData; importing, imported: string) =
   b.dotGraph.addf("\"$1\" -> \"$2\";$n", [rope(importing), rope(imported)])
-  # s1 -> s2_4[label="[0-9]"];
 
-proc addDotDependency(c: PPassContext, n: PNode): PNode =
+proc genDependOpenPreSem(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext {.nosinks.} =
+  discard
+
+proc addPreSemDotDependency(c: PPassContext, n: PNode): PNode =
   result = n
   let g = PGen(c)
-  let b = Backend(g.graph.backend)
-  case n.kind
-  of nkImportStmt:
-    for i in 0..<n.len:
-      var imported = getModuleName(g.config, n[i])
-      addDependencyAux(b, g.module.name.s, imported)
-  of nkFromStmt, nkImportExceptStmt:
-    var imported = getModuleName(g.config, n[0])
-    addDependencyAux(b, g.module.name.s, imported)
-  of nkStmtList, nkBlockStmt, nkStmtListExpr, nkBlockExpr:
-    for i in 0..<n.len: discard addDotDependency(c, n[i])
-  else:
-    discard
+  let b = DependData(g.graph.backend)
+
+  var context: seq[PNode]
+
+  let file = n.info.fileIndex
+
+  proc addImport(n: PNode) =
+    b.maybeImports.mgetOrPut(file, @[]).add (context, n)
+
+  proc addInclude(n: PNode) =
+    b.maybeIncludes.mgetOrPut(file, @[]).add (context, n)
+
+
+  proc aux(n: PNode) =
+    case n.kind:
+      of nkImportStmt:
+        let file = n.info.fileIndex
+        for sub in n:
+          addImport(sub)
+
+      of nkFromStmt, nkImportExceptStmt:
+        addImport(n[0])
+
+      of nkIncludeStmt:
+        for sub in n:
+          addInclude(sub)
+
+      of nkStmtList, nkBlockStmt, nkStmtListExpr, nkBlockExpr:
+        for sub in n:
+          aux(sub)
+
+      of nkWhenStmt:
+        for branch in n:
+          if branch.kind == nkElse:
+            aux(branch[0])
+
+          else:
+            context.add branch[0].copyTree()
+            aux(branch[1])
+            discard context.pop
+
+      else:
+        discard
+
+  aux(n)
+
+proc addPostSemDotDependency(c: PPassContext, n: PNode): PNode =
+  result = n
+  let g = PGen(c)
+  let b = DependData(g.graph.backend)
+  case n.kind:
+    of nkImportStmt:
+      for target in n:
+        b.foundImports.mgetOrPut(g.module, @[]).add target.sym
+
+    of nkFromStmt, nkImportExceptStmt:
+      b.foundImports.mgetOrPut(g.module, @[]).add n[0].sym
+
+    of nkStmtList, nkBlockStmt, nkStmtListExpr, nkBlockExpr:
+      for target in n:
+        discard addPostSemDotDependency(c, target)
+
+    else:
+      discard
+
+proc targetIndex(conf: ConfigRef, source: FileIndex, target: PNode): Option[FileIndex] =
+  let modulename = getModuleName(conf, target)
+  let sourceFull = toFullPath(conf, source)
+  let fullPath = findModule(conf, modulename, sourceFull)
+  if not fullPath.isEmpty():
+    result = some fileInfoIdx(conf, fullPath)
+
+  # else:
+  #   echo sourceFull, " cannot import "
+  #   debug target
+
+
+
+func quoteGraphviz*(str: string): string =
+  result.add '"'
+  for idx, ch in pairs(str):
+    if ch in {'\'', '"'}:
+
+      result.add "\\"
+
+    elif ch in {'\\'} and (
+      # Do not escape `\l` and `\r`
+      idx < str.high and str[idx + 1] notin {'l', 'r'}):
+
+      result.add "\\"
+
+    result.add ch
+
+  result.add '"'
 
 proc generateDot*(graph: ModuleGraph; project: AbsoluteFile) =
-  let b = Backend(graph.backend)
-  discard writeRope("digraph $1 {$n$2}$n" % [
-      rope(project.splitFile.name), b.dotGraph],
-            changeFileExt(project, "dot"))
+  let b = DependData(graph.backend)
 
-when not defined(nimHasSinkInference):
-  {.pragma: nosinks.}
+  var confirmedImports: Table[(FileIndex, FileIndex), TLineInfo]
 
-proc myOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext {.nosinks.} =
+  let conf = graph.config
+  for sym, imports in b.foundImports:
+    let s = sym.info.fileIndex
+    for target in imports:
+      let t = target.info.fileIndex
+      if s != t:
+        # HACK why do we get cyclic imports everywhere?
+        confirmedImports[(s, t)] = target.info
+
+
+  var possibleImports: Table[(FileIndex, FileIndex), (seq[PNode], TLineInfo)]
+  var notFoundImports: seq[(FileIndex, PNode, seq[PNode])]
+
+  for source, imports in b.maybeImports:
+    for (context, target) in imports:
+      let idx = conf.targetIndex(source, target)
+      if idx.isNone():
+        notFoundImports.add((source, target, context))
+
+      elif (source, idx.get()) in confirmedImports:
+        discard
+
+      else:
+        possibleImports[(source, idx.get())] = (context, target.info)
+
+  var possibleIncludes: Table[(FileIndex, FileIndex), (seq[PNode], TLineInfo)]
+  var notFoundIncludes: seq[(FileIndex, PNode, seq[PNode])]
+
+  for source, imports in b.maybeIncludes:
+    for (context, target) in imports:
+      let idx = conf.targetIndex(source, target)
+      if idx.isNone():
+        notFoundIncludes.add((source, target, context))
+
+      else:
+        possibleIncludes[(source, idx.get())] = (context, target.info)
+
+  proc file(idx: FileIndex): string =
+    toFilenameOption(conf, idx, foCanonical)
+
+  proc getNode(idx: FileIndex): string =
+    "_" & $idx.int
+
+  var res = """
+digraph main {
+  rankdir=LR;
+  node[shape=rect, fontname=Consolas];
+  edge[fontname=Consolas];
+"""
+
+  var seen: HashSet[FileIndex]
+  proc declNode(idx: FileIndex) =
+    if idx notin seen:
+      res.addf(
+        "  $#[label=\"$#\"];\n",
+        idx.getNode(),
+        idx.file()
+      )
+
+  for pair, _ in possibleIncludes:
+    declNode(pair[0])
+    declNode(pair[1])
+
+  for pair, _ in possibleImports:
+    declNode(pair[0])
+    declNode(pair[1])
+
+  for (ffrom, fto) in confirmedImports.keys:
+    declNode(ffrom)
+    declNode(fto)
+
+  var tempNode = 0
+  proc condInclude(
+      pair: (FileIndex, FileIndex),
+      context: (seq[PNode], TLineInfo),
+      label: string
+    ) =
+
+    var text = label & " in $#:$#" % [$context[1].line, $context[1].col]
+
+    if 0 < context[0].len:
+      text.add " if ("
+      text.add mapIt(context[0], $it).join(" and ")
+      text.add ")"
+
+    res.addf("""
+  $1[label=$2, shape=plain];
+  $3:e -> $1:w[style=dashed, arrowhead=none];
+  $1:e -> $4:w[style=dashed];
+""",
+      $tempNode,
+      quoteGraphviz(text),
+      pair[0].getNode(),
+      pair[1].getNode(),
+    )
+
+    inc tempNode
+
+
+  for pair, context in possibleImports:
+    condInclude(pair, context, "import")
+
+  for pair, context in possibleIncludes:
+    condInclude(pair, context, "include")
+
+  for pair, info in confirmedImports:
+    condInclude(pair, (@[], info), "import")
+
+
+  res.add "}"
+
+
+  changeFileExt(project, "dot").string.writeFile(res)
+
+proc genDependOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext =
   var g: PGen
   new(g)
   g.module = module
   g.config = graph.config
   g.graph = graph
   if graph.backend == nil:
-    graph.backend = Backend(dotGraph: nil)
+    graph.backend = DependData(dotGraph: nil)
   result = g
 
-const gendependPass* = makePass(open = myOpen, process = addDotDependency)
+const genDependPostSemPass* = makePass(
+  open = genDependOpen,
+  process = addPostSemDotDependency
+)
+
+const genDependPreSemPass* = makePass(
+  open = genDependOpen,
+  process = addPreSemDotDependency
+)

--- a/compiler/modules/modulepaths.nim
+++ b/compiler/modules/modulepaths.nim
@@ -171,7 +171,8 @@ proc getModuleName*(conf: ConfigRef; n: PNode): string =
     result = ""
 
 proc checkModuleName*(conf: ConfigRef; n: PNode; doLocalError=true): FileIndex =
-  # This returns the full canonical path for a given module import
+  ## Get file index from module path, otherwise report a 'cannot find'
+  ## error via report hook.
   let modulename = getModuleName(conf, n)
   let fullPath = findModule(conf, modulename, toFullPath(conf, n.info))
   if fullPath.isEmpty:

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -14,7 +14,7 @@ import
   ],
   experimental/colortext,
   std/[
-    sets,
+    tables,
     strutils,
     strformat,
   ]
@@ -28,6 +28,7 @@ type
     trfPackedFields
     trfSkipAuxError
     trfSymDefined
+    trfIndexVisisted
 
     trfShowSymFlags
     trfShowSymLineInfo
@@ -63,7 +64,8 @@ const treeReprAllFields* = { trfShowSymFlags .. trfShowNodeTypes }
 const defaultTreeReprFlags* = {
   trfPositionIndexed,
   trfReportInfo,
-  trfSkipAuxError
+  trfSkipAuxError,
+  trfIndexVisisted
 } + treeReprAllFields - {
   trfShowNodeLineInfo,
   trfShowSymLineInfo,
@@ -255,9 +257,9 @@ proc treeRepr*(
   coloredResult(1)
 
 
-  var visited: HashSet[int]
+  var visited: Table[int, int]
   var res = addr result
-
+  var nodecount = 0
   proc aux(n: PNode, idx: seq[int]) =
     var indent = indentIncrease
     genFields(res[], indent, flags)
@@ -297,17 +299,33 @@ proc treeRepr*(
       add "<nil>" + fgRed
       return
 
-    elif cast[int](n) in visited:
-      add " <visited>"
+    elif not (n.kind == nkEmpty and n.safeLen == 0) and
+         # empty nodes can be reused. Only check for visitation if it is
+         # not an empty (completely empty) node
+         cast[int](n) in visited:
+
+      if trfIndexVisisted in flags:
+        add "<visited>"
+
+      else:
+        add "<visited "
+        add substr($n.kind, 2) + fgCyan
+        add " at "
+        add $visited[cast[int](n)] + styleDim
+        add ">"
+
       return
 
     elif idx.len > maxDepth:
       add " ..."
       return
 
-    visited.incl cast[int](n)
-
+    visited[cast[int](n)] = nodecount
     add substr($n.kind, 2) + fgCyan
+    add " "
+    add $nodecount + styleDim
+
+    inc nodecount
 
     when defined(useNodeids):
       if trfShowNodeIds in flags:
@@ -316,13 +334,15 @@ proc treeRepr*(
 
     proc addComment(sep: bool = true) =
       if trfShowNodeComments in flags and n.comment.len > 0:
-        add "\n"
         var nl = false
         for line in split(n.comment.strip(leading = false), '\n'):
           if nl: add "\n"
           nl = true
 
-          addi indent, "  # " & line + fgCyan
+          addi indent, "  # " + termFg(4, 2, 1)
+          add line + termFg(4, 2, 1)
+
+        add "\n"
 
       elif sep:
         add " "
@@ -397,6 +417,7 @@ proc treeRepr*(
 
       of nkCommentStmt:
         addFlags()
+        add "\n"
         addComment()
 
       of nkError:
@@ -418,7 +439,7 @@ proc treeRepr*(
         discard
 
 
-    if n.kind notin nkNone .. nkNilLit:
+    if n.kind notin {nkNone .. nkNilLit, nkCommentStmt}:
       addFlags()
       if n.len > 0:
         add "\n"


### PR DESCRIPTION
- Track optional includes
- Generate more readable graph
- Generate graph in two stages - collecting data and then writing out it in
  an analyzed form.

before (empty file, show default processed modules)

![tfile](https://user-images.githubusercontent.com/20562256/151627587-51d55b82-10bf-42f7-9b9a-76bf55c46ae4.png)


after (same empty file, but also shows included files, modules that might've been included, with necessary conditions)

![tfile](https://user-images.githubusercontent.com/20562256/151627106-713d4d46-ea9d-4694-a886-4d261eaa9d9b.png)

todo

- [ ] allow tracking module starting from a specific file in the project instead of tracking every possible dependency
- [ ] Filter out most common least common nodes - make it possible to actually see the patterns in the graph, instead of unconditionally producing unmaintainable mess because `ast.nim` is imported literally **everywhere** - 
![image](https://user-images.githubusercontent.com/20562256/151629681-82bf87de-c4b4-48ca-9087-61af966469fe.png) does not help anyone to understand anything. Everyone imports 'reports' because everyone writes reports, I already know this, and I don't care about this, I want to get down to the other parts of the structure. Everyone has `utils` modules for common stuff. The compiler should actually consider the most common use cases here.
- [ ] output data in the structured manner - we can't predict every possible use case, nor should `genDepend` turn into an all-purpose, all-powerful code graphing tool. A set of sensible defaults and improved graph formatting + documented json output is a nice compromise. 
- [ ] Group nodes into directories based on the project structure - graphviz supports `subgraph cluster_XXX` - can be used in that case.
- [ ] Allow omitting the interdirectory dependencies. For example, you want to check what is going on inside the sem/ directory, but you don't care about intermodule dependencies outside this part, you just want to know if sem imports tables for example, or something similar. In that case, this 
![image](https://user-images.githubusercontent.com/20562256/151630018-a1322fe8-109c-47fc-b753-48e5d3abdc71.png) is most likely better than this 
![image](https://user-images.githubusercontent.com/20562256/151630038-0c6d0af8-fcb5-49f6-897b-a7d7bfed6c30.png) - latter version also would include the world of dependencies outside, but it is hardly necessary, I only care about the mess we have in `sem/*`, it is already bad enough
- [ ] Fix `-o` for `genDepend` - right now it is hardcoded to write to the same file as source project https://github.com/nim-works/nimskull/blob/829ffa1fb6a557bd7e65485383273bafcbde2378/compiler/front/main.nim#L84-L93
- [ ] Commit message
- [ ] Documentation for the use cases, examples, for trivial projects.
- [ ] Use html styling on edge labels
- [ ] Documentation on the implementation
- [ ] Writing dependencies with empty nimcache directory won't create the directory, failing the analysis
- [ ] Generate dependency graph with unique nodes. This would allow to use https://graphviz.org/docs/layouts/twopi/ to analyze the dependency layers. Maybe color-code nodes to make it easier to spot things.

