### PR TITLE
transition lexer to the DOD implementation

### DIFF
--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -98,6 +98,12 @@ proc simpleExprAux(p: var Parser, limit: int, mode: PrimaryMode): ParsedNode
 
 # implementation
 
+<<<<<<< HEAD
+=======
+template prettySection(body) =
+  body
+
+>>>>>>> 939ca47f5 (transition lexer to the DOD implementation)
 proc getTok(p: var Parser) =
   ## Get the next token from the parser's lexer, and store it in the parser's
   ## `tok` member.
@@ -160,6 +166,7 @@ proc rawSkipComment(p: var Parser, node: ParsedNode) =
       node.comment = move rhs
     else:
       p.localError InternalReport(kind: rintUnreachable, msg: "skipComment")
+
     p.getTok
 
 proc skipComment(p: var Parser, node: ParsedNode) =
@@ -1119,6 +1126,7 @@ proc parseExpr(p: var Parser): ParsedNode =
   #|       | forExpr
   #|       | tryExpr)
   #|       / simpleExpr
+<<<<<<< HEAD
   case p.tok.tokType:
     of tkBlock: result = parseBlock(p)
     of tkIf: result = p.parseIfOrWhenExpr(nkIfExpr)
@@ -1127,6 +1135,16 @@ proc parseExpr(p: var Parser): ParsedNode =
     of tkCase: result = parseCase(p)
     of tkTry: result = p.parseTry(isExpr=true)
     else: result = simpleExpr(p)
+=======
+  case p.tok.tokType
+  of tkBlock: result = parseBlock(p)
+  of tkIf: result = p.parseIfOrWhenExpr(nkIfExpr)
+  of tkFor: result = parseFor(p)
+  of tkWhen: result = p.parseIfOrWhenExpr(nkWhenExpr)
+  of tkCase: result = parseCase(p)
+  of tkTry: result = p.parseTry(isExpr=true)
+  else: result = simpleExpr(p)
+>>>>>>> 939ca47f5 (transition lexer to the DOD implementation)
 
 proc parseEnum(p: var Parser): ParsedNode
 proc parseObject(p: var Parser): ParsedNode
@@ -2245,6 +2263,7 @@ proc parseTopLevelStmt(p: var Parser): ParsedNode =
           p.localError ParserReport(kind: rparInvalidIndentation)
     p.firstTok = false
     case p.tok.tokType
+
     of tkSemiColon:
       p.getTok
       if p.tok.indent <= 0:
@@ -2252,7 +2271,10 @@ proc parseTopLevelStmt(p: var Parser): ParsedNode =
       else:
         p.localError ParserReport(kind: rparInvalidIndentation)
       p.firstTok = true
-    of tkEof: break
+
+    of tkEof:
+      break
+
     else:
       result = complexOrSimpleStmt(p)
       if result.kind == nkEmpty:

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -93,7 +93,10 @@ const
   IndentWidth = 2
   longIndentWid = IndentWidth * 2
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> 939ca47f5 (transition lexer to the DOD implementation)
 const
   MaxLineLen = 80
   LineCommentColumn = 30

--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -14,101 +14,301 @@
 
 type
   TSpecialWord* = enum
-    wInvalid = "",
-    wAddr = "addr", wAnd = "and", wAs = "as", wAsm = "asm",
-    wBind = "bind", wBlock = "block", wBreak = "break", wCase = "case", wCast = "cast",
-    wConcept = "concept", wConst = "const", wContinue = "continue", wConverter = "converter",
-    wDefer = "defer", wDiscard = "discard", wDistinct = "distinct", wDiv = "div", wDo = "do",
-    wElif = "elif", wElse = "else", wEnd = "end", wEnum = "enum", wExcept = "except",
-    wExport = "export", wFinally = "finally", wFor = "for", wFrom = "from", wFunc = "func",
-    wIf = "if", wImport = "import", wIn = "in", wInclude = "include", wInterface = "interface",
-    wIs = "is", wIsnot = "isnot",  wIterator = "iterator", wLet = "let", wMacro = "macro",
-    wMethod = "method", wMixin = "mixin", wMod = "mod", wNil = "nil", wNot = "not", wNotin = "notin",
-    wObject = "object", wOf = "of", wOr = "or", wOut = "out", wProc = "proc", wPtr = "ptr",
-    wRaise = "raise", wRef = "ref", wReturn = "return", wShl = "shl", wShr = "shr", wStatic = "static",
-    wTemplate = "template", wTry = "try", wTuple = "tuple", wType = "type", wUsing = "using",
-    wVar = "var", wWhen = "when", wWhile = "while", wXor = "xor", wYield = "yield",
+    wInvalid = ""
+    wAddr = "addr"
+    wAnd = "and"
+    wAs = "as"
+    wAsm = "asm"
+    wBind = "bind"
+    wBlock = "block"
+    wBreak = "break"
+    wCase = "case"
+    wCast = "cast"
+    wConcept = "concept"
+    wConst = "const"
+    wContinue = "continue"
+    wConverter = "converter"
+    wDefer = "defer"
+    wDiscard = "discard"
+    wDistinct = "distinct"
+    wDiv = "div"
+    wDo = "do"
+    wElif = "elif"
+    wElse = "else"
+    wEnd = "end"
+    wEnum = "enum"
+    wExcept = "except"
+    wExport = "export"
+    wFinally = "finally"
+    wFor = "for"
+    wFrom = "from"
+    wFunc = "func"
+    wIf = "if"
+    wImport = "import"
+    wIn = "in"
+    wInclude = "include"
+    wInterface = "interface"
+    wIs = "is"
+    wIsnot = "isnot"
+    wIterator = "iterator"
+    wLet = "let"
+    wMacro = "macro"
+    wMethod = "method"
+    wMixin = "mixin"
+    wMod = "mod"
+    wNil = "nil"
+    wNot = "not"
+    wNotin = "notin"
+    wObject = "object"
+    wOf = "of"
+    wOr = "or"
+    wOut = "out"
+    wProc = "proc"
+    wPtr = "ptr"
+    wRaise = "raise"
+    wRef = "ref"
+    wReturn = "return"
+    wShl = "shl"
+    wShr = "shr"
+    wStatic = "static"
+    wTemplate = "template"
+    wTry = "try"
+    wTuple = "tuple"
+    wType = "type"
+    wUsing = "using"
+    wVar = "var"
+    wWhen = "when"
+    wWhile = "while"
+    wXor = "xor"
+    wYield = "yield"
 
-    wColon = ":", wColonColon = "::", wEquals = "=", wDot = ".", wDotDot = "..",
-    wStar = "*", wMinus = "-",
-    wMagic = "magic", wThread = "thread", wFinal = "final", wProfiler = "profiler",
-    wMemTracker = "memtracker", wObjChecks = "objchecks",
-    wIntDefine = "intdefine", wStrDefine = "strdefine", wBoolDefine = "booldefine",
-    wCursor = "cursor", wNoalias = "noalias", wEffectsOf = "effectsOf",
-    wUncheckedAssign = "uncheckedAssign",
+    wColon = ":"
+    wColonColon = "::"
+    wEquals = "="
+    wDot = "."
+    wDotDot = ".."
+    wStar = "*"
+    wMinus = "-"
+    wMagic = "magic"
+    wThread = "thread"
+    wFinal = "final"
+    wProfiler = "profiler"
+    wMemTracker = "memtracker"
+    wObjChecks = "objchecks"
+    wIntDefine = "intdefine"
+    wStrDefine = "strdefine"
+    wBoolDefine = "booldefine"
+    wCursor = "cursor"
+    wNoalias = "noalias"
+    wEffectsOf = "effectsOf"
+    wUncheckedAssign = "uncheckedAssign"
 
-    wImmediate = "immediate", wConstructor = "constructor", wDestructor = "destructor",
-    wDelegator = "delegator", wOverride = "override", wImportCpp = "importcpp",
-    wCppNonPod = "cppNonPod",
-    wImportObjC = "importobjc", wImportCompilerProc = "importCompilerProc",
-    wImportc = "importc", wImportJs = "importjs", wExportc = "exportc", wExportCpp = "exportcpp",
-    wExportNims = "exportnims",
-    wIncompleteStruct = "incompleteStruct", # deprecated
-    wCompleteStruct = "completeStruct", wRequiresInit = "requiresInit", wAlign = "align",
-    wNodecl = "nodecl", wPure = "pure", wSideEffect = "sideEffect", wHeader = "header",
-    wNoSideEffect = "noSideEffect", wGcSafe = "gcsafe", wNoreturn = "noreturn",
-    wNosinks = "nosinks", wMerge = "merge", wLib = "lib", wDynlib = "dynlib",
-    wCompilerProc = "compilerproc", wCore = "core", wProcVar = "procvar",
-    wBase = "base", wUsed = "used", wFatal = "fatal", wError = "error", wWarning = "warning",
-    wHint = "hint",
-    wWarningAsError = "warningAsError",
-    wHintAsError = "hintAsError",
-    wLine = "line", wPush = "push",
-    wPop = "pop", wDefine = "define", wUndef = "undef", wLineDir = "lineDir",
-    wStackTrace = "stackTrace", wLineTrace = "lineTrace", wLink = "link", wCompile = "compile",
-    wLinksys = "linksys", wDeprecated = "deprecated", wVarargs = "varargs", wCallconv = "callconv",
-    wDebugger = "debugger", wNimcall = "nimcall", wStdcall = "stdcall", wCdecl = "cdecl",
-    wSafecall = "safecall", wSyscall = "syscall", wInline = "inline", wNoInline = "noinline",
-    wFastcall = "fastcall", wThiscall = "thiscall", wClosure = "closure", wNoconv = "noconv",
-    wOn = "on", wOff = "off", wChecks = "checks", wRangeChecks = "rangeChecks",
-    wBoundChecks = "boundChecks", wOverflowChecks = "overflowChecks", wNilChecks = "nilChecks",
-    wFloatChecks = "floatChecks", wNanChecks = "nanChecks", wInfChecks = "infChecks",
-    wStyleChecks = "styleChecks", wStaticBoundchecks = "staticBoundChecks",
-    wNonReloadable = "nonReloadable", wExecuteOnReload = "executeOnReload",
+    wImmediate = "immediate"
+    wConstructor = "constructor"
+    wDestructor = "destructor"
+    wDelegator = "delegator"
+    wOverride = "override"
+    wImportCpp = "importcpp"
+    wCppNonPod = "cppNonPod"
+    wImportObjC = "importobjc"
+    wImportCompilerProc = "importCompilerProc"
+    wImportc = "importc"
+    wImportJs = "importjs"
+    wExportc = "exportc"
+    wExportCpp = "exportcpp"
+    wExportNims = "exportnims"
+    wIncompleteStruct = "incompleteStruct"
+    # deprecated
+    wCompleteStruct = "completeStruct"
+    wRequiresInit = "requiresInit"
+    wAlign = "align"
+    wNodecl = "nodecl"
+    wPure = "pure"
+    wSideEffect = "sideEffect"
+    wHeader = "header"
+    wNoSideEffect = "noSideEffect"
+    wGcSafe = "gcsafe"
+    wNoreturn = "noreturn"
+    wNosinks = "nosinks"
+    wMerge = "merge"
+    wLib = "lib"
+    wDynlib = "dynlib"
+    wCompilerProc = "compilerproc"
+    wCore = "core"
+    wProcVar = "procvar"
+    wBase = "base"
+    wUsed = "used"
+    wFatal = "fatal"
+    wError = "error"
+    wWarning = "warning"
+    wHint = "hint"
+    wWarningAsError = "warningAsError"
+    wHintAsError = "hintAsError"
+    wLine = "line"
+    wPush = "push"
+    wPop = "pop"
+    wDefine = "define"
+    wUndef = "undef"
+    wLineDir = "lineDir"
+    wStackTrace = "stackTrace"
+    wLineTrace = "lineTrace"
+    wLink = "link"
+    wCompile = "compile"
+    wLinksys = "linksys"
+    wDeprecated = "deprecated"
+    wVarargs = "varargs"
+    wCallconv = "callconv"
+    wDebugger = "debugger"
+    wNimcall = "nimcall"
+    wStdcall = "stdcall"
+    wCdecl = "cdecl"
+    wSafecall = "safecall"
+    wSyscall = "syscall"
+    wInline = "inline"
+    wNoInline = "noinline"
+    wFastcall = "fastcall"
+    wThiscall = "thiscall"
+    wClosure = "closure"
+    wNoconv = "noconv"
+    wOn = "on"
+    wOff = "off"
+    wChecks = "checks"
+    wRangeChecks = "rangeChecks"
+    wBoundChecks = "boundChecks"
+    wOverflowChecks = "overflowChecks"
+    wNilChecks = "nilChecks"
+    wFloatChecks = "floatChecks"
+    wNanChecks = "nanChecks"
+    wInfChecks = "infChecks"
+    wStyleChecks = "styleChecks"
+    wStaticBoundchecks = "staticBoundChecks"
+    wNonReloadable = "nonReloadable"
+    wExecuteOnReload = "executeOnReload"
 
-    wAssertions = "assertions", wPatterns = "patterns", wTrMacros = "trmacros",
-    wSinkInference = "sinkInference", wWarnings = "warnings",
-    wHints = "hints", wOptimization = "optimization", wRaises = "raises",
-    wWrites = "writes", wReads = "reads", wSize = "size", wEffects = "effects", wTags = "tags",
-    wAssert = "assert",
-    wDeadCodeElimUnused = "deadCodeElim",  # deprecated, dead code elim always happens
-    wSafecode = "safecode", wPackage = "package",
-    wNoRewrite = "norewrite", wNoDestroy = "nodestroy", wPragma = "pragma",
-    wCompileTime = "compileTime", wNoInit = "noinit", wPassc = "passc", wPassl = "passl",
-    wLocalPassc = "localPassC", wBorrow = "borrow", wDiscardable = "discardable",
-    wFieldChecks = "fieldChecks", wSubsChar = "subschar", wAcyclic = "acyclic",
-    wShallow = "shallow", wLinearScanEnd = "linearScanEnd",
-    wComputedGoto = "computedGoto", wExperimental = "experimental",
-    wWrite = "write", wGensym = "gensym", wInject = "inject", wDirty = "dirty",
-    wInheritable = "inheritable", wThreadVar = "threadvar", wEmit = "emit",
-    wAsmNoStackFrame = "asmNoStackFrame", wImplicitStatic = "implicitStatic",
-    wGlobal = "global", wCodegenDecl = "codegenDecl", wUnchecked = "unchecked",
-    wGuard = "guard", wLocks = "locks", wExplain = "explain",
-    wEnforceNoRaises = "enforceNoRaises",
+    wAssertions = "assertions"
+    wPatterns = "patterns"
+    wTrMacros = "trmacros"
+    wSinkInference = "sinkInference"
+    wWarnings = "warnings"
+    wHints = "hints"
+    wOptimization = "optimization"
+    wRaises = "raises"
+    wWrites = "writes"
+    wReads = "reads"
+    wSize = "size"
+    wEffects = "effects"
+    wTags = "tags"
+    wAssert = "assert"
+    wDeadCodeElimUnused = "deadCodeElim"
+     # deprecated
+    dead code elim always happens
+    wSafecode = "safecode"
+    wPackage = "package"
+    wNoRewrite = "norewrite"
+    wNoDestroy = "nodestroy"
+    wPragma = "pragma"
+    wCompileTime = "compileTime"
+    wNoInit = "noinit"
+    wPassc = "passc"
+    wPassl = "passl"
+    wLocalPassc = "localPassC"
+    wBorrow = "borrow"
+    wDiscardable = "discardable"
+    wFieldChecks = "fieldChecks"
+    wSubsChar = "subschar"
+    wAcyclic = "acyclic"
+    wShallow = "shallow"
+    wLinearScanEnd = "linearScanEnd"
+    wComputedGoto = "computedGoto"
+    wExperimental = "experimental"
+    wWrite = "write"
+    wGensym = "gensym"
+    wInject = "inject"
+    wDirty = "dirty"
+    wInheritable = "inheritable"
+    wThreadVar = "threadvar"
+    wEmit = "emit"
+    wAsmNoStackFrame = "asmNoStackFrame"
+    wImplicitStatic = "implicitStatic"
+    wGlobal = "global"
+    wCodegenDecl = "codegenDecl"
+    wUnchecked = "unchecked"
+    wGuard = "guard"
+    wLocks = "locks"
+    wExplain = "explain"
+    wEnforceNoRaises = "enforceNoRaises"
 
-    wAuto = "auto", wBool = "bool", wCatch = "catch", wChar = "char",
-    wClass = "class", wCompl = "compl", wConst_cast = "const_cast", wDefault = "default",
-    wDelete = "delete", wDouble = "double", wDynamic_cast = "dynamic_cast",
-    wExplicit = "explicit", wExtern = "extern", wFalse = "false", wFloat = "float",
-    wFriend = "friend", wGoto = "goto", wInt = "int", wLong = "long", wMutable = "mutable",
-    wNamespace = "namespace", wNew = "new", wOperator = "operator", wPrivate = "private",
-    wProtected = "protected", wPublic = "public", wRegister = "register",
-    wReinterpret_cast = "reinterpret_cast", wRestrict = "restrict", wShort = "short",
-    wSigned = "signed", wSizeof = "sizeof", wStatic_cast = "static_cast", wStruct = "struct",
-    wSwitch = "switch", wThis = "this", wThrow = "throw", wTrue = "true", wTypedef = "typedef",
-    wTypeid = "typeid", wTypeof = "typeof",  wTypename = "typename",
-    wUnion = "union", wPacked = "packed", wUnsigned = "unsigned", wVirtual = "virtual",
-    wVoid = "void", wVolatile = "volatile", wWchar_t = "wchar_t",
+    wAuto = "auto"
+    wBool = "bool"
+    wCatch = "catch"
+    wChar = "char"
+    wClass = "class"
+    wCompl = "compl"
+    wConst_cast = "const_cast"
+    wDefault = "default"
+    wDelete = "delete"
+    wDouble = "double"
+    wDynamic_cast = "dynamic_cast"
+    wExplicit = "explicit"
+    wExtern = "extern"
+    wFalse = "false"
+    wFloat = "float"
+    wFriend = "friend"
+    wGoto = "goto"
+    wInt = "int"
+    wLong = "long"
+    wMutable = "mutable"
+    wNamespace = "namespace"
+    wNew = "new"
+    wOperator = "operator"
+    wPrivate = "private"
+    wProtected = "protected"
+    wPublic = "public"
+    wRegister = "register"
+    wReinterpret_cast = "reinterpret_cast"
+    wRestrict = "restrict"
+    wShort = "short"
+    wSigned = "signed"
+    wSizeof = "sizeof"
+    wStatic_cast = "static_cast"
+    wStruct = "struct"
+    wSwitch = "switch"
+    wThis = "this"
+    wThrow = "throw"
+    wTrue = "true"
+    wTypedef = "typedef"
+    wTypeid = "typeid"
+    wTypeof = "typeof"
+    wTypename = "typename"
+    wUnion = "union"
+    wPacked = "packed"
+    wUnsigned = "unsigned"
+    wVirtual = "virtual"
+    wVoid = "void"
+    wVolatile = "volatile"
+    wWchar_t = "wchar_t"
 
-    wAlignas = "alignas", wAlignof = "alignof", wConstexpr = "constexpr", wDecltype = "decltype",
-    wNullptr = "nullptr", wNoexcept = "noexcept",
-    wThread_local = "thread_local", wStatic_assert = "static_assert",
-    wChar16_t = "char16_t", wChar32_t = "char32_t",
+    wAlignas = "alignas"
+    wAlignof = "alignof"
+    wConstexpr = "constexpr"
+    wDecltype = "decltype"
+    wNullptr = "nullptr"
+    wNoexcept = "noexcept"
+    wThread_local = "thread_local"
+    wStatic_assert = "static_assert"
+    wChar16_t = "char16_t"
+    wChar32_t = "char32_t"
 
-    wStdIn = "stdin", wStdOut = "stdout", wStdErr = "stderr",
+    wStdIn = "stdin"
+    wStdOut = "stdout"
+    wStdErr = "stderr"
 
-    wInOut = "inout", wByCopy = "bycopy", wByRef = "byref", wOneWay = "oneway",
-    wBitsize = "bitsize", wImportHidden = "all",
+    wInOut = "inout"
+    wByCopy = "bycopy"
+    wByRef = "byref"
+    wOneWay = "oneway"
+    wBitsize = "bitsize"
+    wImportHidden = "all"
 
   TSpecialWords* = set[TSpecialWord]
 

--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -88,7 +88,6 @@ Files: "bin/nim_dbg.exe"
 Files: "bin/nimble.exe"
 Files: "bin/nimgrab.exe"
 Files: "bin/nimgrep.exe"
-Files: "bin/nimpretty.exe"
 Files: "bin/nimsuggest.exe"
 Files: "bin/vccexe.exe"
 

--- a/lib/experimental/dod_helpers.nim
+++ b/lib/experimental/dod_helpers.nim
@@ -25,6 +25,12 @@ template declareIdType*(
     assert not isNil(id), $id
     result = int(BaseType(id) - 1)
 
+  func succ*(id: `Name Id`): `Name Id` =
+    `Name Id`(BaseType(id) + 1)
+
+  func pred*(id: `Name Id`): `Name Id` =
+    `Name Id`(BaseType(id) + 1)
+
   func `to Name Id`*(idx: int): `Name Id` =
     result = `Name Id`(idx + 1)
 
@@ -86,6 +92,9 @@ template declareStoreType*(Name: untyped): untyped {.dirty.} =
 
   template `[]`*(store: var `Name Store`, index: `Name Id`): Name =
     store.data[toIndex(index)]
+
+  template last*(store: `Name Store`): Name =
+    store.data[store.data.high]
 
   iterator items*(store: `Name Store`): Name =
     for item in items(store.data):

--- a/lib/experimental/sexp.nim
+++ b/lib/experimental/sexp.nim
@@ -388,6 +388,21 @@ proc getCons*(n: SexpNode, defaults: Cons = (newSNil(), newSNil())): Cons =
   elif n.kind == SList: return (n.elems[0], n.elems[1])
   else: return defaults
 
+proc `as`*(node: SexpNode, typ: typedesc[string]): string =
+  assert node.kind in { SString, SSymbol }
+  if node.kind == SSymbol:
+    result = node.getSymbol()
+
+  else:
+    result = node.getStr()
+
+
+proc `as`*[T: SomeInteger](node: SexpNode, typ: typedesc[T]): T =
+  return T(node.getNum())
+
+proc `as`*[T: SomeFloat](node: SexpNode, typ: typedesc[T]): T =
+  return T(node.getFNum())
+
 proc sexp*(s: string): SexpNode =
   ## Generic constructor for SEXP data. Creates a new `SString SexpNode`.
   result = SexpNode(kind: SString, str: s)

--- a/tests/compilerunits/lexer/numbers.txt
+++ b/tests/compilerunits/lexer/numbers.txt
@@ -1,0 +1,6 @@
+======
+Lex numerical literals
+======
+1
+----
+(IntLit "1" :line 1 :slice (0 2))

--- a/tests/compilerunits/lexer/tlexer.nim
+++ b/tests/compilerunits/lexer/tlexer.nim
@@ -1,0 +1,77 @@
+## Execute tests for the lexer
+
+import
+  std/[
+    os,
+    strutils,
+    options
+  ],
+  compiler/ast/[
+    lexer
+  ],
+  experimental/[
+    sexp
+  ]
+
+type
+  WantedToken = object
+    kind: TokenKind
+    text: string
+    slice: Option[Slice[int]]
+    line: Option[int]
+    column: Option[int]
+
+  Spec = object
+    title: string
+    testCode: string
+    expected: seq[WantedToken]
+
+
+proc parseWantedToken(sexp: SexpNode): WantedToken =
+  let kind = "tk" & (sexp[0] as string)
+  result.kind = parseEnum[TokenKind](kind)
+  if 1 < len(sexp):
+    result.text = sexp[1] as string
+
+  let line = sexp.getField("line")
+  if not line.isNil():
+    result.line = some(line as int)
+
+  let slice = sexp.getField("slice")
+  if not slice.isNil():
+    result.slice = some((slice[0] as int) .. (slice[1] as int))
+
+  let column = sexp.getField("column")
+  if not column.isNil():
+    result.column = some(column as int)
+
+proc splitLexerSpec(spec: string): Spec =
+  type WhichPart = enum Title, InputText, ExpectedOut
+  var part = Title
+  for line in spec.splitLines():
+    case part:
+      of Title:
+        if line.startsWith("==="):
+          if 0 < result.title.len():
+            part = InputText
+
+        else:
+          result.title = line
+
+      of InputText:
+        if line.startsWith("---"):
+          part = ExpectedOut
+
+        else:
+          result.testCode &= line & "\n"
+
+      of ExpectedOut:
+        if 0 < line.len:
+          result.expected.add parseWantedToken(parseSexp(line))
+
+
+  
+for file in walkDir(currentSourcePath().parentDir()):
+  if file.path.endsWith(".txt"):
+    let spec = readFile(file.path).splitLexerSpec()
+    echo spec


### PR DESCRIPTION
Change lexer to use data-oriented design for tokens instead of the
current solution. Remove nim"pretty" hack-ins from all over the compiler
and the nim"pretty" itself - it should be implemented as a standalone
tool that can actually understand code layout requirements instead of an
ad-hoc kludge that was immured deeply in the lexer and parser source
code.

* General lexer changes

- [X] Normalize token kinds for the literal bases - instead of
  introducing a separate data channel in form of the `NumericalBase`
  enum more token kinds were added.
- [ ] Rewrite base lexer implementation to operate on the whole string
  at once instead of working on the fixed-size buffer and copy-pasting
  character pieces into the `.literal` field in the `Token` (I wonder
  how many thousands of heap relocations this solution were causing in
  each simple run)
