### PR TITLE
Fix type field related issues with variant objects

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -227,6 +227,10 @@ proc searchTypeForAux(t: PType, predicate: TTypePredicate,
   else:
     discard
 
+proc searchTypeNodeFor*(n: PNode, predicate: TTypePredicate): bool =
+  var marker = initIntSet()
+  result = searchTypeNodeForAux(n, predicate, marker)
+
 proc searchTypeFor*(t: PType, predicate: TTypePredicate): bool =
   var marker = initIntSet()
   result = searchTypeForAux(t, predicate, marker)

--- a/tests/objvariant/tinit_type_fields.nim
+++ b/tests/objvariant/tinit_type_fields.nim
@@ -1,0 +1,56 @@
+discard """
+  description: '''Tests variant object initialization with non-pure object
+                  fields in the record-case'''
+  matrix: "--gc:arc; --gc:refc"
+  targets: c cpp js
+"""
+
+type
+  Inh = object of RootObj # `Inh` has a `m_type` field on non-VM back-ends
+
+  A = object of RootObj
+    case k1: bool
+    of false:
+      a: array[2, Inh]
+    of true:
+      b: int
+
+  B = object of A
+    c: (Inh, Inh)
+
+  C = object of B
+    case k2: bool
+    of false:
+      d: Inh # For this test, it's important that `x` is in the default
+             # branch
+    of true:
+      e: int
+      f: Inh
+
+proc test(x: ptr RootObj): bool =
+  x of Inh
+
+proc test(v: ptr C) =
+  doAssert v.e == 0
+  doAssert test(addr v.a[0])
+  doAssert test(addr v.a[1])
+  doAssert test(addr v.c[0])
+  doAssert test(addr v.c[1])
+  doAssert test(addr v.f)
+
+
+proc p() =
+  # test with non-global
+  var v = C(k2: true)
+  test(addr v)
+
+  v = C(k2: false)
+  doAssert test(addr v.d)
+
+p()
+
+var v = C(k2: true) # test with non-ref
+test(addr v)
+
+var v2 = (ref C)(k2: true) # test with ref
+test(addr v2[])


### PR DESCRIPTION
With the c/c++ back-end, during object construction, variant objects had
their type fields initialized _before_ any discriminators were assigned
to, meaning that only the default branches had valid type fields.

In the case that a default branch wasn't also the selected branch, the
previously initialized type fields aliased with fields of the selected
branch, breaking the zero-initialization guarantee. Both `refc` and
ARC/ORC were affected.

Object initialization (`ccgexprs.genObjConstr`) now performs type field
initialization _after_ assigning all discriminator values.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

The `doInitObj` extra parameter is a bit ugly, but it was the simplest solution not requiring larger refactorings that I could come up with.

@haxscramper originally suggested that the test for this fix should go into `ccgbugs` (which makes sense), but after the following discussion regarding test suite organization, I think it makes more sense to put it under `objvariants` while also testing it with all back-ends/GCs