### PR TITLE
koch: improve compatibility with older git

### DIFF
--- a/tools/koch/kochdocs.nim
+++ b/tools/koch/kochdocs.nim
@@ -137,13 +137,13 @@ proc getSourceMetadata*(): tuple[hash, date, versionSuffix: string] =
     except OSError, IOError:
       # If the file does not exist, then this is not a release tarball, try
       # obtaining the data from git instead
-      let hashCall = execCmdEx("git -C " & quoteShell(nimSource) & " rev-parse --verify HEAD")
-      if hashCall.exitCode == 0:
-        hash = hashCall.output.strip()
 
-      let dateCall = execCmdEx("git -C " & quoteShell(nimSource) & " log -1 --format=%cs HEAD")
-      if dateCall.exitCode == 0:
-        date = dateCall.output.strip()
+      # Grab the hash and commit timestamp from git log
+      let hashAndDateCall = execCmdEx("git -C " & quoteShell(nimSource) & " log -1 --format=%H,%cd --date=short HEAD")
+      if hashAndDateCall.exitCode == 0:
+        let splitted = hashAndDateCall.output.strip().split(',')
+        hash = splitted[0]
+        date = splitted[1]
 
       let nearestReleaseTagCall = execCmdEx:
         "git" & " -C " & quoteShell(nimSource) & " describe" &


### PR DESCRIPTION
## Summary
The `%cs` format specifier is relatively new (3 yrs old) and requires
Git >= 2.25.0, which users on older Linux distributions/Windows may not
have.

This commit folds the commit hash and commit date query into one call,
and make use of the older `%cd` format specifier with `--date=short`,
which is equivalent to `%cs` and is supported all the way back to Git
1.6.x (approx. 15 yrs old).