### PR TITLE
sequtils: remove deprecated delete proc

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -563,30 +563,6 @@ func delete*[T](s: var seq[T]; slice: Slice[int]) =
       else:
         defaultImpl()
 
-func delete*[T](s: var seq[T]; first, last: Natural) {.deprecated: "use `delete(s, first..last)`".} =
-  ## Deletes the items of a sequence `s` at positions `first..last`
-  ## (including both ends of the range).
-  ## This modifies `s` itself, it does not return a copy.
-  runnableExamples("--warning:deprecated:off"):
-    let outcome = @[1, 1, 1, 1, 1, 1, 1, 1]
-    var dest = @[1, 1, 1, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1]
-    dest.delete(3, 8)
-    assert outcome == dest
-  doAssert first <= last
-  if first >= s.len:
-    return
-  var i = first
-  var j = min(len(s), last + 1)
-  var newLen = len(s) - j + i
-  while i < newLen:
-    when defined(gcDestructors):
-      s[i] = move(s[j])
-    else:
-      s[i].shallowCopy(s[j])
-    inc(i)
-    inc(j)
-  setLen(s, newLen)
-
 func insert*[T](dest: var seq[T], src: openArray[T], pos = 0) =
   ## Inserts items from `src` into `dest` at position `pos`. This modifies
   ## `dest` itself, it does not return a copy.

--- a/tests/stdlib/tsequtils.nim
+++ b/tests/stdlib/tsequtils.nim
@@ -487,13 +487,10 @@ template main =
   block: # delete tests
     let outcome = @[1, 1, 1, 1, 1, 1, 1, 1]
     var dest = @[1, 1, 1, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1]
-    dest.delete(3, 8)
+    dest.delete(3..8)
     doAssert outcome == dest, """\
     Deleting range 3-9 from [1,1,1,2,2,2,2,2,2,1,1,1,1,1]
     is [1,1,1,1,1,1,1,1]"""
-    var x = @[1, 2, 3]
-    x.delete(100, 100)
-    doAssert x == @[1, 2, 3]
 
   block: # delete tests
     var a = @[10, 11, 12, 13, 14]


### PR DESCRIPTION
remove deprecated `delete[T](var T, int, int)` and its tests