### PR TITLE
debug: improve tree repr prints for `TType`

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3183,31 +3183,14 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
         )
 
       proc render(node: PNode): string =
-        conf.wrap(conf.treeRepr(node,
-          # add tree repr configuration options here
-
-
-          # next is formatting, don't edit
-          indentIncrease = indent + 2
-        ))
+        conf.wrap(conf.treeRepr(node, indent = indent + 2))
 
       proc render(typ: PType): string =
-        conf.wrap(conf.treeRepr(typ,
-          # add tree repr configuration options here
-
-
-          # next is formatting, don't edit
-          indent = indent + 2
-        ))
+        conf.wrap(conf.treeRepr(typ, indent = indent + 2))
 
       proc render(sym: PSym): string =
-        conf.wrap(conf.treeRepr(sym,
-          # add tree repr configuration options here
+        conf.wrap(conf.treeRepr(sym, indent = indent + 2))
 
-
-          # next is formatting, don't edit
-          indent = indent + 2
-        ))
       result.addf("$1]", align($s.level, 2, '#'))
       result.add(
         repeat("  ", s.level),

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -31,6 +31,9 @@ import
   ],
   sem/[
     semdata,
+  ],
+  utils/[
+    astrepr
   ]
 
 from concepts import makeTypeDesc

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -1,4 +1,23 @@
-## `treeRepr()` implementation for the `PNode` tree structures
+## `treeRepr()` implementation for the `PNode` tree structures. This module
+## provides helper procedures that can be used for debugging purposes -
+## dumping compiler IR in the textual form.
+##
+## For each IR type (``PType``, ``PSym``, ``PNode``) there are several
+## procs defined:
+#
+## - `treeRepr` - main implementation to generate the `ColText` chunk for the
+##   object.
+## - `debug` - convenience ovelroads that print generated text immediately.
+##   There are two version of the `debug` - one that accept `ConfigRef` object,
+##   and one that can work without it. Both call `treeRepr` internally, but
+##   with `ConfigRef` present more information can be printed.
+## - `debugAst`, `debugSym`, `debugType` - procs added for use in `gdb` debugging.
+##   They have `{.exportc.}` annotations, so can be used directly by name there
+##
+## `treeRepr` and all other procedures in the module accept `TReprConf`
+## object (default value is provided via `implicitTReprConf` global, for
+## gdb procs it is used implicitly) that controls which fields specifically
+## will be printed.
 
 import
   ast/[
@@ -16,63 +35,120 @@ import
   std/[
     tables,
     strutils,
-    strformat,
+    strformat
   ]
 
 import std/options as std_options
 
 type
   TReprFlag* = enum
-    trfPositionIndexed
-    trfReportInfo
-    trfPackedFields
-    trfSkipAuxError
-    trfSymDefined
-    trfIndexVisisted
+    trfReportInfo ## Show information about embedded semantic report errors
+    trfPackedFields ## Put fields horizontally instead of arranging them
+                    ## out veritcally. Should be used only when a small
+                    ## number of total fields is enabled, otherwise output
+                    ## will be unreadable.
+    trfSkipAuxError ## Skip 'data store' fields of the `nkError` node -
+                    ## elements `[1..2]` are used to store additional
+                    ## metadata and are rarely needed for printing.
+    trfIndexVisisted ## Enumerate each visited node when printing the
+                     ## `PNode` tree
+    trfShowDefaultedFields ## Show fields with defaulted values
 
-    trfShowSymFlags
-    trfShowSymLineInfo
-    trfShowSymTypes
-    trfShowSymMagic
-    trfShowSymKind
-    trfShowSymOwner
-    trfShowSymOptions
-    trfShowSymPosition
-    trfShowSymOffset
-    trfShowSymBitsize
-    trfShowSymAlignment
+    trfShowSymFlags ## Show symbol `.flags` field
+    trfShowSymLineInfo ## Line information
+    trfShowSymTypes ## Flat render of the symbol type
+    trfShowSymMagic ## used symbol magic
+    trfShowSymKind ## `.kind`
+    trfShowSymOwner ## Full chain of the symbol owners
+    trfShowSymOptions ## `.options`
+    trfShowSymPosition ## `.position`
+    trfShowSymOffset ## `.offset`
+    trfShowSymBitsize ## `.bitsize`
+    trfShowSymAlignment ## `.alignment`
 
-    trfShowTypeCallConv
-    trfShowTypeFlags
-    trfShowTypeSize
-    trfShowTypeOwner
-    trfShowTypeBaseId
+    trfShowTypeCallConv ## Calling convention
+    trfShowTypeFlags ## `.flags`
+    trfShowTypeSym ## `.sym`
+    trfShowTypeAlloc ## `.align` and `.size` fields. They represent a
+                     ## single logical chunk of information, and pinter
+                     ## together
+    trfShowTypeOwner ## Full chain of the type owner
+    trfShowTypeBaseId ## `module` and `item` from `itemId` field
 
-    trfShowNodeLineInfo
-    trfShowNodeFlags
-    trfShowNodeIds
-    trfShowNodeValue
-    trfShowNodeComments
-    trfShowNodeErrors
-    trfShowNodeTypes
+    trfShowNodeLineInfo ## Node location information
+    trfShowNodeFlags ## `.flags`
+    trfShowNodeIds ## `.id` field, available when compiler is built with `-d:nodeIds`
+    trfShowNodeComments ## `.comment` field
+    trfShowNodeErrors ## Embedded `nkError` reports
+    trfShowNodeTypes ## Flat render of the node type
+
+  TReprConf* = object
+    ## Main debug configuration object
+    flags*: set[TReprFlag]  ## Set of the formatting options for the
+    ## procedure. Several built-in constants are defined in this module
+    ## that might be suitable for different debugging or AST exploration
+    ## tasks.
+    maxDepth*: int ## Ignore all nodes that are placed deeper than that.
+    ## Useful to see a high-level overview for large nodes, such as full
+    ## proc bodies
+    maxLen*: int ## on each level, print upto that number of subnodes.
+    ## Useful to cut out parts on large `case` trees, toplevel nodes for
+    ## modules, statement lists and such.
+    maxPath*: int ## maximum path length for subnodes
+
 
 
 export colortext.`$`
 
-const treeReprAllFields* = { trfShowSymFlags .. trfShowNodeTypes }
+const treeReprAllFields* = { trfShowSymFlags .. trfShowNodeTypes } ## Set
+                           ## of flags to print all fields in all tree
+                           ## reprs
 
-const defaultTreeReprFlags* = {
-  trfPositionIndexed,
-  trfReportInfo,
-  trfSkipAuxError,
-  trfIndexVisisted
-} + treeReprAllFields - {
-  trfShowNodeLineInfo,
-  trfShowSymLineInfo,
-  trfShowSymOptions,
-}
+const style = (
+  kind: fgBlue,
+  nilIt: fgRed,
+  ident: fgCyan,
+  setIt: termFg(2, 1, 3),
+  number: fgCyan,
+  strLit: fgYellow,
+  floatLit: fgMagenta,
+  dim: termFg(15),
+  errKind: termFg(5, 2, 0),
+  err: fgRed,
+  comment: termFg(4, 2, 1),
+  owner: termFg(1, 3, 0)
+)
 
-const treeReprCompact* = defaultTreeReprFlags + {trfPackedFields}
+const defaultTReprConf* = TReprConf(
+  maxDepth: 120,
+  maxLen: 30,
+  maxPath: 1,
+  flags: {
+    trfReportInfo,
+    trfSkipAuxError,
+    trfIndexVisisted
+  } + treeReprAllFields - {
+    trfShowNodeLineInfo,
+    trfShowSymLineInfo,
+    trfShowSymOptions,
+    trfShowTypeBaseId,
+    trfShowTypeAlloc
+  }
+) ## Default based configuration for the tree repr printing functions
+
+const compactTReprConf* =
+  block:
+    var base = defaultTReprConf
+    base.flags.incl trfPackedFields
+    base
+  ## Compacted tree repr configuration
+
+var implicitTReprConf*: TReprConf = defaultTReprConf ## global
+  ## configuration object that is implicitly used by `debugAst` and
+  ## `debugType`. Can be used in order to configure behaviour of the
+  ## debugging functions that could later be called from `gdb` environment
+  ## (`debugAst`, `debugType`, `debugSym`), or sem execution tracer
+
 
 const IntTypes = {
   tyInt, tyInt8, tyInt16,
@@ -82,10 +158,12 @@ const IntTypes = {
 
 const CompressedBuiltinTypes = {tyBool, tyChar, tyPointer, tyString} + IntTypes
 
+func contains(rconf: TReprConf, flag: TReprFlag): bool = flag in rconf.flags
+
 proc textRepr(conf: ConfigRef, typ: PType): ColText =
-  result.add ($typ.kind)[2..^1] + fgMagenta
+  result.add ($typ.kind)[2..^1] + style.kind
   if not isNil(typ.sym):
-    result &= " sk:" & ($typ.sym.kind)[2..^1] + fgCyan
+    result &= " sk:" & ($typ.sym.kind)[2..^1] + style.kind
 
   if not isNil(typ.n):
     let t = $typ.n
@@ -93,7 +171,7 @@ proc textRepr(conf: ConfigRef, typ: PType): ColText =
       result &= " " & t + fgRed
 
 
-template genFields(res: ColText, indent: int, flags: set[TReprFlag]): untyped =
+template genFields(res: ColText, indent: int, rconf: TReprConf): untyped =
   proc hfield(name: string, text: ColText = default ColText) =
     res.add " "
     res.add name
@@ -107,7 +185,7 @@ template genFields(res: ColText, indent: int, flags: set[TReprFlag]): untyped =
     res.add text
 
   proc field(name: string, text: ColText = default ColText) =
-    if trfPackedFields in flags:
+    if trfPackedFields in rconf:
       hfield(name, text)
     else:
       vfield(name, text)
@@ -122,56 +200,79 @@ proc format[I](s: set[I], sub: int): string =
 
   result.add "}"
 
-const setStyle = termFg(2, 1, 3)
+func format(i: SomeInteger): ColText = $i + style.number
 
-func format(i: SomeInteger): ColText = $i + fgCyan
+proc ownerChain(sym: PSym): string =
+  var own: seq[PSym] = @[sym]
+  var sym = sym
+  while not sym.owner.isNil():
+    sym = sym.owner
+    own.add sym
+
+  for idx in countdown(own.high, 0):
+    if idx < own.high:
+      result.add "."
+
+    result.add own[idx].name.s
+    result.add "("
+    result.add substr($own[idx].kind, 2)
+    result.add ")"
+
+func defaulted(r: TReprConf): bool = trfShowDefaultedFields in r
 
 proc symFields(
     conf: ConfigRef,
     sym: PSym,
-    flags: set[TReprFlag] = defaultTreeReprFlags,
+    rconf: TReprConf = implicitTReprConf,
     indent: int = 0
   ): ColText =
 
   coloredResult(1)
   var res = addr result
-  genFields(res[], indent, flags)
+  genFields(res[], indent, rconf)
 
-  if trfShowSymFlags in flags and sym.flags.len > 0:
-    field("flags", format(sym.flags, 2) + setStyle)
+  if trfShowSymFlags in rconf and
+     (sym.flags.len > 0 or rconf.defaulted()):
+    field("flags", format(sym.flags, 2) + style.setIt)
 
-  if trfShowSymMagic in flags and sym.magic != mNone:
-    field("magic", substr($sym.magic, 1) + setStyle)
+  if trfShowSymMagic in rconf and
+     (sym.magic != mNone or rconf.defaulted()):
+    field("magic", substr($sym.magic, 1) + style.setIt)
 
-  if trfShowSymOptions in flags and 0 < sym.options.len:
-    field("opts", format(sym.options, 3) + setStyle)
+  if trfShowSymOptions in rconf and
+     (0 < sym.options.len or rconf.defaulted()):
+    field("opts", format(sym.options, 3) + style.setIt)
 
-  if trfShowSymOffset in flags and 0 <= sym.offset:
-    field("offset", sym.offset.format())
+  if trfShowSymOffset in rconf and
+     (0 <= sym.offset or rconf.defaulted()):
+    field("offset", $sym.offset + style.number)
 
-  if trfShowSymPosition in flags and sym.position != 0:
-    field("pos", sym.offset.format())
+  if trfShowSymPosition in rconf and
+     (sym.position != 0 or rconf.defaulted()):
+    field("pos", $sym.offset + style.number)
 
-  if trfShowSymTypes in flags and not sym.typ.isNil():
+  if trfShowSymTypes in rconf and not sym.typ.isNil():
     field("typ", conf.textRepr(sym.typ))
 
-  if not isNil(conf) and trfShowSymLineInfo in flags and sym.info != unknownLineInfo:
-    field("info", conf.toMsgFilename(sym.info.fileIndex) + fgBlue)
-    add "(", $sym.info.line + fgCyan
-    add ".", $sym.info.col + fgCyan
+  if not isNil(conf) and
+     trfShowSymLineInfo in rconf and
+     (sym.info != unknownLineInfo or rconf.defaulted()):
+    field("info", conf.toMsgFilename(sym.info.fileIndex) + style.ident)
+    add "(", $sym.info.line + style.number
+    add ".", $sym.info.col + style.number
     add ")"
 
-  if trfShowSymOwner in flags and not sym.owner.isNil():
+  if trfShowSymOwner in rconf and not sym.owner.isNil():
     field("owner")
-    let own = sym.owner
-    hfield("kind", $own.kind + fgGreen)
-    hfield("name", $own.name.s + fgCyan)
+    add sym.owner.ownerChain() + style.owner
 
   if sym.kind in {skLet, skVar, skField, skForVar}:
-    if trfShowSymBitsize in flags and sym.bitsize != 0:
-      field("bitsize", sym.bitsize.format())
+    if trfShowSymBitsize in rconf and
+       (sym.bitsize != 0 or rconf.defaulted()):
+      field("bitsize", $sym.bitsize + style.number)
 
-    if trfShowSymAlignment in flags and sym.alignment != 0:
+    if trfShowSymAlignment in rconf and
+       (sym.alignment != 0 or rconf.defaulted()):
       field("alignment", sym.bitsize.format())
 
 
@@ -179,67 +280,95 @@ proc symFields(
 proc treeRepr*(
     conf: ConfigRef,
     sym: PSym,
-    flags: set[TReprFlag] = defaultTreeReprFlags,
+    rconf: TReprConf = implicitTReprConf,
     indent: int = 0
   ): ColText =
 
   coloredResult(1)
   if sym.isNil():
-    addi indent, "<nil>" + fgRed
+    addi indent, "<nil>" + style.nilIt
 
   else:
-    addi indent, substr($sym.kind, 2) + fgBlue
-    add symFields(conf, sym, flags, indent + 2)
+    addi indent, substr($sym.kind, 2) + style.kind
+    add symFields(conf, sym, rconf, indent + 2)
 
 proc typFields(
     conf: ConfigRef,
     typ: PType,
-    flags: set[TReprFlag],
+    rconf: TReprConf,
     indent: int
   ): ColText =
 
   let res = addr result
-  genFields(res[], indent, flags)
+  genFields(res[], indent, rconf)
 
-  if trfShowTypeCallConv in flags and typ.kind == tyProc:
-    field("callConv", $typ.callConv + fgCyan)
+  if trfShowTypeCallConv in rconf and typ.kind == tyProc:
+    field("callConv", $typ.callConv + style.ident)
 
-  if trfShowTypeFlags in flags and typ.flags.len > 0:
-    field("flags", format(typ.flags, 2) + fgCyan)
+  if trfShowTypeFlags in rconf and
+     (typ.flags.len > 0 or trfShowDefaultedFields in rconf):
+    field("flags", format(typ.flags, 2) + style.ident)
 
-  if trfShowTypeSize in flags and typ.size != -1:
+  if trfShowTypeAlloc in rconf:
     field("size", typ.size.format())
+    if typ.size == -1:
+      res[].add " (unknown)" + style.number
 
-  if trfShowTypeOwner in flags and not typ.owner.isNil():
-    field("owner", typ.owner.name.s + fgCyan)
+    hfield("align", $typ.align + style.number)
+
+  if trfShowTypeOwner in rconf and not typ.owner.isNil():
+    field("owner", typ.owner.ownerChain() + style.owner)
+
+
+proc treeRepr*(
+    conf: ConfigRef,
+    pnode: PNode,
+    rconf: TReprConf = defaultTReprConf,
+    indent: int = 0
+  ): ColText
 
 proc treeRepr*(
     conf: ConfigRef,
     typ: PType,
-    flags: set[TReprFlag] = defaultTreeReprFlags,
+    rconf: TReprConf = implicitTReprConf,
     indent: int = 0
   ): ColText =
 
   coloredResult(1)
 
   var res = addr result
-  genFields(res[], indent, flags)
+  genFields(res[], indent, rconf)
 
   proc aux(typ: PType, level: int) =
     let indent = level * 2 + indent
     if typ.isNil():
-      addi indent, "<nil>" + fgRed
+      addi indent, "<nil>" + style.nilIt
 
     else:
-      addi indent, substr($typ.kind, 2) + fgBlue
-      if trfShowTypeBaseId in flags:
-        hfield("mId", typ.itemId.module.format())
-        hfield("iId", typ.itemId.item.format())
+      addi indent, substr($typ.kind, 2) + style.kind
+      if trfShowTypeBaseId in rconf:
+        hfield("itemId")
+        hfield("module",typ.itemId.module.format())
+        hfield("item", typ.itemId.item.format())
 
-      add typFields(conf, typ, flags, indent + 2)
+      add typFields(conf, typ, rconf, indent + 2)
 
-      for sub in typ.sons:
-        aux(sub, level + 1)
+      if 0 < len(typ.sons):
+        add "\n"
+        addi indent + 2, "sons:"
+        for sub in typ.sons:
+          add "\n"
+          aux(sub, level + 2)
+
+      if not typ.n.isNil():
+        add "\n"
+        addi indent + 2, "n:\n"
+        add treeRepr(conf, typ.n, rconf, indent = indent + 4)
+
+      if not typ.sym.isNil():
+        add "\n"
+        addi indent + 2, "sym:\n"
+        add treeRepr(conf, typ.sym, rconf, indent = indent + 4)
 
   aux(typ, 0)
 
@@ -248,58 +377,52 @@ proc treeRepr*(
 proc treeRepr*(
     conf: ConfigRef,
     pnode: PNode,
-    flags: set[TReprFlag] = defaultTreeReprFlags,
-    maxDepth: int          = 120,
-    maxLen: int            = 30,
-    maxPath: int           = 1,
-    indentIncrease: int = 0
+    rconf: TReprConf = defaultTReprConf,
+    indent: int = 0
   ): ColText =
   ## .. include:: tree_repr_doc.rst
-
 
   coloredResult(1)
 
 
-  var visited: Table[int, int]
-  var res = addr result
-  var nodecount = 0
+  let indentIncrease = indent
+  var
+    visited: Table[int, int]
+    res = addr result
+    nodecount = 0
+
   proc aux(n: PNode, idx: seq[int]) =
     var indent = indentIncrease
-    genFields(res[], indent, flags)
-
+    genFields(res[], indent, rconf)
     addIndent(indentIncrease)
-    if trfPositionIndexed in flags:
-      indent += 2
-      if 0 < idx.len:
-        var first = true
-        for idxIdx, pos in idx:
-          if idx.len - maxPath <= idxIdx:
-            indent += tern(first, 0, 1)
+    indent += 2
+    if 0 < idx.len:
+      var first = true
+      for idxIdx, pos in idx:
+        if idx.len - rconf.maxPath <= idxIdx:
+          indent += tern(first, 0, 1)
 
-            case pos:
-              of 0 .. 9: indent += 1
-              of 10 .. 99: indent += 2
-              else: indent += 3
+          case pos:
+            of 0 .. 9: indent += 1
+            of 10 .. 99: indent += 2
+            else: indent += 3
 
-            if not first:
-              add "." + termFg(15)
+          if not first:
+            add "." + style.dim
 
-            first = false
-            add $pos + termFg(15)
+          first = false
+          add $pos + style.dim
 
-          else:
-            indent += 2
-            add "  "
+        else:
+          indent += 2
+          add "  "
 
-        if 0 < maxPath:
-          add " "
-          inc indent
-
-    else:
-      addIndent(idx.len * 2)
+      if 0 < rconf.maxPath:
+        add " "
+        inc indent
 
     if isNil(n):
-      add "<nil>" + fgRed
+      add "<nil>" + style.nilIt
       return
 
     elif not (n.kind == nkEmpty and n.safeLen == 0) and
@@ -307,11 +430,11 @@ proc treeRepr*(
          # not an empty (completely empty) node
          cast[int](n) in visited:
 
-      if trfIndexVisisted in flags:
+      if trfIndexVisisted in rconf:
         add "<visited "
-        add substr($n.kind, 2) + fgCyan
+        add substr($n.kind, 2) + style.number
         add " at "
-        add $visited[cast[int](n)] + styleDim
+        add $visited[cast[int](n)] + style.dim
         add ">"
 
       else:
@@ -319,33 +442,35 @@ proc treeRepr*(
 
       return
 
-    elif idx.len > maxDepth:
+    elif idx.len > rconf.maxDepth:
       add " ..."
       return
 
     visited[cast[int](n)] = nodecount
-    add substr($n.kind, 2) + fgCyan
+    add substr($n.kind, 2) + style.kind
 
-    if trfIndexVisisted in flags:
+    if trfIndexVisisted in rconf:
       add " "
-      add $nodecount + styleDim
+      add $nodecount + style.dim
 
     inc nodecount
 
     when defined(useNodeids):
-      if trfShowNodeIds in flags:
+      if trfShowNodeIds in rconf:
         hfield("nid")
         add $n.id
 
+    let hasComment = trfShowNodeComments in rconf and n.comment.len > 0
+
     proc addComment(sep: bool = true) =
-      if trfShowNodeComments in flags and n.comment.len > 0:
+      if hasComment:
         var nl = false
         for line in split(n.comment.strip(leading = false), '\n'):
           if nl: add "\n"
           nl = true
 
-          addi indent, "  # " + termFg(4, 2, 1)
-          add line + termFg(4, 2, 1)
+          addi indent, "  # " + style.comment
+          add line + style.comment
 
         add "\n"
 
@@ -353,10 +478,10 @@ proc treeRepr*(
         add " "
 
     proc addFlags() =
-      if trfShowNodeFlags in flags and n.flags.len > 0:
-        field("nflags", format(n.flags, 2) + setStyle)
+      if trfShowNodeFlags in rconf and n.flags.len > 0:
+        field("nflags", format(n.flags, 2) + style.setIt)
 
-      if trfShowNodeTypes in flags and not n.typ.isNil():
+      if trfShowNodeTypes in rconf and not n.typ.isNil():
         if (
           n.typ.kind notin CompressedBuiltinTypes or
           (n.kind in nkIntKinds and n.typ.kind notin IntTypes)
@@ -368,76 +493,77 @@ proc treeRepr*(
 
             else:
               field("typ", conf.textRepr(n.typ))
-              add " != sym.typ" + fgRed
+              add " != sym.typ" + style.err
 
           else:
             field("typ", conf.textRepr(n.typ))
 
-    if not conf.isNil() and trfShowNodeLineInfo in flags and
+    if not conf.isNil() and trfShowNodeLineInfo in rconf and
        n.info != unknownLineInfo:
-      field("info", conf.toMsgFilename(n.info.fileIndex) + fgBlue)
+      field("info", conf.toMsgFilename(n.info.fileIndex) + style.ident)
       add "("
-      add $n.info.line + fgCyan
+      add $n.info.line + style.number
       add "."
-      add $n.info.col + fgCyan
+      add $n.info.col + style.number
       add ")"
 
     case n.kind:
       of nkStrKinds:
         add " "
-        add "\"" & n.strVal + fgYellow & "\""
+        add "\"" & n.strVal + style.strLit & "\""
         addFlags()
+        if hasComment: add "\n"
         addComment()
 
       of nkCharLit .. nkUInt64Lit:
         add " "
-        add $n.intVal + fgBlue
+        add $n.intVal + style.number
         addFlags()
+        if hasComment: add "\n"
         addComment()
 
       of nkFloatLit .. nkFloat128Lit:
         add " "
-        add $n.floatVal + fgMagenta
+        add $n.floatVal + style.floatLit
         addFlags()
+        if hasComment: add "\n"
         addComment()
 
       of nkIdent:
         add " "
-        add n.ident.s + fgGreen
+        add n.ident.s + style.ident
         addFlags()
+        if hasComment: add "\n"
         addComment()
 
       of nkSym:
         add " "
-        add n.sym.name.s + fgCyan
-        hfield "sk", substr($n.sym.kind, 2) + fgBlue
+        add n.sym.name.s + style.ident
+        hfield "sk", substr($n.sym.kind, 2) + style.kind
 
-        if not n.sym.owner.isNil() and
-           n.sym.owner.kind in {skModule, skType}:
-          add &"({n.sym.owner.name.s}.{n.sym.name.s})" + termFg(15)
-
-        add symFields(conf, n.sym, flags, indent)
+        add symFields(conf, n.sym, rconf, indent)
         addFlags()
         addComment()
 
       of nkCommentStmt:
         addFlags()
         add "\n"
+        if hasComment: add "\n"
         addComment()
 
       of nkError:
         if isNil(conf):
-          field("err", substr($n.errorKind(), 4) + termFg(5, 2, 0))
+          field("err", substr($n.errorKind(), 4) + style.errKind)
 
         else:
           let report = conf.getReport(n).semReport
-          field("err", substr($report.kind, 4) + termFg(5, 2, 0))
-          hfield("errid", $n.reportId.int + fgRed)
+          field("err", substr($report.kind, 4) + style.errKind)
+          hfield("errid", $n.reportId.int + style.err)
 
         let (file, line, col) = n.compilerInstInfo()
-        field("info", formatPath(conf, file) + fgBlue)
-        add "(", $line + fgCyan
-        add ".", $col + fgCyan
+        field("info", formatPath(conf, file) + style.ident)
+        add "(", $line + style.number
+        add ".", $col + style.number
         add ")"
 
       else:
@@ -449,19 +575,21 @@ proc treeRepr*(
       if n.len > 0:
         add "\n"
 
-      addComment(false)
+      if hasComment:
+        addComment(false)
+        add "\n"
 
       for newIdx, subn in n:
-        if trfSkipAuxError in flags and n.kind == nkError and newIdx in {1, 2}:
+        if trfSkipAuxError in rconf and n.kind == nkError and newIdx in {1, 2}:
           continue
 
         aux(subn, idx & newIdx)
 
 
-        if idx.len + 1 > maxDepth:
+        if idx.len + 1 > rconf.maxDepth:
           break
 
-        if newIdx > maxLen:
+        if newIdx > rconf.maxLen:
           break
 
         if newIdx < n.len - 1:
@@ -469,7 +597,9 @@ proc treeRepr*(
 
   aux(pnode, @[])
 
-proc debugAst*(it: PNode) {.exportc.} =
+{.pragma: dbg, deprecated: "Debug proc, should not be used in the final build".}
+
+proc debugAst*(it: PNode) {.exportc, dbg.} =
   ## Print out tree representation of the AST node.
   ##
   ## .. note:: there is no `ConfigRef` argument, and because of that some
@@ -479,38 +609,41 @@ proc debugAst*(it: PNode) {.exportc.} =
   ## .. tip:: This proc is annotated with `{.exportc.}` which means it's
   ##     mangled name exactly the same - `debugAst` and you can call it
   ##     from the `gdb` debugging session.
-  echo treeRepr(nil, it)
+  echo treeRepr(nil, it, implicitTReprConf)
 
-proc debugType*(it: PType) {.exportc.} =
+proc debugType*(it: PType) {.exportc, dbg.} =
   ## Print out tree represntation of the type. Can also be used in gdb
   ## debugging session due to `.exportc.` annotation
-  echo treeRepr(nil, it)
+  echo treeRepr(nil, it, implicitTReprConf)
 
-proc debugSym*(it: PSym) {.exportc.} =
+proc debugSym*(it: PSym) {.exportc, dbg.} =
   ## Print out tree represntation of the symbol. Can also be used in gdb
   ## debugging session due to `.exportc.` annotation
-  echo treeRepr(nil, it)
+  echo treeRepr(nil, it, implicitTReprConf)
 
-proc debug*(it: PNode) =
+proc debug*(it: PNode, tconf: TReprConf = implicitTReprConf) {.dbg.} =
   ## Convenience overload of `debugAst`
-  debugAst(it)
+  echo treeRepr(nil, it, tconf)
 
-proc debug*(it: PType) =
+proc debug*(it: PType, tconf: TReprConf = implicitTReprConf) {.dbg.} =
   ## Convenience overload of `debugType`
-  debugType(it)
+  echo treeRepr(nil, it, tconf)
 
-proc debug*(it: PSym) =
+proc debug*(it: PSym, tconf: TReprConf = implicitTReprConf) {.dbg.} =
   ## Convenience overload of `debugSym`
-  debugSym(it)
+  echo treeRepr(nil, it, tconf)
 
-proc debug*(conf: ConfigRef, it: PNode) =
+proc debug*(
+    conf: ConfigRef, it: PNode, tconf: TReprConf = implicitTReprConf) {.dbg.} =
   ## Print tree representation of the AST
-  echo treeRepr(conf, it)
+  echo treeRepr(conf, it, tconf)
 
-proc debug*(conf: ConfigRef, it: PType) =
+proc debug*(
+    conf: ConfigRef, it: PType, tconf: TReprConf = implicitTReprConf) {.dbg.} =
   ## Print tree representation of the type
-  echo treeRepr(conf, it)
+  echo treeRepr(conf, it, tconf)
 
-proc debug*(conf: ConfigRef, it: PSym) =
+proc debug*(
+    conf: ConfigRef, it: PSym, tconf: TReprConf = implicitTReprConf) {.dbg.} =
   ## Print tree reprsentation of the symbol
-  echo treeRepr(conf, it)
+  echo treeRepr(conf, it, tconf)

--- a/compiler/utils/tree_repr_doc.rst
+++ b/compiler/utils/tree_repr_doc.rst
@@ -2,20 +2,13 @@ Generate tree representation from `PNode`.
 
 Procedure arguments:
 
-- `conf`: some configuration options are inferred from it, such as
-  `--filenames:canonical`, but it is mostly used to get full paths from
+- ``conf``: used to get some configuration options, such as
+  ``--filenames:canonical``, but it is mostly used to get full paths from
   file ids
-- `pnode`: node to be printed - can be `nil`, recursive, `nkError` or any
+- ``pnode``: node to print - can be `nil`, recursive, `nkError` or any
   other kind form or shape.
-- `flags`: Set of the formatting options for the procedure. Several
-  built-in constants are defined in this module that might be suitable for
-  different debugging or AST exploration tasks.
-- `maxDepth`: Ignore all nodes that are placed deeper than that. Useful to
-  see a high-level overview for large nodes, such as full proc bodies
-- `maxLength`: on each level, print upto that many subnodes. Useful to cut
-  out parts on large `case` trees, toplevel nodes for modules, statement
-  lists and such.
-- `maxPath`: maximum path length for subnodes
+- ``rconf``: print configuration - all nested calls to ``treeRepr`` also used
+  it (for ``PType`` and ``PSym``)
 - `indentIncreas`: start tree indentation from certain formatting
 
 Generated output packs in a lot of information - here is a short list of
@@ -23,7 +16,7 @@ features, those will be elaborated on
 
 - subnode index in relation to the parent node, optionally extended index
   (like`[0][0]`)
-- symbol symbol kind, flags, other relevant elements
+- symbol kind, flags, other relevant elements
 - type, if exists
 - comment message (optionally)
 - all node flags

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -38,6 +38,14 @@ Define                       Enables
 `nimCompilerDebugTraceDir`   Write call traces to the directory
 ============================ =======
 
+Debug helper modules
+--------------------
+
+`astrepr
+<https://nim-works.github.io/nimskull/compiler/utils/astrepr.html>`_ module
+provides a collection of useful procedures for printing internal
+representation types (``PSym``, ``PType`` and ``PNode``) in a readable
+manner. For more documentation see the module itself.
 
 Semantic analysis
 -----------------
@@ -235,9 +243,9 @@ This change results in the two more entries added to the call trace:
                  owner:  kind:skModule name:file
 
 
-As you can clearly see now, the return values of this procedure are
-different here. We have successfully localized the bug from 'whole
-compiler' to a specific procedure.
+As you can see now, the return values of this procedure are different here.
+We have successfully localized the bug from 'whole compiler' to a specific
+procedure.
 
 
 -------
@@ -284,8 +292,8 @@ VM codegen and execution
 
 VM code generation prints all of the generated procedures. If this is not
 needed (which would be the majority of use cases) you can add
-`--define:expandVmListing=vmTarget`:option: and only code for the specific
-proc would be printed. For example (generated listing might not match
+`--define:expandVmListing=vmTarget`:option: to print only the code
+generated for this proc. For example (generated listing might not match
 exactly)
 
 .. code-block:: nim


### PR DESCRIPTION
- add global configuration object that can be used to provide default
  values for `treeRepr` - now semantic tracer and `debugAst` (used in
  gdb) can be configured as well.
- Move print configuration into `TReprConf` object instead of passing
  four different fields to `treeRepr` for PNode
- Print `n` and `sym` fields for `TType`
- Print `align` field, hide `.size` by default
- Move styling configurations into `const style`, easier to make small
  tweaks in the formatting.
- Add link to `astrepr` in the compiler debugging documentation
- Make `itemId` print more explicit for `PType`
- Show full owner chain instead of the single parent one
- Explicitly print `sons:` field for TType, fix missing newline bug
- Annotate `debug*` procedures with deprecated message

