### PR TITLE
cpp: remove cpp addr/deref handling in sem

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -767,8 +767,7 @@ proc hasUnresolvedArgs(c: PContext, n: PNode): bool =
     return false
 
 proc newHiddenAddrTaken(c: PContext, n: PNode): PNode =
-  if n.kind == nkHiddenDeref and not (c.config.backend == backendCpp or
-                                      sfCompileToCpp in c.module.flags):
+  if n.kind == nkHiddenDeref:
     checkSonsLen(n, 1, c.config)
     result = n[0]
   else:

--- a/compiler/sem/sizealignoffsetimpl.nim
+++ b/compiler/sem/sizealignoffsetimpl.nim
@@ -355,6 +355,8 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
           while st.kind in skipPtrs:
             st = st[^1]
           computeSizeAlign(conf, st)
+          # xxx: instead of dispatching on backend, the padding should be 0 and
+          #      end up being a noop
           if conf.backend == backendCpp:
             OffsetAccum(
               offset: int(st.size) - int(st.paddingAtEnd),

--- a/tests/arc/tconst_to_sink.nim
+++ b/tests/arc/tconst_to_sink.nim
@@ -1,8 +1,11 @@
 discard """
   output: '''@[(s1: "333", s2: ""), (s1: "abc", s2: "def"), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "lastone", s2: "")]'''
   matrix: "--gc:arc"
-  targets: "c cpp"
+  targets: "c !cpp"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 # bug #13240
 

--- a/tests/arc/texceptions.nim
+++ b/tests/arc/texceptions.nim
@@ -1,5 +1,9 @@
 discard """
-  cmd: "nim cpp --gc:arc $file"
+  target: "cpp"
+  matrix: "--gc:arc"
+  knownIssue: '''this should work in CPP, see PR:
+https://github.com/nim-works/nimskull/pull/290
+'''
 """
 
 block: # issue #13071

--- a/tests/arc/tthread.nim
+++ b/tests/arc/tthread.nim
@@ -1,5 +1,9 @@
 discard """
-  cmd: "nim cpp --gc:arc --threads:on $file"
+  target: "cpp"
+  matrix: "--gc:arc --threads:on"
+  knownIssue: '''this should work in CPP, see PR:
+https://github.com/nim-works/nimskull/pull/290
+'''
   output: '''ok1
 ok2
 destroyed

--- a/tests/ccgbugs/tctypes.nim
+++ b/tests/ccgbugs/tctypes.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp"
+  targets: "c !cpp"
   matrix: "--gc:refc; --gc:arc"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 # bug #7308
 proc foo(x: seq[int32]) =

--- a/tests/converter/tconverter_unique_ptr.nim
+++ b/tests/converter/tconverter_unique_ptr.nim
@@ -1,8 +1,11 @@
 
 discard """
-  targets: "c cpp"
-  output: ""
+  targets: "c !cpp"
+  joinable: false
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 ## Bugs 9698 and 9699
 

--- a/tests/cpp/tembarrassing_generic_bug.nim
+++ b/tests/cpp/tembarrassing_generic_bug.nim
@@ -1,6 +1,9 @@
 discard """
   targets: "cpp"
-  cmd: "nim cpp --threads:on $file"
+  matrix: "--threads:on"
+  knownIssue: '''this should work in CPP, see PR:
+https://github.com/nim-works/nimskull/pull/290
+'''
 """
 
 # bug #5142

--- a/tests/cpp/torc.nim
+++ b/tests/cpp/torc.nim
@@ -1,6 +1,9 @@
 discard """
   targets: "cpp"
   matrix: "--gc:orc"
+  knownIssue: '''this should work in CPP, see PR:
+https://github.com/nim-works/nimskull/pull/290
+'''
 """
 
 import std/options

--- a/tests/cpp/tthread_createthread.nim
+++ b/tests/cpp/tthread_createthread.nim
@@ -1,6 +1,9 @@
 discard """
   targets: "cpp"
-  cmd: "nim cpp --hints:on --threads:on $options $file"
+  matrix: "--threads:on"
+  knownIssue: '''this should work in CPP, see PR:
+https://github.com/nim-works/nimskull/pull/290
+'''
 """
 
 proc threadMain(a: int) {.thread.} =

--- a/tests/misc/trunner_special.nim
+++ b/tests/misc/trunner_special.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp"
+  targets: "c !cpp"
   joinable: false
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 #[
 Runs tests that require special treatment, e.g. because they rely on 3rd party code

--- a/tests/misc/ttlsemulation.nim
+++ b/tests/misc/ttlsemulation.nim
@@ -1,7 +1,10 @@
 discard """
   matrix: "-d:nimTtlsemulationCase1 --threads --tlsEmulation:on; -d:nimTtlsemulationCase2 --threads --tlsEmulation:off; -d:nimTtlsemulationCase3 --threads"
-  targets: "c cpp"
+  targets: "c !cpp"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 #[
 tests for: `.cppNonPod`, `--tlsEmulation`

--- a/tests/stdlib/tcstring.nim
+++ b/tests/stdlib/tcstring.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp js"
+  targets: "c !cpp js"
   matrix: "--gc:refc; --gc:arc"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 from std/sugar import collect
 from stdtest/testutils import whenRuntimeJs, whenVMorJs

--- a/tests/stdlib/tdeques.nim
+++ b/tests/stdlib/tdeques.nim
@@ -1,7 +1,10 @@
 discard """
   matrix: "--gc:refc; --gc:orc"
-  targets: "c cpp js"
+  targets: "c !cpp js"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import std/deques
 from std/sequtils import toSeq

--- a/tests/stdlib/texitprocs.nim
+++ b/tests/stdlib/texitprocs.nim
@@ -1,5 +1,5 @@
 discard """
-targets: "c cpp js"
+targets: "c !cpp js"
 output: '''
 ok4
 ok3
@@ -7,6 +7,9 @@ ok2
 ok1
 '''
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import std/exitprocs
 

--- a/tests/stdlib/tisolation.nim
+++ b/tests/stdlib/tisolation.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp"
+  targets: "c !cpp"
   matrix: "--gc:refc; --gc:orc"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import std/[isolation, json]
 

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -1,6 +1,9 @@
 discard """
-  targets: "c cpp js"
+  targets: "c !cpp js"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import std/jsonutils
 import std/json

--- a/tests/stdlib/tlocks.nim
+++ b/tests/stdlib/tlocks.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp js"
+  targets: "c !cpp js"
   matrix: "--threads:on"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 #bug #6049
 import uselocks

--- a/tests/stdlib/tosenv.nim
+++ b/tests/stdlib/tosenv.nim
@@ -1,8 +1,11 @@
 discard """
   matrix: "--threads"
   joinable: false
-  targets: "c js cpp"
+  targets: "c js !cpp"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import std/os
 from std/sequtils import toSeq

--- a/tests/stdlib/tosprocterminate.nim
+++ b/tests/stdlib/tosprocterminate.nim
@@ -1,8 +1,11 @@
 discard """
   cmd: "nim $target $options -r $file"
-  targets: "c cpp"
+  targets: "c !cpp"
   matrix: "--threads:on; "
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import os, osproc, times, std / monotimes
 

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp js"
+  targets: "c !cpp js"
   matrix: ";--gc:arc"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 # if excessive, could remove 'cpp' from targets
 

--- a/tests/stdlib/tstrbasics.nim
+++ b/tests/stdlib/tstrbasics.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp js"
+  targets: "c !cpp js"
   matrix: "--gc:refc; --gc:arc"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import std/[strbasics, sugar]
 

--- a/tests/stdlib/ttasks.nim
+++ b/tests/stdlib/ttasks.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp"
+  targets: "c !cpp"
   matrix: "--gc:orc"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 import std/[tasks, strformat]
 

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -1,6 +1,9 @@
 discard """
-  targets: "c cpp js"
+  targets: "c !cpp js"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 #[
 if https://github.com/nim-lang/Nim/pull/14043 is merged (or at least its

--- a/tests/threads/tjsthreads.nim
+++ b/tests/threads/tjsthreads.nim
@@ -1,6 +1,9 @@
 discard """
-  targets: "c cpp js"
+  targets: "c !cpp js"
   matrix: "--threads"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 echo 123

--- a/tests/vm/t9622.nim
+++ b/tests/vm/t9622.nim
@@ -1,7 +1,10 @@
 discard """
-  targets: "c cpp"
+  targets: "c !cpp"
   matrix: "--gc:refc; --gc:arc"
 """
+
+# xxx: this should work in CPP, it's a knownIssue, see PR:
+#      https://github.com/nim-works/nimskull/pull/290
 
 type
   GlobNodeKind = enum


### PR DESCRIPTION
In semexprs there was a path that changed addr/deref handling for cpp.
This is a layering violation and led to non-idempotent sem. Removal
will result in many code gen issues for the cpp backend.

This commit includes a number of changes to tests in order to ensure
that CI still passes. Identifying tests modified due to cpp related
failures with knownIssues.

Additionally, a few small issues with testament were found and fixed:
- tests weren't always skipped when they weren't in requested targets
- megatest always ran, even if the c target wasn't specified

---
## Notes for Reviewers

Relates to the discussion here: https://github.com/nim-works/nimskull/discussions/289
It's not fully disabling or removing cpp features, but at least we can make honest fixes
instead of hacks.