### PR TITLE
suggest: decouple suggest from main compiler

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -14,7 +14,9 @@ import
     strutils,
     math,
     strtabs,
-    intsets
+    intsets,
+    sets,       # used for markOwnerModuleAsUsed
+    tables,     # used for markOwnerModuleAsUsed
   ],
   compiler/ast/[
     ast,
@@ -82,6 +84,8 @@ import
     vmdef,
     vm
   ]
+
+import compiler/tools/suggest
 
 when defined(nimfix):
   import compiler/nimfix/prettybase

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -12,7 +12,6 @@
 import
   std/[
     intsets,
-    strutils,
   ],
   compiler/ast/[
     ast,
@@ -20,10 +19,7 @@ import
     types,
     renderer,
     idents,
-    lexer,
-    typesrenderer,
     trees,
-    linter,
     lineinfos,
     errorhandling,
     reports,
@@ -95,9 +91,6 @@ type
 
 const
   isNilConversion = isConvertible # maybe 'isIntConv' fits better?
-
-proc markUsed*(c: PContext; info: TLineInfo, s: PSym)
-proc markOwnerModuleAsUsed*(c: PContext; s: PSym)
 
 proc toDebugCallableCandidate*(c: TCandidate): DebugCallableCandidate =
   DebugCallableCandidate(
@@ -2686,8 +2679,6 @@ proc instTypeBoundOp*(c: PContext; dc: PSym; t: PType; info: TLineInfo;
     result = c.semGenerateInstance(c, dc, m.bindings, info)
     if op == attachedDeepCopy:
       assert sfFromGeneric in result.flags
-
-include compiler/tools/suggest
 
 when not declared(tests):
   template tests(s: untyped) = discard

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -47,8 +47,9 @@ import
     sem,
     passes,
     passaux,
-    sigmatch
   ]
+
+from compiler/tools/suggest import isTracked, listUsages, suggestSym, `$`
 
 when defined(windows):
   import winlean
@@ -707,6 +708,9 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   myLog(conf, "START " & conf.projectFull.string)
 
   var graph = newModuleGraph(cache, conf)
+  graph.onMarkUsed = proc (g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; isDecl: bool) =
+    suggestSym(g, info, s, usageSym, isDecl)
+  graph.onSymImport = graph.onMarkUsed # same callback
   if self.loadConfigsAndProcessCmdLine(cache, conf, graph):
     mainCommand(graph)
 


### PR DESCRIPTION
## Summary
- `sigmatch` no longer includes `suggest`
- Overall this is another step to detangling the compiler components.

## Details
- extract usage tracking procs (eg: markUsed) into semData
- introduce suggest callbacks on the module graph
- decouple a few direct links from sem into suggest
- this allowed removal of some import related warnings

---
