### PR TITLE
stdlib: move `varargsLen` to `macros.nim`

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1570,6 +1570,10 @@ macro getCustomPragmaVal*(n: typed, cp: typed{nkSym}): untyped =
   if result.kind == nnkEmpty:
     error(n.repr & " doesn't have a pragma named " & cp.repr()) # returning an empty node results in most cases in a cryptic error,
 
+macro varargsLen*(x: varargs[untyped]): int {.since: (1, 1).} =
+  ## returns number of variadic arguments in `x`
+  newLit(x.len)
+
 macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped =
   ## Calls `callee` with `args` unpacked as individual arguments.
   ## This is useful in 2 cases:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2817,11 +2817,6 @@ when defined(nimV2):
   import system/repr_v2
   export repr_v2
 
-macro varargsLen*(x: varargs[untyped]): int {.since: (1, 1).} =
-  ## returns number of variadic arguments in `x`
-  proc varargsLenImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
-  varargsLenImpl(x)
-
 when false:
   template eval*(blk: typed): typed =
     ## Executes a block of code at compile time just as if it was a macro.

--- a/tests/macros/tvarargslen.nim
+++ b/tests/macros/tvarargslen.nim
@@ -1,13 +1,15 @@
 discard """
   output: '''
-tvarargslen.nim:35:9 (1, 2)
-tvarargslen.nim:36:9 12
-tvarargslen.nim:37:9 1
-tvarargslen.nim:38:8 
+tvarargslen.nim:37:9 (1, 2)
+tvarargslen.nim:38:9 12
+tvarargslen.nim:39:9 1
+tvarargslen.nim:40:8 
 done
 '''
 """
 ## line 10
+
+from std/macros import varargsLen
 
 template myecho*(a: varargs[untyped]) =
   ## shows a useful debugging echo-like proc that is dependency-free (no dependency

--- a/tests/stdlib/tstrbasics.nim
+++ b/tests/stdlib/tstrbasics.nim
@@ -3,7 +3,7 @@ discard """
   matrix: "--gc:refc; --gc:arc"
 """
 
-import std/[strbasics, sugar]
+import std/[strbasics, sugar, macros]
 
 template strip2(input: string, args: varargs[untyped]): untyped =
   var a = input


### PR DESCRIPTION
It could only be implemented in `system` due to a misuse of a
compiler magic, making it dependent on a VM implementation detail.

### Changes
- `varagsLen` is now located in `macros.nim` and doesn't depend on a
 compiler  magic anymore
- the `tvarargslen.nim` test is moved to the `macros` category

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

The macro was originally added to `system` in order to make it available with no extra imports. There also was a discussion in the original [PR](https://github.com/nim-lang/Nim/pull/12907) about whether or not this macro should even be needed in the first place, but the PR was merged without the discussion concluding.
