### PR TITLE
stdlib: remove deprecated `NimIdent` and `NimSym`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -716,8 +716,8 @@ type
     mNccValue, mNccInc, mNcsAdd, mNcsIncl, mNcsLen, mNcsAt,
     mNctPut, mNctLen, mNctGet, mNctHasNext, mNctNext,
 
-    mNIntVal, mNFloatVal, mNSymbol, mNIdent, mNGetType, mNStrVal, mNSetIntVal,
-    mNSetFloatVal, mNSetSymbol, mNSetIdent, mNSetStrVal, mNLineInfo,
+    mNIntVal, mNFloatVal, mNGetType, mNStrVal, mNSetIntVal,
+    mNSetFloatVal, mNSetStrVal, mNLineInfo,
     mNNewNimNode, mNCopyNimNode, mNCopyNimTree, mStrToIdent, mNSigHash, mNSizeOf,
     mNBindSym, mNCallSite,
     mEqIdent, mEqNimrodNode, mSameNodeType, mGetImpl, mNGenSym,

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1735,20 +1735,6 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): TFullReg =
       case a.kind
       of nkFloatLit..nkFloat64Lit: regs[ra].floatVal = a.floatVal
       else: raiseVmError(reportStr(rsemVmFieldNotFound, "floatVal"))
-    of opcNSymbol:
-      decodeB(rkNode)
-      let a = regs[rb].node
-      if a.kind == nkSym:
-        regs[ra].node = copyNode(a)
-      else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "symbol"))
-    of opcNIdent:
-      decodeB(rkNode)
-      let a = regs[rb].node
-      if a.kind == nkIdent:
-        regs[ra].node = copyNode(a)
-      else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "ident"))
     of opcNodeId:
       decodeB(rkInt)
       when defined(useNodeIds):
@@ -2109,20 +2095,6 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): TFullReg =
         dest.floatVal = regs[rb].floatVal
       else:
         raiseVmError(reportStr(rsemVmFieldNotFound, "floatVal"))
-    of opcNSetSymbol:
-      decodeB(rkNode)
-      var dest = regs[ra].node
-      if dest.kind == nkSym and regs[rb].node.kind == nkSym:
-        dest.sym = regs[rb].node.sym
-      else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "symbol"))
-    of opcNSetIdent:
-      decodeB(rkNode)
-      var dest = regs[ra].node
-      if dest.kind == nkIdent and regs[rb].node.kind == nkIdent:
-        dest.ident = regs[rb].node.ident
-      else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "ident"))
     of opcNSetStrVal:
       decodeB(rkNode)
       var dest = regs[ra].node

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -76,15 +76,13 @@ type
     opcNSymKind,
     opcNIntVal,
     opcNFloatVal,
-    opcNSymbol,
-    opcNIdent,
     opcNGetType,
     opcNStrVal,
     opcNSigHash,
     opcNGetSize,
 
     opcNSetIntVal,
-    opcNSetFloatVal, opcNSetSymbol, opcNSetIdent, opcNSetStrVal,
+    opcNSetFloatVal, opcNSetStrVal,
     opcNNewNimNode, opcNCopyNimNode, opcNCopyNimTree, opcNDel, opcGenSym,
 
     opcNccValue, opcNccInc, opcNcsAdd, opcNcsIncl, opcNcsLen, opcNcsAt,

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1324,8 +1324,6 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
 
   of mNIntVal: genUnaryABC(c, n, dest, opcNIntVal)
   of mNFloatVal: genUnaryABC(c, n, dest, opcNFloatVal)
-  of mNSymbol: genUnaryABC(c, n, dest, opcNSymbol)
-  of mNIdent: genUnaryABC(c, n, dest, opcNIdent)
   of mNGetType:
     let tmp = c.genx(n[1])
     if dest < 0: dest = c.getTemp(n.typ)
@@ -1351,12 +1349,6 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mNSetFloatVal:
     unused(c, n, dest)
     genBinaryStmt(c, n, opcNSetFloatVal)
-  of mNSetSymbol:
-    unused(c, n, dest)
-    genBinaryStmt(c, n, opcNSetSymbol)
-  of mNSetIdent:
-    unused(c, n, dest)
-    genBinaryStmt(c, n, opcNSetIdent)
   of mNSetStrVal:
     unused(c, n, dest)
     genBinaryStmt(c, n, opcNSetStrVal)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -121,43 +121,15 @@ type
 
   TNimSymKinds* {.deprecated.} = set[NimSymKind]
 
-type
-  NimIdent* {.deprecated.} = object of RootObj
-    ## Represents a Nim identifier in the AST. **Note**: This is only
-    ## rarely useful, for identifier construction from a string
-    ## use `ident"abc"`.
-
-  NimSymObj = object # hidden
-  NimSym* {.deprecated.} = ref NimSymObj
-    ## Represents a Nim *symbol* in the compiler; a *symbol* is a looked-up
-    ## *ident*.
-
-
 const
   nnkLiterals* = {nnkCharLit..nnkNilLit}
   nnkCallKinds* = {nnkCall, nnkInfix, nnkPrefix, nnkPostfix, nnkCommand,
                    nnkCallStrLit}
   nnkPragmaCallKinds = {nnkExprColonExpr, nnkCall, nnkCallStrLit}
 
-{.push warnings: off.}
-
-proc toNimIdent*(s: string): NimIdent {.magic: "StrToIdent", noSideEffect, deprecated:
-  "Deprecated since version 0.18.0: Use 'ident' or 'newIdentNode' instead.".}
-  ## Constructs an identifier from the string `s`.
-
-proc `==`*(a, b: NimIdent): bool {.magic: "EqIdent", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Use '==' on 'NimNode' instead.".}
-  ## Compares two Nim identifiers.
-
 proc `==`*(a, b: NimNode): bool {.magic: "EqNimrodNode", noSideEffect.}
   ## Compare two Nim nodes. Return true if nodes are structurally
   ## equivalent. This means two independently created nodes can be equal.
-
-proc `==`*(a, b: NimSym): bool {.magic: "EqNimrodNode", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Use '==(NimNode, NimNode)' instead.".}
-  ## Compares two Nim symbols.
-
-{.pop.}
 
 proc sameType*(a, b: NimNode): bool {.magic: "SameNodeType", noSideEffect.} =
   ## Compares two Nim nodes' types. Return true if the types are the same,
@@ -240,25 +212,6 @@ proc strVal*(n: NimNode): string  {.magic: "NStrVal", noSideEffect.}
   ## See also:
   ## * `strVal= proc<#strVal=,NimNode,string>`_ for setting the string value.
 
-{.push warnings: off.} # silence `deprecated`
-
-proc ident*(n: NimNode): NimIdent {.magic: "NIdent", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; All functionality is defined on 'NimNode'.".}
-
-proc symbol*(n: NimNode): NimSym {.magic: "NSymbol", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; All functionality is defined on 'NimNode'.".}
-
-proc getImpl*(s: NimSym): NimNode {.magic: "GetImpl", noSideEffect, deprecated: "use `getImpl: NimNode -> NimNode` instead".}
-
-proc `$`*(i: NimIdent): string {.magic: "NStrVal", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Use 'strVal' instead.".}
-  ## Converts a Nim identifier to a string.
-
-proc `$`*(s: NimSym): string {.magic: "NStrVal", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Use 'strVal' instead.".}
-  ## Converts a Nim symbol to a string.
-
-{.pop.}
 
 when (NimMajor, NimMinor, NimPatch) >= (1, 3, 5) or defined(nimSymImplTransform):
   proc getImplTransformed*(symbol: NimNode): NimNode {.magic: "GetImplTransf", noSideEffect.}
@@ -362,16 +315,6 @@ proc getTypeImpl*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
 proc `intVal=`*(n: NimNode, val: BiggestInt) {.magic: "NSetIntVal", noSideEffect.}
 proc `floatVal=`*(n: NimNode, val: BiggestFloat) {.magic: "NSetFloatVal", noSideEffect.}
 
-{.push warnings: off.}
-
-proc `symbol=`*(n: NimNode, val: NimSym) {.magic: "NSetSymbol", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Generate a new 'NimNode' with 'genSym' instead.".}
-
-proc `ident=`*(n: NimNode, val: NimIdent) {.magic: "NSetIdent", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Generate a new 'NimNode' with 'ident(string)' instead.".}
-
-{.pop.}
-
 proc `strVal=`*(n: NimNode, val: string) {.magic: "NSetStrVal", noSideEffect.}
   ## Sets the string value of a string literal or comment.
   ## Setting `strVal` is disallowed for `nnkIdent` and `nnkSym` nodes; a new node
@@ -425,14 +368,6 @@ proc newFloatLitNode*(f: BiggestFloat): NimNode =
   result = newNimNode(nnkFloatLit)
   result.floatVal = f
 
-{.push warnings: off.}
-
-proc newIdentNode*(i: NimIdent): NimNode {.deprecated: "use ident(string)".} =
-  ## Creates an identifier node from `i`.
-  result = newNimNode(nnkIdent)
-  result.ident = i
-
-{.pop.}
 
 proc newIdentNode*(i: string): NimNode {.magic: "StrToIdent", noSideEffect.}
   ## Creates an identifier node from `i`. It is simply an alias for
@@ -665,18 +600,6 @@ proc newCall*(theProc: NimNode, args: varargs[NimNode]): NimNode =
   result = newNimNode(nnkCall)
   result.add(theProc)
   result.add(args)
-
-{.push warnings: off.}
-
-proc newCall*(theProc: NimIdent, args: varargs[NimNode]): NimNode {.deprecated:
-  "Deprecated since v0.18.1; use 'newCall(string, ...)' or 'newCall(NimNode, ...)' instead".} =
-  ## Produces a new call node. `theProc` is the proc that is called with
-  ## the arguments `args[0..]`.
-  result = newNimNode(nnkCall)
-  result.add(newIdentNode(theProc))
-  result.add(args)
-
-{.pop.}
 
 proc newCall*(theProc: string,
               args: varargs[NimNode]): NimNode =

--- a/tests/gensym/tgensymgeneric.nim
+++ b/tests/gensym/tgensymgeneric.nim
@@ -43,12 +43,8 @@ static:
   let sym1 = genSym()
   let sym2 = genSym()
   let sym3 = sym1
-  let nimsym = sym1.symbol
   doAssert sym1 == sym1
   doAssert sym2 != sym3
-  doAssert sym2.symbol != sym3.symbol
   doAssert sym3 == sym1
-  doAssert sym1.symbol == sym1.symbol
-  doAssert nimsym == nimsym
 
 echo "true"

--- a/tests/macros/tmacros1.nim
+++ b/tests/macros/tmacros1.nim
@@ -21,7 +21,7 @@ macro outterMacro*(n, blck: untyped): untyped =
       "(the_name_you_want)): statements.")
   result = newNimNode(NimNodeKind.nnkStmtList)
   var ass : NimNode = newNimNode(nnkAsgn)
-  ass.add(newIdentNode(n[1].ident))
+  ass.add(n[1])
   ass.add(newStrLitNode(innerProc(4)))
   result.add(ass)
 

--- a/tests/showoff/tdrdobbs_examples.nim
+++ b/tests/showoff/tdrdobbs_examples.nim
@@ -109,7 +109,7 @@ proc matchAgainst(n, pattern: NimNode): NimNode {.compileTime.} =
     newDotExpr(current, newIdentNode(astToStr(field)))
 
   template `==@`(n, pattern: untyped): untyped =
-    newCall("==", n@kind, newIdentNode($pat2kind($pattern.ident)))
+    newCall("==", n@kind, newIdentNode($pat2kind(pattern.strVal)))
 
   case pattern.kind
   of CallNodes:

--- a/tests/vm/tstringnil.nim
+++ b/tests/vm/tstringnil.nim
@@ -15,7 +15,7 @@ proc buildSuiteContents(suiteName, suiteDesc, suiteBloc: NimNode): tuple[tests: 
     tests:seq[SuiteTest] = @[]
 
   for child in suiteBloc.children():
-    case $child[0].ident:
+    case child[0].strVal:
     of "test":
 
       var testObj = SuiteTest()


### PR DESCRIPTION
They were deprecated since as far back as 0.18.0 and are
not compatible with the new VM in their current form