### PR TITLE
hints: source code filter hint now outputs correctly

### DIFF
--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -90,10 +90,8 @@ proc computeNotesVerbosity(): tuple[
     rintErrKind
   }
 
-
   if defined(release):
     result.main[3].excl rintStackTrace
-
 
   result.main[2] = result.main[3] - {
     rsemUninit,
@@ -106,11 +104,15 @@ proc computeNotesVerbosity(): tuple[
   result.main[1] = result.main[2] - repPerformanceHints - {
     rsemProveField,
     rsemErrGcUnsafe,
-    rextPath,
     rsemHintLibDependency,
     rsemGlobalVar,
+
     rintGCStats,
     rintMsgOrigin,
+
+    rextPath,
+
+    rlexSourceCodeFilterOutput,
   }
 
   result.main[0] = result.main[1] - {

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -194,7 +194,7 @@ type
     rlexLineTooLong = "LineTooLong"
     rlexLinterReport = "Name"
 
-    rlexSyntaxesCode
+    rlexSourceCodeFilterOutput = "SourceCodeFilterOutput"
     # hints END !! add reports BEFORE the last enum !!
 
     # Lexer report end
@@ -922,7 +922,7 @@ type
 const rstWarnings* = {rbackRstTestUnsupported .. rbackRstRstStyle}
 
 type
-  LexerReportKind* = range[rlexMalformedUnderscores .. rlexSyntaxesCode]
+  LexerReportKind* = range[rlexMalformedUnderscores .. rlexSourceCodeFilterOutput]
   ParserReportKind* = range[rparInvalidIndentation .. rparName]
 
   SemReportKind* = range[rsemFatalError .. rsemImplicitObjConv]
@@ -942,7 +942,7 @@ type
 const
   #--------------------------------  lexer  --------------------------------#
   repLexerKinds*    = {low(LexerReportKind) .. high(LexerReportKind)}
-  rlexHintKinds*    = {rlexLineTooLong .. rlexSyntaxesCode}
+  rlexHintKinds*    = {rlexLineTooLong .. rlexSourceCodeFilterOutput}
   rlexWarningKinds* = {rlexDeprecatedOctalPrefix .. rlexDeprecatedOctalPrefix}
   rlexErrorKinds*   = {rlexMalformedUnderscores .. rlexUnclosedComment}
 

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -88,6 +88,7 @@ type
     reportFrom*: ReportLineInfo ## Information about submit location of the
     ## report
 
+
 type
   LexerReport* = object of ReportBase
     msg*: string
@@ -95,17 +96,15 @@ type
       of rlexLinterReport:
         wanted*: string
         got*: string
-
       else:
         discard
-
-
 
 func severity*(rep: LexerReport): ReportSeverity =
   case LexerReportKind(rep.kind):
     of rlexHintKinds: rsevHint
     of rlexErrorKinds: rsevError
     of rlexWarningKinds: rsevWarning
+
 
 type
   ParserReport* = object of ReportBase

--- a/compiler/ast/syntaxes.nim
+++ b/compiler/ast/syntaxes.nim
@@ -105,9 +105,9 @@ proc applyFilter(p: var Parser, n: PNode, filename: AbsoluteFile,
              filterReplace(p.lex.config, stdin, filename, n)
   if f != filtNone:
     assert p.lex.config != nil
-    if p.lex.config.hasHint(rlexSyntaxesCode):
+    if p.lex.config.hasHint(rlexSourceCodeFilterOutput):
       p.lex.config.localReport LexerReport(
-        kind: rlexSyntaxesCode, msg: result.s)
+        kind: rlexSourceCodeFilterOutput, msg: result.s)
 
 proc evalPipe(p: var Parser, n: PNode, filename: AbsoluteFile,
               start: PLLStream): PLLStream =

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2990,7 +2990,7 @@ proc reportBody*(conf: ConfigRef, r: LexerReport): string =
       assert false
 
     of rlexCfgInvalidDirective:
-      result.add "?"
+      result.addf("invalid directive: '$1'", r.msg)
 
     of rlexUnclosedComment:
       result.add "end of multiline comment expected"
@@ -3004,8 +3004,10 @@ proc reportBody*(conf: ConfigRef, r: LexerReport): string =
     of rlexLineTooLong:
       result.add "line too long"
 
-    of rlexSyntaxesCode:
-      result.add "?"
+    of rlexSourceCodeFilterOutput:
+      result.add "generated code listing:"
+      result.add r.msg
+      result.add "end of listing"
 
 proc reportFull*(conf: ConfigRef, r: LexerReport): string    =
   assertKind r

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -637,7 +637,6 @@ func isEnabled*(conf: ConfigRef, report: ReportKind): bool =
   ## Uses `options.hasHint`, `options.hasWarn` to check whether particular
   ## report is enabled, otherwise use query global/local options.
 
-
   # Reports related to experimental features and inconsistent CLI flags
   # (such as `--styleCheck` which controls both CLI flags and hints) are
   # checked for with higher priority

--- a/doc/filters.rst
+++ b/doc/filters.rst
@@ -25,9 +25,9 @@ just like an ordinary procedure call with named or positional arguments. The
 available parameters depend on the invoked filter. Before version 0.12.0 of
 the language `#!` was used instead of `#?`.
 
-**Hint:** With `--hint:codeBegin:on`:option: or `--verbosity:2`:option:
-(or higher) while compiling or `nim check`:cmd:, Nim lists the processed code after
-each filter application.
+**Hint:** With `--hint:SourceCodeFilterOutput:on`:option: or
+`--verbosity:2`:option: (or higher) while compiling or `nim check`:cmd:,
+|NimSkull| lists the processed code after each filter application.
 
 Usage
 =====

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -92,7 +92,7 @@ Each hint can be activated individually with `--hint:NAME:on|off`:option: or in 
 Name                             Description
 ==========================       ============================================
 CC                               Shows when the C compiler is called.
-CodeBegin
+SourceCodeFilterOutput           Shows the output of an source code filters
 CodeEnd
 CondTrue
 Conf                             A config file was loaded.


### PR DESCRIPTION
## Summary

Source code filters at verbosity 2 or with the hint
`SourceCodeFilterOutput` will now emit generated output. This behaviour
has been documented in source code filters and the compiler hint reference.

## Details

Previously, a few things were not working or had issues:
- the hint used to be called `CodeBegin`, which makes not sense
- it wasn't being respected; always generated output
- the compiler was generating the report data, but emitting "?"

Additionally, fixed the invalid configuration directive error message
which was previously also emitting "?".
