### PR TITLE
Fix crash when reporting an invalid export statement

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1087,7 +1087,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
     of rsemCannotExport:
       result = "cannot export: " & render(r.ast)
-      if r.sym.kind == skEnumField:
+      if r.sym != nil and r.sym.kind == skEnumField:
         result.add "; enum field cannot be exported individually"
 
     of rsemExpectedModuleNameForImportExcept:

--- a/tests/errmsgs/tmisc.nim
+++ b/tests/errmsgs/tmisc.nim
@@ -2,10 +2,10 @@ discard """
 cmd: "nim check $file"
 action: reject
 nimout: '''
-tmisc.nim(24, 13) Error: object construction uses ':', not '='
-tmisc.nim(26, 5) Error: wrong number of arguments
-tmisc.nim(30, 9) Error: expression has no type: foo
-tmisc.nim(38, 5) Error: type mismatch: got <int, uint>
+tmisc.nim(25, 13) Error: object construction uses ':', not '='
+tmisc.nim(27, 5) Error: wrong number of arguments
+tmisc.nim(31, 9) Error: expression has no type: foo
+tmisc.nim(39, 5) Error: type mismatch: got <int, uint>
 but expected one of:
 template `.=`(a: int; b: untyped; c: int)
   first type mismatch at position: 3
@@ -15,6 +15,7 @@ template b=(a: int; c: int)
   first type mismatch at position: 2
   required type for c: int
   but expression 'c' is of type: uint
+tmisc.nim(41, 11) Error: cannot export: std / something
 '''
 """
 
@@ -37,3 +38,4 @@ let c = 3.uint
 
 a.b = c
 
+export std/something


### PR DESCRIPTION
The specialized enum message check would unconditionally check
r.sym even though that might be nil.