### PR TITLE
add isNimSkull define

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -63,6 +63,13 @@ path="$lib/pure"
 nimblepath="$home/.nimble/pkgs2/"
 nimblepath="$home/.nimble/pkgs/"
 
+# Hardcode `isNimSkull` define so code bases meant to work for both Nim and
+# NimSkull can test to see which compiler they're using. Not done in system
+# as a program can exclude system. This was done in order to allow
+# https://github.com/disruptek/nimph to work across both. See the following
+# PR for some clues: https://github.com/disruptek/nimph/pull/159
+--define:isNimSkull
+
 # Syncronize with compiler/commands.specialDefine
 @if danger or quick:
   obj_checks:off

--- a/tests/compilerapi/tcompilerapi.nim
+++ b/tests/compilerapi/tcompilerapi.nim
@@ -1,4 +1,7 @@
 discard """
+  description: '''Example program that demonstrates how to use the compiler as
+  an API to embed into your own projects.
+  '''
   cmd: '''nim c --warnings:off --hints:off $file'''
   output: '''top level statements are executed!
 (ival: 10, fval: 2.0)
@@ -10,9 +13,6 @@ raising VMQuit
 '''
   joinable: "false"
 """
-
-## Example program that demonstrates how to use the
-## compiler as an API to embed into your own projects.
 
 
 import
@@ -56,8 +56,6 @@ proc vmReport(config: ConfigRef, report: Report): TErrorHandling {.gcsafe.} =
 
   elif report.kind == rintEchoMessage:
     echo report.internalReport.msg
-
-
 
 
 proc main() =
@@ -104,3 +102,7 @@ block error_hook:
   let i = initInterpreter("invalid.nim", vmReport)
   doAssertRaises(VMQuit):
     i.evalScript()
+
+block isNimSkull_define:
+  const isNimSkull {.booldefine.} = false
+  doAssert isNimSkull, "define 'isNimSkull' is not set"


### PR DESCRIPTION
## Summary

This allows code bases to detect whether they're using the Nim or
NimSkull compiler.

Originally motivated by Nimph's needs, see:
https://github.com/disruptek/nimph/pull/159

## Details

Also added a compilerapi test to avoid regressions. This is hardcoded in
the compiler executable because system import can be circumvented.

---
is there a better approach?