### PR TITLE
semcall doesn't assert when missing spelling data

### DIFF
--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -179,6 +179,9 @@ proc notFoundError(c: PContext, n: PNode, errors: seq[SemCallMismatch]): PNode =
     result = c.config.newError(n, reportSem rsemExpressionCannotBeCalled)
     return
 
+  var report = reportAst(rsemCallTypeMismatch, n)
+
+  # attempt to handle spelling
   var f = n[0]
   if f.kind == nkBracketExpr:
     f = f[0]
@@ -186,11 +189,9 @@ proc notFoundError(c: PContext, n: PNode, errors: seq[SemCallMismatch]): PNode =
   if f.kind in {nkOpenSymChoice, nkClosedSymChoice}:
     f = f[0]
 
-  assert f.kind in {nkSym, nkIdent}
-
-  var report = reportAst(rsemCallTypeMismatch, n)
-  report.spellingCandidates = fixSpelling(
-    c, tern(f.kind == nkSym, f.sym.name, f.ident))
+  if f.kind in {nkSym, nkIdent}:
+    report.spellingCandidates = fixSpelling(
+      c, tern(f.kind == nkSym, f.sym.name, f.ident))
 
   discard maybeResemArgs(c, n, 1)
   report.callMismatches = errors


### PR DESCRIPTION
## Summary
There was an assert to ensure we had an ident or sym for spelling
suggestions. This isn't always possible, there is a more fundamental
fix, but that can come later. Prior to this it would crash on any
`nkDotExpr` etc; frankly that's worse than missing spelling
suggestions.