### PR TITLE
Split rsemVm into a separate report object type

### DIFF
--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -62,12 +62,12 @@ proc errorSubNode*(n: PNode): PNode =
       result = errorSubNode(s)
       if result != nil: break
 
-func errorKind*(e: PNode): SemReportKind {.inline.} =
+func errorKind*(e: PNode): SemOrVMReportKind {.inline.} =
   ## property to retrieve the error kind
   assert e != nil, "can't have a nil error node"
   assert e.kind == nkError, "must be an error node to have an ErrorKind"
 
-  result = SemReportKind(e[errorKindPos].intVal)
+  result = SemOrVMReportKind(e[errorKindPos].intVal)
 
 func compilerInstInfo*(e: PNode): InstantiationInfo {.inline.} =
   ## return where the error was instantiated in the compiler
@@ -84,7 +84,13 @@ proc newError*(
     args: varargs[PNode]
   ): PNode =
   ## Create `nkError` node with given error report and additional subnodes.
-  assert errorKind in repSemKinds
+  assert(
+    errorKind in (
+      set[ReportKind](repSemKinds) +
+      set[ReportKind](repVMKinds)),
+    $errorKind
+  )
+
   assert wrongNode != nil, "can't have a nil node for `wrongNode`"
   assert not report.isEmpty(), $report
 

--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -57,11 +57,12 @@ proc computeNotesVerbosity(): tuple[
   # settings
   result.base = (repErrorKinds + repInternalKinds)
 
+
   # Somewhat awkward handing - stack trace report cannot be error (because
   # actual error report must follow), so it is a hint-level report (can't
   # be debug because it is a user-facing, can't be "trace" because it is
   # not for compiler developers use only)
-  result.base.incl {rsemVmStackTrace}
+  result.base.incl {rvmStackTrace}
 
   when defined(debugOptions):
     # debug report for transition of the configuration options
@@ -78,9 +79,12 @@ proc computeNotesVerbosity(): tuple[
     }
 
   when defined(nimDebugUtils):
+    # By default enable only semantic debug trace reports - other changes
+    # might be put in there *temporarily* to aid the debugging.
     result.base.incl repDebugTraceKinds
 
-  result.main[compVerbosityMax] = result.base + repWarningKinds + repHintKinds - {
+  result.main[compVerbosityMax] =
+    result.base + repWarningKinds + repHintKinds - {
     rsemObservableStores,
     rsemResultUsed,
     rsemAnyEnumConvert,
@@ -151,7 +155,7 @@ proc computeNotesVerbosity(): tuple[
   ]:
     assert rbackLinking notin n
     assert rsemImplicitObjConv in n, $idx
-    assert rsemVmStackTrace in n, $idx
+    assert rvmStackTrace in n, $idx
 
 const
   NotesVerbosity* = computeNotesVerbosity()

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -17,6 +17,8 @@ type
     repCmd = "Cmd" ## Report related to execution of the external command -
     ## start of the command, execution failure, succes and so on.
 
+    repVM = "VM" ## Report related to embedded virtual machine
+
     repDebug = "Debug" ## Side channel for the compiler debug report. Sem
     ## expansion traces and other helper messages designed specifically to
     ## aid development of the compiler
@@ -235,6 +237,65 @@ type
     rparPragmaNotFollowingTypeName
     rparEnablePreviewDotOps = "DotLikeOps"
     # warnings END !! add reports BEFORE the last enum !!
+
+
+    #-----------------------------  VM reports  ------------------------------#
+    # VM
+    rvmOpcParseExpectedExpression
+    rvmTooManyRegistersRequired
+    rvmMissingImportcCompleteStruct
+    rvmCannotFindBreakTarget
+    rvmNotUnused
+    rvmUserError
+    rvmNotAFieldSymbol
+    rvmTooLargetOffset
+    rvmUnhandledException
+    rvmCannotGenerateCode
+    rvmCannotCast
+    rvmGlobalError ## Error report that was declared as 'global' in the
+    ## VM - with current 'globalError-is-a-control-flow-mechanism' approach
+    ## this report is largely meaningless, and used only to raise exception.
+    rvmInvalidBindSym
+    rvmBadExpandToAst
+    rvmCannotEvaluateAtComptime
+    rvmCannotImportc
+    rvmCannotCreateNullElement
+    rvmInvalidObjectConstructor
+    rvmNoClosureIterators
+    rvmCannotCallMethod
+    rvmCallingNonRoutine
+    rvmCannotModifyTypechecked
+    rvmNilAccess
+    rvmAccessOutOfBounds
+    rvmAccessTypeMismatch
+    rvmAccessNoLocation
+    rvmDerefUnsupportedPtr
+    rvmErrInternal
+    rvmIndexError
+    rvmOutOfRange
+    rvmOverOrUnderflow
+    rvmDivisionByConstZero
+    rvmNodeNotASymbol
+    rvmNodeNotAProcSymbol
+    rvmNodeNotAFieldSymbol
+    rvmIllegalConv
+    rvmMissingCacheKey
+    rvmCacheKeyAlreadyExists
+    rvmFieldNotFound
+    rvmFieldInavailable
+    rvmCannotSetChild
+    rvmCannotAddChild
+    rvmCannotGetChild
+    rvmNoType
+    rvmNotAField
+    rvmUnsupportedNonNil
+
+    rvmTooManyIterations
+
+    # trace
+    rvmStackTrace
+    # trace
+
 
     #-----------------------------  Sem reports  -----------------------------#
     # semantic fatal
@@ -587,58 +648,6 @@ type
     rsemBorrowOutlivesSource
     rsemImmutableBorrowMutation
 
-    # VM
-    rsemVmOpcParseExpectedExpression
-    rsemTooManyRegistersRequired
-    rsemVmCannotFindBreakTarget
-    rsemVmNotUnused
-    rsemNotAFieldSymbol
-    rsemVmTooLargetOffset
-    rsemVmUnhandledException
-    rsemVmCannotGenerateCode
-    rsemVmCannotCast
-    rsemVmGlobalError ## Error report that was declared as 'global' in the
-    ## VM - with current 'globalError-is-a-control-flow-mechanism' approach
-    ## this report is largely meaningless, and used only to raise exception.
-    rsemVmInvalidBindSym
-    rsemVmBadExpandToAst
-    rsemVmCannotEvaluateAtComptime
-    rsemVmCannotImportc
-    rsemVmCannotCreateNullElement
-    rsemVmInvalidObjectConstructor
-    rsemVmNoClosureIterators
-    rsemVmCannotCallMethod
-    rsemVmCallingNonRoutine
-    rsemVmCannotModifyTypechecked
-    rsemVmNilAccess
-    rsemVmAccessOutOfBounds
-    rsemVmAccessTypeMismatch
-    rsemVmAccessNoLocation
-    rsemVmDerefUnsupportedPtr
-    rsemVmErrInternal
-    rsemVmIndexError
-    rsemVmOutOfRange
-    rsemVmOverOrUnderflow
-    rsemVmDivisionByConstZero
-    rsemVmNodeNotASymbol
-    rsemVmNodeNotAProcSymbol
-    rsemVmNodeNotAFieldSymbol
-    rsemVmIllegalConv
-    rsemVmMissingCacheKey
-    rsemVmCacheKeyAlreadyExists
-    rsemVmFieldNotFound
-    rsemVmFieldInavailable
-    rsemVmCannotSetChild
-    rsemVmCannotAddChild
-    rsemVmCannotGetChild
-    rsemVmNoType
-    rsemVmNotAField
-    rsemVmUnsupportedNonNil
-
-    rsemVmTooManyIterations
-
-    rsemMissingImportcCompleteStruct
-
     rsemCyclicTree
     rsemCyclicDependency
     rsemConstExprExpected
@@ -789,9 +798,6 @@ type
     rsemUseOfGc                = "GcMem" # last !
     # END !! add reports BEFORE the last enum !!
 
-    # trace
-    rsemVmStackTrace
-    # trace
 
     # Semantic hints begin
     rsemUserHint = "User" ## `{.hint: .}` pragma encountereed
@@ -920,10 +926,14 @@ type
 const rstWarnings* = {rbackRstTestUnsupported .. rbackRstRstStyle}
 
 type
-  LexerReportKind* = range[rlexMalformedUnderscores .. rlexSourceCodeFilterOutput]
-  ParserReportKind* = range[rparInvalidIndentation .. rparEnablePreviewDotOps]
+  LexerReportKind* = range[
+    rlexMalformedUnderscores .. rlexSourceCodeFilterOutput]
 
+  ParserReportKind* = range[rparInvalidIndentation .. rparEnablePreviewDotOps]
+  VMReportKind* = range[rvmOpcParseExpectedExpression .. rvmStackTrace]
   SemReportKind* = range[rsemFatalError .. rsemImplicitObjConv]
+  SemOrVMReportKind* = range[low(VMReportKind) .. high(SemReportKind)]
+
   SemReportErrorKind* = range[rsemUserError .. rsemWrappedError]
 
   CmdReportKind* = range[rcmdFailedExecution .. rcmdRunnableExamplesSuccess]
@@ -951,6 +961,13 @@ const
   rparErrorKinds*   = {rparInvalidIndentation .. rparInvalidFilter}
   rparWarningKinds* = {
     rparInconsistentSpacing .. rparEnablePreviewDotOps}
+
+  #---------------------------------  sem  ---------------------------------#
+  repVMKinds* = {low(VMReportKind) .. high(VMReportKind)}
+  rvmHintKinds* = default(set[ReportKind])
+  rvmTraceKinds* = {rvmStackTrace}
+  rvmWarningKinds* = default(set[ReportKind])
+  rvmErrorKinds* = repVMKinds - rvmTraceKinds
 
   #---------------------------------  sem  ---------------------------------#
   repSemKinds* = {low(SemReportKind) .. high(SemReportKind)}
@@ -1016,16 +1033,20 @@ const
       rparWarningKinds +
       rbackWarningKinds +
       rextWarningKinds +
+      rvmWarningKinds +
       rcmdWarningKinds +
       rintWarningKinds
 
-  repTraceKinds*: ReportKinds = {rsemVmStackTrace, rintStackTrace}
+  repTraceKinds*: ReportKinds =
+    {rvmStackTrace, rintStackTrace} +
+    repDebugKinds
 
   repHintKinds*: ReportKinds    =
     rsemHintKinds +
       rlexHintKinds +
       rparHintKinds +
       rbackHintKinds +
+      rvmHintKinds +
       rextHintKinds +
       rcmdHintKinds +
       rintHintKinds
@@ -1035,13 +1056,52 @@ const
       rlexErrorKinds +
       rparErrorKinds +
       rbackErrorKinds +
+      rvmErrorKinds +
       rextErrorKinds +
       rcmdErrorKinds +
       rintErrorKinds
 
-  repFatalKinds*: ReportKinds = rintFatalKinds
+  repDataPassKinds*: ReportKinds =
+    rintDataPassKinds
+
+  repFatalKinds*: ReportKinds = rintFatalKinds + {rsemFatalError}
   repAllKinds* = {low(ReportKind) .. high(ReportKind)}
 
+static:
+  block:
+    let diff = repAllKinds - (
+      repWarningKinds +
+      repHintKinds +
+      repTraceKinds +
+      repErrorKinds +
+      repDataPassKinds +
+      repFatalKinds +
+      { repNone }
+    )
+
+    assert(
+      len(diff) == 0,
+      "Severity grouping is missing some elements: " & $diff
+    )
+
+  block:
+    let diff = repAllKinds - (
+      set[ReportKind](repVMKinds) +
+      set[ReportKind](repSemKinds) +
+      set[ReportKind](repLexerKinds) +
+      set[ReportKind](repParserKinds) +
+      set[ReportKind](repInternalKinds) +
+      set[ReportKind](repExternalKinds) +
+      set[ReportKind](repDebugKinds) +
+      set[ReportKind](repBackendKinds) +
+      set[ReportKind](repCmdKinds) +
+      { repNone }
+    )
+
+    assert(
+      len(diff) == 0,
+      "Report ranges are missing some elements: " & $diff
+    )
 
 const
   rsemReportTwoSym* = {

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -232,23 +232,23 @@ proc effectProblem(f, a: PType; result: var string) =
       result.add "\n  This expression can have side effects. Annotate the " &
           "proc with {.noSideEffect.} to get extended error information."
     else:
-      case compatibleEffects(f, a)
-      of efCompat: discard
-      of efRaisesDiffer:
-        result.add "\n  The `.raises` requirements differ."
-      of efRaisesUnknown:
-        result.add "\n  The `.raises` requirements differ. Annotate the " &
-            "proc with {.raises: [].} to get extended error information."
-      of efTagsDiffer:
-        result.add "\n  The `.tags` requirements differ."
-      of efTagsUnknown:
-        result.add "\n  The `.tags` requirements differ. Annotate the " &
-            "proc with {.tags: [].} to get extended error information."
-      of efLockLevelsDiffer:
-        result.add "\n  The `.locks` requirements differ. Annotate the " &
-            "proc with {.locks: 0.} to get extended error information."
-      of efEffectsDelayed:
-        result.add "\n  The `.effectsOf` annotations differ."
+      case compatibleEffects(f, a):
+        of efCompat: discard
+        of efRaisesDiffer:
+          result.add "\n  The `.raises` requirements differ."
+        of efRaisesUnknown:
+          result.add "\n  The `.raises` requirements differ. Annotate the " &
+              "proc with {.raises: [].} to get extended error information."
+        of efTagsDiffer:
+          result.add "\n  The `.tags` requirements differ."
+        of efTagsUnknown:
+          result.add "\n  The `.tags` requirements differ. Annotate the " &
+              "proc with {.tags: [].} to get extended error information."
+        of efLockLevelsDiffer:
+          result.add "\n  The `.locks` requirements differ. Annotate the " &
+              "proc with {.locks: 0.} to get extended error information."
+        of efEffectsDelayed:
+          result.add "\n  The `.effectsOf` annotations differ."
 
 proc argTypeToString(arg: PNode; prefer: TPreferedDesc): string =
   ## Convert argument node type to string
@@ -348,13 +348,13 @@ proc getProcHeader(
   if getDeclarationPath: result.addDeclaredLoc(conf, sym)
 
 proc getSymRepr*(conf: ConfigRef; s: PSym, getDeclarationPath = true): string =
-  case s.kind
-  of routineKinds, skType:
-    result = getProcHeader(conf, s, getDeclarationPath = getDeclarationPath)
-  else:
-    result = "'$1'" % s.name.s
-    if getDeclarationPath:
-      result.addDeclaredLoc(conf, s)
+  case s.kind:
+    of routineKinds, skType:
+      result = getProcHeader(conf, s, getDeclarationPath = getDeclarationPath)
+    else:
+      result = "'$1'" % s.name.s
+      if getDeclarationPath:
+        result.addDeclaredLoc(conf, s)
 
 proc addTypeDeclVerboseMaybe(result: var string, conf: ConfigRef; typ: PType) =
   ## Calls `typeToString` on given `typ`.
@@ -393,13 +393,16 @@ proc presentSpellingCandidates*(
 
     result.addDeclaredLoc(conf, candidate.sym)
 
-proc presentDiagnostics(conf: ConfigRef, d: SemDiagnostics, startWithNewLine: bool): string
+proc presentDiagnostics(
+  conf: ConfigRef, d: SemDiagnostics, startWithNewLine: bool): string
+
+const defaultRenderFlags: set[TRenderFlag] = {
+    renderNoComments,
+    renderWithoutErrorPrefix
+  }
+
 
 proc reportBody*(conf: ConfigRef, r: SemReport): string =
-  const defaultRenderFlags: set[TRenderFlag] = {
-      renderNoComments,
-      renderWithoutErrorPrefix
-    }
   proc render(n: PNode, rf = defaultRenderFlags): string = renderTree(n, rf)
   proc render(t: PType): string = typeToString(t)
 
@@ -496,29 +499,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         result.add(" = ", typeToString(r.typ, preferDesc))
 
 
-    of rsemVmStackTrace:
-      result = "stack trace: (most recent call last)\n"
-      for idx in countdown(r.stacktrace.high, 0):
-        let (sym, loc) = r.stacktrace[idx]
-        result.add(
-          conf.toStr(loc),
-          " ",
-          if sym != nil: sym.name.s else: "???"
-        )
-        if r.skipped > 0 and idx == r.stacktrace.high:
-          # The entry point is always the last element in the list
-          result.add("\nSkipped ", r.skipped, " entries, calls that led up to printing")
-
-        if idx > 0: 
-          result.add("\n")
-
-    of rsemVmUnhandledException:
-      result.addf(
-        "unhandled exception: $1 [$2]",
-        r.ast[3].skipColon.strVal,
-        r.ast[2].skipColon.strVal
-      )
-
     of rsemExpandArc:
       result.add(
         "--expandArc: ",
@@ -544,84 +524,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
           "\n",
           conf.toStr(r.borrowPair.connectedVia),
           " is the statement that connected the mutation to the parameter")
-
-    of rsemVmNodeNotASymbol:
-      result = "node is not a symbol"
-
-    of rsemVmNodeNotAProcSymbol:
-      result = "node is not a proc symbol"
-
-    of rsemVmDerefUnsupportedPtr:
-      result = "deref unsupported ptr type: $1 $2" % [r.typ.render, $r.typ.kind]
-
-    of rsemVmNilAccess:
-      result = "attempt to access a nil address"
-
-    of rsemVmAccessOutOfBounds:
-      result = "trying to access a location outside of the VM's memory"
-
-    of rsemVmAccessTypeMismatch:
-        # TODO: provide both dynamic and static type in the message
-      result = "trying to access a location with a handle of incompatible type"
-
-    of rsemVmAccessNoLocation:
-      result = "handle doesn't reference a valid location"
-
-    of rsemVmOverOrUnderflow:
-      result = "over- or underflow"
-
-    of rsemVmDivisionByConstZero:
-      result = "division by zero"
-
-    of rsemVmTooManyIterations:
-      result = "interpretation requires too many iterations; " &
-        "if you are sure this is not a bug in your code, compile " &
-        "with `--maxLoopIterationsVM:number` (current value: $1)" %
-        $conf.maxLoopIterationsVM
-
-    of rsemVmCannotModifyTypechecked:
-      result = "typechecked nodes may not be modified"
-
-    of rsemVmNoType:
-      result = "node has no type"
-
-    of rsemVmIllegalConv:
-      result = r.str
-
-    of rsemVmFieldNotFound:
-      result = "node lacks field: " & r.str
-
-    of rsemVmNodeNotAFieldSymbol:
-      result = "symbol is not a field (nskField)"
-
-    of rsemVmCannotSetChild:
-      result = "cannot set child of node kind: n" & $r.ast.kind
-
-    of rsemVmCannotAddChild:
-      result = "cannot add to node kind: n" & $r.ast.kind
-
-    of rsemVmCannotGetChild:
-      result = "cannot get child of node kind: n" & $r.ast.kind
-
-    of rsemVmMissingCacheKey:
-      result = "key does not exist: " & r.str
-
-    of rsemVmCacheKeyAlreadyExists:
-      result = "key already exists: " & r.str
-
-    of rsemVmFieldInavailable:
-      result = r.str
-
-    of rsemVmUnsupportedNonNil:
-      case r.typ.kind
-      of tyRef:
-        result = "static expressions yielding non-nil 'ref' values that are" &
-                " not of 'object'-type are not supported"
-      of tyPtr, tyPointer:
-        result = "static expressions yielding non-nil pointer values are " &
-                "not supported"
-      else:
-        assert false
 
     of rsemBorrowOutlivesSource:
       result.add(
@@ -695,30 +597,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemThisPragmaRequires01Args:
       # FIXME remove this report kind, reuse "wrong number of arguments"
       result = "'this' pragma is allowed to have zero or one arguments"
-
-    of rsemTooManyRegistersRequired:
-      result = "VM problem: too many registers required"
-
-    of rsemVmCannotFindBreakTarget:
-      result = "VM problem: cannot find 'break' target"
-
-    of rsemVmNotUnused:
-      result = "not unused"
-
-    of rsemVmTooLargetOffset:
-      result = "too large offset! cannot generate code for: " &
-        r.sym.name.s
-
-    of rsemVmCannotGenerateCode:
-      result = "cannot generate code for: " &
-        $r.ast
-
-    of rsemVmCannotCast:
-      result = "VM does not support 'cast' from " &
-        $r.actualType.kind & " to " & $r.formalType.kind
-
-    of rsemVmInvalidBindSym:
-      result = "invalid bindSym usage"
 
     of rsemSymbolKindMismatch:
       var ask: string
@@ -850,7 +728,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         inc i
 
 
-    of rsemStaticOutOfBounds, rsemVmIndexError:
+    of rsemStaticOutOfBounds:
       let (i, a, b) = r.indexSpec
       if b < a:
         result = "index out of bounds, the container is empty"
@@ -924,9 +802,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "expression has no address"
       if r.isUnsafeAddr:
         result.add "; maybe use 'unsafeAddr'"
-
-    of rsemVmCannotEvaluateAtComptime:
-      result = "cannot evaluate at compile time: " & r.ast.render
 
     of rsemIntLiteralExpected:
       result = "integer literal expected"
@@ -1308,9 +1183,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         "public implementation '$1' has non-public forward declaration at $2"
       ) % [getProcHeader(conf, r.sym, getDeclarationPath = false), conf $ r.sym.info]
 
-    of rsemVmInvalidObjectConstructor:
-      result = "invalid object constructor"
-
     of rsemImplementationNotAllowed:
       result = "implementation of '$1' is not allowed" % r.symstr
 
@@ -1648,24 +1520,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
     of rsemObjectConstructorIncorrect:
       result = "Invalid object constructor: '$1'" % r.ast.render
-
-    of rsemVmBadExpandToAst:
-      result = "expandToAst requires 1 argument"
-
-    of rsemMissingImportcCompleteStruct:
-      result = "'$1' requires '.importc' types to be '.completeStruct'" % r.str
-
-    of rsemVmCannotImportc:
-      result = "cannot 'importc' variable/proc at compile time: " & r.symstr
-
-    of rsemVmCannotCreateNullElement:
-      result = "cannot create null element for: " & r.typ.render
-
-    of rsemVmNoClosureIterators:
-      result = "Closure iterators are not supported by VM!"
-
-    of rsemVmCannotCallMethod:
-      result = "cannot call method " & r.symstr & " at compile time"
 
     of rsemBorrowTargetNotFound:
       result = "no symbol to borrow from found"
@@ -2149,27 +2003,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemRttiRequestForIncompleteObject:
       result = "request for RTTI generation for incomplete object: " & r.typ.render
 
-    of rsemVmNotAField:
-      result = "symbol is not a field (nskField)"
-
-    of rsemVmOutOfRange:
-      result = "unhandled exception: value out of range"
-
-    of rsemVmErrInternal:
-      result = r.str
-
-    of rsemVmCallingNonRoutine:
-      result = "NimScript: attempt to call non-routine: " & r.symstr
-
-    of rsemVmGlobalError:
-      result = r.str
-
-    of rsemNotAFieldSymbol:
-      result = "no field symbol"
-
-    of rsemVmOpcParseExpectedExpression:
-      result = "expected expression, but got multiple statements"
-
     of rsemCannotDetermineBorrowTarget:
       result = "cannot determine the target of the borrow"
 
@@ -2387,7 +2220,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
 const standalone = {
   rsemExpandArc, # Original compiler did not consider it as a hint
-  rsemVmStackTrace, # Always associated with extra report
+  rvmStackTrace, # Always associated with extra report
   rsemDiagnostics, # Wraps other reports
 }
 
@@ -2492,7 +2325,8 @@ proc reportBody*(conf: ConfigRef, r: ParserReport): string =
       result = r.msg
 
     of rparFuncNotAllowed:
-      result = "func keyword is not allowed in type descriptions, use proc with {.noSideEffect.} pragma instead"
+      result = "func keyword is not allowed in type descriptions, " &
+        "use proc with {.noSideEffect.} pragma instead"
 
     of rparTupleTypeWithPar:
       result = "the syntax for tuple types is 'tuple[...]', not 'tuple(...)'"
@@ -2510,7 +2344,8 @@ proc reportBody*(conf: ConfigRef, r: ParserReport): string =
       result = "pragma already present"
 
     of rparMisplacedExport:
-      result = "invalid indentation; an export marker '*' follows the declared identifier"
+      result = "invalid indentation; an export marker '*' " &
+        "follows the declared identifier"
 
     of rparTemplMissingEndClose:
       result = "'end' does not close a control flow construct"
@@ -2522,10 +2357,12 @@ proc reportBody*(conf: ConfigRef, r: ParserReport): string =
       result = "Number of spaces around '$#' is not consistent"
 
     of rparEnablePreviewDotOps:
-      result = "dot-like operators will be parsed differently with `-d:nimPreviewDotLikeOps`"
+      result = "dot-like operators will be parsed differently " &
+        "with `-d:nimPreviewDotLikeOps`"
 
     of rparPragmaNotFollowingTypeName:
-      result = "type pragmas follow the type name; this form of writing pragmas is deprecated"
+      result = "type pragmas follow the type name; this form of " &
+        "writing pragmas is deprecated"
 
     of rparPragmaBeforeGenericParameters:
       result = "pragma must come after any generic parameter list"
@@ -3517,6 +3354,211 @@ proc reportShort*(conf: ConfigRef, r: BackendReport): string =
     result.add conf.suffixShort(r)
 
 
+
+proc reportBody*(conf: ConfigRef, r: VMReport): string =
+  proc render(n: PNode, rf = defaultRenderFlags): string = renderTree(n, rf)
+  proc render(t: PType): string = typeToString(t)
+
+  case VMReportKind(r.kind):
+    of rvmUserError:
+      result = r.str
+
+    of rvmMissingImportcCompleteStruct:
+      result = "'$1' requires '.importc' types to be '.completeStruct'" % r.str
+
+    of rvmNotAFieldSymbol:
+      result = "no field symbol"
+
+    of rvmBadExpandToAst:
+      result = "expandToAst requires 1 argument"
+
+    of rvmCannotImportc:
+      result = "cannot 'importc' variable/proc at compile time: " & r.symstr
+
+    of rvmCannotCreateNullElement:
+      result = "cannot create null element for: " & r.typ.render
+
+    of rvmInvalidObjectConstructor:
+      result = "invalid object constructor"
+
+    of rvmNoClosureIterators:
+      result = "Closure iterators are not supported by VM!"
+
+    of rvmStackTrace:
+      result = "stack trace: (most recent call last)\n"
+      for idx in countdown(r.stacktrace.high, 0):
+        let (sym, loc) = r.stacktrace[idx]
+        result.add(
+          conf.toStr(loc),
+          " ",
+          if sym != nil: sym.name.s else: "???"
+        )
+        if r.skipped > 0 and idx == r.stacktrace.high:
+          # The entry point is always the last element in the list
+          result.add(
+            "\nSkipped ", r.skipped,
+            " entries, calls that led up to printing")
+
+        if idx > 0:
+          result.add("\n")
+
+    of rvmUnhandledException:
+      result.addf(
+        "unhandled exception: $1 [$2]",
+        r.ast[3].skipColon.strVal,
+        r.ast[2].skipColon.strVal
+      )
+
+    of rvmNodeNotASymbol:
+      result = "node is not a symbol"
+
+    of rvmNodeNotAProcSymbol:
+      result = "node is not a proc symbol"
+
+    of rvmDerefUnsupportedPtr:
+      result = "deref unsupported ptr type: $1 $2" % [
+        r.typ.render, $r.typ.kind]
+
+    of rvmNilAccess:
+      result = "attempt to access a nil address"
+
+    of rvmAccessOutOfBounds:
+      result = "trying to access a location outside of the VM's memory"
+
+    of rvmAccessTypeMismatch:
+        # TODO: provide both dynamic and static type in the message
+      result = "trying to access a location with a handle of incompatible type"
+
+    of rvmAccessNoLocation:
+      result = "handle doesn't reference a valid location"
+
+    of rvmOverOrUnderflow:
+      result = "over- or underflow"
+
+    of rvmDivisionByConstZero:
+      result = "division by zero"
+
+    of rvmTooManyIterations:
+      result = "interpretation requires too many iterations; " &
+        "if you are sure this is not a bug in your code, compile " &
+        "with `--maxLoopIterationsVM:number` (current value: $1)" %
+        $conf.maxLoopIterationsVM
+
+    of rvmCannotModifyTypechecked:
+      result = "typechecked nodes may not be modified"
+
+    of rvmNoType:
+      result = "node has no type"
+
+    of rvmIllegalConv:
+      result = r.str
+
+    of rvmFieldNotFound:
+      result = "node lacks field: " & r.str
+
+    of rvmNodeNotAFieldSymbol:
+      result = "symbol is not a field (nskField)"
+
+    of rvmCannotSetChild:
+      result = "cannot set child of node kind: n" & $r.ast.kind
+
+    of rvmCannotAddChild:
+      result = "cannot add to node kind: n" & $r.ast.kind
+
+    of rvmCannotGetChild:
+      result = "cannot get child of node kind: n" & $r.ast.kind
+
+    of rvmMissingCacheKey:
+      result = "key does not exist: " & r.str
+
+    of rvmCacheKeyAlreadyExists:
+      result = "key already exists: " & r.str
+
+    of rvmFieldInavailable:
+      result = r.str
+
+    of rvmUnsupportedNonNil:
+      case r.typ.kind
+      of tyRef:
+        result = "static expressions yielding non-nil 'ref' values that are" &
+                " not of 'object'-type are not supported"
+      of tyPtr, tyPointer:
+        result = "static expressions yielding non-nil pointer values are " &
+                "not supported"
+      else:
+        assert false
+
+    of rvmCannotFindBreakTarget:
+      result = "VM problem: cannot find 'break' target"
+
+    of rvmNotUnused:
+      result = "not unused"
+
+    of rvmTooLargetOffset:
+      result = "too large offset! cannot generate code for: " &
+        r.sym.name.s
+
+    of rvmCannotGenerateCode:
+      result = "cannot generate code for: " &
+        $r.ast
+
+    of rvmCannotCast:
+      result = "VM does not support 'cast' from " &
+        $r.actualType.kind & " to " & $r.formalType.kind
+
+    of rvmInvalidBindSym:
+      result = "invalid bindSym usage"
+
+    of rvmCannotEvaluateAtComptime:
+      result = "cannot evaluate at compile time: " & r.ast.render
+
+    of rvmTooManyRegistersRequired:
+      result = "VM problem: too many registers required"
+
+    of rvmCannotCallMethod:
+      result = "cannot call method " & r.symstr & " at compile time"
+
+    of rvmNotAField:
+      result = "symbol is not a field (nskField)"
+
+    of rvmOutOfRange:
+      result = "unhandled exception: value out of range"
+
+    of rvmErrInternal:
+      result = r.str
+
+    of rvmCallingNonRoutine:
+      result = "NimScript: attempt to call non-routine: " & r.symstr
+
+    of rvmGlobalError:
+      result = r.str
+
+    of rvmOpcParseExpectedExpression:
+      result = "expected expression, but got multiple statements"
+
+    of rvmIndexError:
+      let (i, a, b) = r.indexSpec
+      if b < a:
+        result = "index out of bounds, the container is empty"
+      else:
+        result = "index " & $i & " not in " & $a & " .. " & $b
+
+
+proc reportFull*(conf: ConfigRef, r: VMReport): string =
+  assertKind r
+  result.add(
+    conf.getContext(r.context),
+    conf.prefix(r),
+    reportBody(conf, r),
+    conf.suffix(r)
+  )
+
+proc reportShort*(conf: ConfigRef, r: VMReport): string =
+  # mostly created for nimsuggest
+  assertKind r
+  reportBody(conf, r) & suffixShort(conf, r)
+
+
 proc reportBody*(conf: ConfigRef, r: CmdReport): string =
   assertKind r
   case CmdReportKind(r.kind):
@@ -3541,7 +3583,7 @@ proc reportFull*(conf: ConfigRef, r: CmdReport): string =
   assertKind r
   reportBody(conf, r)
 
-proc reportShort*(conf: ConfigRef, r: CmdReport): string {.inline.} =
+proc reportShort*(conf: ConfigRef, r: CmdReport): string =
   # mostly created for nimsuggest
   reportBody(conf, r)
 
@@ -3559,6 +3601,7 @@ proc reportBody*(conf: ConfigRef, r: Report): string =
     of repInternal: result = conf.reportBody(r.internalReport)
     of repBackend:  result = conf.reportBody(r.backendReport)
     of repExternal: result = conf.reportBody(r.externalReport)
+    of repVM:       result = conf.reportBody(r.vmReport)
 
 proc reportFull*(conf: ConfigRef, r: Report): string =
   ## Generate full version of the report (location, severity, body,
@@ -3573,6 +3616,7 @@ proc reportFull*(conf: ConfigRef, r: Report): string =
     of repInternal: result = conf.reportFull(r.internalReport)
     of repBackend:  result = conf.reportFull(r.backendReport)
     of repExternal: result = conf.reportFull(r.externalReport)
+    of repVM:       result = conf.reportFull(r.vmReport)
 
 proc reportShort*(conf: ConfigRef, r: Report): string =
   ## Generate short report version of the report
@@ -3586,6 +3630,7 @@ proc reportShort*(conf: ConfigRef, r: Report): string =
     of repInternal: result = conf.reportShort(r.internalReport)
     of repBackend:  result = conf.reportShort(r.backendReport)
     of repExternal: result = conf.reportShort(r.externalReport)
+    of repVM:       result = conf.reportShort(r.vmReport)
 
 const
   rdbgTracerKinds* = {rdbgTraceDefined .. rdbgTraceEnd}

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -665,7 +665,10 @@ func isEnabled*(conf: ConfigRef, report: ReportKind): bool =
           result = true
 
         of repTraceKinds:
-          result = true
+          # Semantic trace kinds are enabled by default and probably should
+          # not be changed - but these reports might (in theory) be
+          # modified at runtime.
+          result = report in conf.notes
 
         else:
           result = (report in conf.notes) and

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -146,6 +146,7 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
       "rsem": "Sem",
       "rpar": "Par",
       "rlex": "Lex",
+      "rvm": "VM",
       "rint": "Int",
       "rext": "Ext",
       "rdbg": "Dbg",
@@ -160,6 +161,7 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
       of repLexer:    s.addFields(r.lexReport, f)
       of repParser:   s.addFields(r.parserReport, f)
       of repCmd:      s.addFields(r.cmdReport, f)
+      of repVM:       s.addFields(r.vmReport, f)
       of repSem:
         if r.kind == rsemProcessingStmt:
           s.addFields(r.semReport, f & "node")

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -30,7 +30,10 @@ proc semTypeOf(c: PContext; n: PNode): PNode =
   if n.len == 3:
     let mode = semConstExpr(c, n[2])
     if mode.kind != nkIntLit:
-      localReport(c.config, n, reportSem rsemVmCannotEvaluateAtComptime)
+      localReport(c.config, VMReport(
+        kind: rvmCannotEvaluateAtComptime,
+        ast: n,
+        location: some(n.info)))
     else:
       m = mode.intVal
   result = newNodeI(nkTypeOfExpr, n.info)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1908,7 +1908,11 @@ proc semTypeOf2(c: PContext; n: PNode; prev: PType): PType =
   if n.len == 3:
     let mode = semConstExpr(c, n[2])
     if mode.kind != nkIntLit:
-      localReport(c.config, n, reportSem rsemVmCannotEvaluateAtComptime)
+      localReport(c.config, VMReport(
+        ast: n,
+        location: some(n.info),
+        kind: rvmCannotEvaluateAtComptime))
+
     else:
       m = mode.intVal
   

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -94,14 +94,14 @@ proc createStackTrace(
     sframe:     StackFrameIndex,
     pc:         int,
     recursionLimit: int = 100
-  ): SemReport =
+  ): VMReport =
   ## Generates a stack-trace report starting at frame `sframe` (inclusive).
   ## The amount of entries in the trace is limited to `recursionLimit`, further
   ## entries are skipped, though the entry function is always included in the
   ## trace
   assert c.sframes.len > 0
 
-  result = SemReport(kind: rsemVmStackTrace)
+  result = VMReport(kind: rvmStackTrace)
   # Just leave the exceptions empty, they aren't used anyways
   result.currentExceptionA = nil
   result.currentExceptionB = nil
@@ -183,7 +183,7 @@ func loadFromLoc(reg: var TFullReg, h: LocHandle) =
 proc toVmError(c: DerefFailureCode, inst: InstantiationInfo): ref VmError =
   ## Creates a `VmError` for the failure code
   new(result)
-  result.report = SemReport(
+  result.report = VMReport(
     kind: FailureCodeToReport[c],
     reportInst: toReportLineInfo(inst))
 
@@ -191,7 +191,7 @@ template toException(x: DerefFailureCode): untyped =
   ## `Result` -> exception translation
   toVmError(x, instLoc())
 
-func toException*(r: sink SemReport): ref VmError {.noinline.} =
+func toException*(r: sink VMReport): ref VmError {.noinline.} =
   ## Implements the `toException` interface for use with `Result`
   new(result)
   result.report = r
@@ -214,7 +214,7 @@ proc reportException(c: TCtx; sframe: StackFrameIndex, raised: LocHandle) =
                     empty, # unused
                     newStrNode(nkStrLit, name),
                     newStrNode(nkStrLit, msg))
-  raiseVmError(reportAst(rsemVmUnhandledException, ast))
+  raiseVmError(VMReport(kind: rvmUnhandledException, ast: ast))
 
 when not defined(nimComputedGoto):
   {.pragma: computedGoto.}
@@ -407,7 +407,10 @@ proc writeLoc(h: LocHandle, x: TFullReg, mm: var VmMemoryManager) =
   case x.kind
   of rkNone: unreachable() # This hints at a programming error somewhere
   of rkInt:
-    assert h.typ.kind == akInt
+    # FIXME assertion should only allow for the `akInt` type, but
+    # tests/vm/taccess_checks.nim fails when executed in debug build if
+    # `akPtr` is removed. This is a vmgen.nim bug acc. to @zerbina
+    assert h.typ.kind in {akInt, akPtr}, $h.typ.kind
     # Narrow/NarrowU made sure that the integer is in the  correct range
     writeInt(h.byteView(), x.intVal)
   of rkFloat:
@@ -734,7 +737,7 @@ template handleJmpBack() {.dirty.} =
     if allowInfiniteLoops in c.features:
       c.loopIterations = c.config.maxLoopIterationsVM
     else:
-      raiseVmError(reportSem(rsemVmTooManyIterations))
+      raiseVmError(VMReport(kind: rvmTooManyIterations))
 
   dec(c.loopIterations)
 
@@ -850,11 +853,11 @@ func raiseAccessViolation(
   let k =
     case reason
     of avrNoError: unreachable()
-    of avrOutOfBounds: rsemVmAccessOutOfBounds
-    of avrTypeMismatch: rsemVmAccessTypeMismatch
-    of avrNoLocation: rsemVmAccessNoLocation
+    of avrOutOfBounds: rvmAccessOutOfBounds
+    of avrTypeMismatch: rvmAccessTypeMismatch
+    of avrNoLocation: rvmAccessNoLocation
 
-  raiseVmError(SemReport(kind: k), inst)
+  raiseVmError(VMReport(kind: k), inst)
 
 template checkHandle(a: VmAllocator, re: TFullReg) =
   ## Tests if the handle in `re` is valid and raises an access violation error
@@ -947,15 +950,15 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
     ## a `VmError` if it doesn't
     if unlikely(not cond): # Treat input violations as unlikely
       # TODO: don't use a string message here; use proper reports
-      raiseVmError(reportStr(rsemVmErrInternal, msg))
+      raiseVmError(VMReport(kind: rvmErrInternal, str: msg))
 
   template checkHandle(re: TFullReg) =
     {.line.}:
       checkHandle(c.allocator, re)
 
-  proc reportVmIdx(usedIdx, maxIdx: SomeInteger): SemReport =
-    SemReport(
-      kind: rsemVmIndexError,
+  proc reportVmIdx(usedIdx, maxIdx: SomeInteger): VMReport =
+    VMReport(
+      kind: rvmIndexError,
       indexSpec: (
         usedIdx: toInt128(usedIdx),
         minIdx: toInt128(0),
@@ -1065,9 +1068,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         of rkAddress:
           intVal = cast[int](regs[rb].addrVal.rawPointer)
         else:
-          raiseVmError(reportStr(
-            rsemVmErrInternal,
-            "opcCastPtrToInt: got " & $regs[rb].kind))
+          raiseVmError(VMReport(
+            kind: rvmErrInternal,
+            str: "opcCastPtrToInt: got " & $regs[rb].kind))
 
       of 2: # tyRef
         case regs[rb].kind
@@ -1094,9 +1097,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         # vmgen abuses this opcode for ptr-to-ptr casting
         ptrVal = regs[rb].addrVal.rawPointer
       else:
-        raiseVmError(reportStr(
-          rsemVmErrInternal,
-          "opcCastIntToPtr: regs[rb].kind: " & $regs[rb].kind))
+        raiseVmError(VMReport(
+          kind: rvmErrInternal,
+          str: "opcCastIntToPtr: regs[rb].kind: " & $regs[rb].kind))
 
       regs[ra].setAddress(makeMemPtr(ptrVal, 0), nil)
     of opcAsgnComplex:
@@ -1390,9 +1393,10 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       of rkHandle:
         regs[ra].setAddress(regs[rb].handle.h, regs[rb].handle.typ)
       else:
-        raiseVmError(reportStr(
-          rsemVmErrInternal,
-          "limited VM support for 'addr', got kind: " & $regs[rb].kind))
+        raiseVmError(VMReport(
+          kind: rvmErrInternal,
+          str: "limited VM support for 'addr', got kind: " & $regs[rb].kind))
+
     of opcLdDeref:
       # a = b[]
       decodeB(rkHandle)
@@ -1407,7 +1411,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
           let p = makeMemPtr(r.addrVal.rawPointer, r.addrTyp.sizeInBytes)
           regs[ra].setHandle(makeLocHandle(p, r.addrTyp))
         else:
-          raiseVmError(reportSem(rsemVmNilAccess))
+          raiseVmError(VMReport(kind: rvmNilAccess))
 
       of rkRegAddr:
         # HACK: rkRegAddr is a hack
@@ -1422,9 +1426,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
 
         regs[ra].setHandle(h)
       else:
-        raiseVmError(reportStr(
-          rsemVmNilAccess,
-          " kind: " & $regs[rb].kind))
+        raiseVmError(VMReport(
+          kind: rvmNilAccess,
+          str: " kind: " & $regs[rb].kind))
 
     of opcWrDeref:
       # a[] = c; b unused
@@ -1451,7 +1455,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
             raiseAccessViolation(cr, instLoc(0))
 
         elif r.addrVal.isNil:
-          raiseVmError(reportSem(rsemVmNilAccess))
+          raiseVmError(VMReport(kind: rvmNilAccess))
 
       of rkRegAddr:
         # HACK: remove this once vmgen is adjusted
@@ -1469,9 +1473,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         writeLoc(h, regs[rc], c.memory)
 
       else:
-        raiseVmError(reportStr(
-          rsemVmErrInternal,
-          "opcWrDeref: regs[ra].kind: " & $r.kind))
+        raiseVmError(VMReport(
+          kind: rvmErrInternal,
+          str: "opcWrDeref: regs[ra].kind: " & $r.kind))
 
     of opcAddInt:
       decodeBC(rkInt)
@@ -1482,7 +1486,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       if (sum xor bVal) >= 0 or (sum xor cVal) >= 0:
         regs[ra].intVal = sum
       else:
-        raiseVmError(reportSem(rsemVmOverOrUnderflow))
+        raiseVmError(VMReport(kind: rvmOverOrUnderflow))
     of opcAddImmInt:
       decodeBImm(rkInt)
       #message(c.config, c.debug[pc], warnUser, "came here")
@@ -1494,7 +1498,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       if (sum xor bVal) >= 0 or (sum xor cVal) >= 0:
         regs[ra].intVal = sum
       else:
-        raiseVmError(reportSem(rsemVmOverOrUnderflow))
+        raiseVmError(VMReport(kind: rvmOverOrUnderflow))
     of opcSubInt:
       decodeBC(rkInt)
       let
@@ -1504,7 +1508,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       if (diff xor bVal) >= 0 or (diff xor not cVal) >= 0:
         regs[ra].intVal = diff
       else:
-        raiseVmError(reportSem(rsemVmOverOrUnderflow))
+        raiseVmError(VMReport(kind: rvmOverOrUnderflow))
     of opcSubImmInt:
       decodeBImm(rkInt)
       let
@@ -1514,7 +1518,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       if (diff xor bVal) >= 0 or (diff xor not cVal) >= 0:
         regs[ra].intVal = diff
       else:
-        raiseVmError(reportSem(rsemVmOverOrUnderflow))
+        raiseVmError(VMReport(kind: rvmOverOrUnderflow))
     of opcLenSeq:
       decodeBImm(rkInt)
       #assert regs[rb].kind == nkBracket
@@ -1585,16 +1589,16 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       elif 32.0 * abs(resAsFloat - floatProd) <= abs(floatProd):
         regs[ra].intVal = product
       else:
-        raiseVmError(reportSem(rsemVmOverOrUnderflow))
+        raiseVmError(VMReport(kind: rvmOverOrUnderflow))
     of opcDivInt:
       decodeBC(rkInt)
       if regs[rc].intVal == 0:
-        raiseVmError(reportSem(rsemVmDivisionByConstZero))
+        raiseVmError(VMReport(kind: rvmDivisionByConstZero))
       else: regs[ra].intVal = regs[rb].intVal div regs[rc].intVal
     of opcModInt:
       decodeBC(rkInt)
       if regs[rc].intVal == 0:
-        raiseVmError(reportSem(rsemVmDivisionByConstZero))
+        raiseVmError(VMReport(kind: rvmDivisionByConstZero))
       else:
         regs[ra].intVal = regs[rb].intVal mod regs[rc].intVal
     of opcAddFloat:
@@ -1743,7 +1747,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       if val != int64.low:
         regs[ra].intVal = -val
       else:
-        raiseVmError(reportSem(rsemVmOverOrUnderflow))
+        raiseVmError(VMReport(kind: rvmOverOrUnderflow))
     of opcUnaryMinusFloat:
       decodeB(rkFloat)
 
@@ -1898,7 +1902,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         regs[ra].nimNode = if a.sym.ast.isNil: newNode(nkNilLit)
                           else: copyTree(a.sym.ast)
       else:
-        raiseVmError(reportSem(rsemVmNodeNotASymbol))
+        raiseVmError(VMReport(kind: rvmNodeNotASymbol))
 
     of opcGetImplTransf:
       decodeB(rkNimNode)
@@ -1914,7 +1918,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
             ast[bodyPos] = transformBody(c.graph, c.idgen, a.sym, cache=true)
             ast.copyTree()
       else:
-        raiseVmError(reportSem(rsemVmNodeNotASymbol))
+        raiseVmError(VMReport(kind: rvmNodeNotASymbol))
 
     of opcExpandToAst:
       decodeBC(rkNimNode)
@@ -1951,7 +1955,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         regs[ra].nimNode = if a.sym.owner.isNil: newNode(nkNilLit)
                           else: newSymNode(a.sym.skipGenericOwner)
       else:
-        raiseVmError(reportSem(rsemVmNodeNotASymbol))
+        raiseVmError(VMReport(kind: rvmNodeNotASymbol))
     of opcSymIsInstantiationOf:
       decodeBC(rkInt)
       let a = regs[rb].nimNode
@@ -1962,7 +1966,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
           if sfFromGeneric in a.sym.flags and a.sym.owner == b.sym: 1
           else: 0
       else:
-        raiseVmError(reportSem(rsemVmNodeNotAProcSymbol))
+        raiseVmError(VMReport(kind: rvmNodeNotAProcSymbol))
 
     of opcEcho:
       # XXX: could be a candidate for turning into a callback
@@ -2048,9 +2052,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         # TODO: are range errors `Exception`s or `Defect`s in normal Nim? If
         #       they are `Exception`s we should raise a user catchable error
         #       here
-        raiseVmError(reportStr(
-          rsemVmIllegalConv,
-          errIllegalConvFromXtoY % [
+        raiseVmError(VMReport(
+          kind: rvmIllegalConv,
+          str: errIllegalConvFromXtoY % [
             regs[ra].toStr,
             "[" & regs[rb].toStr & ".." & regs[rc].toStr & "]"
           ]))
@@ -2115,7 +2119,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
           (default(VmFunctionPtr), false)
 
       if unlikely(fPtr.isNil):
-        raiseVmError(reportSem(rsemVmNilAccess))
+        raiseVmError(VMReport(kind: rvmNilAccess))
 
       let entry = c.functions[int toFuncIndex(fPtr)]
       assert entry.sig == h.typ.routineSig
@@ -2179,9 +2183,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
             else:
               # Since the closure env is protected from to the guest, it
               # should not be possible that it becomes invalid.
-              raiseVmError(reportStr(
-                rsemVmErrInternal,
-                "closure env is invalid"))
+              raiseVmError(VMReport(
+                kind: rvmErrInternal,
+                str: "closure env is invalid"))
 
           else:
             assert envPType == noneType # A programming error that should have
@@ -2489,7 +2493,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       let msg = $regs[ra].strVal
       let discr = $regs[instr.regB].strVal
       let msg2 = formatFieldDefect(msg, discr)
-      raiseVmError(reportStr(rsemVmFieldInavailable, msg2))
+      raiseVmError(VMReport(kind: rvmFieldInavailable, str: msg2))
     of opcSetLenStr:
       # a.setLen(b)
       let rb = instr.regB
@@ -2530,7 +2534,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       let min = -(1.BiggestInt shl (rb-1))
       let max = (1.BiggestInt shl (rb-1))-1
       if regs[ra].intVal < min or regs[ra].intVal > max:
-        raiseVmError(reportSem(rsemVmOutOfRange))
+        raiseVmError(VMReport(kind: rvmOutOfRange))
     of opcNarrowU:
       decodeB(rkInt)
       regs[ra].intVal = regs[ra].intVal and ((1'i64 shl rb)-1)
@@ -2607,7 +2611,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       # TODO: This if-else block should be reordered so as to match the
       #       expectation of occurence
       if src.kind in {nkEmpty..nkNilLit}:
-        raiseVmError(reportAst(rsemVmCannotGetChild, src))
+        raiseVmError(VMReport(kind: rvmCannotGetChild, ast: src))
       elif idx >=% src.len:
         raiseVmError(reportVmIdx(idx, src.len - 1))
       else:
@@ -2617,9 +2621,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       let idx = regs[rb].intVal.int
       var dest = regs[ra].nimNode
       if nfSem in dest.flags and allowSemcheckedAstModification notin c.config.legacyFeatures:
-        raiseVmError(reportSem(rsemVmCannotModifyTypechecked))
+        raiseVmError(VMReport(kind: rvmCannotModifyTypechecked))
       elif dest.kind in {nkEmpty..nkNilLit}:
-        raiseVmError(reportAst(rsemVmCannotSetChild, dest))
+        raiseVmError(VMReport(kind: rvmCannotSetChild, ast: dest))
       elif idx >=% dest.len:
         raiseVmError(reportVmIdx(idx, dest.len - 1))
       else:
@@ -2628,10 +2632,10 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       decodeBC(rkNimNode)
       var u = regs[rb].nimNode
       if nfSem in u.flags and allowSemcheckedAstModification notin c.config.legacyFeatures:
-        raiseVmError(reportSem(rsemVmCannotModifyTypechecked))
+        raiseVmError(VMReport(kind: rvmCannotModifyTypechecked))
       elif u.kind in {nkEmpty..nkNilLit}:
         echo c.config $ c.debug[pc]
-        raiseVmError(reportAst(rsemVmCannotAddChild, u))
+        raiseVmError(VMReport(kind: rvmCannotAddChild, ast: u))
       else:
         u.add(regs[rc].nimNode)
       regs[ra].nimNode = u
@@ -2645,9 +2649,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       let x = regs[rc].handle
       var u = regs[rb].nimNode
       if nfSem in u.flags and allowSemcheckedAstModification notin c.config.legacyFeatures:
-        raiseVmError(reportSem(rsemVmCannotModifyTypechecked))
+        raiseVmError(VMReport(kind: rvmCannotModifyTypechecked))
       elif u.kind in {nkEmpty..nkNilLit}:
-        raiseVmError(reportAst(rsemVmCannotAddChild, u))
+        raiseVmError(VMReport(kind: rvmCannotAddChild, ast: u))
       else:
         let L = arrayLen(x)
         for i in 0..<L:
@@ -2665,7 +2669,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       if a.kind == nkSym:
         regs[ra].intVal = ord(a.sym.kind)
       else:
-        raiseVmError(reportSem(rsemVmNodeNotASymbol))
+        raiseVmError(VMReport(kind: rvmNodeNotASymbol))
       c.comesFromHeuristic = a.info
 
     of opcNIntVal:
@@ -2676,13 +2680,13 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       elif a.kind == nkSym and a.sym.kind == skEnumField:
         regs[ra].intVal = a.sym.position
       else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "intVal"))
+        raiseVmError(VMReport(kind: rvmFieldNotFound, str: "intVal"))
     of opcNFloatVal:
       decodeB(rkFloat)
       let a = regs[rb].nimNode
       case a.kind
       of nkFloatLit..nkFloat64Lit: regs[ra].floatVal = a.floatVal
-      else: raiseVmError(reportStr(rsemVmFieldNotFound, "floatVal"))
+      else: raiseVmError(VMReport(kind: rvmFieldNotFound, str: "floatVal"))
     of opcNodeId:
       decodeB(rkInt)
       regs[ra].intVal = regs[rb].nimNode.id
@@ -2703,7 +2707,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         elif b.kind == nkSym and b.sym.typ != nil:
           regs[ra].nimNode = opMapTypeToAst(c.cache, b.sym.typ, c.debug[pc], c.idgen)
         else:
-          raiseVmError(reportSem(rsemVmNoType))
+          raiseVmError(VMReport(kind: rvmNoType))
       of 1:
         # typeKind opcode:
         ensureKind(rkInt)
@@ -2723,7 +2727,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         elif b.kind == nkSym and b.sym.typ != nil:
           regs[ra].nimNode = opMapTypeInstToAst(c.cache, b.sym.typ, c.debug[pc], c.idgen)
         else:
-          raiseVmError(reportSem(rsemVmNoType))
+          raiseVmError(VMReport(kind: rvmNoType))
       else:
         # getTypeImpl opcode:
         ensureKind(rkNimNode)
@@ -2732,26 +2736,26 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         elif b.kind == nkSym and b.sym.typ != nil:
           regs[ra].nimNode = opMapTypeImplToAst(c.cache, b.sym.typ, c.debug[pc], c.idgen)
         else:
-          raiseVmError(reportSem(rsemVmNoType))
+          raiseVmError(VMReport(kind: rvmNoType))
     of opcNGetSize:
       decodeBImm(rkInt)
       let n = regs[rb].nimNode
       case imm
       of 0: # size
         if n.typ == nil:
-          raiseVmError(reportAst(rsemVmNoType, n))
+          raiseVmError(VMReport(kind: rvmNoType, ast: n))
         else:
           regs[ra].intVal = getSize(c.config, n.typ)
       of 1: # align
         if n.typ == nil:
-          raiseVmError(reportAst(rsemVmNoType, n))
+          raiseVmError(VMReport(kind: rvmNoType, ast: n))
         else:
           regs[ra].intVal = getAlign(c.config, n.typ)
       else: # offset
         if n.kind != nkSym:
-          raiseVmError(reportAst(rsemVmNodeNotASymbol, n))
+          raiseVmError(VMReport(kind: rvmNodeNotASymbol, ast: n))
         elif n.sym.kind != skField:
-          raiseVmError(reportSym(rsemVmNotAField, n.sym))
+          raiseVmError(VMReport(kind: rvmNotAField, sym: n.sym))
         else:
           regs[ra].intVal = n.sym.offset
 
@@ -2768,14 +2772,15 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       of nkSym:
         regs[ra].strVal = a.sym.name.s
       else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "strVal"))
+        raiseVmError(VMReport(kind: rvmFieldNotFound, str: "strVal"))
 
     of opcNSigHash:
       decodeB(akString)
       if regs[rb].nimNode.kind == nkSym:
         regs[ra].strVal = $sigHash(regs[rb].nimNode.sym)
       else:
-        raiseVmError(reportAst(rsemVmNodeNotASymbol, regs[rb].nimNode))
+        raiseVmError(VMReport(
+          kind: rvmNodeNotASymbol, ast: regs[rb].nimNode))
 
     of opcSlurp:
       decodeB(akString)
@@ -2813,13 +2818,13 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       case instr.opcode:
         of opcNError:
           raiseVmError(
-            reportStr(rsemUserError, a), info)
+            VMReport(kind: rvmUserError, str: a), info)
 
         of opcNWarning:
-          localReport(c.config, info, reportStr(rsemUserWarning, a))
+          localReport(c.config, info, SemReport(kind: rsemUserWarning, str: a))
 
         of opcNHint:
-          localReport(c.config, info, reportStr(rsemUserHint, a))
+          localReport(c.config, info, SemReport(kind: rsemUserHint, str: a))
 
         else: discard
     of opcParseExprToAst, opcParseStmtToAst:
@@ -2882,7 +2887,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       # first checking for `parseExpr()` postconditions and then repacking
       # the ast as needed.
       elif ast.len != 1 and instr.opcode == opcParseExprToAst:
-        c.errorFlag = SemReport(kind: rsemVmOpcParseExpectedExpression).wrap()
+        c.errorFlag = SemReport(kind: rvmOpcParseExpectedExpression).wrap()
 
       elif instr.opcode == opcParseStmtToAst:
         regs[ra].nimNode = ast
@@ -2916,8 +2921,13 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
 
     of opcCallSite:
       ensureKind(rkNimNode)
-      if c.callsite != nil: regs[ra].nimNode = c.callsite
-      else: raiseVmError(reportStr(rsemVmFieldNotFound, "callsite"))
+      if c.callsite != nil:
+        regs[ra].nimNode = c.callsite
+
+      else:
+        raiseVmError(VMReport(
+          kind: rvmFieldNotFound, str: "callsite"))
+
     of opcNGetLineInfo:
       decodeBImm()
       let n = regs[rb].nimNode
@@ -3015,12 +3025,12 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       let dt = (desttyp.nimType, desttyp.internal)
       let st = (srctyp.nimType, srctyp.internal)
       if opConv(c, regs[ra], regs[rb], dt, st):
-        raiseVmError(reportStr(
-          rsemVmIllegalConv,
-          errIllegalConvFromXtoY % [
+        raiseVmError(VMReport(
+          kind: rvmIllegalConv,
+          str: errIllegalConvFromXtoY % [
             typeToString(srctyp.nimType),
             typeToString(desttyp.nimType)
-        ]))
+          ]))
     of opcCast:
       let rb = instr.regB
       inc pc
@@ -3032,7 +3042,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       # Since we're soon storing objects in a flat representation, doing the
       # cast in a safe manner becomes possible, but I'm unsure if this feature
       # is really needed, so an error is always reported here for now
-      raiseVmError(reportSem(rsemVmCannotCast))
+      raiseVmError(VMReport(kind: rvmCannotCast))
 
     of opcNSetIntVal:
       decodeB(rkNimNode)
@@ -3040,18 +3050,19 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       if dest.kind in {nkCharLit..nkUInt64Lit}:
         dest.intVal = regs[rb].intVal
       elif dest.kind == nkSym and dest.sym.kind == skEnumField:
-        raiseVmError(reportStr(
-          rsemVmErrInternal,
-          "`intVal` cannot be changed for an enum symbol."))
+        raiseVmError(VMReport(
+          kind: rvmErrInternal,
+          str: "`intVal` cannot be changed for an enum symbol."))
+
       else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "intVal"))
+        raiseVmError(VMReport(kind: rvmFieldNotFound, str: "intVal"))
     of opcNSetFloatVal:
       decodeB(rkNimNode)
       var dest = regs[ra].nimNode
       if dest.kind in {nkFloatLit..nkFloat64Lit}:
         dest.floatVal = regs[rb].floatVal
       else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "floatVal"))
+        raiseVmError(VMReport(kind: rvmFieldNotFound, str: "floatVal"))
     of opcNSetStrVal:
       decodeB(rkNimNode)
       checkHandle(regs[rb])
@@ -3062,7 +3073,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       elif dest.kind == nkCommentStmt:
         dest.comment = $regs[rb].strVal
       else:
-        raiseVmError(reportStr(rsemVmFieldNotFound, "strVal"))
+        raiseVmError(VMReport(kind: rvmFieldNotFound, str: "strVal"))
     of opcNNewNimNode:
       decodeBC(rkNimNode)
       var k = regs[rb].intVal
@@ -3185,8 +3196,9 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         g.cacheTables[destKey].add(key, val)
         recordPut(c, c.debug[pc], destKey, key, val)
       else:
-        raiseVmError(reportStr(
-          rsemVmCacheKeyAlreadyExists, destKey))
+        raiseVmError(VMReport(
+          kind: rvmCacheKeyAlreadyExists,
+          str: destKey))
 
     of opcNctLen:
       let g = c.graph
@@ -3207,9 +3219,13 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         if contains(g.cacheTables[destKey], key):
           regs[ra].nimNode = getOrDefault(g.cacheTables[destKey], key)
         else:
-          raiseVmError(reportStr(rsemVmMissingCacheKey, destKey))
+          raiseVmError(VMReport(
+            kind: rvmMissingCacheKey, str: destKey))
+
       else:
-        raiseVmError(reportStr(rsemVmMissingCacheKey, destKey))
+        raiseVmError(VMReport(
+          kind: rvmMissingCacheKey, str: destKey))
+
     of opcNctHasNext:
       let g = c.graph
       decodeBC(rkInt)
@@ -3237,7 +3253,8 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
         deref(handle.getFieldHandle(FieldIndex(1))).nodeVal = v
         writeInt(handle.getFieldHandle(FieldIndex(2)).byteView(), nextIndex)
       else:
-        raiseVmError(reportStr(rsemVmMissingCacheKey, destKey))
+        raiseVmError(VMReport(
+          kind: rvmMissingCacheKey, str: destKey))
 
     of opcTypeTrait:
       # XXX only supports 'name' for now; we can use regC to encode the
@@ -3245,7 +3262,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
       decodeB(akString)
       var typ = regs[rb].nimNode.typ
       if unlikely(typ != nil):
-        raiseVmError(reportSem(rsemVmNoType))
+        raiseVmError(VMReport(kind: rvmNoType))
       while typ.kind == tyTypeDesc and typ.len > 0: typ = typ[0]
       #createStr regs[ra]
       regs[ra].strVal = typ.typeToString(preferExported)
@@ -3256,8 +3273,8 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): RegisterInd
 
 type
   ExecErrorReport* = object
-    stackTrace*: SemReport ## The report storing the stack-trace
-    report*: SemReport     ## The report detailing the error
+    stackTrace*: VMReport ## The report storing the stack-trace
+    report*: VMReport     ## The report detailing the error
 
   ExecutionResult* = Result[PNode, ExecErrorReport]
 
@@ -3415,7 +3432,7 @@ proc execProc*(c: var TCtx; sym: PSym; args: openArray[PNode]): PNode =
       if result.isError:
         result = nil
   else:
-    localReport(c.config, sym.info, reportSym(rsemVmCallingNonRoutine, sym))
+    localReport(c.config, sym.info, reportSym(rvmCallingNonRoutine, sym))
 
 proc evalStmt(c: var TCtx, n: PNode): PNode =
   let n = transformExpr(c.graph, c.idgen, c.module, n)
@@ -3585,8 +3602,8 @@ proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph; templInstC
   # XXX globalReport() is ugly here, but I don't know a better solution for now
   inc(g.config.evalMacroCounter)
   if g.config.evalMacroCounter > evalMacroLimit:
-    globalReport(g.config, n.info, reportAst(
-      rsemMacroInstantiationTooNested, n))
+    globalReport(g.config, n.info, VMReport(
+      kind: rsemMacroInstantiationTooNested, ast: n))
 
   # immediate macros can bypass any type and arity checking so we check the
   # arity here too:
@@ -3650,7 +3667,8 @@ proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph; templInstC
   result = execute(c[], start, tos, cb).unpackResult(c.config, n)
 
   if result.kind != nkError and cyclicTree(result):
-    globalReport(c.config, n.info, reportAst(rsemCyclicTree, n, sym = sym))
+    globalReport(c.config, n.info, VMReport(
+      kind: rsemCyclicTree, ast: n, sym: sym))
 
   dec(g.config.evalMacroCounter)
   c.callsite = nil

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -80,7 +80,7 @@ proc deserializeRef*(c: TCtx, slot: HeapSlotHandle, vt: PVmType; f, con: PType, 
     else:
       result = c.config.newError(
         wrongNode(base),
-        SemReport(kind: rsemVmUnsupportedNonNil, typ: con))
+        SemReport(kind: rvmUnsupportedNonNil, typ: con))
 
   else:
     let e = r.takeErr()
@@ -288,7 +288,7 @@ proc deserialize(c: TCtx, m: VmMemoryRegion, vt: PVmType, formal, t: PType, info
     else:
       result = c.config.newError(
         wrongNode(),
-        SemReport(kind: rsemVmUnsupportedNonNil, typ: t))
+        SemReport(kind: rvmUnsupportedNonNil, typ: t))
   of tyRef:
     if t.sym == nil or t.sym.magic != mPNimrodNode:
       # TODO: cyclic references will lead to infinite recursion

--- a/compiler/vm/vmconv.nim
+++ b/compiler/vm/vmconv.nim
@@ -74,9 +74,9 @@ proc writeTo*[T](v: T, dest: LocHandle, mm: var VmMemoryManager) =
   if tryWriteTo(v, dest, mm):
     return
 
-  raiseVmError(reportStr(
-    rsemVmErrInternal,
-    "Writing to location failed: " & $T))
+  raiseVmError(VMReport(
+    kind: rvmErrInternal,
+    str: "Writing to location failed: " & $T))
 
 
 func tryReadTo*[T](src: LocHandle, dst: var set[T]): bool =
@@ -92,4 +92,6 @@ func readAs*[T](src: LocHandle, t: typedesc[T]): T =
   if tryReadTo(src, result):
     return
 
-  raiseVmError(reportStr(rsemVmErrInternal, "Reading from location failed"))
+  raiseVmError(VMReport(
+    kind: rvmErrInternal,
+    str: "Reading from location failed"))

--- a/compiler/vm/vmerrors.nim
+++ b/compiler/vm/vmerrors.nim
@@ -18,11 +18,11 @@ import
 
 
 type VmError* = object of CatchableError
-  report*: SemReport
+  report*: VMReport
 
 
 func raiseVmError*(
-  report: sink SemReport;
+  report: sink VMReport;
   inst:   InstantiationInfo = instLoc()
   ) {.noinline, noreturn.} =
   ## Raises a `VmError`. If the report has location information already,
@@ -33,7 +33,7 @@ func raiseVmError*(
 
 
 func raiseVmError*(
-  report:   sink SemReport;
+  report:   sink VMReport;
   location: TLineInfo,
   inst:     InstantiationInfo = instLoc()
   ) {.noinline, noreturn.} =

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -70,13 +70,13 @@ when defined(nimCompilerStacktraceHints):
   import std/stackframes
 
 type
-  VmGenResult* = Result[CodeInfo, SemReport] ## The result of a vmgen invocation
+  VmGenResult* = Result[CodeInfo, VMReport] ## The result of a vmgen invocation
 
   VmGenError = object of CatchableError
-    report: SemReport
+    report: VMReport
 
 func raiseVmGenError(
-  report: sink SemReport,
+  report: sink VMReport,
   loc:    TLineInfo,
   inst:   InstantiationInfo
   ) {.noinline, noreturn.} =
@@ -93,10 +93,9 @@ func fail(
   loc:  InstantiationInfo = instLoc()
   ) {.noinline, noreturn.} =
   raiseVmGenError(
-    SemReport(kind: kind, ast: ast, sym: sym, str: str),
+    VMReport(kind: kind, ast: ast, sym: sym, str: str),
     info,
     loc)
-
 
 template tryOrReturn(code): untyped =
   try:
@@ -323,7 +322,7 @@ proc getFreeRegister(cc: var TCtx; k: TSlotKind; start: int): TRegister =
         c.regInfo[i] = RegInfo(refCount: 1, kind: k)
         return TRegister(i)
   if c.regInfo.len >= high(TRegister):
-    fail(cc.bestEffort, rsemTooManyRegistersRequired)
+    fail(cc.bestEffort, rvmTooManyRegistersRequired)
 
   result = TRegister(max(c.regInfo.len, start))
   c.regInfo.setLen int(result)+1
@@ -418,13 +417,16 @@ proc getTempRange(cc: var TCtx; n: int; kind: TSlotKind): TRegister =
           for k in result..result+n-1: c.regInfo[k] = RegInfo(refCount: 1, kind: kind)
           return
   if c.regInfo.len+n >= high(TRegister):
-    fail(cc.bestEffort, rsemTooManyRegistersRequired)
+    fail(cc.bestEffort, rvmTooManyRegistersRequired)
+
   result = TRegister(c.regInfo.len)
   setLen c.regInfo, c.regInfo.len+n
-  for k in result..result+n-1: c.regInfo[k] = RegInfo(refCount: 1, kind: kind)
+  for k in result .. result + n - 1:
+    c.regInfo[k] = RegInfo(refCount: 1, kind: kind)
 
 proc freeTempRange(c: var TCtx; start: TRegister, n: int) =
-  for i in start..start+n-1: c.freeTemp(TRegister(i))
+  for i in start .. start + n - 1:
+    c.freeTemp(TRegister(i))
 
 template withTemp(tmp, typ, body: untyped) {.dirty.} =
   var tmp = getTemp(c, typ)
@@ -532,7 +534,7 @@ proc genBreak(c: var TCtx; n: PNode) =
       if c.prc.blocks[i].label == n[0].sym:
         c.prc.blocks[i].fixups.add lab1
         return
-    fail(n.info, rsemVmCannotFindBreakTarget)
+    fail(n.info, rvmCannotFindBreakTarget)
   else:
     c.prc.blocks[c.prc.blocks.high].fixups.add lab1
 
@@ -723,7 +725,7 @@ proc genBranchLit(c: var TCtx, n: PNode, t: PType): int =
 
 proc unused(c: TCtx; n: PNode; x: TDest) {.inline.} =
   if x >= 0:
-    fail(n.info, rsemVmNotUnused, n)
+    fail(n.info, rvmNotUnused, n)
 
 proc genCase(c: var TCtx; n: PNode; dest: var TDest) =
   #  if (!expr1) goto lab1;
@@ -945,11 +947,11 @@ proc needsAsgnPatch(n: PNode): bool =
 
 proc genField(c: TCtx; n: PNode): TRegister =
   if n.kind != nkSym or n.sym.kind != skField:
-    fail(n.info, rsemNotAFieldSymbol, ast = n)
+    fail(n.info, rvmNotAFieldSymbol, ast = n)
 
   let s = n.sym
   if s.position > high(typeof(result)):
-    fail(n.info, rsemVmTooLargetOffset, sym = s)
+    fail(n.info, rvmTooLargetOffset, sym = s)
 
   result = s.position
 
@@ -1008,7 +1010,7 @@ proc genAsgnPatch(c: var TCtx; le: PNode, value: TRegister) =
       c.freeTemp(dest)
   of nkError:
     # XXX: do a better job with error generation
-    fail(le.info, rsemVmCannotGenerateCode, le)
+    fail(le.info, rvmCannotGenerateCode, le)
 
   else:
     discard
@@ -1265,8 +1267,8 @@ proc genCastIntFloat(c: var TCtx; n: PNode; dest: var TDest) =
   else:
     # todo: support cast from tyInt to tyRef
     raiseVmGenError(
-      SemReport(
-        kind: rsemVmCannotCast,
+      VMReport(
+        kind: rvmCannotCast,
         typeMismatch: @[c.config.typeMismatch(
           actual = dst, formal = src)]),
       n.info,
@@ -1294,7 +1296,8 @@ proc genBindSym(c: var TCtx; n: PNode; dest: var TDest) =
       if dest.isUnset: dest = c.getTemp(n.typ)
       c.gABx(n, opcNBindSym, dest, idx)
     else:
-      localReport(c.config, n.info, reportAst(rsemVmInvalidBindSym, n))
+      localReport(c.config, n.info, VMReport(
+        kind: rvmInvalidBindSym, ast: n))
 
   else:
     # experimental bindSym
@@ -1767,7 +1770,7 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
     c.genCall(n, dest)
   of mExpandToAst:
     if n.len != 2:
-      fail(n.info, rsemVmBadExpandToAst,
+      fail(n.info, rvmBadExpandToAst,
         str = "expandToAst requires 1 argument")
 
     let arg = n[1]
@@ -1797,17 +1800,17 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
       # do not call clearDest(n, dest) here as getAst has a meta-type as such
       # produces a value
     else:
-      fail(n.info, rsemVmBadExpandToAst,
+      fail(n.info, rvmBadExpandToAst,
         str = "expandToAst requires a call expression")
 
   of mSizeOf:
-    fail(n.info, rsemMissingImportcCompleteStruct, str = "sizeof")
+    fail(n.info, rvmMissingImportcCompleteStruct, str = "sizeof")
 
   of mAlignOf:
-    fail(n.info, rsemMissingImportcCompleteStruct, str = "alignof")
+    fail(n.info, rvmMissingImportcCompleteStruct, str = "alignof")
 
   of mOffsetOf:
-    fail(n.info, rsemMissingImportcCompleteStruct, str = "offsetof")
+    fail(n.info, rvmMissingImportcCompleteStruct, str = "offsetof")
 
   of mRunnableExamples:
     discard "just ignore any call to runnableExamples"
@@ -1827,7 +1830,7 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
     c.genUnaryABC(n, dest, opcNodeId)
   else:
     # mGCref, mGCunref,
-    fail(n.info, rsemVmCannotGenerateCode, str = $m)
+    fail(n.info, rvmCannotGenerateCode, str = $m)
 
 
 proc unneededIndirection(n: PNode): bool =
@@ -1910,7 +1913,7 @@ func setSlot(c: var TCtx; v: PSym): TRegister {.discardable.} =
 
 func cannotEval(c: TCtx; n: PNode) {.noinline, noreturn.} =
   raiseVmGenError(
-    reportAst(rsemVmCannotEvaluateAtComptime, n),
+    VMReport(kind: rvmCannotEvaluateAtComptime, ast: n),
     n.info,
     instLoc())
 
@@ -2066,7 +2069,7 @@ proc genAsgn(c: var TCtx; le, ri: PNode; requiresCopy: bool) =
   case le.kind
   of nkError:
     # XXX: do a better job with error generation
-    fail(le.info, rsemVmCannotGenerateCode, le)
+    fail(le.info, rvmCannotGenerateCode, le)
 
   of nkBracketExpr:
     let typ = le[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind
@@ -2146,7 +2149,7 @@ proc genRdVar(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
     if importcCondVar(s) or c.importcCond(s):
       # Using importc'ed symbols on the left or right side of an expression is
       # not allowed
-      fail(n.info, rsemVmCannotImportc, sym = s)
+      fail(n.info, rvmCannotImportc, sym = s)
 
     var pos: int
     if s.id in c.symToIndexTbl:
@@ -2522,7 +2525,7 @@ proc genObjConstr(c: var TCtx, n: PNode, dest: var TDest) =
                           dest, idx, tmp)
       c.freeTemp(tmp)
     else:
-      fail(n.info, rsemVmInvalidObjectConstructor, it)
+      fail(n.info, rvmInvalidObjectConstructor, it)
 
   if t.kind == tyRef:
     swap(refTemp, dest)
@@ -2568,7 +2571,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
   case n.kind
   of nkError:
     # XXX: do a better job with error generation
-    fail(n.info, rsemVmCannotGenerateCode, n)
+    fail(n.info, rvmCannotGenerateCode, n)
 
   of nkSym:
     let s = n.sym
@@ -2579,9 +2582,9 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
 
     of skProc, skFunc, skConverter, skMacro, skMethod, skIterator:
       if s.kind == skIterator and s.typ.callConv == TCallingConvention.ccClosure:
-        fail(n.info, rsemVmNoClosureIterators, sym = s)
+        fail(n.info, rvmNoClosureIterators, sym = s)
       if importcCond(c, s) and lookup(c.callbackKeys, s) == -1:
-        fail(n.info, rsemVmCannotImportc, sym = s)
+        fail(n.info, rvmCannotImportc, sym = s)
 
       genProcLit(c, n, s, dest)
     of skTemplate:
@@ -2617,14 +2620,14 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
         genRdVar(c, n, dest, flags)
       else:
         fail(n.info,
-          rsemVmCannotGenerateCode,
+          rvmCannotGenerateCode,
           sym = s,
           str = "Attempt to generate VM code for generic parameter in non-macro proc"
         )
 
     else:
       fail(n.info,
-        rsemVmCannotGenerateCode,
+        rvmCannotGenerateCode,
         sym = s,
         str = "Unexpected symbol for VM code - " & $s.kind
       )
@@ -2634,7 +2637,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       if s.magic != mNone:
         genMagic(c, n, dest, s.magic)
       elif s.kind == skMethod:
-        localReport(c.config, n.info, reportSym(rsemVmCannotCallMethod, s))
+        localReport(c.config, n.info, VMReport(kind: rvmCannotCallMethod, sym: s))
       else:
         genCall(c, n, dest)
         clearDest(c, n, dest)
@@ -2745,9 +2748,9 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
     if n.typ != nil and n.typ.isCompileTimeOnly:
       genTypeLit(c, n.typ, dest)
     else:
-      fail(n.info, rsemVmCannotGenerateCode, n)
+      fail(n.info, rvmCannotGenerateCode, n)
 
-proc genStmt*(c: var TCtx; n: PNode): Result[void, SemReport] =
+proc genStmt*(c: var TCtx; n: PNode): Result[void, VMReport] =
   var d: TDest = -1
   try:
     c.gen(n, d)

--- a/compiler/vm/vmmemory.nim
+++ b/compiler/vm/vmmemory.nim
@@ -27,10 +27,10 @@ type DerefFailureCode* = enum
   dfcTypeMismatch ## ref's type is not compatible with the target's type
 
 const FailureCodeToReport* = [
-  dfcNil:          rsemVmNilAccess,
-  dfcInvalid:      rsemVmAccessOutOfBounds,
-  dfcFreed:        rsemVmAccessOutOfBounds,
-  dfcTypeMismatch: rsemVmAccessTypeMismatch
+  dfcNil:          rvmNilAccess,
+  dfcInvalid:      rvmAccessOutOfBounds,
+  dfcFreed:        rvmAccessOutOfBounds,
+  dfcTypeMismatch: rvmAccessTypeMismatch
 ]
 
 # TODO: rename to `allocUntypedMemory`

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -310,8 +310,8 @@ proc registerBasicOps*(c: var TCtx) =
 
     if ePos >= seqVal.length:
       raiseVmError(
-        SemReport(
-          kind: rsemVmIndexError,
+        VMReport(
+          kind: rvmIndexError,
           indexSpec: (
             usedIdx: toInt128(ePos),
             minIdx: toInt128(0),
@@ -437,16 +437,18 @@ proc registerMacroOps*(c: var TCtx) =
   registerCallback c, "stdlib.macros.symBodyHash", proc (a: VmArgs) =
     let n = getNode(a, 0)
     if n.kind != nkSym:
-      raiseVmError(reportAst(
-        rsemVmNodeNotASymbol, n, str = "symBodyHash()"), n.info)
+      raiseVmError(VMReport(
+        kind: rvmNodeNotASymbol,
+        ast: n,
+        str: "symBodyHash()"), n.info)
 
     setResult(a, $symBodyDigest(graph, n.sym))
 
   registerCallback c, "stdlib.macros.isExported", proc(a: VmArgs) =
     let n = getNode(a, 0)
     if n.kind != nkSym:
-      raiseVmError(reportAst(
-        rsemVmNodeNotASymbol, n, str = "isExported()"), n.info)
+      raiseVmError(VMReport(
+        kind: rvmNodeNotASymbol, ast: n, str: "isExported()"), n.info)
 
     setResult(a, sfExported in n.sym.flags)
 

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -116,7 +116,7 @@ proc reportHook(conf: ConfigRef, report: Report): TErrorHandling =
   case report.category
   of repCmd, repDebug, repInternal, repExternal:
     myLog(conf, $report)
-  of repParser, repLexer, repSem:
+  of repParser, repLexer, repSem, repVM:
     if report.category == repSem and
        report.kind in {rsemProcessing, rsemProcessingStmt}:
       # skip processing statements

--- a/tests/vm/taccess_checks.nim
+++ b/tests/vm/taccess_checks.nim
@@ -25,66 +25,67 @@ template access(origTyp, asTyp: type; expr) =
 static:
   var p: ptr int = nil
   discard p[] #[tt.Error
-          ^ (SemVmNilAccess) ]#
+          ^ (VMNilAccess) ]#
 
 static:
   let x = localPtr(string)
   let v = x[] #[tt.Error
-          ^ (SemVmAccessOutOfBounds) ]#
+          ^ (VMAccessOutOfBounds) ]#
 
 static:
   let p = cast[ptr int](1)
   let v = p[] #[tt.Error
-          ^ (SemVmAccessOutOfBounds) ]#
+          ^ (VMAccessOutOfBounds) ]#
+
 
 
 access(uint32, int32): p[] #[tt.Error
-                       ^ (SemVmAccessTypeMismatch) ]#
+                       ^ (VMAccessTypeMismatch) ]#
 
 access(int64, uint64): p[] #[tt.Error
-                       ^ (SemVmAccessTypeMismatch) ]#
+                       ^ (VMAccessTypeMismatch) ]#
 
 access(float, int): p[] #[tt.Error
-                    ^ (SemVmAccessTypeMismatch) ]#
+                    ^ (VMAccessTypeMismatch) ]#
 
 access(char, int): p[] #[tt.Error
-                   ^ (SemVmAccessTypeMismatch) ]#
+                   ^ (VMAccessTypeMismatch) ]#
 
 access(ObjectA, ObjectB): p[] #[tt.Error
-                          ^ (SemVmAccessTypeMismatch) ]#
+                          ^ (VMAccessTypeMismatch) ]#
 
 static:
   var x: int32
   cast[ptr byte](cast[int](addr x) + 1)[] = 1 #[tt.Error
-                                      ^ (SemVmAccessNoLocation) ]#
+                                      ^ (VMAccessNoLocation) ]#
 
 objectTest((int32, int)): # unnamed tuple overlay
   let v = p[][1] #[tt.Error
-            ^ (SemVmAccessTypeMismatch) ]#
+            ^ (VMAccessTypeMismatch) ]#
 
 
 objectTest(tuple[x: int32, y: int]): # named tuple overlay
   let v = p.y #[tt.Error
-          ^ (SemVmAccessTypeMismatch) ]#
+          ^ (VMAccessTypeMismatch) ]#
 
 objectTest(array[4, int32]):
   let v = p[][1] #[tt.Error
-            ^ (SemVmAccessTypeMismatch) ]#
+            ^ (VMAccessTypeMismatch) ]#
 
 
 static:
   var o = Object(b: true)
   let p = cast[ptr tuple[x: bool, y: int]](addr o.b)
   let v = p.y #[tt.Error
-          ^ (SemVmAccessNoLocation) ]#
+          ^ (VMAccessNoLocation) ]#
 
 static:
   var s = newSeq[int](4)
   let p = cast[ptr array[5, int]](addr s[0])
-  # XXX: should report a `SemVmAccessOutOfBounds` but actually reports a
-  #      `SemVmAccessTypeMismatch`. See `tsafety_checks_issues2`
+  # XXX: should report a `VMAccessOutOfBounds` but actually reports a
+  #      `VMAccessTypeMismatch`. See `tsafety_checks_issues2`
   let v = p[][5] #[tt.Error
-            ^ (SemVmAccessTypeMismatch) ]#
+            ^ (VMAccessTypeMismatch) ]#
 
 # TODO: the tests using `testSource` might violate the parameter aliasing
 #       rules, but there's currently no other way to force an invalid source
@@ -107,16 +108,16 @@ proc testSource(x: var seq[string], y: ptr string, m: range[0..2]) =
   of 0:
     # writing to object field
     o.v = y[] #[tt.Error
-    ^ (SemVmAccessOutOfBounds) ]#
+    ^ (VMAccessOutOfBounds) ]#
   of 1:
     # writing through pointer
     var p = addr o.v
     p[] = y[] #[tt.Error
-    ^ (SemVmAccessOutOfBounds) ]#
+    ^ (VMAccessOutOfBounds) ]#
   of 2:
     # writing to array
     o.arr[0] = y[] #[tt.Error
-        ^ (SemVmAccessOutOfBounds) ]#
+        ^ (VMAccessOutOfBounds) ]#
 
 static:
   var s = newSeq[string](1)

--- a/tests/vm/taccess_checks_issues.nim
+++ b/tests/vm/taccess_checks_issues.nim
@@ -26,31 +26,31 @@ template testLocal(t, code) =
     wrapper()
 
 testLocal(int): discard p[] #[tt.Error
-                        ^ (SemVmAccessOutOfBounds)]#
+                        ^ (VMAccessOutOfBounds)]#
 
 testLocal(int): p[] = 1 #[tt.Error
-                ^ (SemVmAccessOutOfBounds)]#
+                ^ (VMAccessOutOfBounds)]#
 
 testLocal(float): discard p[] #[tt.Error
-                          ^ (SemVmAccessOutOfBounds)]#
+                          ^ (VMAccessOutOfBounds)]#
 
 testLocal(float): p[] = 1.0 #[tt.Error
-                  ^ (SemVmAccessOutOfBounds)]#
+                  ^ (VMAccessOutOfBounds)]#
 
 testLocal(ptr int): discard p[] #[tt.Error
-                            ^ (SemVmAccessOutOfBounds)]#
+                            ^ (VMAccessOutOfBounds)]#
 
 testLocal(ptr int): p[] = nil #[tt.Error
-                    ^ (SemVmAccessOutOfBounds)]#
+                    ^ (VMAccessOutOfBounds)]#
 
 testLocal(pointer): discard p[] #[tt.Error
-                            ^ (SemVmAccessOutOfBounds)]#
+                            ^ (VMAccessOutOfBounds)]#
 
 testLocal(pointer): p[] = nil #[tt.Error
-                    ^ (SemVmAccessOutOfBounds)]#
+                    ^ (VMAccessOutOfBounds)]#
 
 testLocal(NimNode): discard p[] #[tt.Error
-                            ^ (SemVmAccessOutOfBounds)]#
+                            ^ (VMAccessOutOfBounds)]#
 
 testLocal(NimNode): p[] = newEmptyNode() #[tt.Error
-                    ^ (SemVmAccessOutOfBounds)]#
+                    ^ (VMAccessOutOfBounds)]#


### PR DESCRIPTION
Long overdue refactoring, no intentional functionality changes, only cleanup for the reporting system implementation. Add the `VMReport` report object, new "VM" category and split mixed semantic analysis report kinds into more manageable chunks.


