### PR TITLE
csources: version updated for cast block pragma

### DIFF
--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -1,5 +1,5 @@
 nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v1
-nim_csourcesUrl=https://github.com/nim-lang/csources_v1.git
+nim_csourcesUrl=https://github.com/nim-works/csources_v1.git
 nim_csourcesBranch=master
-nim_csourcesHash=561b417c65791cd8356b5f73620914ceff845d10
+nim_csourcesHash=c181c28ae63be7c40cd316eb6744a01561617b6a

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -652,7 +652,7 @@ when isMainModule:
       of "tools":
         buildTools(op.cmdLineRest)
       of "pushcsource":
-        quit "use this instead: https://github.com/nim-lang/csources_v1/blob/master/push_c_code.nim"
+        quit "use this instead: https://github.com/nim-works/csources_v1/blob/master/push_c_code.nim"
       of "valgrind": valgrind(op.cmdLineRest)
       of "c2nim": bundleC2nim(op.cmdLineRest)
       of "ic": icTest(op.cmdLineRest)


### PR DESCRIPTION
The particular block pragma is `{.cast(noSideEffect.}:`, which is
required for compiler tracing.

Updates to reference nim-work's csources repository and new commit.

See: https://github.com/nim-works/nimskull/pull/260