### PR TITLE
vm: move `ExpandToAst` logic into own instruction

### DIFF
--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -102,7 +102,9 @@ type
     opcEqIdent,
     opcStrToIdent,
     opcGetImpl,
-    opcGetImplTransf
+    opcGetImplTransf,
+
+    opcExpandToAst,
 
     opcEcho,
     opcIndCall, # dest = call regStart, n; where regStart = fn, arg1, ...


### PR DESCRIPTION
The logic for template expansion as needed by the `mExpandToAst` magic
(used by `quote`) is now implemented as a separate instruction instead
of as part of `IndCallAsgn`. This makes the role of template expansion
less confusing ("why are templates 'called' inside the VM?", "weren't
they expanded already?") and also allows for a different instruction
argument make-up. The latter is required for both a future overhaul
of macro expansion and the refactored VM.

User-facing behaviour stays the same
