### PR TITLE
Disable Performance hints at default verbosity

### DIFF
--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -103,14 +103,14 @@ proc computeNotesVerbosity(): tuple[
     rextConf,
   }
 
-  result.main[1] = result.main[2] - {
+  result.main[1] = result.main[2] - repPerformanceHints - {
     rsemProveField,
     rsemErrGcUnsafe,
     rextPath,
     rsemHintLibDependency,
     rsemGlobalVar,
     rintGCStats,
-    rintMsgOrigin
+    rintMsgOrigin,
   }
 
   result.main[0] = result.main[1] - {

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -1093,3 +1093,33 @@ const
     rsemIndexOutOfBounds,
     rsemExpectedHighCappedDiscriminant
   }
+
+  repPerformanceHints* = {
+    rsemCopiesToSink,
+    rsemCannotMakeSink
+  }
+
+  repLinkingHints* = {
+    rbackLinking,
+    rcmdLinking
+  }
+
+  repStrictNotNilWarnings* = {
+    rsemStrictNotNilExpr,
+    rsemStrictNotNilResult
+  }
+
+
+
+const
+  repHintGroups* = @{
+    "all": repHintKinds,
+    "Performance": repPerformanceHints,
+    "Name": repLinterKinds,
+    "Link": repLinkingHints,
+  }
+
+  repWarningGroups* = @{
+    "all": repWarningKinds,
+    "StrictNotNil": repStrictNotNilWarnings
+  }

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -355,13 +355,6 @@ type
       else:
         discard
 
-const
-  rsemMultiNamed* = @{
-    "Performance": {rsemCopiesToSink, rsemCannotMakeSink},
-    "Name": repLinterKinds,
-    "Link": {rbackLinking, rcmdLinking},
-    "StrictNotNil": {rsemStrictNotNilExpr, rsemStrictNotNilResult}
-  }
 
 func severity*(report: SemReport): ReportSeverity =
   case SemReportKind(report.kind):


### PR DESCRIPTION
## Summary
Disabled Performance hints at default verbosity because they are too spammy and better opt-in.

## Details
Refactored `rsemMultiNamed` and `--hint/warning:all` into `repHintGroups` and `repWarningGroups`.