### PR TITLE
sem: use nkError in lookups.initOverloadIter

### DIFF
--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1048,13 +1048,14 @@ proc pragmaGuard(c: PContext; it: PNode; kind: TSymKind): PSym =
 proc semCustomPragma(c: PContext, n: PNode): PNode =
   var callNode: PNode
 
-  if n.kind in {nkIdent, nkSym}:
+  case n.kind
+  of nkIdent, nkSym:
     # pragma -> pragma()
     callNode = newTree(nkCall, n)
-  elif n.kind == nkExprColonExpr:
+  of nkExprColonExpr:
     # pragma: arg -> pragma(arg)
     callNode = newTree(nkCall, n[0], n[1])
-  elif n.kind in nkPragmaCallKinds:
+  of nkPragmaCallKinds - {nkExprColonExpr}:
     callNode = n
   else:
     result = invalidPragma(c, n)

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -234,6 +234,8 @@ proc semGenericStmt(c: PContext, n: PNode,
     checkMinSonsLen(n, 1, c.config)
     let fn = n[0]
     var s = qualifiedLookUp(c, fn, {})
+    if s.isError:
+      localReport(c.config, s.ast)
     if s == nil and
         {withinMixin, withinConcept}*flags == {} and
         fn.kind in {nkIdent, nkAccQuoted} and

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1092,6 +1092,8 @@ proc handleStmtMacro(c: PContext; n, selector: PNode; magicType: string;
               reportSymbols(rsemAmbiguous, @[match, symx]).withIt do:
                 it.ast = selector
             )
+      elif symx.isError:
+        localReport(c.config, symx.ast)
 
       symx = nextOverloadIter(o, c, headSymbol)
 

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -55,6 +55,8 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
     if a.kind != skModule:
       inc(i)
       if i > 1: break
+    elif a.isError:
+      localReport(c.config, a.ast)
     a = nextOverloadIter(o, c, n)
   let info = getCallLineInfo(n)
   if i <= 1 and r != scForceOpen:
@@ -80,6 +82,8 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
         markOwnerModuleAsUsed(c, a)
         result.add newSymNode(a, info)
         onUse(info, a)
+      elif a.isError:
+        localReport(c.config, a.ast)
       a = nextOverloadIter(o, c, n)
 
 proc semBindStmt(c: PContext, n: PNode, toBind: var IntSet): PNode =

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -471,8 +471,11 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         # this implements the wanted ``var v: V, x: V`` feature ...
         var ov: TOverloadIter
         var amb = initOverloadIter(ov, c, n)
-        while amb != nil and amb.kind != skType:
-          amb = nextOverloadIter(ov, c, n)
+        while amb != nil:
+          if amb.isError:
+            localReport(c.config, amb.ast)
+          if amb.kind != skType:
+            amb = nextOverloadIter(ov, c, n)
         if amb != nil: result = amb
         else:
           if result.kind != skError:


### PR DESCRIPTION
## Summary

Converts old localReport to return an error symbol with an nkError ast.
Callsites were updated to check for error symbols. It's a little messy
but that this is part of the incremental refactoring necessary to have
sem become a simple function `context, untyped_ast -> typed_ast | error`

`qualifiedLookup` was also problematic as a `localReport` had snuck in,
it never should have been there. The report was removed an audit of all
callsites was done to ensure they handled reporting duties as necessary.

## Details
* initOverloadIter no longer uses localReport
* initOverloadIter returns an error sym, if there is an isssue
* callsites updated to check and report on errors
* qualifiedLookup doesn't directly report errors
* fixed callsites for qualifiedLookup to report on errors

---

## Notes for Reviewers
* I didn't tackle it but initOverloadIter should return an Option[PSym]
