### PR TITLE
ci: update macOS runner to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
             },
             {
               "name": "macOS",
-              "runner": "macos-10.15"
+              "runner": "macos-11"
             }
           ]
           EOF


### PR DESCRIPTION
## Summary

This runner is deprecated and will be removed soon. Currently Github is
implementing a brownout period where jobs run at specific time with this
runner will be terminated automatically.

Update the runner to macOS 11 to avoid disruptions.

Ref: https://github.com/actions/virtual-environments/issues/5583