### PR TITLE
fix: make `Result.value` work with tuple values

### DIFF
--- a/lib/experimental/results.nim
+++ b/lib/experimental/results.nim
@@ -200,8 +200,11 @@ func `$`*[E](self: Result[void, E]): string =
   if self.isOk: "Ok()"
   else: "Err(" & $self.e & ")"
 
-template value*[T, E](self: Result[T, E]): T = get self
-template value*[T, E](self: var Result[T, E]): T = get self
+# XXX: the `value` templates only use `untyped` in order to work around a
+#      compiler bug (https://github.com/nim-works/nimskull/issues/328).
+#      Once the bug is fixed, `T` should be used as the return type again
+template value*[T, E](self: Result[T, E]): untyped = get self
+template value*[T, E](self: var Result[T, E]): untyped = get self
 
 template value*[E](self: Result[void, E]) = get self
 template value*[E](self: var Result[void, E]) = get self

--- a/tests/stdlib/tresults.nim
+++ b/tests/stdlib/tresults.nim
@@ -242,6 +242,22 @@ proc main() =
     expect IOError:
       discard get f
 
+  test "Tuple values":
+    type
+      Tup = tuple[a, b: int]
+      R = Result[Tup, int]
+
+    var r = R.ok (1, 2)
+
+    check r.unsafeGet() == (1, 2)
+    check r.get() == (1, 2)
+    check r.value() == (1, 2)
+
+    r.value().a = 3
+
+    check r.unsafeGet() == (3, 2)
+    check r.get() == (3, 2)
+    check r.value() == (3, 2)
 
 # TODO: use the VM target once it's available in testament
 static: main()


### PR DESCRIPTION
Work around a compiler bug by changing the return type of the
`value` template to `untyped`.

The bug in question is: https://github.com/nim-works/nimskull/issues/328