### PR TITLE
compiler: add a first-class VM back-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dnimcache/
 *.iss
 *.log
 *.pdb
+*.nimbc
 
 mapping.txt
 tags

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -883,6 +883,8 @@ type
     rbackJsonScriptMismatch # ??? used in `extccomp.nim`, TODO figure out
     # what the original mesage was responsible for exactly
 
+    rbackVmFileWriteFailed
+
     rbackRstCannotOpenFile
     rbackRstExpected
     rbackRstGridTableNotImplemented

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -567,6 +567,11 @@ type
           outputCurrent, output, jsonFile: string
         ]
 
+      of rbackVmFileWriteFailed:
+        outFilename*: string
+        failureMsg*: string ## string rep of the ``RodFileError``, so that
+                           ## ``rodfiles`` doesn't need to be imported here
+
       else:
         discard
 

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -337,7 +337,7 @@ proc getConfigVar(conf: ConfigRef; c: TSystemCC, suffix: string): string =
   # for niminst support
   var fullSuffix = suffix
   case conf.backend
-  of backendCpp, backendJs, backendObjc: fullSuffix = "." & $conf.backend & suffix
+  of backendCpp, backendJs, backendObjc, backendNimVm: fullSuffix = "." & $conf.backend & suffix
   of backendC: discard
   of backendInvalid:
     # during parsing of cfg files; we don't know the backend yet, no point in

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3411,6 +3411,10 @@ proc reportBody*(conf: ConfigRef, r: BackendReport): string  =
         r.jsonScriptParams[2],
       ]
 
+    of rbackVmFileWriteFailed:
+      result = "writing to output file '$1' failed with error: '$2'" %
+               [r.outFilename, r.failureMsg]
+
     of rbackRstCannotOpenFile:
       result = "cannot open '$1'" % r.msg
 

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -597,6 +597,7 @@ proc parseCommand*(command: string): Command =
   of "cpp", "compiletocpp": cmdCompileToCpp
   of "objc", "compiletooc": cmdCompileToOC
   of "js", "compiletojs": cmdCompileToJS
+  of "vm", "compiletovm": cmdCompileToVM
   of "r": cmdCrun
   of "run": cmdTcc
   of "check": cmdCheck
@@ -626,6 +627,7 @@ proc setCmd*(conf: ConfigRef, cmd: Command) =
   of cmdCompileToCpp: conf.backend = backendCpp
   of cmdCompileToOC: conf.backend = backendObjc
   of cmdCompileToJS: conf.backend = backendJs
+  of cmdCompileToVM: conf.backend = backendNimVm
   else: discard
 
 proc setCommandEarly*(conf: ConfigRef, command: string) =
@@ -771,7 +773,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     processOnOffSwitchG(
       conf, {optWholeProject, optGenIndex}, arg, pass, info, switch)
   of "gc":
-    if conf.backend == backendJs: return # for: bug #16033
+    if conf.backend in {backendJs, backendNimVm}: return # for: bug #16033
     expectArg(conf, switch, arg, pass, info)
     if pass in {passCmd2, passPP}:
       case arg.normalize

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -139,6 +139,7 @@ type
     backendCpp = "cpp"
     backendJs = "js"
     backendObjc = "objc"
+    backendNimVm = "vm"
     # backendNimscript = "nimscript" # this could actually work
     # backendLlvm = "llvm" # probably not well supported; was cmdCompileToLLVM
 
@@ -150,6 +151,7 @@ type
     cmdCompileToCpp
     cmdCompileToOC
     cmdCompileToJS
+    cmdCompileToVM
     cmdCrun        ## compile and run in nimache
     cmdTcc         ## run the project via TCC backend
     cmdCheck       ## semantic checking for whole project

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -47,7 +47,7 @@ const
   spellSuggestSecretSauce* = -1
 
 const
-  cmdBackends* = {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToJS, cmdCrun}
+  cmdBackends* = {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToJS, cmdCompileToVM, cmdCrun}
   cmdDocLike* = {cmdDoc, cmdDoc2tex, cmdJsondoc, cmdCtags, cmdBuildindex}
 
 type

--- a/compiler/front/scriptconfig.nim
+++ b/compiler/front/scriptconfig.nim
@@ -62,6 +62,9 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
               graph: ModuleGraph; idgen: IdGenerator): PEvalContext =
   # For Nimble we need to export 'setupVM'.
   result = newCtx(module, cache, graph, idgen)
+  # for backwards compatibility, allow meta expressions in nimscript (this
+  # matches the previous behaviour)
+  result.codegenInOut.flags = {cgfAllowMeta}
   result.mode = emRepl
   registerBasicOps(result[])
   let conf = graph.config

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -106,6 +106,9 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
         # tasyncjs_fail` would fail, refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
         if cmdPrefix.len == 0: cmdPrefix = findNodeJs().quoteShell
         cmdPrefix.add " --unhandled-rejections=strict"
+      of backendNimVm:
+        if cmdPrefix.len == 0:
+          cmdPrefix = changeFileExt(getAppDir() / "vmrunner", ExeExt)
       else: doAssert false, $conf.backend
       if cmdPrefix.len > 0: cmdPrefix.add " "
         # without the `cmdPrefix.len > 0` check, on windows you'd get a cryptic:

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -159,6 +159,7 @@ proc createInterpreter*(
   incl(m.flags, sfMainModule)
   var idgen = idGeneratorFromModule(m)
   var vm = newCtx(m, cache, graph, idgen)
+  vm.codegenInOut.flags = {cgfAllowMeta}
   vm.mode = emRepl
   vm.features = flags
   if registerOps:

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -1,0 +1,965 @@
+## This module contains the type definitions for a packed representation of
+## all the state required for loading and running a standalone VM instance.
+##
+## In addition, procedures for storing and loading the original objects to and
+## from the packed environment object are also located here.
+##
+## For reading and writing `PackedEnv` to files, a ``rodfile``-based solution
+## is provided.
+##
+## First collecting/packing into a data structure that is then written to disk
+## in a separate is not as resource efficient (both in terms of memory
+## consumption and time) as doing both steps in a combined manner. The first
+## (and current) approach is less complex however, which is why it's chosen
+## over the latter.
+
+import
+  std/[
+    hashes,
+    tables
+  ],
+  compiler/ast/[
+    ast_query,
+    ast_types
+  ],
+  compiler/ic/[
+    bitabs,
+    rodfiles
+  ],
+  compiler/utils/[
+    pathutils # for `AbsoluteFile`
+  ],
+  compiler/vm/[
+    vmdef
+  ]
+
+from compiler/vm/vmaux import findRecCase, findMatchingBranch
+from compiler/vm/vmobjects import `$`, packDiscr
+from compiler/vm/vmtypes import alignedSize
+
+export RodFileError
+
+type
+  PackedDataKind* = enum
+    pdkInt
+    pdkIntLit ## an embedded literal
+    pdkFloat
+    pdkString
+    pdkPtr # also includes ref
+    pdkObj
+    pdkArray
+    pdkSet
+    pdkField
+
+  # XXX: `PackedDataNode` is memory-usage wise quite inefficient. Not only at
+  #      the layout level (3 out of it's 8 bytes are wasted for padding), but
+  #      also for representing data in general. For example: `array[256, byte]`
+  #      requires 2048 bytes!
+  #      A possible different approach: store the data in it's
+  #      raw-byte-serialized representation, with additional metadata
+  #      describing where strings and seqs (i.e. values with non-automatic
+  #      storage) should be placed. Maybe also only store the non-zero parts
+  PackedDataNode* = object
+    ## A single node in a depth-first linear tree that is meant for storing
+    ## complex data. If a node has children, they follow directly after their
+    ## parent node. `PackedDataNode` can be seen as a specialized
+    ## version of `PackedNodeLite`
+    kind*: PackedDataKind
+    pos*: uint32 ## for {pdkInt, pdkFloat, pdkString}: the respective `LitId`
+                 ## for {pdkObj, pdkArray, pdkSet}: the number of children
+                 ## for pdkPtr: `0` if nil, `1` otherwise
+                 ## for `pdkField`: the field's position
+                 ## for `pdkIntLit`: a direct literal that fits into 4 byte
+
+  # PackedSymLite, PackedNodeLite, etc. are similiar to the types in
+  # ``packed_ast.nim``, with the difference that the types here only store the
+  # data necessary for their use-case (they're used to provide type
+  # information for `repr`) and are thus more compact.
+
+  SymId = distinct int32
+  TypeId = distinct int32
+  NodeId = distinct int32
+
+  PackedSymLite = object
+    kind: TSymKind
+    magic: TMagic
+    name: LitId
+    typ: TypeId
+    ast: NodeId
+    flags: TSymFlags
+    position: int
+    offset: int
+
+  PackedTypeLite = object
+    kind: TTypeKind
+    callConv: TCallingConvention
+    flags: TTypeFlags
+    types: seq[TypeId]
+    n: NodeId
+    sym: SymId
+    #typeInst*: TypeId
+
+  PackedNodeLite = object
+    kind: TNodeKind
+    flags: TNodeFlags
+    operand: int32  # for kind in {nkSym}: SymId
+                    # for kind in {nkStrLit, nkIdent, nkNumberLit}: LitId
+                    # for non-atom kinds: the number of children
+    typeId: TypeId
+
+  SliceListType* = BiggestInt|BiggestFloat|ConstantId
+
+  PackedVmType* = object
+    # XXX: inefficient storage. For statically sized atoms, `size` and `align`
+    #      are redundant, wasting space. `VmType` has the same problem
+    size*: uint32
+    align*: uint8
+    kind*: AtomKind
+    numFields*: uint16
+
+  # XXX: the rodfile interface for `BiTable`s stores both `keys` and `values`,
+  #      even though `keys` can be reconstructed during loading (at least in
+  #      our use-case here). This makes the resulting file larger than
+  #      necessary
+
+  PackedEnv* = object
+    strings*: BiTable[string]
+    numbers*: BiTable[BiggestInt] # also includes floats
+
+    files*: seq[string]
+    infos*: BiTable[TLineInfo]
+    dbgSyms*: seq[tuple[name, info: LitId]] # for debugging only
+
+    nodes*: seq[PackedDataNode] ## complex data. Currently used for storing
+                                ## complex constants
+    consts*: seq[(ConstantKind, uint32)]
+    cconsts*: seq[tuple[typ: VmTypeId, packedId: uint32]] ##
+      ## Packed `TCtx.complexConsts`. The constants type together with an
+      ## index referencing a sub-tree in `nodes`
+
+    tfields*: seq[tuple[offset: uint32, typId: uint32]]
+    tbranches*: seq[BranchListEntry]
+    types*: seq[PackedVmType]
+
+    globals*: seq[VmTypeId] ## All globals. Only their types are stored
+    functions*: seq[tuple[sym: uint32, sig: RoutineSigId, t1, t2: VmTypeId, kind: CallableKind, a, b: uint32]]
+    callbacks*: seq[string]
+
+    code*: seq[TInstr]
+    debug*: seq[uint32] # Packed version of `TCtx.debug`. Indices into `infos`
+
+    # rtti related data:
+    nimNodes: seq[PackedNodeLite]
+    nimSyms: seq[PackedSymLite]
+    nimTypes: seq[PackedTypeLite]
+    typeInfos: seq[tuple[nt: TypeId, t: VmTypeId]] ##
+      ## Packed version of `TCtx.rtti`
+
+    entryPoint*: FunctionIndex
+
+  TypeInfoDecoder = object
+    types: seq[PType]
+    syms: seq[PSym]
+    nodes: seq[PNode]
+
+  TypeInfoEncoder = object
+    types: Table[ItemId, TypeId]
+    syms: Table[ItemId, SymId]
+
+    pendingTypes: seq[(PType, TypeId)]
+    pendingSyms: seq[(PSym, SymId)]
+
+  PackedEncoder* = object
+    typeInfoEnc: TypeInfoEncoder
+
+    # XXX: `typeMap` is only necessary until `PVmType` gets replaced
+    #      by `VmTypeId`
+    typeMap*: Table[PVmType, VmTypeId] ## Maps each type instance to it's ID
+
+  DataEncoder* = object
+    ## Contextual state needed for turning data `PNode`-trees into
+    ## `PackedDataNode` trees and storing them into packed environment
+    routineSymLookup*: #[lent]# Table[int, LinkIndex] ##
+      ## symbol-id -> routine's link-index. Only read, not mutated
+    i: int ## the index in `PackedEnv.nodes` where the next item is to be stored
+
+const
+  EmbeddedUInts = {nkCharLit, nkUInt8Lit..nkUInt32Lit}
+  EmbeddedInts = {nkInt8Lit..nkInt32Lit} # these also fit into a `uint32`
+  ExternalInts = {nkIntLit, nkInt64Lit, nkUIntLit, nkUInt64Lit}
+
+  NilSymId = -1.SymId
+  NilTypeId = -1.TypeId
+
+
+# -------- general utilities ---------------------------------------------
+
+func growBy[T](x: var seq[T], n: Natural) {.inline.} =
+  x.setLen(x.len + n)
+
+iterator lpairs[T](x: openArray[T]): tuple[key: int, val: lent T] =
+  ## Custom `pairs` iterator that uses `lent`. As of this comment, the stdlib
+  ## one doesn't
+  var i = 0
+  let L = x.len
+  while i < L:
+    yield (i, x[i])
+    inc i
+
+template mapList*[D, S](d: seq[D], s: openArray[S], it: untyped, code) =
+  ## `s` and `d` get evaluated multiple times, so beware
+  bind lpairs
+  d.newSeq(s.len)
+  for i, it {.inject.} in lpairs(s):
+    d[i] = code
+
+# -------- accessors and shortcuts ---------------------------------------
+
+func hash(x: PVmType): int {.inline.} =
+  # Don't use `x` directly, as the lower 2-3 bits are always empty (due to
+  # the 4 or 8 byte alignment of `VmType`)
+  hash(cast[int](x))
+
+func hash(x: TypeId): Hash {.borrow.}
+func `==`(a, b: TypeId): bool {.borrow.}
+
+func hash(x: SymId): Hash {.borrow.}
+func `==`(a, b: SymId): bool {.borrow.}
+
+template genAccessors(t: type, f: untyped, idTyp: type) {.dirty.} =
+  template `[]`(self: t, id: idTyp): untyped =
+    self.f[id.int]
+
+  template `[]=`(self: var t, id: idTyp, v: untyped) =
+    self.f[id.int] = v
+
+genAccessors(PackedEnv, nimSyms, SymId)
+genAccessors(PackedEnv, nimTypes, TypeId)
+
+genAccessors(TypeInfoDecoder, syms, SymId)
+genAccessors(TypeInfoDecoder, types, TypeId)
+
+
+func getLitId(e: var PackedEnv, x: string): LitId {.inline.} =
+  e.strings.getOrIncl(x)
+
+func getLitId(e: var PackedEnv, x: BiggestInt): LitId {.inline.} =
+  e.numbers.getOrIncl(x)
+
+func getLitId(e: var PackedEnv, x: BiggestFloat): LitId {.inline.} =
+  e.numbers.getOrIncl(cast[BiggestInt](x))
+
+# -------- data storing --------------------------------------------------
+
+func startEncoding*(enc: var DataEncoder, e: PackedEnv) {.inline.} =
+  enc.i = e.nodes.len
+
+func put(enc: var DataEncoder, e: var PackedEnv,
+         d: sink PackedDataNode) {.inline.} =
+  e.nodes[enc.i] = d
+  inc enc.i
+
+func putLater(enc: var DataEncoder): int {.inline.} =
+  result = enc.i
+  inc enc.i
+
+func setAt(enc: var DataEncoder, e: var PackedEnv, i: int,
+           d: sink PackedDataNode) {.inline.} =
+  e.nodes[i] = d
+
+func storeData*(enc: var DataEncoder, e: var PackedEnv, n: PNode)
+  ## Stores the data represented by the Data AST `n` in `e.nodes`.
+  ## The caller is responsible for making sure that there's a slot allocated
+  ## in `e.nodes` for the top data-node. Space allocation for the
+  ## sub-data-nodes is handled by ``storeData``
+
+func storeDiscrData(enc: var DataEncoder, e: var PackedEnv, s: PSym, v: PNode) =
+  let
+    recCase = findRecCase(s.owner.typ, s)
+    b = findMatchingBranch(recCase, v)
+  assert b != -1
+  # We don't have access to vm type information here, so 32 is always
+  # used for `numBits`. This is safe, since the both `value` and `index`
+  # can only take up a maximum of 16 bits.  The loading logic takes care
+  # of repacking the discriminator with the correct `numBits`
+  # XXX: 16 could be safely used for `numBits` and then the resulting
+  #      value could be stored as a `pdkIntLit`
+  let val = packDiscr(v.intVal, b, numBits = 32)
+  enc.put e, PackedDataNode(kind: pdkInt, pos: e.getLitId(val).uint32)
+
+proc storeFieldsData(enc: var DataEncoder, e: var PackedEnv, n: openArray[PNode]) =
+  if n.len == 0:
+    return
+
+  e.nodes.growBy(n.len * 2)
+
+  if n[0].kind == nkExprColonExpr:
+    for x in n.items:
+      let
+        s = x[0].sym
+        v = x[1]
+
+      enc.put e, PackedDataNode(kind: pdkField, pos: s.position.uint32)
+
+      if sfDiscriminant notin s.flags:
+        enc.storeData(e, v)
+      else:
+        enc.storeDiscrData(e, s, v)
+
+  else:
+    for i, x in n.pairs:
+      enc.put e, PackedDataNode(kind: pdkField, pos: i.uint32)
+      enc.storeData(e, x)
+
+proc storeArrayData(enc: var DataEncoder, e: var PackedEnv, n: PNode) =
+  e.nodes.growBy(n.len)
+  for x in n.items:
+    enc.storeData(e, x)
+
+proc storeSetData(enc: var DataEncoder, e: var PackedEnv, n: PNode) =
+  e.nodes.growBy(n.len * 2)
+  # bitsets only store values in the range 0..high(uint16), so the values can
+  # be stored directly
+  for i, x in n.pairs:
+    if x.kind == nkRange:
+      enc.put e, PackedDataNode(kind: pdkIntLit, pos: x[0].intVal.uint32)
+      enc.put e, PackedDataNode(kind: pdkIntLit, pos: x[1].intVal.uint32)
+    else:
+      let d = PackedDataNode(kind: pdkIntLit, pos: x.intVal.uint32)
+      enc.put e, d
+      enc.put e, d
+
+func storeData*(enc: var DataEncoder, e: var PackedEnv, n: PNode) =
+  let dstIdx = enc.putLater()
+  let (kind, item) =
+    case n.kind
+    of EmbeddedUInts: (pdkIntLit, n.intVal.uint32)
+    of EmbeddedInts:  (pdkIntLit, cast[uint32](n.intVal))
+    of ExternalInts:  (pdkInt,    e.getLitId(n.intVal).uint32)
+
+    of nkFloatLit..nkFloat128Lit: (pdkFloat,  e.getLitId(n.floatVal).uint32)
+    of nkStrLit..nkTripleStrLit:  (pdkString, e.getLitId(n.strVal).uint32)
+    of nkNilLit:                  (pdkPtr,    0'u32)
+
+    of nkBracket:
+      enc.storeArrayData(e, n)
+      (pdkArray, uint32(n.len))
+    of nkCurly:
+      enc.storeSetData(e, n)
+      (pdkSet, uint32(n.len * 2))
+    of nkObjConstr:
+      enc.storeFieldsData(e, n.sons.toOpenArray(1, n.sons.high))
+      (pdkObj, uint32(n.len - 1))
+    of nkTupleConstr:
+      enc.storeFieldsData(e, n.sons)
+      (pdkObj, uint32(n.len))
+    of nkClosure:
+      # ignore the potentially non-nil env value
+      let val = enc.routineSymLookup[n[0].sym.id]
+      (pdkIntLit, val)
+    of nkSym:
+      assert n.typ.kind == tyProc
+      let val = enc.routineSymLookup[n.sym.id]
+      (pdkIntLit, val)
+    else:
+      unreachable(n.kind)
+
+  enc.setAt e, dstIdx, PackedDataNode(kind: kind, pos: item)
+
+func getIntVal*(pe: PackedEnv, n: PackedDataNode): BiggestInt {.inline.} =
+  case n.kind
+  of pdkInt:    pe.numbers[n.pos.LitId]
+  of pdkIntLit: n.pos.BiggestInt
+  else:         unreachable(n.kind)
+
+func getFloatVal*(pe: PackedEnv, n: PackedDataNode): BiggestFloat {.inline.} =
+  assert n.kind == pdkFloat
+  cast[BiggestFloat](pe.numbers[n.pos.LitId])
+
+proc storeSliceList[T: SliceListType](e: var PackedEnv,
+                                      sl: seq[Slice[T]]): uint32 =
+  const elemKind =
+    when T is BiggestInt: pdkInt
+    elif T is BiggestFloat: pdkFloat
+    elif T is ConstantId: pdkIntLit
+
+  template toId(a): uint32 =
+    when T is ConstantId: a.uint32
+    else: e.getLitId(a).uint32
+
+  result = e.nodes.len.uint32
+  e.nodes.growBy(sl.len * 2 + 1)
+  e.nodes[result] = PackedDataNode(kind: pdkSet, pos: sl.len.uint32)
+
+  let start = result.int + 1
+  for i, it in sl.pairs:
+    let
+      i1 = start + i * 2
+      i2 = i1 + 1
+
+    if it.a == it.b:
+      let elem = PackedDataNode(kind: elemKind, pos: toId(it.a))
+      e.nodes[i1] = elem
+      e.nodes[i2] = elem
+    else:
+      e.nodes[i1] = PackedDataNode(kind: elemKind, pos: toId(it.a))
+      e.nodes[i2] = PackedDataNode(kind: elemKind, pos: toId(it.b))
+
+proc loadSliceList*[T: SliceListType](p: PackedEnv, id: uint32): seq[Slice[T]] =
+  let top = p.nodes[id]
+  assert top.kind == pdkSet
+
+  let
+    L = top.pos.int
+    start = id.int + 1
+
+  template get(i): untyped =
+    let n = p.nodes[i]
+    when T is BiggestInt:
+      assert n.kind == pdkInt
+      p.numbers[n.pos.LitId]
+    elif T is BiggestFloat:
+      p.getFloatVal(n)
+    elif T is ConstantId:
+      assert n.kind == pdkIntLit
+      n.pos.ConstantId
+
+  result.newSeq(L)
+  for i in 0..<L:
+    let
+      nI = start + i * 2
+      a = get(nI + 0)
+      b = get(nI + 1)
+
+    result[i] = a..b
+
+# -------- `VmType` store and load ---------------------------------------
+
+func numFields(t: PVmType): int =
+  case t.kind
+  of akInt, akFloat, akPNode: 0
+  of akPtr, akRef, akSeq, akString, akSet, akDiscriminator, akCallable, akClosure: 1
+  of akArray: 1
+  of akObject: 1 + t.objFields.len
+
+func storeVmType(enc: var PackedEncoder, dst: var PackedEnv, t: PVmType): PackedVmType =
+  let
+    nf = numFields(t)
+    fieldStart = dst.tfields.len
+
+  result = PackedVmType(size: t.sizeInBytes.uint32,
+                        align: t.alignment,
+                        kind: t.kind,
+                        numFields: nf.uint16)
+
+  if nf == 0:
+    return
+
+  dst.tfields.growBy(nf)
+  dst.tfields[fieldStart] =
+    case t.kind
+    of akPtr, akRef:          (0'u32, enc.typeMap[t.targetType])
+    of akSeq, akString:
+      # it's not strictly necessary to store the stride (since it can
+      # currently be computed from the element type)
+      (t.seqElemStride.uint32, enc.typeMap[t.seqElemType])
+
+    of akSet:                 (t.setLength.uint32, 0'u32)
+    of akDiscriminator:       (t.numBits.uint32, 0'u32)
+    of akCallable, akClosure: (t.routineSig.uint32, 0'u32)
+    of akArray:               (t.elementCount.uint32, enc.typeMap[t.elementType])
+    of akObject:              (t.relFieldStart, t.branches.len.uint32)
+    of akInt, akFloat, akPNode:
+      unreachable()
+
+  if t.kind == akObject:
+    for i, f in t.objFields.pairs:
+      dst.tfields[fieldStart + 1 + i] = (f.offset.uint32, enc.typeMap[f.typ])
+
+    let bStart = dst.tbranches.len
+    dst.tbranches.growBy(t.branches.len)
+
+    for i, b in t.branches.pairs:
+      dst.tbranches[bStart + i] = b
+
+func loadVmType(s: PackedEnv, types: seq[PVmType],
+                t: var VmType, id: uint32,
+                fstart, bstart: int): tuple[numFields, numBranches: int] =
+  let
+    pt = s.types[id]
+    numFields = pt.numFields
+
+  t = VmType(kind: pt.kind, sizeInBytes: pt.size, alignment: pt.align)
+
+  if pt.kind in {akInt, akFloat, akPNode}:
+    return (0, 0)
+
+  assert numFields > 0
+  result = (numFields.int, 0) # valid for all atom kinds except `akObject`
+
+  let firstField = s.tfields[fstart]
+  case pt.kind
+  of akInt, akFloat, akPNode:
+    unreachable()
+  of akPtr, akRef:
+    t.targetType = types[firstField.typId]
+  of akSeq, akString:
+    t.seqElemStride = firstField.offset.int
+    t.seqElemType = types[firstField.typId]
+  of akSet:
+    t.setLength = firstField.offset.int
+  of akDiscriminator:
+    t.numBits = firstField.offset.int
+  of akArray:
+    t.elementCount = firstField.offset.int
+    t.elementType = types[firstField.typId]
+    t.elementStride = alignedSize(t.elementType).int
+  of akCallable, akClosure:
+    t.routineSig = firstField.offset.RoutineSigId
+  of akObject:
+    t.relFieldStart = firstField.offset
+    # The `typId` is used to store the number of branch list entries:
+    let branchListLen = firstField.typId.int
+
+    {.cast(noSideEffect).}: # faulty side-effect-analysis workaround
+      t.objFields.newSeq(numFields - 1)
+      for i in 1..<numFields.int:
+        let f = s.tfields[fstart + i]
+        t.objFields[i - 1] = (f.offset.int, types[f.typId])
+
+      t.branches.newSeq(branchListLen)
+      for i in 0..<branchListLen:
+        t.branches[i] = s.tbranches[bstart + i]
+
+    result.numBranches = branchListLen
+
+func loadVmTypes(src: PackedEnv): seq[PVmType] =
+  var
+    fstart = 0
+    bstart = 0
+
+  result.newSeq(src.types.len + 1) # +1 since the invalid type is not
+                                      # included
+
+  # types can reference other types that have higher ID values. Loading all
+  # types in a single pass thus won't work, since the referenced type might
+  # still be a nil `PVmType`. So instead, we first create a `PVmType` for
+  # each type and then fill them in a separate second step
+
+  for id in 0..<src.types.len:
+    result[id+1] = new(VmType)
+
+  for id in 0..<src.types.len:
+    let
+      t = result[id+1]
+      (fl, bl) = loadVmType(src, result, t[], id.uint32, fstart, bstart)
+    fstart += fl
+    bstart += bl
+
+
+func storeDbgSym(dst: var PackedEnv, sym: PSym): uint32 =
+  let
+    info = dst.infos.getOrIncl(sym.info)
+    name = dst.strings.getOrIncl(sym.name.s)
+
+  result = dst.dbgSyms.len.uint32
+  dst.dbgSyms.add((name: name, info: info))
+
+# -------- auxilliary RTTI data store/load -------------------------------
+
+func storeType(enc: var TypeInfoEncoder, ps: var PackedEnv, t: PType): TypeId
+func storeSym(enc: var TypeInfoEncoder, ps: var PackedEnv, s: PSym): SymId
+
+func storeSymLater(enc: var TypeInfoEncoder, ps: var PackedEnv, s: PSym): SymId =
+  if s == nil:
+    return NilSymId
+
+  let next = ps.nimSyms.len.SymId
+
+  result = enc.syms.mgetOrPut(s.itemId, next)
+  if result == next:
+    ps.nimSyms.growBy(1)
+    enc.pendingSyms.add((s, next))
+
+func storeTypeLater(enc: var TypeInfoEncoder, ps: var PackedEnv, t: PType): TypeId =
+  if t == nil:
+    return NilTypeId
+
+  let next = ps.nimTypes.len.TypeId
+
+  result = enc.types.mgetOrPut(t.itemId, next)
+  if result == next:
+    ps.nimTypes.growBy(1)
+    enc.pendingTypes.add((t, next))
+
+func storeNode(enc: var TypeInfoEncoder, ps: var PackedEnv, n: PNode): NodeId =
+  if n == nil:
+    return NodeId(-1)
+
+  var hasSons = false
+  let item =
+    case n.kind
+    of nkCharLit..nkUInt64Lit:    ps.getLitId(n.intVal).int32
+    of nkFloatLit..nkFloat128Lit: ps.getLitId(n.floatVal).int32
+    of nkStrLit..nkTripleStrLit:  ps.getLitId(n.strVal).int32
+    of nkIdent: ps.getLitId(n.ident.s).int32
+    of nkSym:   enc.storeSymLater(ps, n.sym).int32
+    else:
+      hasSons = true
+      n.sons.len.int32
+
+  result = ps.nimNodes.len.NodeId
+  ps.nimNodes.add(PackedNodeLite(kind: n.kind, flags: n.flags,
+                                 operand: item,
+                                 typeId: storeTypeLater(enc, ps, n.typ)))
+
+  if hasSons:
+    for s in n.sons.items:
+      discard storeNode(enc, ps, s)
+
+func storeSymAt(enc: var TypeInfoEncoder, ps: var PackedEnv, s: PSym, id: SymId) =
+  let p = PackedSymLite(kind: s.kind, magic: s.magic,
+                        name: ps.getLitId(s.name.s),
+                        typ: storeType(enc, ps, s.typ),
+                        ast: storeNode(enc, ps, s.ast),
+                        flags: s.flags,
+                        position: s.position, offset: s.offset)
+  ps[id] = p
+
+func storeTypeAt(enc: var TypeInfoEncoder, ps: var PackedEnv, t: PType, id: TypeId) =
+  var p = PackedTypeLite(kind: t.kind, callConv: t.callConv, flags: t.flags,
+                         n: storeNode(enc, ps, t.n),
+                         sym: storeSym(enc, ps, t.sym))
+
+  mapList(p.types, t.sons, s): storeType(enc, ps, s)
+
+  ps[id] = p
+
+func storeSym(enc: var TypeInfoEncoder, ps: var PackedEnv, s: PSym): SymId =
+  if s == nil:
+    return NilSymId
+
+  let next = ps.nimSyms.len.SymId
+  result = enc.syms.mgetOrPut(s.itemId, next)
+  if result == next:
+    ps.nimSyms.growBy(1)
+    storeSymAt(enc, ps, s, next)
+
+func storeType(enc: var TypeInfoEncoder, ps: var PackedEnv, t: PType): TypeId =
+  if t == nil:
+    return NilTypeId
+
+  let next = ps.nimTypes.len.TypeId
+
+  result = enc.types.mgetOrPut(t.itemId, next)
+  if result == next:
+    ps.nimTypes.growBy(1)
+    storeTypeAt(enc, ps, t, next)
+
+
+proc loadSym(dec: var TypeInfoDecoder, ps: PackedEnv, id: SymId): PSym
+proc loadType(dec: var TypeInfoDecoder, ps: PackedEnv, id: TypeId): PType
+
+proc loadNode(dec: var TypeInfoDecoder, ps: PackedEnv, id: NodeId): (PNode, int32) =
+  if id.int32 == -1:
+    return (nil, 0'i32)
+
+  let n = ps.nimNodes[id.int]
+  var r = PNode(kind: n.kind, flags: n.flags,
+                typ: loadType(dec, ps, n.typeId))
+
+  case n.kind
+  of nkCharLit..nkUInt64Lit:
+    r.intVal = ps.numbers[n.operand.LitId]
+  of nkFloatLit..nkFloat128Lit:
+    # use a `cast` to preserve the bit representation:
+    r.floatVal = cast[BiggestFloat](ps.numbers[n.operand.LitId])
+  of nkStrLit..nkTripleStrLit:
+    r.strVal = ps.strings[n.operand.LitId]
+  of nkSym:
+    r.sym = dec.loadSym(ps, n.operand.SymId)
+  of nkIdent:
+    r.ident = PIdent(s: ps.strings[n.operand.LitId])
+  else:
+    r.sons.newSeq(n.operand)
+    var nextId = id.int32 + 1
+    for i in 0..<n.operand:
+      let (node, skip) = loadNode(dec, ps, nextId.NodeId)
+      r.sons[i] = node
+      nextId += skip
+
+    return (r, nextId - id.int32)
+
+  result = (r, 1'i32)
+
+proc loadSym(dec: var TypeInfoDecoder, ps: PackedEnv, id: SymId): PSym =
+  if id == NilSymId:
+    return nil
+
+  if dec[id] != nil:
+    result = dec[id]
+  else:
+    let p = ps[id]
+    result = PSym(kind: p.kind, name: PIdent(s: ps.strings[p.name]),
+                  flags: p.flags, magic: p.magic,
+                  position: p.position, offset: p.offset)
+    # It's important to put the symbol into the lookup table _before_ calling
+    # `loadType` and `loadNode`, in order to prevent infinite recursion
+    dec[id] = result
+    result.typ = loadType(dec, ps, p.typ)
+    result.ast = loadNode(dec, ps, p.ast)[0]
+
+proc loadType(dec: var TypeInfoDecoder, ps: PackedEnv, id: TypeId): PType =
+  if id == NilTypeId:
+    return nil
+
+  if dec[id] != nil:
+    result = dec[id]
+  else:
+    let p = ps[id]
+    result = PType(kind: p.kind, callConv: p.callConv, flags: p.flags)
+    dec[id] = result
+
+    mapList(result.sons, p.types, it): loadType(dec, ps, it)
+
+    result.sym = loadSym(dec, ps, p.sym)
+    result.n = loadNode(dec, ps, p.n)[0]
+
+# -------- RTTI store/load -----------------------------------------------
+
+func storeTypeInfos(penc: var PackedEncoder, p: var PackedEnv, list: openArray[VmTypeInfo]) =
+  let enc = addr penc.typeInfoEnc
+
+  mapList(p.typeInfos, list, x):
+    (nt: storeType(enc[], p, x.nimType),
+     t:  penc.typeMap[x.internal])
+
+  # Process remaining types and symbols until none is left.
+  # note: each call to `storeXAt` might add new pending symbols or types
+  while true:
+    if enc.pendingTypes.len > 0:
+      let (t, id) = enc.pendingTypes.pop()
+      storeTypeAt(enc[], p, t, id)
+    elif enc.pendingSyms.len > 0:
+      let (s, id) = enc.pendingSyms.pop()
+      storeSymAt(enc[], p, s, id)
+    else:
+      break
+
+proc loadTypeInfos*(p: PackedEnv, types: seq[PVmType]): seq[VmTypeInfo] =
+  var dec: TypeInfoDecoder
+  dec.types.newSeq(p.nimTypes.len)
+  dec.syms.newSeq(p.nimSyms.len)
+
+  mapList(result, p.typeInfos, x):
+    VmTypeInfo(internal: types[x.t],
+               nimType:  dec.loadType(p, x.nt))
+
+proc loadEnv*(dst: var TCtx, src: PackedEnv) =
+  ## Loads all data from `src` into `dst` for which no further/extra
+  ## processing is required. Things that are not loaded are: complex
+  ## constants, globals, `code`, and the callback list.
+
+  # further loading requires a filled `types` list, so `loadVmTypes` has to
+  # happen first:
+  types(dst) = loadVmTypes(src)
+
+  mapList(dst.constants, src.consts, x):
+    var co = VmConstant(kind: x[0])
+    let id = x[1]
+
+    case x[0]
+    of cnstInt:     co.intVal = src.numbers[id.LitId]
+    of cnstFloat:   co.floatVal = cast[BiggestFloat](src.numbers[id.LitId])
+    of cnstString:  co.strVal = src.strings[id.LitId]
+
+    of cnstSliceListInt:   co.intSlices = loadSliceList[BiggestInt](src, id)
+    of cnstSliceListFloat: co.floatSlices = loadSliceList[BiggestFloat](src, id)
+    of cnstSliceListStr:   co.strSlices = loadSliceList[ConstantId](src, id)
+    of cnstNode: unreachable()
+
+    co
+
+  mapList(dst.functions, src.functions, x):
+    let
+      sym = src.dbgSyms[x.sym]
+      nimSym = PSym(name: PIdent(s: src.strings[sym.name]),
+                    info: src.infos[sym.info])
+    # In standalone mode, `sym` is just used to provide line information and
+    # stack trace entries
+    var f = FuncTableEntry(sym: nimSym, sig: x.sig,
+                           retValDesc: dst.types[x.t1],
+                           envParamType: dst.types[x.t2],
+                           kind: x.kind)
+    case x.kind
+    of ckDefault:
+      f.start = x.a.int
+      f.regCount = x.b.uint16
+    of ckCallback:
+      f.cbOffset = x.a.int
+
+    f
+
+  mapList(dst.debug, src.debug, x): src.infos[x.LitId]
+
+  dst.rtti = loadTypeInfos(src, dst.types)
+
+  dst.config.m.fileInfos.newSeq(src.files.len)
+  for i, f in src.files.pairs:
+    dst.config.m.fileInfos[i].fullPath = f.AbsoluteFile
+
+func init*(enc: var PackedEncoder, types: seq[PVmType]) =
+  ## Initializes the encoder. The sequence pass to `types` should not change
+  ## past this point. Else, encoding error may happen
+
+  # set up the `PVmType` -> `VmTypeId` mappings
+  # XXX: this will become unnecessary once `PVmType` is replaced by `VmTypeId`
+  for i in 0..<types.len:
+    let t = types[i]
+    enc.typeMap[t] = i.uint32
+
+  assert enc.typeMap.len == types.len
+
+func storeEnv*(enc: var PackedEncoder, dst: var PackedEnv, c: TCtx) =
+  ## Stores all relevant data provided by `c` into `dst`. Previously stored
+  ## data (except `nodes`, `numbers`, and `strings`) is thrown away. The only
+  ## parts of `dst` not touched by `storeEnv` are: `cconsts`, `globals`,
+  ## `code`, and `entryPoint`. These have to be filled in separately.
+  # store all types:
+  dst.types.newSeq(c.types.len - 1) # -1 since the invalid type is not included
+  for i in 1..<c.types.len:
+    let t = c.types[i]
+    dst.types[i - 1] = storeVmType(enc, dst, t)
+
+  mapList(dst.consts, c.constants, c):
+    let item =
+      case c.kind
+      of cnstInt:     dst.getLitId(c.intVal).uint32
+      of cnstFloat:   dst.getLitId(c.floatVal).uint32
+      of cnstString:  dst.getLitId(c.strVal).uint32
+
+      of cnstSliceListInt:   dst.storeSliceList(c.intSlices)
+      of cnstSliceListFloat: dst.storeSliceList(c.floatSlices)
+      of cnstSliceListStr:   dst.storeSliceList(c.strSlices)
+      of cnstNode:
+        # node constants are not created in a non-compiletime context
+        unreachable()
+
+    (c.kind, item)
+
+  mapList(dst.functions, c.functions, x):
+    let
+      d = dst.storeDbgSym(x.sym)
+      t1 = enc.typeMap[x.retValDesc]
+      t2 = enc.typeMap[x.envParamType]
+
+    let (a, b) =
+      case x.kind
+      of ckCallback: (x.cbOffset.uint32, 0'u32)
+      of ckDefault:  (x.start.uint32, x.regCount.uint32)
+
+    (d, x.sig, t1, t2, x.kind, a, b)
+
+  mapList(dst.debug, c.debug, d):
+    dst.infos.getOrIncl(d).uint32
+
+  # TODO: add support for either `distinct string` or custom `storePrim`
+  #       overloads (or both) to `rodfiles`. Due to the lack of both, we
+  #       have to perform a manual copy instead of a move here
+  mapList(dst.callbacks, c.callbackKeys, c):
+    c.string
+
+  mapList(dst.files, c.config.m.fileInfos, fi):
+    fi.fullPath.string
+
+  storeTypeInfos(enc, dst, c.rtti)
+
+proc writeToFile*(p: PackedEnv, file: AbsoluteFile): RodFileError =
+  var f = rodfiles.create(file.string)
+  f.storeHeader()
+
+  # All changes here need to be reflected in `readFromFile`
+
+  # The order in which the sections are stored doesn't match the data's
+  # dependencies, but the rodfile format writer/parser dictates it this way.
+  # Sorting the data into different sections is only done for stylistic
+  # reasons, it has no semantic meaning.
+
+  f.storeSection stringsSection
+  f.store p.strings
+
+  f.storeSection numbersSection
+  f.store p.numbers
+
+  f.storeSection topLevelSection
+  f.storeSeq p.nodes
+  f.storeSeq p.consts
+  f.storeSeq p.cconsts
+  f.storeSeq p.globals
+
+  f.storeSection bodiesSection
+  f.storePrim p.entryPoint
+  f.storeSeq p.code
+  f.storeSeq p.debug
+
+  f.storeSection symsSection
+  f.store p.infos
+  f.storeSeq p.files
+  f.storeSeq p.dbgSyms
+  f.storeSeq p.functions
+  f.storeSeq p.callbacks
+
+  f.storeSection typesSection
+  f.storeSeq p.tfields
+  f.storeSeq p.tbranches
+  f.storeSeq p.types
+
+  f.storeSeq p.nimNodes
+  f.storeSeq p.nimSyms
+  f.storeSeq p.nimTypes
+  f.storeSeq p.typeInfos
+
+  f.close()
+
+  result = f.err
+
+proc readFromFile*(p: var PackedEnv, file: AbsoluteFile): RodFileError =
+  var f = rodfiles.open(file.string)
+  f.loadHeader()
+
+  f.loadSection stringsSection
+  f.load p.strings
+
+  f.loadSection numbersSection
+  f.load p.numbers
+
+  f.loadSection topLevelSection
+  f.loadSeq p.nodes
+  f.loadSeq p.consts
+  f.loadSeq p.cconsts
+  f.loadSeq p.globals
+
+  f.loadSection bodiesSection
+  f.loadPrim p.entryPoint
+  f.loadSeq p.code
+  f.loadSeq p.debug
+
+  f.loadSection symsSection
+  f.load p.infos
+  f.loadSeq p.files
+  f.loadSeq p.dbgSyms
+  f.loadSeq p.functions
+  f.loadSeq p.callbacks
+
+  f.loadSection typesSection
+  f.loadSeq p.tfields
+  f.loadSeq p.tbranches
+  f.loadSeq p.types
+  f.loadSeq p.nimNodes
+  f.loadSeq p.nimSyms
+  f.loadSeq p.nimTypes
+  f.loadSeq p.typeInfos
+
+  f.close()
+
+  result = f.err

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -1,0 +1,508 @@
+## The backend for the VM. The core code-generation is done by `vmgen`; the
+## linking bits and artifact creation are implemented here
+##
+## Executable generation happens in roughly the following steps:
+## 1. Collect all modules and their top-level statements via the `passes`
+##  interface. This is a pure collection step, no further processing is done
+## 2. Generate all module init procedures (i.e. code for all top-level
+##  statements)
+## 3. Iteratively generate code for all alive routines (excluding `method`s)
+## 4. Generate the main procedure
+## 5. Pack up all required data into `PackedEnv` and write it to the output
+##  file
+##
+## Similiar to the C and JS backend, dead-code-elimination (DCE) happens as a
+## side-effect of how the routines are processed
+
+import
+  std/[
+    tables
+  ],
+  compiler/ast/[
+    ast,
+    ast_types,
+    astalgo, # for `getModule`
+    reports
+  ],
+  compiler/front/[
+    msgs,
+    options
+  ],
+  compiler/sem/[
+    passes,
+    transf
+  ],
+  compiler/modules/[
+    magicsys,
+    modulegraphs
+  ],
+  compiler/vm/[
+    packed_env,
+    vmaux,
+    vmdef,
+    vmgen,
+    vmobjects,
+    vmops,
+    vmtypegen
+  ],
+  experimental/[
+    results
+  ]
+
+import std/options as stdoptions
+
+type
+  CodeFragment = object
+    ## The state required for generating code in multiple steps.
+    ## `CodeFragment` helps when generating code for multiple procedures in
+    ## an interleaved manner.
+    prc: PProc
+    code: seq[TInstr]
+    debug: seq[TLineInfo]
+
+  Module = object
+    stmts: seq[PNode] ## top level statements in the order they were parsed
+    sym: PSym ## module symbol
+
+    initGlobalsCode: CodeFragment ## the bytecode of `initGlobalsProc`. Each
+      ## encountered `{.global.}`'s init statement gets code-gen'ed into the
+      ## `initGlobalCode` of the module that owns it
+    initGlobalsProc: CodeInfo ## the proc that initializes `{.global.}`
+      ## variables
+    initProc: CodeInfo ## the module init proc (top-level statements)
+
+  ModuleListRef = ref ModuleList
+  ModuleList = object of RootObj
+    modules: seq[Module]
+    modulesClosed: seq[int] ## indices into `modules` in the order the modules
+                            ## were closed. The first closed module comes
+                            ## first, then the next, etc.
+    moduleMap: Table[int, int] ## module sym-id -> index into `modules`
+
+  ModuleRef = ref object of TPassContext
+    ## The pass context for the VM backend. Represents a reference to a
+    ## module in the module list
+    list: ModuleListRef
+    index: int
+
+func growBy[T](x: var seq[T], n: Natural) {.inline.} =
+  x.setLen(x.len + n)
+
+iterator cpairs[T](s: seq[T]): (int, lent T) =
+  ## Continous pair iterator. Supports `s` growing during iteration
+  var i = 0
+  while i < s.len:
+    yield (i, s[i])
+    inc i
+
+
+proc registerCallbacks(c: var TCtx) =
+  ## Registers callbacks for various functions, so that no code is
+  ## generated for them and that they can (must) be overridden by the runner
+
+  # the callbacks registered here need to be manually kept in sync with the
+  # callbacks registered in ``vmrunner.registerCallbacks``. The runner will
+  # complain if there's a mismatch
+
+  template cb(key: string) =
+    c.callbackKeys.add(IdentPattern(key))
+
+  registerBasicOps(c)
+  registerDebugOps(c)
+  registerIoReadOps(c)
+  registerIoWriteOps(c)
+  registerOsOps(c)
+  registerOs2Ops(c)
+
+  # Used by some tests
+  cb "stdlib.system.getOccupiedMem"
+
+func initFuncTblEntry(sym: PSym, sig: RoutineSigId, info: CodeInfo): FuncTableEntry =
+  FuncTableEntry(sym: sym, sig: sig,
+                 kind: ckDefault,
+                 start: info.start, regCount: info.regCount.uint16)
+
+proc appendCode(c: var TCtx, f: CodeFragment) =
+  ## Copies the code from the fragment to the end of the global code buffer
+  c.code.add(f.code)
+  c.debug.add(f.debug)
+
+func collectRoutineSyms(ast: PNode, syms: var seq[PSym]) =
+  ## Traverses the `ast`, collects all symbols that are of routine kind and
+  ## appends them to `syms`
+  if ast.kind == nkSym:
+    if ast.sym.kind in routineKinds:
+      syms.add(ast.sym)
+
+    return
+
+  for i in 0..<ast.safeLen:
+    collectRoutineSyms(ast[i], syms)
+
+proc generateTopLevelStmts*(module: var Module, c: var TCtx,
+                            config: ConfigRef) =
+  ## Generates code for all collected top-level statements of `module` and
+  ## compiles the fragments into a single function. The resulting code is
+  ## stored in `module.initProc`
+  let n = newNodeI(nkEmpty, module.sym.info) # for line information
+
+  c.prc = PProc(sym: module.sym)
+  c.prc.regInfo.newSeq(1) # the first register is always the (potentially
+                          # non-existant) result
+
+  # start of init proc
+  let start = c.code.len
+
+  for x in module.stmts.items:
+    let tn = transformExpr(c.graph, c.idgen, c.module, x)
+    let r = c.genStmt(tn)
+
+    if unlikely(r.isErr):
+      config.localReport(r.takeErr)
+
+  c.gABC(n, opcRet)
+
+  module.initProc = (start: start, regCount: c.prc.regInfo.len)
+
+proc generateCodeForProc(c: var TCtx, s: PSym): VmGenResult =
+  let body = transformBody(c.graph, c.idgen, s, cache = false)
+  result = genProc(c, s, body)
+
+proc generateGlobalInit(c: var TCtx, f: var CodeFragment, defs: openArray[PNode]) =
+  ## Generates and emits code for the given `{.global.}` initialization
+  ## statements (`nkIdentDefs` in this case) into `f`
+  template swapState() =
+    swap(c.code, f.code)
+    swap(c.debug, f.debug)
+    swap(c.prc, f.prc)
+
+  # In order to generate code into the fragment, the fragment's state is
+  # swapped with the `TCtx''s one
+  swapState()
+
+  for def in defs.items:
+    assert def.kind == nkIdentDefs
+    for i in 0..<def.len-2:
+      # note: don't transform the expressions here; they already were, during
+      # transformation of their owning procs
+      let
+        asgn = newTreeI(nkAsgn, def[i].info, def[i], def[^1])
+        r = genStmt(c, asgn)
+
+      if unlikely(r.isErr):
+        c.config.localReport(r.takeErr)
+
+  # Swap back once done
+  swapState()
+
+proc generateAliveProcs(c: var TCtx, mlist: var ModuleList) =
+  ## Runs code generation for all routines (except methods) directly used
+  ## by the routines in `c.codegenInOut.newProcs`, including the routines in
+  ## the list itself.
+  ##
+  ## This function can be called multiple times, but `c.codegenInOut.newProcs`
+  ## must only contain not-yet-code-gen'ed routines each time.
+  ##
+  ## An alive routine is a routine who's symbol is used in: a top-level
+  ## statement; another alive routine's body; a ``const``s value
+
+  let start = c.functions.len
+  # adjust the function table size. Since `generateAllProcs` may be called
+  # multiple times, `setLen` has to be used instead of `newSeq`
+  c.functions.setLen(c.codegenInOut.nextProc)
+
+  # `newProcs` can grow during iteration, so `citems` has to be used
+  for ri, sym in c.codegenInOut.newProcs.cpairs:
+    c.config.internalAssert(sym.kind notin {skMacro, skTemplate}):
+      "unexpanded macro or template"
+    c.config.internalAssert(sym.kind != skIterator):
+      "closure iterator wasn't rejected by vmgen"
+
+    let i = start + ri
+    c.functions[i] = c.initProcEntry(sym)
+
+    # don't generate code for a proc that is overridden with a callback:
+    if c.functions[i].kind == ckCallback:
+      continue
+
+    assert c.codegenInOut.globalDefs.len == 0
+
+    c.module = sym.getModule()
+    # code-gen' the routine. This might add new entries to the `newProcs` list
+    let r = generateCodeForProc(c, sym)
+    if r.isOk:
+      fillProcEntry(c.functions[i], r.unsafeGet)
+    else:
+      c.config.localReport(r.takeErr)
+
+    # `{.global.}` initialization is done here, since the initializer
+    # expression might contain references to other functions (which can
+    # also contain further globals...)
+    if c.codegenInOut.globalDefs.len > 0:
+      let mI = mlist.moduleMap[c.module.id]
+      generateGlobalInit(c, mlist.modules[mI].initGlobalsCode,
+                         c.codegenInOut.globalDefs)
+
+      c.codegenInOut.globalDefs.setLen(0)
+
+    # code-gen might've found new functions, so adjust the function table:
+    c.functions.setLen(c.codegenInOut.nextProc)
+
+proc generateEntryProc(c: var TCtx, info: TLineInfo, initProcs: Slice[int],
+                       initProcTyp: VmTypeId): CodeInfo =
+  ## Generates the entry function and returns it's function table index.
+  ## The entry function simply calls all given `initProcs` (ordered from low
+  ## to high by their function table index) and then returns the value of the
+  ## ``programResult`` global
+  let
+    n = newNodeI(nkEmpty, info)
+    start = c.code.len
+
+  # setup code-gen state. One register for the return value and one as a
+  # temporary to hold the init procs
+  c.prc = PProc(regInfo: @[RegInfo(), RegInfo()])
+
+  # the entry procedure simply calls all module init procedures
+  for idx in initProcs.items:
+    c.gABx(n, opcLdNull, 1, initProcTyp.int)
+    c.gABx(n, opcWrProc, 1, idx) # `idx` is the function's table index
+    c.gABC(n, opcIndCall, 0, 1, 1)
+
+  # load ``programResult`` into the result register and then return
+  let prSym = magicsys.getCompilerProc(c.graph, "programResult")
+  c.gABx(n, opcLdGlobal, 0, c.symToIndexTbl[prSym.id].int)
+  c.gABC(n, opcNodeToReg, 0, 0)
+  c.gABC(n, opcRet)
+
+  result = (start: start, regCount: 2)
+
+func addInitProcs(ft: var seq[FuncTableEntry], m: Module, sig: RoutineSigId) =
+  ## Appends entries for module `m`'s initialization procs (if any) to the
+  ## function table
+  # XXX: initializing the globals _before_ top-level statements are
+  #      executed violates the spec. Following the spec would cause
+  #      behaviour than can be considered more broken and is thus
+  #      decided against. The language spec needs to clarify what exactly
+  #      is meant by 'initialization' in this context
+  if m.initGlobalsProc.start != -1:
+    ft.add initFuncTblEntry(m.sym, sig, m.initGlobalsProc)
+
+  if m.initProc.start != -1:
+    ft.add initFuncTblEntry(m.sym, sig, m.initProc)
+
+proc generateMain(c: var TCtx, mainModule: PSym,
+                  mlist: ModuleList): FunctionIndex =
+  ## Generates and links in the main procedure (the entry point) along with
+  ## setting up the required state.
+
+  # first, create a `VmType` for the init proc:
+  let
+    # Use a fresh signature ID for the init functions because we'd need
+    # access to a `proc()` `PType` otherwise:
+    voidSig = c.typeInfoCache.nextSigId
+    typId = c.types.len.VmTypeId
+    typ = PVmType(kind: akCallable, routineSig: voidSig)
+
+  # fill in size information
+  (typ.sizeInBytes, typ.alignment) = c.typeInfoCache.staticInfo[akCallable]
+
+  c.types.add(typ)
+
+  var systemIdx, mainIdx: int
+  # XXX: can't use `pairs` since it copies
+  for i in 0..<mlist.modules.len:
+    let sym = mlist.modules[i].sym
+    if sfMainModule     in sym.flags: mainIdx = i
+    elif sfSystemModule in sym.flags: systemIdx = i
+
+  # then, append the module init procs to the function table:
+  let firstInitProc = c.functions.len
+
+  # `generateEntryProc` uses the function table order as the order the
+  # init procedures are called in, so we need to add the table entries in the
+  # right order. That is, module closed order with special handling for the
+  # main and system module
+  addInitProcs(c.functions, mlist.modules[systemIdx], voidSig)
+  for mI in mlist.modulesClosed.items:
+    let m = mlist.modules[mI]
+    if {sfMainModule, sfSystemModule} * m.sym.flags == {}:
+      addInitProcs(c.functions, m, voidSig)
+
+  addInitProcs(c.functions, mlist.modules[mainIdx], voidSig)
+
+  # lastly, generate the actual code:
+  let
+    initProcs = firstInitProc..c.functions.high
+    info = generateEntryProc(c, mainModule.info, initProcs, typId)
+
+  result = c.functions.len.FunctionIndex
+  c.functions.add initFuncTblEntry(mainModule, voidSig, info)
+
+func storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
+                routineSymLookup: sink Table[int, LinkIndex],
+                consts: seq[(PVmType, PNode)], globals: seq[PVmType]) =
+  ## Stores the previously gathered complex constants and globals into `dst`
+
+  var denc: DataEncoder
+  denc.startEncoding(dst)
+  # XXX: `sink` is used for `routineSymLookup` in order to get around a
+  #      deep copy
+  denc.routineSymLookup = routineSymLookup
+
+  # complex constants (i.e. non-literals):
+  mapList(dst.cconsts, consts, it):
+    let id = dst.nodes.len
+    dst.nodes.growBy(1)
+    denc.storeData(dst, it[1])
+    (enc.typeMap[it[0]], id.uint32)
+
+  # for globals, only their types are stored. All initialization is
+  # done in VM bytecode
+  mapList(dst.globals, globals, it):
+    enc.typeMap[it]
+
+proc generateCode*(g: ModuleGraph) =
+  ## The backend's entry point. Orchestrates code generation and linking. If
+  ## all went well, the resulting binary is written to the project's output
+  ## file
+  let
+    mlist = g.backend.ModuleListRef
+    conf = g.config
+
+  var c = TCtx(config: g.config, cache: g.cache, graph: g, idgen: g.idgen,
+               mode: emStandalone)
+
+  c.typeInfoCache.init()
+  c.codegenInOut.flags = {cgfCollectGlobals}
+
+  # register the extra ops so that code generation isn't performed for the
+  # corresponding procs:
+  registerCallbacks(c)
+
+  # generate all module init procs (i.e. code for the top-level statements):
+  for m in mlist.modules.mitems:
+    c.refresh(m.sym, g.idgen)
+    generateTopLevelStmts(m, c, g.config)
+
+    # combine module list iteration with initialiazing `initGlobalsCode`:
+    m.initGlobalsCode.prc = PProc()
+
+  var startConst = LinkIndex(0)
+  # iteratively generate code for all alive procedures
+  while c.codegenInOut.nextProc.int > c.functions.len:
+    # generate code for the set of active alive routines
+    # (`c.codegenInOut.newProcs`). This can uncover new ``const`` symbols
+    generateAliveProcs(c, mlist[])
+    c.codegenInOut.newProcs.setLen(0)
+
+    # collect routine symbols from new `const`s, if any
+    for i in startConst..<c.codegenInOut.nextConst:
+      collectRoutineSyms(c.codegenInOut.newConsts[i].ast,
+                         c.codegenInOut.newProcs)
+
+    startConst = c.codegenInOut.nextConst
+
+    # create link table entries for the collected routine symbols
+    for sym in c.codegenInOut.newProcs.items:
+      c.symToIndexTbl[sym.id] = c.codegenInOut.nextProc
+      inc c.codegenInOut.nextProc
+
+  # XXX: generation of method dispatchers would go here. Note that `method`
+  #      support will require adjustments to DCE handling
+  #generateMethods(c)
+
+  # create procs from the global initializer code fragments
+  for m in mlist.modules.mitems:
+    template frag: untyped = m.initGlobalsCode
+    if frag.code.len > 0:
+      let
+        start = c.code.len
+        rc = frag.prc.regInfo.len
+
+      c.appendCode(frag)
+      c.gABC(g.emptyNode, opcRet)
+
+      # The code fragment isn't used anymore beyond this point, so it can be
+      # freed already
+      reset(frag)
+
+      m.initGlobalsProc = (start: start, regCount: rc)
+    else:
+      m.initGlobalsProc = (start: -1, regCount: 0)
+
+  let entryPoint =
+    generateMain(c, g.getModule(conf.projectMainIdx), mlist[])
+
+  c.gABC(g.emptyNode, opcEof)
+
+  # code generation is finished
+
+  # collect globals and `const`s:
+  # XXX: these two steps could be combined with storing into `PackedEnv`.
+  #      Pros: no need for the `globals` and `consts` seqs
+  #      Cons: (probably) higher I-cache pressure, slightly more complex logic
+
+  var globals = newSeq[PVmType](c.codegenInOut.newGlobals.len)
+  for i, sym in c.codegenInOut.newGlobals.pairs:
+    let typ = c.typeInfoCache.lookup(conf, sym.typ)
+    # the type was already created during vmgen
+    globals[i] = typ.unsafeGet
+
+  var consts = newSeq[(PVmType, PNode)](c.codegenInOut.newConsts.len)
+  for i, sym in c.codegenInOut.newConsts.pairs:
+    let typ = c.typeInfoCache.lookup(conf, sym.typ)
+    consts[i] = (typ.unsafeGet, sym.ast)
+
+  # pack the data and write it to the ouput file:
+  var
+    enc: PackedEncoder
+    env: PackedEnv
+
+  enc.init(c.types)
+  storeEnv(enc, env, c)
+  storeExtra(enc, env, c.symToIndexTbl, consts, globals)
+  env.code = move c.code
+  env.entryPoint = entryPoint
+
+  let err = writeToFile(env, prepareToWriteOutput(conf))
+  if err != RodFileError.ok:
+    let rep = BackendReport(kind: rbackVmFileWriteFailed,
+                            outFilename: conf.absOutFile.string,
+                            failureMsg: $err)
+    conf.globalReport(rep)
+
+# Below is the `passes` interface implementation
+
+proc myOpen(graph: ModuleGraph, module: PSym, idgen: IdGenerator): PPassContext =
+  if graph.backend == nil:
+    graph.backend = ModuleListRef()
+
+  let
+    mlist = ModuleListRef(graph.backend)
+    next = mlist.modules.len
+
+  # append an empty module to the list
+  mlist.modules.growBy(1)
+  mlist.modules[next] = Module(sym: module)
+  mlist.moduleMap[module.id] = next
+
+  result = ModuleRef(list: mlist, index: next)
+
+proc myProcess(b: PPassContext, n: PNode): PNode =
+  result = n
+  let m = ModuleRef(b)
+
+  const declarativeKinds = routineDefs + {nkTypeSection, nkPragma,
+    nkExportStmt, nkExportExceptStmt, nkFromStmt, nkImportStmt,
+    nkImportExceptStmt}
+
+  if n.kind notin declarativeKinds:
+    m.list.modules[m.index].stmts.add(n)
+
+proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
+  result = myProcess(b, n)
+
+  let m = ModuleRef(b)
+  m.list.modulesClosed.add(m.index)
+
+const vmgenPass* = makePass(myOpen, myProcess, myClose)

--- a/compiler/vm/vmmemory.nim
+++ b/compiler/vm/vmmemory.nim
@@ -216,3 +216,8 @@ func tryDeref*(heap: VmHeap, slot: HeapSlotHandle, typ: PVmType): Result[LocHand
       result.initSuccess(h)
     else:
       result.initFailure(dfcTypeMismatch)
+
+func getUsedMem*(a: VmAllocator): uint =
+  ## Calculates and returns the combined size-in-bytes of all current allocations
+  for r in a.regions.items:
+    result += r.len.uint

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -1,0 +1,273 @@
+## This module implements a standalone runner for the VM. The runner is
+## currently only meant for use by the compiler and thus performs only
+## little to no input validation.
+
+import
+  std/[
+    os,
+    strutils
+  ],
+
+  compiler/ast/[
+    ast_types,
+    ast
+  ],
+  compiler/front/[
+    cli_reporter,
+    msgs,
+    options
+  ],
+  compiler/vm/[
+    packed_env,
+    vm,
+    vmdef,
+    vmmemory,
+    vmobjects,
+    vmops,
+    vmtypes
+  ],
+  compiler/ic/[
+    bitabs
+  ],
+  compiler/utils/[
+    pathutils,
+    bitsets
+  ],
+  experimental/[
+    results
+  ]
+
+
+proc loadDiscrConst(s: PackedEnv, constIdx: int, dst: LocHandle,
+                    objTyp: PVmType, fieldPos: FieldPosition): int =
+  let
+    n =            s.nodes[constIdx]
+    packed =       s.numbers[n.pos.LitId]
+    (owner, idx) = getFieldAndOwner(objTyp, fieldPos) # `owner` might be != `objTyp`
+
+  # During const packing, `packDiscr` is used with `numBits` = 32
+  let (v, i) = unpackDiscr(packed, numBits = 32)
+  writeDiscrField(dst, owner, idx, v, i)
+
+  result = 1
+
+proc loadConst(s: PackedEnv, idx: int, dst: LocHandle,
+               mem: var VmMemoryManager): int =
+  ## Loads the constant data represented by the ``PackedDataNode`` sub-tree at
+  ## `idx` into the given VM memory location. Returns the total number of
+  ## nodes that were part of the processed sub-tree
+  let n = s.nodes[idx]
+  case dst.typ.kind
+  of akInt:
+    # this works for both signed and unsigned integers
+    dst.writeUInt(s.getIntVal(n))
+  of akFloat:
+    dst.writeFloat(s.getFloatVal(n))
+  of akPtr:
+    assert n.kind == pdkPtr
+    case n.pos
+    of 0: discard "nil ptr"
+    else: unreachable()
+  of akRef:
+    assert n.kind == pdkPtr
+    case n.pos
+    of 0: discard "nil ref"
+    else: unreachable()
+  of akSeq, akArray:
+    assert n.kind == pdkArray
+    let L = n.pos.int
+
+    if dst.typ.kind == akSeq:
+      deref(dst).seqVal.newVmSeq(dst.typ, L, mem)
+
+    var i = 0
+    while i < L:
+      result += loadConst(s, idx+1+result, getItemHandle(dst, i), mem)
+      inc i
+
+  of akString:
+    assert n.kind == pdkString
+    deref(dst).strVal.newVmString(s.strings[n.pos.LitId], mem.allocator)
+
+  of akSet:
+    assert n.kind == pdkSet
+    const ValueRange = 0'u32..uint32(uint16.high)
+    let L = n.pos.int
+    for i in countup(0, L-1, 2):
+      let
+        a = s.nodes[idx+1+i+0].pos
+        b = s.nodes[idx+1+i+1].pos
+      assert a in ValueRange
+      assert b in ValueRange
+      bitSetInclRange(mbitSet(dst), BiggestInt(a)..BiggestInt(b))
+
+    result = n.pos.int
+
+  of akCallable:
+    case n.kind
+    of pdkPtr:
+      # must be nil:
+      assert n.pos == 0
+    else:#of pckProc:
+      deref(dst).callableVal = toFuncPtr(n.pos.FunctionIndex)
+
+  of akClosure:
+    case n.kind
+    of pdkPtr:
+      # must be nil
+      assert n.pos == 0
+    else: # of pckProc:
+      let fncPtr = toFuncPtr(n.pos.FunctionIndex)
+      deref(dst).closureVal = VmClosure(fnc: fncPtr, env: 0)
+
+  of akObject:
+    assert n.kind == pdkObj
+    let L = n.pos.int
+    var npos = idx+1
+    for i in 0..<L:
+      assert s.nodes[npos].kind == pdkField
+      let
+        fieldPos = s.nodes[npos].pos.int.fpos
+        subLoc = getFieldHandle(dst, fieldPos)
+
+      inc npos
+      if subLoc.typ.kind != akDiscriminator:
+        npos += loadConst(s, npos, subLoc, mem)
+      else:
+        npos += loadDiscrConst(s, npos, subLoc, dst.typ, fieldPos)
+
+    result = npos - idx - 1 # -1 because of the `inc` below
+
+  of akPNode, akDiscriminator:
+    # `akPNode` is not possible since it's already rejected during executable
+    # generation
+    # `akDiscriminator` is already handled in the `akObject` of-branch
+    unreachable()
+
+  # increment again for the node itself
+  inc result
+
+
+proc loadIntoContext(c: var TCtx, p: PackedEnv) =
+  loadEnv(c, p)
+
+  c.typeInfoCache.emptyType = c.types[1]
+  c.typeInfoCache.boolType = c.types[2]
+  c.typeInfoCache.charType = c.types[3]
+  c.typeInfoCache.stringType = c.types[4]
+  c.typeInfoCache.pointerType = c.types[5]
+  c.typeInfoCache.nodeType = c.types[6]
+
+  c.allocator.byteType = c.typeInfoCache.charType
+
+  mapList(c.globals, p.globals, x):
+    c.heap.heapNew(c.allocator, c.types[x])
+
+  mapList(c.complexConsts, p.cconsts, x):
+    let
+      t = c.types[x.typ]
+      handle = c.allocator.allocConstantLocation(t)
+
+    discard loadConst(p, x.packedId.int, handle, c.memory)
+    handle
+
+  mapList(c.callbackKeys, p.callbacks, it):
+    # the actual callback procs are setup separately via ``registerCallbacks``
+    IdentPattern(it)
+
+proc loadFromFile(c: var TCtx, file: AbsoluteFile): Result[FunctionIndex, RodFileError] =
+  var p: PackedEnv
+  let err = readFromFile(p, file)
+  if err != RodFileError.ok:
+    result.initFailure(err)
+    return
+
+  loadIntoContext(c, p)
+  c.code = move p.code
+
+  result.initSuccess(p.entryPoint)
+
+proc registerCallbacks(c: var TCtx): bool =
+  ## Registers the callbacks and makes sure that they match with the ones the
+  ## executable expects. Returns 'true' on success and 'false' otherwise
+  var other: seq[IdentPattern]
+  swap(other, c.callbackKeys) # `c.callbackKeys` is now empty
+
+  # first, register all ops that the runner knows of:
+  registerBasicOps(c)
+  registerDebugOps(c)
+  registerIoReadOps(c)
+  registerIoWriteOps(c)
+  registerOsOps(c)
+  registerOs2Ops(c)
+
+  registerCallback c, "stdlib.system.getOccupiedMem", proc (a: VmArgs) =
+    setResult(a, a.mem.allocator.getUsedMem().int)
+
+  if c.callbackKeys.len != other.len:
+    # this means one of the following:
+    # - the runner and the executable's compiler were built from different
+    #  compiler sources
+    # - the runner uses a stdlib different from the one the executable uses
+    # In both cases, execution errors are very likely to happen, so we abort
+    return false
+
+  # then make sure that the callbacks are at the indices the function table
+  # entries expect them to be:
+  result = true
+  swap(other, c.callbackKeys)
+  for i, p in c.callbackKeys.pairs:
+    if other[i].string != p.string:
+      echo "expected '$#' callback but got '$#'" % [p.string, other[i].string]
+      result = false
+
+proc main*(args: seq[string]): int =
+  let config = newConfigRef(cli_reporter.reportHook)
+  config.writeHook =
+    proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
+      msgs.msgWrite(conf, msg, flags)
+  config.writelnHook =
+    proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
+      conf.writeHook(conf, msg & "\n", flags)
+
+  # setup the execution context
+  var c = TCtx(config: config, mode: emStandalone)
+  c.features.incl(allowInfiniteLoops)
+  c.heap.slots.newSeq(1) # setup the heap
+
+  let lr = loadFromFile(c, toAbsolute(args[0], getCurrentDir().AbsoluteDir))
+  if lr.isErr:
+    echo "failed to load file: ", lr.takeErr
+    return 1
+
+  if not registerCallbacks(c):
+    # callback setup failed -> abort
+    echo "failed to register callbacks"
+    return 1
+
+  let
+    entryPoint = c.functions[lr.unsafeGet.int]
+    cb = proc (c: TCtx, r: TFullReg): PNode =
+      c.config.internalAssert(r.kind == rkInt):
+        "expected int return value" # either the executable is malformed or
+                                    # there's an issue with the code-generator
+      newIntNode(nkIntLit, r.intVal)
+
+  # setup the starting frame:
+  var frame = TStackFrame(prc: entryPoint.sym, next: -1)
+  frame.slots.newSeq(entryPoint.regCount)
+
+  let r = c.execute(entryPoint.start, frame, cb)
+  if r.isOk:
+    # on successful execution, the executable's main function returns the
+    # value of ``programResult``, which we use as the runner's exit code
+    result = r.unsafeGet.intVal.int
+  else:
+    let err = r.takeErr
+    # an uncaught error occurred
+    c.config.localReport(err.stackTrace)
+    c.config.localReport(err.report)
+    result = 1
+
+when isMainModule:
+  programResult = main(commandLineParams())

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -3,6 +3,7 @@ Advanced commands:
   //compileToCpp, cpp       compile project to C++ code
   //compileToOC, objc       compile project to Objective C code
   //js                      compile project to Javascript
+  //vm                      compile project to NimVM
   //e                       run a Nimscript file
   //rst2html                convert a reStructuredText file to HTML
                             use `--docCmd:skip` to skip compiling snippets
@@ -100,7 +101,7 @@ Advanced options:
                             if path == @default (the default and most useful), will use
                             best match among @pkg,@path.
                             if these are nonexistent, will use project path
-  -b, --backend:c|cpp|js|objc
+  -b, --backend:c|cpp|js|objc|vm
                             sets backend to use with commands like `nim doc` or `nim r`
   --docCmd:cmd              if `cmd == skip`, skips runnableExamples
                             else, runs runnableExamples with given options, e.g.:

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3129,6 +3129,9 @@ When nimvm statement
 `when nimvm` statement to differentiate the execution path between
 compile-time and the executable.
 
+.. note:: For the VM target, the compile-time branch is also taken in the
+  executable. NimScript always takes the compile-time branch.
+
 Example:
 
 .. code-block:: nim

--- a/lib/std/vmutils.nim
+++ b/lib/std/vmutils.nim
@@ -2,7 +2,12 @@
 Experimental API, subject to change.
 ]##
 
-proc vmTrace*(on: bool) {.compileTime.} =
+when defined(vm):
+  {.pragma: vmOnly.}
+else:
+  {.pragma: vmOnly, compileTime.}
+
+proc vmTrace*(on: bool) {.vmOnly.} =
   runnableExamples:
     static: vmTrace(true)
     proc fn =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -551,7 +551,7 @@ const
 include "system/inclrtl"
 
 const
-  isNimVmTarget = defined(nimscript)
+  isNimVmTarget = defined(nimscript) or defined(vm)
   notJSnotNims = not defined(js) and not isNimVmTarget
 
 when not defined(js) and not defined(nimSeqsV2):

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -40,7 +40,7 @@ type
   FileHandle* = cint ## type that represents an OS file handle; this is
                       ## useful for low-level file access
 
-const isNimVmTarget = defined(nimscript)
+const isNimVmTarget = defined(nimscript) or defined(vm)
 
 # text file handling:
 when not isNimVmTarget and not defined(js):

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -59,6 +59,7 @@ type
     targetCpp = "cpp"
     targetObjC = "objc"
     targetJS = "js"
+    targetVM = "vm"
 
   SpecifiedTarget* = enum
     addTargetC = "c"
@@ -69,6 +70,8 @@ type
     remTargetObjC = "!objc"
     addTargetJS = "js"
     remTargetJS = "!js"
+    addTargetVM = "vm"
+    remTargetVM = "!vm"
     addTargetNative = "native"
     addCategoryTargets = "default"
     remCategoryTargets = "!default"
@@ -146,6 +149,7 @@ func ext*(t: TTarget): string {.inline.} =
     of targetCpp:  "nim.cpp"
     of targetObjC: "nim.m"
     of targetJS:   "js"
+    of targetVM:   ""
 
 func cmd*(t: TTarget): string {.inline.} =
   ## read-only field providing the command string for the given target
@@ -154,6 +158,7 @@ func cmd*(t: TTarget): string {.inline.} =
     of targetCpp:  "cpp"
     of targetObjC: "objc"
     of targetJS:   "js"
+    of targetVM:   "vm"
 
 func defaultOptions*(a: TTarget): string {.inline.} =
   case a
@@ -286,6 +291,7 @@ proc parseTargets*(value: string): set[TTarget] =
       of "cpp", "c++": targetCpp
       of "objc":       targetObjC
       of "js":         targetJS
+      of "vm":         targetVM
       else: raise newException(ValueError, "invalid target: '$#'" % v)
 
 proc parseSpecifiedTargets*(value: string): set[SpecifiedTarget] =
@@ -297,12 +303,14 @@ proc parseSpecifiedTargets*(value: string): set[SpecifiedTarget] =
       of "cpp", "c++":   addTargetCpp
       of "objc":         addTargetObjC
       of "js":           addTargetJS
+      of "vm":           addTargetVM
       of "native":       addTargetNative
       of "default":      addCategoryTargets
       of "!c":           remTargetC
       of "!cpp", "!c++": remTargetCpp
       of "!objc":        remTargetObjC
       of "!js":          remTargetJS
+      of "!vm":          remTargetVM
       of "!default":     remCategoryTargets
       else: raise newException(ValueError,
                                "invalid target specificatoin: '$#'" % v)
@@ -496,9 +504,10 @@ proc parseSpec*(filename: string,
           of addTargetCpp: result.targets.incl targetCpp
           of addTargetObjc: result.targets.incl targetObjC
           of addTargetJS: result.targets.incl targetJS
+          of addTargetVM: result.targets.incl targetVM
           of addTargetNative: result.targets.incl nativeTarget
           of addCategoryTargets: result.targets = result.targets + catTargets
-          of remTargetC, remTargetCpp, remTargetObjc, remTargetJS,
+          of remTargetC, remTargetCpp, remTargetObjc, remTargetJS, remTargetVM,
              remCategoryTargets:
                discard
         
@@ -513,8 +522,9 @@ proc parseSpec*(filename: string,
           of remTargetCpp: result.targets.excl targetCpp
           of remTargetObjc: result.targets.excl targetObjC
           of remTargetJS: result.targets.excl targetJS
+          of remTargetVM: result.targets.excl targetVM
           of remCategoryTargets: result.targets = result.targets - catTargets
-          of addTargetC, addTargetCpp, addTargetObjc, addTargetJS,
+          of addTargetC, addTargetCpp, addTargetObjc, addTargetJS, addTargetVM,
              addTargetNative, addCategoryTargets:
                discard
         

--- a/tests/compiler/tvmbackend.nim
+++ b/tests/compiler/tvmbackend.nim
@@ -1,0 +1,104 @@
+discard """
+  description: '''
+    Test to make sure that `vmbackend.writeToFile` is compatible with
+    `vmbackend.readFromFile`
+  '''
+  joinable: false
+"""
+
+import std/[os, tables]
+
+import compiler/ast/ast_types
+import compiler/ic/bitabs
+import compiler/utils/pathutils
+import compiler/vm/vmdef
+import compiler/vm/packed_env {.all.}
+
+func addAll[T](x: var BiTable[T], arr: varargs[T]) =
+  for it in arr.items:
+    discard x.getOrIncl(it)
+
+func `==`(a, b: BranchListEntry): bool =
+  if a.kind != b.kind: return false
+
+  case a.kind
+  of blekStart:
+    a.field == b.field and a.numItems == b.numItems and
+    a.defaultBranch == b.defaultBranch and a.numBranches == b.numBranches
+  of blekBranch, blekEnd:
+    a.fieldRange == b.fieldRange
+
+func `==`(a, b: TInstr): bool {.borrow.}
+func `==`(a, b: packed_env.NodeId): bool {.borrow.}
+
+var env: PackedEnv
+var enc: PackedEncoder
+
+# fill `env` with random non-zero data
+block:
+  let
+    typId1 = VmTypeId(1)
+    typId2 = VmTypeId(2)
+
+  env.strings.addAll("a", "b")
+  env.numbers.addAll(1, 2)
+  env.files = @["a", "b"]
+
+  env.infos.addAll:
+    [TLineInfo(fileIndex: FileIndex(1), line: 2, col: 3),
+     TLineInfo(fileIndex: FileIndex(2), line: 3, col: 4)]
+
+  env.dbgSyms = @[(LitId(1), LitId(2)), (LitId(3), LitId(4))]
+
+  env.nodes = @[PackedDataNode(kind: pdkInt), PackedDataNode(kind: pdkFloat)]
+  env.consts = @[(cnstFloat, 1'u32), (cnstString, 2'u32)]
+  env.cconsts = @[(typId1, 6'u32)]
+
+
+  let vmTyp1 = PVmType(kind: akSet, sizeInBytes: 2, alignment: 3,
+                       setLength: 4)
+  let vmTyp2 = PVmType(kind: akObject, sizeInBytes: 4, alignment: 1,
+                       objFields: @[(2, vmTyp1)],
+                       branches: @[BranchListEntry(kind: blekStart),
+                                   BranchListEntry(kind: blekEnd)])
+
+  enc.typeMap[vmTyp1] = typId1
+  enc.typeMap[vmTyp2] = typId2
+
+  env.types.add enc.storeVmType(env, vmTyp1)
+  env.types.add enc.storeVmType(env, vmTyp2)
+
+  env.globals = @[typId2]
+  env.functions =
+    @[(4'u32, RoutineSigId(18), typId1, typId2, ckCallback, 3'u32, 2'u32)]
+  env.callbacks = @["cb1", "cb2"]
+
+  env.code = @[TInstr(14), TInstr(15)]
+  env.debug = @[128'u32, 256'u32]
+
+  # the content doesn't matter. Just make sure that each field in the
+  # destination `PackedNodeLite`, `PackedSymLit`, and `PackedTypeLite` objects
+  # has a non-zero value
+  let typ = PType(kind: tyProc, flags: {tfNoSideEffect}, sons: @[PType(nil)],
+                  n: PNode(kind: nkStmtList), callConv: ccClosure)
+  let sym = PSym(kind: skProc, magic: mSlice, name: PIdent(s: "slice"),
+                 typ: typ,  offset: 1, position: 2)
+  let typ2 = PType(kind: tyString, flags: {tfVarIsPtr}, sons: @[typ],
+                   n: PNode(kind: nkStrLit, flags: {nfBase2}, typ: typ),
+                   sym: sym)
+
+  let typeInfo = VmTypeInfo(nimType: typ2, internal: vmTyp2)
+
+  # put the types into `env`
+  storeTypeInfos(enc, env, [typeInfo])
+
+
+let file = AbsoluteFile(getTempDir() / "tmp.nimbc")
+
+doAssert writeToFile(env, file) == RodFileError.ok
+
+var inEnv: PackedEnv
+doAssert readFromFile(inEnv, file) == RodFileError.ok
+
+# the data we've read must be the same as the one we wrote
+doAssert env == inEnv

--- a/tests/lang/s02_core/s01_user_defined_data_types/t03_inheritance.nim
+++ b/tests/lang/s02_core/s01_user_defined_data_types/t03_inheritance.nim
@@ -52,8 +52,9 @@ block derive_from_ref_root_obj:
   ## To convert base type back to derived, you can use object conversion
   doAssert Derived(base).f2 == 12
 
-  when not defined(js):
-   when not defined(js) or defined(tryBrokenSpecification):
+  when (not defined(js) and not defined(vm)) or
+       defined(tryBrokenSpecification):
+    # Issue: the VM doesn't raise a user-catchable error for this conversion
     # Bug: js target allows this conversion to happen parent ref -> child ref
     try:
       discard Derived(Base())

--- a/tests/lang/s02_core/s03_inline_iterators/t02_inline_iterators.nim
+++ b/tests/lang/s02_core/s03_inline_iterators/t02_inline_iterators.nim
@@ -4,8 +4,10 @@ Test inline iterators, `break`, `continue`, and other control-flow controls
 for the for loop. Returning values from the iterators, order of control-flow
 transfer bettween body of the iterator and main loop.
 '''
+targets: "!vm"
 """
 
+# knownIssue: try/finally in the VM is broken in non-simple cases
 
 ## An iterator is similar to a procedure, except that it can be called in
 ## the context of a `for` loop. Iterators provide a way to specify the
@@ -137,6 +139,7 @@ block iterator_and_break:
       values.add $item
       break
 
+    echo values
     doAssert values == @[
       "resource setup",
       "before 1",

--- a/tests/lang/s05_pragmas/s02_misc/t02_flag_pragmas.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t02_flag_pragmas.nim
@@ -1,5 +1,5 @@
 discard """
-targets: "!js"
+targets: "!js !vm"
 description: '''
 Enable or disable safety checks applicable to C and C++ targets
 '''

--- a/tests/lang/s05_pragmas/s02_misc/t06_union_pragma.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t06_union_pragma.nim
@@ -1,5 +1,5 @@
 discard """
-targets: "!js"
+targets: "!js !vm"
 """
 
 block union_pragma:

--- a/tests/modules/minit_order1.nim
+++ b/tests/modules/minit_order1.nim
@@ -1,0 +1,8 @@
+import minit_order2
+import minit_order3
+
+echo "init_order1"
+
+let value1* = value(1)
+let valueDep1* = value2
+let valueDep12* = value3

--- a/tests/modules/minit_order2.nim
+++ b/tests/modules/minit_order2.nim
@@ -1,0 +1,7 @@
+import minit_order1
+import minit_order3
+
+echo "init_order2"
+
+let value2* = value(2)
+let valueDep2* = value3

--- a/tests/modules/minit_order3.nim
+++ b/tests/modules/minit_order3.nim
@@ -1,0 +1,8 @@
+
+echo "init_order3"
+
+# prevent the optimizer from figuring out that the globals are constant
+# and subsequently folding them away
+func value*(v: int): int {.noinline.} = v
+
+let value3* = value(3)

--- a/tests/modules/tinit_order.nim
+++ b/tests/modules/tinit_order.nim
@@ -1,0 +1,27 @@
+discard """
+  description: '''
+    Tests the order in which module top-level statements are executed
+  '''
+  output: '''init_order3
+init_order2
+init_order1
+main
+'''
+  targets: c cpp js vm
+"""
+
+# `minit_order1` imports `minit_order2` which imports `minit_order1` again,
+# causing a cyclic import
+
+import minit_order1
+import minit_order2
+import minit_order3
+
+echo "main"
+
+doAssert value1 == 1
+doAssert valueDep1 == 2
+doAssert valueDep12 == 3
+doAssert value2 == 2
+doAssert valueDep2 == 3
+doAssert value3 == 3

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -207,6 +207,11 @@ proc buildTools(args: string = "") =
   when defined(windows): buildVccTool(args)
   bundleNimpretty(args)
 
+  # the VM runs into `setjmp`-related stack-corruption issues when using the
+  # MinGW runtime. ``exceptions:goto`` is used as a workaround
+  nimCompileFold("Compile vmrunner", "compiler/vm/vmrunner.nim",
+                options = "-d:release --exceptions:goto $# $#" % [defineSourceMetadata(), args])
+
   # pre-packages a debug version of nim which can help in many cases investigate issuses
   # withouth having to rebuild compiler.
   # `-d:nimDebugUtils` only makes sense when temporarily editing/debugging compiler


### PR DESCRIPTION
## Summary
- the corresponding compiler commands are `vm` and `compiletovm`
- the backend option is `--backend:vm`
- the produced executable uses the `.nimbc` (Nim Bytecode) file
 extension. They're executed via the standalone `vmrunner` program and
 have no run-time dependencies on the source-code they were built from
- testing for the VM target can be done via `defined(vm)`

All alive code is processed and translated to byte-code during the build
step; the runner doesn't make use of just-in-time code-generation.

Having a dedicated VM back-end makes it easier to grow test coverage
for the VM and it's corresponding code-generator (`vmgen`). With the
`vm` testament target, running tests in the VM that don't depend on
being run at compile-time can now be done without the
`template code = ...; static: code; code` pattern.

## Details
- adjust `vmgen` to support non-compile-time code
- include the `vm` target in the default targets for the 'lang'
 test category
- add a test for module initialization order
- the `vmrunner` program is built by `koch tools` and used by
 `nim r` and testament
- the `passes` interface is not used for code-generation; only for
 collecting the active modules and their top-level statements.
 `vmbackend.generateCode` is responsible for running code-generation
 and writing the output executable file
- when building for the VM target, the `when nimvm` compile-time branch
 is also taken in the executable. This is meant as transition helper,
 but the plan is to make it behave like it does on the other
 targets later on
- dead-code-elimination uses `vmgen`'s existing dependency
 collection facility
- a `.nimbc` file is a `PackedEnv` stored in the existing `rodfiles`
 format
- `PackedEnv` is a packed and easily serialize-able representation of
 all static VM environment state necessary for running the program,
 plus the program's byte-code

---

## Notes for reviewers
- I'm not sure if the doc-comment quality is good enough. They likely need some extra attention