### PR TITLE
macro pragmas: support template and const defs

### DIFF
--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -643,14 +643,25 @@ proc semTemplBodyDirty(c: var TemplCtx, n: PNode): PNode =
     for i in 0..<n.len:
       result[i] = semTemplBodyDirty(c, n[i])
 
+proc semProcAnnotation(c: PContext, prc: PNode; validPragmas: TSpecialWords): PNode
+# from semstmts
+
 proc semTemplateDef(c: PContext, n: PNode): PNode =
+  addInNimDebugUtils(c.config, "semTemplateDef", n, result)
+
+  result = semProcAnnotation(c, n, templatePragmas)
+  if result != nil:
+    return result
+
   result = n
   var s: PSym
+
   if isTopLevel(c):
     s = semIdentVis(c, skTemplate, n[namePos], {sfExported})
     incl(s.flags, sfGlobal)
   else:
     s = semIdentVis(c, skTemplate, n[namePos], {})
+
   assert s.kind == skTemplate
 
   if s.owner != nil:

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -17,7 +17,9 @@ import
   compiler/ast/[
     ast,
     renderer,
-    types
+    types,
+    reports,
+    errorhandling,
   ],
   compiler/front/[
     options,
@@ -198,10 +200,26 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
       result = t
 
 proc typeAllowed*(t: PType, kind: TSymKind; c: PContext; flags: TTypeAllowedFlags = {}): PType =
-  # returns 'nil' on success and otherwise the part of the type that is
-  # wrong!
+  ## returns 'nil' on success and otherwise the part of the type that is wrong!
   var marker = initIntSet()
   result = typeAllowedAux(marker, t, kind, c, flags)
+
+proc typeAllowedOrError*(t: PType, kind: TSymKind, c: PContext,
+                         def: PNode, flags: TTypeAllowedFlags = {}): PType =
+  ## returns the original `t` if allowed, otherwise a type not allowed error
+  let temp = typeAllowed(t, kind, c, flags)
+  if temp.isNil:
+    t
+  else:
+    newTypeError(t, nextTypeId(c.idgen)):
+              c.config.newError(def,
+                                SemReport(
+                                  kind: rsemTypeNotAllowed,
+                                  allowedType: (
+                                    allowed: temp,
+                                    actual: t,
+                                    kind: kind,
+                                    allowedFlags: flags)))
 
 type
   ViewTypeKind* = enum

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7775,9 +7775,10 @@ More examples with custom pragmas:
 Macro pragmas
 -------------
 
-All macros and templates can also be used as pragmas. They can be attached
-to routines (procs, iterators, etc), type names, or type expressions. The
-compiler will perform the following simple syntactic transformations:
+Macros and templates can sometimes be called with the pragma syntax. Cases
+where this is possible include when attached to routine (procs, iterators, etc)
+declarations or routine type expressions. The compiler will perform the
+following simple syntactic transformations:
 
 .. code-block:: nim
   template command(name: string, def: untyped) = discard
@@ -7811,11 +7812,30 @@ This is translated to:
 This is translated to a call to the `schema` macro with a `nnkTypeDef`
 AST node capturing both the left-hand side and right-hand side of the
 definition. The macro can return a potentially modified `nnkTypeDef` tree
-which will replace the original row in the type section.
+which will replace the original row in the type section. Transformation for
+type sections are ill-defined and error prone.
 
-When multiple macro pragmas are applied to the same definition, the
-compiler will apply them consequently from left to right. Each macro
-will receive as input the output of the previous one.
+For variables and constants, it is largely the same, except that an unary
+node with the same kind as the section containing a single definition is
+passed to macros, and macros can return any statement.
+
+.. code-block:: nim
+  var
+    a = ...
+    b {.importc, foo, nodecl.} = ...
+    c = ...
+
+Assuming `foo` is a macro or a template, this is roughly equivalent to:
+
+.. code-block:: nim
+  var a = ...
+  foo:
+    var b {.importc, nodecl.} = ...
+  var c = ...
+
+When multiple macro pragmas are applied to the same definition, the compiler
+will evaluate them from left to right. Each macro can choose to remove the
+remaining macro pragmas - they won't be evaluated then.
 
 
 

--- a/tests/errmsgs/t12844.nim
+++ b/tests/errmsgs/t12844.nim
@@ -2,7 +2,7 @@ discard """
 cmd: "nim check $file"
 errormsg: "invalid type: 'template (args: varargs[string])' for var. Did you mean to call the template with '()'?"
 nimout: '''
-t12844.nim(11, 7) Error: invalid type: 'template (args: varargs[string])' for const. Did you mean to call the template with '()'?
+t12844.nim(11, 11) Error: invalid type: 'template (args: varargs[string])' for const. Did you mean to call the template with '()'?
 t12844.nim(12, 9) Error: invalid type: 'template (args: varargs[string])' for var. Did you mean to call the template with '()'?'''
 """
 

--- a/tests/errmsgs/ttypeAllowed.nim
+++ b/tests/errmsgs/ttypeAllowed.nim
@@ -2,8 +2,8 @@ discard """
 cmd: "nim check $file"
 errormsg: ""
 nimout: '''
-ttypeAllowed.nim(17, 7) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for const
 ttypeAllowed.nim(13, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for let
+ttypeAllowed.nim(17, 12) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for const
 ttypeAllowed.nim(21, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for var
 ttypeAllowed.nim(26, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for result
 '''

--- a/tests/pragmas/tpragmas_misc.nim
+++ b/tests/pragmas/tpragmas_misc.nim
@@ -1,68 +1,86 @@
 discard """
-    disabled: true
+description: "test macros pragmas on templates"
 """
 
 ##[
 tests for misc pragmas that don't need a separate file
 ]##
 
-block:
+block can_undefine_non_existent_define:
+  # this should work as it's idempotent
   static: doAssert not defined(tpragmas_misc_def)
   {.undef(tpragmas_misc_def).} # works even if not set
+
+block can_define_a_fresh_define:
   static: doAssert not defined(tpragmas_misc_def)
   {.define(tpragmas_misc_def).}
+
+block undef_removes_an_existing_define:
   static: doAssert defined(tpragmas_misc_def)
   {.undef(tpragmas_misc_def).}
   static: doAssert not defined(tpragmas_misc_def)
 
-block: # (partial fix) bug #15920
+block: # (partial fix) bug https://github.com/nim-lang/nim/issues/15920
   block: # var template pragmas don't work in templates
-    template foo(lhs, typ, expr) =
-      let lhs = expr
+    template foo(expr) =
+      expr
+    
     proc fun1()=
       let a {.foo.} = 1
+    
     template fun2()=
       let a {.foo.} = 1
+    
     fun1() # ok
-    fun2() # WAS bug
+    fun2() # also works
 
   template foo2() = discard # distractor (template or other symbol kind)
   block:
-    template foo2(lhs, typ, expr) =
-      let lhs = expr
+    template foo2(expr) =
+      expr
+
     proc fun1()=
       let a {.foo2.} = 1
+
     template fun2()=
       let a {.foo2.} = 1
-    fun1() # ok
-    when false: # bug: Error: invalid pragma: foo2
-      fun2()
 
-  block: # proc template pragmas don't work in templates
+    fun1() # ok
+    fun2() # also works
+
+  block template_pragmas_for_templates:
     # adapted from $nim/lib/std/private/since.nim
+
     # case without overload
     template since3(version: (int, int), body: untyped) {.dirty.} =
       when (NimMajor, NimMinor) >= version:
         body
-    when false: # bug
-      template fun3(): int {.since3: (1, 3).} = 12
+    
+    template fun3(): int {.since3: (1, 3).} = 12
 
-  block:
-
+  block template_pragmas_for_templates_with_overloads:
+    # case with overload
     template since2(version: (int, int), body: untyped) {.dirty.} =
       when (NimMajor, NimMinor) >= version:
         body
+
     template since2(version: (int, int, int), body: untyped) {.dirty.} =
       when (NimMajor, NimMinor, NimPatch) >= version:
         body
-    when false: # bug
-      template fun3(): int {.since2: (1, 3).} = 12
 
-when true: # D20210801T100514:here
-  from macros import genSym
-  block:
-    template fn() =
-      var ret {.gensym.}: int # must special case template pragmas so it doesn't get confused
-      discard ret
-    fn()
-    static: discard genSym()
+    template fun3(): int {.since2: (1, 3).} = 12
+
+from macros import genSym
+block:
+  template fn() =
+    var ret {.gensym.}: int # special case template pragmas so it doesn't get confused
+    discard ret
+  fn()
+  static: discard genSym()
+
+block:
+  macro foo(x): untyped = x
+  template bar {.pragma.}
+
+  proc a {.bar.} = discard # works
+  proc b {.bar, foo.} = discard # doesn't

--- a/tests/pragmas/tvar_macro.nim
+++ b/tests/pragmas/tvar_macro.nim
@@ -1,0 +1,131 @@
+discard """
+"""
+
+import macros
+
+block: # test usage
+  macro modify(sec) =
+    result = copy sec
+    result[0][0] = ident(repr(result[0][0]) & "Modified")
+
+  block:
+    let foo {.modify.} = 3
+    doAssert fooModified == 3
+
+  block: # in section 
+    let
+      a = 1
+      b {.modify.} = 2
+      c = 3
+    doAssert (a, bModified, c) == (1, 2, 3)
+
+block: # with single argument
+  macro appendToName(name: static string, sec) =
+    result = sec
+    result[0][0] = ident(repr(result[0][0]) & name)
+
+  block:
+    let foo {.appendToName: "Bar".} = 3
+    doAssert fooBar == 3
+
+  block:
+    let
+      a = 1
+      b {.appendToName("").} = 2
+      c = 3
+    doAssert (a, b, c) == (1, 2, 3)
+
+macro appendToNameAndAdd(name: static string, incr: static int, sec) =
+  result = sec
+  result[0][0] = ident(repr(result[0][0]) & name)
+  result[0][2] = infix(result[0][2], "+", newLit(incr))
+
+block: # with multiple arguments
+  block:
+    let foo {.appendToNameAndAdd("Bar", 5).} = 3
+    doAssert fooBar == 8
+
+  block:
+    let
+      a = 1
+      b {.appendToNameAndAdd("", 15).} = 2
+      c = 3
+    doAssert (a, b, c) == (1, 17, 3)
+
+block: # in other kinds of sections
+  block:
+    const
+      a = 1
+      b {.appendToNameAndAdd("", 15).} = 2
+      c = 3
+    doAssert (a, b, c) == (1, 17, 3)
+    doAssert static(b) == b
+
+  block:
+    var
+      a = 1
+      b {.appendToNameAndAdd("", 15).} = 2
+      c = 3
+    doAssert (a, b, c) == (1, 17, 3)
+    b += a
+    c += b
+    doAssert (a, b, c) == (1, 18, 21)
+
+block: # with other pragmas
+  macro appendToNameAndAdd(name: static string, incr, sec) =
+    result = sec
+    result[0][0][0] = ident(repr(result[0][0][0]) & name)
+    result[0][0][1].add(ident"deprecated")
+    result[0][2] = infix(result[0][2], "+", incr)
+
+  var
+    a = 1
+    foo {.exportc: "exportedFooBar", appendToNameAndAdd("Bar", {'0'..'9'}), used.} = {'a'..'z', 'A'..'Z'}
+    b = 2
+
+  doAssert (a, b) == (1, 2)
+
+  let importedFooBar {.importc: "exportedFooBar", nodecl.}: set[char]
+
+  doAssert importedFooBar == fooBar #[tt.Warning
+                            ^ fooBar is deprecated
+  ]#
+
+
+block: # with stropping
+  macro `cast`(def) =
+    let def = def[0]
+    let
+      lhs = def[0][0]
+      typ = def[1]
+      ex = def[2]
+      addrTyp = if typ.kind == nnkEmpty: typ else: newTree(nnkPtrTy, typ)
+    result = quote do:
+      let tmp: `addrTyp` = unsafeAddr(`ex`)
+      template `lhs`: untyped = tmp[]
+
+  macro assign(def) =
+    result = getAst(`cast`(def))
+
+  block:
+    let s = @["foo", "bar"]
+    let a {.`assign`.} = s[0]
+    doAssert a == "foo"
+    doAssert a[0].addr == s[0][0].addr
+
+  block:
+    let
+      s = @["foo", "bar"]
+      a {.`cast`.} = s[0]
+    doAssert a == "foo"
+    doAssert a[0].addr == s[0][0].addr
+
+block: # bug https://github.com/nim-lang/nim/issues/15920
+  macro foo(def) =
+    result = def
+  proc fun1()=
+    let a {.foo.} = 1
+  template fun2()=
+    let a {.foo.} = 1
+  fun1() # ok
+  fun2() # BUG


### PR DESCRIPTION
## Summary:
* constdef annotation handling same as identdefs in let or var
* annotation processing on template definitions like other routine kinds

## Details:
* reenabled `tests/pragmas/tpragmas_misc`
* updated manual for macros pragmas
* `semstmts.semConst` reworked to be like `semstmts.semLetOrVar`
* constdef annotation handling same as identdefs in let or var
* `semLetOrVarAnnotation` works on const defs, and renamed
* added tracing to `semTemplateDef`
* added tests for let/var section processing
    
Mostly a port of https://github.com/nim-lang/Nim/pull/19406