### PR TITLE
Convert semgnrc to nkError

### DIFF
--- a/compiler/modules/importer.nim
+++ b/compiler/modules/importer.nim
@@ -364,7 +364,7 @@ proc impMod(c: PContext; it: PNode; importStmtResult: PNode): PNode =
     afterImport(c, m)
 
   if hasError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)
 
 proc evalImport*(c: PContext, n: PNode): PNode =
   checkMinSonsLen(n, 1, c.config)
@@ -400,7 +400,7 @@ proc evalImport*(c: PContext, n: PNode): PNode =
       hasError = impMod(c, it, result).kind == nkError
 
   if hasError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)
 
 proc evalFrom*(c: PContext, n: PNode): PNode =
   checkMinSonsLen(n, 2, c.config)
@@ -433,7 +433,7 @@ proc evalFrom*(c: PContext, n: PNode): PNode =
     afterImport(c, m)
 
   if hasError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)
 
 proc readExceptSet(c: PContext, n: PNode): IntSet =
   assert n.kind in {nkImportExceptStmt, nkExportExceptStmt}
@@ -459,4 +459,4 @@ proc evalImportExcept*(c: PContext, n: PNode): PNode =
     afterImport(c, m)
 
   if hasError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -351,9 +351,7 @@ proc wrongRedefinition*(
     c.config.localReport(info, reportSymbols(
       rsemRedefinitionOf, @[s, conflictsWith]))
 
-# xxx pending bootstrap >= 1.4, replace all those overloads with a single one:
-# proc addDecl*(c: PContext, sym: PSym, info = sym.info, scope = c.currentScope) {.inline.} =
-proc addDeclAt*(c: PContext; scope: PScope, sym: PSym, info: TLineInfo) =
+proc addDecl*(c: PContext, sym: PSym, info = sym.info, scope = c.currentScope) =
   let conflict = scope.addUniqueSym(sym)
   if conflict != nil:
     if sym.kind == skModule and
@@ -368,15 +366,6 @@ proc addDeclAt*(c: PContext; scope: PScope, sym: PSym, info: TLineInfo) =
         previous: conflict))
     else:
       wrongRedefinition(c, info, sym, conflict)
-
-proc addDeclAt*(c: PContext; scope: PScope, sym: PSym) {.inline.} =
-  addDeclAt(c, scope, sym, sym.info)
-
-proc addDecl*(c: PContext, sym: PSym, info: TLineInfo) {.inline.} =
-  addDeclAt(c, c.currentScope, sym, info)
-
-proc addDecl*(c: PContext, sym: PSym) {.inline.} =
-  addDeclAt(c, c.currentScope, sym)
 
 proc addPrelimDecl*(c: PContext, sym: PSym) =
   discard c.currentScope.addUniqueSym(sym)
@@ -397,7 +386,7 @@ proc addInterfaceDeclAux(c: PContext, sym: PSym) =
 
 proc addInterfaceDeclAt*(c: PContext, scope: PScope, sym: PSym) =
   ## adds a symbol on the scope and the interface if appropriate
-  addDeclAt(c, scope, sym)
+  addDecl(c, sym, scope = scope)
   if not scope.isShadowScope:
     # adding into a non-shadow scope, we need to handle exports, etc
     addInterfaceDeclAux(c, sym)
@@ -594,7 +583,7 @@ proc errorSym*(c: PContext, n, err: PNode): PSym =
   if c.config.cmd != cmdInteractive and c.compilesContextId == 0:
     c.moduleScope.addSym(result)
 
-proc createUndeclaredIdentifierError(
+proc createUndeclaredIdentifierError*(
     c:PContext; n: PNode; name:string;
     candidates: seq[SemSpellCandidate] = @[]
   ): PNode =
@@ -840,7 +829,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
       # create a copy of n with the error from `m`'s lookup
       var err = copyTreeWithoutNode(n, n[0])
       err[0] = m.ast
-      err = wrapErrorInSubTree(c.config, err)
+      err = wrapError(c.config, err)
       result = errorSym(c, n, err)
   else:
     result = nil
@@ -886,7 +875,7 @@ proc initOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
       errDotExpr.add o.m.ast
       errDotExpr.add n[1]
       result = newQualifiedLookUpError(c, o.m.name, n.info,
-                  c.config.wrapErrorInSubTree(errDotExpr))
+                  c.config.wrapError(errDotExpr))
     elif o.m != nil and o.m.kind == skModule:
       let (ident, err) = considerQuotedIdent(c, n[1])
 
@@ -904,7 +893,7 @@ proc initOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
         errDotExpr.add o.m.ast
         errDotExpr.add err
         result = newQualifiedLookUpError(c, ident, n.info,
-                    c.config.wrapErrorInSubTree(errDotExpr))
+                    c.config.wrapError(errDotExpr))
         # pretend it's from the top level scope to prevent cascading errors:
         if c.config.cmd != cmdInteractive and c.compilesContextId == 0:
           c.moduleScope.addSym(result)

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -293,7 +293,7 @@ proc resolveOverloads(c: PContext, n: PNode,
     let hasError = semOpAux(c, f)
     initialBinding = f
     if hasError:
-      f = c.config.wrapErrorInSubTree(f)
+      f = c.config.wrapError(f)
     else:
       f = f[0]
   else:
@@ -301,7 +301,7 @@ proc resolveOverloads(c: PContext, n: PNode,
 
   if f.isError:
     n[0] = f
-    result.call = c.config.wrapErrorInSubTree(n)
+    result.call = c.config.wrapError(n)
     return
 
   template pickBest(headSymbol) =
@@ -361,7 +361,7 @@ proc resolveOverloads(c: PContext, n: PNode,
             n[2] = c.config.newError(n[2], SemReport(
               kind: rsemUndeclaredField, ast: n[2], sym: sym, typ: sym.typ))
 
-            result.call = wrapErrorInSubTree(c.config, n)
+            result.call = wrapError(c.config, n)
         else:
           let msg = getMsgDiagnostic(c, flags, n, f)
           result.call = c.config.newError(n, msg)
@@ -595,7 +595,7 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
     let e = semExpr(c, n[i])
     if e.isError:
       n[i] = e
-      result = c.config.wrapErrorInSubTree(n)
+      result = c.config.wrapError(n)
       return
     elif e.typ == nil:
       n[i].typ = errorType(c)

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -22,6 +22,10 @@ proc getIdentNode(c: PContext; n: PNode): PNode =
   of nkPostfix: result = getIdentNode(c, n[1])
   of nkPragmaExpr: result = getIdentNode(c, n[0])
   of nkIdent, nkAccQuoted, nkSym: result = n
+  of nkError:
+    # Passing it through; considerQuotedIdent in
+    # newSymS will handle and output this error
+    result = n
   else:
     semReportIllformedAst(c.config, n, {
       nkPostfix, nkPragmaExpr, nkIdent, nkAccQuoted, nkSym})
@@ -124,7 +128,8 @@ proc lookup(c: PContext, n: PNode, flags: TSemGenericFlags,
   result = n
   let (ident, err) = considerQuotedIdent(c, n)
   if err != nil:
-    localReport(c.config, err)
+    result = err
+    return
   var amb = false
   var s = searchInScopes(c, ident, amb).skipAlias(n, c.config)
   if s == nil:
@@ -133,7 +138,7 @@ proc lookup(c: PContext, n: PNode, flags: TSemGenericFlags,
     #  s = nil
   if s == nil:
     if ident.id notin ctx.toMixin and withinMixin notin flags:
-      errorUndeclaredIdentifier(c, n.info, ident.s)
+      result = c.createUndeclaredIdentifierError(n, ident.s)
   else:
     if withinBind in flags or s.id in ctx.toBind:
       result = symChoice(c, n, s, scClosed)
@@ -144,9 +149,7 @@ proc lookup(c: PContext, n: PNode, flags: TSemGenericFlags,
   # else: leave as nkIdent
 
 proc newDot(n, b: PNode): PNode =
-  result = newNodeI(nkDotExpr, n.info)
-  result.add(n[0])
-  result.add(b)
+  newTreeI(nkDotExpr, n.info, [n[0], b])
 
 proc fuzzyLookup(c: PContext, n: PNode, flags: TSemGenericFlags,
                  ctx: var GenericCtx; isMacro: var bool): PNode =
@@ -157,20 +160,23 @@ proc fuzzyLookup(c: PContext, n: PNode, flags: TSemGenericFlags,
 
   var s = qualifiedLookUp(c, n, luf)
   if s.isError:
-    # XXX: move to propagating nkError, skError, and tyError
-    localReport(c.config, s.ast)
     result = s.ast
   elif s != nil:
     result = semGenericStmtSymbol(c, n, s, ctx, flags)
   else:
     n[0] = semGenericStmt(c, n[0], flags, ctx)
+    if n[0].isError:
+      result = c.config.wrapError(n)
+      return
     result = n
     let
       n = n[1]
       (ident, err) = considerQuotedIdent(c, n)
     if err != nil:
-      localReport(c.config, err)
-    var candidates = searchInScopesFilterBy(c, ident, routineKinds) # .skipAlias(n, c.config)
+      result[1] = err
+      result = c.config.wrapError(result)
+      return
+    let candidates = searchInScopesFilterBy(c, ident, routineKinds) # .skipAlias(n, c.config)
     if candidates.len > 0:
       let s = candidates[0] # XXX take into account the other candidates!
       isMacro = s.kind in {skTemplate, skMacro}
@@ -186,12 +192,28 @@ proc fuzzyLookup(c: PContext, n: PNode, flags: TSemGenericFlags,
           result = newDot(result, choice)
         else:
           result = newDot(result, syms)
+          if syms.isError:
+            result = c.config.wrapError(result)
 
 proc addTempDecl(c: PContext; n: PNode; kind: TSymKind) =
+  # newSymS doesn't use nkError/skError currently, so we
+  # don't need to check and wrap here.
   let s = newSymS(skUnknown, getIdentNode(c, n), c)
   addPrelimDecl(c, s)
   styleCheckDef(c.config, n.info, s, kind)
   onDef(n.info, s)
+
+template captureError(conf: ConfigRef, n: PNode, body) =
+  # Should this pattern arise more often, perhaps
+  # consider moving this to errorhandling
+  var hasError = false
+  template checkError(potErr: PNode): PNode =
+    let x = potErr
+    if x.isError: hasError = true
+    x
+  body
+  if hasError:
+    n = conf.wrapError(n)
 
 proc semGenericStmt(c: PContext, n: PNode,
                     flags: TSemGenericFlags, ctx: var GenericCtx): PNode =
@@ -240,7 +262,9 @@ proc semGenericStmt(c: PContext, n: PNode,
     let fn = n[0]
     var s = qualifiedLookUp(c, fn, {})
     if s.isError:
-      localReport(c.config, s.ast)
+      result[0] = s.ast
+      result = wrapError(c.config, result)
+      return
     if s == nil and
         {withinMixin, withinConcept}*flags == {} and
         fn.kind in {nkIdent, nkAccQuoted} and
@@ -262,6 +286,7 @@ proc semGenericStmt(c: PContext, n: PNode,
           onUse(fn.info, s)
           result = semMacroExpr(c, n, s, {efNoSemCheck})
           result = semGenericStmt(c, result, flags, ctx)
+          if result.isError: return
         else:
           n[0] = sc
           result = n
@@ -271,6 +296,7 @@ proc semGenericStmt(c: PContext, n: PNode,
           onUse(fn.info, s)
           result = semTemplateExpr(c, n, s, {efNoSemCheck})
           result = semGenericStmt(c, result, flags, ctx)
+          if result.isError: return
         else:
           n[0] = sc
           result = n
@@ -301,15 +327,8 @@ proc semGenericStmt(c: PContext, n: PNode,
           first = 1
       of skError:
         if s.isError: # has the error ast
-          # XXX: move to propagating nkError, skError, and tyError
-          localReport(c.config, s.ast)
-          # XXX: set keep the symbol lookup error around which means we might run
-          #      into duplicate error messages downt the road when most things
-          #      are nkError aware -- the solution then would be to ensure all
-          #      paths are covered and the `walkErrors` and `localReport` above
-          #      is then removed.
           result[0] = s.ast
-          result = wrapErrorInSubTree(c.config, result)
+          result = wrapError(c.config, result)
           return
         else: # legacy nimsuggest skUnknown usage          
           # Leave it as an identifier.
@@ -320,23 +339,29 @@ proc semGenericStmt(c: PContext, n: PNode,
         first = 1
     elif fn.kind == nkDotExpr:
       result[0] = fuzzyLookup(c, fn, flags, ctx, mixinContext)
+      if result[0].isError:
+        result = c.config.wrapError(result)
       first = 1
     # Consider 'when declared(globalsSlot): ThreadVarSetValue(globalsSlot, ...)'
     # in threads.nim: the subtle preprocessing here binds 'globalsSlot' which
     # is not exported and yet the generic 'threadProcWrapper' works correctly.
-    let flags = if mixinContext: flags+{withinMixin} else: flags
-    for i in first..<result.safeLen:
-      result[i] = semGenericStmt(c, result[i], flags, ctx)
+    if not result.isError:
+      captureError c.config, result:
+        let flags = if mixinContext: flags+{withinMixin} else: flags
+        for i in first..<result.safeLen:
+          result[i] = checkError semGenericStmt(c, result[i], flags, ctx)
   of nkCurlyExpr:
     result = newNodeI(nkCall, n.info)
     result.add newIdentNode(getIdent(c.cache, "{}"), n.info)
     for i in 0..<n.len: result.add(n[i])
     result = semGenericStmt(c, result, flags, ctx)
+    if result.isError: return
   of nkBracketExpr:
     result = newNodeI(nkCall, n.info)
     result.add newIdentNode(getIdent(c.cache, "[]"), n.info)
     for i in 0..<n.len: result.add(n[i])
     result = semGenericStmt(c, result, flags, ctx)
+    if result.isError: return
   of nkAsgn, nkFastAsgn:
     checkSonsLen(n, 2, c.config)
     let a = n[0]
@@ -347,60 +372,68 @@ proc semGenericStmt(c: PContext, n: PNode,
     of nkCurlyExpr:
       result = newNodeI(nkCall, n.info)
       result.add newIdentNode(getIdent(c.cache, "{}="), n.info)
-      for i in 0..<a.len: result.add(a[i])
-      result.add(b)
+      for i in 0..<a.len: result.add a[i]
+      result.add b
       result = semGenericStmt(c, result, flags, ctx)
+      if result.isError: return
     of nkBracketExpr:
       result = newNodeI(nkCall, n.info)
       result.add newIdentNode(getIdent(c.cache, "[]="), n.info)
-      for i in 0..<a.len: result.add(a[i])
-      result.add(b)
+      for i in 0..<a.len: result.add a[i]
+      result.add b
       result = semGenericStmt(c, result, flags, ctx)
+      if result.isError: return
     else:
-      for i in 0..<n.len:
-        result[i] = semGenericStmt(c, n[i], flags, ctx)
+      captureError c.config, result:
+        for i in 0..<n.len:
+          result[i] = checkError semGenericStmt(c, n[i], flags, ctx)
   of nkIfStmt:
-    for i in 0..<n.len:
-      n[i] = semGenericStmtScope(c, n[i], flags, ctx)
+    captureError c.config, result:
+      for i in 0..<n.len:
+        n[i] = checkError semGenericStmtScope(c, n[i], flags, ctx)
   of nkWhenStmt:
-    for i in 0..<n.len:
-      # bug #8603: conditions of 'when' statements are not
-      # in a 'mixin' context:
-      let it = n[i]
-      if it.kind in {nkElifExpr, nkElifBranch}:
-        n[i][0] = semGenericStmt(c, it[0], flags, ctx)
-        n[i][1] = semGenericStmt(c, it[1], flags+{withinMixin}, ctx)
-      else:
-        n[i] = semGenericStmt(c, it, flags+{withinMixin}, ctx)
+    captureError c.config, result:
+      for i in 0..<n.len:
+        # bug #8603: conditions of 'when' statements are not
+        # in a 'mixin' context:
+        let it = n[i]
+        if it.kind in {nkElifExpr, nkElifBranch}:
+          n[i][0] = checkError semGenericStmt(c, it[0], flags, ctx)
+          n[i][1] = checkError semGenericStmt(c, it[1], flags+{withinMixin}, ctx)
+        else:
+          n[i] = checkError semGenericStmt(c, it, flags+{withinMixin}, ctx)
   of nkWhileStmt:
-    openScope(c)
-    for i in 0..<n.len:
-      n[i] = semGenericStmt(c, n[i], flags, ctx)
-    closeScope(c)
+    captureError c.config, result:
+      openScope(c)
+      for i in 0..<n.len:
+        n[i] = checkError semGenericStmt(c, n[i], flags, ctx)
+      closeScope(c)
   of nkCaseStmt:
-    openScope(c)
-    n[0] = semGenericStmt(c, n[0], flags, ctx)
-    for i in 1..<n.len:
-      var a = n[i]
-      checkMinSonsLen(a, 1, c.config)
-      for j in 0..<a.len-1:
-        a[j] = semGenericStmt(c, a[j], flags, ctx)
-      a[^1] = semGenericStmtScope(c, a[^1], flags, ctx)
-    closeScope(c)
+    captureError c.config, result:
+      openScope(c)
+      n[0] = checkError semGenericStmt(c, n[0], flags, ctx)
+      for i in 1..<n.len:
+        var a = n[i]
+        checkMinSonsLen(a, 1, c.config)
+        for j in 0..<a.len-1:
+          a[j] = checkError semGenericStmt(c, a[j], flags, ctx)
+        a[^1] = checkError semGenericStmtScope(c, a[^1], flags, ctx)
+      closeScope(c)
   of nkForStmt:
-    openScope(c)
-    n[^2] = semGenericStmt(c, n[^2], flags, ctx)
-    for i in 0..<n.len - 2:
-      if (n[i].kind == nkVarTuple):
-        for s in n[i]:
-          if (s.kind == nkIdent):
-            addTempDecl(c,s,skForVar)
-      else:
-        addTempDecl(c, n[i], skForVar)
-    openScope(c)
-    n[^1] = semGenericStmt(c, n[^1], flags, ctx)
-    closeScope(c)
-    closeScope(c)
+    captureError c.config, result:
+      openScope(c)
+      n[^2] = checkError semGenericStmt(c, n[^2], flags, ctx)
+      for i in 0..<n.len - 2:
+        if (n[i].kind == nkVarTuple):
+          for s in n[i]:
+            if (s.kind == nkIdent):
+              addTempDecl(c,s,skForVar)
+        else:
+          addTempDecl(c, n[i], skForVar)
+      openScope(c)
+      n[^1] = checkError semGenericStmt(c, n[^1], flags, ctx)
+      closeScope(c)
+      closeScope(c)
   of nkBlockStmt, nkBlockExpr, nkBlockType:
     checkSonsLen(n, 2, c.config)
     openScope(c)
@@ -408,136 +441,146 @@ proc semGenericStmt(c: PContext, n: PNode,
       addTempDecl(c, n[0], skLabel)
     n[1] = semGenericStmt(c, n[1], flags, ctx)
     closeScope(c)
+    if n[1].isError:
+      result = c.config.wrapError(n)
   of nkTryStmt, nkHiddenTryStmt:
     checkMinSonsLen(n, 2, c.config)
-    n[0] = semGenericStmtScope(c, n[0], flags, ctx)
-    for i in 1..<n.len:
-      var a = n[i]
-      checkMinSonsLen(a, 1, c.config)
-      openScope(c)
-      for j in 0..<a.len-1:
-        if a[j].isInfixAs():
-          addTempDecl(c, getIdentNode(c, a[j][2]), skLet)
-          a[j][1] = semGenericStmt(c, a[j][1], flags+{withinTypeDesc}, ctx)
-        else:
-          a[j] = semGenericStmt(c, a[j], flags+{withinTypeDesc}, ctx)
-      a[^1] = semGenericStmtScope(c, a[^1], flags, ctx)
-      closeScope(c)
-
-  of nkVarSection, nkLetSection, nkConstSection:
-    let varKind =
-      case n.kind
-      of nkVarSection: skVar
-      of nkLetSection: skLet
-      else: skConst
-    for i in 0..<n.len:
-      var a = n[i]
-      case a.kind:
-      of nkCommentStmt: continue
-      of nkIdentDefs, nkVarTuple, nkConstDef:
-        checkMinSonsLen(a, 3, c.config)
-        a[^2] = semGenericStmt(c, a[^2], flags+{withinTypeDesc}, ctx)
-        a[^1] = semGenericStmt(c, a[^1], flags, ctx)
-        for j in 0..<a.len-2:
-          addTempDecl(c, getIdentNode(c, a[j]), varKind)
-      else:
-        semReportIllformedAst(c.config, a, {
-          nkCommentStmt, nkIdentDefs, nkVarTuple, nkConstDef})
-
-  of nkGenericParams:
-    for i in 0..<n.len:
-      var a = n[i]
-      if (a.kind != nkIdentDefs):
-        semReportIllformedAst(c.config, a, {nkIdentDefs})
-
-      checkMinSonsLen(a, 3, c.config)
-      a[^2] = semGenericStmt(c, a[^2], flags+{withinTypeDesc}, ctx)
-      # do not perform symbol lookup for default expressions
-      for j in 0..<a.len-2:
-        addTempDecl(c, getIdentNode(c, a[j]), skType)
-  of nkTypeSection:
-    for i in 0..<n.len:
-      var a = n[i]
-      if a.kind == nkCommentStmt: continue
-      if (a.kind != nkTypeDef):
-        semReportIllformedAst(c.config, a, {nkTypeDef})
-      checkSonsLen(a, 3, c.config)
-      addTempDecl(c, getIdentNode(c, a[0]), skType)
-    for i in 0..<n.len:
-      var a = n[i]
-      if a.kind == nkCommentStmt: continue
-      if (a.kind != nkTypeDef):
-        semReportIllformedAst(c.config, a, {nkTypeDef})
-      checkSonsLen(a, 3, c.config)
-      if a[1].kind != nkEmpty:
-        openScope(c)
-        a[1] = semGenericStmt(c, a[1], flags, ctx)
-        a[2] = semGenericStmt(c, a[2], flags+{withinTypeDesc}, ctx)
-        closeScope(c)
-      else:
-        a[2] = semGenericStmt(c, a[2], flags+{withinTypeDesc}, ctx)
-  of nkEnumTy:
-    if n.len > 0:
-      if n[0].kind != nkEmpty:
-        n[0] = semGenericStmt(c, n[0], flags+{withinTypeDesc}, ctx)
+    captureError c.config, result:
+      n[0] = checkError semGenericStmtScope(c, n[0], flags, ctx)
       for i in 1..<n.len:
-        var a: PNode
-        case n[i].kind
-        of nkEnumFieldDef: a = n[i][0]
-        of nkIdent: a = n[i]
+        var a = n[i]
+        checkMinSonsLen(a, 1, c.config)
+        openScope(c)
+        for j in 0..<a.len-1:
+          if a[j].isInfixAs():
+            addTempDecl(c, a[j][2], skLet)
+            a[j][1] = checkError semGenericStmt(c, a[j][1], flags+{withinTypeDesc}, ctx)
+          else:
+            a[j] = checkError semGenericStmt(c, a[j], flags+{withinTypeDesc}, ctx)
+        a[^1] = checkError semGenericStmtScope(c, a[^1], flags, ctx)
+        closeScope(c)
+  of nkVarSection, nkLetSection, nkConstSection:
+    captureError c.config, result:
+      let varKind =
+        case n.kind
+        of nkVarSection: skVar
+        of nkLetSection: skLet
+        else: skConst
+      for i in 0..<n.len:
+        var a = n[i]
+        case a.kind:
+        of nkCommentStmt: continue
+        of nkIdentDefs, nkVarTuple, nkConstDef:
+          checkMinSonsLen(a, 3, c.config)
+          a[^2] = checkError semGenericStmt(c, a[^2], flags+{withinTypeDesc}, ctx)
+          a[^1] = checkError semGenericStmt(c, a[^1], flags, ctx)
+          for j in 0..<a.len-2:
+            addTempDecl(c, a[j], varKind)
         else:
-          semReportIllformedAst(c.config, a, {nkEnumFieldDef, nkIdent})
+          semReportIllformedAst(c.config, a, {
+            nkCommentStmt, nkIdentDefs, nkVarTuple, nkConstDef})
+  of nkGenericParams:
+    captureError c.config, result:
+      for i in 0..<n.len:
+        var a = n[i]
+        if (a.kind != nkIdentDefs):
+          semReportIllformedAst(c.config, a, {nkIdentDefs})
 
-        addDecl(c, newSymS(skUnknown, getIdentNode(c, a), c))
+        checkMinSonsLen(a, 3, c.config)
+        a[^2] = checkError semGenericStmt(c, a[^2], flags+{withinTypeDesc}, ctx)
+        # do not perform symbol lookup for default expressions
+        for j in 0..<a.len-2:
+          addTempDecl(c, a[j], skType)
+  of nkTypeSection:
+    captureError c.config, result:
+      for i in 0..<n.len:
+        var a = n[i]
+        if a.kind == nkCommentStmt: continue
+        if (a.kind != nkTypeDef):
+          semReportIllformedAst(c.config, a, {nkTypeDef})
+        checkSonsLen(a, 3, c.config)
+        addTempDecl(c, a[0], skType)
+      for i in 0..<n.len:
+        var a = n[i]
+        if a.kind == nkCommentStmt: continue
+        if (a.kind != nkTypeDef):
+          semReportIllformedAst(c.config, a, {nkTypeDef})
+        checkSonsLen(a, 3, c.config)
+        if a[1].kind != nkEmpty:
+          openScope(c)
+          a[1] = checkError semGenericStmt(c, a[1], flags, ctx)
+          a[2] = checkError semGenericStmt(c, a[2], flags+{withinTypeDesc}, ctx)
+          closeScope(c)
+        else:
+          a[2] = checkError semGenericStmt(c, a[2], flags+{withinTypeDesc}, ctx)
+  of nkEnumTy:
+    captureError c.config, result:
+      if n.len > 0:
+        if n[0].kind != nkEmpty:
+          n[0] = checkError semGenericStmt(c, n[0], flags+{withinTypeDesc}, ctx)
+
+        for i in 1..<n.len:
+          var a: PNode
+          case n[i].kind
+          of nkEnumFieldDef: a = n[i][0]
+          of nkIdent: a = n[i]
+          else:
+            semReportIllformedAst(c.config, n[i], {nkEnumFieldDef, nkIdent})
+
+          addDecl(c, newSymS(skUnknown, getIdentNode(c, a), c))
   of nkObjectTy, nkTupleTy, nkTupleClassTy:
     discard
   of nkFormalParams:
     checkMinSonsLen(n, 1, c.config)
-    for i in 1..<n.len:
-      var a = n[i]
-      if (a.kind != nkIdentDefs):
-        semReportIllformedAst(c.config, a, {nkIdentDefs})
+    captureError c.config, result:
+      for i in 1..<n.len:
+        var a = n[i]
+        if (a.kind != nkIdentDefs):
+          semReportIllformedAst(c.config, a, {nkIdentDefs})
 
-      checkMinSonsLen(a, 3, c.config)
-      a[^2] = semGenericStmt(c, a[^2], flags+{withinTypeDesc}, ctx)
-      a[^1] = semGenericStmt(c, a[^1], flags, ctx)
-      for j in 0..<a.len-2:
-        addTempDecl(c, getIdentNode(c, a[j]), skParam)
-    # XXX: last change was moving this down here, search for "1.." to keep
-    #      going from this file onward
-    if n[0].kind != nkEmpty:
-      n[0] = semGenericStmt(c, n[0], flags+{withinTypeDesc}, ctx)
+        checkMinSonsLen(a, 3, c.config)
+        a[^2] = checkError semGenericStmt(c, a[^2], flags+{withinTypeDesc}, ctx)
+        a[^1] = checkError semGenericStmt(c, a[^1], flags, ctx)
+        for j in 0..<a.len-2:
+          addTempDecl(c, a[j], skParam)
+      # XXX: last change was moving this down here, search for "1.." to keep
+      #      going from this file onward
+      if n[0].kind != nkEmpty:
+        n[0] = checkError semGenericStmt(c, n[0], flags+{withinTypeDesc}, ctx)
   of nkProcDef, nkMethodDef, nkConverterDef, nkMacroDef, nkTemplateDef,
      nkFuncDef, nkIteratorDef, nkLambdaKinds:
     checkSonsLen(n, bodyPos + 1, c.config)
-    if n[namePos].kind != nkEmpty:
-      addTempDecl(c, getIdentNode(c, n[0]), skProc)
-    openScope(c)
-    n[genericParamsPos] = semGenericStmt(c, n[genericParamsPos],
-                                              flags, ctx)
-    if n[paramsPos].kind != nkEmpty:
-      if n[paramsPos][0].kind != nkEmpty:
-        addPrelimDecl(c, newSym(skUnknown, getIdent(c.cache, "result"), nextSymId c.idgen, nil, n.info))
-      n[paramsPos] = semGenericStmt(c, n[paramsPos], flags, ctx)
-    n[pragmasPos] = semGenericStmt(c, n[pragmasPos], flags, ctx)
-    var body: PNode
-    if n[namePos].kind == nkSym:
-      let s = n[namePos].sym
-      if sfGenSym in s.flags and s.ast == nil:
-        body = n[bodyPos]
-      else:
-        body = getBody(c.graph, s)
-    else: body = n[bodyPos]
-    n[bodyPos] = semGenericStmtScope(c, body, flags, ctx)
-    closeScope(c)
+    captureError c.config, result:
+      if n[namePos].kind != nkEmpty:
+        addTempDecl(c, n[0], skProc)
+      openScope(c)
+      n[genericParamsPos] = checkError semGenericStmt(c, n[genericParamsPos],
+                                                      flags, ctx)
+      if n[paramsPos].kind != nkEmpty:
+        if n[paramsPos][0].kind != nkEmpty:
+          addPrelimDecl(c, newSym(skUnknown, getIdent(c.cache, "result"), nextSymId c.idgen, nil, n.info))
+        n[paramsPos] = checkError semGenericStmt(c, n[paramsPos], flags, ctx)
+      n[pragmasPos] = checkError semGenericStmt(c, n[pragmasPos], flags, ctx)
+      var body: PNode
+      if n[namePos].kind == nkSym:
+        let s = n[namePos].sym
+        if sfGenSym in s.flags and s.ast == nil:
+          body = n[bodyPos]
+        else:
+          body = getBody(c.graph, s)
+      else: body = n[bodyPos]
+      n[bodyPos] = checkError semGenericStmtScope(c, body, flags, ctx)
+      closeScope(c)
   of nkPragma, nkPragmaExpr: discard
   of nkExprColonExpr, nkExprEqExpr:
     checkMinSonsLen(n, 2, c.config)
     result[1] = semGenericStmt(c, n[1], flags, ctx)
+    if result[1].isError:
+      result = c.config.wrapError(result)
   else:
-    for i in 0..<n.len:
-      result[i] = semGenericStmt(c, n[i], flags, ctx)
-
+    captureError c.config, result:
+      for i in 0..<n.len:
+        result[i] = checkError semGenericStmt(c, n[i], flags, ctx)
   when defined(nimsuggest):
     if withinTypeDesc in flags: dec c.inTypeContext
 

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -37,7 +37,7 @@ proc semTypeOf(c: PContext; n: PNode): PNode =
   let typExpr = semExprWithType(c, n[1], if m == 1: {efInTypeof} else: {})
   result.add typExpr
   if typExpr.isError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)
   else:
     result.typ = makeTypeDesc(c, typExpr.typ)
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1407,6 +1407,8 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       block determineType:
         if genericParams.isGenericParams:
           def = semGenericStmt(c, def)
+          if def.isError:
+            localReport(c.config, def)
           if hasUnresolvedArgs(c, def):
             def.typ = makeTypeFromExpr(c, def.copyTree)
             break determineType
@@ -1794,6 +1796,8 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
     addDecl(c, dummyParam)
 
   result.n[3] = semConceptBody(c, n[3])
+  if result.n[3].isError:
+    localReport(c.config, result.n[3])
   closeScope(c)
 
 proc applyTypeSectionPragmas(c: PContext; pragmas, operand: PNode): PNode =
@@ -2094,6 +2098,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
            # the dot expression may refer to a concept type in
            # a different module. allow a normal alias then.
         let preprocessed = semGenericStmt(c, n)
+        if preprocessed.isError:
+          localReport(c.config, preprocessed)
         result = makeTypeFromExpr(c, preprocessed.copyTree)
       else:
         let alias = maybeAliasType(c, result, prev)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2370,7 +2370,7 @@ proc matchesAux(c: PContext, n: PNode, m: var TCandidate, marker: var IntSet) =
   template noMatchDueToError() =
     ## found an nkError along the way so wrap the call in an error, do not use
     ## if the legacy `localReport`s etc are being used.
-    m.call = wrapErrorInSubTree(c.config, m.call)
+    m.call = wrapError(c.config, m.call)
     noMatch()
 
   template checkConstraint(n: untyped) {.dirty.} =

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -143,7 +143,7 @@ proc deserializeTuple(c: TCtx, m: VmMemoryRegion, vt: PVmType; formal, ty: PType
       result[i] = unmarshalField(o, t, ty[i])
 
   if hasError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)
 
 
 proc deserializeObjectPart(c: TCtx,
@@ -215,7 +215,7 @@ proc deserializeObject(c: TCtx, m: VmMemoryRegion, vt: PVmType; f, con: PType; i
   result.sons.setLen(len) # XXX: this should ideally also shrink the capacity
 
   if hasError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)
 
 proc deserializeArray*(
   c: TCtx,
@@ -240,7 +240,7 @@ proc deserializeArray*(
     off += stride
 
   if hasError:
-    result = c.config.wrapErrorInSubTree(result)
+    result = c.config.wrapError(result)
 
 
 proc deserialize(c: TCtx, m: VmMemoryRegion, vt: PVmType, formal, t: PType, info: TLineInfo): PNode =
@@ -342,7 +342,7 @@ proc deserialize(c: TCtx, m: VmMemoryRegion, vt: PVmType, formal, t: PType, info
 
     if result.safeLen == 2 and result[1].isError:
       # The env can be an nkError
-      result = c.config.wrapErrorInSubTree(result)
+      result = c.config.wrapError(result)
 
   of tyObject:
     result = deserializeObject(c, m, vt, formal, t, info)


### PR DESCRIPTION
Rename wrapErrorInSubTree to just wrapError.
Add a debug checker for empty wrapErrors.
Add a captureError template, only used in semgnrc for now
Minor clean up of addDecl/addDeclAt in lookups.nim