### PR TITLE
internal: rewrite semTemplateDef in case style

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2655,8 +2655,13 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     n[miscPos] = c.graph.emptyNode
 
   if tfTriggersCompileTime in s.typ.flags: incl(s.flags, sfCompileTime)
+  
   if n[patternPos].kind != nkEmpty:
     n[patternPos] = semPattern(c, n[patternPos], s)
+    if n[patternPos].kind == nkError:
+      # xxx: convert to nkError propagation
+      c.config.localReport(n[patternPos])
+  
   if s.kind == skIterator:
     s.typ.flags.incl(tfIterator)
   elif s.kind == skFunc:


### PR DESCRIPTION
## Summary
- refactoring to clean-up style and use nkError in more places

## Details
- refactoring of semTemplateDef in a case style
- treats `result` as a production, instead of mutating `n`
-`semPattern` now produces nkErrors
- `semPattern` nkError change required reporting in `semProcAux`