### PR TITLE
compiler/front: add depfile option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -84,3 +84,6 @@ becomes an alias for `addr`.
 
 - There is a new switch `--nimMainPrefix:prefix` to influence the `NimMain` that the
   compiler produces. This is particularly useful for generating static libraries.
+
+- There is a new switch `--depfile:path` to write a GCC-style depfile that can be used with
+  various build systems.

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -149,7 +149,7 @@ const optNames = @[
   # processSwitch
   "eval", "path", "p", "nimblepath", "babelpath", "nonimblepath",
   "nobabelpath", "clearnimblepath", "excludepath", "nimcache", "out", "o",
-  "outdir", "usenimcache", "docseesrcurl", "docroot", "backend", "b",
+  "outdir", "depfile", "usenimcache", "docseesrcurl", "docroot", "backend", "b",
   "doccmd", "define", "d", "undef", "u", "compile", "link", "debuginfo",
   "embedsrc", "compileonly", "c", "nolinking", "nomain", "forcebuild", "f",
   "project", "warnings", "w", "warning", "hint", "warningaserror",
@@ -718,6 +718,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "outdir":
     expectArg(conf, switch, arg, pass, info)
     conf.outDir = processPath(conf, arg, info, switch, notRelativeToProj=true)
+  of "depfile":
+    expectArg(conf, switch, arg, pass, info)
+    conf.depfile = processPath(conf, arg, info, switch, notRelativeToProj=true).AbsoluteFile
   of "usenimcache":
     processOnOffSwitchG(conf, {optUseNimcache}, arg, pass, info, switch)
   of "docseesrcurl":

--- a/compiler/front/depfiles.nim
+++ b/compiler/front/depfiles.nim
@@ -1,0 +1,37 @@
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## Functions for writing target's dependencies in various formats.
+
+import
+  std/[strutils, tables]
+
+import
+  compiler/utils/[pathutils],
+  compiler/modules/[modulegraphs],
+  compiler/ast/[ast_types],
+  compiler/front/[msgs, options]
+
+proc writeDepsFile*(g: ModuleGraph) =
+  let fname = g.config.nimcacheDir / RelativeFile(g.config.projectName & ".deps")
+  let f = open(fname.string, fmWrite)
+  for m in g.ifaces:
+    if m.module != nil:
+      f.writeLine(toFullPath(g.config, m.module.position.FileIndex))
+  for k in g.inclToMod.keys:
+    if g.getModule(k).isNil:  # don't repeat includes which are also modules
+      f.writeLine(toFullPath(g.config, k))
+  f.close()
+
+proc writeGccDepfile*(depfile: File, target: string, paths: openArray[string]) =
+  ## Outputs one `make` rule containing target's file name, a colon, and the
+  ## names of all specified paths. Spaces and hashes are escaped.
+  let target = target.multiReplace((" ", "\\ "), ("#", "\\#"))
+  depfile.write(target & ": \\" & '\n')
+  for it in paths:
+    let path = it.multiReplace((" ", "\\ "), ("#", "\\#"))
+    if path.len == 0:
+      continue
+    depfile.write('\t' & path & " \\" & '\n')

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -295,6 +295,7 @@ type
 
     outFile*: RelativeFile
     outDir*: AbsoluteDir
+    depfile*: AbsoluteFile
 
     implicitImports*: seq[string]  ## modules that are to be implicitly
                                    ## imported

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -298,6 +298,7 @@ passField filenameOption,     FilenameOption
 passField numberOfProcessors, int
 passField outFile,            RelativeFile
 passField outDir,             AbsoluteDir
+passField depfile,            AbsoluteFile
 passField projectPath,        AbsoluteDir
 passField projectName,        string
 passField projectFull,        AbsoluteFile

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -33,6 +33,7 @@ Advanced options:
                             find the definition and all usages of a symbol
   -o:FILE, --out:FILE       set the output filename
   --outdir:DIR              set the path where the output file will be written
+  --depfile:FILE            write target dependencies in GCC format
   --usenimcache             will use `outdir=$$nimcache`, whichever it resolves
                             to after all options have been processed
   --stdout:on|off           output to stdout

--- a/tests/compilerunits/depfiles/readme.md
+++ b/tests/compilerunits/depfiles/readme.md
@@ -1,0 +1,1 @@
+Unit tests for writing target's dependencies in various formats

--- a/tests/compilerunits/depfiles/tgccdepfile.nim
+++ b/tests/compilerunits/depfiles/tgccdepfile.nim
@@ -1,0 +1,19 @@
+discard """
+description: "can write a GCC-format depfile"
+output: '''
+out\ binary: \
+	module1.nim \
+	module\#.nim \
+	package/module.nim \
+'''
+"""
+
+import
+  compiler/front/depfiles
+
+const paths = [
+  "module1.nim",
+  "module#.nim",
+  "package/module.nim"
+]
+stdout.writeGccDepfile("out binary", paths)


### PR DESCRIPTION
### Abstract

Add a new command-line option (e.g. `--depfile`) for the `nim compile` command. It accepts an argument (output path for a depfile, generated for a given target).

### Motivation

This change would improve integrations with language-independent build
systems. Particularly, get better edit-compile cycle times.

Currently a build system needs to rebuild a binary if _any_ of source files has
been changed, even if they aren't used by the binary. The full list of files
that a given source file depends on can only be discovered by the compiler.

It doesn't need to be a standalone command because if the file has never been
compiled, it must be built anyway, generating the header dependencies as a side
effect.

## Description

### Depfile file format

From GCC manual (`-M` option):

> The preprocessor outputs one 'make' rule containing the object file name for
> that source file, a colon, and the names of all the included files, including
> those coming from '-include' or '-imacros' command-line options.

Or, in the BNF notation:  
https://cmake.org/cmake/help/latest/command/add_custom_command.html

It is recognized by all common build systems.

### Code Examples

### Before
*(no command to produce a depfile)*

### After
```sh
$ nim c --depfile main.d main
$ head -4 main.d # system imports not shown
main: \
	/home/project/main.nim \
	/home/project/src/file1.nim \
	/home/project/src/file2.nim \
```

#### Use the depfile in Makefile

```Makefile
main: main.nim
	nim c $(NIMFLAGS) --depfile $@.d $<

-include main.d
```

#### Use the depfile in Ninja

```Ninja
rule nimc:
  deps = gcc
  depfile = $out.d
  command = nim c $nimflags --depfile $out.d $in

build main: nimc main.nim
```

#### Use the depfile in CMake

```CMake
...

add_custom_command(
    OUTPUT main
    COMMAND nim c ${NIMFLAGS} --depfile main.d main.nim
    DEPFILE main.d
    VERBATIM
)
```

#### Use the depfile in Meson

```Meson
...

nim = find_program('nim')
custom_target(
  input : 'main.nim',
  output : 'main',
  depfile : '@BASENAME@.d',
  command : [nim, 'c', '--depfile', '@DEPFILE@', '@INPUT@'],
  build_by_default : true
)
```

### Backwards Compatibility

This feature introduces no backward-incompatible changes.