### PR TITLE
vm: add back support for non-ordinal `case` selectors

### DIFF
--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -327,7 +327,14 @@ type
     cnstFloat
     cnstString
     cnstNode ## AST, type literals
-    cnstBranchLit
+
+    # slice-lists are used for implementing `opcBranch` (branch for case stmt)
+    cnstSliceListInt
+    cnstSliceListFloat
+    cnstSliceListStr
+
+  ConstantId* = int ## The ID of a `VmConstant`. Currently just an index into
+                    ## `PCtx.constants`
 
   VmConstant* = object
     ## `VmConstant`s are used for passing constant data from `vmgen` to the
@@ -347,11 +354,16 @@ type
       #      `opcMatConst` mechanism and `strVal` should be a simple `string`
     of cnstNode:
       node*: PNode
-    of cnstBranchLit:
-      # Used for implementing multi-value 'of' branches
+
+    of cnstSliceListInt:
       # XXX: always using `BiggestInt` is inredibly wasteful for when the
       #      values are small (e.g. `char`)
-      ranges*: seq[BiggestInt]
+      intSlices*: seq[Slice[BiggestInt]]
+    of cnstSliceListFloat:
+      floatSlices*: seq[Slice[BiggestFloat]]
+    of cnstSliceListStr:
+      strSlices*: seq[Slice[ConstantId]] ## Stores the ids of string constants
+                                         ## as a storage optimization
 
   RegInfo* = object
     refCount*: uint16

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -422,7 +422,7 @@ func asgnVmString*(dest: var VmString, src: VmString, a: var VmAllocator) =
   else:
     dest = newVmString(nilMemPtr, 0)
 
-func cmp(a, b: VmString): int =
+func cmp*(a, b: VmString): int =
   let minLen = min(a.len, b.len)
   result = cmpMem(a.data.rawPointer, b.data.rawPointer, minLen)
   if result == 0:

--- a/tests/vm/tcasestmt.nim
+++ b/tests/vm/tcasestmt.nim
@@ -1,0 +1,51 @@
+discard """
+  description: "Tests for case statement with selector of non-ordinal type"
+  action: compile
+"""
+
+## XXX: merge into `casestmt/tcasestmt.nim` once testament has a VM target
+
+# case stmt with string slice-lists
+static:
+  proc p(str: string): int =
+    case str
+    of "a": 1
+    of "b".."e", "l".."o", "p": 2 # slice-list with gap
+    of "f".."k": 3
+    of "q".."z": 4
+    #of "9".."1": 5 # empty range; rejected by sem
+    else: 6
+
+  doAssert p("a") == 1
+  doAssert p("d") == 2
+  doAssert p("h") == 3
+  doAssert p("p") == 2
+  doAssert p("z") == 4
+  doAssert p("z1") == 6
+  doAssert p("2") == 6
+  doAssert p("other") == 6
+
+# case stmt with float slice-lists
+static:
+  proc p(f: float): int =
+    case f
+    of 5.0, -2.0 .. 1.2, 6.0: 0 # slice-list with gaps
+    of 1.5: 1
+    of 20.0 .. 32.0: 2
+    else: 3
+
+  # direct matches
+  doAssert p(5.0) == 0
+  doAssert p(-2.0) == 0
+  doAssert p(1.2) == 0
+  doAssert p(6.0) == 0
+  doAssert p(1.5) == 1
+  doAssert p(20.0) == 2
+  doAssert p(32.0) == 2
+
+  # in ranges
+  doAssert p(0.1) == 0
+  doAssert p(-1.0) == 0
+  doAssert p(1.1) == 0
+  doAssert p(1.6) == 3
+  doAssert p(25.0) == 2


### PR DESCRIPTION
`case` statements using _slicelists_ in their `of` branches now compile
and run again when the selector is of `float` or `string` type