### PR TITLE
use atomic reference counting when threading

### DIFF
--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -70,7 +70,7 @@ proc barrierEnter(b: ptr Barrier) {.compilerproc, inline.} =
   # will be called which already will perform a fence for us.
 
 proc barrierLeave(b: ptr Barrier) {.compilerproc, inline.} =
-  atomicInc b.left
+  discard atomicInc b.left
   when not defined(x86): fence()
   # We may not have seen the final value of b.entered yet,
   # so we need to check for >= instead of ==.
@@ -340,7 +340,7 @@ proc slave(w: ptr Worker) {.thread.} =
   while true:
     if w.shutdown:
       w.shutdown = false
-      atomicDec currentPoolSize
+      discard atomicDec currentPoolSize
       while true:
         if w.data != nil:
           sleep(threadpoolWaitMs)
@@ -502,7 +502,7 @@ proc nimSpawn3(fn: WorkerProc; data: pointer) {.compilerproc.} =
           if not workersData[currentPoolSize].initialized:
             activateWorkerThread(currentPoolSize)
           let w = addr(workersData[currentPoolSize])
-          atomicInc currentPoolSize
+          discard atomicInc currentPoolSize
           if selectWorker(w, fn, data):
             release(stateLock)
             return
@@ -514,7 +514,7 @@ proc nimSpawn3(fn: WorkerProc; data: pointer) {.compilerproc.} =
             if not workersData[currentPoolSize].initialized:
               activateWorkerThread(currentPoolSize)
             let w = addr(workersData[currentPoolSize])
-            atomicInc currentPoolSize
+            discard atomicInc currentPoolSize
             if selectWorker(w, fn, data):
               release(stateLock)
               return
@@ -540,7 +540,7 @@ proc nimSpawn3(fn: WorkerProc; data: pointer) {.compilerproc.} =
             if not workersData[currentPoolSize].initialized:
               activateWorkerThread(currentPoolSize)
             let w = addr(workersData[currentPoolSize])
-            atomicInc currentPoolSize
+            discard atomicInc currentPoolSize
             if selectWorker(w, fn, data):
               return
           else:

--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -214,7 +214,7 @@ var
 
 proc disableProfiling*() =
   when declared(system.StackTrace):
-    atomicDec disabled
+    discard atomicDec disabled
     system.profilingRequestedHook = nil
 
 proc enableProfiling*() =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1813,14 +1813,6 @@ when not declared(sysFatal):
 when not isNimVmTarget:
   {.push stackTrace: off, profiler: off.}
 
-  proc atomicInc*(memLoc: var int, x: int = 1): int {.inline,
-    discardable, benign.}
-    ## Atomic increment of `memLoc`. Returns the value after the operation.
-
-  proc atomicDec*(memLoc: var int, x: int = 1): int {.inline,
-    discardable, benign.}
-    ## Atomic decrement of `memLoc`. Returns the value after the operation.
-
   include "system/atomics"
 
   {.pop.}

--- a/lib/system/atomics.nim
+++ b/lib/system/atomics.nim
@@ -211,13 +211,24 @@ elif someVcc and hasThreadSupport:
         importc: "_InterlockedExchangeAdd", header: "<intrin.h>".}
 
 else:
+  type AtomMemModel* = distinct cint
+
+  const
+    ATOMIC_RELAXED = 0.AtomMemModel
+    ATOMIC_CONSUME = 1.AtomMemModel
+    ATOMIC_ACQUIRE = 2.AtomMemModel
+    ATOMIC_RELEASE = 3.AtomMemModel
+    ATOMIC_ACQ_REL = 4.AtomMemModel
+    ATOMIC_SEQ_CST = 5.AtomMemModel
+
   proc addAndFetch*(p: ptr int, val: int): int {.inline.} =
     inc(p[], val)
     result = p[]
 
-proc atomicInc*(memLoc: var int, x: int = 1): int =
+proc atomicInc*(memLoc: var int; x: int = 1; order = ATOMIC_RELAXED): int =
+  ## Atomic increment of `memLoc`. Returns the value after the operation.
   when someGcc and hasThreadSupport:
-    result = atomicAddFetch(memLoc.addr, x, ATOMIC_RELAXED)
+    result = atomicAddFetch(memLoc.addr, x, order)
   elif someVcc and hasThreadSupport:
     result = addAndFetch(memLoc.addr, x)
     inc(result, x)
@@ -225,12 +236,13 @@ proc atomicInc*(memLoc: var int, x: int = 1): int =
     inc(memLoc, x)
     result = memLoc
 
-proc atomicDec*(memLoc: var int, x: int = 1): int =
+proc atomicDec*(memLoc: var int; x: int = 1; order = ATOMIC_RELAXED): int =
+  ## Atomic decrement of `memLoc`. Returns the value after the operation.
   when someGcc and hasThreadSupport:
     when declared(atomicSubFetch):
-      result = atomicSubFetch(memLoc.addr, x, ATOMIC_RELAXED)
+      result = atomicSubFetch(memLoc.addr, x, order)
     else:
-      result = atomicAddFetch(memLoc.addr, -x, ATOMIC_RELAXED)
+      result = atomicAddFetch(memLoc.addr, -x, order)
   elif someVcc and hasThreadSupport:
     result = addAndFetch(memLoc.addr, -x)
     dec(result, x)

--- a/lib/system/cyclebreaker.nim
+++ b/lib/system/cyclebreaker.nim
@@ -109,7 +109,7 @@ var markerGeneration: int
 proc breakCycles(s: Cell; desc: PNimTypeV2) =
   let markerColor = if (markerGeneration and 1) == 0: colRed
                     else: colYellow
-  atomicInc markerGeneration
+  discard atomicInc markerGeneration
   when traceCollector:
     cprintf("[BreakCycles] starting: %p %s RC %ld trace proc %p\n",
       s, desc.name, s.rc shr rcShift, desc.traceImpl)

--- a/lib/system/gc_common.nim
+++ b/lib/system/gc_common.nim
@@ -90,7 +90,7 @@ template decTypeSize(cell, t) =
 
 template incTypeSize(typ, size) =
   when defined(nimTypeNames):
-    atomicInc typ.instances
+    discard atomicInc typ.instances
     atomicInc typ.sizes, size+sizeof(Cell)
 
 proc dispose*(x: ForeignCell) =

--- a/tests/destructor/tatomicptrs.nim
+++ b/tests/destructor/tatomicptrs.nim
@@ -21,9 +21,10 @@ type
 #proc isNil[T](s: SharedPtr[T]): bool {.inline.} = s.x.isNil
 
 template incRef(x) =
-  atomicInc(x.refcount)
+  discard atomicInc(x.refcount)
 
-template decRef(x): untyped = atomicDec(x.refcount)
+template decRef(x): untyped =
+  atomicDec(x.refcount)
 
 proc makeShared*[T](x: sink T): SharedPtr[T] =
   # XXX could benefit from a macro that generates it.

--- a/tests/destructor/trecursive.nim
+++ b/tests/destructor/trecursive.nim
@@ -23,7 +23,7 @@ proc pushFront*[T] (list: var ForwardList[T], val: sink T) =
     var head = list.first
     newNode.get.next = head
     result = list.first.cas(head, newNode)
-  list.len.atomicInc()
+  discard atomicInc(list.len)
 
 proc test1() =
   var list: ForwardList[int]

--- a/tests/system/tatomics1.nim
+++ b/tests/system/tatomics1.nim
@@ -3,7 +3,7 @@ discard """
 """
 
 var x = 10
-atomicInc(x)
+discard atomicInc(x)
 doAssert x == 11
-atomicDec(x)
+discard atomicDec(x)
 doAssert x == 10

--- a/tests/threads/threadex.nim
+++ b/tests/threads/threadex.nim
@@ -23,7 +23,7 @@ proc consume() {.thread.} =
     var x = recv(chan)
     if x.k == mEof: break
     echo x.data
-    atomicInc(printedLines)
+    discard atomicInc(printedLines)
 
 proc produce() {.thread.} =
   prodId = getThreadId()


### PR DESCRIPTION
This is a reimplementation of the atomic reference counting patch.
When using threads, reference counting uses atomic operations.
This change also removes the `discardable` pragma from `atomicInc` and `atomicDec`, as well as adding an optional `AtomMemModel` parameter to these functions.

This code is tested extensively via https://github.com/sesco-llc/gread and a more complete version, which includes identical patching against `refs_v2` in mainline Nim, is available in https://github.com/nim-works/gitnim/tree/1.6.7.