### PR TITLE
add start process callback to osproc.execProcesses

### DIFF
--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -853,7 +853,8 @@ proc execCmdsInParallel(conf: ConfigRef; cmds: seq[string]; prettyCb: proc (idx:
   else:
     tryExceptOSErrorMessage(conf, "invocation of external compiler program failed."):
       res = execProcesses(cmds, {poStdErrToStdOut, poUsePath, poParentStreams},
-                            conf.numberOfProcessors, prettyCb, afterRunEvent=runCb)
+                            conf.numberOfProcessors, beforeRunEvent=prettyCb,
+                            afterRunEvent=runCb)
 
   if res != 0:
     if conf.numberOfProcessors <= 1:

--- a/tests/osproc/texecps.nim
+++ b/tests/osproc/texecps.nim
@@ -1,30 +1,54 @@
 discard """
 joinable: false
+matrix: "--lib:lib"
+description: '''This test runs itself as a set of parallel processes in order
+to test `osproc.execProcesses`.'''
 """
 
 import osproc, streams, strutils, os
 
 const NumberOfProcesses = 13
 
-var gResults {.threadvar.}: seq[string]
+var
+  gSetup {.threadvar.}: seq[int]
+  gStartupPid {.threadvar.}: seq[int]
+  gAfterPid {.threadvar.}: seq[int]
+  gResults {.threadvar.}: seq[string]
 
-proc execCb(idx: int, p: Process) =
+proc beforeRun(idx: int) =
+  # called before a process is started
+  gSetup[idx] = idx
+
+proc startRun(idx: int, p: Process) =
+  # process just started
+  gStartupPid[idx] = p.processID
+
+proc afterRun(idx: int, p: Process) =
   let exitCode = p.peekExitCode
   if exitCode < len(gResults):
     gResults[exitCode] = p.outputStream.readAll.strip
+  gAfterPid[idx] = p.processID
 
 when true:
   if paramCount() == 0:
+    gSetup = newSeq[int](NumberOfProcesses)
+    gStartupPid = newSeq[int](NumberOfProcesses)
+    gAfterPid = newSeq[int](NumberOfProcesses)
     gResults = newSeq[string](NumberOfProcesses)
-    var checks = newSeq[string](NumberOfProcesses)
-    var commands = newSeq[string](NumberOfProcesses)
+    var
+      checks = newSeq[string](NumberOfProcesses)
+      commands = newSeq[string](NumberOfProcesses)
     for i in 0..len(commands) - 1:
       commands[i] = getAppFileName() & " " & $i
       checks[i] = $i
     let cres = execProcesses(commands, options = {poStdErrToStdOut},
-                             afterRunEvent = execCb)
+                              beforeRunEvent = beforeRun,
+                              startRunEvent = startRun,
+                              afterRunEvent = afterRun)
     doAssert(cres == len(commands) - 1)
     doAssert(gResults == checks)
+    doAssert(gSetup == @[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+    doAssert(gStartupPid == gAfterPid)
   else:
     echo paramStr(1)
     programResult = parseInt(paramStr(1))

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -450,7 +450,7 @@ proc winRelease*() =
 template `|`(a, b): string = (if a.len > 0: a else: b)
 
 proc tests(args: string) =
-  nimexec "cc --opt:speed testament/testament"
+  nimexec "--lib:lib cc --opt:speed testament/testament"
   var testCmd = quoteShell(getCurrentDir() / "testament/testament".exe)
   testCmd.add " " & quoteShell("--nim:" & findNim())
   testCmd.add " " & (args|"all")


### PR DESCRIPTION
## Summary

`osproc.execProcesses` now supports a callback for process start. This
is necessary for parallelizing testament runs.