### PR TITLE
Replace `PCtx` parameters with `TCtx` in VM code

### DIFF
--- a/compiler/sem/macrocacheimpl.nim
+++ b/compiler/sem/macrocacheimpl.nim
@@ -19,17 +19,17 @@ import
   ]
 
 
-proc append(c: PCtx; n: PNode) =
+func append(c: var TCtx; n: PNode) =
   c.vmstateDiff.add((c.module, n))
 
-proc recordInc*(c: PCtx; info: TLineInfo; key: string; by: BiggestInt) =
+proc recordInc*(c: var TCtx; info: TLineInfo; key: string; by: BiggestInt) =
   var recorded = newNodeI(nkReplayAction, info)
   recorded.add newStrNode("inc", info)
   recorded.add newStrNode(key, info)
   recorded.add newIntNode(nkIntLit, by)
   c.append(recorded)
 
-proc recordPut*(c: PCtx; info: TLineInfo; key: string; k: string; val: PNode) =
+proc recordPut*(c: var TCtx; info: TLineInfo; key: string; k: string; val: PNode) =
   var recorded = newNodeI(nkReplayAction, info)
   recorded.add newStrNode("put", info)
   recorded.add newStrNode(key, info)
@@ -37,14 +37,14 @@ proc recordPut*(c: PCtx; info: TLineInfo; key: string; k: string; val: PNode) =
   recorded.add copyTree(val)
   c.append(recorded)
 
-proc recordAdd*(c: PCtx; info: TLineInfo; key: string; val: PNode) =
+proc recordAdd*(c: var TCtx; info: TLineInfo; key: string; val: PNode) =
   var recorded = newNodeI(nkReplayAction, info)
   recorded.add newStrNode("add", info)
   recorded.add newStrNode(key, info)
   recorded.add copyTree(val)
   c.append(recorded)
 
-proc recordIncl*(c: PCtx; info: TLineInfo; key: string; val: PNode) =
+proc recordIncl*(c: var TCtx; info: TLineInfo; key: string; val: PNode) =
   var recorded = newNodeI(nkReplayAction, info)
   recorded.add newStrNode("incl", info)
   recorded.add newStrNode(key, info)

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -80,14 +80,17 @@ proc selectRoutine*(i: Interpreter; name: string): PSym =
 
 proc callRoutine*(i: Interpreter; routine: PSym; args: openArray[PNode]): PNode =
   assert i != nil
-  result = vm.execProc(PCtx i.graph.vm, routine, args)
+  let c = PCtx(i.graph.vm)
+  result = vm.execProc(c[], routine, args)
 
 proc getGlobalValue*(i: Interpreter; letOrVar: PSym): PNode =
-  result = vm.getGlobalValue(PCtx i.graph.vm, letOrVar)
+  let c = PCtx(i.graph.vm)
+  result = vm.getGlobalValue(c[], letOrVar)
 
 proc setGlobalValue*(i: Interpreter; letOrVar: PSym, val: PNode) =
   ## Sets a global value to a given PNode, does not do any type checking.
-  vm.setGlobalValue(PCtx i.graph.vm, letOrVar, val)
+  let c = PCtx(i.graph.vm)
+  vm.setGlobalValue(c[], letOrVar, val)
 
 proc implementRoutine*(i: Interpreter; pkg, module, name: string;
                        impl: proc (a: VmArgs) {.closure, gcsafe.}) =

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -189,16 +189,21 @@ proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph; idgen: IdGenerator
     idgen: idgen
   )
 
-proc refresh*(c: PCtx, module: PSym; idgen: IdGenerator) =
+func refresh*(c: var TCtx, module: PSym; idgen: IdGenerator) =
   addInNimDebugUtils(c.config, "refresh")
   c.module = module
   c.prc = PProc(blocks: @[])
   c.loopIterations = c.config.maxLoopIterationsVM
   c.idgen = idgen
 
-proc registerCallback*(c: PCtx; name: string; callback: VmCallback): int {.discardable.} =
+proc registerCallback*(c: var TCtx; name: string; callback: VmCallback): int {.discardable.} =
   result = c.callbacks.len
   c.callbacks.add((name, callback))
+
+template registerCallback*(c: PCtx; name: string; callback: VmCallback): int {.deprecated.} =
+  ## A transition helper. Use the `registerCallback` proc that takes
+  ## `var TCtx` instead
+  registerCallback(c[], name, callback)
 
 const
   slotSomeTemp* = slotTempUnknown

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -154,7 +154,7 @@ when defined(nimHasInvariant):
 
 proc stackTrace2(c: PCtx, report: SemReport, n: PNode) =
   stackTrace(
-    c,
+    c[],
     PStackFrame(prc: c.prc.sym, comesFrom: 0, next: nil),
     c.exceptionInstr, report, n.info)
 

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -16,12 +16,12 @@ import
   ]
 
 
-proc enter*(prof: var Profiler, c: PCtx, tos: PStackFrame) {.inline.} =
+proc enter*(prof: var Profiler, c: var TCtx, tos: PStackFrame) {.inline.} =
   if optProfileVM in c.config.globalOptions:
     prof.tEnter = cpuTime()
     prof.tos = tos
 
-proc leaveImpl(prof: var Profiler, c: PCtx) {.noinline.} =
+proc leaveImpl(prof: var Profiler, c: TCtx) {.noinline.} =
   let tLeave = cpuTime()
   var tos = prof.tos
   var data = c.config.vmProfileData.data
@@ -35,7 +35,7 @@ proc leaveImpl(prof: var Profiler, c: PCtx) {.noinline.} =
         inc data[li].count
     tos = tos.next
 
-proc leave*(prof: var Profiler, c: PCtx) {.inline.} =
+proc leave*(prof: var Profiler, c: TCtx) {.inline.} =
   if optProfileVM in c.config.globalOptions:
     leaveImpl(prof, c)
 


### PR DESCRIPTION
* Where `TCtx` is now used, also use `func` instead of `proc`, if applicable

Not all usages of `PCtx` are replaced. `PCtx` is still used in procedures
that form the border between non-VM/VM code. `vmops` also still uses
 `PCtx`, as some ops need to capture a reference to the context