### PR TITLE
improve naming of `sigmatch.paramTypesMatch` vars

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -18,8 +18,15 @@ import
   ]
 
 const
-  OverloadableSyms* = {skProc, skFunc, skMethod, skIterator,
-    skConverter, skTemplate, skMacro, skEnumField,
+  OverloadableSyms* = {
+    skProc,
+    skFunc,
+    skMethod,
+    skIterator,
+    skConverter,
+    skTemplate,
+    skMacro,
+    skEnumField,
 
     # BUGFIX: a module is overloadable so that a proc can have the
     # same name as an imported module. This is necessary because of

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -9,6 +9,30 @@
 
   "Abstraction is layering ignorance on top of reality." -- Richard Gabriel
 
+Glossary
+========
+
+Some specific terms and names are used throughout this document and in the
+wider compiler codebase. In order to reduce confusion and specify internal
+naming consistency this section tries to provide a comprehensive list of
+said terms/names.
+
+Language-related terms
+----------------------
+
+- instantiation: substitution of the placeholder generic parameters in the
+  procedure or type definition.
+
+Compiler internal terms
+-----------------------
+
+Things that are *mostly* seen in the compiler codebase internally and not
+often used in the regular language.
+
+- formal: expected, "as defined" mostly mentioned in relation to the
+  function processing (`sigmatch.nim`), used to refer to the
+
+- callsite: location of the function call in the code
 
 Directory structure
 ===================


### PR DESCRIPTION
No functional changes - improve naming of the `paramTypesMatch`
procedure and better document its implementation. Replace multiple `==
nil` usages with `.isNil()` checks.