### PR TITLE
testament: add native target and exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ lib/**/*.html
 testament.db
 /tests/**/*.json
 /tests/**/*.js
+/testament/tests/**/*.js
 
 /csources
 /csources_v1
@@ -93,7 +94,7 @@ tweeter_test.db
 /t15148.txt
 /tests/vm/tfile_rw.txt
 
-/lib/pure/*.js
+/lib/pure/**/*.js
 
 !/.builds/
 

--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -106,7 +106,9 @@ Test execution options
   example: ``"nim c -r $file"``
 
 - ``targets`` supported backend compilation targets for test into (c,
-  cpp, objc, js).
+  cpp, objc, js). Targets can be excluded via a `!`, eg: `!js` to exclude js.
+  Additionally, a `native` target is supported in order to use the same target
+  used for the compiler itself.
 
 - ``matrix`` flags with which to run the test, delimited by `;`
 


### PR DESCRIPTION
## Summary
- add target exclusions by preceding a target with an `!`, eg: `!js`
- adds a `native` target, using the same target as the compiler
- updated testament docs

Misc/Internals
- testament module, move usage doc, types, and state to the top
- adds a gitignore for js files generated when testing stdlib
- sets up default targets based on category
- spec spearates specified target vs actual targets

---
## Notes for Reviewers
* getting ready for target clean-up
