### PR TITLE
algorithm: remove deprecated reversed proc

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -143,10 +143,6 @@ proc reversed*[T](a: openArray[T]): seq[T] {.inline.} =
   result.setLen(n)
   for i in 0..<n: result[i] = a[n - (i + 1)]
 
-proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T]
-  {.inline, deprecated: "use: `reversed(toOpenArray(a, first, last))`".} =
-  reversed(toOpenArray(a, first, last))
-
 when defined(nimHasEffectsOf):
   {.experimental: "strictEffects".}
 else:

--- a/tests/stdlib/talgorithm.nim
+++ b/tests/stdlib/talgorithm.nim
@@ -45,8 +45,8 @@ block:
   var arr1 = @[0, 1, 2, 3, 4]
   doAssert arr1.reversed() == @[4, 3, 2, 1, 0]
   for i in 0 .. high(arr1):
-    doAssert arr1.reversed(0, i) == arr1.reversed()[high(arr1) - i .. high(arr1)]
-    doAssert arr1.reversed(i, high(arr1)) == arr1.reversed()[0 .. high(arr1) - i]
+    doAssert arr1[0..i].reversed() == arr1.reversed()[high(arr1) - i .. high(arr1)]
+    doAssert arr1[i..high(arr1)].reversed() == arr1.reversed()[0 .. high(arr1) - i]
 
 block:
   var list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]


### PR DESCRIPTION
## Summary

- remove deprecated `reversed[T](var openArray[T], int, int): seq[T]`
- removed associated tests
