### PR TITLE
lang: remove deprecated c/C octal prefix

### DIFF
--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -358,8 +358,7 @@ proc getNumber(L: var Lexer, result: var Token) =
     isBase10 = true
     numDigits = 0
   const
-    # 'c', 'C' is deprecated
-    baseCodeChars = {'X', 'x', 'o', 'b', 'B', 'c', 'C'}
+    baseCodeChars = {'X', 'x', 'o', 'b', 'B'}
     literalishChars = baseCodeChars + {'A'..'F', 'a'..'f', '0'..'9', '_', '\''}
     floatTypes = {tkFloatLit, tkFloat32Lit, tkFloat64Lit, tkFloat128Lit}
   result.tokType = tkIntLit   # int literal until we know better
@@ -378,19 +377,10 @@ proc getNumber(L: var Lexer, result: var Token) =
     field = (if isPositive: value else: -value)
 
   # First stage: find out base, make verifications, build token literal string
-  # {'c', 'C'} is added for deprecation reasons to provide a clear error message
-  if L.buf[L.bufpos] == '0' and L.buf[L.bufpos + 1] in baseCodeChars + {'c', 'C', 'O'}:
+  if L.buf[L.bufpos] == '0' and L.buf[L.bufpos + 1] in baseCodeChars + {'O'}:
     isBase10 = false
     eatChar(L, result, '0')
     case L.buf[L.bufpos]
-    of 'c', 'C':
-      lexMessageLitNum(L,
-                       "$1 will soon be invalid for oct literals; Use '0o' " &
-                       "for octals. 'c', 'C' prefix",
-                       startpos,
-                       rlexDeprecatedOctalPrefix)
-      eatChar(L, result, 'c')
-      numDigits = matchUnderscoreChars(L, result, {'0'..'7'})
     of 'O':
       lexMessageLitNum(L, "$1 is an invalid int literal; For octal literals " &
                           "use the '0o' prefix.", startpos, rlexInvalidIntegerPrefix)
@@ -484,8 +474,7 @@ proc getNumber(L: var Lexer, result: var Token) =
             if L.buf[pos] != '_':
               xi = `shl`(xi, 1) or (ord(L.buf[pos]) - ord('0'))
             inc(pos)
-        # 'c', 'C' is deprecated (a warning is issued elsewhere)
-        of 'o', 'c', 'C':
+        of 'o':
           result.base = base8
           while pos < endpos:
             if L.buf[pos] != '_':

--- a/tests/lexer/tintegerliterals.nim
+++ b/tests/lexer/tintegerliterals.nim
@@ -4,6 +4,3 @@ doAssert 0B10 == 2
 doAssert 0x10 == 16
 doAssert 0X10 == 16
 doAssert 0o10 == 8
-# the following is deprecated:
-doAssert 0c10 == 8
-doAssert 0C10 == 8


### PR DESCRIPTION
## Summary
- can no longer use 0c1
- this has long since been deprecated and not referenced in the manual
