### PR TITLE
add contributing.rst into the source archive

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -70,6 +70,8 @@ Files: "testament"
 Files: "nimsuggest"
 Files: "nimsuggest/tests/*.nim"
 
+Files: ".github/contributing.rst"
+
 [Lib]
 Files: "lib"
 


### PR DESCRIPTION
Without it, documentation cannot be built from the source archive.