### PR TITLE
Include exit code in report for `execExternalProgram`

### DIFF
--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -436,8 +436,9 @@ proc execWithEcho(conf: ConfigRef; cmd: string, execKind: ReportKind): int =
   result = execCmd(cmd)
 
 proc execExternalProgram*(conf: ConfigRef; cmd: string, kind: ReportKind) =
-  if execWithEcho(conf, cmd, kind) != 0:
-    conf.localReport CmdReport(kind: rcmdFailedExecution, cmd: cmd)
+  let code = execWithEcho(conf, cmd, kind)
+  if code != 0:
+    conf.localReport CmdReport(kind: rcmdFailedExecution, cmd: cmd, code: code)
 
 proc generateScript(conf: ConfigRef; script: Rope) =
   let (_, name, _) = splitFile(conf.outFile.string)


### PR DESCRIPTION
The `execution of external program failed` error messages now
contain the exit code again, instead of always showing '0'

Fixes https://github.com/nim-works/nimskull/issues/205

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* I tried adding a test for the message using `cmd: "nim r $file"`, but this doesn't work, as `nimout` is compared on a per-line basis and the the external program name is platform specific