### PR TITLE
Replace all localReport errors with nkError in pragmas.nim

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -680,7 +680,6 @@ type
     # Pragma
     rsemInvalidPragma
       ## suplied pragma is invalid
-    rsemCannotAttachPragma
     rsemUnexpectedPragma
     rsemPropositionExpected
     rsemIllegalCustomPragma

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2156,9 +2156,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemUnexpectedPragma:
       result = "unexpected pragma"
 
-    of rsemCannotAttachPragma:
-      result = "cannot attach a custom pragma to '" & r.symstr & "'"
-
     of rsemDisallowedReprForNewruntime:
       result = "'repr' is not available for --newruntime"
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3122,23 +3122,19 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkCurlyExpr:
     result = semExpr(c, buildOverloadedSubscripts(n, getIdent(c.cache, "{}")), flags)
   of nkPragmaExpr:
-    var
+    let
       pragma = n[1]
       pragmaName = considerQuotedIdent(c, pragma[0])
-      flags = flags
-      finalNodeFlags: TNodeFlags = {}
 
     case whichKeyword(pragmaName)
     of wExplain:
-      flags.incl efExplain
+      result = semExpr(c, n[0], flags + {efExplain})
     of wExecuteOnReload:
-      finalNodeFlags.incl nfExecuteOnReload
+      result = semExpr(c, n[0], flags)
+      result.flags.incl nfExecuteOnReload
     else:
       # what other pragmas are allowed for expressions? `likely`, `unlikely`
-      invalidPragma(c, n)
-
-    result = semExpr(c, n[0], flags)
-    result.flags.incl finalNodeFlags
+      result = invalidPragma(c, n)
   of nkPar, nkTupleConstr:
     case checkPar(c, n)
     of paNone: result = errorNode(c, n)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -55,9 +55,13 @@ proc semBreakOrContinue(c: PContext, n: PNode): PNode =
 
 proc semAsm(c: PContext, n: PNode): PNode =
   checkSonsLen(n, 2, c.config)
-  var marker = pragmaAsm(c, n[0])
-  if marker == '\0': marker = '`' # default marker
-  result = semAsmOrEmit(c, n, marker)
+  let (marker, err) = pragmaAsm(c, n[0])
+  if err.isNil:
+    result = semAsmOrEmit(c, n, marker)
+  else:
+    result = n
+    result[0] = err
+    result = c.config.wrapErrorInSubTree(result)
 
 proc semWhile(c: PContext, n: PNode; flags: TExprFlags): PNode =
   result = n

--- a/tests/errmsgs/tinvalidasmstmt.nim
+++ b/tests/errmsgs/tinvalidasmstmt.nim
@@ -1,0 +1,34 @@
+discard """
+  cmd: "nim check $options $file"
+  action: reject
+  nimout: '''
+tinvalidasmstmt.nim(14, 3) Error: empty 'asm' statement
+tinvalidasmstmt.nim(19, 22) Error: illformed AST: asm ha
+tinvalidasmstmt.nim(30, 9) Error: invalid pragma: invalid
+tinvalidasmstmt.nim(31, 16) Error: invalid pragma: invalid("a")
+tinvalidasmstmt.nim(32, 17) Error: invalid pragma: subschar(1)
+'''
+"""
+
+proc emptyAsmStmt =
+  asm ""
+emptyAsmStmt()
+
+import macros
+macro defA =
+  result = newNimNode(nnkAsmStmt)
+  result.add(
+    newEmptyNode(),
+    ident "ha"
+  )
+
+proc invalidAST =
+  defA
+invalidAST()
+
+proc invalidPragma =
+  asm {.invalid.} ""
+  asm {.invalid("a").} ""
+  asm {.subschar(1).} "" # subschar('`') would be valid for example
+
+invalidPragma()

--- a/tests/errmsgs/tinvalidpragma.nim
+++ b/tests/errmsgs/tinvalidpragma.nim
@@ -2,10 +2,13 @@ discard """
   cmd: "nim check $options $file"
   action: reject
   nimout: '''
-tinvalidpragma.nim(10, 20) Error: invalid pragma: warning[XYZ]: off
-tinvalidpragma.nim(11, 15) Error: invalid pragma: warning[XYZ]: off
+tinvalidpragma.nim(11, 20) Error: invalid pragma: warning[XYZ]: off
+tinvalidpragma.nim(12, 15) Error: invalid pragma: warning[XYZ]: off
+tinvalidpragma.nim(14, 22) Error: invalid pragma: "expression" {.invalid.}
 '''
 """
 
 {.push warning[XYZ]: off.}
 {.warning[XYZ]: off, push warning[XYZ]: off.}
+
+discard "expression" {.invalid.}


### PR DESCRIPTION
## Summary
Convert all localReport calls used for errors in pragmas.nim
to  nkError/newError.
Also adds tests for invalid asm statements in invalidasmstmt.nim and a invalid pragma expression test to invalidpragma.nim.