### PR TITLE
Fix invalid push pragmas creating cyclic AST

### DIFF
--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1879,7 +1879,13 @@ proc pragmaRec(c: PContext, sym: PSym, n: PNode, validPragmas: TSpecialWords;
 
     if p.isErrorLike:
       assert not cyclicTree(result)
-      result[i] = p
+      if p.isError and p[0] == result:
+        # This can happen because processPush for example may
+        # return the whole pragma node wrapped in an error.
+        # We don't want to accidently create a cycle in that case.
+        result = p
+      else:
+        result[i] = p
       assert not cyclicTree(result)
       result = wrapErrorInSubTree(c.config, result)
       return

--- a/tests/errmsgs/tinvalidpragma.nim
+++ b/tests/errmsgs/tinvalidpragma.nim
@@ -1,0 +1,11 @@
+discard """
+  cmd: "nim check $options $file"
+  action: reject
+  nimout: '''
+tinvalidpragma.nim(10, 20) Error: invalid pragma: warning[XYZ]: off
+tinvalidpragma.nim(11, 15) Error: invalid pragma: warning[XYZ]: off
+'''
+"""
+
+{.push warning[XYZ]: off.}
+{.warning[XYZ]: off, push warning[XYZ]: off.}


### PR DESCRIPTION
## Summary
The added test would previously produce cyclic AST
which would then trigger asserts. With this fix it
produces the expected error message.

Also cleaned up ast.copyNode to reuse copyNodeImpl.

## Details
It fixes it by checking if the node returned by prepareSinglePragma (which in turn invokes processPush) in the case of an error wraps the whole pragma node, and not just one of it's childs and handles it approriately (not assigning the child to it's parent)/

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
