### PR TITLE
testament: no longer a general tool

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -66,7 +66,6 @@ Files: "doc/html"
 Files: "tools"
 Files: "tools/nim-gdb.py"
 Files: "nimpretty"
-Files: "testament"
 Files: "nimsuggest"
 Files: "nimsuggest/tests/*.nim"
 
@@ -92,7 +91,6 @@ Files: "bin/nimgrab.exe"
 Files: "bin/nimgrep.exe"
 Files: "bin/nimpretty.exe"
 Files: "bin/nimsuggest.exe"
-Files: "bin/testament.exe"
 Files: "bin/vccexe.exe"
 
 Files: "finish.exe"
@@ -108,7 +106,6 @@ Files: "bin/nim_dbg"
 Files: "bin/nimgrep"
 Files: "bin/nimpretty"
 Files: "bin/nimsuggest"
-Files: "bin/testament"
 
 [Unix]
 InstallScript: "yes"

--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -10,15 +10,13 @@ Testament is a test runner for running tests in the development of |NimSkull| it
 It offers process isolation for tests, it can generate statistics about test cases,
 supports multiple targets (C, C++, ObjectiveC, JavaScript, etc),
 simulated `Dry-Runs <https://en.wikipedia.org/wiki/Dry_run_(testing)>`_,
-has logging, can generate HTML reports, skip tests from a file, and more,
-so can be useful to run tests, even the most complex ones.
+has logging, can generate HTML reports, skip tests from a file, and more.
 
 
 Test files location
 ===================
 
-By default Testament looks for test files on ``"./tests/*.nim"``.
-You can overwrite this pattern glob using `pattern <glob>`:option:.
+By default Testament looks for test files on ``"./tests/**/*.nim"``.
 The default working directory path can be changed using
 `--directory:"folder/subfolder/"`:option:.
 
@@ -62,20 +60,6 @@ not very useful for production, but easy to understand:
   $ testament r test0
   PASS: tests/test0.nim C                                    ( 0.2 sec)
 
-
-Running all tests from a directory
-==================================
-
-.. code:: console
-
-  $ testament pattern "tests/*.nim"
-
-To search for tests deeper in a directory, use
-
-.. code:: console
-
-  $ testament pattern "tests/**/*.nim"    # one level deeper
-  $ testament pattern "tests/**/**/*.nim" # two levels deeper
 
 HTML Reports
 ============

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -1,6 +1,6 @@
-========================
-Tools available with Nim
-========================
+=============================
+Tools available with NimSkull
+=============================
 
 .. default-role:: code
 .. include:: rstcommon.rst
@@ -27,13 +27,5 @@ The standard distribution ships with the following tools:
   | Nim search and replace utility.
 
 - | nimpretty
-  | `nimpretty`:cmd: is a Nim source code beautifier,
+  | `nimpretty`:cmd: is a |NimSkull| source code beautifier,
     to format code according to the official style guide.
-
-- | `testament <https://nim-lang.github.io/Nim/testament.html>`_
-  | `testament`:cmd: is an advanced automatic *unittests runner* for Nim tests,
-    is used for the development of Nim itself, offers process isolation for your tests,
-    it can generate statistics about test cases, supports multiple targets (C, JS, etc),
-    `simulated Dry-Runs <https://en.wikipedia.org/wiki/Dry_run_(testing)>`_,
-    has logging, can generate HTML reports, skip tests from a file, and more,
-    so can be useful to run your tests, even the most complex ones.

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -20,15 +20,6 @@
 ## Compiled test files as well as `nim c -r <testfile.nim>`
 ## exit with 0 for success (no failed tests) or 1 for failure.
 ##
-## Testament
-## =========
-##
-## Instead of `unittest`, please consider using
-## `the Testament tool <testament.html>`_ which offers process isolation for your tests.
-##
-## Alternatively using `when isMainModule: doAssert conditionHere` is usually a
-## much simpler solution for testing purposes.
-##
 ## Running a single test
 ## =====================
 ##

--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,7 @@ be used to run the Nim test suite.
 
 You may execute the tests using ``./koch.py tests``. The tests take a while to
 run, but you can run a subset of tests by specifying a category (for example
-``./koch.py tests cat async``).
+``./koch.py tests cat lang``).
 
 For more information on the ``koch`` build tool please see the documentation
 within the [doc/koch.rst](doc/koch.rst) file.

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -176,7 +176,6 @@ proc bundleWinTools(args: string) =
   buildVccTool(args)
   nimCompile("tools/nimgrab.nim", options = "-d:ssl " & args)
   nimCompile("tools/nimgrep.nim", options = args)
-  nimCompile("testament/testament.nim", options = args)
   when false:
     # not yet a tool worth including
     nimCompile(r"tools\downloader.nim",
@@ -207,7 +206,6 @@ proc buildTools(args: string = "") =
                  options = "-d:release " & defineSourceMetadata() & " " & args)
   when defined(windows): buildVccTool(args)
   bundleNimpretty(args)
-  nimCompileFold("Compile testament", "testament/testament.nim", options = "-d:release " & defineSourceMetadata() & " " & args)
 
   # pre-packages a debug version of nim which can help in many cases investigate issuses
   # withouth having to rebuild compiler.

--- a/tools/koch/kochdocs.nim
+++ b/tools/koch/kochdocs.nim
@@ -349,7 +349,7 @@ proc buildDocSamples(nimArgs, destPath: string) =
     [nimArgs, destPath / "docgen_sample.html", "doc" / "docgen_sample.nim"])
 
 proc buildDocPackages(nimArgs, destPath: string) =
-  # compiler docs; later, other packages (perhaps tools, testament etc)
+  # compiler docs; later, other packages
   let nim = findNim().quoteShell()
     # to avoid broken links to manual from compiler dir, but a multi-package
     # structure could be supported later


### PR DESCRIPTION
Testament isn't ready to be a general test runner by any means. This
removes testament from releases and part of tools build. In addition it
drops the pattern option as categories are now a must.

Part of a broader effort to streamline testament.

Changes:
- removes testament from installer and koch tools build
- removes doc references for pattern option
- removes testament references as a tool
- unittest module no longer recommends testament
- remove stale reference to async category in readme.md