### PR TITLE
vm: don't depend on `PType` for exception handling

### DIFF
--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -509,7 +509,7 @@ proc serialize*(c: var TCtx, n: PNode, dest: LocHandle, t: PType = nil) =
       of nkNilLit: discard "nothing to do"
       of nkObjConstr:
         let typ = c.getOrCreate(t)
-        let r = c.heap.heapNew(c.allocator, typ.targetType, t)
+        let r = c.heap.heapNew(c.allocator, typ.targetType)
         c.serialize(n, c.heap.unsafeDeref(r), t[0])
       else: unreachable()
     else:
@@ -535,7 +535,7 @@ proc serialize*(c: var TCtx, n: PNode, dest: LocHandle, t: PType = nil) =
             # The closure's env type was already created, so we can just look
             # it up here
             let envTyp = c.typeInfoCache.lookup(c.config, nEnvTyp).unsafeGet
-            let e = c.heap.heapNew(c.allocator, envTyp.targetType, nEnvTyp[0])
+            let e = c.heap.heapNew(c.allocator, envTyp.targetType)
             c.serialize(n[1], c.heap.unsafeDeref(e), nEnvTyp[0])
               # we wan't to fill the object, so pass the object type (not the
               # ref-type, i.e. `nEnvTyp`)

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -308,8 +308,6 @@ type
     handle*: LocHandle
     refCount*: int
 
-    nType*: PType ## The `PType` of the slot. Only needed for exceptions
-
   VmHeap* = object
     ## `VmHeap` manages all ref-counted locations. These are used for `new`'ed
     ## values as well as globals.

--- a/compiler/vm/vmmemory.nim
+++ b/compiler/vm/vmmemory.nim
@@ -142,12 +142,12 @@ func deref*(handle: LocHandle): ptr Atom {.inline.} =
 template byteView*(handle: LocHandle): untyped =
   handle.h.subView(handle.typ.sizeInBytes)
 
-func heapNew*(heap: var VmHeap, a: var VmAllocator, typ: PVmType, nimTyp: PType): HeapSlotHandle =
+func heapNew*(heap: var VmHeap, a: var VmAllocator, typ: PVmType): HeapSlotHandle =
   ## Creates a new managed slot of type `typ` and sets the ref-count to 1
   assert heap.slots.len > 0
   result = heap.slots.len
   # XXX: slots are currently not reused
-  heap.slots.add(HeapSlot(handle: a.allocSingleLocation(typ), refCount: 1, nType: nimTyp))
+  heap.slots.add(HeapSlot(handle: a.allocSingleLocation(typ), refCount: 1))
 
 func heapIncRef*(heap: var VmHeap, slot: HeapSlotHandle) =
   ## Increments the ref-counter for the given slot (expected to be valid)

--- a/tests/vm/texception.nim
+++ b/tests/vm/texception.nim
@@ -1,4 +1,10 @@
-proc someFunc() =
+discard """
+  description: "VM exception handling related tests"
+  action: compile
+"""
+
+proc someFunc(): int =
+  result = 1 # for this test, it's important that the result is initialized
   try:
     raise newException(ValueError, "message")
   except ValueError as err:
@@ -8,7 +14,7 @@ proc someFunc() =
 
 static:
   try:
-    someFunc()
+    discard someFunc()
   except:
     discard
   


### PR DESCRIPTION
- use `VmType`s type relation analysis during exception type matching
- pass the name of the raised exception's static type as a constant.
 This makes exception name setting behaviour the same as on other
 back-ends
- `HeapSlot.nType` is removed since it's no longer needed

In addition, a long-standing bug with re-raising in a function with
non-void return type is also fixed

This is the first step towards decoupling VM execution from compiler
state