### PR TITLE
vm: callback related clean-ups

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2140,7 +2140,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         for i in (rb+1)..<(rb+rc):
           checkHandle(regs[i])
 
-        c.callbacks[bb.cbOffset].value(
+        c.callbacks[bb.cbOffset](
           VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[ptr UncheckedArray[TFullReg]](addr regs[0]),
                  currentException: c.currentExceptionA,
                  currentLineInfo: c.debug[pc],
@@ -2599,7 +2599,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         rb = instr.regB
         rc = instr.regC
         idx = int(regs[rb+rc-1].intVal)
-        callback = c.callbacks[idx].value
+        callback = c.callbacks[idx]
         args = VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[ptr UncheckedArray[TFullReg]](addr regs[0]),
                 currentException: c.currentExceptionA,
                 currentLineInfo: c.debug[pc],

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2546,7 +2546,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
     of skProc, skFunc, skConverter, skMacro, skMethod, skIterator:
       if s.kind == skIterator and s.typ.callConv == TCallingConvention.ccClosure:
         fail(n.info, rsemVmNoClosureIterators, sym = s)
-      if importcCond(c, s) and not procIsCallback(c, s):
+      if importcCond(c, s) and lookup(c.callbackKeys, s) == -1:
         fail(n.info, rsemVmCannotImportc, sym = s)
 
       genProcLit(c, n, s, dest)


### PR DESCRIPTION
## Summary

- replace usage of `split` function with iterator
- split up the `callbacks` list because `key` and `value` both have
 different lifetimes as well as readers and writers
- don't cache the callback index in the routine symbol's `position`
 field. This makes callback lookup side-effect free

Part of the ongoing effort to split up `TCtx` into smaller parts.

## Future work

Depending on how the planned bigger callback rework goes, a dedicated
data structure to accelerate the identifier pattern matching might make
sense, as the current `seq`-based implementation is rather inefficient - in
terms of both memory consumption and run time