### PR TITLE
testament: enable logging and pass it to runners

### DIFF
--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -1244,7 +1244,7 @@ proc parseArgs(execState: var Execution, p: var OptParser): ParseCliResult =
 proc main() =
   ## Define CLI Options/Args Parsing loops
   var
-    execState = Execution(flags: {outputColour})
+    execState = Execution(flags: {outputColour, logBackend})
     p = initOptParser()
 
   ## Main procedure
@@ -1310,6 +1310,8 @@ proc main() =
         myself &= " --batch:" & testamentData0.batchArg
       if skipFrom.len > 0:
         myself &= " " & quoteShell("--skipFrom:" & skipFrom)
+      if not backendLogging:
+        myself &= " " & quoteShell("--backendLogging:off")
 
     # Traverse the test directory
     for kind, dir in walkDir(testsDir):


### PR DESCRIPTION
## Summary
Re-enable logging by default, as it was disabled (probably a mistake)
by the refactoring.

Also forward the logging switch to runners spawned from testament.

## Details
* This is required by `ci_testresults` to function, and is also required by `--failing` and friends
* The feature is supposed to be enabled by default (according to cmdline docs)