### PR TITLE
Enable debugging unreported errors

### DIFF
--- a/compiler/ast/errorreporting.nim
+++ b/compiler/ast/errorreporting.nim
@@ -13,7 +13,7 @@
 ## * write an error reporting proc that handles string conversion and also
 ##   determines which error handling strategy to use doNothing, raise, etc.
 
-import ast, errorhandling, renderer, reports
+import ast, errorhandling, renderer, reports, std/tables
 from front/options import ConfigRef
 from front/msgs import TErrorHandling
 
@@ -34,6 +34,12 @@ proc errorHandling*(err: PNode): TErrorHandling =
 template localReport*(conf: ConfigRef, node: PNode) =
   ## Write out existing sem report that is stored in the nkError node
   assert node.kind == nkError, $node.kind
+
+  when defined(nimDebugUnreportedErrors):
+    conf.unreportedErrors.del node.reportId
+    for err in walkErrors(conf, node):
+      conf.unreportedErrors.del err.reportId
+
   for err in walkErrors(conf, node):
     if true or canReport(conf, err):
       handleReport(conf, err.reportId, instLoc(), node.errorHandling)

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -955,4 +955,5 @@ func getReport*(list: ReportList, id: ReportId): Report =
 
 func actualType*(r: SemReport): PType = r.typeMismatch[0].actualType
 func formalType*(r: SemReport): PType = r.typeMismatch[0].formalType
+func formalTypeKind*(r: SemReport): set[TTypeKind] = r.typeMismatch[0].formalTypeKind
 func symstr*(r: SemReport): string = r.sym.name.s

--- a/compiler/ast/typesrenderer.nim
+++ b/compiler/ast/typesrenderer.nim
@@ -157,7 +157,7 @@ proc rangeToStr(n: PNode): string =
 const
   preferToResolveSymbols = {preferName, preferTypeName, preferModuleInfo,
   preferGenericArg, preferResolved, preferMixed}
-  typeToStr: array[TTypeKind, string] = ["None", "bool", "char", "empty",
+  typeToStr*: array[TTypeKind, string] = ["None", "bool", "char", "empty",
     "Alias", "typeof(nil)", "untyped", "typed", "typeDesc",
     # xxx typeDesc=>typedesc: typedesc is declared as such, and is 10x more common.
     "GenericInvocation", "GenericBody", "GenericInst", "GenericParam",

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -910,6 +910,14 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
     of rsemTypeKindMismatch:
       result = r.str
+      result.add  " got '$1'" % typeToString(r.actualType)
+      result.add " but expected "
+      var first = true
+      for typKind in r.formalTypeKind:
+        if not first:
+          result.add " or "
+        result.add "'$1'" % typeToStr[typKind]
+        first = false
 
     of rsemExprHasNoAddress:
       result = "expression has no address"

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -19,6 +19,7 @@ export in_options
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
 from std/private/globs import nativeToUnixPath
+
 const
   hasTinyCBackend* = defined(tinyc)
   useEffectSystem* = true
@@ -243,6 +244,9 @@ type
     when defined(nimDebugUtils):
       debugUtilsStack*: seq[string] ## which proc name to stop trace output
       ## len is also used for output indent level
+
+    when defined(nimDebugUnreportedErrors):
+      unreportedErrors*: OrderedTable[ReportId, PNode]
 
 template `[]`*(conf: ConfigRef, idx: FileIndex): TFileInfo =
   conf.m.fileInfos[idx.uint32]

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -20,13 +20,14 @@ overhead, because some debugging tools are not exactly cheap to run.
 
 **Used when compiling temporary compiler**
 
-==================== =======
-Define               Enables
--------------------- -------
-`nimVMDebugExecute`    Print out every instruction executed by the VM
-`nimVMDebugGenerate`   List VM code generated for every procedure called at compile-time
-`nimDebugUtils`        Enable semantic analysis execution tracer
-==================== =======
+=========================== =======
+Define                      Enables
+--------------------------- -------
+`nimVMDebugExecute`         Print out every instruction executed by the VM
+`nimVMDebugGenerate`        List VM code generated for every procedure called at compile-time
+`nimDebugUtils`             Enable semantic analysis execution tracer
+`nimDebugUnreportedErrors`  Enable unreported error debugging
+=========================== =======
 
 **Used when executing temporary compiler**
 

--- a/tests/errmsgs/tnested_errors.nim
+++ b/tests/errmsgs/tnested_errors.nim
@@ -1,0 +1,18 @@
+discard """
+description: "Tests that nested errors are not being lost or output in the wrong order"
+cmd: '''nim check $file'''
+action: reject
+nimout: '''
+tnested_errors.nim(15, 12) Error: undeclared identifier: 'b'
+tnested_errors.nim(15, 12) Error: expression has no type: b
+tnested_errors.nim(16, 11) Error: undeclared identifier: 'b'
+tnested_errors.nim(15, 9) Error: expression has no type: if b: b else: 1
+'''
+"""
+
+
+
+var a = if b:
+          b
+        else:
+          1


### PR DESCRIPTION
## Summary
Enabled with -d:nimDebugUnreportedErrors
Doesn't keep track of where the nodes were created yet.
Also fix semIf not handling nkError nodes correctly.
Also cleanup buildErrorList/walkErrors roundabout way
of doing post-visit DFS.
Also improve rsemTypeKindMismatch error message.