### PR TITLE
qualifying compiler imports as such

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -10,15 +10,15 @@
 ## abstract syntax tree + symbol table
 
 import
-  ast/[
+  compiler/ast/[
     lineinfos, # Positional information
     idents, # Ast identifiers
     ast_types # Main ast type definitions
   ],
-  front/[
+  compiler/front/[
     options
   ],
-  utils/[
+  compiler/utils/[
     ropes,
     int128 # Values for integer nodes
   ],

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1,7 +1,7 @@
-import utils/ropes
+import compiler/utils/ropes
 import std/[hashes]
 
-from front/in_options import TOption, TOptions # Stored in `PSym`
+from compiler/front/in_options import TOption, TOptions # Stored in `PSym`
 
 
 type

--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -12,7 +12,7 @@
 ## the data structures here are used in various places of the compiler.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     idents,
     renderer
@@ -22,7 +22,7 @@ import
     intsets,
     strutils,
   ],
-  utils/[
+  compiler/utils/[
     ropes,
   ]
 

--- a/compiler/ast/astmsgs.nim
+++ b/compiler/ast/astmsgs.nim
@@ -1,10 +1,10 @@
 # this module avoids ast depending on msgs or vice versa
 import std/strutils
 import
-  ast/[
+  compiler/ast/[
     ast,
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ]

--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -1,10 +1,10 @@
 import
-  ast/[
+  compiler/ast/[
     ast,
     idents,
     lineinfos
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
     magicsys
   ]

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -32,15 +32,15 @@
 ##   structure on the side instead of directly in the node
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     reports,
     lineinfos
   ],
-  utils/[
+  compiler/utils/[
     debugutils,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],

--- a/compiler/ast/errorreporting.nim
+++ b/compiler/ast/errorreporting.nim
@@ -14,8 +14,8 @@
 ##   determines which error handling strategy to use doNothing, raise, etc.
 
 import ast, errorhandling, renderer, reports, std/tables
-from front/options import ConfigRef
-from front/msgs import TErrorHandling
+from compiler/front/options import ConfigRef
+from compiler/front/msgs import TErrorHandling
 
 export compilerInstInfo, walkErrors, errorKind
 # export because keeping the declaration in `errorhandling` acts as a reminder

--- a/compiler/ast/filter_tmpl.nim
+++ b/compiler/ast/filter_tmpl.nim
@@ -10,17 +10,17 @@
 ## This module implements Nim's standard template filter.
 
 import
-  front/[
+  compiler/front/[
     msgs,
     options,
   ],
   std/[
     strutils,
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ],
-  ast/[
+  compiler/ast/[
     llstream,
     ast,
     filters,

--- a/compiler/ast/filters.nim
+++ b/compiler/ast/filters.nim
@@ -10,7 +10,7 @@
 ## This module implements Nim's simple filters and helpers for filters.
 
 import
-  ast/[
+  compiler/ast/[
     llstream,
     ast,
     renderer,
@@ -19,10 +19,10 @@ import
   std/[
     strutils,
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ]

--- a/compiler/ast/layouter.nim
+++ b/compiler/ast/layouter.nim
@@ -10,18 +10,18 @@
 ## Layouter for nimpretty.
 
 import
-  ast/[
+  compiler/ast/[
     idents,
     lexer,
     lineinfos,
     llstream,
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ],
   std/[

--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -17,11 +17,11 @@
 ## format.
 
 import
-  utils/[
+  compiler/utils/[
     platform,
     pathutils,
   ],
-  ast/[
+  compiler/ast/[
     wordrecg,
     nimlexbase,
     llstream,
@@ -34,7 +34,7 @@ import
     hashes,
     strutils
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ]

--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -12,7 +12,7 @@
 
 import
   std/[tables, hashes],
- utils/[ropes, pathutils]
+  compiler/utils/[ropes, pathutils]
 
 from ast_types import
   PSym,     # Contextual details of the instantnation stack optionally refer to

--- a/compiler/ast/linter.nim
+++ b/compiler/ast/linter.nim
@@ -12,13 +12,13 @@ import
   std/[
     strutils
   ],
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos,
     wordrecg,
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ]

--- a/compiler/ast/llstream.nim
+++ b/compiler/ast/llstream.nim
@@ -10,7 +10,7 @@
 ## Low-level streams for high performance.
 
 import
-  utils/pathutils
+  compiler/utils/pathutils
 
 # support `useGnuReadline`, `useLinenoise` for backwards compatibility
 const hasRstdin = (defined(nimUseLinenoise) or defined(useLinenoise) or defined(useGnuReadline)) and

--- a/compiler/ast/ndi.nim
+++ b/compiler/ast/ndi.nim
@@ -11,14 +11,14 @@
 ## support of Nim code. "ndi" stands for "Nim debug info".
 
 import
-  ast/[
+  compiler/ast/[
     ast
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  utils/[
+  compiler/utils/[
     ropes,
     pathutils
   ]

--- a/compiler/ast/nimsets.nim
+++ b/compiler/ast/nimsets.nim
@@ -10,11 +10,11 @@
 ## this unit handles Nim sets; it implements symbolic sets
 
 import
-  ast/[ast, astalgo, lineinfos, types],
-  front/[
+  compiler/ast/[ast, astalgo, lineinfos, types],
+  compiler/front/[
     options
   ],
-  utils/[
+  compiler/utils/[
     bitsets
   ]
 

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -30,7 +30,7 @@ when isMainModule:
   checkGrammarFile()
 
 import
-  ast/[
+  compiler/ast/[
     llstream,
     lexer,
     idents,
@@ -41,11 +41,11 @@ import
   std/[
     strutils,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ]
 

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -15,7 +15,7 @@ when defined(nimHasUsed):
   {.used.}
 
 import
-  ast/[
+  compiler/ast/[
     lexer,
     idents,
     ast,
@@ -25,7 +25,7 @@ import
   std/[
     strutils,
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ]

--- a/compiler/ast/renderverbatim.nim
+++ b/compiler/ast/renderverbatim.nim
@@ -1,11 +1,11 @@
 import std/strutils
 
-import ast/ast, front/options, front/msgs
+import compiler/ast/ast, compiler/front/options, compiler/front/msgs
 
 const isDebug = false
 when isDebug:
-  import ast/renderer
-  import ast/astalgo
+  import compiler/ast/renderer
+  import compiler/ast/astalgo
 
 proc lastNodeRec(n: PNode): PNode =
   result = n

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -17,10 +17,10 @@
 import std/[options, packedsets]
 
 import
-  vm/vm_enums,
-  ast/ast_types,
-  utils/[int128, platform],
-  sem/nilcheck_enums
+  compiler/vm/vm_enums,
+  compiler/ast/ast_types,
+  compiler/utils/[int128, platform],
+  compiler/sem/nilcheck_enums
 
 export
   ast_types,
@@ -30,7 +30,7 @@ export
   int128.toInt128
 
 
-from front/in_options import TOption, TOptions
+from compiler/front/in_options import TOption, TOptions
 type InstantiationInfo* = typeof(instantiationInfo())
 
 # Importing and reexporting enums and 'external' reports in order to avoid

--- a/compiler/ast/syntaxes.nim
+++ b/compiler/ast/syntaxes.nim
@@ -10,8 +10,8 @@
 ## Implements the dispatcher for the different parsers.
 
 import
-  strutils,
-  ast/[
+  std/strutils,
+  compiler/ast/[
     llstream,
     ast,
     idents,
@@ -23,11 +23,11 @@ import
     lineinfos,
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ]
 

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -14,7 +14,7 @@ import
     intsets,
     strutils,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     trees,
@@ -23,15 +23,15 @@ import
     errorhandling,
     reports
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ],
-  utils/[
+  compiler/utils/[
     platform,
     int128,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
   ]
 
@@ -988,7 +988,7 @@ proc matchType*(a: PType, pattern: openArray[tuple[k:TTypeKind, i:int]],
   result = a.kind == last
 
 
-include sem/sizealignoffsetimpl
+include compiler/sem/sizealignoffsetimpl
 
 proc computeSize*(conf: ConfigRef; typ: PType): BiggestInt =
   computeSizeAlign(conf, typ)

--- a/compiler/ast/typesrenderer.nim
+++ b/compiler/ast/typesrenderer.nim
@@ -9,13 +9,13 @@
 
 import
   std/strutils,
-  ast/[
+  compiler/ast/[
     ast,
     astmsgs,
     renderer,
     types,
   ],
-  front/options
+  compiler/front/options
 
 const defaultParamSeparator* = ","
 

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -331,7 +331,7 @@ proc genArgNoParam(p: BProc, n: PNode, needsTmp = false): Rope =
     initLocExprSingleUse(p, n, a)
     result = rdLoc(withTmpIfNeeded(p, a, needsTmp))
 
-from sem/dfa import aliases, AliasKind
+from compiler/sem/dfa import aliases, AliasKind
 
 proc potentialAlias(n: PNode, potentialWrites: seq[PNode]): bool =
   for p in potentialWrites:

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2612,7 +2612,7 @@ proc genStmtList(p: BProc, n: PNode) =
   genStmtListExprImpl:
     genStmts(p, n[^1])
 
-from sem/parampatterns import isLValue
+from compiler/sem/parampatterns import isLValue
 
 proc upConv(p: BProc, n: PNode, d: var TLoc) =
   var a: TLoc

--- a/compiler/backend/ccgmerge_unused.nim
+++ b/compiler/backend/ccgmerge_unused.nim
@@ -11,8 +11,30 @@
 ## is needed for incremental compilation.
 
 import
-  ast, ropes, options, strutils, nimlexbase, cgendata, rodutils,
-  intsets, llstream, tables, modulegraphs, pathutils
+  std[
+    strutils,
+    intsets,
+    tables
+  ],
+  compiler/ast[
+    ast,
+    llstream,
+    nimlexbase
+  ],
+  compiler/front[
+    options
+  ],
+  compiler/modules[
+    modulegraphs
+  ],
+  compiler/sem[
+    rodutils
+  ],
+  compiler/utils[
+    ropes,
+    pathutils
+  ],
+  cgendata
 
 # Careful! Section marks need to contain a tabulator so that they cannot
 # be part of C string literals.

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -11,7 +11,7 @@
 
 # ------------------------- Name Mangling --------------------------------
 
-import sem/sighashes, modules/modulegraphs
+import compiler/sem/sighashes, compiler/modules/modulegraphs
 
 proc genProcHeader(m: BModule, prc: PSym, asPtr: bool = false): Rope
 

--- a/compiler/backend/ccgutils.nim
+++ b/compiler/backend/ccgutils.nim
@@ -13,22 +13,22 @@ import
   std/[
     hashes, strutils
   ],
-  ast/[
+  compiler/ast/[
     wordrecg,
     ast,
     types,
     trees
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  utils/[
+  compiler/utils/[
     platform
   ],
-  sem/[
+  compiler/sem/[
   ],
-  backend/[
+  compiler/backend/[
     cgendata
   ]
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -18,7 +18,7 @@ import
     tables,
     sets
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     trees,
@@ -34,21 +34,21 @@ import
     astmsgs,
     ndi
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  utils/[
+  compiler/utils/[
     platform,
     nversion,
     bitsets,
     ropes,
     pathutils
   ],
-  sem/[
+  compiler/sem/[
     passes,
     rodutils,
     aliases,
@@ -56,22 +56,22 @@ import
     transf,
     injectdestructors
   ],
-  backend/[
+  compiler/backend/[
     extccomp,
     ccgutils,
     cgmeth,
     cgendata
   ],
-  plugins/[
+  compiler/plugins/[
   ]
 
 
 when not defined(leanCompiler):
-  import sem/[spawn, semparallel]
+  import compiler/sem/[spawn, semparallel]
 
 import std/strutils except `%` # collides with ropes.`%`
 
-from ic / ic import ModuleBackendFlag
+from compiler/ic/ic import ModuleBackendFlag
 import dynlib
 
 when not declared(dynlib.libCandidates):

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -15,18 +15,18 @@ import
     tables,
     sets
   ],
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos,
     ndi
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options
   ],
-  utils/[
+  compiler/utils/[
     ropes,
     pathutils
   ]

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -13,22 +13,22 @@ import
   std/[
     intsets,
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     renderer,
     types,
     lineinfos,
     reports
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs,
   ],
-  sem/[
+  compiler/sem/[
     sempass2,
   ]
 

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -13,16 +13,16 @@
 ## compile nim files.
 
 import
-  utils/[
+  compiler/utils/[
     ropes,
     platform,
     pathutils
   ],
-  ast/[
+  compiler/ast/[
     lineinfos,
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -36,7 +36,7 @@ import
     intsets,
     strutils
   ],
-  ast/[
+  compiler/ast/[
     ast,
     trees,
     idents,
@@ -47,19 +47,19 @@ import
     astmsgs,
     reports
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  utils/[
+  compiler/utils/[
     nversion,
     ropes
   ],
-  sem/[
+  compiler/sem/[
     passes,
     lowerings,
     sighashes,
@@ -68,13 +68,13 @@ import
     transf,
     sourcemap
   ],
-  backend/[
+  compiler/backend/[
     ccgutils,
     cgmeth,
   ],
-  plugins/[
+  compiler/plugins/[
   ],
-  vm/[
+  compiler/vm/[
   ]
 
 

--- a/compiler/backend/tccgen.nim
+++ b/compiler/backend/tccgen.nim
@@ -8,7 +8,14 @@
 #
 
 import
-  os, strutils, options, msgs, tinyc, lineinfos, sequtils
+  os, strutils, tinyc, sequtils
+  compiler/ast[
+    lineinfos,
+  ],
+  compiler/front/[
+    options,
+    msgs
+  ]
 
 const tinyPrefix = "dist/nim-tinyc-archive".unixToNativePath
 const nimRoot = currentSourcePath.parentDir.parentDir

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -26,7 +26,7 @@ import
   experimental/[
     colortext
   ],
-  ast/[
+  compiler/ast/[
     lineinfos,
     astalgo,
     astmsgs,
@@ -36,22 +36,22 @@ import
     ast,
     reports
   ],
-  utils/[
+  compiler/utils/[
     platform,
     nversion,
     astrepr
   ],
-  front/[
+  compiler/front/[
     msgs
   ],
-  sem/[
+  compiler/sem/[
     nilcheck_enums
   ],
-  vm/[
+  compiler/vm/[
     vm_enums
   ]
 
-import front/options as compiler_options
+import compiler/front/options as compiler_options
 
 func assertKind(r: ReportTypes | Report) = assert r.kind != repNone
 

--- a/compiler/front/cmdlinehelper.nim
+++ b/compiler/front/cmdlinehelper.nim
@@ -13,24 +13,24 @@ import
   std/[
     os
   ],
-  ast/[
+  compiler/ast/[
     idents,
     reports
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     nimconf,
     commands,
     msgs,
     options,
     condsyms
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ],
-  backend/[
+  compiler/backend/[
     extccomp
   ]
 

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -34,31 +34,31 @@ import
     strtabs,
     pathnorm
   ],
-  modules/[
+  compiler/modules/[
     nimblecmd,
   ],
-  ast/[
+  compiler/ast/[
     lineinfos,
     reports,
     wordrecg,
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
     cli_reporter,
     sexp_reporter
   ],
-  backend/[
+  compiler/backend/[
     extccomp
   ],
-  utils/[
+  compiler/utils/[
     nversion,
     pathutils,
     platform
   ]
 
 
-from ast/ast import setUseIc, eqTypeFlags, tfGcSafe, tfNoSideEffect
+from compiler/ast/ast import setUseIc, eqTypeFlags, tfGcSafe, tfNoSideEffect
 
 bootSwitch(usedTinyC, hasTinyCBackend, "-d:tinyc")
 

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -12,8 +12,8 @@
 import
   std/strtabs
 
-from front/options import Feature
-import ast/reports
+from compiler/front/options import Feature
+import compiler/ast/reports
 
 
 proc initDefines*(symbols: StringTableRef) =

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -1,8 +1,8 @@
 ## This module contains defintions of all types and configuration objects
 ## that are used to determine nim compiler inputs.
 
-import utils/[pathutils, platform]
-import ast/[report_enums]
+import compiler/utils/[pathutils, platform]
+import compiler/ast/[report_enums]
 import std/[sets, strtabs]
 
 type

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -14,7 +14,7 @@ when not defined(nimcore):
 
 import
   std/[strutils, os, times, tables, sha1, with, json],
-  ast/[
+  compiler/ast/[
     llstream,    # Input data stream
     ast,
     lexer,
@@ -23,45 +23,51 @@ import
     reports,     # Error report information
     lineinfos    # Positional data
   ],
-  front/[
+  compiler/front/[
     options,
     condsyms,
     msgs,
     nimconf      # Configuration file reading
   ],
-  sem/[
+  compiler/sem/[
     sem,         # Implementation of the semantic pass
     passes,      # Main procs for compilation pass setups
     passaux
   ],
-  modules/[
+  compiler/modules/[
     depends,     # Generate dependency information
     modules,
     modulegraphs # Project module graph
   ],
-  backend/[
+  compiler/backend/[
     extccomp,    # Calling C compiler
     cgen,        # C code generation
   ],
-  utils/[
+  compiler/utils/[
     platform,    # Target platform data
     nversion,
     pathutils    # Input file handling
   ],
-  vm/[
+  compiler/vm/[
     vm,          # Configuration file evaluation, `nim e`
     vmprofiler
   ]
 
-import ic / [cbackend, integrity, navigator]
-from ic / ic import rodViewer
+import compiler/ic/[
+    cbackend,
+    integrity,
+    navigator
+  ]
+from compiler/ic/ic import rodViewer
 
 when not defined(leanCompiler):
-  import backend/jsgen, tools/[docgen, docgen2]
+  import
+    compiler/backend/jsgen,
+    compiler/tools/[docgen, docgen2]
 
 when defined(nimDebugUnreportedErrors):
   import std/exitprocs
-  import utils/astrepr
+  import compiler/utils/astrepr
 
   proc echoAndResetUnreportedErrors(conf: ConfigRef) =
     if conf.unreportedErrors.len > 0:

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -15,11 +15,11 @@ import
   std/options as std_options
 
 import
-  utils/[ropes, pathutils, strutils2],
-  ast/[reports, lineinfos],
-  front/[options]
+  compiler/utils/[ropes, pathutils, strutils2],
+  compiler/ast/[reports, lineinfos],
+  compiler/front/[options]
 
-from ast/ast_types import PSym
+from compiler/ast/ast_types import PSym
 
 export InstantiationInfo
 export TErrorHandling

--- a/compiler/front/nimconf.nim
+++ b/compiler/front/nimconf.nim
@@ -10,13 +10,18 @@
 # This module handles the reading of the config file.
 
 import
-  front/[
+  std/[
+    os,
+    strutils,
+    strtabs,
+  ],
+  compiler/front/[
     commands,
     msgs,
     options,
     scriptconfig
   ],
-  ast/[
+  compiler/ast/[
     lexer,
     reports,
     idents,
@@ -24,12 +29,7 @@ import
     llstream,
     ast
   ],
-  std/[
-    os,
-    strutils,
-    strtabs,
-  ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ]
 

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -9,11 +9,11 @@
 
 import
   std/[os, strutils, strtabs, sets, tables],
-  utils/[prefixmatches, pathutils, platform],
-  ast/[reports, lineinfos],
-  modules/nimpaths
+  compiler/utils/[prefixmatches, pathutils, platform],
+  compiler/ast/[reports, lineinfos],
+  compiler/modules/nimpaths
 
-import ./in_options
+import compiler/front/in_options
 export in_options
 
 from terminal import isatty
@@ -1047,7 +1047,7 @@ proc clearNimblePath*(conf: ConfigRef) =
   conf.lazyPaths = @[]
   conf.nimblePaths = @[]
 
-include modules/packagehandling
+include compiler/modules/packagehandling
 
 proc getOsCacheDir(): string =
   when defined(posix):

--- a/compiler/front/scriptconfig.nim
+++ b/compiler/front/scriptconfig.nim
@@ -11,38 +11,38 @@
 ## language.
 
 import
-  ast/[
-    ast,
-    idents,
-    wordrecg,
-    reports,
-    llstream,
-  ],
   std/[
     os,
     times,
     osproc,
     strtabs,
   ],
-  modules/[
+  compiler/ast/[
+    ast,
+    idents,
+    wordrecg,
+    reports,
+    llstream,
+  ],
+  compiler/modules/[
     modules,
     modulegraphs,
   ],
-  sem/[
+  compiler/sem/[
     passes,
     sem,
   ],
-  vm/[
+  compiler/vm/[
     vm,
     vmdef,
   ],
-  front/[
+  compiler/front/[
     msgs,
     condsyms,
     options,
     commands,
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ]
 

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -9,12 +9,12 @@ import
     colortext,
     sexp_diff
   ],
-  ast/[
+  compiler/ast/[
     lineinfos,
     ast,
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
@@ -28,8 +28,6 @@ var writeConf: ConfigRef
 
 
 proc addFields[T](s: var SexpNode, r: T, ignore: seq[string] = @[])
-
-
 
 proc sexpItems*[T](s: T): SexpNode =
   result = newSList()

--- a/compiler/ic/cbackend.nim
+++ b/compiler/ic/cbackend.nim
@@ -22,28 +22,31 @@ import
   std/[
     packedsets, algorithm, tables
   ],
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ],
-  backend/[
+  compiler/backend/[
     cgendata,
     cgen,
     extccomp
+  ],
+  compiler/ic/[
+    packed_ast,
+    ic,
+    dce,
+    rodfiles
   ]
-
-
-import packed_ast, ic, dce, rodfiles
 
 proc unpackTree(g: ModuleGraph; thisModule: int;
                 tree: PackedTree; n: NodePos): PNode =

--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -14,11 +14,11 @@ import
     intsets,
     tables
   ],
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos
   ],
-  front/[
+  compiler/front/[
     options
   ]
 

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -10,22 +10,22 @@
 import std/[hashes, tables, intsets, sha1]
 
 import
-  ic/[
+  compiler/ic/[
     packed_ast,
     bitabs,
     rodfiles
   ],
-  ast/[
+  compiler/ast/[
     ast,
     idents,
     lineinfos,
     reports
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  utils/[
+  compiler/utils/[
     ropes,
     pathutils
   ]

--- a/compiler/ic/integrity.nim
+++ b/compiler/ic/integrity.nim
@@ -11,7 +11,7 @@
 ## The set must cover a complete Nim project.
 
 import std/sets
-import ast/ast, modules/modulegraphs
+import compiler/ast/ast, compiler/modules/modulegraphs
 import packed_ast, bitabs, ic
 
 type

--- a/compiler/ic/navigator.nim
+++ b/compiler/ic/navigator.nim
@@ -12,14 +12,14 @@
 ## its task. The set must cover a complete Nim project.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     reports
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -13,8 +13,8 @@
 ## it is superior.
 
 import std/[hashes, tables, strtabs]
-import ic/bitabs
-import ast/ast, front/options
+import compiler/ic/bitabs
+import compiler/ast/ast, compiler/front/options
 
 type
   SymId* = distinct int32

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -12,28 +12,28 @@
 ## support.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     trees,
     reports,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
   ],
-  utils/[
+  compiler/utils/[
     btrees,
     pathutils,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ],
-  backend/[
+  compiler/backend/[
     extccomp,
     cgmeth
   ]
 
-import tables
+import std/tables
 
 import packed_ast, ic, bitabs
 

--- a/compiler/modules/depends.nim
+++ b/compiler/modules/depends.nim
@@ -10,21 +10,21 @@
 ## This module implements a dependency file generator.
 
 import
-  ast/[
+  compiler/ast/[
     ast
   ],
-  modules/[
+  compiler/modules/[
     modulepaths,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options
   ],
-  utils/[
+  compiler/utils/[
     ropes,
     pathutils
   ],
-  sem/[
+  compiler/sem/[
     passes
   ]
 

--- a/compiler/modules/importer.nim
+++ b/compiler/modules/importer.nim
@@ -15,7 +15,7 @@ import
     sets,
     tables
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     idents,
@@ -23,15 +23,15 @@ import
     wordrecg,
     reports
   ],
-  modules/[
+  compiler/modules/[
     modulepaths,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     lookups,
     semdata,
     sigmatch

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -10,10 +10,10 @@
 ## Built-in types and compilerprocs are registered here.
 
 import
-  utils/[
+  compiler/utils/[
     platform,
   ],
-  ast/[
+  compiler/ast/[
     lineinfos,
     errorhandling,
     idents,
@@ -21,10 +21,10 @@ import
     ast,
     astalgo,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ]

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -18,23 +18,23 @@ import
     hashes,
     md5
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     lineinfos,
     idents,
     reports
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
     btrees,
     ropes,
   ],
-  ic/[
+  compiler/ic/[
     packed_ast,
     ic
   ]

--- a/compiler/modules/modulepaths.nim
+++ b/compiler/modules/modulepaths.nim
@@ -12,16 +12,16 @@ import
     strutils,
     os,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos,
     renderer,
     reports,
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ]

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -10,7 +10,10 @@
 ## Implements the module handling, including the caching of modules.
 
 import
-  ast/[
+  std/[
+    tables
+  ],
+  compiler/ast/[
     ast,
     astalgo,
     idents,
@@ -20,24 +23,21 @@ import
     reports,
     syntaxes,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     passes,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
     magicsys,
   ],
-  std/[
-    tables
-  ],
-  utils/[
+  compiler/utils/[
     pathutils
   ],
-  ic/[
+  compiler/ic/[
     replayer
   ]
 

--- a/compiler/modules/nimblecmd.nim
+++ b/compiler/modules/nimblecmd.nim
@@ -18,15 +18,15 @@ import
     tables,
     sequtils
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  ast/[
+  compiler/ast/[
     lineinfos,
     reports
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ]
 

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -31,5 +31,4 @@ define:useStdoutAsStdmsg
   warningAsError:Effect:on
 @end
 
-path:"$config"
-path:"$config/lib"
+path:"$config/.."

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -24,19 +24,19 @@ when defined(windows) and not defined(nimKochBootstrap):
     {.link: "../icons/nim-i386-windows-vcc.res".}
 
 import
-  backend/[
+  compiler/backend/[
     extccomp
   ],
-  front/[
+  compiler/front/[
     msgs, main, cmdlinehelper, options, commands, cli_reporter
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ],
-  ast/[
+  compiler/ast/[
     reports, idents
   ]
 
@@ -47,10 +47,10 @@ import
 #   pathutils, modulegraphs, reports
 
 from std/browsers import openDefaultBrowser
-from utils/nodejs import findNodeJs
+from compiler/utils/nodejs import findNodeJs
 
 when hasTinyCBackend:
-  import backend/tccgen
+  import compiler/backend/tccgen
 
 when defined(profiler) or defined(memProfiler):
   {.hint: "Profiling support is turned on!".}

--- a/compiler/nimfix/nimfix.nim
+++ b/compiler/nimfix/nimfix.nim
@@ -15,27 +15,27 @@ import
     os,
     parseopt
   ],
-  ast/[
+  compiler/ast/[
     idents
   ],
-  modules/[
+  compiler/modules/[
     modules,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     commands,
     msgs,
     condsyms,
     nimconf
   ],
-  sem/[
+  compiler/sem/[
     sem,
     passes,
     passaux,
     linter
   ],
-  backend/[
+  compiler/backend/[
     extccomp
   ]
 

--- a/compiler/nimfix/prettybase.nim
+++ b/compiler/nimfix/prettybase.nim
@@ -12,13 +12,13 @@ import std/strutils except Letters
 import
   std/[
   ],
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos,
     idents,
     linter
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ]

--- a/compiler/plugins/active.nim
+++ b/compiler/plugins/active.nim
@@ -10,14 +10,14 @@
 ## Include file that imports all plugins that are active.
 
 import
-  ast/[
+  compiler/ast/[
     idents,
     ast
   ],
-  utils/[
+  compiler/utils/[
     pluginsupport
   ],
-  plugins/[
+  compiler/plugins/[
     locals, itersgen
   ]
 

--- a/compiler/plugins/itersgen.nim
+++ b/compiler/plugins/itersgen.nim
@@ -10,17 +10,17 @@
 ## Plugin to transform an inline iterator into a data structure.
 
 import
-  ast/[
+  compiler/ast/[
     reports,
     ast
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs
   ],
-  sem/[
+  compiler/sem/[
     lookups,
     semdata,
     lambdalifting

--- a/compiler/plugins/locals.nim
+++ b/compiler/plugins/locals.nim
@@ -10,14 +10,14 @@
 ## The builtin 'system.locals' implemented as a plugin.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
   ],
-  sem/[
+  compiler/sem/[
     semdata,
     lowerings,
     lookups

--- a/compiler/sem/aliases.nim
+++ b/compiler/sem/aliases.nim
@@ -14,7 +14,7 @@ import
   std/[
     intsets
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     types,

--- a/compiler/sem/closureiters.nim
+++ b/compiler/sem/closureiters.nim
@@ -157,21 +157,21 @@ import
   std/[
     tables
   ],
-  ast/[
+  compiler/ast/[
     ast,
     idents,
     renderer,
     lineinfos
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  sem/[
+  compiler/sem/[
     lowerings,
     lambdalifting
   ]

--- a/compiler/sem/concepts.nim
+++ b/compiler/sem/concepts.nim
@@ -15,7 +15,7 @@ import
   std/[
     intsets
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     renderer,
@@ -24,15 +24,15 @@ import
     idents,
     lineinfos
   ],
-  front/[
+  compiler/front/[
     msgs
   ],
-  sem/[
+  compiler/sem/[
     lookups,
     semdata
   ]
 
-from modules/magicsys import addSonSkipIntLit
+from compiler/modules/magicsys import addSonSkipIntLit
 
 const
   logBindings = false

--- a/compiler/sem/dfa.nim
+++ b/compiler/sem/dfa.nim
@@ -33,11 +33,9 @@ import
   std/[
     intsets
   ],
-  ast/[
+  compiler/ast/[
+    ast,
     renderer
-  ],
-  ast/[
-    ast
   ]
 
 import std/private/asciitables

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -10,7 +10,7 @@
 ## Template evaluation engine. Now hygienic.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     lineinfos,
@@ -18,7 +18,7 @@ import
     renderer,
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ]

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -10,7 +10,7 @@
 ## This module implements the 'implies' relation for guards.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     renderer,
@@ -21,15 +21,15 @@ import
     lineinfos,
     reports
   ],
-  utils/[
+  compiler/utils/[
     saturate,
     int128,
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ]

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -20,7 +20,7 @@ import
     strutils,
     tables
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     renderer,
@@ -30,15 +30,15 @@ import
     lineinfos,
     reports
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     dfa,
     lowerings,
     parampatterns,
@@ -48,7 +48,7 @@ import
     varpartitions
   ]
 
-from ast/trees import exprStructuralEquivalent, getRoot
+from compiler/ast/trees import exprStructuralEquivalent, getRoot
 
 type
   Con = object

--- a/compiler/sem/isolation_check.nim
+++ b/compiler/sem/isolation_check.nim
@@ -11,7 +11,7 @@
 ## https://github.com/nim-lang/RFCs/issues/244 for more details.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     types,
     renderer,

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -14,7 +14,7 @@ import
     intsets,
     tables
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     reports,
@@ -23,15 +23,15 @@ import
     types,
     lineinfos
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  sem/[
+  compiler/sem/[
     typeallowed,
     liftdestructors,
     transf,

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -11,7 +11,10 @@
 ## (``=sink``, ``=``, ``=destroy``, ``=deepCopy``).
 
 import
-  ast/[
+  std/[
+    tables
+  ],
+  compiler/ast/[
     lineinfos,
     idents,
     ast,
@@ -20,25 +23,22 @@ import
     reports,
     trees
   ],
-  std/[
-    tables
-  ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
     magicsys
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  utils/[
+  compiler/utils/[
   ],
-  sem/[
+  compiler/sem/[
     semdata,
     sighashes,
     lowerings
   ],
-  backend/[
+  compiler/backend/[
     ccgutils
   ]
 

--- a/compiler/sem/liftlocals.nim
+++ b/compiler/sem/liftlocals.nim
@@ -10,23 +10,23 @@
 ## This module implements the '.liftLocals' pragma.
 
 import
-  ast/[
+  compiler/ast/[
     reports,
     idents,
     renderer,
     lineinfos,
     ast
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  sem/[
+  compiler/sem/[
     lowerings
   ]
 
-from sem/pragmas import getPragmaVal
-from ast/wordrecg import wLiftLocals
+from compiler/sem/pragmas import getPragmaVal
+from compiler/ast/wordrecg import wLiftLocals
 
 type
   Ctx = object

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -15,7 +15,7 @@ import
     strutils,
     intsets
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     idents,
@@ -25,20 +25,20 @@ import
     errorreporting,
     reports
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  utils/[
+  compiler/utils/[
     debugutils
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     semdata
   ],
-  nimfix/[
+  compiler/nimfix/[
     prettybase
   ]
 
@@ -413,7 +413,7 @@ proc addDecl*(c: PContext, sym: PSym) {.inline.} =
 proc addPrelimDecl*(c: PContext, sym: PSym) =
   discard c.currentScope.addUniqueSym(sym)
 
-from ic/ic import addHidden
+from compiler/ic/ic import addHidden
 
 proc addInterfaceDeclAux(c: PContext, sym: PSym) =
   ## adds symbol to the module for either private or public access.

--- a/compiler/sem/lowerings.nim
+++ b/compiler/sem/lowerings.nim
@@ -13,7 +13,7 @@ const
   genPrefix* = ":tmp"         ## prefix for generated names
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     types,
@@ -21,11 +21,11 @@ import
     lineinfos,
     reports
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
     magicsys
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ]

--- a/compiler/sem/macrocacheimpl.nim
+++ b/compiler/sem/macrocacheimpl.nim
@@ -10,11 +10,11 @@
 ## This module implements helpers for the macro cache.
 
 import
-  ast/[
+  compiler/ast/[
     lineinfos,
     ast
   ],
-  vm/[
+  compiler/vm/[
     vmdef
   ]
 

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -9,14 +9,6 @@
 
 
 import
-  ast/[
-    ast,
-    renderer,
-    lineinfos,
-    idents,
-    reports,
-    treetab,
-  ],
   std/[
     hashes,
     intsets,
@@ -26,14 +18,22 @@ import
     strutils,
     sets
   ],
-  modules/[
+  compiler/ast/[
+    ast,
+    renderer,
+    lineinfos,
+    idents,
+    reports,
+    treetab,
+  ],
+  compiler/modules/[
     modulegraphs,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ],
-  sem/[
+  compiler/sem/[
     nilcheck_enums
   ]
 

--- a/compiler/sem/optimizer.nim
+++ b/compiler/sem/optimizer.nim
@@ -12,9 +12,9 @@
 ## - recognize "all paths lead to 'wasMoved(x)'"
 
 import
-  ast/[ast, renderer], std/intsets
+  compiler/ast/[ast, renderer], std/intsets
 
-from ast/trees import exprStructuralEquivalent
+from compiler/ast/trees import exprStructuralEquivalent
 
 const
   nfMarkForDeletion = nfNone # faster than a lookup table

--- a/compiler/sem/parampatterns.nim
+++ b/compiler/sem/parampatterns.nim
@@ -14,7 +14,7 @@ import
   std/[
     strutils
   ],
-  ast/[
+  compiler/ast/[
     ast,
     types,
     renderer,
@@ -22,7 +22,7 @@ import
     trees,
     reports
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ]

--- a/compiler/sem/passaux.nim
+++ b/compiler/sem/passaux.nim
@@ -10,18 +10,18 @@
 ## implements some little helper passes
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     reports
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     passes
   ]
 

--- a/compiler/sem/passes.nim
+++ b/compiler/sem/passes.nim
@@ -11,21 +11,21 @@
 ## `TPass` interface.
 
 import
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     llstream,
     syntaxes,
     reports,
     lineinfos,
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ]
 

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -11,12 +11,12 @@
 ## macro support.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     types,
     trees
   ],
-  sem/[
+  compiler/sem/[
     semdata,
     sigmatch,
     aliases,

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -15,41 +15,41 @@ import
     math,
     os
   ],
-  ast/[
-     ast,
-     astalgo,
-     idents,
-     renderer,
-     wordrecg,
-     trees,
-     linter,
-     errorhandling,
-     reports,
-     lineinfos
+  compiler/ast/[
+    ast,
+    astalgo,
+    idents,
+    renderer,
+    wordrecg,
+    trees,
+    linter,
+    errorhandling,
+    reports,
+    lineinfos
   ],
-  modules/[
+  compiler/modules/[
     magicsys
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  utils/[
+  compiler/utils/[
     ropes,
     pathutils,
     debugUtils
   ],
-  sem/[
+  compiler/sem/[
     semdata,
     lookups
   ],
-  backend/[
+  compiler/backend/[
     extccomp
   ]
 
 
 
-from ic/ic import addCompilerProc
+from compiler/ic/ic import addCompilerProc
 
 const
   FirstCallConv* = wNimcall

--- a/compiler/sem/procfind.nim
+++ b/compiler/sem/procfind.nim
@@ -11,17 +11,17 @@
 ## This is needed for proper handling of forward declarations.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     types,
     trees,
     reports
   ],
-  front/[
+  compiler/front/[
      msgs,
   ],
-  sem/[
+  compiler/sem/[
      semdata,
      lookups,
   ]

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -16,7 +16,7 @@ import
     strtabs,
     intsets
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     trees,
@@ -33,17 +33,17 @@ import
     enumtostr,
     linter
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulepaths,
     importer,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  utils/[
+  compiler/utils/[
     ropes,
     platform,
     nversion,
@@ -51,7 +51,7 @@ import
     int128,
     astrepr
   ],
-  sem/[
+  compiler/sem/[
     semfold,
     concepts,
     semmacrosanity,
@@ -73,22 +73,22 @@ import
     evaltempl,
     lowerings,
   ],
-  backend/[
+  compiler/backend/[
     cgmeth
   ],
-  plugins/[
+  compiler/plugins/[
     active
   ],
-  vm/[
+  compiler/vm/[
     vmdef,
     vm
   ]
 
 when defined(nimfix):
-  import nimfix/prettybase
+  import compiler/nimfix/prettybase
 
 when not defined(leanCompiler):
-  import sem/spawn
+  import compiler/sem/spawn
 
 # implementation
 

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -16,11 +16,11 @@ import
     tables,
     strutils
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     idents,
@@ -28,17 +28,17 @@ import
     lineinfos,
     reports
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs,
   ],
-  vm/[
+  compiler/vm/[
     vmdef,
   ],
-  ic/[
+  compiler/ic/[
     ic
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ]
 

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -11,7 +11,12 @@
 ## and evaluation phase
 
 import
-  ast/[
+  std/[
+    strutils,
+    strtabs,
+    math,
+  ],
+  compiler/ast/[
     renderer,
     types,
     nimsets,
@@ -20,26 +25,18 @@ import
     lineinfos,
     reports
   ],
-  std/[
-    strutils,
-    strtabs,
-    math,
-  ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs,
   ],
-  front/[
+  compiler/front/[
     commands,
     msgs,
     options,
   ],
-  utils/[
+  compiler/utils/[
     platform,
   ]
-
-
-
 
 from system/memory import nimCStrLen
 

--- a/compiler/sem/semmacrosanity.nim
+++ b/compiler/sem/semmacrosanity.nim
@@ -13,13 +13,13 @@ import
   std/[
     strutils
   ],
-  ast/[
+  compiler/ast/[
     ast,
     types,
     typesrenderer,
     reports,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ]

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -10,7 +10,7 @@
 # This include file implements the semantic checking for magics.
 # included from sem.nim
 
-import ast/typesrenderer
+import compiler/ast/typesrenderer
 
 proc semAddrArg(c: PContext; n: PNode; isUnsafeAddr = false): PNode =
   let x = semExprWithType(c, n)

--- a/compiler/sem/semparallel.nim
+++ b/compiler/sem/semparallel.nim
@@ -22,7 +22,7 @@
 # - output slices need special logic (+)
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     idents,
@@ -30,22 +30,22 @@ import
     types,
     reports
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     lowerings,
     guards,
     spawn
   ]
 
 
-from ast/trees import getMagic, isTrue, getRoot
+from compiler/ast/trees import getMagic, isTrue, getRoot
 from std/strutils import `%`
 
 discard """

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -13,7 +13,7 @@ import
     tables,
     intsets,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     renderer,
     astalgo,
@@ -26,18 +26,18 @@ import
     lineinfos,
     trees,
   ],
-  front/[
+  compiler/front/[
    options,
    msgs,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
     magicsys,
   ],
-  utils/[
+  compiler/utils/[
     debugutils
   ],
-  sem/[
+  compiler/sem/[
     varpartitions,
     typeallowed,
     guards,

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -13,7 +13,7 @@ import
   std/[
     strutils
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     types,
@@ -21,18 +21,18 @@ import
     lineinfos,
     reports,
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs,
   ],
-  front/[
+  compiler/front/[
      msgs,
      options,
   ],
-  sem/[
+  compiler/sem/[
     semdata,
   ],
-  utils/[
+  compiler/utils/[
     astrepr
   ]
 

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -14,14 +14,14 @@ import
     md5,
     hashes
   ],
-  ast/[
+  compiler/ast/[
     ast,
     types
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  utils/[
+  compiler/utils/[
     ropes
   ]
 

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -14,7 +14,7 @@ import
     intsets,
     strutils,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     types,
@@ -28,15 +28,15 @@ import
     errorhandling,
     reports,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
     magicsys,
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
   ],
-  sem/[
+  compiler/sem/[
     semdata,
     semtypinst,
     lookups,
@@ -2677,7 +2677,7 @@ proc instTypeBoundOp*(c: PContext; dc: PSym; t: PType; info: TLineInfo;
     if op == attachedDeepCopy:
       assert sfFromGeneric in result.flags
 
-include tools/suggest
+include compiler/tools/suggest
 
 when not declared(tests):
   template tests(s: untyped) = discard

--- a/compiler/sem/sourcemap.nim
+++ b/compiler/sem/sourcemap.nim
@@ -2,7 +2,7 @@ import
   std/[
     os, strformat, strutils, tables, sets, json, algorithm
   ],
-  utils/[
+  compiler/utils/[
     ropes
   ]
 

--- a/compiler/sem/spawn.nim
+++ b/compiler/sem/spawn.nim
@@ -9,7 +9,7 @@
 
 ## This module implements threadpool's ``spawn``.
 import
-  ast/[
+  compiler/ast/[
     trees,
     ast,
     types,
@@ -17,15 +17,15 @@ import
     renderer,
     reports
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     lowerings,
     liftdestructors
   ]

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -19,7 +19,7 @@
 ## * transforms 'defer' into a 'try finally' statement
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     astalgo,
     trees,
@@ -30,20 +30,20 @@ import
     lineinfos,
     errorreporting
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  sem/[
+  compiler/sem/[
     liftlocals,
     semfold,
     lowerings
   ],
-  backend/[
+  compiler/backend/[
     cgmeth
   ]
 

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -14,15 +14,15 @@ import
   std/[
     intsets,
   ],
-  ast/[
+  compiler/ast/[
     ast,
     renderer,
     types
   ],
-  front/[
+  compiler/front/[
     options,
   ],
-  sem/[
+  compiler/sem/[
     semdata,
   ]
 

--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -29,25 +29,26 @@
 ## for a high-level description of how borrow checking works.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos,
     types,
     renderer,
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
   ],
-  sem/[
+  compiler/sem/[
     typeallowed,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
   ]
 
-from ast/trees import getMagic, isNoSideEffectPragma, stupidStmtListExpr
+from compiler/ast/trees import getMagic, isNoSideEffectPragma,
+                               stupidStmtListExpr
 from isolation_check import canAlias
 
 type

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -23,7 +23,7 @@ import
     tables,
     osproc
   ],
-  ast/[
+  compiler/ast/[
     ast,
     idents,
     wordrecg,
@@ -37,14 +37,14 @@ import
     renderverbatim,
     reports
   ],
-  modules/[
+  compiler/modules/[
     nimpaths
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ]
 
@@ -57,7 +57,7 @@ import packages/docutils/rstast except FileIndex, TLineInfo
 
 from std/uri import encodeUrl
 from std/private/globs import nativeToUnixPath
-from utils/nodejs import findNodeJs
+from compiler/utils/nodejs import findNodeJs
 
 const
   exportSection = skField

--- a/compiler/tools/docgen2.nim
+++ b/compiler/tools/docgen2.nim
@@ -11,26 +11,26 @@
 # semantic checking.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ],
-  sem/[
+  compiler/sem/[
     passes
   ],
-  tools/[
+  compiler/tools/[
     docgen
   ]
 
+from compiler/modules/modulegraphs import ModuleGraph, PPassContext
 
-from modules/modulegraphs import ModuleGraph, PPassContext
 
 type
   TGen = object of PPassContext

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -39,17 +39,17 @@ import
     sets,
     tables
   ],
-  ast/[
+  compiler/ast/[
     wordrecg
   ],
-  utils/[
+  compiler/utils/[
     prefixmatches
   ]
 
 
 
 when defined(nimsuggest):
-  import sem/passes, std/tables, utils/pathutils # importer
+  import compiler/sem/passes, std/tables, compiler/utils/pathutils # importer
 
 const
   sep = '\t'

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -43,14 +43,14 @@ next `debug` you call will provide needed information.
 
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     reports,
     renderer,
     lineinfos,
     errorhandling
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -12,11 +12,11 @@ useful debugging flags:
 ]#
 
 import
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  ast/[
+  compiler/ast/[
     reports,
   ]
 
@@ -28,14 +28,17 @@ proc isCompilerDebug*(conf: ConfigRef): bool {.inline.} =
   if conf.isCompilerDebug():
     echo n.sym.typ.len
   ```
+
+  Example region to trace:
+  ```nim
+  proc main =
+    echo 2
+    {.define(nimCompilerDebug).}
+    echo 3.5 # code section in which `isCompilerDebug` will be true
+    {.undef(nimCompilerDebug).}
+    echo 'x'
+  ```
   ]##
-  runnableExamples:
-    proc main =
-      echo 2
-      {.define(nimCompilerDebug).}
-      echo 3.5 # code section in which `isCompilerDebug` will be true
-      {.undef(nimCompilerDebug).}
-      echo 'x'
   conf.isDefined("nimCompilerDebug")
 
 

--- a/compiler/utils/nodejs.nim
+++ b/compiler/utils/nodejs.nim
@@ -1,4 +1,4 @@
-import os
+import std/os
 
 proc findNodeJs*(): string {.inline.} =
   ## Find NodeJS executable and return it as a string.

--- a/compiler/utils/pathutils.nim
+++ b/compiler/utils/pathutils.nim
@@ -10,7 +10,7 @@
 ## Path handling utilities for Nim. Strictly typed code in order
 ## to avoid the never ending time sink in getting path handling right.
 
-import os, pathnorm
+import std/[os, pathnorm]
 
 type
   AbsoluteFile* = distinct string

--- a/compiler/utils/platform.nim
+++ b/compiler/utils/platform.nim
@@ -14,7 +14,7 @@
 # Feel free to test for your excentric platform!
 
 import
-  strutils
+  std/strutils
 
 type
   TSystemOS* = enum # Also add OS in initialization section and alias

--- a/compiler/utils/pluginsupport.nim
+++ b/compiler/utils/pluginsupport.nim
@@ -12,11 +12,11 @@
 ## DLLs or the FFI will not work.
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     idents
   ],
-  sem/[
+  compiler/sem/[
     semdata
   ]
 

--- a/compiler/utils/prefixmatches.nim
+++ b/compiler/utils/prefixmatches.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-from strutils import toLowerAscii
+from std/strutils import toLowerAscii
 
 type
   PrefixMatch* {.pure.} = enum

--- a/compiler/utils/ropes.nim
+++ b/compiler/utils/ropes.nim
@@ -56,7 +56,7 @@
 #  To cache them they are inserted in a `cache` array.
 
 import
-  hashes
+  std/hashes
 
 from pathutils import AbsoluteFile
 

--- a/compiler/vm/gorgeimpl.nim
+++ b/compiler/vm/gorgeimpl.nim
@@ -16,14 +16,14 @@ import
     osproc,
     streams,
   ],
-  ast/[
+  compiler/ast/[
     lineinfos
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ]
 

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -14,30 +14,30 @@ import
     compilesettings,
     os
   ],
-  ast/[
+  compiler/ast/[
     ast,
     llstream,
     idents,
     reports
   ],
-  modules/[
+  compiler/modules/[
     modules,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     condsyms,
     options,
     scriptconfig
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ],
-  sem/[
+  compiler/sem/[
     passes,
     sem,
     passaux
   ],
-  vm/[
+  compiler/vm/[
     vmdef,
     vm
   ]

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -16,7 +16,7 @@ import
     tables,
     parseutils
   ],
-  ast/[
+  compiler/ast/[
     errorhandling,
     errorreporting,
     lineinfos,
@@ -29,22 +29,22 @@ import
     nimsets,
     parser # `parseExpr()` and `parseStmt()`
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
     magicsys
   ],
-  front/[
+  compiler/front/[
     options,
     msgs,
     cli_reporter # Imported to generate literal error message for VM exception
                  # handling
   ],
-  utils/[
+  compiler/utils/[
     debugutils,
     int128,
     btrees
   ],
-  sem/[
+  compiler/sem/[
     sighashes,
     macrocacheimpl,
     transf,
@@ -52,7 +52,7 @@ import
     evaltempl,
     semfold
   ],
-  vm/[
+  compiler/vm/[
     vmprofiler,
     gorgeimpl,
     vmdeps,
@@ -62,7 +62,7 @@ import
   ]
 
 
-import ast/ast except getstr
+import compiler/ast/ast except getstr
 import std/options as stdoptions
 
 

--- a/compiler/vm/vmconv.nim
+++ b/compiler/vm/vmconv.nim
@@ -1,4 +1,4 @@
-import ast/ast
+import compiler/ast/ast
 
 template elementType*(T: typedesc): typedesc =
   typeof(block:

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -13,19 +13,19 @@
 import tables
 
 import
-  ast/[
+  compiler/ast/[
     ast,
     idents,
     lineinfos,
     reports,
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs,
   ],
-  front/[
+  compiler/front/[
     options,
   ],
-  utils/[
+  compiler/utils/[
     debugutils
   ]
 

--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -11,18 +11,18 @@ import
   std/[
     os
   ],
-  ast/[
+  compiler/ast/[
     types,
     ast,
     idents,
     lineinfos,
     reports
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  utils/[
+  compiler/utils/[
     pathutils
   ]
 

--- a/compiler/vm/vmerrors.nim
+++ b/compiler/vm/vmerrors.nim
@@ -9,10 +9,10 @@
 ## nor inside VM code-generation (`vmgen`)
 
 import
-  ast/[
+  compiler/ast/[
     reports
   ],
-  front/[
+  compiler/front/[
     msgs
   ]
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -33,7 +33,7 @@ import
     strutils,
     intsets
   ],
-  ast/[
+  compiler/ast/[
     renderer,
     types,
     ast,
@@ -41,19 +41,19 @@ import
     lineinfos,
     astmsgs
   ],
-  modules/[
+  compiler/modules/[
     magicsys,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     msgs,
     options
   ],
-  sem/[
+  compiler/sem/[
     lowerings,
     transf
   ],
-  vm/[
+  compiler/vm/[
     vmdef,
     vmerrors
   ]

--- a/compiler/vm/vmhooks.nim
+++ b/compiler/vm/vmhooks.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-import utils/pathutils
+import compiler/utils/pathutils
 
 template setX(k, field) {.dirty.} =
   a.slots[a.ra].ensureKind(k)

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -4,14 +4,14 @@ import
     strutils,
     tables
   ],
-  ast/[
+  compiler/ast/[
     lineinfos,
   ],
-  front/[
+  compiler/front/[
     options,
     msgs
   ],
-  vm/[
+  compiler/vm/[
     vmdef
   ]
 

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -13,17 +13,17 @@ when not defined(nimpretty):
   {.error: "This needs to be compiled with --define:nimPretty".}
 
 import
-  ast/[
+  compiler/ast/[
     idents,
     syntaxes,
     layouter
   ],
-  front/[
+  compiler/front/[
     msgs,
     options,
     cli_reporter
   ],
-  utils/[
+  compiler/utils/[
     pathutils,
   ]
 

--- a/nimpretty/nimpretty.nim.cfg
+++ b/nimpretty/nimpretty.nim.cfg
@@ -1,2 +1,2 @@
 --define: nimpretty
-path:"$config/../compiler"
+path:"$config/.."

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -22,28 +22,28 @@ import std/options as std_options
 
 
 import
-  ast/[
+  compiler/ast/[
     reports,
     idents,
     lineinfos,
     ast
   ],
-  modules/[
+  compiler/modules/[
     modules,
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     commands,
     msgs,
     cmdlinehelper,
     cli_reporter
   ],
-  utils/[
+  compiler/utils/[
     prefixmatches,
     pathutils
   ],
-  sem/[
+  compiler/sem/[
     sem,
     passes,
     passaux,

--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -20,5 +20,5 @@ define:nimcore
 #define:useNodeIds
 #define:booting
 #define:noDocgen
---path:"$config/../compiler"
+--path:"$config/.."
 --threads:on

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -16,7 +16,7 @@ import std/[
 ]
 import backend, htmlgen, specs
 from std/sugar import dup
-import utils/nodejs
+import compiler/utils/nodejs
 import lib/stdtest/testutils
 from lib/stdtest/specialpaths import splitTestFile
 import experimental/[sexp, sexp_diff, colortext, colordiff]

--- a/testament/testament.nim.cfg
+++ b/testament/testament.nim.cfg
@@ -1,6 +1,6 @@
 # don't move this file without updating the logic in `isNimRepoTests`
 
-path = "$config/../compiler" # For utils/nodejs
+path = "$config/.." # For utils/nodejs
 path = "."    # to allow for package qualified imports
 -d:ssl # For some CI (previously Azure)
 # my SSL doesn't have this feature and I don't care:

--- a/tests/compilerapi/tcompilerapi.nim
+++ b/tests/compilerapi/tcompilerapi.nim
@@ -19,16 +19,16 @@ import
   std/[
     os
   ],
-  ast/[
+  compiler/ast/[
     ast,
     lineinfos,
     reports,
     llstream
   ],
-  front/[
+  compiler/front/[
     options
   ],
-  vm/[
+  compiler/vm/[
     vmdef,
     vm,
     nimeval,

--- a/tests/compilerapi/tcompilerapi.nim.cfg
+++ b/tests/compilerapi/tcompilerapi.nim.cfg
@@ -1,1 +1,1 @@
-path="$config/../../compiler/"
+path="$nim"

--- a/tests/compilerunits/confread/tcli_parsing.nim
+++ b/tests/compilerunits/confread/tcli_parsing.nim
@@ -4,10 +4,10 @@ joinable: false
 """
 
 import
-  ast/[
+  compiler/ast/[
     reports
   ],
-  front/[
+  compiler/front/[
     options,
     commands
   ],

--- a/tests/compilerunits/confread/treport_filtering.nim
+++ b/tests/compilerunits/confread/treport_filtering.nim
@@ -19,14 +19,14 @@ import
     os,
     sequtils
   ],
-  ast/[
+  compiler/ast/[
     reports,
     idents
   ],
-  modules/[
+  compiler/modules/[
     modulegraphs
   ],
-  front/[
+  compiler/front/[
     options,
     commands,
     cli_reporter,

--- a/tests/compilerunits/nim.cfg
+++ b/tests/compilerunits/nim.cfg
@@ -1,1 +1,1 @@
---path:"$config/../../compiler"
+--path:"$config/../.."

--- a/tools/grammar_nanny.nim
+++ b/tools/grammar_nanny.nim
@@ -4,9 +4,9 @@
 import std / [strutils, sets]
 
 import
-  ast/[llstream, lexer, idents, lineinfos, reports],
-  utils/[pathutils],
-  front/[options, msgs, cli_reporter]
+  compiler/ast/[llstream, lexer, idents, lineinfos, reports],
+  compiler/utils/[pathutils],
+  compiler/front/[options, msgs, cli_reporter]
 
 # import ".." / compiler / [
 #   llstream, lexer, options, msgs, idents,

--- a/tools/koch/koch.nim.cfg
+++ b/tools/koch/koch.nim.cfg
@@ -5,3 +5,5 @@
   # workaround see https://github.com/nim-lang/Nim/pull/14291
   --lib:lib
 @end
+
+path:"$config/.."

--- a/tools/nim.cfg
+++ b/tools/nim.cfg
@@ -1,1 +1,1 @@
-path:"$config/../compiler"
+path:"$config/.."

--- a/tools/winrelease.nim
+++ b/tools/winrelease.nim
@@ -4,6 +4,6 @@
 ## The problem is that 'koch.exe' too is part of the zip bundle and
 ## needs to have the right 32/64 bit version. (Bug #6147)
 
-import "../koch"
+import koch/koch
 
 winRelease()


### PR DESCRIPTION
## Summary
I cannot build nimph with nimskull because I want to simply `--path="$nim"` and then import compiler modules as in `import compiler/utils/pathutils`.  This changes the code so that pattern works.

## Details
Compiler imports are now qualified with a `compiler` prefix. This
restores the ability to use the compiler API, previously resulted in
errors due to failed imports.

Due to the nature of this change many files had to be modified.

This particular fix was motivated in order to have `disruptek/nimph`
working under nimskull. Compiler API consumers can now use the API by
including `--path:"$nim"` in their cfg.

Misc:
- `tests/compilerapi/tcompilerapi` should catch regressions now
- doc work around, disabled example in `compiler/utils/nimdebugutils`,
    required because runnable examples doesn't account for the `path`
----
I don't see why I should need this `nim.cfg` to include `--path="$config"` in the repository root.  This behavior feels intentional, though.  What's the thinking here?