### PR TITLE
vm: rename `FunctionTypeId` to `RoutineSigId`

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1315,7 +1315,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       let handle = regs[ra].handle
       assert handle.typ.kind in {akCallable, akClosure}
 
-      assert handle.typ.funcTypeId == c.functions[fncIdx.int].typ
+      assert handle.typ.routineSig == c.functions[fncIdx.int].sig
 
       # XXX: as a direct consequence of the state of vmgen, opcWrProc and
       #      opcWrClosure are both implemented in a rather hacky way
@@ -2113,7 +2113,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         raiseVmError(reportSem(rsemVmNilAccess))
 
       let bb = c.functions[int toFuncIndex(fPtr)]
-      assert bb.typ == h.typ.funcTypeId
+      assert bb.sig == h.typ.routineSig
       let retType = bb.retValDesc
 
       let prc = bb.prc

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -111,7 +111,7 @@ proc getOrCreateFunction*(c: var TCtx, prc: PSym): FunctionIndex =
       if procIsCallback(c, prc): f.cbOffset = -prc.offset - 2; ckCallback
       else: ckDefault
 
-    f.typ = c.typeInfoCache.getOrCreateFuncType(prc.typ)
+    f.sig = c.typeInfoCache.makeSignatureId(prc.typ)
     let rTyp = prc.getReturnType()
     if rTyp != nil and rTyp.kind != tyVoid:
       f.retValDesc = c.getOrCreate(rTyp)


### PR DESCRIPTION
The old name was confusing and didn't communicate the purpose/usage
very well. `RoutineSigId` better reflects the type's purpose.

Field and function names at `RoutineSigId` usage sites are also adjusted

### Misc:
- documentation improvements
- a redundant table lookup in `makeSignatureId` is eliminated
