### PR TITLE
Improve `compiler/utils/bitsets.nim` module

### DIFF
--- a/compiler/ast/nimsets.nim
+++ b/compiler/ast/nimsets.nim
@@ -64,10 +64,11 @@ proc someInSet*(s: PNode, a, b: PNode): bool =
         return true
   result = false
 
-proc toBitSet*(conf: ConfigRef; s: PNode): TBitSet =
+proc inclTreeSet*(result: var TBitSetView, conf: ConfigRef; s: PNode) =
+  ## Includes all elements from tree-set `s` into `result`
+  assert result.len == int(getSize(conf, s.typ))
   var first, j: Int128
   first = firstOrd(conf, s.typ[0])
-  bitSetInit(result, int(getSize(conf, s.typ)))
   for i in 0..<s.len:
     if s[i].kind == nkRange:
       j = getOrdValue(s[i][0], first)
@@ -77,7 +78,12 @@ proc toBitSet*(conf: ConfigRef; s: PNode): TBitSet =
     else:
       bitSetIncl(result, toInt64(getOrdValue(s[i]) - first))
 
-proc toTreeSet*(conf: ConfigRef; s: TBitSet, settype: PType, info: TLineInfo): PNode =
+proc toBitSet*(conf: ConfigRef; s: PNode): TBitSet =
+  ## Creates a bit set from tree-set `s`
+  bitSetInit(result, int(getSize(conf, s.typ)))
+  inclTreeSet(result, conf, s)
+
+proc toTreeSet*(conf: ConfigRef; s: TBitSetView, settype: PType, info: TLineInfo): PNode =
   var
     a, b, e, first: BiggestInt # a, b are interval borders
     elemType: PType

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -294,11 +294,11 @@ proc evalOp(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): P
     let argB = maskBytes(getInt(b), int(a.typ.size))
     if argB != Zero:
       result = newIntNodeT(argA div argB, n, idgen, g)
-  of mLeSet: result = newIntNodeT(toInt128(ord(containsSets(g.config, a, b))), n, idgen, g)
+  of mLeSet: result = newIntNodeT(toInt128(ord(containsSets(g.config, b, a))), n, idgen, g)
   of mEqSet: result = newIntNodeT(toInt128(ord(equalSets(g.config, a, b))), n, idgen, g)
   of mLtSet:
     result = newIntNodeT(toInt128(ord(
-      containsSets(g.config, a, b) and not equalSets(g.config, a, b))), n, idgen, g)
+      containsSets(g.config, b, a) and not equalSets(g.config, a, b))), n, idgen, g)
   of mMulSet:
     result = nimsets.intersectSets(g.config, a, b)
     result.info = n.info

--- a/compiler/utils/bitsets.nim
+++ b/compiler/utils/bitsets.nim
@@ -15,50 +15,100 @@ type
   TBitSet* = seq[ElemType]    # we use byte here to avoid issues with
                               # cross-compiling; uint would be more efficient
                               # however
+  TBitSetView* = openArray[ElemType] ## A view into a bit set. This doesn't
+                                     ## necessarily have to be a `TBitSet`,
+                                     ## but can be any byte sequence storing
+                                     ## representing a bit set
+
 const
   ElemSize* = 8
   One = ElemType(1)
   Zero = ElemType(0)
+  AllOne = ElemType(0xFF)
 
 template modElemSize(arg: untyped): untyped = arg and 7
 template divElemSize(arg: untyped): untyped = arg shr 3
 
-proc bitSetIn*(x: TBitSet, e: BiggestInt): bool =
+func bitSetIn*(x: TBitSetView, e: BiggestInt): bool =
+  ## Tests if `e` is an element of `x`
   result = (x[int(e.divElemSize)] and (One shl e.modElemSize)) != Zero
 
-proc bitSetIncl*(x: var TBitSet, elem: BiggestInt) =
+func bitSetIncl*(x: var TBitSetView, elem: BiggestInt) =
+  ## If `elem` is not in set `x` yet, includes the element
   assert(elem >= 0)
   x[int(elem.divElemSize)] = x[int(elem.divElemSize)] or
       (One shl elem.modElemSize)
 
-proc bitSetExcl*(x: var TBitSet, elem: BiggestInt) =
+func bitSetExcl*(x: var TBitSetView, elem: BiggestInt) =
+  ## If `elem` is in set `x`, removes it, otherwise does nothing
   x[int(elem.divElemSize)] = x[int(elem.divElemSize)] and
       not(One shl elem.modElemSize)
 
-proc bitSetInit*(b: var TBitSet, length: int) =
+func bitSetInclRange*(x: var TBitSetView, s: Slice[BiggestInt]) =
+  ## Includes elements in the slice `r` that aren't part of `x` yet into `x`
+  if unlikely(s.a > s.b): return # Do nothing for empty slices
+
+  # This functions aims to be more efficient than a for loop with `bitSetIncl`
+
+  let start = int(s.a.divElemSize)
+  let last = int(s.b.divElemSize)
+
+  let firstBit = s.a.modElemSize
+  let endBit = s.b.modElemSize + 1 # lastBit + 1
+
+  # The position of the last bit + 1 in the start element
+  let startElemEndBit =
+    if start < last: ElemSize
+    else: int(endBit)
+
+  # Calculate the intersection between the bit ranges `0..lastBit` and `firstBit..high`
+  let startElemBits = ((One shl startElemEndBit) - 1) and (AllOne shl firstBit)
+
+  x[start] = x[start] or startElemBits
+
+  for i in (start+1)..<last:
+    x[i] = AllOne
+
+  if start < last:
+    x[last] = x[last] or ((One shl endBit) - 1)
+
+func bitSetInit*(b: var TBitSet, length: int) =
+  ## Creates a new bitset in `b` with a size-in-bytes of `length * ElemSize` .
+  ## The resulting bitset allows for elements in the
+  ## range `0..<(length * ElemSize * 8)`
   newSeq(b, length)
 
-proc bitSetUnion*(x: var TBitSet, y: TBitSet) =
+func bitSetUnion*(x: var TBitSetView, y: TBitSetView) =
+  ## Calculate the union between sets `x` and `y`
   for i in 0..high(x): x[i] = x[i] or y[i]
 
-proc bitSetDiff*(x: var TBitSet, y: TBitSet) =
+func bitSetDiff*(x: var TBitSetView, y: TBitSetView) =
+  ## Calculates the difference between sets `x` and `y` and stores the result
+  ## in `x`
   for i in 0..high(x): x[i] = x[i] and not y[i]
 
-proc bitSetSymDiff*(x: var TBitSet, y: TBitSet) =
+func bitSetSymDiff*(x: var TBitSetView, y: TBitSetView) =
+  ## Calculates the symmetric set difference between `x` and `y` and store the
+  ## result in `x`
   for i in 0..high(x): x[i] = x[i] xor y[i]
 
-proc bitSetIntersect*(x: var TBitSet, y: TBitSet) =
+func bitSetIntersect*(x: var TBitSetView, y: TBitSetView) =
+  ## Calculates the set intersection between `x` and `y` and store the result
+  ## in `x`
   for i in 0..high(x): x[i] = x[i] and y[i]
 
-proc bitSetEquals*(x, y: TBitSet): bool =
+func bitSetEquals*(x, y: TBitSetView): bool =
+  ## Set equality test. Evaluates to `true` ff all elements (bits) in `x` are
+  ## also in `y` and both sets have the same number of elements
   for i in 0..high(x):
     if x[i] != y[i]:
       return false
   result = true
 
-proc bitSetContains*(x, y: TBitSet): bool =
+func bitSetContains*(x, y: TBitSetView): bool =
+  ## Tests if `y` is a subset `x`
   for i in 0..high(x):
-    if (x[i] and not y[i]) != Zero:
+    if (not x[i] and y[i]) != Zero:
       return false
   result = true
 
@@ -66,7 +116,7 @@ proc bitSetContains*(x, y: TBitSet): bool =
 const populationCount: array[uint8, uint8] = block:
     var arr: array[uint8, uint8]
 
-    proc countSetBits(x: uint8): uint8 =
+    func countSetBits(x: uint8): uint8 =
       return
         ( x and 0b00000001'u8) +
         ((x and 0b00000010'u8) shr 1) +
@@ -83,6 +133,7 @@ const populationCount: array[uint8, uint8] = block:
 
     arr
 
-proc bitSetCard*(x: TBitSet): BiggestInt =
+func bitSetCard*(x: TBitSetView): BiggestInt =
+  ## Calculates the number of elements in the `x`
   for it in x:
     result.inc int(populationCount[it])

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1235,7 +1235,7 @@ proc rawExecute(c: var TCtx, start: int, sframe: StackFrameIndex): TFullReg =
       regs[ra].intVal = ord(regs[rb].node.strVal < regs[rc].node.strVal)
     of opcLeSet:
       decodeBC(rkInt)
-      regs[ra].intVal = ord(containsSets(c.config, regs[rb].node, regs[rc].node))
+      regs[ra].intVal = ord(containsSets(c.config, regs[rc].node, regs[rb].node))
     of opcEqSet:
       decodeBC(rkInt)
       regs[ra].intVal = ord(equalSets(c.config, regs[rb].node, regs[rc].node))
@@ -1243,7 +1243,7 @@ proc rawExecute(c: var TCtx, start: int, sframe: StackFrameIndex): TFullReg =
       decodeBC(rkInt)
       let a = regs[rb].node
       let b = regs[rc].node
-      regs[ra].intVal = ord(containsSets(c.config, a, b) and not equalSets(c.config, a, b))
+      regs[ra].intVal = ord(containsSets(c.config, b, a) and not equalSets(c.config, a, b))
     of opcMulSet:
       decodeBC(rkNode)
       createSet(regs[ra])

--- a/tests/compiler/tbitsets.nim
+++ b/tests/compiler/tbitsets.nim
@@ -1,0 +1,187 @@
+discard """
+  description: "Test the utils/bitsets compiler module"
+  targets: "c cpp js"
+"""
+
+import compiler/utils/bitsets
+
+block incl_excl:
+  var a: TBitSet
+  bitSetInit(a, 1)
+
+  doAssert not bitSetIn(a, 0)
+  doAssert not bitSetIn(a, 7)
+  doAssertRaises(IndexDefect):
+    discard bitSetIn(a, 8)
+
+  # Excluding an element not in the set is valid
+  bitSetExcl(a, 2)
+
+  bitSetIncl(a, 3)
+  doAssert bitSetIn(a, 3)
+  bitSetExcl(a, 3)
+  doAssert not bitSetIn(a, 3)
+
+
+block incl_range:
+  var a: TBitSet
+  bitSetInit(a, 3)
+
+  template testCase(slice) =
+    let s = slice
+    # reset set
+    for x in a.mitems:
+      x = 0
+
+    bitSetInclRange(a, BiggestInt(slice.a)..BiggestInt(slice.b))
+    {.line.}:
+      for x {.inject.} in s:
+        doAssert bitSetIn(a, x), $x
+
+      doAssert bitSetCard(a) == s.len
+
+  # Empty slice
+  testCase(2..1)
+  # Empty negative slice (must not fail)
+  testCase(-8..(-9))
+  # single bit
+  testCase(1..1)
+  # slice modifies only a single bit set element
+  testCase(4..(ElemSize-1))
+  # test `lastBit mod ElemSize < firstBit mod ElemSize`
+  testCase(4..ElemSize)
+  # test `lastBit mod ElemSize == firstBit mod ElemSize`
+  testCase(4..(ElemSize+4))
+  # test `lastBit mod ElemSize > firstBit mod ElemSize`
+  testCase(4..(ElemSize+6))
+  # more than 2 bit set elements are modified
+  testCase(4..(ElemSize * 2 + 4))
+
+
+template test(ac, bc: int, equal, bInA, aInB) =
+  {.line.}:
+    doAssert bitSetCard(a) == ac
+    doAssert bitSetCard(b) == bc
+    let eqA = bitSetEquals(a, b)
+    let eqB = bitSetEquals(b, a)
+    doAssert eqA == equal
+    doAssert eqA == eqB
+    doAssert bitSetContains(a, b) == bInA
+    doAssert bitSetContains(b, a) == aInB
+
+
+block comparison:
+  var a, b: TBitSet
+  bitSetInit(a, 10)
+  bitSetInit(b, 10)
+
+  # empty sets
+  test(ac = 0, bc = 0, equal = true, bInA = true, aInB = true)
+
+
+  # same elements, not empty
+  bitSetIncl(a, 10)
+  bitSetIncl(a, 15)
+  bitSetIncl(b, 10)
+  bitSetIncl(b, 15)
+
+  test(ac = 2, bc = 2, equal = true, bInA = true, aInB = true)
+
+
+  # same elements, full possible range
+  for i in 0..79:
+    bitSetIncl(a, i)
+    bitSetIncl(b, i)
+
+  test(ac = 80, bc = 80, equal = true, bInA = true, aInB = true)
+
+
+  # a < b (proper subset)
+  bitSetExcl(a, 30)
+
+  test(ac = 79, bc = 80, equal = false, bInA = false, aInB = true)
+
+
+  # a != b
+  bitSetExcl(b, 10)
+
+  test(ac = 79, bc = 79, equal = false, bInA = false, aInB = false)
+
+
+
+# Utility functions
+
+func asgn[T](x: var TBitSet, s: set[T]) =
+  assert x.len == sizeof(s)
+  for v in x.mitems:
+    v = 0
+  for e in s.items:
+    bitSetIncl(x, int(e))
+
+func `==`[T](x: TBitSet, s: set[T]): bool =
+  var tmp: TBitSet
+  tmp.bitSetInit(x.len)
+  tmp.asgn(s)
+  result = bitSetEquals(x, tmp)
+
+
+# The following tests treat Nim's `set` implementation as the
+# source of truth
+
+template test(bitSetOp, setOp, sa, sb) =
+  a.asgn(sa)
+  b.asgn(sb)
+
+  c = a
+  bitSetOp(c, b)
+  {.line.}: doAssert c == setOp(sa, sb)
+
+  c = b
+  bitSetOp(c, a)
+  {.line.}: doAssert c == setOp(sb, sa)
+
+template test(bitSetOp, setOp) =
+  bitSetInit(a, 32)
+  bitSetInit(b, 32)
+
+  # disjoint sets
+  test(bitSetOp, setOp, {10'u8..20'u8}, {30'u8..40'u8})
+  # overlapping sets
+  test(bitSetOp, setOp, {10'u8..20'u8}, {15'u8..25'u8})
+  # same sets
+  test(bitSetOp, setOp, {10'u8..20'u8}, {10'u8..20'u8})
+
+block set_operations:
+  var a, b, c: TBitSet
+
+  test(bitSetDiff, `-`)
+  test(bitSetUnion, `+`)
+  test(bitSetIntersect, `*`)
+
+  func symDiff[T](a, b: set[T]): set[T] =
+    (a - b) + (b - a)
+
+  test(bitSetSymDiff, symDiff)
+
+
+block mismatching_length:
+  var a, b: TBitSet
+  bitSetInit(a, 2)
+  bitSetInit(b, 1)
+
+  template test(code) =
+    ## Test if the statement or expression `code`
+    ## raises an IndexDefect
+    {.line.}:
+      doAssertRaises(IndexDefect):
+        when typeof(code) is void:
+          code
+        else:
+          discard code
+
+  test bitSetEquals(a, b)
+  test bitSetContains(a, b)
+  test bitSetUnion(a, b)
+  test bitSetSymDiff(a, b)
+  test bitSetDiff(a, b)
+  test bitSetIntersect(a, b)


### PR DESCRIPTION
* Add tests for all functions (there were none previously)
* Turn procs into funcs
* All `bitset` functions use set views now. This makes them
  usable in cases where the bit-set is not stored as a `seq`
* Add `bitSetInclRange`, which aims to be more efficient than a
  simple `for x in a..b: s.bitSetIncl(x)`
* Add tests for `bitSetInclRange`
* Adjust functions in `nimsets` to take bit-set views as arguments

The `bitSetContains(x, y)` function previously calculated if "x is a
subset of y" instead of if "y is a subset of x". This is now changed
in order to make `bitSetContains` consistent with `contains`
