### PR TITLE
stdlib: times, remove deprecated procs

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1353,23 +1353,6 @@ proc dateTime*(year: int, month: Month, monthday: MonthdayRange,
   )
   result = initDateTime(zone.zonedTimeFromAdjTime(dt.toAdjTime), zone)
 
-proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
-                   hour: HourRange, minute: MinuteRange, second: SecondRange,
-                   nanosecond: NanosecondRange,
-                   zone: Timezone = local()): DateTime {.deprecated: "use `dateTime`".} =
-  ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
-  runnableExamples("--warning:deprecated:off"):
-    assert $initDateTime(30, mMar, 2017, 00, 00, 00, 00, utc()) == "2017-03-30T00:00:00Z"
-  dateTime(year, month, monthday, hour, minute, second, nanosecond, zone)
-
-proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
-                   hour: HourRange, minute: MinuteRange, second: SecondRange,
-                   zone: Timezone = local()): DateTime {.deprecated: "use `dateTime`".} =
-  ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
-  runnableExamples("--warning:deprecated:off"):
-    assert $initDateTime(30, mMar, 2017, 00, 00, 00, utc()) == "2017-03-30T00:00:00Z"
-  dateTime(year, month, monthday, hour, minute, second, 0, zone)
-
 proc `+`*(dt: DateTime, dur: Duration): DateTime =
   runnableExamples:
     let dt = dateTime(2017, mMar, 30, 00, 00, 00, 00, utc())
@@ -2650,44 +2633,3 @@ when not defined(js):
         toFloat(ts.tv_nsec.int) / 1_000_000_000
     else:
       result = toFloat(int(getClock())) / toFloat(clocksPerSec)
-
-
-#
-# Deprecations
-#
-
-proc `nanosecond=`*(dt: var DateTime, value: NanosecondRange) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.nanosecond = value
-
-proc `second=`*(dt: var DateTime, value: SecondRange) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.second = value
-
-proc `minute=`*(dt: var DateTime, value: MinuteRange) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.minute = value
-
-proc `hour=`*(dt: var DateTime, value: HourRange) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.hour = value
-
-proc `monthdayZero=`*(dt: var DateTime, value: int) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.monthdayZero = value
-
-proc `monthZero=`*(dt: var DateTime, value: int) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.monthZero = value
-
-proc `year=`*(dt: var DateTime, value: int) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.year = value
-
-proc `weekday=`*(dt: var DateTime, value: WeekDay) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.weekday = value
-
-proc `yearday=`*(dt: var DateTime, value: YeardayRange) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.yearday = value
-
-proc `isDst=`*(dt: var DateTime, value: bool) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.isDst = value
-
-proc `timezone=`*(dt: var DateTime, value: Timezone) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.timezone = value
-
-proc `utcOffset=`*(dt: var DateTime, value: int) {.deprecated: "Deprecated since v1.3.1".} =
-  dt.utcOffset = value

--- a/tests/metatype/tstaticparams.nim
+++ b/tests/metatype/tstaticparams.nim
@@ -194,4 +194,4 @@ block: # #12864
 
 when true: #12864 original snippet
   import times
-  discard times.format(initDateTime(30, mMar, 2017, 0, 0, 0, 0, utc()), TimeFormat())
+  discard times.format(dateTime(2017, mMar, 30, 0, 0, 0, 0, utc()), TimeFormat())

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -473,7 +473,7 @@ proc main() =
     # Note: times.format adheres to the format protocol. Test that this
     # works:
 
-    var dt = initDateTime(01, mJan, 2000, 00, 00, 00)
+    var dt = dateTime(2000, mJan, 01, 00, 00, 00)
     check &"{dt:yyyy-MM-dd}", "2000-01-01"
 
     var tm = fromUnix(0)


### PR DESCRIPTION
Removed deprecated constructors and setters for `times.DateTime`

Updated associated broken tests.