### PR TITLE
Initial implementation of the newstyle error reporting

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -991,13 +991,13 @@ type
                               ## is required by the --incremental:on mode.
 
   TPair* = object
-    key*, val*: RootRef
+    key*, val*: PIdObj
 
   TPairSeq* = seq[TPair]
 
   TIdPair* = object
     key*: PIdObj
-    val*: RootRef
+    val*: PIdObj
 
   TIdPairSeq* = seq[TIdPair]
   TIdTable* = object # the same as table[PIdent] of PObject

--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -31,7 +31,7 @@ proc hashNode*(p: RootRef): Hash
 # --------------------------- ident tables ----------------------------------
 proc idTableGet*(t: TIdTable, key: PIdObj): RootRef
 proc idTableGet*(t: TIdTable, key: int): RootRef
-proc idTablePut*(t: var TIdTable, key: PIdObj, val: RootRef)
+proc idTablePut*(t: var TIdTable, key, val: PIdObj)
 proc idTableHasObjectAsKey*(t: TIdTable, key: PIdObj): bool
   # checks if `t` contains the `key` (compared by the pointer value, not only
   # `key`'s id)
@@ -457,7 +457,7 @@ iterator pairs*(t: TIdTable): tuple[key: int, value: RootRef] =
     if t.data[i].key != nil:
       yield (t.data[i].key.id, t.data[i].val)
 
-proc idTableRawInsert(data: var TIdPairSeq, key: PIdObj, val: RootRef) =
+proc idTableRawInsert(data: var TIdPairSeq, key, val: PIdObj) =
   var h: Hash
   h = key.id and high(data)
   while data[h].key != nil:
@@ -467,7 +467,7 @@ proc idTableRawInsert(data: var TIdPairSeq, key: PIdObj, val: RootRef) =
   data[h].key = key
   data[h].val = val
 
-proc idTablePut(t: var TIdTable, key: PIdObj, val: RootRef) =
+proc idTablePut(t: var TIdTable, key, val: PIdObj) =
   var
     index: int
     n: TIdPairSeq
@@ -486,7 +486,7 @@ proc idTablePut(t: var TIdTable, key: PIdObj, val: RootRef) =
     idTableRawInsert(t.data, key, val)
     inc(t.counter)
 
-iterator idTablePairs*(t: TIdTable): tuple[key: PIdObj, val: RootRef] =
+iterator idTablePairs*(t: TIdTable): tuple[key, val: PIdObj] =
   for i in 0..high(t.data):
     if not isNil(t.data[i].key): yield (t.data[i].key, t.data[i].val)
 

--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -219,12 +219,16 @@ type
     # on. This should be replaced with `.inTryExpr` or something similar,
     # and let the reporting hook deal with all the associated heuristics.
 
-    msgContext*: seq[tuple[info: TLineInfo, detail: PSym]] ## \ Contextual
+    msgContext*: seq[tuple[
+      info: TLineInfo, detail: PSym, params: TIdTable]] ## Contextual
     ## information about instantiation stack - "template/generic
     ## instantiation of" message is constructed from this field. Right now
     ## `.detail` field is only used in the `sem.semMacroExpr()`,
     ## `seminst.generateInstance()` and `semexprs.semTemplateExpr()`. In
-    ## all other cases this field is left empty (SemReport is `skUnknown`)
+    ## all other cases this field is left empty (SemReport is `skUnknown`).
+    ##
+    ## `params` is used for generic instantiations and stores key-value
+    ## mapping between generic parameter names and their concrete values
     reports*: ReportList ## Intermediate storage for the
     writtenSemReports*: ReportSet
     lastError*: TLineInfo

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -67,6 +67,7 @@ type
     case kind*: ReportContextKind
       of sckInstantiationOf:
         entry*: PSym ## Instantiated entry symbol
+        params*: TIdTable
 
       of sckInstantiationFrom:
         discard
@@ -147,12 +148,15 @@ type
 
   SemDiagnostics* = object
     diagnosticsTarget*: PSym ## The concept sym that didn't match
-    reports*: seq[SemReport] ## The reports that explain why the concept didn't match
+    reports*: seq[SemReport] ## The reports that explain why the concept
+                             ## didn't match
 
   MismatchInfo* = object
     kind*: MismatchKind ## reason for mismatch
-    pos*: int           ## position of provided argument that mismatches. This doesn't always correspond to
-                        ## the *expression* subnode index (e.g. `.=`) nor the *target parameter* index (varargs)
+    pos*: int           ## position of provided argument that mismatches.
+                        ## This doesn't always correspond to the
+                        ## *expression* subnode index (e.g. `.=`) nor the
+                        ## *target parameter* index (varargs)
     arg*: PNode         ## the node of the mismatching provided argument
     formal*: PSym       ## parameter that mismatches against provided argument
                         ## its position can differ from `arg` because of varargs
@@ -166,7 +170,8 @@ type
     firstMismatch*: MismatchInfo ## mismatch info for better error messages
 
     diag*: SemDiagnostics
-    diagnosticsEnabled*: bool ## Set by sfExplain. efExplain or notFoundError ignore this
+    diagnosticsEnabled*: bool ## Set by sfExplain. efExplain or
+                              ## notFoundError ignore this
 
   SemSpellCandidate* = object
     dist*: int

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -1550,7 +1550,7 @@ proc genStmts(p: BProc, t: PNode) =
   var a: TLoc
 
   let isPush = p.config.hasHint(rsemExtendedContext)
-  if isPush: pushInfoContext(p.config, t.info)
+  if isPush: pushInfoContext(p.config, t.info, TIdTable())
   expr(p, t, a)
   if isPush: popInfoContext(p.config)
   internalAssert p.config, a.k in {locNone, locTemp, locLocalVar, locExpr}

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -114,7 +114,8 @@ func dropExt(path: string, doDrop: bool): string =
   ## Optionally drop `.nim` file extension
   if doDrop and path.endsWith(".nim"): path[0 .. ^5] else: path
 
-proc toStr(conf: ConfigRef, loc: TLineInfo, dropExt: bool = false): string =
+proc toStr*(
+  conf: ConfigRef, loc: TLineInfo, dropExt: bool = false): string =
   ## Convert location to printable string
   conf.wrap(
     "$1($2, $3)" % [
@@ -125,7 +126,8 @@ proc toStr(conf: ConfigRef, loc: TLineInfo, dropExt: bool = false): string =
     fgDefault,
     {styleBright})
 
-proc toStr(conf: ConfigRef, loc: ReportLineInfo, dropExt: bool = false): string =
+proc toStr*(
+  conf: ConfigRef, loc: ReportLineInfo, dropExt: bool = false): string =
   ## Convert location to printable string
   conf.wrap(
     "$1($2, $3)" % [
@@ -137,7 +139,7 @@ proc toStr(conf: ConfigRef, loc: ReportLineInfo, dropExt: bool = false): string 
     {styleBright})
 
 const
-  reportTitles: array[ReportSeverity, string] = [
+  reportTitles*: array[ReportSeverity, string] = [
     "Debug: ", "Hint: ", "Warning: ", "Error: ", "Fatal: ", "Trace: "
   ]
 
@@ -972,7 +974,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "'old' takes a parameter name"
 
     of rsemOldDoesNotBelongTo:
-      result = r.ast.sym.name.s & " does not belong to " & r.symstr
+      result = r.ast.getIdentStr() & " does not belong to " & r.symstr
 
     of rsemCannotFindPlugin:
       result = "cannot find plugin " & r.symstr
@@ -1246,7 +1248,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
     of rsemDoubleCompletionOf:
       result = "cannot complete type '" &
-        r.symbols[1].name.s &
+        r.symbols[1].getIdentStr() &
         "' twice; " &
         "previous type completion was here: " &
         (conf $ r.symbols[0].info)
@@ -1367,8 +1369,8 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         result.addf(
           "'$1' can have side effects.\nan object reachable " &
             "from '$2' is potentially mutated",
-          part.isUnsafe.name.s,
-          part.unsafeVia.name.s
+          part.isUnsafe.getIdentStr(),
+          part.unsafeVia.getIdentStr()
         )
 
         if part.location != unknownLineInfo:
@@ -1400,31 +1402,31 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
           case part.trace:
             of ssefUsesGlobalState:
               addHint(
-                "accesses global state '$#'" % u.name.s,
-                useLineInfo, s.name.s, part.level)
+                "accesses global state '$#'" % u.getIdentStr(),
+                useLineInfo, s.getIdentStr(), part.level)
 
               addHint(
-                "accessed by '$#'" % s.name.s, u.info,
-                u.name.s, part.level + 1)
+                "accessed by '$#'" % s.getIdentStr(), u.info,
+                u.getIdentStr(), part.level + 1)
 
             of ssefCallsSideEffect:
               addHint(
-                "calls `.sideEffect` '$#'" % u.name.s,
-                useLineInfo, s.name.s, part.level)
+                "calls `.sideEffect` '$#'" % u.getIdentStr(),
+                useLineInfo, s.getIdentStr(), part.level)
 
               addHint(
-                "called by '$#'" % s.name.s,
-                u.info, u.name.s, part.level + 1)
+                "called by '$#'" % s.getIdentStr(),
+                u.info, u.getIdentStr(), part.level + 1)
 
             of ssefCallsViaHiddenIndirection:
               addHint(
                 "calls routine via hidden pointer indirection",
-                useLineInfo, s.name.s, part.level)
+                useLineInfo, s.getIdentStr(), part.level)
 
             of ssefCallsViaIndirection:
               addHint(
                 "calls routine via pointer indirection",
-                useLineInfo, s.name.s, part.level)
+                useLineInfo, s.getIdentStr(), part.level)
 
             of ssefParameterMutation:
               assert false, "Must be handled as a standalone effect"
@@ -1711,8 +1713,8 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       let proto = r.symbols[0]
       let s = r.symbols[1]
       result = "pragmas are only allowed in the header of a proc; redefinition of $1" %
-        ("'" & proto.name.s & "' from " & conf $ proto.info &
-        " '" & s.name.s & "' from " & conf $ s.info)
+        ("'" & proto.getIdentStr() & "' from " & conf $ proto.info &
+        " '" & s.getIdentStr() & "' from " & conf $ s.info)
 
     of rsemDisjointFields:
       result = ("The fields '$1' and '$2' cannot be initialized together, " &
@@ -1774,7 +1776,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "invalid module name: '$1'" % r.ast.render
 
     of rsemInvalidMethodDeclarationOrder:
-      result = "invalid declaration order; cannot attach '" & r.symbols[0].name.s &
+      result = "invalid declaration order; cannot attach '" & r.symbols[0].getIdentStr() &
         "' to method defined here: " & conf$r.symbols[1].info
 
     of rsemRecursiveInclude:
@@ -1941,7 +1943,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       if r.sym.isNil:
         result.addf(
           "redefinition of '$1'; previous declaration here: $2",
-          r.symbols[0].name.s,
+          r.symbols[0].getIdentStr(),
           conf.toStr(r.symbols[1].info)
         )
 
@@ -1997,7 +1999,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       let path = toFilenameOption(conf, r.processing.fileIdx, conf.filenameOption)
       let indent = repeat(">", r.processing.importStackLen)
       let fromModule = r.sym
-      let fromModule2 = if fromModule != nil: $fromModule.name.s else: "(toplevel)"
+      let fromModule2 = if fromModule != nil: $fromModule.getIdentStr() else: "(toplevel)"
       let mode = if r.processing.isNimscript: "(nims) " else: ""
       result = "$#$# $#: $#: $#" % [mode, indent, fromModule2, r.processing.moduleStatus, path]
 
@@ -2298,7 +2300,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "found no symbol at position"
 
     of rsemOverrideSafetyMismatch:
-      result = "base method is GC-safe, but '$1' is not" % r.symbols[1].name.s
+      result = "base method is GC-safe, but '$1' is not" % r.symbols[1].getIdentStr()
 
     of rsemOverrideLockMismatch:
       result = "base method has lock level $1, but dispatcher has $2" % [
@@ -2365,7 +2367,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
     of rsemWarnGcUnsafeListing, rsemErrGcUnsafeListing:
       let trace = r.gcUnsafeTrace
-      let (s, u) = (trace.isUnsafe.name.s, trace.unsafeVia.name.s)
+      let (s, u) = (trace.isUnsafe.getIdentStr(), trace.unsafeVia.getIdentStr())
       case trace.unsafeRelation:
         of sgcuCallsUnsafe:
           result.addf("'$#' is not GC-safe as it calls '$#'", s, u)
@@ -2421,7 +2423,7 @@ func suffixShort(conf: ConfigRef, r: ReportTypes): string {.inline.} =
   else:
     ""
 
-proc suffix(
+proc suffix*(
     conf: ConfigRef,
     r: ReportTypes
   ): string =
@@ -2565,7 +2567,7 @@ proc presentDiagnostics(conf: ConfigRef, d: SemDiagnostics, startWithNewLine: bo
       let sev = conf.severity(report)
       result.add conf.wrap(
         if sev == rsevError:
-          d.diagnosticsTarget.name.s & ": "
+          d.diagnosticsTarget.getIdentStr() & ": "
         else:
           prefixShort(conf, report)
         , reportColors[sev])
@@ -2633,7 +2635,7 @@ proc presentFailedCandidates(
 
     let nArg = err.firstMismatch.arg
 
-    let nameParam = if err.firstMismatch.formal != nil: err.firstMismatch.formal.name.s else: ""
+    let nameParam = if err.firstMismatch.formal != nil: err.firstMismatch.formal.getIdentStr() else: ""
     if n.len > 1:
       candidates.add("  first type mismatch at position: " & $err.firstMismatch.pos)
       # candidates.add "\n  reason: " & $err.firstMismatch.kind # for debugging
@@ -3122,9 +3124,9 @@ const
   reportCaller = on
 
 proc reportBody*(conf: ConfigRef, r: DebugReport): string =
+  ## NOTE !!DEBUG Main part of the debug report formatting.
   assertKind r
   func toStr(opc: TOpcode): string = substr($opc, 3)
-
   case DebugReportKind(r.kind):
     of rdbgTraceStep:
       let
@@ -3162,6 +3164,9 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
           ""))
 
       var res = addr result
+      # NOTE !!DEBUG This part controls printing of the extra data for each
+      # step. `field` is a shorthand for data output, subsequent `case`
+      # dispatches into specific properties and prints fields.
       proc field(name: string, value: string = "\n") =
         res[].add "\n"
         res[].add repeat(" ", indent)
@@ -3257,6 +3262,7 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
 
 
     of rdbgTraceLine:
+      # Inline tracing annotations
       let ind = repeat("  ", r.ctraceData.level)
       var
         paths: seq[string]
@@ -3328,7 +3334,7 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
       if not l.sym.isNil():
         result.addf(
           " for the '$#' $#\n\n",
-          l.sym.name.s,
+          l.sym.getIdentStr(),
           conf.toStr(l.sym.info))
 
       else:
@@ -3619,10 +3625,13 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
   # be written.
   if wkind == writeDisabled:
     return
+
   elif r.kind in rdbgTracerKinds and conf.isDefined(traceDir):
     rotatedTrace(conf, r)
+
   elif wkind == writeForceEnabled:
     echo conf.reportFull(r)
+
   elif r.kind == rsemProcessing and conf.hintProcessingDots:
     # REFACTOR 'processing with dots' - requires special hacks, pretty
     # useless, need to be removed in the future.
@@ -3637,16 +3646,21 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
       var indent {.global.}: int
       if r.kind == rdbgTraceStep:
         indent = r.debugReport.semstep.level
-      case r.kind
-      of rdbgTracerKinds:
-        conf.writeln(conf.reportFull(r))
-      of repSemKinds:
-        if 0 < indent:
-          for line in conf.reportFull(r).splitLines():
-            conf.writeln("  ]", repeat("  ", indent), " ! ", line)
+
+      case r.kind:
+        of rdbgTracerKinds:
+          conf.writeln(conf.reportFull(r))
+
+        of repSemKinds:
+          if 0 < indent:
+            for line in conf.reportFull(r).splitLines():
+              conf.writeln("  ]", repeat("  ", indent), " ! ", line)
+
+          else:
+            conf.writeln(conf.reportFull(r))
+
         else:
           conf.writeln(conf.reportFull(r))
-      else:
-        conf.writeln(conf.reportFull(r))
+
     else:
       conf.writeln(conf.reportFull(r))

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -46,7 +46,8 @@ import
     options,
     msgs,
     cli_reporter,
-    sexp_reporter
+    sexp_reporter,
+    new_reporter
   ],
   compiler/backend/[
     extccomp
@@ -1149,14 +1150,12 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
 
   of "msgformat":
     case arg.normalize:
-      of "text":
-        conf.setReportHook cli_reporter.reportHook
-
-      of "sexp":
-        conf.setReportHook sexp_reporter.reportHook
-
+      of "text": conf.setReportHook cli_reporter.reportHook
+      of "new": conf.setReportHook new_reporter.reportHook
+      of "sexp": conf.setReportHook sexp_reporter.reportHook
       else:
-        conf.localReport(info, invalidSwitchValue @["text", "sexp"])
+        conf.localReport(info, invalidSwitchValue(
+          @["text", "sexp", "new"]))
 
   of "processing":
     incl(conf, cnCurrent, rsemProcessing)

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -184,10 +184,11 @@ proc setInfoContextLen*(conf: ConfigRef; L: int) = setLen(conf.m.msgContext, L)
 proc pushInfoContext*(
     conf: ConfigRef;
     info: TLineInfo,
-    detail: PSym = nil
+    instTable: TIdTable,
+    detail: PSym = nil,
   ) =
   ## Add entry to the message context information stack.
-  conf.m.msgContext.add((info, detail))
+  conf.m.msgContext.add((info, detail, instTable))
 
 proc popInfoContext*(conf: ConfigRef) =
   ## Remove one entry from the message context information stack
@@ -413,10 +414,11 @@ proc errorActions(
       # only really quit when we're not in the new 'nim check --def' mode:
       if conf.ideCmd == ideNone:
         return (doAbort, false)
+
     elif eh == doAbort and conf.cmd != cmdIdeTools:
       return (doAbort, false)
+
     elif eh == doRaise:
-      {.warning: "[IMPLEMENT] Convert report to string message?".}
       return (doRaise, false)
 
   return (doNothing, false)
@@ -443,7 +445,9 @@ proc getContext*(conf: ConfigRef; lastinfo: TLineInfo): seq[ReportContext] =
         result.add ReportContext(
           kind: sckInstantiationOf,
           location: context.info,
-          entry: context.detail)
+          entry: context.detail,
+          params: context.params
+        )
 
     info = context.info
 

--- a/compiler/front/new_reporter.nim
+++ b/compiler/front/new_reporter.nim
@@ -1,0 +1,700 @@
+## New-style error message reporter
+
+import
+  experimental/[
+    diff,
+    colordiff,
+    colortext
+  ],
+  std/[
+    algorithm,
+    sequtils,
+    strformat,
+    strutils,
+    enumerate
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/ast/[
+    ast_types,
+    ast,
+    reports,
+    astalgo,
+    renderer,
+    typesrenderer
+  ],
+  compiler/utils/[
+    astrepr
+  ]
+
+import cli_reporter as old
+
+type
+  StringMismatchCandidate* = object
+    ## Description of a single string edit operation
+    distance*: int ## Edit distance between target (provided) and input string (not provided)
+    edits*: seq[SeqEdit] ## Sequence of edit operations to convert input string into target
+    target*: string ## Target string
+
+proc stringMismatchCandidates*(
+    input: string,
+    expected: openArray[string]
+  ): seq[StringMismatchCandidate] =
+
+  var results: seq[tuple[
+    edits: tuple[distance: int, operations: seq[SeqEdit]],
+    target: string
+  ]]
+
+  for str in expected:
+    if str == input:
+      return @[]
+
+    else:
+      let (distance, edits) = levenshteinDistance(input.toSeq(), str.toSeq())
+      result.add StringMismatchCandidate(
+        distance: distance,
+        edits: edits,
+        target: str
+      )
+
+type ItDiff = tuple[it: StringMismatchCandidate, idx: int]
+proc mismatchCandidates*(
+      input: string,
+      expected: openArray[string]): seq[ItDiff] =
+
+   let expected = deduplicate(expected)
+   for idx, it in enumerate(stringMismatchCandidates(input, expected)):
+     result.add((it, idx))
+
+   return result.sortedByIt(it.it.distance)
+
+proc countEdits(best: StringMismatchCandidate): int =
+  for edit in best.edits:
+    if edit.kind != sekKeep:
+      inc result
+
+proc inlineFormatter(): DiffFormatConf =
+  var fmt = diffFormatter(false)
+  let default = fmt.formatChunk
+  fmt.lineSplit = proc(s: string): seq[string] = mapIt(s, $it)
+  fmt.formatChunk = proc(
+    text: string, mode, secondary: SeqEditKind, inline: bool): ColText =
+    if mode == sekReplace and inline:
+      if secondary == sekDelete:
+        text + fgRed
+
+      else:
+        text + fgGreen
+
+    else:
+      default(text, mode, secondary, inline)
+
+  return fmt
+
+
+proc formatEdit*(input: string, best: StringMismatchCandidate): ColText =
+  var fmt = inlineFormatter()
+  coloredResult()
+  if countEdits(best) < min(3, input.len div 2):
+    add formatInlineDiff(input, best.target, fmt)
+
+  else:
+    add input + fgRed
+    add " -> "
+    add best.target + fgGreen
+
+proc formatAlternatives(input: string, results: seq[StringMismatchCandidate]): ColText =
+  coloredResult()
+  var fmt = inlineFormatter()
+  for idx, alt in results:
+    if idx > 0:
+      add " "
+
+    if countEdits(alt) < min(3, input.len div 2):
+      add formatInlineDiff(input, alt.target, fmt)
+
+    else:
+      add alt.target + fgGreen
+
+    add "?"
+
+proc didYouMean(input: string, candidates: seq[ItDiff]): ColText =
+  coloredResult()
+  add "did you mean to use "
+  add formatEdit(input, candidates[0].it)
+  if 1 < candidates.len:
+    add " ("
+    add formatAlternatives(input, candidates[1 ..^ 1].mapIt(it.it))
+    add ")"
+
+  add "?"
+
+
+proc stringMismatchMessage*(
+    input: string,
+    expected: openArray[string],
+    fixSuggestion: bool = true,
+    showAll: bool = true,
+  ): ColText =
+
+  coloredResult()
+
+  let results = mismatchCandidates(input, expected)
+  if expected.len == 0:
+    add "No matching alternatives"
+    return
+
+  let best = results[0].it
+
+  if best.distance > int(input.len.float * 0.8):
+    add "no close matches to "
+    add input + fgRed
+    add ", possible alternative(s): "
+    var first = true
+    for it in results[0 .. min(results.high, 3)]:
+      if not first: add " or "
+      first = false
+      add it.it.target + fgYellow
+
+  else:
+    add "Did you mean to use '"
+    add best.target + fgYellow
+    add "'?'"
+
+    if fixSuggestion:
+      add formatEdit(input, best)
+
+    if showAll and expected.len > 1:
+      add "\n  ("
+      add formatAlternatives(input, results[1..^1].mapIt(it.it))
+      add ")"
+
+## Large rank/cost value means the error was severe (error in the first
+## argument, completely different types). Smaller cost means the error was
+## pretty minor (typo in the named argument, mismatch in the 8th position)
+
+const cost = (
+  genericLayer: 1 shl 10, # Base value of the first level of the type
+                          # mismatch. When recursing into generics cost
+                          # decreases exponentially, so `int-float` mismatch
+                          # is ranked higher than `seq[int]-seq[float]`.
+
+  literalMultiplier: 0.3  # Multiplier applied when provided expression has
+                          # type mismatched /and/ it was a literal value.
+                          # For example function expects `uint8` and `int`
+                          # literal was provided.
+)
+
+type
+  Arg = PNode
+  ArgList = seq[Arg] ## List of the procedure arguments - either passed,
+                       ## or expected
+
+  RankedCallMismatch = object
+    sem: SemCallMismatch ## Original call mismatch
+    rank: int ## Final rank value
+    mismatches: seq[ArgCompare]
+
+  ArgCompare = object
+    ## Structural diff between two types
+    wanted, found: PType
+    rank: int
+    nested: seq[ArgCompare]
+
+func rankMismatch(wanted, found: Arg): ArgCompare =
+  assert not isNil(wanted.typ)
+  assert not isNil(found.typ)
+  ArgCompare(wanted: wanted.typ, found: found.typ)
+
+func typoCost(used: string, expected: seq[string]): int =
+  # Specific details of the typo correction costs can be checked for later,
+  # since candidate that has /only/ typo in the name would have a low cost
+  # anyway (all types match, the only error is in the named parameter).
+  12
+
+func argSyms(procType: PType): seq[PNode] =
+  procType.n.sons[1 ..^ 1]
+
+proc updateRank*(mis: var RankedCallMismatch, args: ArgList) =
+  let sem = mis.sem
+  let argSyms = sem.target.typ.argSyms()
+  let matchingLen = min(argSyms.len(), args.len())
+  for idx in 0 ..< matchingLen:
+    var mismatch = rankMismatch(argSyms[idx], args[idx])
+    mis.mismatches.add mismatch
+    if idx <= sem.firstMismatch.pos:
+      # Cost is declreased from the first mismatch position - error in the
+      # first argument is more likely
+      mis.rank += mismatch.rank * ((matchingLen - idx) - sem.firstMismatch.pos)
+
+  case sem.firstMismatch.kind:
+    of kTypeMismatch:
+      # Type mismatch arguments are handled uniformly and decreasing
+      # ranking based on the first mismatch position
+      discard
+
+    of kUnknownNamedParam:
+      mis.rank += typoCost(
+        $sem.firstMismatch.arg,
+        sem.target.typ.argSyms().mapIt(it.sym.name.s))
+
+    else:
+      discard
+
+
+proc toRanked(
+    mis: seq[SemCallMismatch],
+    args: ArgList
+  ): seq[RankedCallMismatch] =
+  for m in mis:
+    result.add RankedCallMismatch(sem: m)
+    result[^1].updateRank(args)
+
+proc typeHeadName(t: PType, withModule: bool = false): string =
+  case t.kind:
+    of tyGenericBody:
+      result = t.lastSon.typeToString()
+
+    of tyInt: result = "int"
+
+    else:
+      result = t.typeToString()
+
+proc format(target: PType, other: PType = nil): ColText =
+  ## Custom type format implementation, used *specifically* for error
+  ## reporting - it might fall back to general type rendering logic from
+  ## time to time, but otherwise is specifically geared towards
+  ## human-readable, colored representation.
+  coloredResult()
+  const
+    ctarget = fgGreen
+    cother = fgRed
+
+  proc aux(target, other: PType) =
+    if other.isNil:
+      add typeToString(target)
+      return
+
+    else:
+      var tname = target.typeHeadName()
+      var oname = other.typeHeadName()
+      if tname == oname:
+        add tname
+
+      elif (tname, oname) in [
+        ("float", "float64"),
+        ("float", "float32"),
+      ]:
+        add tname
+
+      elif target.kind == tyTuple and other.kind == tyTuple:
+        let
+          tnamed = target.isNamedTuple()
+          onamed = other.isNamedTuple()
+
+        add tern(tnamed, "tuple[", "(")
+
+        for idx in 0 ..< min(len(target), len(other)):
+          if 0 < idx: add ", "
+          let
+            tfield = tern(tnamed, target.n[idx].getIdentStr(), "")
+            ofield = tern(onamed, other.n[idx].getIdentStr(), "")
+
+          if tnamed:
+            if tfield != ofield and onamed:
+              add tfield + ctarget
+              add " != "
+              add ofield + cother
+
+            else:
+              add tfield
+
+            add ": "
+
+          aux(target[idx], other[idx])
+
+        if len(target) < len(other):
+          for sub in len(target) ..< len(other):
+            if 0 < sub: add ", "
+            if onamed: add (other.n[sub].getIdentStr() & ": ") + ctarget
+            add format(other[sub]) + ctarget
+
+        if len(other) < len(target):
+          for sub in len(other) ..< len(target):
+            if 0 < sub: add ", "
+            if tnamed: add (target.n[sub].getIdentStr() & ": ") + cother
+            add format(target[sub]) + cother
+
+        add tern(tnamed, "]", ")")
+
+      else:
+        add &"{tname}" + cother
+        add " != "
+        add &"{oname}" + ctarget
+
+    case target.kind:
+      of tyGenericBody, tyBuiltInTypeClass:
+        add "["
+        for idx in 0 ..< len(target):
+          if idx > 0: add ", "
+          aux(target[idx], other[idx])
+
+        add "]"
+
+      else:
+        discard
+
+  aux(target, other)
+
+  endResult()
+
+proc formatProc(p: PSym): ColText =
+  coloredResult()
+
+  add "proc "
+  add p.name.s + fgGreen
+  add "("
+  for idx, arg in pairs(p.typ.n.sons[1 ..^ 1]):
+    if idx > 0: add ", "
+    add arg.getIdentStr() + fgCyan
+    add ": "
+    add arg.typ.format()
+
+  add ")"
+
+  endResult()
+
+
+
+proc format(arg: ArgCompare): ColText =
+  assert not isNil(arg.wanted)
+  assert not isNil(arg.found)
+  result.add format(arg.wanted, arg.found)
+
+proc format(mis: RankedCallMismatch): ColText =
+  ## Format single call mismatch instance - procedure with incorrect
+  ## argument types, unknown named parameter.
+  coloredResult()
+
+  let sem = mis.sem
+  case sem.firstMismatch.kind:
+    of kUnknownNamedParam:
+      # This part deals with typos in the arguments - current
+      # implementation provides rather strange-looking elements
+      add "unknown named argument - "
+      add sem.target.formatProc()
+      add ":\n"
+      add stringMismatchMessage(
+        $sem.firstMismatch.arg,
+        sem.target.typ.argSyms().mapIt(it.getIdentStr())).
+        indent(2)
+
+    of kTypeMismatch:
+      # Argment type mismatch message
+      add "("
+      var first = true
+      let syms = sem.target.typ.argSyms()
+      for idx, argMis in mis.mismatches:
+        if not first: add ", "
+        first = false
+        add $syms[idx] + fgCyan
+        add ": "
+        add argMis.format()
+
+      add ")"
+
+    else:
+      discard
+
+  endResult()
+
+
+func groupByIdx(mis: sink seq[SemCallMismatch]): tuple[
+    byType: seq[seq[SemCallMismatch]],
+    other: seq[SemCallMismatch]
+  ] =
+  ## Split overload candidates into ones that failed because of the
+  ## argument mismatch, and everything else.
+
+  var mis = mis
+  mis.sort(proc(a, b: SemCallMismatch): int =
+             cmp($a.firstMismatch.arg, $b.firstMismatch.arg))
+
+  var prev = -1
+  for mis in mis:
+    if mis.firstMismatch.kind != kTypeMismatch:
+      result.other.add mis
+
+    elif mis.firstMismatch.pos != prev:
+      prev = mis.firstMismatch.pos
+      result.byType.add @[mis]
+
+    else:
+      result.byType[^1].add mis
+
+proc reportCallMismatch(conf: ConfigRef, r: SemReport): ColText =
+  let args = mapIt(r.ast, it)[1 .. ^1]
+  # First group call candidates by argument index and mismatch kind. This
+  # allows to show 'but expression is of type' and other diagnostics only
+  # once per argument position.
+  let (byType, other) = r.callMismatches.groupByIdx()
+
+  let name =
+    if 0 < byType.len:
+      byType[0][0].target.getIdentStr()
+
+    else:
+      other[0].target.getIdentStr()
+
+  coloredResult()
+  add "Cannot call "
+  add name + fgRed
+  add " due to type mismatch failures:"
+  for group in byType:
+    # Convert each group's items into ranked nodes and sort candidates
+    # within the byType using more advanced heuristics.
+    let first = group[0].firstMismatch
+    let expr = first.arg
+    add "\n  Mismatch for argument #"
+    add $first.pos
+    add "\n  Expression '"
+    add $first.arg
+    add "' is of type "
+    add first.arg.typ.format() + fgRed
+    add ", but expected any of\n"
+    for mis in group.toRanked(args).sortedByIt(-it.rank):
+      add "\n    "
+      add mis.format()
+
+  block:
+    let other = other.toRanked(args).sortedByIt(-it.rank)
+    if 0 < len(other):
+      add "\n\nor other mismatches:"
+      for mis in other:
+        add "\n  "
+        add mis.format()
+
+
+proc objFields(obj: PNode): seq[PNode] =
+  ## Collect list of fields from the object.
+  # I failed to understand how field lookup is perofmed, it is all mixed in
+  # with the general overload resolution, so I have almost no chances on
+  # decoding this abomination right now
+  proc aux(n: PNode, r: var seq[PNode]) =
+    case n.kind:
+      of nkTypeDef:
+        for sub in n[2][2]:
+          aux(sub, r)
+
+      of nkRecList:
+        for sub in n:
+          aux(n, r)
+
+
+      of nkIdentDefs:
+        for it in n.sons[0..^3]:
+          r.add it
+
+      else:
+        debug obj
+        assert false, $n.kind
+
+  aux(obj, result)
+
+proc reportBody*(conf: ConfigRef, r: SemReport): ColText =
+  coloredResult()
+  echo "Semantic report body ", r.kind
+  case r.kind:
+    of rsemCallTypeMismatch:
+      add reportCallMismatch(conf, r)
+
+    of rsemUndeclaredIdentifier:
+      add "undeclared identifier: '" & r.str & "' - "
+      let candidates = mismatchCandidates(
+        r.str, mapIt(r.spellingCandidates, it.sym.getIdentStr()))
+      if 0 < candidates.len:
+        add didYouMean(r.str, candidates)
+      else:
+        add "no matching alternatives"
+
+    of rsemInvalidOrderInEnum:
+      addf(
+        "invalid order for enum field '$#': got $#, but expected $# or more",
+        r.sym.getIdentStr() + fgGreen,
+        $r.countMismatch.got + fgCyan,
+        $r.countMismatch.expected + fgCyan
+      )
+
+    of rsemExpectedOrdinal:
+      add "ordinal type expected; given "
+      add format(r.typ)
+
+    of rsemHasSideEffects:
+      if r.sideEffectTrace[0].trace == ssefParameterMutation:
+        result.add old.reportBody(conf, r)
+
+      else:
+        result.addf("'$1' can have side effects", r.symstr)
+        for part in r.sideEffectTrace:
+          let s = part.isUnsafe
+          let u = part.unsafeVia
+          add "\n"
+          addf(repeat(">", part.level))
+          add " "
+          add conf.toStr(part.location)
+          addf(" '$#' ", s.getIdentStr() + fgGreen)
+
+          case part.trace:
+            of ssefUsesGlobalState:
+              addf(
+                "$# '$#' ($# in $#)",
+                "accesses external" + fgYellow,
+                u.getIdentStr() + fgGreen,
+                toHumanStr(u.kind),
+                conf.toStr(u.info))
+
+            of ssefCallsSideEffect:
+              addf(
+                "calls '$#' ($# in $#)",
+                u.getIdentStr() + fgGreen,
+                toHumanStr(u.kind),
+                conf.toStr(u.info))
+
+            of ssefCallsViaHiddenIndirection:
+              addf(
+                "calls routine via $#",
+                "hidden pointer indirection" + fgYellow)
+
+            of ssefCallsViaIndirection:
+              addf(
+                "calls routine via $#",
+                "pointer indirection" + fgYellow)
+
+            of ssefParameterMutation:
+              assert false, "Must be handled as a standalone effect"
+
+    of rsemDuplicateCaseLabel:
+      addf(
+        "duplicate case label: $# on line $# overlaps with $# on line $#",
+        $r.overlappingGroup + fgRed,
+        $r.overlappingGroup.info.line,
+        $r.ast + fgGreen,
+        $r.ast.info.line
+      )
+
+    of rsemUndeclaredField:
+      # TODO check if field had been exported or not
+      let flds = objFields(r.sym.ast).mapIt(it.getIdentStr())
+      let candidates = mismatchCandidates(r.str, flds)
+      addf(
+        "undeclared field '$#' for type $# - $#",
+        $r.ast,
+        $r.sym.typ,
+        tern(
+          candidates.len == 0,
+          "object has no fields" + fgDefault,
+          didYouMean($r.ast, candidates)
+        )
+      )
+
+
+      # debug r.ast
+      # debug r.sym.typ
+
+    else:
+      add old.reportBody(conf, r)
+
+proc getContext(conf: ConfigRef, ctx: seq[ReportContext]): ColText =
+  ## Format report context message
+  coloredResult()
+  for ctx in items(ctx):
+    # Instantiation reports have their own context message information
+    add(old.toStr(conf, ctx.location))
+    case ctx.kind:
+      of sckInstantiationOf:
+        add " instantiation of "
+        add ctx.entry.getIdentStr()
+        if 0 < ctx.params.data.len:
+          add "["
+          var first = true
+          for pair in ctx.params.data:
+            # Instantiation context has random items mixed in - not
+            # everything is a type or a symbol, so we need to filter out
+            # unwanted elements here.
+            if pair.key of PType:
+              if not first:
+                add ", "
+              first = false
+              add pair.key.PType().format() + fgYellow
+              add " = "
+
+            if pair.val of PType:
+              add pair.val.PType().format() + fgGreen
+
+          add "]"
+        add " from here\n"
+
+      of sckInstantiationFrom:
+        add(" template/generic instantiation from here\n")
+
+proc reportFull*(conf: ConfigRef, r: SemReport): ColText =
+  if r.kind == rsemProcessing and conf.hintProcessingDots:
+    result.add "."
+    return
+
+  result.add conf.getContext(r.context)
+  result.add reportBody(conf, r)
+  result.add "\n"
+  result.add conf.suffix(r)
+
+proc reportFull*(conf: ConfigRef, r: LexerReport): ColText =
+  result.add old.reportFull(conf, r)
+
+proc reportFull*(conf: ConfigRef, r: CmdReport): ColText =
+  result.add old.reportFull(conf, r)
+
+proc reportFull*(conf: ConfigRef, r: ParserReport): ColText =
+  result.add old.reportFull(conf, r)
+
+proc reportFull*(conf: ConfigRef, r: DebugReport): ColText =
+  result.add old.reportFull(conf, r)
+
+proc reportFull*(conf: ConfigRef, r: InternalReport): ColText =
+  result.add old.reportFull(conf, r)
+
+proc reportFull*(conf: ConfigRef, r: BackendReport): ColText =
+  result.add old.reportFull(conf, r)
+
+proc reportFull*(conf: ConfigRef, r: ExternalReport): ColText =
+  result.add old.reportFull(conf, r)
+
+proc reportFull*(conf: ConfigRef, r: Report): ColText =
+  ## Generate full version of the report (location, severity, body,
+  ## optional suffix)
+  case r.category:
+    of repLexer:    result = conf.reportFull(r.lexReport)
+    of repParser:   result = conf.reportFull(r.parserReport)
+    of repCmd:      result = conf.reportFull(r.cmdReport)
+    of repSem:      result = conf.reportFull(r.semReport)
+    of repDebug:    result = conf.reportFull(r.debugReport)
+    of repInternal: result = conf.reportFull(r.internalReport)
+    of repBackend:  result = conf.reportFull(r.backendReport)
+    of repExternal: result = conf.reportFull(r.externalReport)
+
+proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
+  conf.incl(cnCurrent, rintMsgOrigin)
+  conf.incl(cnCurrent, rintErrKind)
+
+  let wkind = conf.writabilityKind(r)
+  if wkind == writeDisabled:
+    return
+
+  elif wkind in { writeForceEnabled, writeEnabled }:
+    echo conf.reportFull(r)
+    if r.kind notin rdbgTracerKinds:
+      echo ""
+
+  else:
+    echo "?"

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -51,6 +51,33 @@ const
   cmdDocLike* = {cmdDoc, cmdDoc2tex, cmdJsondoc, cmdCtags, cmdBuildindex}
 
 type
+  HackController* = object
+    ## additional configuration switches to control the behavior of the
+    ## debug printer. Most of them are for compiler debugging, and for now
+    ## they can't be set up from the cli/defines - in the future this will
+    ## be changed. For now you can just edit `defaultHackController` value
+    ## in this module as you see fit.
+    ##
+    ## If you need to do some extra-extra configuration you can also look
+    ## into default printing implementation of the debug trace in the
+    ## `cli_reporter.nim`. Relevant chunks have `NOTE !!DEBUG`
+    ## annotation with commentary.
+    semStack*: bool  ## Show `| context` entries in the call tracer
+
+    reportInTrace*: bool ## Error messages are shown with matching indentation
+    ## if report was triggered during execution of the sem trace
+
+    semTraceData*: bool ## For each sem step show processed data, or only
+    ## procedure calls.
+
+const defaultHackController = HackController(
+  semStack: off,
+  reportInTrace: off,
+  semTraceData: off
+)
+
+
+type
   NimVer* = tuple[major: int, minor: int, patch: int]
   TStringSeq* = seq[string]
 
@@ -116,20 +143,6 @@ type
     doRaise ## Raise recoverable error
 
   ReportHook* = proc(conf: ConfigRef, report: Report): TErrorHandling {.closure.}
-
-  HackController* = object
-    ## additional configuration switches to control the behavior of the
-    ## debug printer. Most of them are for compiler debugging, and for now
-    ## they can't be set up from the cli/defines - in the future this will
-    ## be changed. For now you can just edit `defaultHackController` value
-    ## in this module as you see fit.
-    semStack*: bool  ## Show `| context` entries in the call tracer
-
-    reportInTrace*: bool ## Error messages are shown with matching indentation
-    ## if report was triggered during execution of the sem trace
-
-    semTraceData*: bool ## For each sem step show processed data, or only
-    ## procedure calls.
 
   ConfigRef* {.acyclic.} = ref object ## every global configuration
                           ## fields marked with '*' are subject to
@@ -793,11 +806,6 @@ proc newProfileData(): ProfileData =
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 
-const defaultHackController = HackController(
-  semStack: on,
-  reportInTrace: off,
-  semTraceData: on
-)
 
 proc initConfigRefCommon(conf: ConfigRef) =
   conf.symbols = newStringTable(modeStyleInsensitive)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -135,8 +135,24 @@ when compileOption("gc", "refc"):
   # the new correct mark&sweep collector is too slow :-/
   GC_disableMarkAndSweep()
 
+import compiler/utils/astrepr
+
 when not defined(selftest):
   var conf = newConfigRef(cli_reporter.reportHook)
+  implicitTReprConf.incl {
+    trfShowNilFields
+  }
+
+  implicitTReprConf.excl {
+    trfShowTypeFlags,
+    trfShowSymMagic,
+    trfShowSymFlags,
+    trfShowSymTypes,
+    trfShowSymOwner,
+    trfShowNodeIds,
+    trfShowSymName,
+  }
+
   conf.writeHook =
     proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
       msgs.msgWrite(conf, msg, flags)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1872,7 +1872,7 @@ proc implicitPragmas*(c: PContext, sym: PSym, info: TLineInfo,
     for it in c.optionStack:
       let o = it.otherPragmas
       if not o.isNil and sfFromGeneric notin sym.flags: # see issue #12985
-        pushInfoContext(c.config, info)
+        pushInfoContext(c.config, info, TIdTable())
         var i = 0
         while i < o.len:
           let p = prepareSinglePragma(c, sym, o, i, validPragmas, true, false)

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -473,7 +473,7 @@ proc semConstExpr(c: PContext, n: PNode): PNode =
     of {nkEmpty, nkError}:
       let withContext = e.info != n.info
       if withContext:
-        pushInfoContext(c.config, n.info)
+        pushInfoContext(c.config, n.info, TIdTable())
 
       if result.kind == nkEmpty:
         localReport(c.config, e.info, SemReport(kind: rsemConstExprExpected))
@@ -573,7 +573,7 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
 proc semMacroExpr(c: PContext, n: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode =
   rememberExpansion(c, n.info, sym)
-  pushInfoContext(c.config, n.info, sym)
+  pushInfoContext(c.config, n.info, TIdTable(), sym)
 
   let info = getCallLineInfo(n)
   markUsed(c, info, sym)

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -213,9 +213,10 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
                      hasDestructor(t)
     result = newIntNodeT(toInt128(ord(not complexObj)), traitCall, c.idgen, c.graph)
   of "isNamedTuple":
-    var operand = operand.skipTypes({tyGenericInst})
-    let cond = operand.kind == tyTuple and operand.n != nil
-    result = newIntNodeT(toInt128(ord(cond)), traitCall, c.idgen, c.graph)
+    result = newIntNodeT(
+      toInt128(ord(isNamedTuple(operand))),
+      traitCall, c.idgen, c.graph)
+
   of "tupleLen":
     var operand = operand.skipTypes({tyGenericInst})
     assert operand.kind == tyTuple, $operand.kind

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -346,15 +346,15 @@ proc listSideEffects(
     for (useLineInfo, u) in context.sideEffects[s.id]:
       if u != nil and not cycleCheck.containsOrIncl(u.id):
         var trace: SemSideEffectCallKind
-        case u.kind
-        of skLet, skVar:
-          trace = ssefUsesGlobalState
-        of routineKinds:
-          trace = ssefCallsSideEffect
-        of skParam, skForVar:
-          trace = ssefCallsViaHiddenIndirection
-        else:
-          trace = ssefCallsViaIndirection
+        case u.kind:
+          of skLet, skVar:
+            trace = ssefUsesGlobalState
+          of routineKinds:
+            trace = ssefCallsSideEffect
+          of skParam, skForVar:
+            trace = ssefCallsViaHiddenIndirection
+          else:
+            trace = ssefCallsViaIndirection
 
         result.sideEffectTrace.add((
           isUnsafe: s,
@@ -1354,7 +1354,7 @@ proc checkRaisesSpec(
           used.incl(s)
           break search
       # XXX call graph analysis would be nice here!
-      pushInfoContext(g.config, spec.info)
+      pushInfoContext(g.config, spec.info, TIdTable())
       var rr = if r.kind == nkRaiseStmt: r[0] else: r
       while rr.kind in {nkStmtList, nkStmtListExpr} and rr.len > 0:
         rr = rr.lastSon

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -610,8 +610,9 @@ proc checkForOverlap(c: PContext, t: PNode, currentEx, branchIndex: int) =
       if overlap(t[i][j].skipConv, ex):
         localReport(c.config, ex.info, SemReport(
           kind: rsemDuplicateCaseLabel,
-          ast: ex,
-          overlappingGroup: t[i][j].skipConv))
+          ast: t[i][j].skipConv,
+          overlappingGroup: ex
+        ))
 
 proc semBranchRange(c: PContext, t, a, b: PNode, covered: var Int128): PNode =
   checkMinSonsLen(t, 1, c.config)

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -694,7 +694,7 @@ proc replaceTypesInBody*(p: PContext, pt: TIdTable, n: PNode;
   var typeMap = initLayeredTypeMap(pt)
   var cl = initTypeVars(p, typeMap, n.info, owner)
   cl.allowMetaTypes = allowMetaTypes
-  pushInfoContext(p.config, n.info)
+  pushInfoContext(p.config, n.info, pt)
   result = replaceTypeVarsN(cl, n)
   popInfoContext(p.config)
 
@@ -733,7 +733,7 @@ proc generateTypeInstance*(p: PContext, pt: TIdTable, info: TLineInfo,
   # proc (x: T = 0); T -> int ---->  proc (x: int = 0)
   var typeMap = initLayeredTypeMap(pt)
   var cl = initTypeVars(p, typeMap, info, nil)
-  pushInfoContext(p.config, info)
+  pushInfoContext(p.config, info, pt)
   result = replaceTypeVarsT(cl, t)
   popInfoContext(p.config)
   let objType = result.skipTypes(abstractInst)
@@ -746,7 +746,7 @@ proc prepareMetatypeForSigmatch*(p: PContext, pt: TIdTable, info: TLineInfo,
   var typeMap = initLayeredTypeMap(pt)
   var cl = initTypeVars(p, typeMap, info, nil)
   cl.allowMetaTypes = true
-  pushInfoContext(p.config, info)
+  pushInfoContext(p.config, info, pt)
   result = replaceTypeVarsT(cl, t)
   popInfoContext(p.config)
 

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -755,7 +755,7 @@ proc transformFor(c: PTransf, n: PNode): PNode =
         idNodeTablePut(newC.mapping, formal, temp)
 
     let body = transformBody(c.graph, c.idgen, iter, true)
-    pushInfoContext(c.graph.config, n.info)
+    pushInfoContext(c.graph.config, n.info, TIdTable())
     inc(c.inlining)
     stmtList.add(transform(c, body))
     #findWrongOwners(c, stmtList.PNode)

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -121,7 +121,7 @@ type
     trfShowNodeIds ## `.id` field, available when compiler is built with `-d:nodeIds`
     trfShowNodeComments ## `.comment` field
     trfShowNodeErrors ## Embedded `nkError` reports
-    trfShowNodeTypes
+    trfShowNodeTypes ## Flat render of the node type
     trfDescFlag ## For each formatted field, show name of the flag that
                 ## controls it
 

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -105,7 +105,6 @@ section.
              purposes.
 
 
-
 **Do debugging only for a limited range of code**
 
 Wrap the code range in define-undef of `nimCompilerDebug` and put the

--- a/lib/experimental/colortext.nim
+++ b/lib/experimental/colortext.nim
@@ -820,9 +820,17 @@ func addf*(
         assert false, "var/expr formatting is not supported for colored text yet"
 
       of addfPositional, addfIndexed, addfBackIndexed:
-        let idx = if fr.kind == addfBackIndexed: len(colored) - fr.idx else: fr.idx
+        let idx = if fr.kind == addfBackIndexed:
+                    len(colored) - fr.idx
+                  else:
+                    fr.idx
+
         assert (0 <= idx and idx < colored.len)
         text.add colored[idx]
+
+func clformat*(
+    formatstr: string, colored: varargs[ColText, toColText]): ColText =
+  result.addf(formatstr, colored)
 
 func `%`*(format: string, interpolate: openArray[ColText]): ColText =
   ## Shorthand for colored text interpolation


### PR DESCRIPTION
I managed to get some free time to write a proof-of-concept implementation of the cleaned-up error formatting implementation using colored text messages and reporting. 

For some reason, it took me quite a while to realize it is not mandatory to have a full conversion of the test suite (to structured error messages) before I can start working on the formatted version. At the start, it is quite possible to work on the newstyle errors (`--errorformat=new`) while keeping old implementation in place.

Right now, function call mismatch messages are implemented partially, and I added contextual information for the generic procedure instantiation context messages.

This is a draft PR - I will continue working on it when I have enough time to dive into it, but if anyone is interested in picking it up - you are more than welcome, so don't hesitate to ask for directions or suggestions.

before:

![image](https://user-images.githubusercontent.com/20562256/170861463-5007bc3b-175a-40d3-ad05-5d21978989a9.png)

after (proof-of-concept, so formatting and representation is guaranteed to change):

![image](https://user-images.githubusercontent.com/20562256/170861496-6727942b-27f3-48bf-bad6-9ea9fd3565b7.png)
