### PR TITLE
fix: issues with VM stack-frame handling

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -918,13 +918,15 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
     updateRegsAlias
 
   template popFrame() =
+    assert tos == c.sframes.high
+    cleanUpLocations(c.memory, c.sframes[tos])
+
+    # if `popFrame` is called during exception handling (e.g. on returning
+    # from a function call in a `finally` block), `next` is not neccessarily
+    # `tos - 1`
     tos = c.sframes[tos].next
-    # Possibly throws aways all frames left alive for `raise`
-    # handling, but since the exception is swallowed anyway,
-    # it doesn't really matter
-    for i in (tos+1)..<c.sframes.len:
-      cleanUpLocations(c.memory, c.sframes[i])
-    c.sframes.setLen(tos + 1)
+
+    c.sframes.setLen(c.sframes.len - 1)
     updateRegsAlias
 
   template gotoFrame(f: int) =
@@ -933,6 +935,8 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
     updateRegsAlias
 
   template unwindToFrame(f: int) =
+    ## Destroys all frames above `f` (the stack top is the most recent frame)
+    ## and sets the frame pointer to `f`
     let nf = f
     assert nf in 0..c.sframes.high
     for i in (nf+1)..<c.sframes.len:
@@ -2316,8 +2320,10 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         # Jump to the handler, do nothing when the `finally` block ends.
         savedPC = -1
         pc = jumpTo.where - 1
-        if tos != frame:
-          unwindToFrame(frame)
+        # Unwind even if `tos == frame`, since there might be (now stale)
+        # frames above `tos`. This can happen when raising inside a `finally`
+        # while an exception is already active
+        unwindToFrame(frame)
       of ExceptionGotoFinally:
         # Jump to the `finally` block first then re-jump here to continue the
         # traversal of the exception chain

--- a/tests/vm/texception.nim
+++ b/tests/vm/texception.nim
@@ -17,4 +17,23 @@ static:
     discard someFunc()
   except:
     discard
-  
+
+static:
+  proc raiseEx() =
+    raise ValueError.newException("A")
+
+  proc doSomething() = discard
+
+  try:
+    try:
+      raiseEx() # it's important that the exception is raised from a
+                # function here
+    finally:
+      doSomething()
+      raise ValueError.newException("B") # raise a different exception while
+                                         # another exception is already active
+
+  except ValueError as e:
+    # the `except` needs to be on the same stack-frame as the `raise` in the
+    # `finally` block
+    doAssert e.msg == "B"


### PR DESCRIPTION
When a `finally` block was entered during exception related stack
unwinding:
- functions calls inside the block always crashed the VM
- raising an exception and catching it on the same stack-frame lead
 to memory leaks

`popFrame` didn't properly account for non-simple stack layouts
 (i.e. cactus stack) that can occur during exception handling, causing
 the first issue.