### PR TITLE
Fixes #263

### DIFF
--- a/lib/experimental/sexp.nim
+++ b/lib/experimental/sexp.nim
@@ -143,15 +143,6 @@ proc parseString(my: var SexpParser): TTokKind =
       of 'f':
         add(my.a, '\f')
         inc(pos, 2)
-      of 'n':
-        add(my.a, '\L')
-        inc(pos, 2)
-      of 'r':
-        add(my.a, '\C')
-        inc(pos, 2)
-      of 't':
-        add(my.a, '\t')
-        inc(pos, 2)
       of 'u':
         inc(pos, 2)
         var r: int


### PR DESCRIPTION
## Summary
Changes to Sexp parsing. 

We are changing it because it does not  work as expected when the string contains literal \n , \t, \r. this is very common in path  expressions, and are currently parsed as literals. 

I'm not sure about the message, nor the effects.