### PR TITLE
readme: set recommented Matrix client to Element

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -274,4 +274,4 @@ MIT
 
 [nim-site]: https://nim-lang.org
 [csources-v1-repo]: https://github.com/nim-lang/csources_v1
-[nim-works-matrix]: https://matrix.to/#/#nimworks:envs.net
+[nim-works-matrix]: https://matrix.to/#/#nimworks:envs.net?client=element.io


### PR DESCRIPTION
Clients other than element.io does not appear to support Space discovery
and may leave users confused when they either see an empty room or just
nothing at all.

This commit modify the matrix.to link so that it recommends element.io,
as it's a safe option that have support for Space discovery.

Ref https://github.com/nim-works/nimskull/issues/250