### PR TITLE
Fix `of` operator crashing in some cases

### DIFF
--- a/lib/system/assign.nim
+++ b/lib/system/assign.nim
@@ -216,6 +216,13 @@ proc objectInit(dest: pointer, typ: PNimType) =
       var pint = cast[ptr PNimType](dest)
       pint[] = typ
     objectInitAux(dest, typ.node)
+
+    # initialize the bases. `objectInit` can't be used directly, since it
+    # would change the header type field that was filled above
+    var t = typ.base
+    while t != nil:
+      objectInitAux(dest, t.node)
+      t = t.base
   of tyTuple:
     objectInitAux(dest, typ.node)
   of tyArray, tyArrayConstr:

--- a/tests/init/tbases.nim
+++ b/tests/init/tbases.nim
@@ -1,0 +1,39 @@
+discard """
+  description: "Test the initialization of type fields in parent objects"
+  matrix: "--gc:arc; --gc:refc"
+  targets: c cpp js
+"""
+
+type
+  Inh = object of RootObj
+
+  A = object of RootObj
+    x: Inh
+  B = object of A
+    y: Inh
+  C = object of B
+    z: Inh
+
+proc test[T](x: ptr RootObj, t: typedesc[T]): bool =
+  x of T
+
+proc test(v: ptr C) =
+  doAssert test(addr v.x, Inh)
+  doAssert test(addr v.y, Inh)
+  doAssert test(addr v.z, Inh)
+  doAssert test(v, C) # make sure that the type header is set correctly
+
+var v = C() # test with non-ref
+test(addr v)
+
+var v2 = new(C) # test with new'ed ref
+test(addr v2[])
+
+var v3 = (ref C)() # test with implicit `new`
+test(addr v3[])
+
+proc p() =
+  var v = C() # test with non-global
+  test(addr v)
+
+p()


### PR DESCRIPTION
The type headers in base types for non-global variables wasn't
initialized, making any operation (e.g. `of`) using them crash with a
nil-access.

`objectInit` now correctly walks the base types and initializes their
type fields