### PR TITLE
Improve internal reporting of errors in `vm`/`vmgen`

### DIFF
--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -923,7 +923,7 @@ type
 func incl*(s: var ReportSet, id: ReportId) = s.ids.incl uint32(id)
 func contains*(s: var ReportSet, id: ReportId): bool = s.ids.contains uint32(id)
 
-func addReport*(list: var ReportList, report: Report): ReportId =
+func addReport*(list: var ReportList, report: sink Report): ReportId =
   ## Add report to the report list
   list.list.add report
   result = ReportId(uint32(list.list.high) + 1)

--- a/compiler/vm/vmerrors.nim
+++ b/compiler/vm/vmerrors.nim
@@ -1,0 +1,44 @@
+## This module contains the definitions for error reporting inside
+## VM execution.
+##
+## To raise a `VmError` use `raiseVmError`. To override the source
+## location where the error is reported to have happened, use the overload
+## that takes an additional `TLineInfo`.
+##
+## `raiseVmError` must not be used outside of VM execution (`rawExecute`)
+## nor inside VM code-generation (`vmgen`)
+
+import
+  ast/[
+    reports
+  ],
+  front/[
+    msgs
+  ]
+
+
+type VmError* = object of CatchableError
+  report*: SemReport
+
+
+func raiseVmError*(
+  report: sink SemReport;
+  inst:   InstantiationInfo = instLoc()
+  ) {.noinline, noreturn.} =
+  ## Raises a `VmError`. If the report has location information already,
+  ## it's reset to none.
+  report.location = none(TLineInfo)
+  report.reportInst = toReportLineInfo(inst)
+  raise (ref VmError)(report: report)
+
+
+func raiseVmError*(
+  report:   sink SemReport;
+  location: TLineInfo,
+  inst:     InstantiationInfo = instLoc()
+  ) {.noinline, noreturn.} =
+  ## Raises a `VmError`. If the report has location information already,
+  ## it's replaced with `location`.
+  report.location = some(location)
+  report.reportInst = toReportLineInfo(inst)
+  raise (ref VmError)(report: report)


### PR DESCRIPTION
Reporting of guest code related errors was done in an inconsistent
manner via either `stackTrace` or `globalReport`, where `stackTrace` used
`localReport` and an injected `return` statement to terminate the
execution loop. `stackTrace` was sometimes used in nested functions,
thus not terminating execution at all.

### Changes
Both the execution engine and `vmgen` now use exceptions for error
propagation internally, translating them into a result value at their
respective interface edges. In case of an error, the result value stores the
error report. Otherwise, it stores the actual result.

In addition, some usages of `globalReport` are also replaced with the
 new error propagation mechanism.

Depending on whether or not a VM invocation is expected to return
something, errors reported from VM execution and/or `vmgen` are either
turned into a `nkError` node or handled directly via `handleReport`

Fixes https://github.com/nim-works/nimskull/issues/160

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

This implements an adjusted/simplified version of the proposal from the VM discussion thread. Error reporting should be a bit more consistent and streamlined now, making future changes to it a bit easier. 

## Notes for Reviewers
* I'm not sure if I got the details regarding `newError` usage right
* I was also not sure what the best approach to putting the guest stack-trace into the `nkError` was, so the stack-traces are simply dropped right now