### PR TITLE
Remove nkParForStmt node

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -151,7 +151,6 @@ type
     nkIfStmt              ## an if statement
     nkWhenStmt            ## a when expression or statement
     nkForStmt             ## a for statement
-    nkParForStmt          ## a parallel for statement
     nkWhileStmt           ## a while statement
     nkCaseStmt            ## a case statement
     nkTypeSection         ## a type section (consists of type definitions)

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -1487,7 +1487,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
   of nkPragmaBlock: gpragmaBlock(g, n)
   of nkCaseStmt, nkRecCase: gcase(g, n)
   of nkTryStmt, nkHiddenTryStmt: gtry(g, n)
-  of nkForStmt, nkParForStmt: gfor(g, n)
+  of nkForStmt: gfor(g, n)
   of nkBlockStmt, nkBlockExpr: gblock(g, n)
   of nkStaticStmt: gstaticStmt(g, n)
   of nkAsmStmt: gasm(g, n)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -3080,7 +3080,6 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
           # by ensuring it's no inner proc (owner is a module).
           # Generate proc even if empty body, bugfix #11651.
           genProc(p.module, prc)
-  of nkParForStmt: genParForStmt(p, n)
   of nkState: genState(p, n)
   of nkGotoState:
     # simply never set it back to 0 here from here on...

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2679,7 +2679,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkWhileStmt: genWhileStmt(p, n)
   of nkVarSection, nkLetSection: genVarStmt(p, n)
   of nkConstSection: discard
-  of nkForStmt, nkParForStmt:
+  of nkForStmt:
     internalError(p.config, n.info, "for statement not eliminated")
   of nkCaseStmt: genCaseJS(p, n, r)
   of nkReturnStmt: genReturnStmt(p, n)

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -121,3 +121,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasEffectsOf")
   defineSymbol("nimHasEnforceNoRaises")
   defineSymbol("nimHasNkComesFromNodeRemoved")
+  defineSymbol("nimHasNkParForStmtNodeRemoved")

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -674,18 +674,6 @@ template handleNestedTempl(n, processCall: untyped, willProduceStmt = false) =
     result.add processScope(c, bodyScope, bodyResult)
     dec c.inLoop
 
-  of nkParForStmt:
-    inc c.inLoop
-    result = shallowCopy(n)
-    let last = n.len-1
-    for i in 0..<last-1:
-      result[i] = n[i]
-    result[last-1] = p(n[last-1], c, s, normal)
-    var bodyScope = nestedScope(s)
-    let bodyResult = p(n[last], c, bodyScope, normal)
-    result[last] = processScope(c, bodyScope, bodyResult)
-    dec c.inLoop
-
   of nkBlockStmt, nkBlockExpr:
     result = copyNode(n)
     result.add n[0]
@@ -762,7 +750,7 @@ proc pRaiseStmt(n: PNode, c: var Con; s: var Scope): PNode =
 
 proc p(n: PNode; c: var Con; s: var Scope; mode: ProcessMode): PNode =
   if n.kind in {nkStmtList, nkStmtListExpr, nkBlockStmt, nkBlockExpr, nkIfStmt,
-                nkIfExpr, nkCaseStmt, nkWhen, nkWhileStmt, nkParForStmt, nkTryStmt}:
+                nkIfExpr, nkCaseStmt, nkWhen, nkWhileStmt, nkTryStmt}:
     template process(child, s): untyped = p(child, c, s, mode)
     handleNestedTempl(n, process)
   elif mode == sinkArg:

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3150,7 +3150,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkWhileStmt: result = semWhile(c, n, flags)
   of nkTryStmt, nkHiddenTryStmt: result = semTry(c, n, flags)
   of nkBreakStmt, nkContinueStmt: result = semBreakOrContinue(c, n)
-  of nkForStmt, nkParForStmt: result = semFor(c, n, flags)
+  of nkForStmt: result = semFor(c, n, flags)
   of nkCaseStmt: result = semCase(c, n, flags)
   of nkReturnStmt: result = semReturn(c, n)
   of nkUsingStmt: result = semUsing(c, n)

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -387,7 +387,7 @@ proc semGenericStmt(c: PContext, n: PNode,
         a[j] = semGenericStmt(c, a[j], flags, ctx)
       a[^1] = semGenericStmtScope(c, a[^1], flags, ctx)
     closeScope(c)
-  of nkForStmt, nkParForStmt:
+  of nkForStmt:
     openScope(c)
     n[^2] = semGenericStmt(c, n[^2], flags, ctx)
     for i in 0..<n.len - 2:

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1166,7 +1166,7 @@ proc track(tracked: PEffects, n: PNode) =
       track(tracked, n[1])
       setLen(tracked.init, oldState)
       setLen(tracked.guards.s, oldFacts)
-  of nkForStmt, nkParForStmt:
+  of nkForStmt:
     # we are very conservative here and assume the loop is never executed:
     let oldState = tracked.init.len
 

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -436,7 +436,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
         a[j] = semTemplBody(c, a[j])
       a[^1] = semTemplBodyScope(c, a[^1])
     closeScope(c)
-  of nkForStmt, nkParForStmt:
+  of nkForStmt:
     openScope(c)
     n[^2] = semTemplBody(c, n[^2])
     for i in 0..<n.len - 2:

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -228,7 +228,7 @@ proc transformConstSection(c: PTransf, v: PNode): PNode =
 
 proc hasContinue(n: PNode): bool =
   case n.kind
-  of nkEmpty..nkNilLit, nkForStmt, nkParForStmt, nkWhileStmt: discard
+  of nkEmpty..nkNilLit, nkForStmt, nkWhileStmt: discard
   of nkContinueStmt: result = true
   else:
     for i in 0..<n.len:
@@ -943,8 +943,6 @@ proc transform(c: PTransf, n: PNode): PNode =
     result = n
   of nkForStmt:
     result = transformFor(c, n)
-  of nkParForStmt:
-    result = transformSons(c, n)
   of nkCaseStmt:
     result = transformCase(c, n)
   of nkWhileStmt: result = transformWhile(c, n)

--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -781,7 +781,7 @@ proc traverse(c: var Partitions; n: PNode) =
     inc c.inNoSideEffectSection, enforceNoSideEffects
     traverse(c, n.lastSon)
     dec c.inNoSideEffectSection, enforceNoSideEffects
-  of nkWhileStmt, nkForStmt, nkParForStmt:
+  of nkWhileStmt, nkForStmt:
     for child in n: traverse(c, child)
     # analyse loops twice so that 'abstractTime' suffices to detect cases
     # like:
@@ -866,7 +866,7 @@ proc computeLiveRanges(c: var Partitions; n: PNode) =
 
   of nkPragmaBlock:
     computeLiveRanges(c, n.lastSon)
-  of nkWhileStmt, nkForStmt, nkParForStmt:
+  of nkWhileStmt, nkForStmt:
     for child in n: computeLiveRanges(c, child)
     # analyse loops twice so that 'abstractTime' suffices to detect cases
     # like:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -33,7 +33,7 @@ type
     nnkDotCall = when defined(nimHasNkComesFromNodeRemoved):
                    ord(nnkNilLit) + 1
                  else:
-                   # Skip what would be nnkComesFrom, if we compiling with a
+                   # Skip what would be nnkComesFrom, if compiled with a
                    # compiler that still has nkComesFrom (e.g. in bootstrapping)
                    ord(nnkNilLit) + 2
     nnkCommand, nnkCall, nnkCallStrLit, nnkInfix,
@@ -57,7 +57,14 @@ type
     nnkMacroDef, nnkTemplateDef, nnkIteratorDef, nnkOfBranch,
     nnkElifBranch, nnkExceptBranch, nnkElse,
     nnkAsmStmt, nnkPragma, nnkPragmaBlock, nnkIfStmt, nnkWhenStmt,
-    nnkForStmt, nnkParForStmt, nnkWhileStmt, nnkCaseStmt,
+    nnkForStmt,
+    nnkWhileStmt = when defined(nimHasNkParForStmtNodeRemoved):
+                     ord(nnkForStmt) + 1
+                   else:
+                     # Skip what would be nnkParForStmt, if compiled with a compiler
+                     # compiler that still has nkParForStmt (e.g. in bootstrapping)
+                     ord(nnkForStmt) + 2
+    nnkCaseStmt,
     nnkTypeSection, nnkVarSection, nnkLetSection, nnkConstSection,
     nnkConstDef, nnkTypeDef,
     nnkYieldStmt, nnkDefer, nnkTryStmt, nnkFinally, nnkRaiseStmt,


### PR DESCRIPTION
## Summary
Removes nkParForStmt node which is unused since https://github.com/nim-works/nimskull/commit/60d96a55953b8d2778e3d461858f515e45369c4a

## Details
Bootstrapping is made to work by changing the ordinal mapping of node kinds in lib/macros depending on wether we compile with a compiler that has or doesn't have nkParForStmt, similar to https://github.com/nim-works/nimskull/commit/63bea9dcda428b47ca0885d660e13c980a9c1f10

