### PR TITLE
cpp: fix `var` parameter regression

### DIFF
--- a/tests/arc/tconst_to_sink.nim
+++ b/tests/arc/tconst_to_sink.nim
@@ -1,11 +1,8 @@
 discard """
   output: '''@[(s1: "333", s2: ""), (s1: "abc", s2: "def"), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "lastone", s2: "")]'''
   matrix: "--gc:arc"
-  targets: "c !cpp"
+  targets: "c cpp"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 # bug #13240
 

--- a/tests/arc/texceptions.nim
+++ b/tests/arc/texceptions.nim
@@ -1,9 +1,6 @@
 discard """
   target: "cpp"
   matrix: "--gc:arc"
-  knownIssue: '''this should work in CPP, see PR:
-https://github.com/nim-works/nimskull/pull/290
-'''
 """
 
 block: # issue #13071

--- a/tests/arc/tthread.nim
+++ b/tests/arc/tthread.nim
@@ -1,9 +1,6 @@
 discard """
   target: "cpp"
   matrix: "--gc:arc --threads:on"
-  knownIssue: '''this should work in CPP, see PR:
-https://github.com/nim-works/nimskull/pull/290
-'''
   output: '''ok1
 ok2
 destroyed

--- a/tests/ccgbugs/tctypes.nim
+++ b/tests/ccgbugs/tctypes.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
   matrix: "--gc:refc; --gc:arc"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 # bug #7308
 proc foo(x: seq[int32]) =

--- a/tests/ccgbugs/tvar_param.nim
+++ b/tests/ccgbugs/tvar_param.nim
@@ -1,0 +1,73 @@
+discard """
+  targets: "c cpp" # For good measure, also test with the C back-end
+  matrix: "--gc:arc"
+"""
+
+# These are tests for the fix for the regressions introduced by PR
+# https://github.com/nim-works/nimskull/pull/290.
+# Since temporaries are only generated with arc/orc (see
+# `ccgcalls.withTmpIfNeeded`) we explicitly build with `gc:arc` here
+
+type T1 = object
+  i: int
+
+block:
+  proc a(x: var T1, y: var int) =
+    discard
+
+  proc b(x: var T1) =
+    a(x, x.i) # `nkHiddenAddr(nkHiddenDeref(`x`))` is collapsed to just `x`
+              # after the PR mentioned above. Without a `nkHiddenAddr`, the
+              # current implementation in `ccgcalls.genParams` forces
+              # a temporary for `x` here, leading to faulty code being
+              # generated
+
+  var v: T1
+  b(v)
+
+block pass_through:
+  proc a(x: var T1) = discard
+
+  proc b(x: var T1) =
+    a(x)
+
+  var v: T1
+  b(v)
+
+block importc:
+
+  # importc'ed procs with `nodecl` or `header` treat `var` params as `T*`
+  # instead of `T&` in cpp mode. We emulate a function coming from C with
+  # `pseudoCProc` here
+  proc pseudoCProc(x: ptr int) {.exportc.} = discard
+  proc cproc(x: var int) {.importc: "pseudoCProc", nodecl.}
+
+  proc a(x: var int) =
+    cproc(x) # `x` is a `T&` and needs to be correctly translated to `&x` here,
+             # since `cproc` takes a `T*`
+
+    var y = 1
+    cproc(y) # this needs to still work too
+
+  var v = 1
+  a(v)
+
+# Tests to make sure that the regression fix doesn't break other things
+
+block:
+  proc a(x: var int) = discard
+
+  proc b(x: ptr int) =
+    a(x[])
+
+  var x: int
+  b(addr x)
+
+block:
+  proc p(s: var seq[int]) =
+    s = newSeq[int](1) #
+      # arrives as `nkCall('=sink', nkHiddenAddr(nkHiddenDeref(s)), ...)` at
+      # the back-end
+
+  var s: seq[int]
+  p(s)

--- a/tests/converter/tconverter_unique_ptr.nim
+++ b/tests/converter/tconverter_unique_ptr.nim
@@ -1,11 +1,8 @@
 
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
   joinable: false
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 ## Bugs 9698 and 9699
 

--- a/tests/cpp/tembarrassing_generic_bug.nim
+++ b/tests/cpp/tembarrassing_generic_bug.nim
@@ -1,9 +1,6 @@
 discard """
   targets: "cpp"
   matrix: "--threads:on"
-  knownIssue: '''this should work in CPP, see PR:
-https://github.com/nim-works/nimskull/pull/290
-'''
 """
 
 # bug #5142

--- a/tests/cpp/torc.nim
+++ b/tests/cpp/torc.nim
@@ -1,9 +1,6 @@
 discard """
   targets: "cpp"
   matrix: "--gc:orc"
-  knownIssue: '''this should work in CPP, see PR:
-https://github.com/nim-works/nimskull/pull/290
-'''
 """
 
 import std/options

--- a/tests/cpp/tthread_createthread.nim
+++ b/tests/cpp/tthread_createthread.nim
@@ -1,9 +1,6 @@
 discard """
   targets: "cpp"
   matrix: "--threads:on"
-  knownIssue: '''this should work in CPP, see PR:
-https://github.com/nim-works/nimskull/pull/290
-'''
 """
 
 proc threadMain(a: int) {.thread.} =

--- a/tests/misc/trunner_special.nim
+++ b/tests/misc/trunner_special.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
   joinable: false
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 #[
 Runs tests that require special treatment, e.g. because they rely on 3rd party code

--- a/tests/misc/ttlsemulation.nim
+++ b/tests/misc/ttlsemulation.nim
@@ -1,10 +1,7 @@
 discard """
   matrix: "-d:nimTtlsemulationCase1 --threads --tlsEmulation:on; -d:nimTtlsemulationCase2 --threads --tlsEmulation:off; -d:nimTtlsemulationCase3 --threads"
-  targets: "c !cpp"
+  targets: "c cpp"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 #[
 tests for: `.cppNonPod`, `--tlsEmulation`

--- a/tests/stdlib/tcstring.nim
+++ b/tests/stdlib/tcstring.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   matrix: "--gc:refc; --gc:arc"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 from std/sugar import collect
 from stdtest/testutils import whenRuntimeJs, whenVMorJs

--- a/tests/stdlib/tdeques.nim
+++ b/tests/stdlib/tdeques.nim
@@ -1,10 +1,7 @@
 discard """
   matrix: "--gc:refc; --gc:orc"
-  targets: "c !cpp js"
+  targets: "c cpp js"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import std/deques
 from std/sequtils import toSeq

--- a/tests/stdlib/texitprocs.nim
+++ b/tests/stdlib/texitprocs.nim
@@ -1,5 +1,5 @@
 discard """
-targets: "c !cpp js"
+targets: "c cpp js"
 output: '''
 ok4
 ok3
@@ -7,9 +7,6 @@ ok2
 ok1
 '''
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import std/exitprocs
 

--- a/tests/stdlib/tisolation.nim
+++ b/tests/stdlib/tisolation.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
   matrix: "--gc:refc; --gc:orc"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import std/[isolation, json]
 

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -1,9 +1,6 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import std/jsonutils
 import std/json

--- a/tests/stdlib/tlocks.nim
+++ b/tests/stdlib/tlocks.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   matrix: "--threads:on"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 #bug #6049
 import uselocks

--- a/tests/stdlib/tosenv.nim
+++ b/tests/stdlib/tosenv.nim
@@ -1,11 +1,8 @@
 discard """
   matrix: "--threads"
   joinable: false
-  targets: "c js !cpp"
+  targets: "c js cpp"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import std/os
 from std/sequtils import toSeq

--- a/tests/stdlib/tosprocterminate.nim
+++ b/tests/stdlib/tosprocterminate.nim
@@ -1,11 +1,8 @@
 discard """
   cmd: "nim $target $options -r $file"
-  targets: "c !cpp"
+  targets: "c cpp"
   matrix: "--threads:on; "
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import os, osproc, times, std / monotimes
 

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   matrix: ";--gc:arc"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 # if excessive, could remove 'cpp' from targets
 

--- a/tests/stdlib/tstrbasics.nim
+++ b/tests/stdlib/tstrbasics.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   matrix: "--gc:refc; --gc:arc"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import std/[strbasics, sugar]
 

--- a/tests/stdlib/ttasks.nim
+++ b/tests/stdlib/ttasks.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
   matrix: "--gc:orc"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 import std/[tasks, strformat]
 

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -1,9 +1,6 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 #[
 if https://github.com/nim-lang/Nim/pull/14043 is merged (or at least its

--- a/tests/threads/tjsthreads.nim
+++ b/tests/threads/tjsthreads.nim
@@ -1,9 +1,6 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   matrix: "--threads"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 echo 123

--- a/tests/vm/t9622.nim
+++ b/tests/vm/t9622.nim
@@ -1,10 +1,7 @@
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
   matrix: "--gc:refc; --gc:arc"
 """
-
-# xxx: this should work in CPP, it's a knownIssue, see PR:
-#      https://github.com/nim-works/nimskull/pull/290
 
 type
   GlobNodeKind = enum


### PR DESCRIPTION
Fixes at least some of the code-gen issues introduced by
https://github.com/nim-works/nimskull/pull/290. All previously
disabled tests work again.

For more details, refer to ``tests/ccgbugs/tvar_param.nim``.

Since temporaries are now also used in places where they previously
weren't (for the C back-end), this is a breaking change.

