### PR TITLE
vm: make the `nimVMDebugGenerate` define work again

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -71,6 +71,9 @@ import
     results
   ]
 
+when defined(nimVMDebugGenerate):
+  import compiler/vm/vmutils
+
 # XXX: instead of `assert` a special `vmAssert` could be used for internal
 #      checks. This would allow for also reporting things like the current
 #      executed instruction
@@ -86,8 +89,6 @@ const
 
 const
   errIllegalConvFromXtoY = "illegal conversion from '$1' to '$2'"
-
-
 
 proc createStackTrace(
     c:          TCtx,
@@ -3519,8 +3520,9 @@ proc evalConstExprAux(module: PSym; idgen: IdGenerator;
 
   if c.code[start].opcode == opcEof: return newNodeI(nkEmpty, n.info)
   assert c.code[start].opcode != opcEof
-  when debugEchoCode:
-    c.codeListing(prc, n)
+  when defined(nimVMDebugGenerate):
+    c.config.localReport():
+      initVmCodeListingReport(c[], prc, n)
 
   var tos = TStackFrame(prc: prc, comesFrom: 0, next: -1)
   tos.slots.newSeq(regCount)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -33,11 +33,12 @@ import
     results
   ]
 
+when defined(nimVMDebugGenerate):
+  import
+    compiler/front/msgs,
+    compiler/vm/vmutils
+
 export VmGenResult
-
-const
-  debugEchoCode* = defined(nimVMDebugGenerate)
-
 
 # TODO: use `stdlib.pairs` instead once it uses `lent`
 iterator lpairs[T](x: seq[T]): tuple[key: int, value: lent T] =
@@ -173,8 +174,11 @@ proc compile*(c: var TCtx, fnc: FunctionIndex): VmGenResult =
 
   fillProcEntry(c.functions[fnc.int], result.unsafeGet)
 
-  when debugEchoCode:
-    c.codeListing(s, nil, start = result.unsafeGet.start)
+  when defined(nimVMDebugGenerate):
+    # XXX: ``compile`` shouldn't be responsible for neither the generating nor
+    #      the reporting of a code-listing
+    c.config.localReport():
+      initVmCodeListingReport(c, prc.sym, nil, start = result.unsafeGet.start)
 
 proc loadProc*(c: var TCtx, sym: PSym): VmGenResult =
   ## The main entry point into the JIT code-generator. Retrieves the

--- a/compiler/vm/vmutils.nim
+++ b/compiler/vm/vmutils.nim
@@ -1,0 +1,91 @@
+## This module contains some utility procedures for inspecting VM-related
+## data.
+##
+## The VM doesn't depend on the procedures here in order to
+## function - they are only meant as a logging and debugging aid.
+
+import
+  std/[
+    intsets
+  ],
+  compiler/ast/[
+    ast,
+    reports
+  ],
+  compiler/vm/[
+    vmdef
+  ]
+
+func codeListing*(c: TCtx; start = 0; last = -1): seq[DebugVmCodeEntry] =
+  ## Produces a listing of the instructions in `c` that are located in the
+  ## instruction range ``start..last``. If ``last < 0``, then all instructions
+  ## after position `start` are included in the listing. The instructions are
+  ## ordered by their position
+  let last =
+    if last < 0: c.code.high
+    else:        min(last, c.code.high)
+
+  # first iteration: compute all necessary labels:
+  var jumpTargets = initIntSet()
+  for i in start..last:
+    let x = c.code[i]
+    if x.opcode in relativeJumps:
+      jumpTargets.incl(i+x.regBx-wordExcess)
+
+  # because some instructions take up more than one instruction word, there's
+  # not a 1-to-1 mapping between instruction words and the resulting list
+  # entries
+  result = newSeqOfCap[DebugVmCodeEntry](last - start + 1)
+
+  var i = start
+  while i <= last:
+    let
+      x = c.code[i]
+      opc = opcode(x)
+
+    var code = DebugVmCodeEntry(
+      pc: i,
+      opc: opc,
+      ra: x.regA,
+      rb: x.regB,
+      rc: x.regC,
+      idx: x.regBx - wordExcess,
+      info: c.debug[i],
+      isTarget: i in jumpTargets
+    )
+
+    case opc:
+    of opcConv, opcCast:
+      code.types = (c.rtti[c.code[i + 1].regBx-wordExcess].nimType,
+                    c.rtti[c.code[i + 2].regBx-wordExcess].nimType)
+      inc i, 2
+
+    of opcLdConst, opcAsgnConst:
+      let cnst = c.constants[code.idx]
+      code.ast =
+        case cnst.kind
+        of cnstInt:    newIntNode(nkIntLit, cnst.intVal)
+        of cnstFloat:  newFloatNode(nkFloatLit, cnst.floatVal)
+        of cnstString: newStrNode(nkStrLit, cnst.strVal)
+        of cnstNode:   cnst.node
+        of cnstSliceListInt..cnstSliceListStr:
+          # XXX: translate into an `nkOfBranch`?
+          newNode(nkEmpty)
+
+    else:
+      discard
+
+    result.add code
+    inc i
+
+func initVmCodeListingReport*(c: TCtx, prc: PSym, ast: PNode;
+                              start = 0; last = -1): DebugReport =
+  ## Convenience procedure for initializing a code-listing debug report with
+  ## the given arguments.
+  ##
+  ## See also:
+  ## * `codeListing <#codeListing,TCtx,int,int>`_
+  result = DebugReport(kind: rdbgVmCodeListing)
+  result.vmgenListing.sym = prc
+  result.vmgenListing.ast = ast
+  result.vmgenListing.entries = codeListing(c, start, last)


### PR DESCRIPTION
## Summary
Fix the compilation error in `vmjit` that happened when
`debugEchoCode` was enabled.

In addition, refactor, clean-up, and document the `codeListing`
procedure and move it to the new module `vmutils`. `codeListing` also
doesn't directly report the generated listing anymore - that's the
responsibility of it's caller now.

## Details
* the `debugEchoCode` constant is removed and replaced with
 direct usage of `defined(nimVMDebugGenerate)`