### PR TITLE
vm: improve aliasing of `slots` under ORC

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -574,10 +574,11 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): TFullReg =
   var savedPC = -1
   var savedFrame: StackFrameIndex
   when defined(gcArc) or defined(gcOrc):
-    var tosPtr: ptr TStackFrame
-    template regs: untyped = tosPtr.slots
+    # Use {.cursor.} as a way to get a shallow copy of the seq. This is safe,
+    # since `slots` is never changed in length (no add/delete)
+    var regs {.cursor.}: seq[TFullReg]
     template updateRegsAlias =
-      tosPtr = addr c.sframes[tos]
+      regs = c.sframes[tos].slots
     updateRegsAlias
   else:
     template updateRegsAlias =


### PR DESCRIPTION
Indirectly accessing `slots` via a `TStackFrame` pointer was done to
work around `shallowCopy` not being available for `seq` with ORC.

The shallow copy is now replicated with the `cursor` pragma, saving
one pointer indirection

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

I ran the test suite with an ORC enabled compiler and there were no (VM related) failures. This change allows to get rid of `SlotStorage` in the VM refactoring [PR](https://github.com/nim-works/nimskull/pull/242)