### PR TITLE
stdlib: add experimental ``results`` module

### DIFF
--- a/lib/experimental/results.nim
+++ b/lib/experimental/results.nim
@@ -1,0 +1,283 @@
+##[
+This module implements a result-type which encapsulates both a success and a
+failure in one value. Only one of the two states can be active.
+
+Based on https://github.com/disruptek/badresults, which was itself based on
+https://github.com/arnetheduck/nim-result.
+
+Exception translation
+=====================
+
+Using `get` or `value` raises an exception if the `Result` stores a failure.
+For `Result[T, E]` the exception raised is:
+ * if `E` is a `ref` type that inherits from `Exception`, the `error` value
+ * if a custom overload of `toException <#toException, E>`_ exists, the result
+  of `toException(r)`
+ * otherwise, a new `ResultError[E]` with `error` as the payload
+
+]##
+
+import std/options
+
+type
+  ResultError*[E] = object of ValueError
+    error: E
+
+  ResultErrorRef*[E] = ref ResultError[E]
+
+  Result*[T, E] = object
+    ## A `Result` is typically used to augment a return value of type `T`
+    ## indicating that a computation (proc, etc...) is uncertain and should
+    ## return a value of type `T` or end in an error of type `E`. This is
+    ## useful to avoid encoding entirely expected error cases as values instead
+    ## of resorting to exception handling for program control flow or various
+    ## side-channel data.
+    case o: bool
+    of false:
+      e: E
+    of true:
+      v: T
+
+template reportNoError() =
+  raise ResultErrorRef[void](msg: "Result does not contain an error")
+
+func error*[T, E](self: Result[T, E]): lent E {.inline.} =
+  ## Retrieves the error from a `Result`; raises `ResultError[void]`
+  ## if the `Result` is not an error.
+  if self.isErr:
+    result = self.e
+  else:
+    reportNoError()
+
+func unsafeGet*[T, E](self: var Result[T, E]): var T {.inline.} =
+  ## Fetches the value of a `Result` if set, undefined behavior if unset.
+  ##
+  ## See also:
+  ## * `unsafeGet <options.html#unsafeGet,Option[T]>`_
+  assert not isErr(self)
+  result = self.v
+
+func unsafeGet*[T, E](self: Result[T, E]): lent T {.inline.} =
+  ## Fetches the value of a `Result` if set, undefined behavior if unset.
+  ## See also:
+  ## * `unsafeGet <options.html#unsafeGet,Option[T]>`_
+  assert not isErr(self)
+  result = self.v
+
+func unsafeGet*[E](self: Result[void, E]) {.inline.} =
+  ## Does nothing if `Result` is set, undefined behavior if unset.
+  ## See also:
+  ## * `unsafeGet <options.html#unsafeGet,Option[T]>`_
+  assert not self.isErr
+
+func newResultError[E](e: sink E;
+                       s: sink string): ResultErrorRef[E] {.inline, nimcall.} =
+  ## capturing ResultError...
+  ResultErrorRef[E](error: e, msg: s)
+
+template toException*[E](err: E): ResultErrorRef[E] =
+  ## Refer to `this <#exception-translation>`_ for more information.
+  ##
+  ## The returned exception is required to be a `ref`.
+  mixin `$`
+  when compiles($err):
+    newResultError(err, "Result isErr: " & $err)
+  else:
+    newResultError(err, "Result isErr; no `$` in scope.")
+
+template raiseResultError[T, E](self: Result[T, E]) =
+  mixin toException
+  when E is ref Exception:
+    if self.error.isNil: # for example Result.default()!
+      raise ResultErrorRef[void](msg: "Result isErr; no exception.")
+    else:
+      raise self.error
+  else:
+    type ET = typeof(self.error.toException)
+    when typeof(ET) is ref:
+      raise self.error.toException
+    else:
+      # In theory, the non-ref exception could be turned into a ref
+      # exception here
+      {.error:
+        "The provided `toException` overload doesn't produce a `ref` value".}
+
+func ok*[E](R: typedesc[Result[void, E]]): Result[void, E] =
+  ## Returns a result as success.
+  R(o: true)
+
+func initSuccess*[E](self: var Result[void, E]) =
+  ## Sets a result to success.
+  runnableExamples:
+    var r: Result[void, string]
+    r.initSuccess()
+    doAssert r.isOk
+
+  self = ok[E](typeOf(self))
+
+func ok*[T, E](R: typedesc[Result[T, E]]; v: sink T): Result[T, E] =
+  ## Returns a result with a success and value.
+  runnableExamples:
+    let r = Result[int, string].ok(42)
+    doAssert r.value == 42
+
+  R(o: true, v: v)
+
+proc initSuccess*[T, E](self: var Result[T, E]; v: sink T) =
+  ## Sets the result to success and updates value.
+  self = ok[T, E](typeOf(self), v)
+
+func err*[T, E](R: typedesc[Result[T, E]]; e: sink E): Result[T, E] =
+  ## Returns a result with an error.
+  runnableExamples:
+    let r = Result[int, string].err("uh-oh")
+    doAssert r.error == "uh-oh"
+
+  R(o: false, e: e)
+
+func initFailure*[T, E](self: var Result[T, E]; e: sink E) =
+  ## Sets the result as an error.
+  self = err[T, E](typeOf(self), e)
+
+func isOk*(self: Result): bool {.inline.} = self.o
+func isErr*(self: Result): bool {.inline.} = not self.o
+
+func `==`*(a, b: Result): bool {.inline.} =
+  ## Equal if both `a` and `b` have the same ok/err status, then compares the
+  ## value or error pairs using available `==` for those type of values.
+  if a.isOk == b.isOk:
+    if a.isOk: a.v == b.v
+    else:      a.e == b.e
+  else:
+    false
+
+template get*[T: not void, E](self: Result[T, E]): untyped =
+  ## If `self` is set, returns the value. Raises `self.error` as an Exception
+  ## otherwise.
+  ##
+  ## See also:
+  ## * `get <options#get,Option[T]>`_
+  if self.isErr:
+    raiseResultError self
+  unsafeGet self
+
+template get*[T, E](self: Result[T, E]; otherwise: T): untyped =
+  ## If `self` is set, returns the value. Returns `otherwise` if `self` is
+  ## an error.
+  ##
+  ## See also:
+  ## * `get <options#get,Option[T]>`_
+  if self.isErr:
+    otherwise
+  else:
+    unsafeGet self
+
+template get*[T, E](self: var Result[T, E]): untyped =
+  ## If `self` is set, returns the mutable value. Raises `self.error` as an
+  ## `Exception` otherwise.
+  ##
+  ## See also:
+  ## * `get <options#get,Option[T]>`_
+  if self.isErr:
+    raiseResultError self
+  unsafeGet self
+
+template get*[E](self: Result[void, E]) =
+  ## Raise error as an `Exception` if `self.isErr`.
+  ##
+  ## See also:
+  ## * `get <options#get,Option[T]>`_
+  if self.isErr:
+    raiseResultError self
+
+proc `$`*[T: not void; E](self: Result[T, E]): string =
+  ## Returns the string representation of `self`
+  if self.isOk: "Ok(" & $self.v & ")"
+  else: "Err(" & $self.e & ")"
+
+func `$`*[E](self: Result[void, E]): string =
+  ## Returns the string representation of `self`
+  if self.isOk: "Ok()"
+  else: "Err(" & $self.e & ")"
+
+template value*[T, E](self: Result[T, E]): T = get self
+template value*[T, E](self: var Result[T, E]): T = get self
+
+template value*[E](self: Result[void, E]) = get self
+template value*[E](self: var Result[void, E]) = get self
+
+template valueOr*[T, E](self: Result[T, E], def: T): T =
+  ## Fetches the value of result if set, or supplied default
+  ## `def` will not be evaluated iff value is set
+  self.get(def)
+
+proc map*[T: not void; E, R](r: Result[T, E],
+                             callback: proc(v: T): R
+                            ): Result[R, E] {.effectsOf: callback.} =
+  ## See also:
+  ## * `mapErr <#mapErr,Result[T, E],proc(E)>`_
+  ## * `map <options#map,Option[T],proc(T)>`_
+  if r.isOk: Result[R, E].ok(callback(r.unsafeGet))
+  else:      Result[R, E].err(r.e)
+
+proc mapErr*[T: not void; E, R](r: Result[T, E],
+                                callback: proc(e: E): R
+                               ): Result[T, R] {.effectsOf: callback.} =
+  ## See also:
+  ## * `map <#map,Result[T, E],proc(T)>`_
+  ## * `map <options#map,Option[T],proc(T)>`_
+  if r.isErr: Result[T, R].err callback(r.e)
+  else:       Result[T, R].ok r.unsafeGet
+
+proc flatMap*[T: not void; E, R](r: Result[T, E],
+                                 callback: proc(v: T): Result[R, E]
+                                ): Result[R, E] {.effectsOf: callback.} =
+  ## See also:
+  ## * `flatMapErr <#flatMapErr,Result[T, E],proc(E)>`_
+  ## * `flatMap <options#flatMap,Option[T],proc(T)>`_
+  if r.isOk: callback(r.unsafeGet)
+  else:      Result[R, E].err r.e
+
+proc flatMapErr*[T: not void; E, R](r: Result[T, E],
+                                    callback: proc(e: E): Result[T, R]
+                                   ): Result[T, R] {.effectsOf: callback.} =
+  ## See also:
+  ## * `flatMap <#flatMap,Result[T, E],proc(T)>`_
+  ## * `flatMap <options#flatMap,Option[T],proc(T)>`_
+  if r.isErr: callback(r.e)
+  else:       Result[T, R].ok r.unsafeGet
+
+func filter*[T: not void; E](r: Result[T, E],
+                             callback: proc(v: T): bool): Option[T] =
+  ## See also:
+  ## * `filterErr <#filterErr,Result[T, E],proc(E)>`_ for filtering based on
+  ##  the error
+  ## * `filter <options#filter,Option[T],proc(T)>`_
+  if r.isOk and callback(r.v):
+    some(r.v)
+  else:
+    none(T)
+
+func filterErr*[T, E](r: Result[T, E],
+                      callback: proc(e: E): bool): Option[E] =
+  ## See also:
+  ## * `filter <#filter,Result[T, E],proc(T)>`_ for filtering based on the
+  ##  value
+  ## * `filter <options#filter,Option[T],proc(T)>`_
+  if r.isErr and callback(r.e):
+    some(r.e)
+  else:
+    none(E)
+
+func take*[T: not void; E](r: sink Result[T, E]): T =
+  ## Returns the result's value if it stores one. Raises the result's error as
+  ## an exception otherwise
+  result = move(r.value)
+
+func takeErr*[T, E](r: sink Result[T, E]): E =
+  ## Returns the result's error if it stores one. Raises a `ResultError[void]`
+  ## otherwise
+  if r.isErr:
+    result = move(r.e)
+  else:
+    reportNoError()

--- a/tests/stdlib/tresults.nim
+++ b/tests/stdlib/tresults.nim
@@ -1,0 +1,248 @@
+discard """
+  description: "Tests for the std/experimental/results module"
+  matrix: "--gc:refc; --gc:arc"
+  targets: "c cpp !js"
+"""
+
+# knownIssue: fails on the JS back-end due to a code-gen issue. The issue
+#             seems to be related to sink parameters
+
+# This file was based on the ``test.nim`` file
+# from https://github.com/disruptek/badresults
+
+import experimental/results
+import std/options
+import std/macros
+
+# Translation helpers
+template check(cond: bool, msg: string = "") =
+  {.line.}:
+    doAssert cond, msg
+
+macro check(msg: string, body: untyped) =
+  result = newStmtList()
+
+  body.expectKind nnkStmtList
+  for n in body:
+    result.add(newCall(bindSym"check", n, msg))
+
+template expect(e: typed, body: untyped) =
+  doAssertRaises e, body
+
+template test(m, body) =
+  block:
+    body
+
+
+proc main() =
+  type R = Result[int, string]
+
+  ## Basic usage, producer
+  func works(): R = R.ok(42)
+  func works2(): R = result.initSuccess(42)
+  func fails(): R = R.err("dummy")
+  func fails2(): R = result.initFailure("dummy")
+
+  ## Basic usage, consumer
+  let
+    rOk = works()
+    rOk2 = works2()
+    rErr = fails()
+    rErr2 = fails2()
+
+  test "Basic operations":
+    check "":
+      rOk.isOk
+      rOk2.isOk
+      rOk.get() == 42
+      (not rOk.isErr)
+      rErr.isErr
+      rErr2.isErr
+
+  test "Exception on access (1)":
+    let va = try: discard rOk.error; false except: true
+    check va, "not an error, should raise"
+
+  test "Exception on access (2)":
+    let vb = try: discard rErr.value; false except: true
+    check vb, "not an value, should raise"
+
+  test "Mutate":
+    var x = rOk
+
+    x.initFailure("failed now")
+
+    check x.isErr
+
+    check rOk.valueOr(50) == rOk.value
+    check rErr.valueOr(50) == 50
+
+  test "Comparisons":
+    check (works() == works2())
+    check (fails() == fails2())
+    check (works() != fails())
+
+  test "Custom exceptions":
+    type
+      AnEnum = enum
+        anEnumA
+        anEnumB
+      AnException = ref object of ValueError
+        v: AnEnum
+
+    func toException(v: AnEnum): AnException = AnException(v: v)
+
+    func testToException(): int =
+      try:
+        var r = Result[int, AnEnum].err(anEnumA)
+        get r
+      except AnException:
+        42
+
+    check testToException() == 42
+
+  test "Adhoc string rendering of exception":
+    type
+      AnEnum2 = enum
+        anEnum2A
+        anEnum2B
+
+    func testToString(): int =
+      try:
+        var r = Result[int, AnEnum2].err(anEnum2A)
+        get r
+      except ResultError[AnEnum2]:
+        42
+
+    check testToString() == 42
+
+  test "Dollar-based string rendering of an error":
+    type
+      AnEnum3 = enum
+        anEnum3A
+        anEnum3B
+
+    func `$`(e: AnEnum3): string =
+      case e
+      of anEnum3A: "first"
+      of anEnum3B: "second"
+
+    proc testToString2(): int =
+      try:
+        var r = Result[int, AnEnum3].err(anEnum3B)
+        get r
+      except ResultError[AnEnum3] as e:
+        check e.msg == "Result isErr: second"
+        42
+
+    check testToString2() == 42
+
+  test "Void Results":
+    type VoidRes = Result[void, int]
+
+    func worksVoid(): VoidRes = VoidRes.ok()
+    func worksVoid2(): VoidRes = result.initSuccess()
+    func failsVoid(): VoidRes = VoidRes.err(42)
+    func failsVoid2(): VoidRes = result.initFailure(42)
+
+    let
+      vOk = worksVoid()
+      vOk2 = worksVoid2()
+      vErr = failsVoid()
+      vErr2 = failsVoid2()
+
+    check vOk.isOk
+    check vOk2.isOk
+    check vErr.isErr
+    check vErr2.isErr
+
+    vOk.get()
+
+  test "Functional operations":
+    type
+      FloatRes = Result[float, int]
+      StrRes = Result[string, int]
+      Res2 = Result[float, string]
+
+    let
+      vOk = FloatRes.ok(1.0)
+      vErr = FloatRes.err(1)
+
+    func toStr(x: int): string = $x
+    func toStr(x: float): string = $x
+
+    let
+      vOk2 = vOk.map(toStr)
+      vErr2 = vErr.mapErr(toStr)
+      vOk3 = vOk.mapErr(toStr)
+      vErr3 = vErr.map(toStr)
+
+    check vOk2.value == "1.0"
+    check vOk3.value == 1.0
+    check vErr2.error == "1"
+    check vErr3.error == 1
+
+    let
+      vS = vOk.filter(proc(x: float): bool = x == 1.0)
+      vN = vOk.filter(proc(x: float): bool = x == 0.0)
+      vN2 = vErr.filter(proc(x: float): bool = true)
+      eS = vErr.filterErr(proc(x: int): bool = x == 1)
+      eN = vErr.filterErr(proc(x: int): bool = x == 0)
+      eN2 = vOk.filterErr(proc(x: int): bool = true)
+
+    check vS.get() == 1.0
+    check vN.isNone
+    check vN2.isNone
+    check eS.get() == 1
+    check eN.isNone
+    check eN2.isNone
+
+    check vOk2.take == "1.0"
+    check vErr2.takeErr == "1"
+
+    expect ResultError[void]:
+      discard vOk3.takeErr
+
+    expect ResultError[int]:
+      discard vErr3.take
+
+  test "Symbol resolution":
+    type
+      Q = Result[float, int]
+      R = Result[void, int]
+      S = Result[float, ref IOError]
+
+    let
+      a = Q.ok 5.3
+      b = ok R
+      c = Q.err 5
+      d = R.err 3
+      e = S.ok 5.3
+      f = S.err: IOError.newException "uh-oh"
+
+    proc `$`(s: S): string =
+      case s.isOk
+      of true:  $s.get
+      of false: "BIO:" & $s.error.name & "/" & s.error.msg
+
+    check get(a) == 5.3
+    check get(e) == 5.3
+    get(b)
+    check c.error == 5
+    check d.error == 3
+    check f.error is ref IOError
+    check $a == "Ok(5.3)"
+    check $b == "Ok()"
+    check $e == "5.3"
+    check $f == "BIO:IOError/uh-oh"
+    check unsafeGet(a) == 5.3
+    check unsafeGet(e) == 5.3
+    check get(c, 3.2) == 3.2
+    check get(f, 3.2) == 3.2
+    expect IOError:
+      discard get f
+
+
+# TODO: use the VM target once it's available in testament
+static: main()
+main()


### PR DESCRIPTION
This extends the standard library with a `Result` type.

Based on https://github.com/disruptek/badresults with the following
changes:
* removed windows `{.inline.}` work-around
* documentation adjustments
* added `lent` and `sink` annotations
* used `func` instead of `proc` where applicable
* added functional-style procedures (e.g. `map`, `filter`, etc.)
* added some `runnableExamples`
* adjusted the tests to work without ``balls``
* the tests are also run inside the VM

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

### Notes for Reviewers
* the documentation is probably a bit insufficient. Any help in this area is appreciated!
* is it possible to include the original author/contributor information somehow?

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
