### PR TITLE
compiler: make `vmops` and `vmhooks` importable

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -63,8 +63,10 @@ import
     vmerrors,
     vmgen,
     vmdef,
+    vmhooks,
     vmmemory,
     vmobjects,
+    vmops,
     vmtypegen,
     vmtypes
   ],
@@ -78,6 +80,9 @@ import
 
 import std/options as stdoptions
 from std/math import round
+
+# these were includes previously, so they're re-exported for compatibility
+export vmhooks, vmops
 
 const
   traceCode = defined(nimVMDebugExecute)
@@ -339,7 +344,6 @@ template decodeBx() {.dirty.} =
 template move(a, b: untyped) {.dirty.} = system.shallowCopy(a, b)
 # XXX fix minor 'shallowCopy' overloading bug in compiler
 
-include vmhooks
 
 template rawPointer(x: LocHandle): untyped =
   x.h.rawPointer
@@ -3454,8 +3458,6 @@ proc setGlobalValue*(c: var TCtx; s: PSym, val: PNode) =
   let slot = c.heap.slots[slotIdx]
 
   c.serialize(val, slot.handle)
-
-include vmops
 
 proc setupGlobalCtx*(module: PSym; graph: ModuleGraph; idgen: IdGenerator) =
   addInNimDebugUtils(graph.config, "setupGlobalCtx")

--- a/compiler/vm/vmhooks.nim
+++ b/compiler/vm/vmhooks.nim
@@ -7,7 +7,21 @@
 #    distribution, for details about the copyright.
 #
 
-import compiler/utils/pathutils
+## Various helpers for interacting with registers from inside a VM callback
+## implementations
+
+import
+  compiler/ast/[
+    ast_types
+  ],
+  compiler/utils/[
+    pathutils
+  ],
+  compiler/vm/[
+    vmdef,
+    vmmemory,
+    vmobjects
+  ]
 
 # XXX: proper error handling is missing here. Since these functions are exposed
 # via the compilerapi, `doAssert` is used for pre-condition checking

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -7,8 +7,33 @@
 #    distribution, for details about the copyright.
 #
 
-# Unfortunately this cannot be a module yet:
-#import vmdeps, vm
+import
+  compiler/ast/[
+    ast_types,
+    ast,
+    idents,
+    reports,
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/sem/[
+    sighashes
+  ],
+  compiler/vm/[
+    gorgeimpl,
+    vmconv,
+    vmdef,
+    vmdeps,
+    vmerrors,
+    vmhooks,
+    vmmemory,
+    vmobjects
+  ],
+  experimental/[
+    results
+  ]
+
 from std/math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
   arctan, arctan2, cos, cosh, hypot, sinh, sin, tan, tanh, pow, trunc,
   floor, ceil, `mod`, cbrt, arcsinh, arccosh, arctanh, erf, erfc, gamma,
@@ -30,9 +55,8 @@ from std/hashes import hash
 from std/osproc import nil
 from system/formatfloat import writeFloatToBufferSprintf
 
+from compiler/modules/modulegraphs import `$`
 
-# There are some useful procs in vmconv.
-import vmconv
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -112,7 +136,7 @@ proc getCurrentExceptionMsgWrapper(a: VmArgs) {.nimcall.} =
   else:
     let h = tryDeref(a.heap[], a.currentException, noneType).value()
 
-    a.slots[a.ra].strVal.asgnVmString(
+    deref(a.slots[a.ra].handle).strVal.asgnVmString(
       deref(h.getFieldHandle(FieldPosition(2))).strVal,
       a.mem.allocator)
 


### PR DESCRIPTION
For backwards compatibility, both modules are re-exported from `vm`
