### PR TITLE
ci: update workspace sharing actions dependencies

### DIFF
--- a/.github/actions/download-compiler/action.yml
+++ b/.github/actions/download-compiler/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v2.0.10
+    - uses: actions/download-artifact@v3.0.0
       with:
         name: compiler ${{ runner.os }}
         path: '${{ runner.temp }}'

--- a/.github/actions/upload-compiler/action.yml
+++ b/.github/actions/upload-compiler/action.yml
@@ -20,7 +20,10 @@ runs:
       shell: bash
       working-directory: '${{ inputs.source }}'
 
-    - uses: actions/upload-artifact@v2.2.4
+    - uses: actions/upload-artifact@v3.0.0
       with:
         name: compiler ${{ runner.os }}
         path: '${{ runner.temp }}/compiler.tar'
+        # This action is only used to share data between jobs, there is no need
+        # to keep this artifact for long.
+        retention-days: 1


### PR DESCRIPTION
* `actions/download-artifact` updated from 2.0.10 -> 3.0.0
* `actions/upload-artifact` updated from 2.2.4 -> 3.0.0
* The artifact used to share workspace now expire in a day instead of
  the default 90 days.