### PR TITLE
sem: clean-up TContext docs, readers, and writers

### DIFF
--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -91,81 +91,595 @@ type
       exceptSet*: IntSet         # of PIdent.id
 
   PContext* = ref TContext
+
+  # Refactoring of `TContext` in progress:
+  # --------------------------------------
+  #
+  # TContext is used for a lot of stuff that it probably shouldn't be. In terms
+  # of compiler architecture this is post parsing, so we're taking parsed code
+  # and evaluating it. The result of this evaluation should be a value, an
+  # error, or code that can be compiled (think of the exe as a partially
+  # evaluated function, waiting for params to finish and become a value).
+  #
+  # So we're analysing, interpreting, and compiling, etc... that means we'll
+  # have various environments, overall compilation, host env, nested
+  # compilations, scopes, symbol tables, type environments, etc... all of these
+  # have various lifetimes where they're written/updated and then read/queried.
+  #
+  # `TContext` is meant to do that, but:
+  # - some things should be in the AST/IR itself (long-term)
+  # - read and write lifetimes are unclear (first thing to figure out)
+  # - there are latent bugs because of the previous point
+  #
+  # Strategy for fixing `TContext`:
+  # 1. figure out when things are written/change
+  # 2. know the various consumers/uses
+  # 3. limit the lifetime of writes and ensure ordered reads
+  # 4. refined the above until the code is not dumb
+  # 
+  # Notes about documenting `TContext` (step 1 and 2 above):
+  # 1. what writes something
+  # 2. what reads something/why
+  # 3. (optional) additional collective purpose of 1/2
+  # 4. what's the write lifetime
+  # 5. what's the read lifetime
+  # 6. is the overall lifetime less than that of the modules?
+
   TContext* = object of TPassContext ## a context represents the module
                                      ## that is currently being compiled
+
+    # -------------------------------------------------------------------------
+    # start: scope/traversal lifetime
+    # -------------------------------------------------------------------------
     enforceVoidContext*: PType
       ## for `if cond: stmt else: foo`, `foo` will be evaluated under
-      ## enforceVoidContext != nil
-    voidType*: PType # for typeof(stmt)
-    module*: PSym              ## the module sym belonging to the context
-    currentScope*: PScope      ## current scope
-    moduleScope*: PScope       ## scope for modules
-    imports*: seq[ImportedModule] ## scope for all imported symbols
-    topLevelScope*: PScope     ## scope for all top-level symbols
-    p*: PProcCon               ## procedure context
-    intTypeCache*: array[-5..32, PType] ## cache some common integer types
-                                        ## to avoid type allocations
-    nilTypeCache*: PType
-    matchedConcept*: ptr TMatchedConcept ## the current concept being matched
-    friendModules*: seq[PSym]  ## friend modules; may access private data;
-                               ## this is used so that generic instantiations
-                               ## can access private object fields
-    instCounter*: int          ## to prevent endless instantiations
-    templInstCounter*: ref int ## gives every template instantiation a unique id
-    inGenericContext*: int     ## > 0 if we are in a generic type
-    inStaticContext*: int      ## > 0 if we are inside a static: block
-    inUnrolledContext*: int    ## > 0 if we are unrolling a loop
-    compilesContextId*: int    ## > 0 if we are in a ``compiles`` magic
-    compilesContextIdGenerator*: int
-    inGenericInst*: int        ## > 0 if we are instantiating a generic
-    converters*: seq[PSym]
-    patterns*: seq[PSym]       ## sequence of pattern matchers
-    optionStack*: seq[POptionEntry]
-    symMapping*: TIdTable      ## every gensym'ed symbol needs to be mapped
-                               ## to some new symbol in a generic instantiation
-    libs*: seq[PLib]           ## all libs used by this module
-    semConstExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # for the pragmas
-    semExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
-    semTryExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
-    semTryConstExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.}
-    computeRequiresInit*: proc (c: PContext, t: PType): bool {.nimcall.}
-    hasUnresolvedArgs*: proc (c: PContext, n: PNode): bool
+      ## enforceVoidContext != nil; meaning we infered if to contain a a `stmt`
+      ## (void) and so `foo` must result in an expression that can be `void`.
+      ## Which plays into discard checks.
+      ##
+      ## It's used as a sentinel value, setting a node's typ field to this can
+      ## then be compared with later to raise errors or to see if something is
+      ## meant to be in the void context.
+      ##
+      ## `enforceVoidContext` is not the `void` type, see `voidType`
+      ## 
+      ## written: once at sem start
+      ## read:
+      ##  - semExprWithType: check if an expr has no type
+      ##  - semAsgn: ensure assignments aren't an expression
+      ##  - semstmts: for/while/etc stmt enforcement 
+    currentScope*: PScope
+      ## current scope based on semantic analysis' traversal through the ast,
+      ## then read during lookups of various symbols/idents
+      ##
+      ## written: sem/exprs/call/...
+      ## read: lookups
+    p*: PProcCon
+      ## procedure context used all over semantic analysis. Tracks various
+      ## aspects of when traversal is in a proc, top level module, blocks,
+      ## loops, etc
+      ##
+      ## written: all over sem
+      ## read: all over sem
+    # xxx: semtempl for example has a specialized context, maybe we should pull
+    #      this out too? it's not straightfoward, but even an attempt will
+    #      clean things up
 
+    # type related contexts
+    matchedConcept*: ptr TMatchedConcept
+      ## the current concept being matched
+      ##
+      ## written:
+      ##  - seminst: start of generateInstance save old one, at end restore it
+      ##  - sigmatch matchUserTypeClass
+      ## read:
+      ##  - afterCallActions
+      ##  - semExpr after ident/sym lookup and type nodes nkTypeOfExpr, etc
+      ##  - semstmts var/let, discard, list
+      ##  - sigmatch: typeRel and friends
+    inTypeContext*: int
+      ## track whether we're in a "type context", eg: type section, used by
+      ## `suggest`, but that might leak into other parts of sem.
+      ##
+      ## written: semgnrc, semstmts, semtempl, semtypes
+      ## read: suggest
+    inConceptDecl*: int
+      ## whether we're in a concept declaration, `concepts` tracks this so we
+      ## can differentiate whether it's the concept description vs the concept
+      ## check (hence need implementations and should error without one)
+      ##
+      ## written: concepts
+      ## read: semIterator (one line for errors, seems janky)
+      ##
+      ## xxx: some refactoring should allow for removal
+
+    # template and general instantiation
+    templInstCounter*: ref int
+      ## gives each template instantiation a unique id
+      ##
+      ## written:
+      ##  - init once at sem start per module
+      ##  - strung along to each new context per macro
+      ##    or template eval; it's mutable
+      ##  - evalTemplate increments it
+      ## read: captured and read in `TemplCtx`
+    instCounter*: int
+      ## To prevent endless macro pragma and generic instantiations.
+      ##
+      ## written:
+      ##  - pragmas: track macro pragmas expansions
+      ##  - seminst: track generic instantiations
+      ## read:
+      ##  - pragmas: check count and error
+      ##  - seminst: check count and error
+    inGenericContext*: int
+      ## > 0 if we are in a generic type
+      ##
+      ## written:
+      ##  - semexprs: save/restore in `tryExpr`
+      ##  - semstmts: `typeSectionRighSidePass`, guard `semTypeNode`
+      ## read:
+      ##  - semexprs: checked in `semIs`
+      ##  - semInst: `generateInstance` guard instantiation until we're out
+      ##  - semtypes: `semTypeNode` and friends guard instantiation
+    inGenericInst*: int
+      ## > 0 if we are instantiating a generic, weird this seems an awful lot
+      ## like `instCounter`
+      ## 
+      ## written:
+      ##  - semexprs: save/restore in `tryExpr`
+      ##  - semstmts: `typeSectionRighSidePass`, guard `semTypeNode`
+      ## read:
+      ##  - semexprs: checked in `semIs`
+      ##  - semInst: `generateInstance` guard instantiation until we're out
+      ##  - semtypes: `semTypeNode` and friends guard instantiation
+    generics*: seq[TInstantiationPair]
+      ## pending list of instantiated generics to compile accumulates generics
+      ## to compile for the backend on module close
+      ## 
+      ## written:
+      ##  - semexprs: save/restore in `tryExpr`
+      ##  - seminst: `fixupInsantiatedSymbols` scan generics looking for a
+      ##             match based on symbol id
+      ## read:
+      ##  - sem: module close read and add to module ast
+      ##  - seminst: `fixupInsantiatedSymbols` updates the generic, one reason
+      ##              it's mutated is to support forward declarations
+    lastGenericIdx*: int      ## used for the generics stack (`generics`)
+                              ##
+                              ## written/read:
+                              ##  - sem: updated after each close of a module,
+                              ##         why? xxx: is this because of suggest?
+                              ## NB this isn't preserved restored in `tryExpr`,
+                              ##    but it's not mutated anywhere else, suggest
+                              ##    seems to be the only thing that might need
+                              ##    this and it's likely a leak -- growing over
+                              ##    time.
+
+    # static contexts
+    inStaticContext*: int
+      ## > 0 if we are inside a static: block
+      ##
+      ## written:
+      ##  - semStaticExpr: inc/dec around semExprWithType call likely for the
+      ##                   evalAtCompileTime, see below
+      ##  - semexprs: save/restore in `tryExpr`
+      ##  - semstmts: inc/dec around semConst and semStaticStmt
+      ## read:
+      ##  - evalAtCompileTime: guard compile time eval
+      ##  - semBindSym: whether to resolve the binding or not
+      ##  - semDynamicSym: whether to bind the sym or not
+
+    # hlo??
+    inUnrolledContext*: int    ## > 0 if we are unrolling a loop
+                               ##
+                               ## written:
+                               ##  - semexprs: save/restore in `tryExpr`
+                               ##  - semfields: inc/dec guards in semForFields
+                               ##               and semForObjectFields
+                               ## read: `semVarOrLet` to determine if the var
+                               ##       or let is shadowed
+                               ## xxx: we don't read it for const, but prior to
+                               ##      evaluation aren't they shadowed?
+
+    # recursive compilation `compiles` magic
+    compilesContextId*: int 
+      ## > 0 if we are in a ``compiles`` magic
+      ## 
+      ## written:
+      ##  - semexprs: save/restore in `tryExpr`
+      ##              xxx: only for 1 level nesting some generics related hacks
+      ##  - suggest: inc/dec likely used to supress excessive error output
+      ## read:
+      ##  - lookups: guard error output and cascading errors during compiles
+      ##  - semcall: guard diagnostic/errors during compiles
+      ##  - semexpr: check imports are top level
+      ##  - seminst: use to set/fetch from the generic cache
+      ##  - sempass2: guard diagnostics during compiles context
+      ##  xxx: much of this simplifies with nkError
+    compilesContextIdGenerator*: int
+      ## sequence to generate `compilesContextId` values, only gets bumped when
+      ## we go from a non-compilesContext to a compiles context, but not from
+      ## compiles to compiles context.
+      ## 
+      ## written:
+      ##  - semexprs: save/restore in `tryExpr`; increment if we're heading
+      ##              into a nested compile from the level
+      ##              xxx: only for 1 level nesting some generics related hacks
+      ## read:
+      ##  - `tryExpr`: read and assigned to `compilesContextId`
+
+    # pragma stack varies by traversal. maybe base entries are module wide?
+    optionStack*: seq[POptionEntry]
+      ## when pragmas are pushed/popped
+      ##
+      ## written:
+      ##  - pragmas: pushed calling convention, dyn lib, etc or process pop
+      ##  - semdata: setters used to init compiler settings etc
+      ## read:
+      ##  - pragmas: check to see if proc should remove from stacktrace and
+      ##             which implicit pragmas to include
+      ##  - semtypes: if there are options then create a dummy proc type node
+      ##              to merge pragmas... xxx: this seems silly
+
+    # object construction, signature matching (named args?)
+    inUncheckedAssignSection*: int
+      ## if we're in an unassigned check, via a pragma block
+      ##
+      ## written:
+      ##  - sempragmablock in semstmts
+      ## read:
+      ##  - sigmatch: islvalue
+      ##  - semobjconstr: errors for case object/discriminator assignments
+      ##  - newHiddenAddrTaken: check to see if we're in an unsafe assignment
+      ##                        cast xxx: seems overly broad
+      ##  - analyseIfAddressTakenInCall: same check as newHiddenAddrTaken
+
+    # using statement parameter tracking
+    signatures*: TStrTable
+      ## stores types for params in `using` statements
+      ## 
+      ## written:
+      ##  - semUsing: adds an skParam symbol for lookup in semProcTypeNode
+      ## read:
+      ##  - semProcTypeNode: lookup of params defined via the `using` statement
+    # -------------------------------------------------------------------------
+    # end: scope/traversal lifetime
+    # -------------------------------------------------------------------------
+
+
+    # -------------------------------------------------------------------------
+    # start: module env; module lifetime
+    # -------------------------------------------------------------------------
+    selfName*: PIdent 
+      ## used for the experimental `this` pragma support (remove me!)
+      ## 
+      ## written:
+      ##  - pragmas: `prepareSinglePragma` writes the name of the `this` param
+      ## read:
+      ##  - seminst: `rawHandleSelf` reads the name of the `this` param
+      # xxx: remove the pragma features and this field
+
+    # lookups: imports / scopes
+    module*: PSym
+      ## the module sym belonging to the context used everywhere
+    topLevelScope*: PScope 
+      ## scope for all top-level symbols of the module as in the module's scope
+      ## 
+      ## written:
+      ##  - sem: `myopen` is called per module, and we open a new module scope
+      ##         and reset in `recoverContext` for exception recovery
+      ## read:
+      ##  - lookups: for symbol search and check if a sym is at the top level
+      ##  - semexprs: `semexpr` guard for no top level defer stmts and in
+      ##              `lookupForDeclared` for module qualified symbols
+      ##  - suggest: iterate through top level symbols for suggestions
+    imports*: seq[ImportedModule]
+      ## scope for all imported symbols
+      ##
+      ## written:
+      ##  - importer: written when adding imports
+      ## read:
+      ##  - importer: look for duplicate imports
+      ##  - lookups: to scan for imported symbols
+    friendModules*: seq[PSym] 
+      ## friend modules; may access private data; this is used so that generic
+      ## instantiations can access private object fields.
+      ##
+      ## written:
+      ##  - semdata: for each `newContext` a module is its own friend
+      ##  - semAfterMacroCall: calling a macro declared in another macro adds
+      ##                       the declaring module as a friend for the life of
+      ##                       the `semAfterMacroCall`, then we remove it
+      ##  - generateInstance: instancing a generic, like macro above, makes the
+      ##                      declaring module a friend for the lifetime of the
+      ##                      instancing, then we remove it
+      ## read:
+      ##  - suggest: scan for visible fields in `fieldVisible` which is used
+      ##             beyond suggestions
+    
+    # lookups: imports / scopes, technical whole program but maybe sandboxed
+    moduleScope*: PScope
+      ## scope where we shove module symbols, the module itself, and other
+      ## modules that are imported.
+      ## 
+      ## written:
+      ##  - lookups: push error symbols here to avoid cascading errors in
+      ##             interactive or outside of nested compilation contexts
+      ##  - sem: init in `myopen`, then add itself, during system import add
+      ##         the system module symbol
+      ## read:
+      ##  - implicitly read as it's part of the chain of scopes
+
+    # module statistics
+    topStmts*: int
+      ## counts the number of encountered top level statements
+      ##
+      ## written:
+      ##  - sem: incremented in semStmtAndGenerateGenerics
+      ## read:
+      ##  - semData: query if it's the first top level statement
+
+    # recursive includes detection
+    includedFiles*: IntSet
+      ## used to detect recursive include files
+      ##
+      ## written:
+      ##  - semdata: initialized
+      ##  - semstmts: remove included file after processing
+      ##              xxx: this is buggy and leads to bad error messages, we
+      ##                   should instead mark it as already processed for nice
+      ##                   errors about duplicate includes and declarations
+      ## read:
+      ##  - semstmts: check for recursive includes
+
+    # error reporting and suggestions
+    unusedImports*: seq[(PSym, TLineInfo)]
+      ## tracks which imports are unused, assume all new imports are unused,
+      ## then remove them from here as we encounter usages.
+      ## 
+      ## written:
+      ##  - importer: add all imported module as unused
+      ##  - suggest: `markOwnerModuleAsUsed`, used beyond suggestions
+      ## read:
+      ##  - sem: on pass close report all unused modules
+
+    features*: set[Feature]
+      ## compiler feature flags, can be varied via pragmas, so per module;
+      ## maybe that shouldn't be a thing?
+      ## 
+      ## written:
+      ##  - pragmas: `processExperimental` enable experimental features
+      ##  - semdata: init, push/pop pragma options
+      ##  - sempass2: save/restore features during strict nil checks
+      ##  - nileval: initialized for the interpreter
+      ## read:
+      ##  - lexer: for unicode operators
+      ##  - semcall: implicit deref
+      ##  - lookups: query overloadable enums
+      ##  - semgnrc: query overloadable enums
+      ##  - semtempl: query overloadable enums
+      ##  - semtypes: query overloadable enums and strict not nil
+      ##  - options: query nil checks enabled
+      ##  - sempass2: query strict effects, views, funcs, and not nil
+      ##  - typeallowed: query views
+      ##  - semmagic: query dynamic bind sym
+      ##  - semstmts: query dot and call operators
+      ##  - vm/gen/ops: query allowInfiniteLoops and vmopsDanger
+    importModuleMap*: Table[int, int]
+      ## module.id => module.id; the key is an imported module, and the value
+      ## is the real module in case of alias
+      ##
+      ## written:
+      ##  - importer: track imported module/alias and the real module
+      ## read:
+      ##  - suggest: `markOwnerModuleAsUsed`, used beyond suggestions, query
+      ##             imported module to exclude from unused modules
+    exportIndirections*: HashSet[(int, int)]
+      ## (module.id, symbol.id); the first is the exporting/origin module and
+      ## the second is the exported symbol
+      ##
+      ## written:
+      ##  - importer: track if we're reexporting a symbol
+      ## read:
+      ##  - suggest: `markOwnerModuleAsUsed`, used beyond suggestions, query
+      ##             export indirections to track usage info
+    recursiveDep*: seq[tuple[importer, importee: string]]
+      ## used to detect recursive `importer` issues populated by importer and
+      ## used by `lookups`
+      ## 
+      ## written:
+      ##  - importer: add dependency
+      ##  - lookups: truncated to avoid excessive nim check errors
+      ## read:
+      ##  - lookups: query if for possible recursive dependencies
+    # -------------------------------------------------------------------------
+    # end: module env; module lifetime
+    # -------------------------------------------------------------------------
+
+
+    # -------------------------------------------------------------------------
+    # start: caches/common defs, likely whole program, per modules sandboxing?
+    # -------------------------------------------------------------------------
+    
+    # ident cache used everywhere; sandboxed to avoid pollution?
+    cache*: IdentCache
+      ## used everywhere for identifier caching
+
+    # module graph, access back to the whole compilation
+    graph*: ModuleGraph
+      ## access to the compilation graph, used everywhere
+
+    # type lookups
+    voidType*: PType
+      ## for typeof(stmt)
+      ## 
+      ## written: sem: initialized
+      ## read: semExprWithType: set type for ast to void
+
+    intTypeCache*: array[-5..32, PType]
+      ## cache some common integer types to avoid type allocations
+      ##
+      ## written/read entirely in semdata `getIntLitType`
+    nilTypeCache*: PType
+      ## store the nil type
+      ##
+      ## written/read in semexprs getNilType
+      # xxx: seems weird we don't just init it like the voidType
+
+    # symbols/dispatch
+    converters*: seq[PSym]
+      ## track current converters and then look them up during dispatch in
+      ## `sigmatch`.
+      ##
+      ## written:
+      ##  - semdata: init and append in `addConverter` which is used when a
+      ##             converter is defined or imported
+      ## read:
+      ##  - sigmatch: to query converters
+    pureEnumFields*: TStrTable
+      ## pure enum fields that can be used unambiguously
+      ## 
+      ## written:
+      ##  - importer: add when a pure enum field is declared or imported
+      ##  - semdata: init
+      ## read:
+      ##  - lookups: search for pure enums if all else fails
+      ##  - semgnrc: lookup pure enums
+
+    # term rewriting/hlo
+    patterns*: seq[PSym]
+      ## sequence of pattern matchers used for term rewriting and also `hlo`,
+      ## where highlevel optimizations are effectively pattern matches.
+      ## 
+      ## written:
+      ##  - semdata: init and updated via addPattern, which isn't used by hlo??
+      ##  - hlo: `applyPatterns` add patterns for optimizations
+      ##  - semstmts: semProcAux adds term rewriting definitions
+      ##  - semtempl: semTemplateDef adds term rewriting definitions
+      ## read:
+      ##  - hlo: check len to see if there are patterns to apply
+    
+    # pragmas and codegen ref
+    userPragmas*: TStrTable
+      ## user pragma symbols
+      ## 
+      ## written:
+      ##  - pragmas: add user defined pragmas as encountered
+      ##  - semdata: init
+      ## read:
+      ##  - pragmas: query user pragmas to see if we need to process it now
+      ##  - semstmts: query user pragmas for proc/conv/etc annotation lookup
+      ##  - semtypes: query user pragmas for type section pragmas
+    libs*: seq[PLib]
+      ## all libs used by this module, mostly setup pragmas.
+      ##
+      ## written:
+      ##  - semdata: init
+      ##  - pragmas: add to dynamic libs
+      ## read:
+      ##  - pragmas: query dynamic libs
+
+    # hacks used for lookups
+    isAmbiguous*: bool # little hack <-- it never is "little"
+      ## track whether ident lookups are in ambiguous mode
+      ## 
+      ## written:
+      ##  - lookups: set so it can be fetched in `semexpr`
+      ##  - semexpr: set prior to lookup
+      ## read:
+      ##  - semexpr: queried to see how to treat symbol ambiguity
+    # -------------------------------------------------------------------------
+    # end: caches/common defs, likely whole program, per modules sandboxing?
+    # -------------------------------------------------------------------------
+
+
+    # -------------------------------------------------------------------------
+    # start: not entirely clear why, function pionters for certain sem calls?
+    # -------------------------------------------------------------------------
+    semConstExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # for the pragmas
+      ## used to break cyclic dependencies, init in sem during module open and
+      ## read in pragmas, semmagic, and semtypinst
+    semExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in concepts, pragmas, semtypinst, sigmatch, and suggest
+    semTryExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in sigmatch
+    semTryConstExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in semcall and sigmatch
+    computeRequiresInit*: proc (c: PContext, t: PType): bool {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in semtypinst
+    hasUnresolvedArgs*: proc (c: PContext, n: PNode): bool
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in pragmas
     semOperand*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in semcall and sigmatch
     semConstBoolExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # XXX bite the bullet
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in pragmas
     semOverloadedCall*: proc (c: PContext, n: PNode,
                               filter: TSymKinds, flags: TExprFlags): PNode {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in pragmas and semtypinst
     semTypeNode*: proc(c: PContext, n: PNode, prev: PType): PType {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in pragmas
     semInferredLambda*: proc(c: PContext, pt: TIdTable, n: PNode): PNode
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in sigmatch
     semGenerateInstance*: proc (c: PContext, fn: PSym, pt: TIdTable,
                                 info: TLineInfo): PSym
-    includedFiles*: IntSet    ## used to detect recursive include files
-    pureEnumFields*: TStrTable   ## pure enum fields that can be used unambiguously
-    userPragmas*: TStrTable
-    evalContext*: PEvalContext
-    unknownIdents*: IntSet     ## ids of all unknown identifiers to prevent
-                               ## naming it multiple times
-    generics*: seq[TInstantiationPair] ## pending list of instantiated generics to compile
-    topStmts*: int ## counts the number of encountered top level statements
-    lastGenericIdx*: int      ## used for the generics stack
-    hloLoopDetector*: int     ## used to prevent endless loops in the HLO
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in sigmatch
     instTypeBoundOp*: proc (c: PContext; dc: PSym; t: PType; info: TLineInfo;
                             op: TTypeAttachedOp; col: int): PSym {.nimcall.}
-    selfName*: PIdent
-    cache*: IdentCache
-    graph*: ModuleGraph
-    signatures*: TStrTable
-    recursiveDep*: seq[tuple[importer, importee: string]]
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in liftdestructors and semtypinst
+    # -------------------------------------------------------------------------
+    # end: not entirely clear why, function pionters for certain sem calls?
+    # -------------------------------------------------------------------------
+
+
+    # -------------------------------------------------------------------------
+    # start: sempass2; updated via traversal, lifetime module
+    # -------------------------------------------------------------------------
+    sideEffects*: Table[int, seq[(TLineInfo, PSym)]]
+      ## symbol.id => (info, sym); indexed on symbol id, tracks effects per sym
+      ## 
+      ## written/read in sempass2, for marking and listing side effects
+    # -------------------------------------------------------------------------
+    # end: sempass2; updated via traversal, lifetime module
+    # -------------------------------------------------------------------------
+
+
+    # -------------------------------------------------------------------------
+    # start: hlo; module lifetime
+    # -------------------------------------------------------------------------
+    hloLoopDetector*: int
+      ## used to prevent endless loops in the HLO
+      ## 
+      ## written/read in hlo, detect if hlo pattern
+      ## applications are looping
+    # -------------------------------------------------------------------------
+    # end: hlo; module lifetime
+    # -------------------------------------------------------------------------
+
+
+    # -------------------------------------------------------------------------
+    # start: suggestion/code completion; lifetime unsure
+    # -------------------------------------------------------------------------
     suggestionsMade*: bool
-    isAmbiguous*: bool # little hack
-    features*: set[Feature]
-    inTypeContext*, inConceptDecl*: int
-    unusedImports*: seq[(PSym, TLineInfo)]
-    exportIndirections*: HashSet[(int, int)] ## (module.id, symbol.id)
-    importModuleMap*: Table[int, int] ## (module.id, module.id)
+      ## track whether suggestion were made, written/read in sem
     lastTLineInfo*: TLineInfo
-    sideEffects*: Table[int, seq[(TLineInfo, PSym)]] ## symbol.id index
-    inUncheckedAssignSection*: int
+      ## last line info used in suggest by `markUsed` to track deprecated
+      ## symbol locations
+    # -------------------------------------------------------------------------
+    # end: suggestion/code completion; lifetime unsure
+    # -------------------------------------------------------------------------
 
 template config*(c: PContext): ConfigRef = c.graph.config
 
@@ -321,7 +835,6 @@ proc newContext*(graph: ModuleGraph; module: PSym): PContext =
   initStrTable(result.pureEnumFields)
   initStrTable(result.userPragmas)
   result.generics = @[]
-  result.unknownIdents = initIntSet()
   result.cache = graph.cache
   result.graph = graph
   initStrTable(result.signatures)

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -356,7 +356,12 @@ proc generateInstance(c: PContext, fn: PSym, pt: TIdTable,
     "Expected macro or template, but found " & $fn.kind)
 
   # generates an instantiated proc
-  if 64 < c.instCounter:
+  if c.instCounter > 64:
+    # xxx: likely buggy:
+    #      - we check for a different constant in `pragmas` (100)
+    #      - also each pragmas requires a macro eval, so it's a new context
+    #      - we don't seem to copy this value between contexts
+    #      - which means in non-trivial cases we can't terminate
     globalReport(c.config, info, SemReport(
       kind: rsemGenericInstantiationTooNested))
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1466,7 +1466,6 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
         let param = strTableGet(c.signatures, arg.name)
         if param != nil:
           typ = param.typ
-
         else:
           localReport(c.config, a, reportSym(
             rsemParameterRequiresAType, arg))


### PR DESCRIPTION
## Summary
* documented each field for TContext, purpose, writers, and consumers
* docs to understand the compiler internals and what needs fixing
* remove dead code, fix bugs/issues in writers/consumer of the data

## Details
* removed dead fields: evalContext, unknownIdents, symMapping, etc
* documented refactor strategy to allow this to be a longer lived refactor

---

## Notes for Reviewers
* the comment blocks are kinda ugly/chunky right now to first see the mess
* the idea with the above is after seeing the mess actually clean-up starts
* this will likely be a long running refactor
* after each field is documented, will figure out which clean-ups to include