### PR TITLE
options: remove deprecated UnpackError

### DIFF
--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -90,7 +90,6 @@ type
       has: bool
 
   UnpackDefect* = object of Defect
-  UnpackError* {.deprecated: "See corresponding Defect".} = UnpackDefect
 
 proc option*[T](val: sink T): Option[T] {.inline.} =
   ## Can be used to convert a pointer type (`ptr`, `pointer`, `ref` or `proc`) to an option type.


### PR DESCRIPTION
## Summary

Removed UnpackError, was replaced with UnpackDefect a while back

## Details

Defects in general are a bad idea, but less code is good too