### PR TITLE
koch: use epoch 0 if metadata is not available

### DIFF
--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -610,8 +610,14 @@ when isMainModule:
   # current time. Currently these tools are known to use the current time:
   #
   # - nim doc
-  let epoch = getSourceMetadata().date.parse("yyyy-MM-dd", zone = utc())
-                                      .toTime.toUnix()
+  let epoch =
+    if getSourceMetadata().date.len > 0:
+      getSourceMetadata().date.parse("yyyy-MM-dd", zone = utc())
+                              .toTime.toUnix()
+    else:
+      # The data is not available, opt for epoch 0 for reproducibility
+      0
+
   putEnv("SOURCE_DATE_EPOCH", $epoch)
   while true:
     op.next()


### PR DESCRIPTION
## Summary
In cases where no metadata is available (ie. a source dump from Github),
use epoch 0 instead of attempting to parse an empty string.
    
This fixes a crash when the Github-generated source tarball is used
(which doesn't have the metadata).
