### PR TITLE
Implement variant object branch changing for `gc:refc`

### DIFF
--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -63,7 +63,9 @@ proc searchObjCaseImpl(obj: PNode; field: PSym): PNode =
         result = searchObjCaseImpl(x, field)
         if result != nil: break
 
-proc searchObjCase(t: PType; field: PSym): PNode =
+# TODO: this is also useful outside `enumtostr` and should be moved
+# somewhere else
+proc searchObjCase*(t: PType; field: PSym): PNode =
   result = searchObjCaseImpl(t.n, field)
   if result == nil and t.len > 0:
     result = searchObjCase(t[0].skipTypes({tyAlias, tyGenericInst, tyRef, tyPtr}), field)

--- a/tests/objvariant/tbranch_change.nim
+++ b/tests/objvariant/tbranch_change.nim
@@ -1,0 +1,159 @@
+discard """
+  description: "Tests to make sure branch changing works correctly"
+  targets: "c cpp"
+  matrix: "--gc:refc; --gc:arc; --gc:orc"
+"""
+
+# XXX: remove this together with arc/orc related workarounds once
+# `tbranch_reset_arc_orc_issue.nim` works
+const isArcOrOrc = defined(gcArc) or defined(gcOrc)
+
+block:
+
+  # This is also a test for generic variant objects
+
+  type A[T] = object
+    case kind: bool
+    of false:
+      a: T
+    of true:
+      b: T
+
+
+  # variant with simple types (no destructors exist)
+  when not isArcOrOrc:
+    block:
+      # ARC/ORC fails this test as branch resets are not injected here
+      var a = A[int](kind: false, a: 1)
+      a.kind = true
+      doAssert a.b == 0
+
+  # variant with type using destructors
+  block:
+    var a = A[string](kind: false, a: "a")
+    a.kind = true
+    doAssert a.b == ""
+
+
+block update_discrim_same_of_branch:
+
+  type B = object
+    s: seq[string]
+    case kind: bool
+    of false, true:
+      str: string
+
+
+  var b = B(kind: false)
+  b.str = "a"
+  b.kind = true # Event though both true and false refer to the same
+                # of branch, the branch is reset
+  doAssert b.str == ""
+
+
+block non_case_object_field:
+
+  type A = object
+    s: seq[string]
+    case kind: bool
+    of false:
+      str: string
+    of true:
+      i: int
+
+
+  var a: A
+  a.s = @["a"]
+
+  a.kind = true # change
+  a.i = 1
+  doAssert a.s[0] == "a"
+
+  a.kind = false # change
+  a.str = "str"
+  doAssert a.s[0] == "a"
+
+  a.kind = false # update, but the active branch is not changed
+  doAssert a.s[0] == "a"
+  doAssert a.str == "str"
+
+  a.kind = true # change
+  a.i = 2
+  doAssert a.s[0] == "a"
+
+
+block sub_case_object:
+  # Change the branch for a record case inside another record case
+
+  type T = object
+    fix: string # fix to force arc/orc to generate branch reset logic
+
+    case k: bool
+    of false:
+      a: int
+
+    of true:
+      case k2: bool
+      of false:
+        b: int
+      of true:
+        c: int
+
+      other: int
+
+  var t = T(k: false, a: 1)
+  t.k = true # change active branch
+  doAssert t.k2 == false
+  doAssert t.b == 0
+  doAssert t.other == 0
+
+  t.other = 3
+
+  t.k2 = true # change active branch for the sub-case
+  doAssert t.c == 0
+  doAssert t.other == 3
+  t.c = 2
+
+  t.k = false
+  doAssert t.a == 0
+
+
+block case_in_parent_obj:
+  # Change the branch where the rec-case is in a parent object
+
+  type A = ref object of RootObj # the `ref object` here is intentional
+    case kind: bool
+    of false:
+      x: int
+    of true:
+      y: int
+
+  type B = ref object of A
+    z: int
+
+
+  var a = B(kind: false, x: 1, z: 2)
+  a.kind = true
+  doAssert a.y == 0
+  doAssert a.z == 2
+
+
+block discr_update_in_field:
+  # Update the discriminator of a field
+
+  type
+    A = object
+      fix: string # fix to force arc/orc to generate branch reset logic
+
+      case kind: bool
+      of false:
+        x: int
+      of true:
+        y: int
+
+    B = object
+      a: A
+
+  var b = B(a: A(kind: false, x: 1))
+  b.a.kind = true
+  doAssert b.a.y == 0

--- a/tests/objvariant/tbranch_reset_arc_orc_issue.nim
+++ b/tests/objvariant/tbranch_reset_arc_orc_issue.nim
@@ -1,0 +1,24 @@
+discard """
+  action: run
+  description: "Test for "
+  targets: "c cpp"
+  matrix: "--gc:arc; --gc:orc"
+
+  knownIssue: ""
+"""
+
+# ARC/ORC doesn't inject branch reset logic for discriminators that are
+# part of objects which don't have an auto-generated destructor
+
+block:
+  type A = object # `A` has no auto-generated destructor
+    case k: bool
+    of false:
+      a: int
+    of true:
+      b: int
+
+  var a = A(k: false, a: 1)
+  a.k = true # change branch
+  doAssert a.b == 0 # `a.a` was not reset and since it shares it's location
+                    # with `a.b`, `a.b` is 1

--- a/tests/objvariant/tbranch_reset_issue.nim
+++ b/tests/objvariant/tbranch_reset_issue.nim
@@ -1,0 +1,22 @@
+discard """
+  description: "Padding bytes are not reset when switching branches"
+  targets: "c cpp"
+  matrix: "--gc:refc; --gc:arc; --gc:orc"
+
+  outputsub: '''[AssertionDefect]'''
+  exitcode: 1
+"""
+
+block:
+  type T = object
+    case k: bool
+    of false:
+      x: uint32
+    of true:
+      y: uint64
+
+  var t = T(k: false)
+  cast[ptr uint64](addr(t.x))[] = high(uint64) # Write outside the
+                                               # locations storage
+  t.k = true
+  doAssert t.y == 0 # fails


### PR DESCRIPTION
This was previously forbidden and rejected at run-time. In order to get
`refc` closer to `arc`'s behaviour, it is now allowed.

The new logic is implemented in cgen and thus does not apply to the JS
back-end. It works by injecting reset logic for the assigned-to
discriminator's record-case in front of the assignment.

Behaviour is now the same as with `arc`, which means that:
* a branch reset now also happens when changing the discriminator value
  to a new value which refers to the same of-branch as the old one
* only the 'from' (source) branch is reset. This can lead to unexpected
  behaviour or crashes when modifying padding bits/bytes

---

As discussed on Matrix.

With `refc`, changing the discriminator value to something that referred to the same of-branch didn't perform a reset previously, so this is a breaking change. However, it is consistent with `arc` now.
