### PR TITLE
vm: clean up callback registration (`vmops`)

### DIFF
--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -162,7 +162,8 @@ proc createInterpreter*(
   vm.mode = emRepl
   vm.features = flags
   if registerOps:
-    vm.registerAdditionalOps() # Required to register parts of stdlib modules
+    # Register basic system operations and parts of stdlib modules
+    vm[].registerBasicOps()
   graph.vm = vm
   graph.compileSystemModule()
   result = Interpreter(mainModule: m, graph: graph, scriptName: scriptName, idgen: idgen)

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -3464,7 +3464,13 @@ proc setupGlobalCtx*(module: PSym; graph: ModuleGraph; idgen: IdGenerator) =
   addInNimDebugUtils(graph.config, "setupGlobalCtx")
   if graph.vm.isNil:
     graph.vm = newCtx(module, graph.cache, graph, idgen)
-    registerAdditionalOps(PCtx graph.vm)
+    let
+      ctx = PCtx graph.vm
+      disallowDangerous =
+        defined(nimsuggest) or graph.config.cmd == cmdCheck or
+        vmopsDanger notin ctx.config.features
+
+    registerAdditionalOps(ctx[], disallowDangerous)
   else:
     let c = PCtx(graph.vm)
     refresh(c[], module, idgen)

--- a/tests/stdlib/tosenv.nim
+++ b/tests/stdlib/tosenv.nim
@@ -1,5 +1,6 @@
 discard """
-  matrix: "--threads"
+  # `vmopsDanger` is required for compile-time `putEnv`/`delEnv`
+  matrix: "--threads --experimental:vmopsDanger"
   joinable: false
   targets: "c js cpp"
 """

--- a/tests/vm/tfile_rw.nim
+++ b/tests/vm/tfile_rw.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--experimental:vmopsDanger"
   output: '''ok'''
 """
 

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -1,3 +1,8 @@
+discard """
+  matrix: "--experimental:vmopsDanger" # for compile-time `putEnv`
+  target: native
+"""
+
 # bug #4462
 import macros
 import os

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--experimental:vmopsDanger"
   targets: "c cpp js"
 """
 


### PR DESCRIPTION
## Summary
- split up registration into multiple functions
- improve documentation in `vmops`
- adjust meaning of `vmopsDanger` option. All functions that can modify
 the host's environment are now no-ops by default
- `gorge` and `gorgeEx` are still available without
 specifying `experimental:vmopsDanger`.
- the operations registered by default when using the compiler API
 now only include the basic system and math ops

The split up makes callback registration more modular and allows
the newly introduced categories to be registered independently from
each other (or not at all).

This is an intermediate change, aimed at making callback handling
easier for the VM back-end.

## Details
Operations that are now no-ops without `vmopsDanger`:
- `putEnv`, `delEnv`

Operations that were no-ops without `vmopsDanger` but now aren't:
- `getCurrentDir`, `getTime`