### PR TITLE
Compiler Tracing: fixed compiler execution tracing

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -341,8 +341,6 @@ iterator definedSymbolNames*(conf: ConfigRef): string =
 proc countDefinedSymbols*(conf: ConfigRef): int =
   conf.symbols.len
 
-
-
 template changed(conf: ConfigRef, s: ConfNoteSet, body: untyped) =
   # Template for debugging purposes - single place to track all changes in
   # the enabled note sets.
@@ -517,12 +515,10 @@ proc report*(conf: ConfigRef, id: ReportId): TErrorHandling =
   ##           enter the error message system twice.
   return conf.report(conf.m.reports.getReport(id))
 
-
 proc report*(conf: ConfigRef, node: PNode): TErrorHandling =
   ## Write out report from the nkError node
   assert node.kind == nkError
   return conf.report(node.reportId)
-
 
 template report*[R: ReportTypes](
     conf: ConfigRef, inReport: R): TErrorHandling =
@@ -559,7 +555,6 @@ template store*(
   ## Add report with given location information to the postponed list
   conf.addReport(wrap(report, instLoc(), linfo))
 
-
 func isCompilerFatal*(conf: ConfigRef, report: Report): bool =
   ## Check if report stores fatal compilation error
   report.category == repInternal and
@@ -571,16 +566,13 @@ func severity*(conf: ConfigRef, report: ReportTypes | Report): ReportSeverity =
   # the different configuration as hints/warnings as errors
   if report.kind in repLinterKinds and optStyleError in conf.globalOptions:
     result = rsevError
-
   else:
     result = report.severity(conf.warningAsErrors + conf.hintsAsErrors)
-
 
 func isCodeError*(conf: ConfigRef, report: Report): bool =
   ## Check if report stores a regular code error, or warning/hint that has
   ## been configured to be treated as error under "warningAsError"
   conf.severity(report) == rsevError
-
 
 func ignoreMsgBecauseOfIdeTools(conf: ConfigRef, msg: ReportKind): bool =
   msg notin (repErrorKinds + repFatalKinds) and
@@ -589,7 +581,6 @@ func ignoreMsgBecauseOfIdeTools(conf: ConfigRef, msg: ReportKind): bool =
 
 func useColor*(conf: ConfigRef): bool =
   optUseColors in conf.globalOptions
-
 
 proc parseNimVersion*(a: string): NimVer =
   # could be moved somewhere reusable
@@ -630,12 +621,10 @@ proc hasHint*(conf: ConfigRef, note: ReportKind): bool =
   # ternary states instead of binary states would simplify logic
   if optHints notin conf.options:
     false
-
   elif note in {rextConf, rsemProcessing}:
     # could add here other special notes like hintSource
     # these notes apply globally.
     note in conf.mainPackageNotes
-
   else:
     note in conf.notes
 
@@ -730,7 +719,7 @@ func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
 
   elif r.kind == rdbgVmCodeListing or (
     # Optionally Ignore context stacktrace
-    not conf.hack.semStack and r.kind == rdbgTraceLine
+    r.kind == rdbgTraceLine and not conf.hack.semStack
   ):
     return writeDisabled
 
@@ -745,7 +734,7 @@ func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
     return writeForceEnabled
 
   elif (
-    # Not explicitly enanled
+    # Not explicitly enabled
     not conf.isEnabled(r) and
     # And not added for forced write
     r.kind notin forceWrite
@@ -760,24 +749,13 @@ func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
   else:
     return writeEnabled
 
-
-
-
-
 proc hcrOn*(conf: ConfigRef): bool =
   return optHotCodeReloading in conf.globalOptions
 
-when false:
-  template depConfigFields*(fn) {.dirty.} = # deadcode
-    fn(target)
-    fn(options)
-    fn(globalOptions)
-    fn(selectedGC)
-
-const oldExperimentalFeatures* = {
-  implicitDeref, dotOperators, callOperator, parallel}
-
 const
+  oldExperimentalFeatures* = {
+    implicitDeref, dotOperators, callOperator, parallel}
+
   ChecksOptions* = {optObjCheck, optFieldCheck, optRangeCheck,
     optOverflowCheck, optBoundsCheck, optAssert, optNaNCheck, optInfCheck,
     optStyleCheck}
@@ -815,11 +793,10 @@ template newPackageCache*(): untyped =
 proc newProfileData(): ProfileData =
   ProfileData(data: newTable[TLineInfo, ProfileInfo]())
 
-
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 
 const defaultHackController = HackController(
-  semStack: off,
+  semStack: on,
   reportInTrace: off,
   semTraceData: on
 )

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -725,7 +725,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
   ## XXX: maybe remove the flags for ambiguity and undeclared and let the call
   ##      sites figure it out instead?
   const allExceptModule = {low(TSymKind)..high(TSymKind)} - {skModule, skPackage}
-  c.config.addInNimDebugUtils("qualifiedLookup2", n, result)
+  c.config.addInNimDebugUtils("qualifiedLookup", n, result)
 
   proc symFromCandidates(
     c: PContext, candidates: seq[PSym], ident: PIdent, n: PNode,

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -36,7 +36,8 @@ import
   ],
   utils/[
     ropes,
-    pathutils
+    pathutils,
+    debugUtils
   ],
   sem/[
     semdata,
@@ -1916,6 +1917,7 @@ proc implicitPragmas*(c: PContext, sym: PSym, info: TLineInfo,
 
 proc pragma*(c: PContext, sym: PSym, n: PNode, validPragmas: TSpecialWords;
             isStatement: bool): PNode {.discardable.} =
+  addInNimDebugUtils(c.config, "pragma", sym, n, result)
   if n == nil or n.kind == nkError: return
   result = pragmaRec(c, sym, n, validPragmas, isStatement)
   if result != nil and result.kind == nkError:

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -56,6 +56,7 @@ proc semOperand(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     result = c.config.newError(n, reportAst(rsemExpressionHasNoType, result))
 
 proc semExprCheck(c: PContext, n: PNode, flags: TExprFlags): PNode =
+  addInNimDebugUtils(c.config, "semExprCheck", n, result, flags)
   rejectEmptyNode(n)
   result = semExpr(c, n, flags+{efWantValue})
 
@@ -72,6 +73,7 @@ proc semExprCheck(c: PContext, n: PNode, flags: TExprFlags): PNode =
     result = c.config.newError(n, reportSem rsemExpressionHasNoType)
 
 proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
+  addInNimDebugUtils(c.config, "semExprWithType", n, result, flags)
   result = semExprCheck(c, n, flags)
   if result.typ == nil and efInTypeof in flags:
     result.typ = c.voidType
@@ -1036,7 +1038,7 @@ proc afterCallActions(c: PContext; n: PNode, flags: TExprFlags): PNode =
     result = evalAtCompileTime(c, result)
 
 proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode =
-  addInNimDebugUtils(c.config, "semIndirectOp")
+  addInNimDebugUtils(c.config, "semIndirectOp", n, result, flags)
   result = nil
   checkMinSonsLen(n, 1, c.config)
   if n.kind == nkError: return n

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -473,8 +473,10 @@ proc errorSymChoiceUseQualifier(c: PContext; n: PNode) =
   localReport(c.config, n.info, rep)
 
 proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
-  var b: PNode
-  var hasError = false
+  addInNimDebugUtils(c.config, "semVarOrLet", n, result)
+  var
+    b: PNode
+    hasError = false
     ## not fully converted to using nkError, so track this flag and then wrap
     ## the result if true in an nkError.
     ## xxx: this should be replaced once nkError is more pervasive

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -1,7 +1,7 @@
 .. include:: rstcommon.rst
 
 =========================================
-    Internals of the |NimSkull| Compiler
+    Internals of the NimSkull Compiler
 =========================================
 
 .. default-role:: code

--- a/tests/arithm/tarithm.nim
+++ b/tests/arithm/tarithm.nim
@@ -1,20 +1,4 @@
 discard """
-  output: '''
-int32
-int32
-1280
-1280
-3
-1
-2
-2
-3
-4294967295
-2
-0
-tUnsignedOps OK
-'''
-nimout: "tUnsignedOps OK"
 """
 
 import typetraits
@@ -22,26 +6,21 @@ import typetraits
 
 block tand:
   # bug #5216
-  echo(name typeof((0x0A'i8 and 0x7F'i32) shl 7'i32))
+  doAssert (name typeof((0x0A'i8 and 0x7F'i32) shl 7'i32)) == "int32"
 
   let i8 = 0x0A'i8
-  echo(name typeof((i8 and 0x7F'i32) shl 7'i32))
+  doAssert (name typeof((i8 and 0x7F'i32) shl 7'i32)) == "int32"
 
-  echo((0x0A'i8 and 0x7F'i32) shl 7'i32)
+  doAssert ((0x0A'i8 and 0x7F'i32) shl 7'i32) == 1280
 
   let ii8 = 0x0A'i8
-  echo((ii8 and 0x7F'i32) shl 7'i32)
-
-
+  doAssert ((ii8 and 0x7F'i32) shl 7'i32) == 1280
 
 block tcast:
   template crossCheck(ty: untyped, exp: untyped) =
     let rt = ty(exp)
     const ct = ty(exp)
-    if $rt != $ct:
-      echo astToStr(exp)
-      echo "Got ", ct
-      echo "Expected ", rt
+    doAssert $rt == $ct, astToStr(exp) & "\nGot " & $ct & "\nExpected " & $rt
 
   template add1(x: uint8): untyped = x + 1
   template add1(x: uint16): untyped = x + 1
@@ -160,28 +139,30 @@ block tissue12177:
   var a: uint16 = 1
   var b: uint32 = 2
 
-  echo(b + a)
-  echo(b - a)
-  echo(b * a)
-  echo(b div a)
+  doAssert b + a == 3
+  doAssert b - a == 1
+  doAssert b * a == 2
+  doAssert b div a == 2
 
-  echo(a + b)
-  echo(a - b)
-  echo(a * b)
-  echo(a div b)
+  doAssert a + b == 3
+  doAssert a - b == 4294967295'u32
+  doAssert a * b == 2
+  doAssert a div b == 0
 
 block tUnsignedOps:
-  proc testUnsignedOps() =
-    let a: int8 = -128
-    let b: int8 = 127
+  proc testUnsignedOps(): bool =
+    let
+      a: int8 = -128
+      b: int8 = 127
 
     doAssert b +% 1 == -128
     doAssert b -% -1 == -128
     doAssert b *% 2 == -2
     doAssert a /% 4 == 32
     doAssert a %% 7 == 2
-    echo "tUnsignedOps OK"
 
-  testUnsignedOps()
+    result = true
+
+  doAssert testUnsignedOps()
   static:
-    testUnsignedOps()
+    doAssert testUnsignedOps()


### PR DESCRIPTION
- enabled intermediate stack traces by default
- updated compiler internals doc to make it easier to get started
- added tracing to a few more procs, noteably `semletOrVar` and `pragma`
- removed redundant `HackController` declaration

Miscellaneous Changes:
- lots of little white space removal, code was harder to follow
- removed echos in `airthm/tarithm` test

The Issue:
- defer is broken when inside a pragma block, this happened with both
  `cast` and `line`
- this caused the pop of the `config.debugUtilsStack` to happen for
  the block instead of the routine the template was being called in
---

## Notes for Reviewers
* note sure the exact cause
* leaving this PR here so I can come back to it or someone can help
