### PR TITLE
vm: don't depend on `lambdalifting` module

### DIFF
--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -37,7 +37,6 @@ import
 # XXX: the function signatures are a bit cumbersome here
 
 from compiler/ast/trees import exprStructuralEquivalent, cyclicTree
-from compiler/sem/lambdalifting import getEnvParam
 
 const SkipSet = abstractRange + {tyStatic} - {tyTypeDesc}
 


### PR DESCRIPTION
## Summary
`vmcompilerserdes` and `vmaux` both imported `lambdalifting` for
the `getEnvParam` function. Due to the cyclic import dependency
between `transf` and `lambdalifting`, this could cause
`undeclared identifier` errors.

## Details
Usage of `getEnvParam` is replaced with manual lookup (it's only two
lines of simple code and there are only two usage sites).