### PR TITLE
More context in `undeclared identifier` error messages

### DIFF
--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -268,11 +268,11 @@ type
       of rsemExprHasNoAddress:
         isUnsafeAddr*: bool
 
-      of rsemUndeclaredIdentifier,
-         rsemCallNotAProcOrField,
-           :
-        potentiallyRecursive*: bool
+      of rsemUndeclaredIdentifier:
+        recursiveDep*: seq[tuple[importer, importee: string]] ## The list of
+        ## present recursive module imports
 
+      of rsemCallNotAProcOrField:
         explicitCall*: bool ## Whether `rsemCallNotAProcOrField` error was
         ## caused by expression with explicit dot call: `obj.cal()`
         unexpectedCandidate*: seq[PSym] ## Symbols that are syntactically

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1973,6 +1973,14 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
     of rsemUndeclaredIdentifier:
       result = "undeclared identifier: '" & r.str & "'"
+      if r.recursiveDep.len > 0:
+        result.add "\nThis might be caused by a recursive module dependency:"
+        result.add "\n "
+        for dep in r.recursiveDep.items:
+          result.addf("'$1' -> ", dep.importer)
+
+        result.addf("'$1'", r.recursiveDep[^1].importee)
+
       if r.spellingCandidates.len > 0:
         result.add "\n"
         result.add presentSpellingCandidates(

--- a/tests/errmsgs/mcyclic_import1.nim
+++ b/tests/errmsgs/mcyclic_import1.nim
@@ -1,0 +1,3 @@
+import mcyclic_import2
+
+proc x*() = discard

--- a/tests/errmsgs/mcyclic_import2.nim
+++ b/tests/errmsgs/mcyclic_import2.nim
@@ -1,0 +1,3 @@
+import mcyclic_import1
+
+proc y*() = x()

--- a/tests/errmsgs/tcyclic_import_ident_error.nim
+++ b/tests/errmsgs/tcyclic_import_ident_error.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: '''Undeclared identifier: 'x'
+'tests/errmsgs/mcyclic_import1.nim' -> 'tests/errmsgs/mcyclic_import2.nim' -> 'tests/errmsgs/mcyclic_import1.nim'
+'''
+  file: "mcyclic_import2.nim"
+"""
+
+import mcyclic_import1


### PR DESCRIPTION
## Summary
- add back hint about present recursive imports
- add corresponding error message test
- use `createUndeclaredIdentifierError` in place of manual
 re-implementation