### PR TITLE
cpp: fix parameters named `this` causing compilation failure

### DIFF
--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -95,7 +95,7 @@ type
     wProtected = "protected", wPublic = "public", wRegister = "register",
     wReinterpret_cast = "reinterpret_cast", wRestrict = "restrict", wShort = "short",
     wSigned = "signed", wSizeof = "sizeof", wStatic_cast = "static_cast", wStruct = "struct",
-    wSwitch = "switch", wThrow = "throw", wTrue = "true", wTypedef = "typedef",
+    wSwitch = "switch", wThis = "this", wThrow = "throw", wTrue = "true", wTypedef = "typedef",
     wTypeid = "typeid", wTypeof = "typeof",  wTypename = "typename",
     wUnion = "union", wPacked = "packed", wUnsigned = "unsigned", wVirtual = "virtual",
     wVoid = "void", wVolatile = "volatile", wWchar_t = "wchar_t",

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -1,6 +1,6 @@
 discard """
 joinable: false
-target: "c !cpp js"
+target: "c cpp js"
 labels: "array"
 description: '''
   . From https://github.com/nim-lang/Nim/issues/1669

--- a/tests/ccgbugs/tcodegen_anonymous_aggregate.nim
+++ b/tests/ccgbugs/tcodegen_anonymous_aggregate.nim
@@ -1,5 +1,5 @@
 discard """
-targets: "c !cpp"
+targets: "c cpp"
 labels: "atomics pragma union"
 description: '''
   . From https://github.com/nim-lang/Nim/issues/13062

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -7,7 +7,7 @@ And we get here
 3
 '''
 joinable: false
-targets: "c !cpp js"
+targets: "c cpp js"
 """
 
 # xxx wrap in a template to test in VM, see https://github.com/timotheecour/Nim/issues/534#issuecomment-769565033

--- a/tests/cpp/temitlist.nim
+++ b/tests/cpp/temitlist.nim
@@ -3,7 +3,6 @@ discard """
   output: '''
 6.0
 0'''
-knownIssue: "Broken from this pragma removal"
 disabled: "windows" # pending bug #18011
 """
 

--- a/tests/float/tfloatmod.nim
+++ b/tests/float/tfloatmod.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   output: "ok"
   exitcode: "0"
 """

--- a/tests/float/tfloats.nim
+++ b/tests/float/tfloats.nim
@@ -1,6 +1,6 @@
 discard """
   matrix: "-d:nimPreviewFloatRoundtrip; -u:nimPreviewFloatRoundtrip"
-  targets: "c !cpp js"
+  targets: "c cpp js"
 """
 
 #[

--- a/tests/misc/treservedcidentsasfields.nim
+++ b/tests/misc/treservedcidentsasfields.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
 """
 
 import macros

--- a/tests/statictypes/tstaticimportcpp.nim
+++ b/tests/statictypes/tstaticimportcpp.nim
@@ -1,5 +1,4 @@
 discard """
-knownIssue: "Broke after this pragma removal"
 targets: "cpp"
 output: "[0, 0, 10, 0]\n5\n1.2\n15\ntest\n[0, 0, 20, 0]\n4"
 """

--- a/tests/stdlib/tisolation.nim
+++ b/tests/stdlib/tisolation.nim
@@ -1,8 +1,7 @@
 discard """
-  targets: "c !cpp"
+  targets: "c cpp"
   matrix: "--gc:refc; --gc:orc"
 """
-# cpp: broken from implicit pragma removal
 
 import std/[isolation, json]
 

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -1,7 +1,7 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
 """
-# cpp: broken from implicit pragma removal
+
 
 #[
 Note: Macro tests are in tests/stdlib/tjsonmacro.nim

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -1,7 +1,7 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
 """
-# cpp: broken from implicit pragma removal
+
 import std/jsonutils
 import std/json
 from std/math import isNaN, signbit

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -1,8 +1,8 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   matrix:"; -d:danger"
 """
-# cpp: broken from implicit pragma removal
+
 # xxx: there should be a test with `-d:nimTmathCase2 -d:danger --passc:-ffast-math`,
 # but it requires disabling certain lines with `when not defined(nimTmathCase2)`
 

--- a/tests/stdlib/tpegs.nim
+++ b/tests/stdlib/tpegs.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   output: '''
 PEG AST traversal output
 ------------------------
@@ -50,7 +50,7 @@ Event parser output
 @[-150.0]
 '''
 """
-# cpp: broken from implicit pragma removal
+
 when defined(nimHasEffectsOf):
   {.experimental: "strictEffects".}
 

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -1,8 +1,8 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
   matrix: ";--gc:arc"
 """
-# cpp: broken from implicit pragma removal
+
 # if excessive, could remove 'cpp' from targets
 
 from strutils import endsWith, contains, strip

--- a/tests/stdlib/tresults.nim
+++ b/tests/stdlib/tresults.nim
@@ -1,16 +1,13 @@
 discard """
   description: "Tests for the std/experimental/results module"
   matrix: "--gc:refc; --gc:arc"
-  targets: "c !cpp !js"
+  targets: "c cpp !js"
 """
 
 # knownIssue: fails on the JS back-end due to a code-gen issue. The issue
 #             seems to be related to sink parameters
 
 # knownIssue: fails for the VM back-end due to code-gen issues
-
-# knownIssue: fails for the CPP back-end due to code-gen issues, after this
-#             pragma removal
 
 # This file was based on the ``test.nim`` file
 # from https://github.com/disruptek/badresults

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c !cpp js"
+  targets: "c cpp js"
 """
 
 #[


### PR DESCRIPTION
## Summary
The `wThis` enum item is restored and the tests that were previously
disabled because of it's removal are enabled again.

## Details
Identifiers that are keywords in the target language need to be escaped
in the generated code. For the C-like targets, the `ccgtypes.isKeyword`
procedure is responsible for testing if an identifier is a keyword  - it
compares the `PIdent.id` against a slice of IDs specified in `wordrecg`
(in this case, `ccgKeywordsLow..ccgKeywordsHigh`).

With the removal of the `wThis` enum item, which - due to it's enum
position - was part of the aforementioned slice and supplied the ID and
keyword name, `this` is no longer recognized as a keyword and is thus
not escaped in the generated C/C++ code anymore.