### PR TITLE
Remove `mNSetType` magic and associated VM opcode

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -720,7 +720,7 @@ type
     mNctPut, mNctLen, mNctGet, mNctHasNext, mNctNext,
 
     mNIntVal, mNFloatVal, mNSymbol, mNIdent, mNGetType, mNStrVal, mNSetIntVal,
-    mNSetFloatVal, mNSetSymbol, mNSetIdent, mNSetType, mNSetStrVal, mNLineInfo,
+    mNSetFloatVal, mNSetSymbol, mNSetIdent, mNSetStrVal, mNLineInfo,
     mNNewNimNode, mNCopyNimNode, mNCopyNimTree, mStrToIdent, mNSigHash, mNSizeOf,
     mNBindSym, mNCallSite,
     mEqIdent, mEqNimrodNode, mSameNodeType, mGetImpl, mNGenSym,

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2168,18 +2168,6 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): TFullReg =
         dest.ident = regs[rb].node.ident
       else:
         raiseVmError(reportStr(rsemVmFieldNotFound, "ident"))
-    of opcNSetType:
-      decodeB(rkNode)
-      let b = regs[rb].node
-      internalAssert(
-        c.config,
-        b.kind == nkSym and b.sym.kind == skType,
-        "Canot set type to a non-skType symbol")
-
-      internalAssert(
-        c.config, regs[ra].node != nil, "Target node must not be nil")
-
-      regs[ra].node.typ = b.sym.typ
     of opcNSetStrVal:
       decodeB(rkNode)
       var dest = regs[ra].node

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -84,7 +84,7 @@ type
     opcNGetSize,
 
     opcNSetIntVal,
-    opcNSetFloatVal, opcNSetSymbol, opcNSetIdent, opcNSetType, opcNSetStrVal,
+    opcNSetFloatVal, opcNSetSymbol, opcNSetIdent, opcNSetStrVal,
     opcNNewNimNode, opcNCopyNimNode, opcNCopyNimTree, opcNDel, opcGenSym,
 
     opcNccValue, opcNccInc, opcNcsAdd, opcNcsIncl, opcNcsLen, opcNcsAt,

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1359,9 +1359,6 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mNSetIdent:
     unused(c, n, dest)
     genBinaryStmt(c, n, opcNSetIdent)
-  of mNSetType:
-    unused(c, n, dest)
-    genBinaryStmt(c, n, opcNSetType)
   of mNSetStrVal:
     unused(c, n, dest)
     genBinaryStmt(c, n, opcNSetStrVal)


### PR DESCRIPTION
They're dead code, originally used for implementing `macros.typ=`,
which was removed in commit `9465b5db443b98d7ac2c1683e986716fb9a9290f`
