### PR TITLE
automatic support for backwards index

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -173,9 +173,6 @@ proc `[]`*(n: NimNode, i: int): NimNode {.magic: "NChild", noSideEffect.}
 proc `[]`*(n: NimNode, i: BackwardsIndex): NimNode = n[n.len - i.int]
   ## Get `n`'s `i`'th child.
 
-template `^^`(n: NimNode, i: untyped): untyped =
-  (when i is BackwardsIndex: n.len - int(i) else: int(i))
-
 proc `[]`*[T, U: Ordinal](n: NimNode, x: HSlice[T, U]): seq[NimNode] =
   ## Slice operation for NimNode.
   ## Returns a seq of child of `n` who inclusive range [n[x.a], n[x.b]].

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2542,8 +2542,40 @@ template spliceImpl(s, a, L, b: untyped): untyped =
   # fill the hole:
   for i in 0 ..< b.len: s[a+i] = b[i]
 
-template `^^`(s, i: untyped): untyped =
-  (when i is BackwardsIndex: s.len - int(i) else: int(i))
+template `^^`*(s: typed; i: BackwardsIndex): int =
+  ## General converter template to convert the Backwards index back to
+  ## a normal integer index. If your own type has a special conversion
+  ## from Backwards index to int, you can write your own overload,
+  ## otherwis it will be just default to this: `s.len - int(i)`.
+  ##
+  ## .. code-block:: nim
+  ##
+  ##   type
+  ##     MyType = object
+  ##
+  ##   template `^^`(a: MyType, b: BackwardsIndex): int =
+  ##     ## my conversion of `BackwardsIndex` for `MyType`
+  ##     1000 + int(b)
+  ##
+  ##   proc `[]`(arg: MyType; idx: int): int =
+  ##     idx
+  ##
+  ##   var mt: MyType
+  ##   echo mt[^1] # 1001
+  s.len - int(i)
+
+template `^^`*[Idx, T](a: array[Idx, T], i: BackwardsIndex): int =
+  ## Converter template specialized for the array type.
+  int(a.low) + a.len - int(i)
+
+template `^^`*[Idx, T](a: array[Idx, T], i: Idx): int =
+  ## Converter template specialized for the array type.
+  int(i)
+
+template `^^`*(s: typed; i: int): int =
+  ## No operation in case the index is not a backwards index. For
+  ## generic programming only.
+  i
 
 template `[]`*(s: string; i: int): char = arrGet(s, i)
 template `[]=`*(s: string; i: int; val: char) = arrPut(s, i, val)
@@ -2586,9 +2618,11 @@ proc `[]`*[Idx, T; U, V: Ordinal](a: array[Idx, T], x: HSlice[U, V]): seq[T] =
   ##    var a = [1, 2, 3, 4]
   ##    assert a[0..2] == @[1, 2, 3]
   let xa = a ^^ x.a
-  let L = (a ^^ x.b) - xa + 1
+  let L: int = (a ^^ x.b) - xa + 1
   result = newSeq[T](L)
-  for i in 0..<L: result[i] = a[Idx(i + xa)]
+  for i in 0..<L:
+    let idx: Idx = Idx(i + xa)
+    result[i] = a[idx]
 
 proc `[]=`*[Idx, T; U, V: Ordinal](a: var array[Idx, T], x: HSlice[U, V], b: openArray[T]) =
   ## Slice assignment for arrays.
@@ -2633,25 +2667,17 @@ proc `[]=`*[T; U, V: Ordinal](s: var seq[T], x: HSlice[U, V], b: openArray[T]) =
   else:
     spliceImpl(s, a, L, b)
 
-proc `[]`*[T](s: openArray[T]; i: BackwardsIndex): T {.inline.} =
-  system.`[]`(s, s.len - int(i))
+template `[]`*[T](s: T; i: BackwardsIndex): untyped =
+  ## Default behavior for the backwards index, so that when your type
+  ## supports `len` and the index operator, `BackwardsIndex` will work, too.
+  s[s ^^ i]
 
-proc `[]`*[Idx, T](a: array[Idx, T]; i: BackwardsIndex): T {.inline.} =
-  a[Idx(a.len - int(i) + int low(a))]
-proc `[]`*(s: string; i: BackwardsIndex): char {.inline.} = s[s.len - int(i)]
-
-proc `[]`*[T](s: var openArray[T]; i: BackwardsIndex): var T {.inline.} =
-  system.`[]`(s, s.len - int(i))
-proc `[]`*[Idx, T](a: var array[Idx, T]; i: BackwardsIndex): var T {.inline.} =
-  a[Idx(a.len - int(i) + int low(a))]
 proc `[]`*(s: var string; i: BackwardsIndex): var char {.inline.} = s[s.len - int(i)]
 
-proc `[]=`*[T](s: var openArray[T]; i: BackwardsIndex; x: T) {.inline.} =
-  system.`[]=`(s, s.len - int(i), x)
-proc `[]=`*[Idx, T](a: var array[Idx, T]; i: BackwardsIndex; x: T) {.inline.} =
-  a[Idx(a.len - int(i) + int low(a))] = x
-proc `[]=`*(s: var string; i: BackwardsIndex; x: char) {.inline.} =
-  s[s.len - int(i)] = x
+template `[]=`*[T,U](s: T; i: BackwardsIndex; x: U): untyped =
+  ## Default behavior for the backwards index, so that when your type
+  ## supports `len` and the index operator, `BackwardsIndex` will work, too.
+  s[s ^^ i] = x
 
 proc slurp*(filename: string): string {.magic: "Slurp".}
   ## This is an alias for `staticRead <#staticRead,string>`_.

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -251,13 +251,6 @@ block troof:
   y[3..5] = [1, 2, 3]
   echo y[3..5]
 
-
-  var d: array['a'..'c', string] = ["a", "b", "c"]
-  doAssert d[^1] == "c"
-
-
-
-
 import strutils, sequtils, typetraits, os
 
 type
@@ -602,3 +595,33 @@ block t18643:
   except IndexDefect:
     caught = true
   doAssert caught, "IndexDefect not caught!"
+
+block backwardsindex:
+  # test for default implementation of backwards index
+
+  type
+    MyType = object
+
+  proc len(arg: MyType): int = 100
+  proc `[]`(arg: MyType; idx: int): int = idx
+
+  var mt: MyType
+
+  doAssert mt[0] == 0
+  doAssert mt[^0] == 100
+  doAssert mt[^1] == 99
+
+  # test for custom backwards index conversion
+
+  type
+    MyOtherType = object
+
+  template `^^`(a: MyOtherType, b: BackwardsIndex): int =
+    ## my conversion of `BackwardsIndex` for `MyOtherType`
+    1000 + int(b)
+
+  proc `[]`(arg: MyOtherType; idx: int): int =
+    idx
+
+  var mot: MyOtherType
+  doAssert mot[^1] == 1001


### PR DESCRIPTION
All types that have the `[]` operator and the `len` overloaded can now
also be accesed using a backwards index (^1). Old versions of Nim
already supported this, but it got lost over time. So this is actually a
regression fix.

What it takes away though is accessing enum indexed
arrays (``array[MyEnum, T]``) via backwards index. Not sure why that was
ever supported, after all you can't even access them with normal forward
indices, so why should backwards indices be allowed?

This is actually a revival of my old PR here: https://github.com/nim-lang/Nim/pull/7265
