### PR TITLE
ast: rearrange code and clean-ups

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -12,8 +12,10 @@
 import
   compiler/ast/[
     lineinfos, # Positional information
-    idents, # Ast identifiers
-    ast_types # Main ast type definitions
+    idents,    # Ast identifiers
+    ast_types, # Main ast type definitions
+    ast_idgen, # Per module Id generation
+    ast_query, # querying/reading the ast
   ],
   compiler/front/[
     options
@@ -23,359 +25,21 @@ import
     int128 # Values for integer nodes
   ],
   std/[
-    hashes,
     strutils,
     tables # For symbol table mapping
   ]
 
-export ast_types, int128
-
-type Gconfig = object
-  ## we put comments in a side channel to avoid increasing `sizeof(TNode)`,
-  ## which reduces memory usage given that `PNode` is the most allocated
-  ## type by far.
-  comments: Table[int, string] # nodeId => comment
-  useIc*: bool
-
-var gconfig {.threadvar.}: Gconfig
-
-proc setUseIc*(useIc: bool) = gconfig.useIc = useIc
-
-proc comment*(n: PNode): string =
-  if nfHasComment in n.flags and not gconfig.useIc:
-    # IC doesn't track comments, see `packed_ast`, so this could fail
-    result = gconfig.comments[n.id]
-
-proc `comment=`*(n: PNode, a: string) =
-  if a.len > 0:
-    # if needed, we could periodically cleanup gconfig.comments when its size increases,
-    # to ensure only live nodes (and with nfHasComment) have an entry in gconfig.comments;
-    # for compiling compiler, the waste is very small:
-    # num calls to newNodeImpl: 14984160 (num of PNode allocations)
-    # size of gconfig.comments: 33585
-    # num of nodes with comments that were deleted and hence wasted: 3081
-    n.flags.incl nfHasComment
-    gconfig.comments[n.id] = a
-  elif nfHasComment in n.flags:
-    n.flags.excl nfHasComment
-    gconfig.comments.del(n.id)
-
-# BUGFIX: a module is overloadable so that a proc can have the
-# same name as an imported module. This is necessary because of
-# the poor naming choices in the standard library.
-
-const
-  OverloadableSyms* = {skProc, skFunc, skMethod, skIterator,
-    skConverter, skModule, skTemplate, skMacro, skEnumField}
-
-  skipForDiscardable* = {nkIfStmt, nkIfExpr, nkCaseStmt, nkOfBranch,
-    nkElse, nkStmtListExpr, nkTryStmt, nkFinally, nkExceptBranch,
-    nkElifBranch, nkElifExpr, nkElseExpr, nkBlockStmt, nkBlockExpr,
-    nkHiddenStdConv, nkHiddenDeref}
-
-
-  GenericTypes*: TTypeKinds = {tyGenericInvocation, tyGenericBody,
-    tyGenericParam}
-
-  StructuralEquivTypes*: TTypeKinds = {tyNil, tyTuple, tyArray,
-    tySet, tyRange, tyPtr, tyRef, tyVar, tyLent, tySequence, tyProc, tyOpenArray,
-    tyVarargs}
-
-  ConcreteTypes*: TTypeKinds = { # types of the expr that may occur in::
-                                 # var x = expr
-    tyBool, tyChar, tyEnum, tyArray, tyObject,
-    tySet, tyTuple, tyRange, tyPtr, tyRef, tyVar, tyLent, tySequence, tyProc,
-    tyPointer,
-    tyOpenArray, tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat128,
-    tyUInt..tyUInt64}
-  IntegralTypes* = {tyBool, tyChar, tyEnum, tyInt..tyInt64,
-    tyFloat..tyFloat128, tyUInt..tyUInt64} # weird name because it contains tyFloat
-  ConstantDataTypes*: TTypeKinds = {tyArray, tySet,
-                                    tyTuple, tySequence}
-  NilableTypes*: TTypeKinds = {tyPointer, tyCstring, tyRef, tyPtr,
-    tyProc, tyError} # TODO
-  PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
-  PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
-                                      nfDotSetter, nfDotField,
-                                      nfIsRef, nfIsPtr, nfPreventCg, nfLL,
-                                      nfFromTemplate, nfDefaultRefsParam,
-                                      nfExecuteOnReload, nfLastRead, nfFirstWrite}
-  namePos*          = 0 ## Name of the type/proc-like node
-  patternPos*       = 1 ## empty except for term rewriting macros
-  genericParamsPos* = 2 ## Generic parametesr in the procedure-like nodes
-  paramsPos*        = 3 ## Formal parameters in the procedure-like nodes
-  pragmasPos*       = 4 ## Position of the pragma in the procedure-like nodes
-  miscPos*          = 5 ## used for undocumented and hacky stuff
-  bodyPos*          = 6 ## position of body; use rodread.getBody() instead!
-  resultPos*        = 7
-  dispatcherPos*    = 8
-
-  wrongNodePos*     = 0 ## Error the ast node we swapped
-  errorKindPos*     = 1 ## Error kind enum as an intlit
-  compilerInfoPos*  = 2 ## Error compiler source file as strlit, line & col
-                        ## on info
-  firstArgPos*      = 3 ## Error first 0..n additional nodes depends on
-                        ## error kind
-
-
-  nfAllFieldsSet* = nfBase2
-
-  nkCallKinds* = {nkCall, nkInfix, nkPrefix, nkPostfix,
-                  nkCommand, nkCallStrLit, nkHiddenCallConv}
-  nkIdentKinds* = {nkIdent, nkSym, nkAccQuoted, nkOpenSymChoice,
-                   nkClosedSymChoice}
-
-  nkPragmaCallKinds* = {nkExprColonExpr, nkCall, nkCallStrLit}
-  nkLiterals* = {nkCharLit..nkTripleStrLit}
-  nkFloatLiterals* = {nkFloatLit..nkFloat128Lit}
-  nkLambdaKinds* = {nkLambda, nkDo}
-  declarativeDefs* = {nkProcDef, nkFuncDef, nkMethodDef, nkIteratorDef, nkConverterDef}
-  routineDefs* = declarativeDefs + {nkMacroDef, nkTemplateDef}
-  procDefs* = nkLambdaKinds + declarativeDefs
-  callableDefs* = nkLambdaKinds + routineDefs
-
-  nkSymChoices* = {nkClosedSymChoice, nkOpenSymChoice}
-  nkStrKinds* = {nkStrLit..nkTripleStrLit}
-  nkIntKinds* = {nkCharLit .. nkUInt64Lit}
-
-  skLocalVars* = {skVar, skLet, skForVar, skParam, skResult}
-  skProcKinds* = {skProc, skFunc, skTemplate, skMacro, skIterator,
-                  skMethod, skConverter}
-
-  defaultSize = -1
-  defaultAlignment = -1
-  defaultOffset* = -1
-
-  nodeKindsProducedByParse* = {
-    nkError, nkEmpty,
-    nkIdent,
-
-    nkCharLit,
-    nkIntLit, nkInt8Lit, nkInt16Lit, nkInt32Lit, nkInt64Lit,
-    nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit,
-    nkFloatLit, nkFloat32Lit, nkFloat64Lit, nkFloat128Lit,
-    nkStrLit, nkRStrLit, nkTripleStrLit,
-    nkNilLit,
-
-    nkCall, nkCommand, nkCallStrLit, nkInfix, nkPrefix, nkPostfix,
-
-    nkExprEqExpr, nkExprColonExpr, nkIdentDefs, nkConstDef, nkVarTuple, nkPar,
-    nkBracket, nkCurly, nkTupleConstr, nkObjConstr, nkTableConstr,
-    nkBracketExpr, nkCurlyExpr,
-
-    nkPragmaExpr, nkPragma, nkPragmaBlock,
-
-    nkDotExpr, nkAccQuoted,
-
-    nkIfExpr, nkIfStmt, nkElifBranch, nkElifExpr, nkElse, nkElseExpr,
-    nkCaseStmt, nkOfBranch,
-    nkWhenStmt,
-
-    nkForStmt, nkWhileStmt,
-
-    nkBlockExpr, nkBlockStmt,
-
-    nkDiscardStmt, nkContinueStmt, nkBreakStmt, nkReturnStmt, nkRaiseStmt,
-    nkYieldStmt,
-
-    nkTryStmt, nkExceptBranch, nkFinally,
-
-    nkDefer,
-
-    nkLambda, nkDo,
-
-    nkBind, nkBindStmt, nkMixinStmt,
-
-    nkCast,
-    nkStaticStmt,
-
-    nkAsgn,
-
-    nkGenericParams,
-    nkFormalParams,
-
-    nkStmtList, nkStmtListExpr,
-
-    nkImportStmt, nkImportExceptStmt, nkImportAs, nkFromStmt,
-
-    nkIncludeStmt,
-
-    nkExportStmt, nkExportExceptStmt,
-
-    nkConstSection, nkLetSection, nkVarSection,
-
-    nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef, nkIteratorDef,
-    nkMacroDef, nkTemplateDef,
-
-    nkTypeSection, nkTypeDef,
-
-    nkEnumTy, nkEnumFieldDef,
-
-    nkObjectTy, nkTupleTy, nkProcTy, nkIteratorTy,
-
-    nkRecList, nkRecCase, nkRecWhen,
-
-    nkTypeOfExpr,
-
-    # nkConstTy,
-    nkRefTy, nkVarTy, nkPtrTy, nkStaticTy, nkDistinctTy,
-    nkMutableTy,
-
-    nkTupleClassTy, nkTypeClassTy,
-
-    nkOfInherit,
-
-    nkArgList,
-
-    nkWith, nkWithout,
-
-    nkAsmStmt,
-    nkCommentStmt,
-
-    nkUsingStmt,
-  }
-
-proc getPIdent*(a: PNode): PIdent {.inline.} =
-  ## Returns underlying `PIdent` for `{nkSym, nkIdent}`, or `nil`.
-  # xxx consider whether also returning the 1st ident for {nkOpenSymChoice, nkClosedSymChoice}
-  # which may simplify code.
-  case a.kind
-  of nkSym: a.sym.name
-  of nkIdent: a.ident
-  else: nil
-
-proc getnimblePkg*(a: PSym): PSym =
-  result = a
-  while result != nil:
-    case result.kind
-    of skModule:
-      result = result.owner
-      assert result.kind == skPackage
-    of skPackage:
-      if result.owner == nil:
-        break
-      else:
-        result = result.owner
-    else:
-      assert false, $result.kind
-
-const
-  moduleShift = when defined(cpu32): 20 else: 24
-
-template id*(a: PIdObj): int =
-  let x = a
-  (x.itemId.module.int shl moduleShift) + x.itemId.item.int
-
-type
-  IdGenerator* = ref object # unfortunately, we really need the 'shared mutable' aspect here.
-    module*: int32
-    symId*: int32
-    typeId*: int32
-    sealed*: bool
-
-const
-  PackageModuleId* = -3'i32
-
-proc idGeneratorFromModule*(m: PSym): IdGenerator =
-  assert m.kind == skModule
-  result = IdGenerator(module: m.itemId.module, symId: m.itemId.item, typeId: 0)
-
-proc nextSymId*(x: IdGenerator): ItemId {.inline.} =
-  assert(not x.sealed)
-  inc x.symId
-  result = ItemId(module: x.module, item: x.symId)
-
-proc nextTypeId*(x: IdGenerator): ItemId {.inline.} =
-  assert(not x.sealed)
-  inc x.typeId
-  result = ItemId(module: x.module, item: x.typeId)
-
-when false:
-  proc nextId*(x: IdGenerator): ItemId {.inline.} =
-    inc x.item
-    result = x[]
-
-when false:
-  proc storeBack*(dest: var IdGenerator; src: IdGenerator) {.inline.} =
-    assert dest.ItemId.module == src.ItemId.module
-    if dest.ItemId.item > src.ItemId.item:
-      echo dest.ItemId.item, " ", src.ItemId.item, " ", src.ItemId.module
-    assert dest.ItemId.item <= src.ItemId.item
-    dest = src
-
-proc getnimblePkgId*(a: PSym): int =
-  let b = a.getnimblePkg
-  result = if b == nil: -1 else: b.id
+export ast_types, ast_idgen, ast_query, int128
 
 var ggDebug* {.deprecated.}: bool ## convenience switch for trying out things
-#var
-#  gMainPackageId*: int
-
-proc isCallExpr*(n: PNode): bool =
-  result = n.kind in nkCallKinds
-
-proc discardSons*(father: PNode)
-
-type Indexable = PNode | PType
-
-proc len*(n: Indexable): int {.inline.} =
-  result = n.sons.len
-
-proc safeLen*(n: PNode): int {.inline.} =
-  ## works even for leaves.
-  if n.kind in {nkNone..nkNilLit}: result = 0
-  else: result = n.len
-
-proc add*(father, son: Indexable) =
-  assert son != nil
-  father.sons.add(son)
-
-proc addAllowNil*(father, son: Indexable) {.inline.} =
-  father.sons.add(son)
-
-template `[]`*(n: Indexable, i: int): Indexable = n.sons[i]
-template `[]=`*(n: Indexable, i: int; x: Indexable) = n.sons[i] = x
-
-template `[]`*(n: Indexable, i: BackwardsIndex): Indexable = n[n.len - i.int]
-template `[]=`*(n: Indexable, i: BackwardsIndex; x: Indexable) = n[n.len - i.int] = x
-
-proc getDeclPragma*(n: PNode): PNode =
-  ## return the `nkPragma` node for declaration `n`, or `nil` if no pragma was found.
-  ## Currently only supports routineDefs + {nkTypeDef}.
-  case n.kind
-  of routineDefs:
-    if n[pragmasPos].kind != nkEmpty: result = n[pragmasPos]
-  of nkTypeDef:
-    #[
-    type F3*{.deprecated: "x3".} = int
-
-    TypeSection
-      TypeDef
-        PragmaExpr
-          Postfix
-            Ident "*"
-            Ident "F3"
-          Pragma
-            ExprColonExpr
-              Ident "deprecated"
-              StrLit "x3"
-        Empty
-        Ident "int"
-    ]#
-    if n[0].kind == nkPragmaExpr:
-      result = n[0][1]
-  else:
-    # support as needed for `nkIdentDefs` etc.
-    result = nil
-  if result != nil:
-    assert result.kind == nkPragma, $(result.kind, n.kind)
-
-const invalidNodeId* = 0
-var gNodeId: int
 
 when defined(useNodeIds):
   const nodeIdToDebug* = -1 # 2322968
 
+proc addAllowNil*(father, son: Indexable) {.inline.} =
+  father.sons.add(son)
+
+var gNodeId: int
 template setNodeId() =
   inc gNodeId
   result.id = gNodeId
@@ -432,9 +96,6 @@ proc newTreeIT*(kind: TNodeKind; info: TLineInfo; typ: PType; children: varargs[
   result = newNodeIT(kind, info, typ)
   result.sons = @children
 
-template previouslyInferred*(t: PType): PType =
-  if t.sons.len > 1: t.lastSon else: nil
-
 when false:
   import tables, strutils
   var x: CountTable[string]
@@ -455,21 +116,6 @@ proc newSym*(symKind: TSymKind, name: PIdent, id: ItemId, owner: PSym,
       echo "kind ", symKind, " ", name.s
       if owner != nil: echo owner.name.s
 
-proc astdef*(s: PSym): PNode =
-  # get only the definition (initializer) portion of the ast
-  if s.ast != nil and s.ast.kind == nkIdentDefs:
-    s.ast[2]
-  else:
-    s.ast
-
-proc isMetaType*(t: PType): bool =
-  return t.kind in tyMetaTypes or
-         (t.kind == tyStatic and t.n == nil) or
-         tfHasMeta in t.flags
-
-proc isUnresolvedStatic*(t: PType): bool =
-  return t.kind == tyStatic and t.n == nil
-
 proc linkTo*(t: PType, s: PSym): PType {.discardable.} =
   t.sym = s
   s.typ = t
@@ -479,14 +125,6 @@ proc linkTo*(s: PSym, t: PType): PSym {.discardable.} =
   t.sym = s
   s.typ = t
   result = s
-
-template fileIdx*(c: PSym): FileIndex =
-  # XXX: this should be used only on module symbols
-  c.position.FileIndex
-
-template filename*(c: PSym): string =
-  # XXX: this should be used only on module symbols
-  c.position.FileIndex.toFilename
 
 proc appendToModule*(m: PSym, n: PNode) =
   ## The compiler will use this internally to add nodes that will be
@@ -550,23 +188,6 @@ proc newIntNode*(kind: TNodeKind, intVal: Int128): PNode =
   result = newNode(kind)
   result.intVal = castToInt64(intVal)
 
-func lastSon*(n: Indexable): Indexable =
-  {.cast(noSideEffect).}:
-    # erroneously inferred side-effect
-    n.sons[^1]
-
-proc skipTypes*(t: PType, kinds: TTypeKinds): PType =
-  ## Used throughout the compiler code to test whether a type tree contains or
-  ## doesn't contain a specific type/types - it is often the case that only the
-  ## last child nodes of a type tree need to be searched. This is a really hot
-  ## path within the compiler!
-  result = t
-  while result.kind in kinds: result = lastSon(result)
-
-proc skipDistincts*(t: PType): PType {.inline.} =
-  ## Skips over all possible distinct instantiations, getting base.
-  skipTypes(t, {tyAlias, tyGenericInst, tyDistinct})
-
 proc newIntTypeNode*(intVal: BiggestInt, typ: PType): PNode =
   let kind = skipTypes(typ, abstractVarRange).kind
   case kind
@@ -613,24 +234,6 @@ proc newProcNode*(kind: TNodeKind, info: TLineInfo, body: PNode,
   result = newNodeI(kind, info)
   result.sons = @[name, pattern, genericParams, params,
                   pragmas, exceptions, body]
-
-const
-  UnspecifiedLockLevel* = TLockLevel(-1'i16)
-  MaxLockLevel* = 1000'i16
-  UnknownLockLevel* = TLockLevel(1001'i16)
-  AttachedOpToStr*: array[TTypeAttachedOp, string] = [
-    "=destroy", "=copy", "=sink", "=trace", "=deepcopy"]
-
-proc `$`*(x: TLockLevel): string =
-  if x.ord == UnspecifiedLockLevel.ord: result = "<unspecified>"
-  elif x.ord == UnknownLockLevel.ord: result = "<unknown>"
-  else: result = $int16(x)
-
-proc `$`*(s: PSym): string =
-  if s != nil:
-    result = s.name.s & "@" & $s.id
-  else:
-    result = "<nil>"
 
 proc newType*(kind: TTypeKind, id: ItemId; owner: PSym): PType =
   result = PType(kind: kind, owner: owner, size: defaultSize,
@@ -742,21 +345,6 @@ proc newIdNodeTable*: TIdNodeTable =
 proc initNodeTable*(x: var TNodeTable) =
   x.counter = 0
   newSeq(x.data, StartSize)
-
-proc skipTypes*(t: PType, kinds: TTypeKinds; maxIters: int): PType =
-  result = t
-  var i = maxIters
-  while result.kind in kinds:
-    result = lastSon(result)
-    dec i
-    if i == 0: return nil
-
-proc skipTypesOrNil*(t: PType, kinds: TTypeKinds): PType =
-  ## same as skipTypes but handles 'nil'
-  result = t
-  while result != nil and result.kind in kinds:
-    if result.len == 0: return nil
-    result = lastSon(result)
 
 proc isGCedMem*(t: PType): bool {.inline.} =
   result = t.kind in {tyString, tyRef, tySequence} or
@@ -892,223 +480,12 @@ proc copyTreeWithoutNodes*(src: PNode; skippedNodes: varargs[PNode]): PNode =
       if n notin skippedNodes:
         result.sons.add copyTreeWithoutNodes(n, skippedNodes)
 
-proc hasSonWith*(n: PNode, kind: TNodeKind): bool =
-  for i in 0..<n.len:
-    if n[i].kind == kind:
-      return true
-  result = false
-
-proc hasNilSon*(n: PNode): bool =
-  for i in 0..<n.safeLen:
-    if n[i] == nil:
-      return true
-    elif hasNilSon(n[i]):
-      return true
-  result = false
-
-proc containsNode*(n: PNode, kinds: TNodeKinds): bool =
-  if n == nil: return
-  case n.kind
-  of nkEmpty..nkNilLit: result = n.kind in kinds
-  else:
-    for i in 0..<n.len:
-      if n.kind in kinds or containsNode(n[i], kinds): return true
-
-proc hasSubnodeWith*(n: PNode, kind: TNodeKind): bool =
-  case n.kind
-  of nkEmpty..nkNilLit, nkFormalParams: result = n.kind == kind
-  else:
-    for i in 0..<n.len:
-      if (n[i].kind == kind) or hasSubnodeWith(n[i], kind):
-        return true
-    result = false
-
-proc getInt*(a: PNode): Int128 =
-  case a.kind
-  of nkCharLit, nkUIntLit..nkUInt64Lit:
-    result = toInt128(cast[uint64](a.intVal))
-  of nkInt8Lit..nkInt64Lit:
-    result = toInt128(a.intVal)
-  of nkIntLit:
-    # XXX: enable this assert
-    # assert a.typ.kind notin {tyChar, tyUint..tyUInt64}
-    result = toInt128(a.intVal)
-  else:
-    raiseRecoverableError("cannot extract number from invalid AST node")
-
-proc getInt64*(a: PNode): int64 {.deprecated: "use getInt".} =
-  case a.kind
-  of nkCharLit, nkUIntLit..nkUInt64Lit, nkIntLit..nkInt64Lit:
-    result = a.intVal
-  else:
-    raiseRecoverableError("cannot extract number from invalid AST node")
-
-proc getFloat*(a: PNode): BiggestFloat =
-  case a.kind
-  of nkFloatLiterals: result = a.floatVal
-  of nkCharLit, nkUIntLit..nkUInt64Lit, nkIntLit..nkInt64Lit:
-    result = BiggestFloat a.intVal
-  else:
-    raiseRecoverableError("cannot extract number from invalid AST node")
-    #doAssert false, "getFloat"
-    #internalError(a.info, "getFloat")
-    #result = 0.0
-
-proc getStr*(a: PNode): string =
-  case a.kind
-  of nkStrLit..nkTripleStrLit: result = a.strVal
-  of nkNilLit:
-    # let's hope this fixes more problems than it creates:
-    result = ""
-  else:
-    raiseRecoverableError("cannot extract string from invalid AST node")
-    #doAssert false, "getStr"
-    #internalError(a.info, "getStr")
-    #result = ""
-
-proc getStrOrChar*(a: PNode): string =
-  case a.kind
-  of nkStrLit..nkTripleStrLit: result = a.strVal
-  of nkCharLit..nkUInt64Lit: result = $chr(int(a.intVal))
-  else:
-    raiseRecoverableError("cannot extract string from invalid AST node")
-    #doAssert false, "getStrOrChar"
-    #internalError(a.info, "getStrOrChar")
-    #result = ""
-
-proc isGenericParams*(n: PNode): bool {.inline.} =
-  ## used to judge whether a node is generic params.
-  n != nil and n.kind == nkGenericParams
-
-proc isGenericRoutine*(n: PNode): bool  {.inline.} =
-  n != nil and n.kind in callableDefs and n[genericParamsPos].isGenericParams
-
-proc isError*(n: PNode): bool {.inline.} =
-  ## whether the node is an error, strictly checks nkError and is nil safe
-  n != nil and n.kind == nkError
-
-proc isError*(s: PSym): bool {.inline.} =
-  ## whether the symbol is an error, strictly checks skError, an error node
-  ## exists, and is nil safe.
-  s != nil and s.kind == skError and s.ast.isError
-
-proc isError*(t: PType): bool {.inline.} =
-  ## whether the type is an error. useful because of compiler legacy, as
-  ## `tyError` isn't an enum field rather a const refering to `tyProxy`.
-  ##
-  ## xxx: currently we have no way to disambiguate between legacy and new
-  t != nil and t.kind == tyError
-
-proc isErrorLike*(t: PType): bool {.inline.} =
-  ## whether the type is an error. useful because of compiler legacy, as
-  ## `tyError` isn't an enum field rather a const refering to `tyProxy`.
-  ##
-  ## xxx: currently we have no way to disambiguate between legacy and new
-  t != nil and (t.kind == tyError or t.sym.isError)
-
-proc isErrorLike*(s: PSym): bool {.inline.} =
-  ## whether the symbol is an error. useful because of compiler legacy, as
-  ## `skError` isn't an enum field rather a const refering to `skUnkonwn`. we
-  ## disambiguate via the presence of the ast field being non-nil and of kind
-  ## `nkError`
-  s != nil and (s.isError or s.typ.isError)
-
-proc isErrorLike*(n: PNode): bool {.inline.} =
-  ## whether the node is an error, including error symbol, or error type
-  ## xxx: longer term we should probably not produce nodes like these in the
-  ##      first place and mark them as nkErrors with an appropriate error kind.
-  n != nil and (
-      case n.kind
-      of nkError: true
-      of nkSym: n.sym.isErrorLike
-      of nkType: n.typ.isErrorLike
-      else: n.typ.isError # if it has a type, it shouldn't be an error
-    )
-
-proc isGenericRoutineStrict*(s: PSym): bool {.inline.} =
-  ## determines if this symbol represents a generic routine
-  ## the unusual name is so it doesn't collide and eventually replaces
-  ## `isGenericRoutine`
-  s.kind in skProcKinds and s.ast.isGenericRoutine
-
-proc isGenericRoutine*(s: PSym): bool {.inline.} =
-  ## determines if this symbol represents a generic routine or an instance of
-  ## one. This should be renamed accordingly and `isGenericRoutineStrict`
-  ## should take this name instead.
-  ##
-  ## Warning/XXX: Unfortunately, it considers a proc kind symbol flagged with
-  ## sfFromGeneric as a generic routine. Instead this should likely not be the
-  ## case and the concepts should be teased apart:
-  ## - generic definition
-  ## - generic instance
-  ## - either generic definition or instance
-  s.kind in skProcKinds and (sfFromGeneric in s.flags or
-                             s.ast.isGenericRoutine)
-
-proc skipGenericOwner*(s: PSym): PSym =
-  ## Generic instantiations are owned by their originating generic
-  ## symbol. This proc skips such owners and goes straight to the owner
-  ## of the generic itself (the module or the enclosing proc).
-  result = if s.kind in skProcKinds and sfFromGeneric in s.flags:
-             s.owner.owner
-           else:
-             s.owner
-
-proc originatingModule*(s: PSym): PSym =
-  result = s.owner
-  while result.kind != skModule: result = result.owner
-
-proc isRoutine*(s: PSym): bool {.inline.} =
-  result = s.kind in skProcKinds
-
-proc isCompileTimeProc*(s: PSym): bool {.inline.} =
-  result = s.kind == skMacro or
-           s.kind in {skProc, skFunc} and sfCompileTime in s.flags
-
-proc isRunnableExamples*(n: PNode): bool =
-  # Templates and generics don't perform symbol lookups.
-  result = n.kind == nkSym and n.sym.magic == mRunnableExamples or
-    n.kind == nkIdent and n.ident.s == "runnableExamples"
-
-proc requiredParams*(s: PSym): int =
-  # Returns the number of required params (without default values)
-  # XXX: Perhaps we can store this in the `offset` field of the
-  # symbol instead?
-  for i in 1..<s.typ.len:
-    if s.typ.n[i].sym.ast != nil:
-      return i - 1
-  return s.typ.len - 1
-
-proc hasPattern*(s: PSym): bool {.inline.} =
-  result = isRoutine(s) and s.ast[patternPos].kind != nkEmpty
-
-iterator items*(n: PNode): PNode =
-  for i in 0..<n.safeLen: yield n[i]
-
-iterator pairs*(n: PNode): tuple[i: int, n: PNode] =
-  for i in 0..<n.safeLen: yield (i, n[i])
-
-proc isAtom*(n: PNode): bool {.inline.} =
-  result = n.kind >= nkNone and n.kind <= nkNilLit
-
-proc isEmptyType*(t: PType): bool {.inline.} =
-  ## 'void' and 'typed' types are often equivalent to 'nil' these days:
-  result = t == nil or t.kind in {tyVoid, tyTyped}
-
 proc makeStmtList*(n: PNode): PNode =
   if n.kind == nkStmtList:
     result = n
   else:
     result = newNodeI(nkStmtList, n.info)
     result.add n
-
-proc skipStmtList*(n: PNode): PNode =
-  if n.kind in {nkStmtList, nkStmtListExpr}:
-    for i in 0..<n.len-1:
-      if n[i].kind notin {nkEmpty, nkCommentStmt}: return n
-    result = n.lastSon
-  else:
-    result = n
 
 proc toVar*(typ: PType; kind: TTypeKind; idgen: IdGenerator): PType =
   ## If ``typ`` is not a tyVar then it is converted into a `var <typ>` and
@@ -1154,70 +531,6 @@ proc toObjectFromRefPtrGeneric*(typ: PType): PType =
     else: break
   assert result.sym != nil
 
-proc isImportedException*(t: PType; conf: ConfigRef): bool =
-  assert t != nil
-
-  if conf.exc != excCpp:
-    return false
-
-  let base = t.skipTypes({tyAlias, tyPtr, tyDistinct, tyGenericInst})
-
-  if base.sym != nil and {sfCompileToCpp, sfImportc} * base.sym.flags != {}:
-    result = true
-
-proc isInfixAs*(n: PNode): bool =
-  return n.kind == nkInfix and n[0].kind == nkIdent and n[0].ident.s == "as"
-
-proc skipColon*(n: PNode): PNode =
-  result = n
-  if n.kind == nkExprColonExpr:
-    result = n[1]
-
-proc findUnresolvedStatic*(n: PNode): PNode =
-  # n.typ == nil: see issue #14802
-  if n.kind == nkSym and n.typ != nil and n.typ.kind == tyStatic and n.typ.n == nil:
-    return n
-
-  for son in n:
-    let n = son.findUnresolvedStatic
-    if n != nil: return n
-
-  return nil
-
-when false:
-  proc containsNil*(n: PNode): bool =
-    # only for debugging
-    if n.isNil: return true
-    for i in 0..<n.safeLen:
-      if n[i].containsNil: return true
-
-
-template hasDestructor*(t: PType): bool = {tfHasAsgn, tfHasOwned} * t.flags != {}
-
-template incompleteType*(t: PType): bool =
-  t.sym != nil and {sfForward, sfNoForward} * t.sym.flags == {sfForward}
-
-template typeCompleted*(s: PSym) =
-  incl s.flags, sfNoForward
-
-template detailedInfo*(sym: PSym): string =
-  sym.name.s
-
-proc isInlineIterator*(typ: PType): bool {.inline.} =
-  typ.kind == tyProc and tfIterator in typ.flags and typ.callConv != ccClosure
-
-proc isClosureIterator*(typ: PType): bool {.inline.} =
-  typ.kind == tyProc and tfIterator in typ.flags and typ.callConv == ccClosure
-
-proc isClosure*(typ: PType): bool {.inline.} =
-  typ.kind == tyProc and typ.callConv == ccClosure
-
-proc isSinkParam*(s: PSym): bool {.inline.} =
-  s.kind == skParam and (s.typ.kind == tySink or tfHasOwned in s.typ.flags)
-
-proc isSinkType*(t: PType): bool {.inline.} =
-  t.kind == tySink or tfHasOwned in t.flags
-
 proc newProcType*(info: TLineInfo; id: ItemId; owner: PSym): PType =
   result = newType(tyProc, id, owner)
   result.n = newNodeI(nkFormalParams, info)
@@ -1232,31 +545,6 @@ proc addParam*(procType: PType; param: PSym) =
   procType.n.add newSymNode(param)
   rawAddSon(procType, param.typ)
 
-const magicsThatCanRaise = {
-  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
-
-proc canRaiseConservative*(fn: PNode): bool =
-  if fn.kind == nkSym and fn.sym.magic notin magicsThatCanRaise:
-    result = false
-  else:
-    result = true
-
-proc canRaise*(fn: PNode): bool =
-  if fn.kind == nkSym and (fn.sym.magic notin magicsThatCanRaise or
-      {sfImportc, sfInfixCall} * fn.sym.flags == {sfImportc} or
-      sfGeneratedOp in fn.sym.flags):
-    result = false
-  elif fn.kind == nkSym and fn.sym.magic == mEcho:
-    result = true
-  else:
-    # TODO check for n having sons? or just return false for now if not
-    if fn.typ != nil and fn.typ.n != nil and fn.typ.n[0].kind == nkSym:
-      result = false
-    else:
-      result = fn.typ != nil and fn.typ.n != nil and ((fn.typ.n[0].len < effectListLen) or
-        (fn.typ.n[0][exceptionEffects] != nil and
-        fn.typ.n[0][exceptionEffects].safeLen > 0))
-
 proc toHumanStrImpl[T](kind: T, num: static int): string =
   result = $kind
   result = result[num..^1]
@@ -1269,10 +557,3 @@ proc toHumanStr*(kind: TSymKind): string =
 proc toHumanStr*(kind: TTypeKind): string =
   ## strips leading `tk`
   result = toHumanStrImpl(kind, 2)
-
-proc skipAddr*(n: PNode): PNode {.inline.} =
-  (if n.kind == nkHiddenAddr: n[0] else: n)
-
-proc isNewStyleConcept*(n: PNode): bool {.inline.} =
-  assert n.kind == nkTypeClassTy
-  result = n[0].kind == nkEmpty

--- a/compiler/ast/ast_idgen.nim
+++ b/compiler/ast/ast_idgen.nim
@@ -1,0 +1,44 @@
+## id generator for modules, symbols, and types.
+
+import
+  compiler/ast/[
+    ast_types, # Main ast type definitions
+  ]
+
+type
+  IdGenerator* = ref object # unfortunately, we really need the 'shared mutable' aspect here.
+    module*: int32
+    symId*: int32
+    typeId*: int32
+    sealed*: bool
+
+const
+  PackageModuleId* = -3'i32
+
+proc idGeneratorFromModule*(m: PSym): IdGenerator =
+  assert m.kind == skModule
+  result = IdGenerator(
+    module: m.itemId.module, symId: m.itemId.item, typeId: 0)
+
+proc nextSymId*(x: IdGenerator): ItemId {.inline.} =
+  assert(not x.sealed)
+  inc x.symId
+  result = ItemId(module: x.module, item: x.symId)
+
+proc nextTypeId*(x: IdGenerator): ItemId {.inline.} =
+  assert(not x.sealed)
+  inc x.typeId
+  result = ItemId(module: x.module, item: x.typeId)
+
+when false:
+  proc nextId*(x: IdGenerator): ItemId {.inline.} =
+    inc x.item
+    result = x[]
+
+when false:
+  proc storeBack*(dest: var IdGenerator; src: IdGenerator) {.inline.} =
+    assert dest.ItemId.module == src.ItemId.module
+    if dest.ItemId.item > src.ItemId.item:
+      echo dest.ItemId.item, " ", src.ItemId.item, " ", src.ItemId.module
+    assert dest.ItemId.item <= src.ItemId.item
+    dest = src

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -1,0 +1,665 @@
+## abstract syntax tree + symbol table querying operations
+## 
+## A companion module to `ast_types` containing things related to querying the
+## AST and Symbol Table. Not all reads are here as some base level reading is
+## required for manipulation, which are contained in `ast` itself.
+
+import
+  compiler/ast/[
+    lineinfos, # Positional information
+    idents,    # Ast identifiers
+    ast_types  # Main ast type definitions
+  ],
+  compiler/front/[
+    options,
+  ],
+  compiler/utils/[
+    int128 # Values for integer nodes
+  ]
+
+const
+  OverloadableSyms* = {skProc, skFunc, skMethod, skIterator,
+    skConverter, skTemplate, skMacro, skEnumField,
+
+    # BUGFIX: a module is overloadable so that a proc can have the
+    # same name as an imported module. This is necessary because of
+    # the poor naming choices in the standard library.
+    skModule}
+
+  skipForDiscardable* = {nkIfStmt, nkIfExpr, nkCaseStmt, nkOfBranch,
+    nkElse, nkStmtListExpr, nkTryStmt, nkFinally, nkExceptBranch,
+    nkElifBranch, nkElifExpr, nkElseExpr, nkBlockStmt, nkBlockExpr,
+    nkHiddenStdConv, nkHiddenDeref}
+
+  GenericTypes*: TTypeKinds = {tyGenericInvocation, tyGenericBody,
+    tyGenericParam}
+
+  StructuralEquivTypes*: TTypeKinds = {tyNil, tyTuple, tyArray,
+    tySet, tyRange, tyPtr, tyRef, tyVar, tyLent, tySequence, tyProc, tyOpenArray,
+    tyVarargs}
+
+  ConcreteTypes*: TTypeKinds = { # types of the expr that may occur in::
+                                 # var x = expr
+    tyBool, tyChar, tyEnum, tyArray, tyObject,
+    tySet, tyTuple, tyRange, tyPtr, tyRef, tyVar, tyLent, tySequence, tyProc,
+    tyPointer,
+    tyOpenArray, tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat128,
+    tyUInt..tyUInt64}
+  
+  IntegralTypes* = {tyBool, tyChar, tyEnum, tyInt..tyInt64,
+    tyFloat..tyFloat128, tyUInt..tyUInt64} # weird name because it contains tyFloat
+  
+  ConstantDataTypes*: TTypeKinds = {tyArray, tySet,
+                                    tyTuple, tySequence}
+  
+  NilableTypes*: TTypeKinds = {tyPointer, tyCstring, tyRef, tyPtr,
+    tyProc, tyError} # TODO
+  
+  PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
+  
+  PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
+                                      nfDotSetter, nfDotField,
+                                      nfIsRef, nfIsPtr, nfPreventCg, nfLL,
+                                      nfFromTemplate, nfDefaultRefsParam,
+                                      nfExecuteOnReload, nfLastRead, nfFirstWrite}
+  
+  namePos*          = 0 ## Name of the type/proc-like node
+  patternPos*       = 1 ## empty except for term rewriting macros
+  genericParamsPos* = 2 ## Generic parametesr in the procedure-like nodes
+  paramsPos*        = 3 ## Formal parameters in the procedure-like nodes
+  pragmasPos*       = 4 ## Position of the pragma in the procedure-like nodes
+  miscPos*          = 5 ## used for undocumented and hacky stuff
+  bodyPos*          = 6 ## position of body; use rodread.getBody() instead!
+  resultPos*        = 7
+  dispatcherPos*    = 8
+
+  wrongNodePos*     = 0 ## Error the ast node we swapped
+  errorKindPos*     = 1 ## Error kind enum as an intlit
+  compilerInfoPos*  = 2 ## Error compiler source file as strlit, line & col
+                        ## on info
+  firstArgPos*      = 3 ## Error first 0..n additional nodes depends on
+                        ## error kind
+
+  nfAllFieldsSet* = nfBase2
+
+  nkCallKinds* = {nkCall, nkInfix, nkPrefix, nkPostfix,
+                  nkCommand, nkCallStrLit, nkHiddenCallConv}
+  nkIdentKinds* = {nkIdent, nkSym, nkAccQuoted, nkOpenSymChoice,
+                   nkClosedSymChoice}
+
+  nkPragmaCallKinds* = {nkExprColonExpr, nkCall, nkCallStrLit}
+  nkLiterals* = {nkCharLit..nkTripleStrLit}
+  nkFloatLiterals* = {nkFloatLit..nkFloat128Lit}
+  nkLambdaKinds* = {nkLambda, nkDo}
+  declarativeDefs* = {nkProcDef, nkFuncDef, nkMethodDef, nkIteratorDef, nkConverterDef}
+  routineDefs* = declarativeDefs + {nkMacroDef, nkTemplateDef}
+  procDefs* = nkLambdaKinds + declarativeDefs
+  callableDefs* = nkLambdaKinds + routineDefs
+
+  nkSymChoices* = {nkClosedSymChoice, nkOpenSymChoice}
+  nkStrKinds* = {nkStrLit..nkTripleStrLit}
+  nkIntKinds* = {nkCharLit .. nkUInt64Lit}
+
+  skLocalVars* = {skVar, skLet, skForVar, skParam, skResult}
+  skProcKinds* = {skProc, skFunc, skTemplate, skMacro, skIterator,
+                  skMethod, skConverter}
+
+  # memory layout consts for types
+  defaultSize* = -1
+  defaultAlignment* = -1
+  defaultOffset* = -1
+
+  nodeKindsProducedByParse* = {
+    nkError, nkEmpty,
+    nkIdent,
+
+    nkCharLit,
+    nkIntLit, nkInt8Lit, nkInt16Lit, nkInt32Lit, nkInt64Lit,
+    nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit,
+    nkFloatLit, nkFloat32Lit, nkFloat64Lit, nkFloat128Lit,
+    nkStrLit, nkRStrLit, nkTripleStrLit,
+    nkNilLit,
+
+    nkCall, nkCommand, nkCallStrLit, nkInfix, nkPrefix, nkPostfix,
+
+    nkExprEqExpr, nkExprColonExpr, nkIdentDefs, nkConstDef, nkVarTuple, nkPar,
+    nkBracket, nkCurly, nkTupleConstr, nkObjConstr, nkTableConstr,
+    nkBracketExpr, nkCurlyExpr,
+
+    nkPragmaExpr, nkPragma, nkPragmaBlock,
+
+    nkDotExpr, nkAccQuoted,
+
+    nkIfExpr, nkIfStmt, nkElifBranch, nkElifExpr, nkElse, nkElseExpr,
+    nkCaseStmt, nkOfBranch,
+    nkWhenStmt,
+
+    nkForStmt, nkWhileStmt,
+
+    nkBlockExpr, nkBlockStmt,
+
+    nkDiscardStmt, nkContinueStmt, nkBreakStmt, nkReturnStmt, nkRaiseStmt,
+    nkYieldStmt,
+
+    nkTryStmt, nkExceptBranch, nkFinally,
+
+    nkDefer,
+
+    nkLambda, nkDo,
+
+    nkBind, nkBindStmt, nkMixinStmt,
+
+    nkCast,
+    nkStaticStmt,
+
+    nkAsgn,
+
+    nkGenericParams,
+    nkFormalParams,
+
+    nkStmtList, nkStmtListExpr,
+
+    nkImportStmt, nkImportExceptStmt, nkImportAs, nkFromStmt,
+
+    nkIncludeStmt,
+
+    nkExportStmt, nkExportExceptStmt,
+
+    nkConstSection, nkLetSection, nkVarSection,
+
+    nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef, nkIteratorDef,
+    nkMacroDef, nkTemplateDef,
+
+    nkTypeSection, nkTypeDef,
+
+    nkEnumTy, nkEnumFieldDef,
+
+    nkObjectTy, nkTupleTy, nkProcTy, nkIteratorTy,
+
+    nkRecList, nkRecCase, nkRecWhen,
+
+    nkTypeOfExpr,
+
+    # nkConstTy,
+    nkRefTy, nkVarTy, nkPtrTy, nkStaticTy, nkDistinctTy,
+    nkMutableTy,
+
+    nkTupleClassTy, nkTypeClassTy,
+
+    nkOfInherit,
+
+    nkArgList,
+
+    nkWith, nkWithout,
+
+    nkAsmStmt,
+    nkCommentStmt,
+
+    nkUsingStmt,
+  }
+
+proc getPIdent*(a: PNode): PIdent {.inline.} =
+  ## Returns underlying `PIdent` for `{nkSym, nkIdent}`, or `nil`.
+  # xxx consider whether also returning the 1st ident for {nkOpenSymChoice, nkClosedSymChoice}
+  # which may simplify code.
+  case a.kind
+  of nkSym: a.sym.name
+  of nkIdent: a.ident
+  else: nil
+
+proc getnimblePkg*(a: PSym): PSym =
+  result = a
+  while result != nil:
+    case result.kind
+    of skModule:
+      result = result.owner
+      assert result.kind == skPackage
+    of skPackage:
+      if result.owner == nil:
+        break
+      else:
+        result = result.owner
+    else:
+      assert false, $result.kind
+
+const
+  moduleShift = when defined(cpu32): 20 else: 24
+
+template id*(a: PIdObj): int =
+  let x = a
+  (x.itemId.module.int shl moduleShift) + x.itemId.item.int
+
+
+const
+  UnspecifiedLockLevel* = TLockLevel(-1'i16)
+  MaxLockLevel* = 1000'i16
+  UnknownLockLevel* = TLockLevel(1001'i16)
+  AttachedOpToStr*: array[TTypeAttachedOp, string] = [
+    "=destroy", "=copy", "=sink", "=trace", "=deepcopy"]
+
+
+proc `$`*(x: TLockLevel): string =
+  if x.ord == UnspecifiedLockLevel.ord: result = "<unspecified>"
+  elif x.ord == UnknownLockLevel.ord: result = "<unknown>"
+  else: result = $int16(x)
+
+proc `$`*(s: PSym): string =
+  if s != nil:
+    result = s.name.s & "@" & $s.id
+  else:
+    result = "<nil>"
+
+
+proc getnimblePkgId*(a: PSym): int =
+  let b = a.getnimblePkg
+  result = if b == nil: -1 else: b.id
+
+
+proc isCallExpr*(n: PNode): bool =
+  result = n.kind in nkCallKinds
+
+proc safeLen*(n: PNode): int {.inline.} =
+  ## works even for leaves.
+  if n.kind in {nkNone..nkNilLit}: result = 0
+  else: result = n.len
+
+proc getDeclPragma*(n: PNode): PNode =
+  ## return the `nkPragma` node for declaration `n`, or `nil` if no pragma was found.
+  ## Currently only supports routineDefs + {nkTypeDef}.
+  case n.kind
+  of routineDefs:
+    if n[pragmasPos].kind != nkEmpty: result = n[pragmasPos]
+  of nkTypeDef:
+    #[
+    type F3*{.deprecated: "x3".} = int
+
+    TypeSection
+      TypeDef
+        PragmaExpr
+          Postfix
+            Ident "*"
+            Ident "F3"
+          Pragma
+            ExprColonExpr
+              Ident "deprecated"
+              StrLit "x3"
+        Empty
+        Ident "int"
+    ]#
+    if n[0].kind == nkPragmaExpr:
+      result = n[0][1]
+  else:
+    # support as needed for `nkIdentDefs` etc.
+    result = nil
+  if result != nil:
+    assert result.kind == nkPragma, $(result.kind, n.kind)
+
+
+template previouslyInferred*(t: PType): PType =
+  if t.sons.len > 1: t.lastSon else: nil
+
+
+proc astdef*(s: PSym): PNode =
+  ## get only the definition (initializer) portion of the ast
+  if s.ast != nil and s.ast.kind == nkIdentDefs:
+    s.ast[2]
+  else:
+    s.ast
+
+
+proc isMetaType*(t: PType): bool =
+  return t.kind in tyMetaTypes or
+         (t.kind == tyStatic and t.n == nil) or
+         tfHasMeta in t.flags
+
+proc isUnresolvedStatic*(t: PType): bool =
+  return t.kind == tyStatic and t.n == nil
+
+template fileIdx*(c: PSym): FileIndex =
+  assert c.kind == skModule, "this should be used only on module symbols"
+  c.position.FileIndex
+
+template filename*(c: PSym): string =
+  assert c.kind == skModule, "this should be used only on module symbols"
+  c.position.FileIndex.toFilename
+
+
+func lastSon*(n: Indexable): Indexable =
+  {.cast(noSideEffect).}:
+    # erroneously inferred side-effect
+    n.sons[^1]
+
+
+proc skipTypes*(t: PType, kinds: TTypeKinds): PType =
+  ## Used throughout the compiler code to test whether a type tree contains or
+  ## doesn't contain a specific type/types - it is often the case that only the
+  ## last child nodes of a type tree need to be searched. This is a really hot
+  ## path within the compiler!
+  result = t
+  while result.kind in kinds: result = lastSon(result)
+
+proc skipDistincts*(t: PType): PType {.inline.} =
+  ## Skips over all possible distinct instantiations, getting base.
+  skipTypes(t, {tyAlias, tyGenericInst, tyDistinct})
+
+proc skipTypes*(t: PType, kinds: TTypeKinds; maxIters: int): PType =
+  result = t
+  var i = maxIters
+  while result.kind in kinds:
+    result = lastSon(result)
+    dec i
+    if i == 0: return nil
+
+proc skipTypesOrNil*(t: PType, kinds: TTypeKinds): PType =
+  ## same as skipTypes but handles 'nil'
+  result = t
+  while result != nil and result.kind in kinds:
+    if result.len == 0: return nil
+    result = lastSon(result)
+
+proc hasSonWith*(n: PNode, kind: TNodeKind): bool =
+  for i in 0..<n.len:
+    if n[i].kind == kind:
+      return true
+  result = false
+
+proc hasNilSon*(n: PNode): bool =
+  for i in 0..<n.safeLen:
+    if n[i] == nil:
+      return true
+    elif hasNilSon(n[i]):
+      return true
+  result = false
+
+proc containsNode*(n: PNode, kinds: TNodeKinds): bool =
+  if n == nil: return
+  case n.kind
+  of nkEmpty..nkNilLit: result = n.kind in kinds
+  else:
+    for i in 0..<n.len:
+      if n.kind in kinds or containsNode(n[i], kinds): return true
+
+proc hasSubnodeWith*(n: PNode, kind: TNodeKind): bool =
+  case n.kind
+  of nkEmpty..nkNilLit, nkFormalParams: result = n.kind == kind
+  else:
+    for i in 0..<n.len:
+      if (n[i].kind == kind) or hasSubnodeWith(n[i], kind):
+        return true
+    result = false
+
+proc getInt*(a: PNode): Int128 =
+  case a.kind
+  of nkCharLit, nkUIntLit..nkUInt64Lit:
+    result = toInt128(cast[uint64](a.intVal))
+  of nkInt8Lit..nkInt64Lit:
+    result = toInt128(a.intVal)
+  of nkIntLit:
+    # XXX: enable this assert
+    # assert a.typ.kind notin {tyChar, tyUint..tyUInt64}
+    result = toInt128(a.intVal)
+  else:
+    raiseRecoverableError("cannot extract number from invalid AST node")
+
+proc getInt64*(a: PNode): int64 {.deprecated: "use getInt".} =
+  case a.kind
+  of nkCharLit, nkUIntLit..nkUInt64Lit, nkIntLit..nkInt64Lit:
+    result = a.intVal
+  else:
+    raiseRecoverableError("cannot extract number from invalid AST node")
+
+proc getFloat*(a: PNode): BiggestFloat =
+  case a.kind
+  of nkFloatLiterals: result = a.floatVal
+  of nkCharLit, nkUIntLit..nkUInt64Lit, nkIntLit..nkInt64Lit:
+    result = BiggestFloat a.intVal
+  else:
+    raiseRecoverableError("cannot extract number from invalid AST node")
+    #doAssert false, "getFloat"
+    #internalError(a.info, "getFloat")
+    #result = 0.0
+
+proc getStr*(a: PNode): string =
+  case a.kind
+  of nkStrLit..nkTripleStrLit: result = a.strVal
+  of nkNilLit:
+    # let's hope this fixes more problems than it creates:
+    result = ""
+  else:
+    raiseRecoverableError("cannot extract string from invalid AST node")
+    #doAssert false, "getStr"
+    #internalError(a.info, "getStr")
+    #result = ""
+
+proc getStrOrChar*(a: PNode): string =
+  case a.kind
+  of nkStrLit..nkTripleStrLit: result = a.strVal
+  of nkCharLit..nkUInt64Lit: result = $chr(int(a.intVal))
+  else:
+    raiseRecoverableError("cannot extract string from invalid AST node")
+    #doAssert false, "getStrOrChar"
+    #internalError(a.info, "getStrOrChar")
+    #result = ""
+
+proc isGenericParams*(n: PNode): bool {.inline.} =
+  ## used to judge whether a node is generic params.
+  n != nil and n.kind == nkGenericParams
+
+proc isGenericRoutine*(n: PNode): bool  {.inline.} =
+  n != nil and n.kind in callableDefs and n[genericParamsPos].isGenericParams
+
+proc isError*(n: PNode): bool {.inline.} =
+  ## whether the node is an error, strictly checks nkError and is nil safe
+  n != nil and n.kind == nkError
+
+proc isError*(s: PSym): bool {.inline.} =
+  ## whether the symbol is an error, strictly checks skError, an error node
+  ## exists, and is nil safe.
+  s != nil and s.kind == skError and s.ast.isError
+
+proc isError*(t: PType): bool {.inline.} =
+  ## whether the type is an error. useful because of compiler legacy, as
+  ## `tyError` isn't an enum field rather a const refering to `tyProxy`.
+  ##
+  ## xxx: currently we have no way to disambiguate between legacy and new
+  t != nil and t.kind == tyError
+
+proc isErrorLike*(t: PType): bool {.inline.} =
+  ## whether the type is an error. useful because of compiler legacy, as
+  ## `tyError` isn't an enum field rather a const refering to `tyProxy`.
+  ##
+  ## xxx: currently we have no way to disambiguate between legacy and new
+  t != nil and (t.kind == tyError or t.sym.isError)
+
+proc isErrorLike*(s: PSym): bool {.inline.} =
+  ## whether the symbol is an error. useful because of compiler legacy, as
+  ## `skError` isn't an enum field rather a const refering to `skUnkonwn`. we
+  ## disambiguate via the presence of the ast field being non-nil and of kind
+  ## `nkError`
+  s != nil and (s.isError or s.typ.isError)
+
+proc isErrorLike*(n: PNode): bool {.inline.} =
+  ## whether the node is an error, including error symbol, or error type
+  ## xxx: longer term we should probably not produce nodes like these in the
+  ##      first place and mark them as nkErrors with an appropriate error kind.
+  n != nil and (
+      case n.kind
+      of nkError: true
+      of nkSym: n.sym.isErrorLike
+      of nkType: n.typ.isErrorLike
+      else: n.typ.isError # if it has a type, it shouldn't be an error
+    )
+
+proc isGenericRoutineStrict*(s: PSym): bool {.inline.} =
+  ## determines if this symbol represents a generic routine
+  ## the unusual name is so it doesn't collide and eventually replaces
+  ## `isGenericRoutine`
+  s.kind in skProcKinds and s.ast.isGenericRoutine
+
+proc isGenericRoutine*(s: PSym): bool {.inline.} =
+  ## determines if this symbol represents a generic routine or an instance of
+  ## one. This should be renamed accordingly and `isGenericRoutineStrict`
+  ## should take this name instead.
+  ##
+  ## Warning/XXX: Unfortunately, it considers a proc kind symbol flagged with
+  ## sfFromGeneric as a generic routine. Instead this should likely not be the
+  ## case and the concepts should be teased apart:
+  ## - generic definition
+  ## - generic instance
+  ## - either generic definition or instance
+  s.kind in skProcKinds and (sfFromGeneric in s.flags or
+                             s.ast.isGenericRoutine)
+
+proc skipGenericOwner*(s: PSym): PSym =
+  ## Generic instantiations are owned by their originating generic
+  ## symbol. This proc skips such owners and goes straight to the owner
+  ## of the generic itself (the module or the enclosing proc).
+  result = if s.kind in skProcKinds and sfFromGeneric in s.flags:
+             s.owner.owner
+           else:
+             s.owner
+
+proc originatingModule*(s: PSym): PSym =
+  result = s.owner
+  while result.kind != skModule: result = result.owner
+
+proc isRoutine*(s: PSym): bool {.inline.} =
+  result = s.kind in skProcKinds
+
+proc isCompileTimeProc*(s: PSym): bool {.inline.} =
+  result = s.kind == skMacro or
+           s.kind in {skProc, skFunc} and sfCompileTime in s.flags
+
+proc isRunnableExamples*(n: PNode): bool =
+  # Templates and generics don't perform symbol lookups.
+  result = n.kind == nkSym and n.sym.magic == mRunnableExamples or
+    n.kind == nkIdent and n.ident.s == "runnableExamples"
+
+proc requiredParams*(s: PSym): int =
+  # Returns the number of required params (without default values)
+  # XXX: Perhaps we can store this in the `offset` field of the
+  # symbol instead?
+  for i in 1..<s.typ.len:
+    if s.typ.n[i].sym.ast != nil:
+      return i - 1
+  return s.typ.len - 1
+
+proc hasPattern*(s: PSym): bool {.inline.} =
+  result = isRoutine(s) and s.ast[patternPos].kind != nkEmpty
+
+iterator items*(n: PNode): PNode =
+  for i in 0..<n.safeLen: yield n[i]
+
+iterator pairs*(n: PNode): tuple[i: int, n: PNode] =
+  for i in 0..<n.safeLen: yield (i, n[i])
+
+proc isAtom*(n: PNode): bool {.inline.} =
+  result = n.kind >= nkNone and n.kind <= nkNilLit
+
+proc isEmptyType*(t: PType): bool {.inline.} =
+  ## 'void' and 'typed' types are often equivalent to 'nil' these days:
+  result = t == nil or t.kind in {tyVoid, tyTyped}
+
+proc skipStmtList*(n: PNode): PNode =
+  if n.kind in {nkStmtList, nkStmtListExpr}:
+    for i in 0..<n.len-1:
+      if n[i].kind notin {nkEmpty, nkCommentStmt}: return n
+    result = n.lastSon
+  else:
+    result = n
+
+
+proc isImportedException*(t: PType; conf: ConfigRef): bool =
+  assert t != nil
+  if conf.exc != excCpp:
+    return false
+
+  let base = t.skipTypes({tyAlias, tyPtr, tyDistinct, tyGenericInst})
+
+  if base.sym != nil and {sfCompileToCpp, sfImportc} * base.sym.flags != {}:
+    result = true
+
+proc isInfixAs*(n: PNode): bool =
+  return n.kind == nkInfix and n[0].kind == nkIdent and n[0].ident.s == "as"
+
+proc skipColon*(n: PNode): PNode =
+  result = n
+  if n.kind == nkExprColonExpr:
+    result = n[1]
+
+proc findUnresolvedStatic*(n: PNode): PNode =
+  # n.typ == nil: see issue #14802
+  if n.kind == nkSym and n.typ != nil and n.typ.kind == tyStatic and n.typ.n == nil:
+    return n
+
+  for son in n:
+    let n = son.findUnresolvedStatic
+    if n != nil: return n
+
+  return nil
+
+when false:
+  proc containsNil*(n: PNode): bool =
+    # only for debugging
+    if n.isNil: return true
+    for i in 0..<n.safeLen:
+      if n[i].containsNil: return true
+
+
+template hasDestructor*(t: PType): bool = {tfHasAsgn, tfHasOwned} * t.flags != {}
+
+template incompleteType*(t: PType): bool =
+  t.sym != nil and {sfForward, sfNoForward} * t.sym.flags == {sfForward}
+
+template typeCompleted*(s: PSym) =
+  incl s.flags, sfNoForward
+
+template detailedInfo*(sym: PSym): string =
+  sym.name.s
+
+proc isInlineIterator*(typ: PType): bool {.inline.} =
+  typ.kind == tyProc and tfIterator in typ.flags and typ.callConv != ccClosure
+
+proc isClosureIterator*(typ: PType): bool {.inline.} =
+  typ.kind == tyProc and tfIterator in typ.flags and typ.callConv == ccClosure
+
+proc isClosure*(typ: PType): bool {.inline.} =
+  typ.kind == tyProc and typ.callConv == ccClosure
+
+proc isSinkParam*(s: PSym): bool {.inline.} =
+  s.kind == skParam and (s.typ.kind == tySink or tfHasOwned in s.typ.flags)
+
+proc isSinkType*(t: PType): bool {.inline.} =
+  t.kind == tySink or tfHasOwned in t.flags
+
+const magicsThatCanRaise = {
+  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
+
+proc canRaiseConservative*(fn: PNode): bool =
+  if fn.kind == nkSym and fn.sym.magic notin magicsThatCanRaise:
+    result = false
+  else:
+    result = true
+
+proc canRaise*(fn: PNode): bool =
+  if fn.kind == nkSym and (fn.sym.magic notin magicsThatCanRaise or
+      {sfImportc, sfInfixCall} * fn.sym.flags == {sfImportc} or
+      sfGeneratedOp in fn.sym.flags):
+    result = false
+  elif fn.kind == nkSym and fn.sym.magic == mEcho:
+    result = true
+  else:
+    # TODO check for n having sons? or just return false for now if not
+    if fn.typ != nil and fn.typ.n != nil and fn.typ.n[0].kind == nkSym:
+      result = false
+    else:
+      result = fn.typ != nil and fn.typ.n != nil and ((fn.typ.n[0].len < effectListLen) or
+        (fn.typ.n[0][exceptionEffects] != nil and
+        fn.typ.n[0][exceptionEffects].safeLen > 0))
+
+proc skipAddr*(n: PNode): PNode {.inline.} =
+  if n.kind == nkHiddenAddr: n[0] else: n
+
+proc isNewStyleConcept*(n: PNode): bool {.inline.} =
+  assert n.kind == nkTypeClassTy
+  result = n[0].kind == nkEmpty

--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -132,6 +132,8 @@ proc lookupInRecord(n: PNode, field: PIdent): PSym =
   else: return nil
 
 proc getModule*(s: PSym): PSym =
+  ## if it's a module returns itself, otherwise looks through `s`' owners, may
+  ## return nil if none are found.
   result = s
   assert((result.kind == skModule) or (result.owner != result))
   while result != nil and result.kind != skModule: result = result.owner

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -142,7 +142,8 @@ template wrapErrorInSubTree*(conf: ConfigRef, wrongNodeContainer: PNode): PNode 
   ## down the tree, this is used to wrap the `wrongNodeContainer` in an nkError
   ## node but no message will be reported for it.
   var e = errorSubNode(wrongNodeContainer)
-  assert e != nil, "there must be an error node within"
+  {.line.}:
+    assert e != nil, "there must be an error node within"
   newError(
     conf,
     wrongNodeContainer,

--- a/compiler/ast/idents.nim
+++ b/compiler/ast/idents.nim
@@ -13,9 +13,14 @@
 ## id. This module is essential for the compiler's performance.
 
 import
-  hashes, wordrecg
+  std/[
+    hashes
+  ],
+  compiler/ast/[
+    ast_types,
+    wordrecg
+  ]
 
-import ast_types
 export PIdent
 
 type

--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -149,8 +149,15 @@ proc getLineInfo*(L: Lexer, tok: Token): TLineInfo {.inline.} =
     result.commentOffsetA = tok.commentOffsetA
     result.commentOffsetB = tok.commentOffsetB
 
-proc isKeyword*(kind: TokType): bool =
+func isKeyword*(kind: TokType): bool =
   (kind >= tokKeywordLow) and (kind <= tokKeywordHigh)
+
+func isKeyword*(i: PIdent): bool =
+  ## is this the `i`dentifier a keyword?
+  # xxx: not the best place for this, but putting it in `idents` leads to a
+  #      circular dependency; likely need an intermediate module
+  (i.id >= ord(tokKeywordLow) - ord(tkSymbol)) and
+    (i.id <= ord(tokKeywordHigh) - ord(tkSymbol))
 
 template ones(n): untyped = ((1 shl n)-1) # for utf-8 conversion
 

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -30,7 +30,6 @@ import
     msgs,
   ]
 
-
 type
   TRenderFlag* = enum
     renderNone, renderNoBody, renderNoComments, renderDocComments,
@@ -80,11 +79,6 @@ proc disamb(g: var TSrcGen; s: PSym): int =
     if s.name.s == g.mangler[i].name.s: inc result
   g.mangler.add s
 
-proc isKeyword*(i: PIdent): bool =
-  if (i.id >= ord(tokKeywordLow) - ord(tkSymbol)) and
-      (i.id <= ord(tokKeywordHigh) - ord(tkSymbol)):
-    result = true
-
 proc renderDefinitionName*(s: PSym, noQuotes = false): string =
   ## Returns the definition name of the symbol.
   ##
@@ -92,7 +86,7 @@ proc renderDefinitionName*(s: PSym, noQuotes = false): string =
   ## happen if the name happens to be a keyword or the first character is not
   ## part of the SymStartChars set.
   let x = s.name.s
-  if noQuotes or (x[0] in SymStartChars and not renderer.isKeyword(s.name)):
+  if noQuotes or (x[0] in SymStartChars and not lexer.isKeyword(s.name)):
     result = x
   else:
     result = '`' & x & '`'
@@ -1315,7 +1309,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
                 elif n[0].kind in {nkOpenSymChoice, nkClosedSymChoice}: n[0][0].sym.name
                 else: nil
       let nNext = skipHiddenNodes(n[1])
-      if nNext.kind == nkPrefix or (opr != nil and renderer.isKeyword(opr)):
+      if nNext.kind == nkPrefix or (opr != nil and lexer.isKeyword(opr)):
         put(g, tkSpaces, Space)
       if nNext.kind == nkInfix:
         put(g, tkParLe, "(")

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -108,7 +108,7 @@ proc initLoc(result: var TLoc, k: TLocKind, lode: PNode, s: TStorageLoc) =
   result.flags = {}
 
 proc fillLoc(a: var TLoc, k: TLocKind, lode: PNode, r: Rope, s: TStorageLoc) =
-  # fills the loc if it is not already initialized
+  ## fills the loc if it is not already initialized
   if a.k == locNone:
     a.k = k
     a.lode = lode

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -673,7 +673,7 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   ## level statement basis, with the `PContext` parameter `c` acting as an
   ## accumulator across the various top level statements, modules, and overall
   ## program compilation.
-  addInNimDebugUtils(c.config, "semStmtAndGenerateGenerics")
+  addInNimDebugUtils(c.config, "semStmtAndGenerateGenerics", n, result)
 
   if c.isfirstTopLevelStmt and not isImportSystemStmt(c.graph, n):
     if sfSystemModule notin c.module.flags and not isEmptyTree(n):

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1959,9 +1959,10 @@ proc whereToBindTypeHook(c: PContext; t: PType): PType =
 proc bindTypeHook(c: PContext; s: PSym; n: PNode; op: TTypeAttachedOp) =
   let t = s.typ
   var noError = false
-  let cond = if op == attachedDestructor:
+  let cond = case op
+             of attachedDestructor:
                t.len == 2 and t[0] == nil and t[1].kind == tyVar
-             elif op == attachedTrace:
+             of attachedTrace:
                t.len == 3 and t[0] == nil and t[1].kind == tyVar and t[2].kind == tyPointer
              else:
                t.len >= 2 and t[0] == nil

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -300,13 +300,13 @@ template addInNimDebugUtils*(
     addInNimDebugUtilsAux(c, action, enterMsg, leaveMsg)
 
 template addInNimDebugUtils*(
-    c: ConfigRef; action: string; sym: PSym; n: PNode; res: PNode) =
+    c: ConfigRef; action: string; s: PSym; n: PNode; res: PNode) =
   ## add tracing to procs that are primarily `PSym, PNode -> PNode`, such as
   ## applying pragmas to a symbol
   when defined(nimDebugUtils):
     template enterMsg(indentLevel: int) =
       traceEnterIt(stepParams(c, stepSymNodeToNode, indentLevel, action)):
-        it.sym = sym
+        it.sym = s
         it.node = n
 
     template leaveMsg(indentLevel: int) =

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -3496,7 +3496,7 @@ const evalPass* = makePass(myOpen, myProcess, myClose)
 proc evalConstExprAux(module: PSym; idgen: IdGenerator;
                       g: ModuleGraph; prc: PSym, n: PNode,
                       mode: TEvalMode): PNode =
-  addInNimDebugUtils(g.config, "evalConstExprAux")
+  addInNimDebugUtils(g.config, "evalConstExprAux", prc, n, result)
   #if g.config.errorCounter > 0: return n
   let n = transformExpr(g, idgen, module, n)
   setupGlobalCtx(module, g, idgen)

--- a/tools/koch/kochdocs.nim
+++ b/tools/koch/kochdocs.nim
@@ -1,9 +1,14 @@
 ## Part of 'koch' responsible for the documentation generation.
 
-import os, strutils, osproc, sets, pathnorm, sequtils, json
+import std/[ os, strutils, osproc, sets, sequtils, json ]
+
+when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
+  import std/pathnorm
+
 # XXX: Remove this feature check once the csources supports it.
 when defined(nimHasCastPragmaBlocks):
   import std/pegs
+
 from std/private/globs import nativeToUnixPath, walkDirRecFilter, PathEntry
 from packages/docutils/highlite import nimKeywordsSynchronizationCheck
 import ".."/".."/compiler/utils/[nversion]


### PR DESCRIPTION
## Summary

Broke up the ast module a bit more just to see various independent parts
more clearly.

## Details

It's meant as an intermediate change to help identify issues.
Initially I tried to rework sem to avoid includes, these are takeaways
from that exercise.

### Misc:

- moved isKeyword: PIdent -> bool to lexer from renderer
- cleaned up tracing in sem and vm
---