### PR TITLE
internal: semexprs.changeType converted to nkError

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1146,6 +1146,20 @@ proc skipConv*(n: PNode): PNode =
       result = n[1]
   else: discard
 
+proc mutableSkipConv*(n: var PNode): var PNode =
+  result = n
+  case n.kind
+  of nkObjUpConv, nkObjDownConv, nkChckRange, nkChckRangeF, nkChckRange64:
+    # only skip the conversion if it doesn't lose too important information
+    # (see bug #1334)
+    if n[0].typ.classify == n.typ.classify:
+      result = n[0]
+  of nkHiddenStdConv, nkHiddenSubConv, nkConv:
+    if n[1].typ.classify == n.typ.classify:
+      result = n[1]
+  else: discard
+
+
 proc skipHidden*(n: PNode): PNode =
   result = n
   while true:

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -480,6 +480,10 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   ## ``flags`` Some flags for more contextual information on how the
   ## "macro" is calld.
 
+  if n.isError:
+    result = n
+    return
+
   case n[0].sym.magic
   of mAddr:
     checkSonsLen(n, 2, c.config)


### PR DESCRIPTION
## Summary

`changeType` now returns a PNode to support nkError propagation.

## Details

Some call site modifications were made to continue error propagation.
As part of this semexprs.fixAbstractType now returns PNode as well
A number of procs also saw guards added for nkError.
