### PR TITLE
Make `newNode` side-effect free again

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -390,10 +390,11 @@ template setNodeId() =
       echo "KIND ", result.kind
       writeStackTrace()
 
-proc newNodeI*(kind: TNodeKind, info: TLineInfo): PNode =
+func newNodeI*(kind: TNodeKind, info: TLineInfo): PNode =
   ## new node with line info, no type, and no children
   result = PNode(kind: kind, info: info, reportId: emptyReportId)
-  setNodeId()
+  {.cast(noSideEffect).}:
+    setNodeId()
   when false:
     # this would add overhead, so we skip it; it results in a small amount of leaked entries
     # for old PNode that gets re-allocated at the same address as a PNode that


### PR DESCRIPTION
Wrap the `setNodeId` usage in a `{.cast(noSideEffect).}` block in order
to make the `newNode` family of functions available in `noSideEffect`
contexts.

This might become a problem in the far future, but it's okay for now

---
As discussed on Matrix