### PR TITLE
tests: prep lang category for the vm backend

### DIFF
--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -1041,6 +1041,8 @@ func nativeTarget(): TTarget =
 func defaultTargets(category: Category): set[TTarget] =
   const standardTargets = {nativeTarget()}
   case category.string
+  of "lang":
+    {targetC, targetJs, targetCpp}
   of "arc", "avr", "destructor", "distros", "dll", "gc", "osproc", "parallel",
      "realtimeGC", "threads", "views", "valgrind":
     standardTargets - {targetJs}

--- a/tests/lang/s01_basics/s00_atoms/t00_builtins.nim
+++ b/tests/lang/s01_basics/s00_atoms/t00_builtins.nim
@@ -2,7 +2,6 @@ discard """
 description: '''
 This test specifies basic operations used in other tests.
 '''
-targets:"c cpp js"
 """
 
 block builtin_assert:

--- a/tests/lang/s01_basics/s00_atoms/t01_statement.nim
+++ b/tests/lang/s01_basics/s00_atoms/t01_statement.nim
@@ -3,7 +3,6 @@ description: '''
 This test covers statements, sequential evaluation and control flow.
 '''
 joinable: false
-targets:"c cpp js"
 """
 
 ## This section of specification explains what *statemetn* is, and two different

--- a/tests/lang/s01_basics/s00_atoms/t02_expression.nim
+++ b/tests/lang/s01_basics/s00_atoms/t02_expression.nim
@@ -2,7 +2,6 @@ discard """
 description: '''
 Test expression evaluation - via blocks, noreturn statements, regular expressions.
 '''
-targets:"c cpp js"
 """
 
 ## Basic expressions. This section explains and tests basic expressions -

--- a/tests/lang/s01_basics/s00_atoms/t03_compiletime.nim
+++ b/tests/lang/s01_basics/s00_atoms/t03_compiletime.nim
@@ -5,7 +5,6 @@ Execution of the code at compilation time.
 output: '''
 echo outside of static
 '''
-targets:"c cpp js"
 """
 
 # Given this is a specification I don't think it is an appropriate place to

--- a/tests/lang/s01_basics/s03_literals/s1_string/t01_escape_sequences.nim
+++ b/tests/lang/s01_basics/s03_literals/s1_string/t01_escape_sequences.nim
@@ -6,7 +6,6 @@ particular escaping method used. Otherwise the tests are pretty silly.
 
 ASCII reference: https://en.wikipedia.org/wiki/ASCII#Control_characters
 '''
-targets: "c cpp js"
 """
 
 # NB: `\[0-9]+` - is the decimal encoding of a character

--- a/tests/lang/s01_basics/s03_literals/s1_string/t02_triplequoted.nim
+++ b/tests/lang/s01_basics/s03_literals/s1_string/t02_triplequoted.nim
@@ -5,7 +5,6 @@ Triple Quoted string literals:
 - do not need to escape non-consecutive occurences of `"`
 - end when three double quotes are followed by a non-doublequote character
 '''
-targets: "c cpp js"
 """
 
 doAssert """""" == "", "empty string and triplequoted literals are equivalent"

--- a/tests/lang/s01_basics/s03_literals/s1_string/t03_raw_and_generalized.nim
+++ b/tests/lang/s01_basics/s03_literals/s1_string/t03_raw_and_generalized.nim
@@ -11,7 +11,6 @@ Raw and generalized raw string literals:
 - generalized raw string literals can be applied to triplequoted strings
     unlike normal raw string literals
 '''
-targets: "c cpp js"
 """
 
 doAssert r"\n" == "\\n", "raw string literals don't apply escape sequences"

--- a/tests/lang/s01_basics/s03_literals/s1_string/t03_raw_no_triplequote_fail.nim
+++ b/tests/lang/s01_basics/s03_literals/s1_string/t03_raw_no_triplequote_fail.nim
@@ -4,9 +4,8 @@ There are no raw triplequoted string literals, though generalized string
 literals do support this, and result in an unclosed triplequoted literal error
 '''
 errormsg: "closing \"\"\" expected, but end of file reached"
-line: 12
+line: 11
 column: 1
-targets: "c cpp js"
 """
 
 discard r""" == "\"", "tripleQuoted raw string literals are not possible"

--- a/tests/lang/s01_basics/s03_literals/s2_character/t01_escape_sequences.nim
+++ b/tests/lang/s01_basics/s03_literals/s2_character/t01_escape_sequences.nim
@@ -6,7 +6,6 @@ particular escaping method used. Otherwise the tests are pretty silly.
 
 ASCII reference: https://en.wikipedia.org/wiki/ASCII#Control_characters
 '''
-targets: "c cpp js"
 """
 
 # NB: `\[0-9]+` - is the decimal encoding of a character

--- a/tests/lang/s01_basics/s03_literals/s3_numeric/t01_literals.nim
+++ b/tests/lang/s01_basics/s03_literals/s3_numeric/t01_literals.nim
@@ -2,7 +2,6 @@ discard """
 description: '''
 Covers numeric literals, in particular defaults and how suffixes are handled
 '''
-targets: "c cpp js"
 """
 
 # basic int literals

--- a/tests/lang/s01_basics/s04_varables/t01_const_let_var.nim
+++ b/tests/lang/s01_basics/s04_varables/t01_const_let_var.nim
@@ -2,7 +2,6 @@ discard """
 description: '''
 The very basics of const, let, and var
 '''
-targets: "c cpp js"
 """
 
 # assign a value to `foo`, it's set once at a compile time

--- a/tests/lang/s01_basics/s05_primitive_types/t01_integer.nim
+++ b/tests/lang/s01_basics/s05_primitive_types/t01_integer.nim
@@ -3,7 +3,6 @@ description: '''
 Pre-defined integer types, the listing is under numeric literals, this covers
 additional operations and conversion.
 '''
-target: "c cpp js"
 """
 
 # Conversions types:

--- a/tests/lang/s01_basics/s05_primitive_types/t02_unsigned_backwards_compat.nim
+++ b/tests/lang/s01_basics/s05_primitive_types/t02_unsigned_backwards_compat.nim
@@ -3,7 +3,6 @@ description: '''
 Unsigned integer operations kept for backwards compatibility, but should be
 removed from the language eventually
 '''
-target: "c cpp js"
 """
 
 # unsigned operators treat operands as unsigned, returning original type.

--- a/tests/lang/s01_basics/s05_primitive_types/t03_boolean.nim
+++ b/tests/lang/s01_basics/s05_primitive_types/t03_boolean.nim
@@ -2,7 +2,6 @@ discard """
 description: '''
 Basics of boolean types
 '''
-target: "c cpp js"
 """
 
 # overlaps heavily with literals, not going to cover here

--- a/tests/lang/s01_basics/s05_primitive_types/t05_strings.nim
+++ b/tests/lang/s01_basics/s05_primitive_types/t05_strings.nim
@@ -7,7 +7,6 @@ String type related tests, covering key properties regarding:
 - indexing is per byte (char)
 - lexographic comparison
 '''
-target: "c cpp js"
 """
 
 block strings_valid_from_empty_string:

--- a/tests/lang/s01_basics/s06_primitive_compound_types/t01_array.nim
+++ b/tests/lang/s01_basics/s06_primitive_compound_types/t01_array.nim
@@ -6,7 +6,6 @@ Describe the basics of arrays:
 - indexing
 - length
 '''
-target: "c cpp js"
 """
 
 block literal:

--- a/tests/lang/s01_basics/s06_primitive_compound_types/t02_sequence.nim
+++ b/tests/lang/s01_basics/s06_primitive_compound_types/t02_sequence.nim
@@ -6,7 +6,6 @@ Basics of sequences:
 - indexing
 - length
 '''
-target: "c cpp js"
 """
 
 block literal:

--- a/tests/lang/s01_basics/s07_operators/t01_operators.nim
+++ b/tests/lang/s01_basics/s07_operators/t01_operators.nim
@@ -10,7 +10,6 @@ To be covered elsewhere:
   - though not all operators are available for overload
   - user defined operators one or a a combination of tokens
 '''
-targets: "c cpp js"
 """
 
 #[

--- a/tests/lang/s01_basics/s08_control_flow/t02_if.nim
+++ b/tests/lang/s01_basics/s08_control_flow/t02_if.nim
@@ -2,7 +2,6 @@ discard """
 description: '''
 If statements, if expressions
 '''
-targets:"c cpp js"
 """
 
 #[

--- a/tests/lang/s02_core/s01_user_defined_data_types/t03_inheritance.nim
+++ b/tests/lang/s02_core/s01_user_defined_data_types/t03_inheritance.nim
@@ -2,7 +2,7 @@ discard """
 description: '''
 It is possible for objects to inherit fields from another object. Each
 object has at most one parent type. This practice is common in Object
-Orientated Programming.
+Oriented Programming.
 '''
 """
 
@@ -37,8 +37,8 @@ block derive_from_ref_root_obj:
     Derived = ref object of Base
       f2: int
 
-  ## Using ref object allows to store values of derived type in variable
-  ## of base type
+  ## Using ref object allows storing a reference of derived type in variable
+  ## of the base type
   let base: Base = Derived(f2: 12)
 
   ## Or storing multuple derived objects in the same sequence
@@ -52,11 +52,12 @@ block derive_from_ref_root_obj:
   ## To convert base type back to derived, you can use object conversion
   doAssert Derived(base).f2 == 12
 
-  ## If expressions cannot be converted to the derived type, it will
-  ## result in an `ObjectConversionDefect` begin raised
-  try:
-    discard Derived(Base())
-    doAssert false, "Had to raise defect"
+  when not defined(js):
+   when not defined(js) or defined(tryBrokenSpecification):
+    # Bug: js target allows this conversion to happen parent ref -> child ref
+    try:
+      discard Derived(Base())
+      doAssert false, "Should have raised defect"
 
-  except ObjectConversionDefect as def:
-    discard
+    except ObjectConversionDefect as def:
+      discard

--- a/tests/lang/s02_core/s01_user_defined_data_types/t04_enum.nim
+++ b/tests/lang/s02_core/s01_user_defined_data_types/t04_enum.nim
@@ -4,7 +4,6 @@ An enumeration defines a type with a closed set of values. These values
 have an identifier, are ordered, and have corresponding integer and string
 values.
 '''
-target: "c cpp js"
 """
 
 block enum_definition_syntax:

--- a/tests/lang/s02_core/s02_procedures/t02_argument_passing.nim
+++ b/tests/lang/s02_core/s02_procedures/t02_argument_passing.nim
@@ -2,9 +2,10 @@ discard """
 description: '''
 Covers the multitude of ways you can pass arguments to procedures.
 '''
+targets: "!cpp"
 """
 
-##
+# knownIssue: broken in cpp
 
 
 block different_number_of_arguments:
@@ -341,7 +342,7 @@ block passing_subtypes:
   ## `object of RootObj` (in addition to `ref object of RootObj`) whereas `method`
   ## requires `ref` to be used.
   block inheritable_pragma:
-    ## `{.inheritable.}` provides subtyping capabilities
+    ## `{.inheritable.}` marks the object as non-final
     type
       Base {.inheritable.} = object
         fbase: int

--- a/tests/lang/s02_core/s02_procedures/t02_argument_passing_bugs/t01_varargs_does_not_support_polymorphic.nim
+++ b/tests/lang/s02_core/s02_procedures/t02_argument_passing_bugs/t01_varargs_does_not_support_polymorphic.nim
@@ -1,6 +1,6 @@
 discard """
 description: '''
-Passing derived types via varargs reaises an "invalid object assignment" exception
+Passing derived types via varargs raises an "invalid object assignment" exception
 instead of passing values directly.
 
 `varargs` is defined to behave the same way as procedure with multiple arguments,

--- a/tests/lang/s02_core/s02_procedures/t03_overload_core_conversion/t01_generic_converter.nim
+++ b/tests/lang/s02_core/s02_procedures/t03_overload_core_conversion/t01_generic_converter.nim
@@ -6,17 +6,17 @@ parameters
 joinable: false
 """
 
-type
-  Generic[T] = object
-    s: seq[T]
+when not defined(cpp) or defined(tryBrokenSpecification):
+  # C++ backend generates invalid code for the converter
+  type
+    Generic[T] = object
+      s: seq[T]
 
-converter toGeneric[T](s: seq[T]): Generic[T] = Generic[T](s: s)
+  converter toGeneric[T](s: seq[T]): Generic[T] = Generic[T](s: s)
 
-var x = Generic @[1, 2, 3]
+  var x = Generic @[1, 2, 3]
 
-doAssert x.s == @[1, 2, 3], "Argument copied in converter"
-doAssert x is Generic[int], "Type is inferred on construction"
+  doAssert x.s == @[1, 2, 3], "Argument copied in converter"
+  doAssert x is Generic[int], "Type is inferred on construction"
 
-doAssert Generic(@[0'u8, 1, 2]) is Generic[uint8]
-
-echo 123
+  doAssert Generic(@[0'u8, 1, 2]) is Generic[uint8]

--- a/tests/lang/s05_pragmas/s01_interop/t03_emit_c.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t03_emit_c.nim
@@ -1,3 +1,10 @@
+discard """
+targets: "c"
+description: '''
+Emit pragma outputs code directly through the back, these are C examples.
+'''
+"""
+
 block emit_type:
   {.emit: """/*TYPESECTION*/
 struct CStruct { int field; };

--- a/tests/lang/s05_pragmas/s02_misc/t01_ident_pragmas.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t01_ident_pragmas.nim
@@ -3,7 +3,7 @@ description: '''
 Test pragma annotations that can be used on identifier declaratios.
 '''
 
-cmd: "nim c -r -d:strdefineUsed='test' -d:intdefineUsed=2 -d:booldefineUsed=false $options $file"
+matrix: "-d:strdefineUsed='test' -d:intdefineUsed=2 -d:booldefineUsed=false"
 
 """
 

--- a/tests/lang/s05_pragmas/s02_misc/t02_flag_pragmas.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t02_flag_pragmas.nim
@@ -1,6 +1,7 @@
 discard """
+targets: "!js"
 description: '''
-Disable or enable safety checks
+Enable or disable safety checks applicable to C and C++ targets
 '''
 """
 
@@ -38,7 +39,7 @@ block disable_bound_checking:
   {.pop.}
 
   impl()
-    
+
 block enable_overflow_checks:
   {.push overflowChecks:on.}
   proc impl() = 

--- a/tests/lang/s05_pragmas/s02_misc/t03_hint_pragmas.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t03_hint_pragmas.nim
@@ -5,7 +5,7 @@ description: '''
 
 nimout: '''
 t03_hint_pragmas.nim(15, 7) Hint: User-provided hint message [User]
-t03_hint_pragmas.nim(19, 9) Hint: gen1 size of the argument is 8 [User]
+t03_hint_pragmas.nim(19, 9) Hint: gen1 name of the argument is int [User]
 t03_hint_pragmas.nim(31, 6) Hint: 'declaredButNotUsed' is declared but not used [XDeclaredButNotUsed]
 '''
 
@@ -16,14 +16,14 @@ t03_hint_pragmas.nim(31, 6) Hint: 'declaredButNotUsed' is declared but not used 
 
 
 proc gen1[T](arg: T) =
-  {.hint: "gen1 size of the argument is " & $sizeof(arg).}
+  {.hint: "gen1 name of the argument is " & $T.}
 
 gen1[int](1)
 
 when defined(tryBrokenSpecification):
   proc gen2[T](arg: T) =
     {.line: instantiationInfo().}:
-      {.hint: "gen2 size of the argument is " & $sizeof(arg).}
+      {.hint: "gen2 name of the argument is " & $T.}
 
   gen2[int](1)
 

--- a/tests/lang/s05_pragmas/s02_misc/t04_warning.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t04_warning.nim
@@ -6,9 +6,9 @@ description: '''
 nimout: '''
 t04_warning.nim(17, 10) Warning: User-provided warning message [User]
 t04_warning.nim(22, 5) template/generic instantiation of `gen1` from here
-t04_warning.nim(20, 12) Warning: gen1 size of the argument is 8 [User]
+t04_warning.nim(20, 12) Warning: gen1 name of the argument is int [User]
 t04_warning.nim(23, 5) template/generic instantiation of `gen1` from here
-t04_warning.nim(20, 12) Warning: gen1 size of the argument is 8 [User]
+t04_warning.nim(20, 12) Warning: gen1 name of the argument is float [User]
 '''
 
 
@@ -17,7 +17,7 @@ t04_warning.nim(20, 12) Warning: gen1 size of the argument is 8 [User]
 {.warning: "User-provided warning message".}
 
 proc gen1[T](arg: T) =
-  {.warning: "gen1 size of the argument is " & $sizeof(arg).}
+  {.warning: "gen1 name of the argument is " & $T.}
 
 gen1[int](1)
 gen1[float](1.0)

--- a/tests/lang/s05_pragmas/s02_misc/t06_union_pragma.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t06_union_pragma.nim
@@ -1,3 +1,7 @@
+discard """
+targets: "!js"
+"""
+
 block union_pragma:
   ## The union pragma can be applied to any object type. It means all of the object's 
   ## fields are overlaid in memory.This produces a union instead of a struct in the 

--- a/tests/lang/s06_experimental/s01_views/s00_bugs/t01_var_openarray.nim
+++ b/tests/lang/s06_experimental/s01_views/s00_bugs/t01_var_openarray.nim
@@ -3,7 +3,7 @@ description: '''
 `var openarray` must either generate a proper error message or be allowed,
 currently fails with codegen error
 '''
-knownIssue: "var openarray fails with C codegen errro"
+knownIssue: "var openarray fails with C codegen error"
 
 """
 


### PR DESCRIPTION
## Summary
- ready to add the vm backend as lang categories default target
- lang category now runs for all categories

Changes:
- default the lang category to run on all relevant backends
- fixed test target declarations
- disabled some tests for broken backends like cpp

---
