### PR TITLE
Internals: simplify let var section analysis

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -346,6 +346,9 @@ const
   effectListLen* = 3    ## list of effects list
   nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt}
                         ## these must be last statements in a block
+  nkVariableSections* = {nkLetSection, nkVarSection}
+                        # xxx: doesn't include const because const section
+                        #      analysis isn't unified with them
 
 type
   TTypeKind* = enum  # order is important!
@@ -971,6 +974,7 @@ type
                               ## for procs and tyGenericBody, it's the
                               ## formal param list
                               ## for concepts, the concept body
+                              ## for errors, nkError or nil if legacy
                               ## else: unused
     owner*: PSym              ## the 'owner' of the type
     sym*: PSym                ## types have the sym associated with them
@@ -982,7 +986,7 @@ type
     lockLevel*: TLockLevel    ## lock level as required for deadlock checking
     loc*: TLoc
     typeInst*: PType          ## for generic instantiations the tyGenericInst that led to this
-                              ## type.
+                              ## type; for tyError the previous type if avaiable
     uniqueId*: ItemId         ## due to a design mistake, we need to keep the real ID here as it
                               ## is required by the --incremental:on mode.
 

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -88,12 +88,12 @@ proc newError*(
   assert wrongNode != nil, "can't have a nil node for `wrongNode`"
   assert not report.isEmpty(), $report
 
-  result = PNode(
-    kind: nkError,
-    info: wrongNode.info,
-    typ: newType(tyError, ItemId(module: -2, item: -1), nil),
-    reportId: report
+  result = newNodeIT(
+    nkError,
+    wrongNode.info,
+    newType(tyError, ItemId(module: -2, item: -1), nil)
   )
+  result.reportId = report
 
   addInNimDebugUtilsError(conf, wrongNode, result)
 

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3135,13 +3135,19 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
         )
 
       proc render(node: PNode): string =
-        conf.wrap(conf.treeRepr(node, indent = indent + 2))
+        conf.wrap(conf.treeRepr(node,
+                                indent = indent + 2,
+                                rconf = compilerTraceReprConf))
 
       proc render(typ: PType): string =
-        conf.wrap(conf.treeRepr(typ, indent = indent + 2))
+        conf.wrap(conf.treeRepr(typ,
+                                indent = indent + 2,
+                                rconf = compilerTraceReprConf))
 
       proc render(sym: PSym): string =
-        conf.wrap(conf.treeRepr(sym, indent = indent + 2))
+        conf.wrap(conf.treeRepr(sym,
+                                indent = indent + 2,
+                                rconf = compilerTraceReprConf))
 
       result.addf("$1]", align($s.level, 2, '#'))
       result.add(
@@ -3240,10 +3246,12 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
               if s.candidate.call.isNil:
                 field("mismatch kind", $s.candidate.error.firstMismatch.kind)
               else:
-                field("callee")
-                result.add render(s.candidate.callee)
-                field("calleeSym")
-                result.add render(s.candidate.calleeSym)
+                if s.candidate.calleeSym.isNil:
+                  field("callee")
+                  result.add render(s.candidate.callee)
+                else:
+                  field("calleeSym")
+                  result.add render(s.candidate.calleeSym)
                 field("call")
                 result.add render(s.candidate.call)
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -572,12 +572,15 @@ proc semReportCountMismatch*(
   result = SemReport(kind: kind, ast: node)
   result.countMismatch = (toInt128(expected), toInt128(got))
 
+proc illformedAstReport*(node: PNode, explain: string): SemReport {.inline.} =
+  SemReport(kind: rsemIllformedAst, ast: node, str: explain)
+
 template semReportIllformedAst*(
     conf: ConfigRef, node: PNode, explain: string): untyped =
   handleReport(
     conf,
     wrap(
-      SemReport(kind: rsemIllformedAst, ast: node, str: explain),
+      illformedAstReport(node, explain),
       instLoc(),
       node.info),
     instLoc(),
@@ -611,6 +614,10 @@ template createSemIllformedAstMsg*(node: PNode,
     exp.add e
 
   "Expected $1, but found $2" % [joinAnyOf(exp), $node.kind]
+
+proc illformedAstReport*(node: PNode, 
+                         expected: set[TNodeKind]): SemReport {.inline.} =
+  illformedAstReport(node, createSemIllformedAstMsg(node, expected))
 
 template semReportIllformedAst*(
   conf: ConfigRef, node: PNode, expected: set[TNodeKind]): untyped =

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -17,7 +17,8 @@ import
     idents,
     renderer,
     reports,
-    errorhandling
+    errorhandling,
+    errorreporting
   ],
   compiler/front/[
     options,
@@ -197,6 +198,9 @@ proc evalTemplate*(n: PNode, tmpl, genSymOwner: PSym;
     ctx.instLines = sfCallsite in tmpl.flags
     result = copyNode(ctx, body, n)
     for i in 0..<body.safeLen:
+      # xxx: likely should simply emit the error and wrap the body
+      if body[i].kind == nkError:
+        conf.localReport(body[i])
       evalTemplateAux(body[i], args, ctx, result)
   result.flags.incl nfFromTemplate
   result = wrapInComesFrom(n.info, tmpl, result)

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -43,6 +43,7 @@ import
   ],
   compiler/utils/[
     pathutils,
+    astrepr,
   ]
 
 export TExprFlag, TExprFlags
@@ -1036,6 +1037,7 @@ proc errorType*(c: PContext): PType =
   result.flags.incl tfCheckedForDestructor
 
 proc errorNode*(c: PContext, n: PNode): PNode =
+  # xxx: convert to `nkError` instead of `nkEmpty`
   result = newNodeI(nkEmpty, n.info)
   result.typ = errorType(c)
 
@@ -1135,7 +1137,12 @@ proc extractPragma(s: PSym): PNode =
 
 proc warnAboutDeprecated(conf: ConfigRef; info: TLineInfo; s: PSym) =
   var pragmaNode: PNode
-  pragmaNode = if s.kind == skEnumField: extractPragma(s.owner) else: extractPragma(s)
+  pragmaNode =
+    if s.kind == skEnumField:
+      extractPragma(s.owner)
+    else:
+      extractPragma(s)
+
   if pragmaNode != nil:
     for it in pragmaNode:
       if whichPragma(it) == wDeprecated and it.safeLen == 2 and
@@ -1143,6 +1150,7 @@ proc warnAboutDeprecated(conf: ConfigRef; info: TLineInfo; s: PSym) =
         localReport(conf, info, reportSym(
           rsemDeprecated, s, str = it[1].strVal))
         return
+
   localReport(conf, info, reportSym(rsemDeprecated, s))
 
 proc userError(conf: ConfigRef; info: TLineInfo; s: PSym) =

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -35,7 +35,8 @@ import
     magicsys,
   ],
   compiler/utils/[
-    debugutils
+    debugutils,
+    astrepr,
   ],
   compiler/sem/[
     varpartitions,
@@ -1162,6 +1163,8 @@ proc track(tracked: PEffects, n: PNode) =
       let oldState = tracked.init.len
       let oldFacts = tracked.guards.s.len
       addFact(tracked.guards, n[0])
+      if n[0].kind == nkError:
+        echo n.id
       track(tracked, n[0])
       track(tracked, n[1])
       setLen(tracked.init, oldState)

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -149,7 +149,6 @@ type
     extraTypInfo*: proc(typ: PType): ColText ## Extra info for type
 
 
-
 const treeReprAllFields* = {trfShowSymFlags .. trfShowNodeTypes} ## Set of
   ## flags to print all fields in all tree reprs
 
@@ -224,11 +223,31 @@ let verboseTReprConf* =
   ## Show absolutely everything
 
 
-var implicitTReprConf*: TReprConf = defaultTReprConf ## global
-  ## configuration object that is implicitly used by `debugAst` and
-  ## `debugType`. Can be used in order to configure behaviour of the
-  ## debugging functions that could later be called from `gdb` environment
-  ## (`debugAst`, `debugType`, `debugSym`), or sem execution tracer
+var
+  compilerTraceReprConf*: TReprConf =
+    block:
+      var base = defaultTReprConf
+      base.maxDepth = 3
+      base.maxLen = 5
+      base.flags = {
+        trfPackedFields,
+        trfSkipAuxError,
+        trfShowKindTypes,
+        trfShowSymName,
+        trfShowSymTypes,
+        trfShowSymKind,
+        trfShowNodeErrors,
+        trfShowNodeIds,
+        trfShowNodeLineInfo
+      }
+      base
+    ## default tree repr config for compiler tracing, meant to be compact as
+    ## there is a lot of tracing spam.
+  implicitTReprConf*: TReprConf = defaultTReprConf
+    ## global configuration object that is implicitly used by `debugAst` and
+    ## `debugType`. Can be used in order to configure behaviour of the
+    ## debugging functions that could later be called from `gdb` environment
+    ## (`debugAst`, `debugType`, `debugSym`), or sem execution tracer
 
 
 const IntTypes = {
@@ -501,7 +520,7 @@ proc typFields(
 
     hfield("align", trfShowTypeAlloc, $typ.align + style.number)
 
-  if typ.owner.isNil():
+  if typ.owner != nil:
     field("owner", trfShowTypeOwner, rconf.ownerChain(typ.owner) + style.owner)
 
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1470,11 +1470,18 @@ proc customPragmaNode(n: NimNode): NimNode =
     else:
       return impl[0] # handle types which don't have macro at all
 
-  if n.kind == nnkSym: # either an variable or a proc
+  if n.kind == nnkSym: # either a variable or a proc
     let impl = n.getImpl()
     if impl.kind in RoutineNodes:
       return impl.pragma
-    elif impl.kind == nnkIdentDefs and impl[0].kind == nnkPragmaExpr:
+    # xxx: this and the next branch are a hack, it may seem "helpful" to lookup
+    #      pragmas on the type, but that doesn't actually make sense. metadata
+    #      on the type is not metadata on the symbol. This also demonstrates
+    #      how compiler internals are leaking out unnecessarily, as the
+    #      compiler further normalizes the ast, the implied schema of NimNode
+    #      will keep churning and these traversals are all very fragile.
+    elif impl.kind == nnkIdentDefs and impl[0].kind == nnkPragmaExpr and
+         impl[0][1].len > 0:
       return impl[0][1]
     else:
       let timpl = typ.getImpl()

--- a/tests/array/tarray_no_typedesc.nim
+++ b/tests/array/tarray_no_typedesc.nim
@@ -3,7 +3,7 @@ cmd: "nim check $file"
 errormsg: "invalid type: 'typedesc[int]' in this context: 'array[0..0, typedesc[int]]' for var"
 nimout: '''
 tarray_no_typedesc.nim(16, 5) Error: invalid type: 'type' in this context: 'array[0..0, type]' for var
-tarray_no_typedesc.nim(17, 5) Error: invalid type: 'typedesc[int]' in this context: 'array[0..0, typedesc[int]]' for var
+tarray_no_typedesc.nim(17, 9) Error: invalid type: 'typedesc[int]' in this context: 'array[0..0, typedesc[int]]' for var
 '''
 labels: "array typedesc"
 description: '''

--- a/tests/errmsgs/t12844.nim
+++ b/tests/errmsgs/t12844.nim
@@ -3,7 +3,7 @@ cmd: "nim check $file"
 errormsg: "invalid type: 'template (args: varargs[string])' for var. Did you mean to call the template with '()'?"
 nimout: '''
 t12844.nim(11, 7) Error: invalid type: 'template (args: varargs[string])' for const. Did you mean to call the template with '()'?
-t12844.nim(12, 5) Error: invalid type: 'template (args: varargs[string])' for var. Did you mean to call the template with '()'?'''
+t12844.nim(12, 9) Error: invalid type: 'template (args: varargs[string])' for var. Did you mean to call the template with '()'?'''
 """
 
 template z*(args: varargs[string, `$`]) =

--- a/tests/errmsgs/ttypeAllowed.nim
+++ b/tests/errmsgs/ttypeAllowed.nim
@@ -2,9 +2,9 @@ discard """
 cmd: "nim check $file"
 errormsg: ""
 nimout: '''
-ttypeAllowed.nim(13, 5) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for let
 ttypeAllowed.nim(17, 7) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for const
-ttypeAllowed.nim(21, 5) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for var
+ttypeAllowed.nim(13, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for let
+ttypeAllowed.nim(21, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for var
 ttypeAllowed.nim(26, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for result
 '''
 """

--- a/tests/errmsgs/twrongcolon.nim
+++ b/tests/errmsgs/twrongcolon.nim
@@ -1,9 +1,9 @@
 discard """
-errormsg: "in expression ' do:"
+errormsg: "in expression '(890)"
 nimout: '''
-twrongcolon.nim(10, 12) Error: in expression ' do:
-  890': identifier expected, but found ''
+twrongcolon.nim(10, 12) Error: in expression '(890)': identifier expected, but found ''
 '''
+
 
 """
 

--- a/tests/exception/tdefer1.nim
+++ b/tests/exception/tdefer1.nim
@@ -16,10 +16,11 @@ let x = try: parseInt("133a")
 
 
 template atFuncEnd =
-  defer:
-    echo "A"
-  defer:
-    echo "B"
+  {.line.}: # this is a span, and shouldn't mess up the defer
+    defer:
+      echo "A"
+    defer:
+      echo "B"
 
 template testB(): untyped =
     let a = 0

--- a/tests/generics/tpointerprocs.nim
+++ b/tests/generics/tpointerprocs.nim
@@ -2,13 +2,13 @@ discard """
 cmd: "nim check $options --hints:off $file"
 action: "reject"
 nimout:'''
-tpointerprocs.nim(15, 11) Error: 'foo' doesn't have a concrete type, due to unspecified generic parameters.
 tpointerprocs.nim(27, 11) Error: cannot instantiate: 'foo[int]'; got 1 typeof(s) but expected 2
+tpointerprocs.nim(15, 11) Error: 'foo' doesn't have a concrete type, due to unspecified generic parameters.
+tpointerprocs.nim(16, 11) Error: expression has no type: bar
 tpointerprocs.nim(27, 14) Error: expression has no type: foo[int]
 tpointerprocs.nim(28, 11) Error: expression has no type: bar
 '''
 """
-
 block:
   proc foo(x: int | float): float = result = 1.0
   let


### PR DESCRIPTION
## Summary

- let and var section semantics clarified:
  - section normalization rules
  - macro pragmas now allow for a complete rewrite
  - nkError generation
  - normalize symbol pragma data storage
- block semantic analysis uses case/let style
- stmt list semantic analysis clarified:
  - collapses nested stmtLists, unless a block arg
- pragma block analysis less likely to break defer
- number of other fixes

## Details

let and var section semantics clarifications:
- section asts are normalized per identdef and var tuple
- macro pragmas are processed on the normalized ast
- macro pragmas receive one normalized section at a time
- then each normalized section is semantically analysed
- identifier related pragmas are processed here
- other pragmas remain and are processed on the symbol during codegen
- identdef symbols always have a pragmaexpr, even if empty

let and var section internal change remarks:
- semVarOrLet renamed to semLetOrVar
- uses nkError exclusively, resulting in some cascade changes
- production nodes (result) are now entirely distinct from input nodes
  this results in more allocations but it'll make DOD easier in the end
- introduced `ast.newTypeError` to create error types with the `n` field
  containing an nkError, establishing a tyError convention
- documented analysis in proc comment

cascade internal changes:
- vmgen and transf handling of let/var sections and normalized data
- `msgs.illformedAstReport` introduced to stop forced `localReport`

cascade changes template evaluation:
- template evaluation watches and reports nkErrors -- not ideal

cascade changes block semantic analysis:
- `semBlock`: now produces nkErrors
- production and input nodes are now separated
- added some docs

cascade changes stmtlist semantic analysis:
- `semStmtList`: now produces nkErrors
- production and input nodes are now separated
- flattens nested stmts, unless a `do:` `nfBlockArg`
- added some docs

cascade changes type sections:
- semTypeNode and semTypeOf/2 are becoming nk/tyError aware

cascade changes semPragmaBlock:
- pragmas blocks are less likely to screw up defer processing
- pragmas block items disappear after processing from the production
- updated `exception/tdefer1` test with a `{.line.}` pragma for this

miscellaneous changes:
- adding tracing to more sem procs (block, stmtlist, when, const expr, ...)
- added many more asserts and checks to clarify input expectations
- tracing output is more compact and also faster
- introduced `ast.newSymNode2` that is skError aware, future refactors
  will likely have this used nearly everywhere in the compiler
- slightly more precise error messages for let and var sections
- fixed bug in astrepr leading to NPE for type printing
- fixed bug so error nodes now generate node ids
- fixed bug in stdlib.macros to handle empty nkPragmaExprs

next steps for later:
- bring semConstSection in line with this section
- `nfBlockArg` is a hack, should be removed for a node
- error msg in `errmsgs/twrongcolon` wasn't good before not great now