### PR TITLE
internal: add missing reports and clean-up

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -236,8 +236,6 @@ type
     rparEnablePreviewDotOps = "DotLikeOps"
     # warnings END !! add reports BEFORE the last enum !!
 
-    rparName = "Name" ## Linter report about used identifier
-
     #-----------------------------  Sem reports  -----------------------------#
     # semantic fatal
     rsemFatalError
@@ -785,7 +783,7 @@ type
     rsemUnsafeSetLen           = "UnsafeSetLen"
     rsemUnsafeDefault          = "UnsafeDefault"
     rsemBindDeprecated
-    rsemUncollectableRefCycle  =  "CycleCreated"
+    rsemUncollectableRefCycle  = "CycleCreated"
     rsemObservableStores       = "ObservableStores"
     rsemCaseTransition         = "CaseTransition"
     rsemUseOfGc                = "GcMem" # last !
@@ -923,7 +921,7 @@ const rstWarnings* = {rbackRstTestUnsupported .. rbackRstRstStyle}
 
 type
   LexerReportKind* = range[rlexMalformedUnderscores .. rlexSourceCodeFilterOutput]
-  ParserReportKind* = range[rparInvalidIndentation .. rparName]
+  ParserReportKind* = range[rparInvalidIndentation .. rparEnablePreviewDotOps]
 
   SemReportKind* = range[rsemFatalError .. rsemImplicitObjConv]
   SemReportErrorKind* = range[rsemUserError .. rsemWrappedError]
@@ -949,7 +947,7 @@ const
 
   #-------------------------------  parser  --------------------------------#
   repParserKinds* = {low(ParserReportKind) .. high(ParserReportKind)}
-  rparHintKinds*    = {rparName}
+  rparHintKinds*    = {}
   rparErrorKinds*   = {rparInvalidIndentation .. rparInvalidFilter}
   rparWarningKinds* = {
     rparInconsistentSpacing .. rparEnablePreviewDotOps}
@@ -1034,7 +1032,6 @@ const
 
   repFatalKinds*: ReportKinds = rintFatalKinds
   repAllKinds* = {low(ReportKind) .. high(ReportKind)}
-
 
 
 const

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -13,6 +13,10 @@
 ## Not using compiler-specific types also allows this report to be easily
 ## reused by external tooling - custom error pretty-printers, test runners
 ## and so on.
+## 
+## Debug Defines:
+## `compilerDebugCompilerReportStatistics`: output stats of counts for various
+##                                          report kinds
 
 import std/[options, packedsets]
 
@@ -28,7 +32,6 @@ export
   options.none,
   options.Option,
   int128.toInt128
-
 
 from compiler/front/in_options import TOption, TOptions
 type InstantiationInfo* = typeof(instantiationInfo())
@@ -179,7 +182,6 @@ type
     nilability*: Nilability ## the nilability
     kind*: NilTransition ## what kind of transition was that
     node*: PNode ## the node of the expression
-
 
   SemReport* = object of ReportBase
     ast*: PNode
@@ -352,7 +354,6 @@ type
 
       else:
         discard
-
 
 func severity*(report: SemReport): ReportSeverity =
   case SemReportKind(report.kind):
@@ -656,7 +657,6 @@ type
     cpu*: TSystemCPU ## Target CPU
     os*: TSystemOS ## Target OS
 
-
   InternalReport* = object of ReportBase
     ## Report generated for the internal compiler workings
     msg*: string
@@ -685,8 +685,6 @@ type
       else:
         discard
 
-
-
 func severity*(report: InternalReport): ReportSeverity =
   case InternalReportKind(report.kind):
     of rintFatalKinds:    rsevFatal
@@ -694,8 +692,6 @@ func severity*(report: InternalReport): ReportSeverity =
     of rintWarningKinds:  rsevWarning
     of rintErrorKinds:    rsevError
     of rintDataPassKinds: rsevTrace
-
-
 
 
 type
@@ -737,12 +733,11 @@ type
         externalReport*: ExternalReport
 
 static:
-  when false:
+  when defined(compilerDebugCompilerReportStatistics):
     echo(
       "Nimskull compiler outputs ",
-      ord(high(ReportKind)),
+      ord(high(ReportKind) + 1),
       " different kinds of diagnostics")
-
 
     echo "size of ReportBase     ", sizeof(ReportBase)
     echo "size of LexerReport    ", sizeof(LexerReport)
@@ -762,7 +757,6 @@ static:
 let reportEmpty* = Report(
   category: repInternal,
   internalReport: InternalReport(kind: repNone))
-
 
 template eachCategory*(report: Report, field: untyped): untyped =
   case report.category:
@@ -819,8 +813,6 @@ func severity*(
 
   else:
     severity(report)
-
-
 
 func severity*(
     report: Report,
@@ -899,7 +891,6 @@ func wrap*[R: ReportTypes](rep: sink R, iinfo: InstantiationInfo): Report =
   tmp.reportInst = toReportLineInfo(iinfo)
   return wrap(tmp)
 
-
 func wrap*[R: ReportTypes](
     rep: sink R, iinfo: ReportLineInfo, point: TLineInfo): Report =
   var tmp = rep
@@ -911,13 +902,12 @@ func wrap*[R: ReportTypes](
     rep: sink R, iinfo: InstantiationInfo, point: TLineInfo): Report =
   wrap(rep, toReportLineInfo(iinfo), point)
 
-
 func wrap*[R: ReportTypes](iinfo: InstantiationInfo, rep: sink R): Report =
   wrap(rep, iinfo)
 
-
 template wrap*(rep: ReportTypes): Report =
   wrap(rep, toReportLineInfo(instLoc()))
+
 
 func `$`*(point: ReportLineInfo): string =
   point.file & "(" & $point.line & ", " & $point.col & ")"
@@ -943,7 +933,6 @@ func addReport*(list: var ReportList, report: sink Report): ReportId =
 
 func addReport*[R: ReportTypes](list: var ReportList, report: R): ReportId =
   addReport(list, wrap(report))
-
 
 func getReport*(list: ReportList, id: ReportId): Report =
   ## Get report from the report list using it's id

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -92,7 +92,6 @@ func wrap*(
 func wrap(conf: ConfigRef, text: ColText): string =
   toString(text, conf.useColor())
 
-
 proc formatTrace*(conf: ConfigRef, trace: seq[StackTraceEntry]): string =
   ## Format stack trace entries for reporting
   var paths: seq[string]
@@ -222,7 +221,6 @@ proc addPragmaAndCallConvMismatch*(
     expectedPragmas.setLen(max(0, expectedPragmas.len - 2)) # Remove ", "
     message.add "\n  Pragma mismatch: got '{.$1.}', but expected '{.$2.}'." % [gotPragmas, expectedPragmas]
 
-
 proc effectProblem(f, a: PType; result: var string) =
   ## Add effect difference annotation for `f` (aka formal/expected) and `a`
   ## (aka actual/provided) types
@@ -265,8 +263,6 @@ proc argTypeToString(arg: PNode; prefer: TPreferedDesc): string =
 
   else:
     result = arg.typ.typeToString(prefer)
-
-
 
 proc describeArgs(conf: ConfigRef, args: seq[PNode]; prefer = preferName): string =
   ## Generate comma-separated list of arguments
@@ -2516,10 +2512,10 @@ proc reportBody*(conf: ConfigRef, r: ParserReport): string =
       result = "invalid indentation; an export marker '*' follows the declared identifier"
 
     of rparTemplMissingEndClose:
-      result = "?"
+      result = "'end' does not close a control flow construct"
 
     of rparTemplInvalidExpression:
-      result = "?"
+      result = "invalid expression"
 
     of rparInconsistentSpacing:
       result = "Number of spaces around '$#' is not consistent"
@@ -2533,11 +2529,8 @@ proc reportBody*(conf: ConfigRef, r: ParserReport): string =
     of rparPragmaBeforeGenericParameters:
       result = "pragma must come after any generic parameter list"
 
-    of rparName:
-      result = "?"
-
     of rparInvalidFilter:
-      result = "?"
+      result = "invalid filter: $1" % r.node.renderTree
 
 proc reportFull*(conf: ConfigRef, r: ParserReport): string =
   assertKind r
@@ -3639,6 +3632,7 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
       var indent {.global.}: int
       if r.kind == rdbgTraceStep:
         indent = r.debugReport.semstep.level
+
       case r.kind
       of rdbgTracerKinds:
         conf.writeln(conf.reportFull(r))

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -255,16 +255,20 @@ proc expectNoArg(conf: ConfigRef; switch, arg: string, pass: TCmdLinePass, info:
 
 proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
                          info: TLineInfo; orig: string; conf: ConfigRef) =
-  var id = ""  # arg = key or [key] or key:val or [key]:val;  with val=on|off
-  var i = 0
-  var notes: ReportKinds
-  var isBracket = false
+  var
+    id = ""  # arg = key or [key] or key:val or [key]:val;  with val=on|off
+    i = 0
+    notes: ReportKinds
+    isBracket = false
+  
   if i < arg.len and arg[i] == '[':
     isBracket = true
     inc(i)
+  
   while i < arg.len and (arg[i] notin {':', '=', ']'}):
     id.add(arg[i])
     inc(i)
+  
   if isBracket:
     if i < arg.len and arg[i] == ']': inc(i)
     else: invalidCmdLineOption(conf, pass, orig, info)
@@ -288,7 +292,6 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     let x = findStr(noteSet, id, onFail)
     if x != onFail:
       notes = {x}
-
     else:
       var r = ExternalReport(kind: onFail)
       r.cmdlineProvided = id
@@ -312,7 +315,6 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     # `hints|warnings|warningAsErrors` for all the code they depend on.
     conf.localReport ExternalReport(
       kind: rextExpectedOnOrOff, cmdlineProvided: arg)
-
   else:
     let isOn = val == "on"
     if isOn and id.normalize == "all":
@@ -328,7 +330,6 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
         if state in {wWarningAsError, wHintAsError}:
           # xxx rename warningAsErrors to noteAsErrors
           conf.flip(cnWarnAsError, n, isOn)
-
         else:
           conf.flip(cnCurrent, n, isOn)
           conf.flip(cnMainPackage, n, isOn)
@@ -1057,7 +1058,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if verbosity notin {0 .. 3}:
       conf.localReport(
         info, invalidSwitchValue @["0", "1", "2", "3"])
-    conf.verbosity = verbosity
+    conf.verbosity = CompilerVerbosity(verbosity)
     var verb = NotesVerbosity.main[conf.verbosity]
     ## We override the default `verb` by explicitly modified (set/unset) notes.
     conf.notes = (conf.modifiedyNotes * conf.notes + verb) -

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -343,10 +343,10 @@ proc `$`*(conf: ConfigRef; info: TLineInfo): string = toFileLineCol(conf, info)
 proc `$`*(info: TLineInfo): string {.error.} = discard
 
 proc msgWrite*(conf: ConfigRef; s: string, flags: MsgFlags = {}) =
-  ## Writes given message string to stderr by default.
+  ## Writes given message `s`tring to stderr by default.
   ## If ``--stdout`` option is given, writes to stdout instead. If message hook
   ## is present, then it is used to output message rather than stderr/stdout.
-  ## This behavior can be altered by given optional flags.
+  ## This behavior can be altered by given optional `flags`.
   ##
   ## This is used for 'nim dump' etc. where we don't have nimsuggest
   ## support.
@@ -410,7 +410,6 @@ proc errorActions(
     elif eh == doAbort and conf.cmd != cmdIdeTools:
       return (doAbort, false)
     elif eh == doRaise:
-      {.warning: "[IMPLEMENT] Convert report to string message?".}
       return (doRaise, false)
 
   return (doNothing, false)
@@ -475,22 +474,22 @@ proc getSurroundingSrc*(conf: ConfigRef; info: TLineInfo): string =
 
 proc handleReport*(
     conf: ConfigRef,
-    report: Report,
+    r: Report,
     reportFrom: InstantiationInfo,
     eh: TErrorHandling = doNothing
   ) {.noinline.} =
 
-  var report = report
-  report.reportFrom = toReportLineInfo(reportFrom)
-  if report.category == repSem and report.location.isSome():
-    report.semReport.context = conf.getContext(report.location.get())
+  var rep = r
+  rep.reportFrom = toReportLineInfo(reportFrom)
+  if rep.category == repSem and rep.location.isSome():
+    rep.semReport.context = conf.getContext(rep.location.get())
 
   let
-    userAction = conf.report(report)
+    userAction = conf.report(rep)
     (action, trace) =
       case userAction
       of doDefault:
-        errorActions(conf, report, eh)
+        errorActions(conf, rep, eh)
       else:
         (userAction, false)
 

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -25,7 +25,6 @@ const
   useEffectSystem* = true
   useWriteTracking* = false
   copyrightYear* = "2022"
-
   nimEnableCovariance* = defined(nimEnableCovariance)
 
 const
@@ -63,8 +62,8 @@ type
     External   ## file was introduced via .compile pragma
 
   Cfile* = object
-    nimname*: string ## Original name of the nim file, constructed from the
-    ## module name.
+    nimname*: string           ## Original name of the nim file, constructed
+                               ## from the module name.
     cname*, obj*: AbsoluteFile
     flags*: set[CfileFlag]
     customArgs*: string
@@ -74,19 +73,20 @@ type
   Suggest* = ref object
     section*: IdeCmd
     qualifiedPath*: seq[string]
-    name*: ptr string         ## not used beyond sorting purposes; name is also
-                              ## part of 'qualifiedPath'
+    name*: ptr string           ## not used beyond sorting purposes; name is
+                                ## also part of 'qualifiedPath'
     filePath*: string
-    line*: int                   ## Starts at 1
-    column*: int                 ## Starts at 0
-    doc*: string           ## Unescaped documentation string
-    forth*: string               ## type
-    quality*: range[0..100]   ## matching quality
-    isGlobal*: bool ## is a global variable
-    contextFits*: bool ## type/non-type context matches
+    line*: int                  ## Starts at 1
+    column*: int                ## Starts at 0
+    doc*: string                ## Unescaped documentation string
+    forth*: string              ## type
+    quality*: range[0..100]     ## matching quality
+    isGlobal*: bool             ## is a global variable
+    contextFits*: bool          ## type/non-type context matches
     prefix*: PrefixMatch
     symkind*: byte
-    scope*, localUsages*, globalUsages*: int # more usages is better
+    scope*:int
+    localUsages*, globalUsages*: int # usage counters
     tokenLen*: int
     version*: int
   Suggestions* = seq[Suggest]
@@ -104,7 +104,7 @@ type
 
   MsgFlag* = enum  ## flags altering msgWriteln behavior
     msgStdout,     ## force writing to stdout, even stderr is default
-    msgNoUnitSep  ## the message is a complete "paragraph".
+    msgNoUnitSep   ## the message is a complete "paragraph".
   MsgFlags* = set[MsgFlag]
 
   TErrorHandling* = enum
@@ -112,8 +112,8 @@ type
               ## order for automatic handing to decide appropriate
               ## reaction.
     doNothing ## Don't do anything
-    doAbort ## Immediately abort compilation
-    doRaise ## Raise recoverable error
+    doAbort   ## Immediately abort compilation
+    doRaise   ## Raise recoverable error
 
   ReportHook* = proc(conf: ConfigRef, report: Report): TErrorHandling {.closure.}
 
@@ -123,18 +123,16 @@ type
     ## they can't be set up from the cli/defines - in the future this will
     ## be changed. For now you can just edit `defaultHackController` value
     ## in this module as you see fit.
-    semStack*: bool  ## Show `| context` entries in the call tracer
+    semStack*: bool       ## Show `| context` entries in the call tracer
+    reportInTrace*: bool  ## Error messages are shown with matching indentation
+                          ## if report was triggered during execution of the
+                          ## sem trace
+    semTraceData*: bool   ## For each sem step show processed data, or only
+                          ## procedure calls.
 
-    reportInTrace*: bool ## Error messages are shown with matching indentation
-    ## if report was triggered during execution of the sem trace
-
-    semTraceData*: bool ## For each sem step show processed data, or only
-    ## procedure calls.
-
-  ConfigRef* {.acyclic.} = ref object ## every global configuration
-                          ## fields marked with '*' are subject to
-                          ## the incremental compilation mechanisms
-                          ## (+) means "part of the dependency"
+  ConfigRef* {.acyclic.} = ref object
+    ## every global configuration fields marked with '*' are subject to the
+    ## incremental compilation mechanisms (+) means "part of the dependency"
 
     # active configuration handling
     active*: CurrentConf
@@ -145,13 +143,12 @@ type
 
     # Set and only read for `testCompileOptionArg`, so not sure if this is
     # 'active' configuration
-    verbosity*: int           ## how verbose the compiler is
+    verbosity*: CompilerVerbosity     ## how verbose the compiler is
 
     # 'arguments' aka a single string aka 'joining strings for external
     # program is bad'
     arguments*: string ## the arguments to be passed to the program that
                        ## should be run
-
 
     linesCompiled*: int   # all lines that have been compiled
     m*: MsgConfig
@@ -162,15 +159,12 @@ type
     ## against infinite macro expansion recursion
     exitcode*: int8
 
-
     # `--eval` flag handling
     cmdInput*: string    ## Code to evaluate from `--eval` switch
     projectIsCmd*: bool  ## whether we're compiling from a command input (`--eval` switch)
     implicitCmd*: bool   ## whether some flag triggered an implicit `command` (`--eval`)
 
-
     hintProcessingDots*: bool ## true for dots, false for filenames
-
 
     lastCmdTime*: float       ## Start of the last compiler commmand - set
     ## in the `main.mainCommand` and then read to generate 'successX'
@@ -179,7 +173,6 @@ type
     headerFile*: string
     ideCmd*: IdeCmd
     oldNewlines*: bool
-
 
     mainPackageId*: int
     errorCounter*: int
@@ -281,7 +274,6 @@ template passSeqField(fieldname, itemtype: untyped): untyped =
   passField(fieldname, seq[itemtype])
   proc `fieldname Add`*(conf: ConfigRef, item: itemtype | seq[itemtype]) =
     conf.active.fieldname.add item
-
 
 passField backend,            TBackend
 passField symbolFiles,        SymbolFilesOption
@@ -801,15 +793,15 @@ const defaultHackController = HackController(
 proc initConfigRefCommon(conf: ConfigRef) =
   conf.symbols = newStringTable(modeStyleInsensitive)
   conf.selectedGC = gcRefc
-  conf.verbosity = 1
+  conf.verbosity = compVerbosityDefault
   conf.hintProcessingDots = true
   conf.options = DefaultOptions
   conf.globalOptions = DefaultGlobalOptions
   conf.filenameOption = foAbs
   conf.foreignPackageNotes = NotesVerbosity.foreign
-  conf.notes = NotesVerbosity.main[1]
+  conf.notes = NotesVerbosity.main[conf.verbosity]
   conf.hack = defaultHackController
-  conf.mainPackageNotes = NotesVerbosity.main[1]
+  conf.mainPackageNotes = NotesVerbosity.main[conf.verbosity]
   when defined(nimDebugUtils):
     # ensures that `nimDebugUtils` is defined for the compiled code so it can
     # access the `system.nimCompilerDebugRegion` template

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -637,7 +637,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
         conf.incl optIdeDebug
       of "epc":
         gMode = mepc
-        conf.verbosity = 0          # Port number gotta be first.
+        conf.verbosity = compVerbosityMin  # Port number gotta be first.
       of "debug": conf.incl optIdeDebug
       of "v2": conf.suggestVersion = 0
       of "v1": conf.suggestVersion = 1


### PR DESCRIPTION
## Summary

added missing reports for the parser:
- template missing end close
- invalid expression
- invalid filter

Misc:
- created an enum for compiler verbosity
- removed `rparName`, doesn't seem used at all
- formatting fixes
