### PR TITLE
strutils: remove deprecated delete proc

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -757,7 +757,7 @@ proc stripTocHtml(s: string): string =
     if last < 0:
       # Abort, since we didn't found a closing angled bracket.
       return
-    result.delete(first, last)
+    result.delete(first..last)
     first = result.find('<', first)
 
 proc renderHeadline(d: PDoc, n: PRstNode, result: var string) =

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1507,29 +1507,6 @@ func delete*(s: var string, slice: Slice[int]) =
       inc(j)
     setLen(s, newLen)
 
-func delete*(s: var string, first, last: int) {.rtl, extern: "nsuDelete", deprecated: "use `delete(s, first..last)`".} =
-  ## Deletes in `s` the characters at positions `first .. last` (both ends included).
-  runnableExamples("--warning:deprecated:off"):
-    var a = "abracadabra"
-
-    a.delete(4, 5)
-    doAssert a == "abradabra"
-
-    a.delete(1, 6)
-    doAssert a == "ara"
-
-    a.delete(2, 999)
-    doAssert a == "ar"
-
-  var i = first
-  var j = min(len(s), last+1)
-  var newLen = len(s)-j+i
-  while i < newLen:
-    s[i] = s[j]
-    inc(i)
-    inc(j)
-  setLen(s, newLen)
-
 func startsWith*(s: string, prefix: char): bool {.inline.} =
   ## Returns true if `s` starts with character `prefix`.
   ##

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -223,17 +223,6 @@ template main() =
     delete(s, 0..0)
     doAssert s == "b"
 
-  block: # delete(first, last)
-    {.push warning[deprecated]:off.}
-    var s = "0123456789ABCDEFGH"
-    delete(s, 4, 5)
-    doAssert s == "01236789ABCDEFGH"
-    delete(s, s.len-1, s.len-1)
-    doAssert s == "01236789ABCDEFG"
-    delete(s, 0, 0)
-    doAssert s == "1236789ABCDEFG"
-    {.pop.}
-
   block: # find
     doAssert "0123456789ABCDEFGH".find('A') == 10
     doAssert "0123456789ABCDEFGH".find('A', 5) == 10


### PR DESCRIPTION
## Summary

- remove deprecated `delete(var string, int, int)`
- removed associated tests
- updated usage of removed proc in rstgen