### PR TITLE
vm: improve `unreachable` template

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1146,7 +1146,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       of akSeq, akArray:
         regs[ra].setHandle(getItemHandle(regs[rb].handle, idx))
       else:
-        unreachable($srcTyp.kind)
+        unreachable(srcTyp.kind)
 
     of opcLdArrAddr:
       # a = addr(b[c])
@@ -1171,7 +1171,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         let h = getItemHandle(src, idx)
         regs[ra].setAddress(h.h, h.typ)
       else:
-        unreachable($src.typ.kind) # vmgen issue
+        unreachable(src.typ.kind) # vmgen issue
 
     of opcLdStrIdx:
       decodeBC(rkInt)
@@ -1227,7 +1227,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
            dTyp.elementCount,
            dTyp.elementStride, dTyp.elementType)
         of akInt, akFloat, akSet, akPtr, akRef, akObject, akPNode, akCallable, akClosure, akDiscriminator:
-          unreachable($dTyp.kind)
+          unreachable(dTyp.kind)
 
       if idx <% maxLen:
         writeLoc(makeLocHandle(mHandle.getSubHandle(stride * idx), eTyp), regs[rc], c.memory)
@@ -2032,7 +2032,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         case x.kind
         of rkInt: $x.intVal
         of rkFloat: $x.floatVal
-        else: unreachable($x.kind)
+        else: unreachable(x.kind)
 
       let a = addr regs[ra]
       let l = addr regs[rb]
@@ -2235,7 +2235,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
               break
 
       else:
-        unreachable($value.kind)
+        unreachable(value.kind)
 
       assert c.code[pc+1].opcode == opcFJmp
       inc pc
@@ -2562,7 +2562,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         of akClosure:
           res = atom.closureVal.fnc.isNil
         of akInt, akFloat, akSet, akObject, akArray, akPNode, akDiscriminator:
-          unreachable($regs[rb].kind)
+          unreachable(regs[rb].kind)
       of rkNimNode:
         res = regs[rb].nimNode.kind == nkNilLit
       of rkAddress:
@@ -2962,7 +2962,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
           else:
             discard
         else:
-          unreachable($a.kind) # vmgen issue
+          unreachable(a.kind) # vmgen issue
 
       checkHandle(regs[rb])
       checkHandle(regs[rc])

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -542,7 +542,7 @@ proc serialize*(c: var TCtx, n: PNode, dest: LocHandle, t: PType = nil) =
             e
 
         deref(dest).closureVal = VmClosure(fnc: fnc, env: env)
-      else: unreachable($n.kind)
+      else: unreachable(n.kind)
     else:
       assert n.kind == nkSym
       assert dest.typ.kind == akCallable
@@ -593,4 +593,4 @@ proc serialize*(c: var TCtx, n: PNode, dest: LocHandle, t: PType = nil) =
         allowedFlags: {})))
 
   of tyError: unreachable("error nodes must not reach here")
-  else: unreachable($t.kind)
+  else: unreachable(t.kind)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -716,7 +716,7 @@ proc genBranchLit(c: var TCtx, n: PNode, t: PType): int =
         c.toStringCnst(it.strVal)
 
     else:
-      unreachable($t.kind)
+      unreachable(t.kind)
 
     result = c.rawGenLiteral(cnst)
 

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -362,7 +362,7 @@ func arrayLen*(loc: LocHandle): int =
   of akString:
     deref(loc).strVal.len
   else:
-    unreachable($loc.typ.kind)
+    unreachable(loc.typ.kind)
 
 
 template toOpenArray(a: VmString): untyped =
@@ -516,7 +516,7 @@ func getItemHandle*(loc: LocHandle, index: Natural): LocHandle =
     makeLocHandle(getSubHandle(loc.h, typ.elementStride * index), typ.elementType)
   else:
     # Not an array like type
-    unreachable($typ.kind)
+    unreachable(typ.kind)
 
 
 proc arrayCopy*(mm: var VmMemoryManager, dest, src: MemRegionPtr, count: Natural, elemTyp: PVmType, reset: static[bool]) =

--- a/compiler/vm/vmtypes.nim
+++ b/compiler/vm/vmtypes.nim
@@ -22,7 +22,7 @@ func elemType*(typ: PVmType): PVmType =
   of akArray:
     typ.elementType
   else:
-    unreachable($typ.kind)
+    unreachable(typ.kind)
 
 func alignedSize*(t: PVmType): uint {.inline.} =
   let


### PR DESCRIPTION
## Summary

- add an optimized overload for enum values (they're often used with
 `unreachable`)
- use the `enum` overload where applicable
- move the `raise` statement and message formatting code into
 a `.noinline` function in order to improve code size

## Details

Since the `raise` is not inside a template anymore, the original line
information is also added to the message in order to still have some
context when stact-traces are disabled

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

The `unreachable` helper template is not strictly related to only the VM and is also useful in general, so maybe it should be moved somewhere else?