### PR TITLE
Fix crash when reporting call mismatch of transformed calls

### DIFF
--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -151,34 +151,24 @@ type
     diagnosticsTarget*: PSym ## The concept sym that didn't match
     reports*: seq[SemReport] ## The reports that explain why the concept didn't match
 
+  MismatchInfo* = object
+    kind*: MismatchKind ## reason for mismatch
+    pos*: int           ## position of provided argument that mismatches. This doesn't always correspond to
+                        ## the *expression* subnode index (e.g. `.=`) nor the *target parameter* index (varargs)
+    arg*: PNode         ## the node of the mismatching provided argument
+    formal*: PSym       ## parameter that mismatches against provided argument
+                        ## its position can differ from `arg` because of varargs
+
   SemCallMismatch* = object
     ## Description of the single candidate mismatch. This type is later
     ## used to construct meaningful type mismatch message, and must contain
     ## all the necessary information to provide meaningful sorting,
     ## collapse and other operations.
     target*: PSym ## Procedure that was tried for an overload resolution
-    expression*: PNode ## Full typed expression that was used as a
-    ## procedure call
-    arg*: int ## Mismatched argument index. This corresponds to the
-    ## *expression* subnode index - due to varargs actual *target
-    ## parameter* index might differe. See `.formal` field for the actual
-    ## target argument symbol.
-    targetArg*: PSym ## parameter that mismatches against provided
-    ## argument its position can differ from `arg` because of varargs
-    arguments*: seq[PNode]
-    case kind*: MismatchKind
-      of kTypeMismatch, kVarNeeded:
-        typeMismatch*: SemTypeMismatch ## Argument type mismatch
-                                       ## elaboration
-        diag*: SemDiagnostics
+    firstMismatch*: MismatchInfo ## mismatch info for better error messages
 
-      of kPositionalAlreadyGiven, kUnknownNamedParam,
-         kAlreadyGiven, kMissingParam:
-        ## Parameter name (if used) is stored in the `.targetArg` symbol
-        discard
-
-      else:
-        discard
+    diag*: SemDiagnostics
+    diagnosticsEnabled*: bool ## Set by sfExplain. efExplain or notFoundError ignore this
 
   SemSpellCandidate* = object
     dist*: int

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -921,7 +921,7 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
   toResolve.add newIdentNode(getIdent(c.cache, "case"), n.info)
   toResolve.add n[0]
 
-  var errors: CandidateErrors
+  var errors: seq[SemCallMismatch]
   var r = resolveOverloads(c, toResolve, {skTemplate, skMacro}, {}, errors)
   if r.state == csMatch:
     var match = r.calleeSym

--- a/tests/errmsgs/tmisc.nim
+++ b/tests/errmsgs/tmisc.nim
@@ -2,9 +2,19 @@ discard """
 cmd: "nim check $file"
 action: reject
 nimout: '''
-tmisc.nim(14, 13) Error: object construction uses ':', not '='
-tmisc.nim(16, 5) Error: wrong number of arguments
-tmisc.nim(20, 9) Error: expression has no type: foo
+tmisc.nim(24, 13) Error: object construction uses ':', not '='
+tmisc.nim(26, 5) Error: wrong number of arguments
+tmisc.nim(30, 9) Error: expression has no type: foo
+tmisc.nim(38, 3) Error: type mismatch: got <int, uint>
+but expected one of:
+template `.=`(a: int; b: untyped; c: int)
+  first type mismatch at position: 3
+  required type for c: int
+  but expression 'c' is of type: uint
+template b=(a: int; c: int)
+  first type mismatch at position: 2
+  required type for c: int
+  but expression 'c' is of type: uint
 '''
 """
 
@@ -18,3 +28,12 @@ discard O(f = 1)
 macro foo = discard
 
 let x = foo
+
+template `b=`(a: int, c: int) = discard
+template `.=`(a: int, b: untyped, c: int) = discard
+
+let a = 1
+let c = 3.uint
+
+a.b = c
+


### PR DESCRIPTION
## Summary
Like `.=` for example (see tests/errmsgs/tmisc.nim).

Also refactor and merge CandidateError and SemCallMismatch.