### PR TITLE
niminst: set default path for binary to bin/

### DIFF
--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -114,7 +114,7 @@ func iniConfigData(c: var ConfigData) =
 
 func firstBinPath(c: ConfigData): string =
   if c.binPaths.len > 0: result = c.binPaths[0]
-  else: result = ""
+  else: result = "bin"
 
 func `\`(a, b: string): string =
   result = if a.len == 0: b else: a & '\\' & b


### PR DESCRIPTION
This is used by csources builder to know where to put its binary.
Defaults to the bin/ folder relative to the source.

Without this, the generated csources will not be built due to missing
output folder.