### PR TITLE
internals: case/let style semArrGet semArrayAccess

### DIFF
--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -216,7 +216,7 @@ proc bracketNotFoundError(c: PContext; n: PNode): PNode =
     if symx.kind in routineKinds:
       errors.add SemCallMismatch(target: symx, firstMismatch: MismatchInfo())
     elif symx.isError:
-      # xxx: unlike we ever get here; defensive code
+      # xxx: unlikely we ever get here; defensive code
       continue
     symx = nextOverloadIter(o, c, headSymbol)
 


### PR DESCRIPTION
## Summary

clean up some sem procs to follow case/let style of writing

semArrGet:
- separate subscript vs derefencing

Both:
- added asserts and validators
- adding debug tracing

---
