### PR TITLE
internals: semexprs rewrites to case/let style

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3166,7 +3166,7 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
       let enter = s.direction == semstepEnter
       if conf.hack.semTraceData and
          s.kind != stepTrack #[ 'track' has no extra data fields ]#:
-        field("kind", $s.kind)
+        # field("kind", $s.kind) # useful if you're new to reading traces
         case s.kind:
           of stepNodeToNode:
             if enter:

--- a/compiler/plugins/locals.nim
+++ b/compiler/plugins/locals.nim
@@ -27,7 +27,7 @@ import
 proc semLocals*(c: PContext, n: PNode): PNode =
   var counter = 0
   var tupleType = newTypeS(tyTuple, c)
-  result = newNodeIT(nkPar, n.info, tupleType)
+  result = newNodeIT(nkTupleConstr, n.info, tupleType)
   tupleType.n = newNodeI(nkRecList, n.info)
   let owner = getCurrOwner(c)
   # for now we skip openarrays ...

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -22,6 +22,9 @@ import
   compiler/front/[
     options,
     msgs
+  ],
+  compiler/utils/[
+    debugutils
   ]
 
 type
@@ -164,6 +167,8 @@ proc evalTemplate*(n: PNode, tmpl, genSymOwner: PSym;
                    ic: IdentCache; instID: ref int;
                    idgen: IdGenerator;
                    fromHlo=false): PNode =
+  addInNimDebugUtils(conf, "evalTemplate", n, result)
+
   inc(conf.evalTemplateCounter)
   if conf.evalTemplateCounter > evalTemplateLimit:
     globalReport(conf, n.info, SemReport(

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -711,7 +711,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
   ## XXX: maybe remove the flags for ambiguity and undeclared and let the call
   ##      sites figure it out instead?
   const allExceptModule = {low(TSymKind)..high(TSymKind)} - {skModule, skPackage}
-  c.config.addInNimDebugUtils("qualifiedLookup", n, result)
+  c.config.addInNimDebugUtils("qualifiedLookUp", n, result)
 
   proc symFromCandidates(
     c: PContext, candidates: seq[PSym], ident: PIdent, n: PNode,

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -548,8 +548,7 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
       haveGivenTyp = givenTyp != nil and not givenTyp.isError
       haveInit = initType != nil and not initType.isError
     
-    # xxx: this was hacked in to disallow typedesc in arrays, outside of
-    #      macros, but it feels wrong here
+    # xxx: this was hacked in to disallow typedesc in arrays outside of macros
     if haveInit and initType.kind == tyTypeDesc and c.p.owner.kind != skMacro:
       typFlags.incl taProcContextIsNotMacro
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1906,11 +1906,11 @@ proc semTypeOf2(c: PContext; n: PNode; prev: PType): PType =
   result = t.typ
 
 proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
+  addInNimDebugUtils(c.config, "semTypeNode", n, prev, result)
   result = nil
   inc c.inTypeContext
 
   if c.config.cmd == cmdIdeTools: suggestExpr(c, n)
-  addInNimDebugUtils(c.config, "semTypeNode", n, prev, result)
   case n.kind
   of nkEmpty: result = n.typ
   of nkTypeOfExpr:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2652,11 +2652,11 @@ proc argtypeMatches*(c: PContext, f, a: PType, fromHlo = false): bool =
   #instantiateGenericConverters(c, res, m)
   # XXX this is used by patterns.nim too; I think it's better to not
   # instantiate generic converters for that
-  if not fromHlo:
-    res != nil
-  else:
+  if fromHlo:
     # pattern templates do not allow for conversions except from int literal
     res != nil and m.convMatches == 0 and m.intConvMatches in [0, 256]
+  else:
+    res != nil
 
 when not defined(nimHasSinkInference):
   {.pragma: nosinks.}

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -324,7 +324,6 @@ proc symFields(
   var res = addr result
   genFields(res[], indent, rconf)
 
-
   if not rconf.extraSymInfo.isNil():
     let text = rconf.extraSymInfo(sym)
     if 0 < len(text):
@@ -332,6 +331,7 @@ proc symFields(
 
   if trfShowSymName in rconf:
     field("name.s", sym.name.s + style.ident)
+    hfield("sym.id", $sym.id + style.number)
     hfield("name.id", $sym.name.id + style.number)
 
   if trfShowSymFlags in rconf and
@@ -341,7 +341,6 @@ proc symFields(
   if trfShowSymMagic in rconf and
      (sym.magic != mNone or rconf.defaulted()):
     field("magic", substr($sym.magic, 1) + style.setIt)
-
 
   if trfShowSymId in rconf:
     field("itemId")


### PR DESCRIPTION
## Summary
- rewrite a few more procs in the case/let style
- many of the procs in semexprs are now converted
- next steps is cleaning up other modules similarly

## Details
- tuple constructor and par handling cleaned up
- eliminated the need for semexprs.checkPar
- dotTransformation is now nkError ready
- semTupleConstr now handles all tuple construction

### Misc Changes
- added sym id to trace output
- added in more tracing into various procs
- removed step kind in tracing, too much spam
- explain output in ill formed error messages

next steps is cleaning up other modules similarly

---

## Notes for Reviewers
* the rest doesn't clean-up all that easily
* this should become easier after other files are cleaned and the APIs can change