### PR TITLE
nimdoc: remove doc0 and jsondoc0

### DIFF
--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -364,8 +364,8 @@ const gcNames = @[
 
 const cmdNames = @[
   "c", "cc", "compile", "compiletoc", "cpp", "compiletocpp", "objc",
-  "compiletooc", "js", "compiletojs", "r", "run", "check", "e", "doc0",
-  "doc2", "doc", "doc2tex", "rst2html", "rst2tex", "jsondoc0", "jsondoc2",
+  "compiletooc", "js", "compiletojs", "r", "run", "check", "e",
+  "doc2", "doc", "doc2tex", "rst2html", "rst2tex", "jsondoc2",
   "jsondoc", "ctags", "buildindex", "gendepend", "dump", "parse", "rod",
   "secret", "nop", "help", "jsonscript",
 ]
@@ -601,12 +601,10 @@ proc parseCommand*(command: string): Command =
   of "run": cmdTcc
   of "check": cmdCheck
   of "e": cmdNimscript
-  of "doc0": cmdDoc0
   of "doc2", "doc": cmdDoc
   of "doc2tex": cmdDoc2tex
   of "rst2html": cmdRst2html
   of "rst2tex": cmdRst2tex
-  of "jsondoc0": cmdJsondoc0
   of "jsondoc2", "jsondoc": cmdJsondoc
   of "ctags": cmdCtags
   of "buildindex": cmdBuildindex

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -157,12 +157,10 @@ type
     cmdRod         ## .rod to some text representation (for debugging)
     cmdIdeTools    ## ide tools (e.g. nimsuggest)
     cmdNimscript   ## evaluate nimscript
-    cmdDoc0
     cmdDoc         ## convert .nim doc comments to HTML
     cmdDoc2tex     ## convert .nim doc comments to LaTeX
     cmdRst2html    ## convert a reStructuredText file to HTML
     cmdRst2tex     ## convert a reStructuredText file to TeX
-    cmdJsondoc0
     cmdJsondoc
     cmdCtags
     cmdBuildindex

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -347,7 +347,6 @@ proc mainCommand*(graph: ModuleGraph) =
       globalReport(conf, ExternalReport(
         kind: rextExpectedTinyCForRun))
 
-  of cmdDoc0: docLikeCmd commandDoc(cache, conf)
   of cmdDoc:
     docLikeCmd():
       conf.setNoteDefaults(rsemLockLevelMismatch, false) # issue #13218
@@ -380,7 +379,6 @@ proc mainCommand*(graph: ModuleGraph) =
         commandRst2TeX(cache, conf)
       else:
         docLikeCmd commandDoc2(graph, TexExt)
-  of cmdJsondoc0: docLikeCmd commandJson(cache, conf)
   of cmdJsondoc: docLikeCmd commandDoc2(graph, JsonExt)
   of cmdCtags: docLikeCmd commandTags(cache, conf)
   of cmdBuildindex: docLikeCmd commandBuildIndex(conf, $conf.projectFull, conf.outFile)

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -49,8 +49,7 @@ const
 
 const
   cmdBackends* = {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToJS, cmdCrun}
-  cmdDocLike* = {cmdDoc0, cmdDoc, cmdDoc2tex, cmdJsondoc0, cmdJsondoc,
-                 cmdCtags, cmdBuildindex}
+  cmdDocLike* = {cmdDoc, cmdDoc2tex, cmdJsondoc, cmdCtags, cmdBuildindex}
 
 type
   NimVer* = tuple[major: int, minor: int, patch: int]

--- a/doc/docgen.rst
+++ b/doc/docgen.rst
@@ -204,30 +204,7 @@ Output::
     ]
   }
 
-Similarly to the old `doc`:option: command, the old `jsondoc`:option: command has been
-renamed to `jsondoc0`:option:.
-
-The `jsondoc0`:option: command:
-
-.. code:: cmd
-
-  nim jsondoc0 docgen_sample.nim
-
-Output::
-  [
-    {
-      "comment": "This module is a sample."
-    },
-    {
-      "name": "helloWorld",
-      "type": "skProc",
-      "description": "Takes an integer and outputs as many &quot;hello world!&quot;s",
-      "code": "proc helloWorld*(times: int)"
-    }
-  ]
-
-Note that the `jsondoc`:option: command outputs its JSON without pretty-printing it,
-while `jsondoc0`:option: outputs pretty-printed JSON.
+Note that the `jsondoc`:option: command outputs its JSON without pretty-printing it.
 
 Related Options
 ===============

--- a/tools/koch/kochdocs.nim
+++ b/tools/koch/kochdocs.nim
@@ -240,11 +240,6 @@ niminst.rst
 gc.rst
 """.splitWhitespace().mapIt("doc" / it)
 
-  doc0 = """
-lib/system/threads.nim
-lib/system/channels_builtin.nim
-""".splitWhitespace() # ran by `nim doc0` instead of `nim doc`
-
   withoutIndex = """
 lib/wrappers/mysql.nim
 lib/wrappers/sqlite3.nim
@@ -289,7 +284,6 @@ when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
 
 proc getDocList(): seq[string] =
   var docIgnore: HashSet[string]
-  for a in doc0: docIgnore.incl a
   for a in withoutIndex: docIgnore.incl a
   for a in ignoredModules: docIgnore.incl a
 
@@ -363,15 +357,11 @@ proc buildDoc(nimArgs, destPath: string) =
   # call nim for the documentation:
   let rst2html = getRst2html()
   var
-    commands = newSeq[string](rst2html.len + len(doc0) + len(doc) + withoutIndex.len)
+    commands = newSeq[string](rst2html.len + len(doc) + withoutIndex.len)
     i = 0
   let nim = findNim().quoteShell()
   for d in items(rst2html):
     commands[i] = nim & " rst2html --git.url:$# -o:$# --index:on $# $#" %
-      [gitUrl, destPath / changeFileExt(splitFile(d).name, "html"), nimArgs, d]
-    i.inc
-  for d in items(doc0):
-    commands[i] = nim & " doc0 --git.url:$# -o:$# --index:on $# $#" %
       [gitUrl, destPath / changeFileExt(splitFile(d).name, "html"), nimArgs, d]
     i.inc
   for d in items(doc):


### PR DESCRIPTION
These are deprecated doc commands, no longer necessary.

## Summary
* dropped support for `doc0` and `jsondoc0` commands
* these have been deprecated for a long time

---
## Notes for Reviewers
* likely some deadcode left behind, can't find it all :D