### PR TITLE
compiler: use nkError in sem for import export

### DIFF
--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -151,21 +151,22 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags, fr
     processModuleAux("import(dirty)")
     graph.markClientsDirty(fileIdx)
 
+
 proc importModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
-  # this is called by the semantic checking phase
+  ## this is called by the semantic checking phase
   assert graph.config != nil
+
   result = compileModule(graph, fileIdx, {}, s)
   graph.addDep(s, fileIdx)
+
   # keep track of import relationships
   if graph.config.hcrOn:
     graph.importDeps.mgetOrPut(FileIndex(s.position), @[]).add(fileIdx)
-  #if sfSystemModule in result.flags:
-  #  localReport(result.info, errAttemptToRedefine, result.name.s)
+
   # restore the notes for outer module:
   if s.getnimblePkgId == graph.config.mainPackageId or
      isDefined(graph.config, "booting"):
     graph.config.asgn(cnCurrent, cnMainPackage)
-
   else:
     graph.config.asgn(cnCurrent, cnForeign)
 

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -115,7 +115,7 @@ template legacyConsiderQuotedIdent*(c: PContext; n, origin: PNode): PIdent =
       if origin.isNil or n == origin:
         localReport(c.config, err)
       else:
-        # xxx: janky error gen, the way tot fix is this by starting at the
+        # xxx: janky error gen, the way to fix is this by starting at the
         #      callsites and reworking how things are consumed/passed in.
         #      also, the nkAccQuote handling likely requires alpha-rewriting
         let
@@ -610,7 +610,7 @@ proc createUndeclaredIdentifierError(
     # prevent excessive errors for 'nim check'
     c.recursiveDep.setLen 0
 
-proc errorUndeclaredIdentifierHint(
+proc errorUndeclaredIdentifierHint*(
     c: PContext; n: PNode, ident: PIdent): PSym =
   var candidates: seq[SemSpellCandidate]
   if c.mustFixSpelling:
@@ -663,7 +663,7 @@ proc errorExpectedIdentifier(
 
   result = newQualifiedLookUpError(c, ident, n.info, ast)
 
-proc errorUndeclaredIdentifierWithHint(
+proc errorUndeclaredIdentifierWithHint*(
     c: PContext; n: PNode; name: string,
     candidates: seq[SemSpellCandidate] = @[]
   ): PSym =


### PR DESCRIPTION
## Summary
- semExportExceptStmt is reworked like semVarOrLet
- removed deadcode in importer `importForwarded`
- more of importer is now nkError aware

`semVarOrLet` refactor: https://github.com/nim-works/nimskull/pull/316

---
## Notes for Reviewers
* the cut off point for porting is a little arbitrary (not too big)
* is the semExportExcept easier to read/reason about?