### PR TITLE
remove code reordering dead code

### DIFF
--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -72,7 +72,7 @@ type
     wWrites = "writes", wReads = "reads", wSize = "size", wEffects = "effects", wTags = "tags",
     wAssert = "assert",
     wDeadCodeElimUnused = "deadCodeElim",  # deprecated, dead code elim always happens
-    wSafecode = "safecode", wPackage = "package", wNoForward = "noforward",
+    wSafecode = "safecode", wPackage = "package",
     wNoRewrite = "norewrite", wNoDestroy = "nodestroy", wPragma = "pragma",
     wCompileTime = "compileTime", wNoInit = "noinit", wPassc = "passc", wPassl = "passl",
     wLocalPassc = "localPassC", wBorrow = "borrow", wDiscardable = "discardable",

--- a/compiler/sem/passes.nim
+++ b/compiler/sem/passes.nim
@@ -184,18 +184,7 @@ proc processModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator;
       if graph.stopCompile(): break
       var n = parseTopLevelStmt(p)
       if n.kind == nkEmpty: break
-      if sfSystemModule notin module.flags and
-          {sfNoForward} * module.flags != {}:
-        # read everything, no streaming possible
-        var sl = newNodeI(nkStmtList, n.info)
-        sl.add n
-        while true:
-          var n = parseTopLevelStmt(p)
-          if n.kind == nkEmpty: break
-          sl.add n
-        discard processTopLevelStmt(graph, sl, a)
-        break
-      elif n.kind in imperativeCode:
+      if n.kind in imperativeCode:
         # read everything until the next proc declaration etc.
         var sl = newNodeI(nkStmtList, n.info)
         sl.add n

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -89,7 +89,7 @@ const
     wDeadCodeElimUnused,  # deprecated, always on
     wDeprecated,
     wFloatChecks, wInfChecks, wNanChecks, wPragma, wEmit, wUnroll,
-    wLinearScanEnd, wPatterns, wTrMacros, wEffects, wNoForward, wComputedGoto,
+    wLinearScanEnd, wPatterns, wTrMacros, wEffects, wComputedGoto,
     wExperimental, wThis, wUsed, wAssert}
   lambdaPragmas* = {FirstCallConv..LastCallConv,
     wNoSideEffect, wSideEffect, wNoreturn, wNosinks, wDynlib, wHeader,
@@ -352,21 +352,6 @@ proc onOff(c: PContext, n: PNode, op: TOptions, resOptions: var TOptions): PNode
            else:         err
   if r: resOptions.incl op
   else: resOptions.excl op
-
-proc pragmaNoForward(c: PContext, n: PNode): PNode =
-  ## `n` must be a callable pragma of length two, or an error is produced,
-  ## otherwise produces (mutates) the boolean arg (2nd) in `n` and the
-  ## current modules flags, enabling no forward, disables code re-ordering.
-  var (isOn, err) = isTurnedOn(c, n)
-  result =
-    if err.isNil:
-      if isOn:
-        incl(c.module.flags, sfNoForward)
-      else:
-        excl(c.module.flags, sfNoForward)
-      n
-    else:
-      err
 
 proc processCallConv(c: PContext, n: PNode): PNode =
   ## sets the calling convention on the the `c`ontext's option stack, and upon
@@ -1379,8 +1364,6 @@ proc prepareSinglePragma(
         result = noVal(c, it)
         incl(sym.flags, {sfThread, sfGlobal})
       of wDeadCodeElimUnused: discard  # xxx: deprecated, dead code elim always on
-      of wNoForward:
-        result = pragmaNoForward(c, it)
       of wMagic:
         result = processMagic(c, it, sym)
       of wCompileTime:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -700,12 +700,7 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   else:
     inc c.topStmts
 
-  # xxx: can noforward be deprecated? might be repurposed for IC, not sure.
-  if sfNoForward in c.module.flags:
-    result = semAllTypeSections(c, n)
-  else:
-    result = n
-
+  result = n
   result = semStmt(c, result, {})
   result = hloStmt(c, result)
 

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1538,7 +1538,7 @@ proc semTypeSection(c: PContext, n: PNode): PNode =
   ## Processes a type section. This must be done in separate passes, in order
   ## to allow the type definitions in the section to reference each other
   ## without regard for the order of their definitions.
-  if sfNoForward notin c.module.flags or nfSem notin n.flags:
+  if nfSem notin n.flags:
     inc c.inTypeContext
     typeSectionLeftSidePass(c, n)
     typeSectionRightSidePass(c, n)
@@ -1964,13 +1964,6 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   else:
     s = semIdentDef(c, n[namePos], kind)
     n[namePos] = newSymNode(s)
-    when false:
-      # disable for now
-      if sfNoForward in c.module.flags and
-         sfSystemModule notin c.module.flags:
-        addInterfaceOverloadableSymAt(c, c.currentScope, s)
-        s.flags.incl sfForward
-        return
 
   assert s.kind in skProcKinds
 


### PR DESCRIPTION
## Summary
- drop the `noforward` pragma
- this is dead code

## Details
- no longer apply sfNoForward to module symbols
- remove various unnecessary checks