### PR TITLE
vm: split up `opcSetType`

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2984,14 +2984,13 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       regs[ra].nimNode.ident = getIdent(c.cache, $regs[rb].strVal)
     of opcSetType:
       let typ = c.types[instr.regBx - wordExcess]
-      case regs[ra].kind
-      of rkAddress:
-        assert typ.layoutDesc.kind == akPtr
-        regs[ra].addrTyp = typ.layoutDesc.targetType
-      of rkNimNode:
-        regs[ra].nimNode.typ = typ.nType
-      else:
-        assert false # vmgen issue
+      assert typ.layoutDesc.kind == akPtr
+      regs[ra].addrTyp = typ.layoutDesc.targetType
+
+    of opcNSetType:
+      # Only used internally
+      let typ = c.types[instr.regBx - wordExcess]
+      regs[ra].nimNode.typ = typ.nType
 
     of opcConv:
       let rb = instr.regB

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -167,6 +167,7 @@ type
     opcLdImmInt,  # dest = immediate value
     opcNBindSym,
     opcSetType,   # dest.typ = types[Bx]
+    opcNSetType,  # dest.nimNode.typ = types[Bx]
     opcTypeTrait,
     opcSymOwner,
     opcSymIsInstantiationOf

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1637,7 +1637,7 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mTypeTrait:
     let tmp = c.genx(n[1])
     if dest.isUnset: dest = c.getTemp(n.typ)
-    c.gABx(n, opcSetType, tmp, c.genType(n[1].typ, n[1].info))
+    c.gABx(n, opcNSetType, tmp, c.genType(n[1].typ, n[1].info))
     c.gABC(n, opcTypeTrait, dest, tmp)
     c.freeTemp(tmp)
   of mSlurp: genUnaryABC(c, n, dest, opcSlurp)


### PR DESCRIPTION
The instruction was used for both setting the type of an address
register (pointer) and for internally setting the type of a `NimNode`.

Both usages require different kinds of type information (`PType`
vs. `VmType`), so it makes sense to split them up