### PR TITLE
Rework stack-frame handling in the VM

### DIFF
--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -251,6 +251,7 @@ type
         currentExceptionA*, currentExceptionB*: PNode
         traceReason*: ReportKind
         stacktrace*: seq[tuple[sym: PSym, location: TLineInfo]]
+        skipped*: int
 
       of rsemReportCountMismatch,
          rsemWrongNumberOfVariables:

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -527,13 +527,19 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
     of rsemVmStackTrace:
       result = "stack trace: (most recent call last)\n"
-      for idx, (sym, loc) in r.stacktrace:
+      for idx in countdown(r.stacktrace.high, 0):
+        let (sym, loc) = r.stacktrace[idx]
         result.add(
           conf.toStr(loc),
           " ",
-          sym.name.s,
-          if idx == r.stacktrace.high: "" else: "\n"
+          if sym != nil: sym.name.s else: "???"
         )
+        if r.skipped > 0 and idx == r.stacktrace.high:
+          # The entry point is always the last element in the list
+          result.add("\nSkipped ", r.skipped, " entries, calls that led up to printing")
+
+        if idx > 0: 
+          result.add("\n")
 
     of rsemVmUnhandledException:
       result.addf(

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -128,6 +128,7 @@ type
     code*: seq[TInstr]
     debug*: seq[TLineInfo]  # line info for every instruction; kept separate
                             # to not slow down interpretation
+    sframes*: seq[TStackFrame] ## The stack of the currently running code
     globals*: PNode         #
     constants*: PNode       # constant data
     types*: seq[PType]      # some instructions reference types (e.g. 'except')
@@ -152,19 +153,20 @@ type
     vmstateDiff*: seq[(PSym, PNode)] # we remember the "diff" to global state here (feature for IC)
     procToCodePos*: Table[int, int]
 
-  PStackFrame* = ref TStackFrame
-  TStackFrame* {.acyclic.} = object
+  StackFrameIndex* = int
+
+  TStackFrame* = object
     prc*: PSym                 # current prc; proc that is evaluated
     slots*: seq[TFullReg]      # parameters passed to the proc + locals;
                               # parameters come first
-    next*: PStackFrame         # for stacking
+    next*: StackFrameIndex         # for stacking
     comesFrom*: int
     safePoints*: seq[int]      # used for exception handling
                               # XXX 'break' should perform cleanup actions
                               # What does the C backend do for it?
   Profiler* = object
     tEnter*: float
-    tos*: PStackFrame
+    sframe*: StackFrameIndex   ## The current stack frame
 
   TPosition* = distinct int
 


### PR DESCRIPTION
Instead of having the stack frames as `ref` objects that are chained
together via their `next` field, store them in a `seq` in `TCtx`. This
makes it easier to reason about them, and also connects the frames
to their owning context.

While the frame list should ideally be first-in last-out (stack), this
isn't currently possible due to how exception handling is implemented.

In addition, the stack trace now always includes the entry function
and also the number of skipped frames. A nil access error when
no entry function exists (happens when a statement is evaluated)
is also fixed.

---

**Notes for reviewers**:
* The name "tos" is still used for variables/parameters storing the stack frame index. I was not able to figure out what it's supposed to mean/stand for. If wanted, I can replace it's usages with something more descriptive