### PR TITLE
tuple unpacking in const/let/var disallows pragmas

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -885,6 +885,13 @@ proc copyTreeWithoutNode*(src, skippedNode: PNode): PNode =
       if n != skippedNode:
         result.sons.add copyTreeWithoutNode(n, skippedNode)
 
+proc copyTreeWithoutNodes*(src: PNode; skippedNodes: varargs[PNode]): PNode =
+  copyNodeImpl(result, src):
+    result.sons = newSeqOfCap[PNode](src.len)
+    for n in src.sons:
+      if n notin skippedNodes:
+        result.sons.add copyTreeWithoutNodes(n, skippedNodes)
+
 proc hasSonWith*(n: PNode, kind: TNodeKind): bool =
   for i in 0..<n.len:
     if n[i].kind == kind:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -700,6 +700,12 @@ type
       ## there is no meaningful error to construct, but there is an error
       ## further down the AST that invalidates the whole
 
+    rsemPragmaDisallowedForTupleUnpacking
+      ## we disallow pragma blocks `let (foo {.somePragma.}, bar) = (1,2)` as
+      ## the semantics of pragmas in the face of unpacking are not woefully
+      ## underspecified. This is not a matter of reenabling it as a rethinking
+      ## the approach from a first principles perspective is required.
+
     rsemSymbolKindMismatch
     rsemIllformedAst
     rsemInitHereNotAllowed
@@ -750,8 +756,6 @@ type
     rsemMissingPragmaArg
     rsemErrGcUnsafe
     rsemEmptyAsm
-
-
     # END !! add reports BEFORE the last enum !!
 
     # Semantic warnings begin

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -121,8 +121,6 @@ type
       else:
         discard
 
-
-
 func severity*(parser: ParserReport): ReportSeverity =
   case ParserReportKind(parser.kind):
     of rparHintKinds: rsevHint
@@ -423,7 +421,6 @@ template tern*(predicate: bool, tBranch: untyped, fBranch: untyped): untyped =
     block:
       if predicate: tBranch else: fBranch
 
-
 type
   CmdReport* = object of ReportBase
     cmd*: string
@@ -443,7 +440,6 @@ func severity*(report: CmdReport): ReportSeverity =
     of rcmdErrorKinds: rsevError
 
 type
-
   DebugSemStepDirection* = enum semstepEnter, semstepLeave
   DebugSemStepKind* = enum
     stepNodeToNode
@@ -452,10 +448,20 @@ type
     stepNodeFlagsToNode
     stepNodeTypeToNode
     stepTypeTypeToType
+    stepResolveOverload
+    stepNodeSigMatch
     stepWrongNode
     stepError
     stepTrack
 
+  DebugCallableCandidate* = object
+    ## stripped down version of `sigmatch.TCandidate`
+    state*: string
+    callee*: PType
+    calleeSym*: PSym
+    calleeScope*: int
+    call*: PNode
+    error*: SemCallMismatch
 
   DebugSemStep* = object
     direction*: DebugSemStepDirection
@@ -477,6 +483,11 @@ type
 
       of stepNodeFlagsToNode:
         flags*: TExprFlags
+      
+      of stepNodeSigMatch, stepResolveOverload:
+        filters*: TSymKinds
+        candidate*: DebugCallableCandidate
+        errors*: seq[SemCallMismatch]
 
   DebugVmCodeEntry* = object
     isTarget*: bool
@@ -493,7 +504,6 @@ type
     ra*: int
     rb*: int
     rc*: int
-
 
   DebugReport* = object of ReportBase
     case kind*: ReportKind
@@ -554,11 +564,11 @@ type
 
       of rbackJsonScriptMismatch:
         jsonScriptParams*: tuple[
-          outputCurrent, output, jsonFile: string]
+          outputCurrent, output, jsonFile: string
+        ]
 
       else:
         discard
-
 
 func severity*(report: BackendReport): ReportSeverity =
   case BackendReportKind(report.kind):

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -998,6 +998,11 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemWrongIdent:
       result = joinAnyOf(r.expectedIdents, quote = true) & " expected"
 
+    of rsemPragmaDisallowedForTupleUnpacking:
+      result = "pragmas are disallowed during tuple unpacking assignment, " &
+        "this is a know design issue; as a work around split pragmas and " &
+        "unpacking into two steps."
+
     of rsemPragmaOptionExpected:
       result = "option expected"
 
@@ -3276,6 +3281,22 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
             else:
               field("to type")
               result.add render(s.typ)
+          
+          of stepNodeSigMatch, stepResolveOverload:
+            if enter:
+              field("from node")
+              result.add render(s.node)
+            else:
+              field("match status", s.candidate.state)
+              if s.candidate.call.isNil:
+                field("mismatch kind", $s.candidate.error.firstMismatch.kind)
+              else:
+                field("callee")
+                result.add render(s.candidate.callee)
+                field("calleeSym")
+                result.add render(s.candidate.calleeSym)
+                field("call")
+                result.add render(s.candidate.call)
 
 
     of rdbgTraceLine:

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -44,7 +44,6 @@ const
   DocTexConfig* = RelativeFile"nimdoc.tex.cfg"
   htmldocsDir* = htmldocsDirname.RelativeDir
   docRootDefault* = "@default" # using `@` instead of `$` to avoid shell quoting complications
-  oKeepVariableNames* = true
   spellSuggestSecretSauce* = -1
 
 const

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -126,8 +126,6 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
     else:
       break
 
-
-
 proc maybeResemArgs*(c: PContext, n: PNode, startIdx: int = 1): seq[PNode] =
   # HACK original implementation of the `describeArgs` used `semOperand`
   # here, but until there is a clear understanding /why/ is it necessary to
@@ -162,7 +160,7 @@ proc notFoundError(c: PContext, n: PNode, errors: seq[SemCallMismatch]): PNode =
   ## as semOverloadedCall is already pretty slow (and we need this information
   ## only in case of an error).
   ## returns an nkError
-  addInNimDebugUtils(c.config, "notFoundError")
+  addInNimDebugUtils(c.config, "notFoundError", n, result)
   if c.config.m.errorOutputs == {}:
     # xxx: this is a hack to detect we're evaluating a constant expression or
     #      some other vm code, it seems
@@ -197,7 +195,6 @@ proc notFoundError(c: PContext, n: PNode, errors: seq[SemCallMismatch]): PNode =
   report.callMismatches = errors
 
   result = newError(c.config, n, report)
-
 
 proc bracketNotFoundError(c: PContext; n: PNode): PNode =
   var errors: seq[SemCallMismatch]
@@ -268,6 +265,7 @@ proc getMsgDiagnostic(
 proc resolveOverloads(c: PContext, n: PNode,
                       filter: TSymKinds, flags: TExprFlags,
                       errors: var seq[SemCallMismatch]): TCandidate =
+  addInNimDebugUtils(c.config, "resolveOverloads", n, filter, errors, result)
   var initialBinding: PNode
   var alt: TCandidate
   var f = n[0]
@@ -499,7 +497,7 @@ proc canDeref(n: PNode): bool {.inline.} =
 
 proc semOverloadedCall(c: PContext, n: PNode,
                        filter: TSymKinds, flags: TExprFlags): PNode {.nosinks.} =
-  addInNimDebugUtils(c.config, "semOverloadedCall")
+  addInNimDebugUtils(c.config, "semOverloadedCall", n, result)
   var errors: seq[SemCallMismatch]
 
   var r = resolveOverloads(c, n, filter, flags, errors)

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -443,10 +443,13 @@ proc computeRequiresInit(c: PContext, t: PType): bool =
 
 proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
   var objType = t
+  
   while objType.kind notin {tyObject, tyDistinct}:
     objType = objType.lastSon
     assert objType != nil
-  if objType.kind == tyObject:
+  
+  case objType.kind
+  of tyObject:
     var constrCtx = initConstrContext(objType, newNodeI(nkObjConstr, info))
     let initResult = semConstructTypeAux(c, constrCtx, {})
     if constrCtx.missingFields.len > 0:
@@ -455,11 +458,11 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
         reportSymbols(
           rsemObjectRequiresFieldInitNoDefault,
           constrCtx.missingFields, typ = t))
-
-  elif objType.kind == tyDistinct:
+  
+  of tyDistinct:
     localReport(c.config, info, reportTyp(
       rsemDistinctDoesNotHaveDefaultValue, t))
-
+  
   else:
     assert false, "Must not enter here."
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -501,6 +501,7 @@ proc semAnonTuple(c: PContext, n: PNode, prev: PType): PType =
     addSonSkipIntLit(result, semTypeNode(c, it, nil), c.idgen)
 
 proc semTuple(c: PContext, n: PNode, prev: PType): PType =
+  addInNimDebugUtils(c.config, "semTuple", n, prev, result)
   var typ: PType
   result = newOrPrevType(tyTuple, prev, c)
   result.n = newNodeI(nkRecList, n.info)
@@ -569,6 +570,7 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
 
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym =
+  addInNimDebugUtils(c.config, "semIdentWithPragma", n, result)
   if n.kind == nkPragmaExpr:
     checkSonsLen(n, 2, c.config)
     result = semIdentVis(c, kind, n[0], allowed)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -43,6 +43,9 @@ import
     lowerings,
     parampatterns,
     concepts,
+  ],
+  compiler/utils/[
+    debugutils,
   ]
 
 
@@ -90,12 +93,21 @@ type
 
   TTypeRelFlags* = set[TTypeRelFlag]
 
-
 const
   isNilConversion = isConvertible # maybe 'isIntConv' fits better?
 
 proc markUsed*(c: PContext; info: TLineInfo, s: PSym)
 proc markOwnerModuleAsUsed*(c: PContext; s: PSym)
+
+proc toDebugCallableCandidate*(c: TCandidate): DebugCallableCandidate =
+  DebugCallableCandidate(
+    state: $c.state,
+    callee: c.callee,
+    calleeSym: c.calleeSym,
+    calleeScope: c.calleeScope,
+    call: c.call,
+    error: c.error
+  )
 
 template hasFauxMatch*(c: TCandidate): bool = c.fauxMatch != tyNone
 
@@ -302,7 +314,6 @@ proc cmpCandidates*(a, b: TCandidate): int =
   # only as a last resort, consider scoping:
   if result != 0: return
   result = a.calleeScope - b.calleeScope
-
 
 
 proc concreteType(c: TCandidate, t: PType; f: PType = nil): PType =
@@ -2585,7 +2596,7 @@ proc partialMatch*(c: PContext, n: PNode, m: var TCandidate) =
   matchesAux(c, n, m, marker)
 
 proc matches*(c: PContext, n: PNode, m: var TCandidate) =
-  # addInNimDebugUtils(c.config, "matches", n, nOrig)
+  addInNimDebugUtils(c.config, "matches", n, m)
   if m.magic in {mArrGet, mArrPut}:
     m.state = csMatch
     m.call = n

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -10,7 +10,7 @@ defined:
 - `treeRepr` - main implementation to generate the `ColText` chunk for the
   object.
 
-- `debug` - convenience ovelroads that print generated text immediately.
+- `debug` - convenience overloads that print generated text immediately.
   There are two version of the `debug` - one that accept `ConfigRef`
   object, and one that can work without it. Both call `treeRepr`
   internally, but with `ConfigRef` present more information can be printed.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1,8 +1,7 @@
-==========
-Nim Manual
-==========
+===============
+NimSkull Manual
+===============
 
-:Authors: Andreas Rumpf, Zahary Karadjov
 :Version: |nimversion|
 
 .. default-role:: code
@@ -18,8 +17,8 @@ Nim Manual
 About this document
 ===================
 
-**Note**: This document is a draft! Several of Nim's features may need more
-precise wording. This manual is constantly evolving into a proper specification.
+**Note**: This document is a draft! Several of |NimSkull|'s features may need
+more precise wording. This manual is constantly evolving.
 
 **Note**: The experimental features of Nim are
 covered `here <manual_experimental.html>`_.
@@ -2904,7 +2903,10 @@ identifier `_` can be used to ignore some parts of the tuple:
 
     let (x, _, z) = returnsTuple()
 
-
+.. warning::
+  Use of pragmas is not supporting during let, var, or const tuple unpacking.
+  This is a known issue and will be addressed in the future, it's currently
+  unclear how this will or should be resolved, unfortunately.
 
 Const section
 -------------

--- a/tests/tuples/tunpack_with_pragma_disallowed_const.nim
+++ b/tests/tuples/tunpack_with_pragma_disallowed_const.nim
@@ -1,0 +1,12 @@
+discard """
+description: "can't mix pragmas and tuple unpacking"
+errormsg: "pragmas are disallowed during tuple unpacking assignment, this is a know design issue; as a work around split pragmas and unpacking into two steps."
+line: 12
+"""
+
+import macros
+
+macro foo(l, t, e: untyped): untyped =
+  discard
+
+const (x {.foo.}, b) = (1, 2)

--- a/tests/tuples/tunpack_with_pragma_disallowed_let.nim
+++ b/tests/tuples/tunpack_with_pragma_disallowed_let.nim
@@ -1,0 +1,12 @@
+discard """
+description: "can't mix pragmas and tuple unpacking"
+errormsg: "pragmas are disallowed during tuple unpacking assignment, this is a know design issue; as a work around split pragmas and unpacking into two steps."
+line: 12
+"""
+
+import macros
+
+macro foo(l, t, e: untyped): untyped =
+  discard
+
+let (x {.foo.}, b) = (1, 2)

--- a/tests/tuples/tunpack_with_pragma_disallowed_var.nim
+++ b/tests/tuples/tunpack_with_pragma_disallowed_var.nim
@@ -1,0 +1,12 @@
+discard """
+description: "can't mix pragmas and tuple unpacking"
+errormsg: "pragmas are disallowed during tuple unpacking assignment, this is a know design issue; as a work around split pragmas and unpacking into two steps."
+line: 12
+"""
+
+import macros
+
+macro foo(l, t, e: untyped): untyped =
+  discard
+
+var (x {.foo.}, b) = (1, 2)


### PR DESCRIPTION
## Summary
tuple unpacking in const/let/var disallows pragmas

`let (a {.compileTime.}, b) = (1, 2)` and most other pragmas led to nil
pointer exceptions in the compiler, didn't make sense as the example, or
in some other way posed a significant issue. For now they've been made
illegal.

## Details

### Primary Changes
- the compiler will show an error message if attempted
- there tests for these errors
- the manual.rst has a note added to the tuple unpacking section

### Other Changes/Notes:
- add more compiler trace points, as needed for debugging
- added trace points for PNode -> TCandidate procs
- `semVarOrLet` is much longer and a bit more linear
- minor formatting touch ups here and there

### Future work:
- `semVarOrLet` and `semConst` should likely get merged
- need to take more advantage of nkError to reduce code

### Random Lessons:
- the compiler is already using lowerings in sem due to ambiguities
- assignment overloads don't work in const/var/let
- tuple unpacking potentially evaluates the rhs multiple times