### PR TITLE
astrepr: location filtering, custom data support

### DIFF
--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -350,10 +350,6 @@ proc `$`*(conf: ConfigRef; info: TLineInfo): string = toFileLineCol(conf, info)
 
 proc `$`*(info: TLineInfo): string {.error.} = discard
 
-proc `??`* (conf: ConfigRef; info: TLineInfo, filename: string): bool =
-  # only for debugging purposes
-  result = filename in toFilename(conf, info)
-
 proc msgWrite*(conf: ConfigRef; s: string, flags: MsgFlags = {}) =
   ## Writes given message string to stderr by default.
   ## If ``--stdout`` option is given, writes to stdout instead. If message hook


### PR DESCRIPTION
- Move line info formatting logic to a separate helper proc
- Allow symbol/type name/id to be shown
- Add callbacks that can be used to provide additional information
  for nodes/symbols/types printed. With planned move to the
  data-oriented AST it is likely that not *all* data will be
  readily available from the `P(Node|Sym|Type)` itself.
- Minor changes to the default formatting options to reduce the
  verbosity.
- In case of the cyclic AST node numbers are now put on the leftmost
  column instead of being mixed in with the rest of the identifiers.
  This makes it easier to figure out what node "cyclic" annotation
  refers. Also when pasting things to the matrix it is easier to
  explain what you are talking about - (aka "see node number 3").
- Overloads for set operations on the `TReprConf` - include and
  exclude flags just like you do with regular sets.
- Add 'verbose' trepr config - print every possible field
- show 'unknown' location data in the info as well.
- Optionally show symbol AST - was missing from dump
- Check if node is `inFile` or `inLines`
- Support setting implicit config ref as well - otherwise
  `debugSym` in the gdb is unable to print node file paths
  properly.
