### PR TITLE
sem: clean-up legaci lookups procs

### DIFF
--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -238,7 +238,7 @@ proc getMsgDiagnostic(
   # HACK apparently this call is still necessary to provide some additional
   # input validation and optionally raise the 'identifier expected but
   # found' error.
-  discard considerQuotedIdent(c, f, n)
+  discard legacyConsiderQuotedIdent(c, f, n)
 
   if c.compilesContextId > 0 and efExplain notin flags:
     # we avoid running more diagnostic when inside a `compiles(expr)`, to
@@ -355,7 +355,6 @@ proc resolveOverloads(c: PContext, n: PNode,
         if n[0] != nil and n[0].kind == nkIdent and n[0].ident.s in [".", ".="] and n[2].kind == nkIdent:
           let sym = n[1].typ.typSym
           if sym == nil:
-            # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
             let msg = getMsgDiagnostic(c, flags, n, f)
             result.call = c.config.newError(n, msg)
           else:
@@ -364,7 +363,6 @@ proc resolveOverloads(c: PContext, n: PNode,
 
             result.call = wrapErrorInSubTree(c.config, n)
         else:
-          # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
           let msg = getMsgDiagnostic(c, flags, n, f)
           result.call = c.config.newError(n, msg)
 

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -75,7 +75,7 @@ proc locateFieldInInitExpr(c: PContext, field: PSym, initExpr: PNode): PNode =
       match =
         if atLeastPartiallyValid:
           let
-            (ident, errNode) = considerQuotedIdent2(c, assignment[0])
+            (ident, errNode) = considerQuotedIdent(c, assignment[0])
             validIdent = errNode.isNil
           validIdent and fieldId == ident.id
         else:
@@ -534,11 +534,15 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
         hasError = true
         continue
 
-      let id = considerQuotedIdent(c, field[0])
+      let (id, err) = considerQuotedIdent(c, field[0])
+      if err != nil:
+        localReport(c.config, err)
       # This node was not processed. There are two possible reasons:
       # 1) It was shadowed by a field with the same name on the left
       for j in 1..<i:
-        let prevId = considerQuotedIdent(c, result[j][0])
+        let (prevId, err) = considerQuotedIdent(c, result[j][0])
+        if err != nil:
+          localReport(c.config, err)
         if prevId.id == id.id:
           localReport(c.config, field.info, reportAst(
             rsemFieldInitTwice, result[j][0]))

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1316,9 +1316,10 @@ proc typeDefLeftSidePass(c: PContext, typeSection: PNode, i: int) =
   var name = typeDef[0]
   var s: PSym
   if name.kind == nkDotExpr and typeDef[2].kind == nkObjectTy:
-    let pkgName = considerQuotedIdent(c, name[0])
-    let typName = considerQuotedIdent(c, name[1])
-    let pkg = c.graph.packageSyms.strTableGet(pkgName)
+    let
+      pkgName = legacyConsiderQuotedIdent(c, name[0], nil)
+      typName = legacyConsiderQuotedIdent(c, name[1], nil)
+      pkg = c.graph.packageSyms.strTableGet(pkgName)
     if pkg.isNil or pkg.kind != skPackage:
       localReport(c.config, name.info, reportStr(
         rsemUnknownPackageName, pkgName.s))
@@ -1802,7 +1803,9 @@ proc semProcAnnotation(c: PContext, prc: PNode;
       # Not a custom pragma
       continue
     else:
-      let ident = considerQuotedIdent(c, key)
+      let (ident, err) = considerQuotedIdent(c, key)
+      if err != nil:
+        localReport(c.config, err)
       if strTableGet(c.userPragmas, ident) != nil:
         continue # User defined pragma
       else:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -755,14 +755,14 @@ proc matchUserTypeClass*(m: var TCandidate; ff, a: PType): PType =
   result.n = checkedBody
 
 proc shouldSkipDistinct(m: TCandidate; rules: PNode, callIdent: PIdent): bool =
-  # XXX This is bad as 'considerQuotedIdent' can produce an error!
+  # xxx: `considerQuotedIdent` can produce an error and is not being handled
   if rules.kind == nkWith:
     for r in rules:
-      if considerQuotedIdent(m.c, r) == callIdent: return true
+      if considerQuotedIdent(m.c, r) == (callIdent, nil): return true
     return false
   else:
     for r in rules:
-      if considerQuotedIdent(m.c, r) == callIdent: return false
+      if considerQuotedIdent(m.c, r) == (callIdent, nil): return false
     return true
 
 proc maybeSkipDistinct(m: TCandidate; t: PType, callee: PSym): PType =
@@ -2327,8 +2327,7 @@ proc prepareNamedParam(a: PNode; c: PContext) =
   else:
     let
       info = a[0].info
-      (i, err) = considerQuotedIdent2(c, a[0])
-    # a[0] = newIdentNode(considerQuotedIdent(c, a[0]), info)
+      (i, err) = considerQuotedIdent(c, a[0])
     a[0] =
       if err.isNil():
         newIdentNode(i, info)


### PR DESCRIPTION
## Summary
* removed legacy version of `considerQuotedIdent`
* removed legacy version of `errorSym`
* more progress towards nkError everywhere

## Details
* lots of editing of callsites to ensure error reporting

---
## Notes for Reviewers
* making a nice commit message and squashing