### PR TITLE
stdlib: prepare `system` and `io` for the VM target

### DIFF
--- a/lib/std/private/digitsutils.nim
+++ b/lib/std/private/digitsutils.nim
@@ -46,7 +46,7 @@ func addChars[T](result: var string, x: T, start: int, n: int) {.inline.} =
     for i in 0..<n: result[old + i] = x[start + i]
   when nimvm: impl
   else:
-    when defined(js) or defined(nimscript): impl
+    when not declared(copyMem): impl
     else:
       {.noSideEffect.}:
         copyMem result[old].addr, x[start].unsafeAddr, n


### PR DESCRIPTION
Replace `defined(nimscript)` in `when` statements with the new
`isNimVmTarget` constant. Only the `isNimVmTarget` definition needs to
be modified as part of the VM target introduction commit then.