### PR TITLE
pragmas: type pragmas must follow generic params

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -220,6 +220,8 @@ type
     rparPragmaAlreadyPresent
     rparMisplacedExport
 
+    rparPragmaBeforeGenericParameters
+
     # template parser `filter_tmpl.nim`
     rparTemplMissingEndClose
     rparTemplInvalidExpression
@@ -230,9 +232,8 @@ type
 
     # warnings begin
     rparInconsistentSpacing = "Spacing"
-    rparEnablePreviewDotOps = "DotLikeOps"
     rparPragmaNotFollowingTypeName
-    rparPragmaBeforeGenericParameters
+    rparEnablePreviewDotOps = "DotLikeOps"
     # warnings END !! add reports BEFORE the last enum !!
 
     rparName = "Name" ## Linter report about used identifier
@@ -951,7 +952,7 @@ const
   rparHintKinds*    = {rparName}
   rparErrorKinds*   = {rparInvalidIndentation .. rparInvalidFilter}
   rparWarningKinds* = {
-    rparInconsistentSpacing .. rparPragmaBeforeGenericParameters}
+    rparInconsistentSpacing .. rparEnablePreviewDotOps}
 
   #---------------------------------  sem  ---------------------------------#
   repSemKinds* = {low(SemReportKind) .. high(SemReportKind)}

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2525,13 +2525,13 @@ proc reportBody*(conf: ConfigRef, r: ParserReport): string =
       result = "Number of spaces around '$#' is not consistent"
 
     of rparEnablePreviewDotOps:
-      result = "?"
+      result = "dot-like operators will be parsed differently with `-d:nimPreviewDotLikeOps`"
 
     of rparPragmaNotFollowingTypeName:
-      result = "?"
+      result = "type pragmas follow the type name; this form of writing pragmas is deprecated"
 
     of rparPragmaBeforeGenericParameters:
-      result = "?"
+      result = "pragma must come after any generic parameter list"
 
     of rparName:
       result = "?"

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -1133,7 +1133,7 @@ proc extractPragma(s: PSym): PNode =
       if s.ast[0].kind == nkPragmaExpr and s.ast[0].len > 1:
         # s.ast = nkTypedef / nkPragmaExpr / [nkSym, nkPragma]
         result = s.ast[0][1]
-  doAssert result == nil or result.kind == nkPragma
+  doAssert result == nil or result.kind in {nkPragma, nkEmpty}
 
 proc warnAboutDeprecated(conf: ConfigRef; info: TLineInfo; s: PSym) =
   var pragmaNode: PNode

--- a/tests/arc/tweave.nim
+++ b/tests/arc/tweave.nim
@@ -1,7 +1,7 @@
 discard """
   outputsub: '''Success'''
-  cmd: '''nim c --gc:arc --threads:on $file'''
   disabled: "bsd"
+  matrix: "--gc:arc --threads:on"
 """
 
 # bug #13936

--- a/tests/cpp/temitlist.nim
+++ b/tests/cpp/temitlist.nim
@@ -8,7 +8,7 @@ disabled: "windows" # pending bug #18011
 
 # bug #4730
 
-type Vector* {.importcpp: "std::vector", header: "<vector>".}[T] = object
+type Vector*[T] {.importcpp: "std::vector", header: "<vector>".} = object
 
 template `[]=`*[T](v: var Vector[T], key: int, val: T) =
   {.emit: [v, "[", key, "] = ", val, ";"].}

--- a/tests/cpp/tvector_iterator.nim
+++ b/tests/cpp/tvector_iterator.nim
@@ -12,8 +12,8 @@ struct Vector {
 """.}
 
 type
-  Vector {.importcpp: "Vector".} [T] = object
-  VectorIterator {.importcpp: "Vector<'0>::Iterator".} [T] = object
+  Vector[T] {.importcpp: "Vector".} = object
+  VectorIterator[T] {.importcpp: "Vector<'0>::Iterator".} = object
 
 var x: VectorIterator[void]
 

--- a/tests/errmsgs/tinvalidinout.nim
+++ b/tests/errmsgs/tinvalidinout.nim
@@ -9,7 +9,7 @@ tinvalidinout.nim(18, 9) Error: the 'in' modifier can be used only with imported
 """
 
 type
-  Foo {.header: "foo.h", importcpp.} [in T] = object
+  Foo[in T] {.header: "foo.h", importcpp.} = object
 
   Bar[out X] = object
     x: int

--- a/tests/exception/tcpp_imported_exc.nim
+++ b/tests/exception/tcpp_imported_exc.nim
@@ -76,7 +76,7 @@ doAssert(getCurrentException() == nil)
 # raise by pointer and also generic type
 
 type
-  std_vector {.importcpp"std::vector", header"<vector>".} [T] = object
+  std_vector[T] {.importcpp"std::vector", header"<vector>".} = object
 
 proc newVector[T](len: int): ptr std_vector[T] {.importcpp: "new std::vector<'1>(@)".}
 proc deleteVector[T](v: ptr std_vector[T]) {.importcpp: "delete @; @ = NIM_NIL;".}

--- a/tests/generics/tgeneric3.nim
+++ b/tests/generics/tgeneric3.nim
@@ -12,7 +12,7 @@ import strutils
 
 type
   PNode[T,D] = ref TNode[T,D]
-  TItem {.acyclic, pure, final, shallow.} [T,D] = object
+  TItem[T,D] {.acyclic, pure, final, shallow.} = object
         key: T
         value: D
         node: PNode[T,D]
@@ -20,7 +20,7 @@ type
           val_set: bool
 
   TItems[T,D] = seq[ref TItem[T,D]]
-  TNode {.acyclic, pure, final, shallow.} [T,D] = object
+  TNode[T,D] {.acyclic, pure, final, shallow.} = object
         slots: TItems[T,D]
         left: PNode[T,D]
         count: int32

--- a/tests/iter/titer2.nim
+++ b/tests/iter/titer2.nim
@@ -17,7 +17,7 @@ type
   TSlotEnum = enum seEmpty, seFilled, seDeleted
   TKeyValuePair[A, B] = tuple[slot: TSlotEnum, key: A, val: B]
   TKeyValuePairSeq[A, B] = seq[TKeyValuePair[A, B]]
-  TTable* {.final.}[A, B] = object
+  TTable*[A, B] {.final.} = object
     data: TKeyValuePairSeq[A, B]
     counter: int
 

--- a/tests/misc/tsimplesort.nim
+++ b/tests/misc/tsimplesort.nim
@@ -10,7 +10,7 @@ type
   TSlotEnum = enum seEmpty, seFilled, seDeleted
   TKeyValuePair[A, B] = tuple[slot: TSlotEnum, key: A, val: B]
   TKeyValuePairSeq[A, B] = seq[TKeyValuePair[A, B]]
-  TTable* {.final, myShallow.}[A, B] = object
+  TTable*[A, B] {.final, myShallow.} = object
     data: TKeyValuePairSeq[A, B]
     counter: int
 
@@ -137,8 +137,8 @@ proc `$`*[A, B](t: TTable[A, B]): string =
 # ------------------------------ count tables -------------------------------
 
 type
-  TCountTable* {.final, myShallow.}[
-      A] = object ## table that counts the number of each key
+  TCountTable*[A] {.final, myShallow.} = object
+    ## table that counts the number of each key
     data: seq[tuple[key: A, val: int]]
     counter: int
 

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -175,7 +175,9 @@ proc transformObjectconfigPacked(arg: NimNode): NimNode =
       result.add transformObjectconfigPacked(child)
 
 proc removeObjectconfig(arg: NimNode): NimNode =
-  if arg.kind == nnkPragmaExpr and arg[1][0].eqIdent "objectconfig":
+  if arg.kind == nnkPragmaExpr and
+     arg[1].kind != nnkEmpty and
+     arg[1][0].eqIdent "objectconfig":
     result = arg[0]
   else:
     result = copyNimNode(arg)

--- a/tests/statictypes/tstaticimportcpp.nim
+++ b/tests/statictypes/tstaticimportcpp.nim
@@ -23,12 +23,12 @@ struct SimpleStruct {
 """ .}
 
 type
-  GenericIntType {.importcpp: "GenericIntType<'0, '1>".} [N: static[int]; T] = object
+  GenericIntType[N: static[int]; T] {.importcpp: "GenericIntType<'0, '1>".} = object
     data: array[N, T]
 
-  GenericIntTypeAlt {.importcpp: "GenericIntType".} [N: static[int]; T] = object
+  GenericIntTypeAlt[N: static[int]; T] {.importcpp: "GenericIntType".} = object
 
-  GenericTType {.importcpp: "GenericTType<'0>".} [T] = object
+  GenericTType[T] {.importcpp: "GenericTType<'0>".} = object
     field: T
 
   GenInt4 = GenericIntType[4, int]


### PR DESCRIPTION
## Summary

removed the previous deprecation where pragmas could preceed the generic
parameter list in a type definition, eg:

```
type Foo{.somePragma}[T] = ... # now an error
type Foo[T] {.somePragma.} = ... # acceptable
```

## Details

Due to lots of issues, mostly stylistic, I've pragmas on the RHS of a
type definition as legal. Largely because after changing it I realized a
more significant rethink of type declaration syntax should cover this in
the future.

Fixed a number of test failures along the way due to this change.