### PR TITLE
vm: change how string constants are stored

### DIFF
--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -347,8 +347,8 @@ type
 
   VmConstant* = object
     ## `VmConstant`s are used for passing constant data from `vmgen` to the
-    ## execution engine. This currently includes constants for both internal
-    ## use as well as user-defined literal values (e.g. string literals).
+    ## execution engine. This includes constants for both internal use as well
+    ## as user-defined literal values (e.g. string literals).
 
     case kind*: ConstantKind
     of cnstInt:
@@ -356,8 +356,7 @@ type
     of cnstFloat:
       floatVal*: BiggestFloat
     of cnstString:
-      strVal*: LocHandle
-      # XXX: `strVal` should be a simple `string`
+      strVal*: string
     of cnstNode:
       node*: PNode
 


### PR DESCRIPTION
## Summary

Store string VM constants as `string` instead of `VmString`.

This previous approach required a layering violation and an unwanted
dependency, since the VM's allocator (a run-time resource) needed for
creating `VmString`s was used and modified during code-generation
(i.e. compile-time).

## Details

As a consequence of this change, string literals usage (in both `var`
and `let` contexts) always means an additional allocation + copy for
now. Implementing support for foreign memory in the VM will provide
the framework to fix this.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

For a perspective, the first steps of foreign memory support as would be required for storing string literals in `VmString` are currently planned after the `vmgen` rewrite/overhaul (which itself is planned after the first-class VM back-end is merged).
