### PR TITLE
internal: don't use VM callback for `addFloatRoundtrip`

### DIFF
--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -339,11 +339,6 @@ proc registerAdditionalOps*(c: PCtx) =
     let fn = getNode(a, 0)
     setResult(a, fn.kind == nkClosure or (fn.typ != nil and fn.typ.callConv == ccClosure))
 
-  registerCallback c, "stdlib.formatfloat.addFloatRoundtrip", proc(a: VmArgs) =
-    let p = a.getVar(0)
-    let x = a.getFloat(1)
-    addFloatRoundtrip(p.strVal, x)
-
   registerCallback c, "stdlib.formatfloat.addFloatSprintf", proc(a: VmArgs) =
     let p = a.getVar(0)
     let x = a.getFloat(1)


### PR DESCRIPTION
The function doesn't need to be overridden with a VM callback
implementation in order to work in the VM. In addition, the usage of
a callback was problematic in this case, as the callback has no way
to know if the input is a `float32` or `float64` and always treated
it as the latter

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

Fixes the `tfloats.nim` test in the data layout [PR](https://github.com/nim-works/nimskull/pull/242)