### PR TITLE
niminst: remove koch detection from build scripts

### DIFF
--- a/tools/niminst/buildbat.nimf
+++ b/tools/niminst/buildbat.nimf
@@ -19,8 +19,6 @@ IF DEFINED ARCH (
 )
 ECHO Building with %ARCH% bit %CC%
 
-if EXIST ..\koch.nim SET BIN_DIR=..\bin
-
 if NOT EXIST %BIN_DIR%\nul mkdir %BIN_DIR%
 
 REM call the compiler:

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -71,10 +71,6 @@ uosname=
 #  add(result, "# bin dir detection\n")
 binDir=?{firstBinPath(c).toUnix}
 
-if [ -s ../koch.nim ]; then
-  binDir="../bin"
-fi
-
 if [ ! -d $binDir ]; then
   mkdir $binDir
 fi

--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -8,12 +8,6 @@ CC ??= gcc
 CFLAGS += -Ic_code ?{c.ccompiler.flags}
 LDFLAGS += ?{c.linker.flags}
 binDir = ?{firstBinPath(c).toUnix}
-
-koch := $(shell sh -c 'test -s ../koch.nim && echo "yes"')
-ifeq ($(koch),yes)
-  binDir = ../bin
-endif
-
 target := ?{"$(binDir)/" & toLowerAscii(c.name)}
 
 ucpu := $(shell sh -c 'uname -m | tr "[:upper:]" "[:lower:]"')


### PR DESCRIPTION
This function is used for placing csources compiler into the binary
directory of the compiler source. However, as csources is now fully
managed by koch.py, this functionality is obsolete.