### PR TITLE
do node consistency

### DIFF
--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -14,6 +14,7 @@
 ## reused by external tooling - custom error pretty-printers, test runners
 ## and so on.
 
+import macros
 import std/[options, packedsets]
 
 import
@@ -410,11 +411,18 @@ func reportSym*(
 
   SemReport(kind: kind, ast: ast, str: str, typ: typ, sym: sym)
 
-template withIt*(expr: untyped, body: untyped): untyped =
-  block:
-    var it {.inject.} = expr
-    body
-    it
+# template withIt*(expr: untyped, body: untyped): untyped =
+#   block:
+#     var it {.inject.} = expr
+#     stripDoNode(body)
+#     it
+macro withIt*(expr: untyped, body: untyped): untyped =
+  let body = if body.kind == nnkDo: body[^1] else: body
+  let it = ident"it"
+  quote:
+    var `it` {.inject.} = `expr`
+    `body`
+    `it`
 
 template tern*(predicate: bool, tBranch: untyped, fBranch: untyped): untyped =
   ## Shorthand for inline if/else. Allows use of conditions in strformat,

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -213,6 +213,10 @@ type
       ## Historically and especially in version 1.0.0 of the language
       ## conversions to unsigned numbers were checked. In 1.0.4 they
       ## are not anymore.
+    optOldDoNode
+      ## Do blocks without arguments magically become nkStmtList;
+      ## Nodes of kind nkStmtList automatically convert to lambda
+      ## expressions without arguments.
 
   TSystemCC* = enum
     ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccBcc, ccVcc,

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2228,6 +2228,8 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
       # this will store the generated param names
       # leave some room for the result symbol
 
+  if quotedBlock.kind == nkDo:
+    quotedBlock = quotedBlock[^1]
   if quotedBlock.kind != nkStmtList:
     semReportIllformedAst(c.config, n, {nkStmtList})
 

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -19,7 +19,7 @@ proc semAddrArg(c: PContext; n: PNode; isUnsafeAddr = false): PNode =
   if isAssignable(c, x, true) notin {arLValue, arLocalLValue}:
     # Do not suggest the use of unsafeAddr if this expression already is a
     # unsafeAddr
-    localReport(c.config, n.info) do:
+    localReport(c.config, n.info):
       reportSem(rsemExprHasNoAddress).withIt do:
         it.isUnsafeAddr = true
 

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -1990,7 +1990,8 @@ proc incMatches(m: var TCandidate; r: TTypeRelation; convMatch = 1) =
   of isEqual: inc(m.exactMatches)
   of isNone: discard
 
-template matchesVoidProc(t: PType): bool =
+proc matchesVoidProc(t: PType): bool =
+  # used only for legacy optOldDoProc
   (t.kind == tyProc and t.len == 1 and t[0] == nil) or
     (t.kind == tyBuiltInTypeClass and t[0].kind == tyProc)
 
@@ -2156,8 +2157,8 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
       m.fauxMatch = a.kind
       result = arg
       return
-    elif a.kind == tyVoid and f.matchesVoidProc and arg.kind == nkStmtList:
-      # lift do blocks without params to lambdas
+    elif optOldDoNode in c.config.legacyFeatures and a.kind == tyVoid and f.matchesVoidProc and arg.kind == nkStmtList:
+      # lift stmtList nodes to lambdas
       let p = c.graph
       let lifted = c.semExpr(c, newProcNode(nkDo, arg.info, body = arg,
           params = nkFormalParams.newTree(p.emptyNode), name = p.emptyNode, pattern = p.emptyNode,

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1686,6 +1686,17 @@ proc getProjectPath*(): string = discard
   ## See also:
   ## * `getCurrentDir proc <os.html#getCurrentDir>`_
 
+macro stripDoNode*(arg: untyped): untyped =
+  ## for templates that expect multiple blocks of code with the do
+  ## notation, this macro will strip the do lambda node to inline the
+  ## body.
+  if arg.kind == nnkDo:
+    expectLen(arg[3], 1)
+    expectKind(arg[3][0], nnkEmpty)
+    result = arg[6]
+  else:
+    result = arg
+
 proc getSize*(arg: NimNode): int {.magic: "NSizeOf", noSideEffect.} =
   ## Returns the same result as `system.sizeof` if the size is
   ## known by the Nim compiler. Returns a negative value if the Nim

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -242,17 +242,19 @@ proc readDataStr*(s: Stream, buffer: var string, slice: Slice[int]): int =
     # fallback
     result = s.readData(addr buffer[slice.a], slice.b + 1 - slice.a)
 
+from macros import stripDoNode
+
 template jsOrVmBlock(caseJsOrVm, caseElse: untyped): untyped =
   when nimvm:
     block:
-      caseJsOrVm
+      stripDoNode(caseJsOrVm)
   else:
     block:
       when defined(js) or defined(nimscript):
         # nimscript has to be here to avoid semantic checking of caseElse
-        caseJsOrVm
+        stripDoNode(caseJsOrVm)
       else:
-        caseElse
+        stripDoNode(caseElse)
 
 when (NimMajor, NimMinor) >= (1, 3) or not defined(js):
   proc readAll*(s: Stream): string =

--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -66,6 +66,8 @@ template enableRemoteNetworking*: bool =
   ## a `nim` invocation (possibly via additional intermediate processes).
   getEnv("NIM_TESTAMENT_REMOTE_NETWORKING") == "1"
 
+from macros import stripDoNode
+
 template whenRuntimeJs*(bodyIf, bodyElse) =
   ##[
   Behaves as `when defined(js) and not nimvm` (which isn't legal yet).
@@ -78,17 +80,19 @@ template whenRuntimeJs*(bodyIf, bodyElse) =
   do:
     discard
   ]##
-  when nimvm: bodyElse
+  when nimvm: stripDoNode(bodyElse)
   else:
-    when defined(js): bodyIf
-    else: bodyElse
+    when defined(js): stripDoNode(bodyIf)
+    else: stripDoNode(bodyElse)
+
+from macros import stripDoNode
 
 template whenVMorJs*(bodyIf, bodyElse) =
   ## Behaves as: `when defined(js) or nimvm`
-  when nimvm: bodyIf
+  when nimvm: stripDoNode(bodyIf)
   else:
-    when defined(js): bodyIf
-    else: bodyElse
+    when defined(js): stripDoNode(bodyIf)
+    else: stripDoNode(bodyElse)
 
 template accept*(a) =
   doAssert compiles(a)


### PR DESCRIPTION
do nodes are now consistently lambda expressions no matter if they have arguments or not.
stmtLists are no longer lifted implicitly to lambda expressions

## Summary
 * do nodes without arguments are not implicitly converted to bare `stmtList` anymore.
 * bare `stmtList` is not lifted to a lambda expression anymore.
 * The behavior that got removed was a hack that cause more problems than it solved. 

## Details

It caused problems in my macro library, especially the implicit lifting of `stmtList` to a λ expression is a liability that is really hard to work around. It is not a feature to be proud upon. It is a breaking change, especially cases when `do` blocks need to be treated as bare `stmtList` and not λ expressions.

---

This is a change I've made a long time ago on my own fork of Nim.