### PR TITLE
Internals: nkError branch in TNode 

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -798,7 +798,6 @@ type
     typ*: PType
     info*: TLineInfo
     flags*: TNodeFlags
-    reportId*:  ReportId
     case kind*: TNodeKind
     of nkCharLit..nkUInt64Lit:
       intVal*: BiggestInt
@@ -812,6 +811,9 @@ type
       ident*: PIdent
     of nkEmpty, nkNone:
       discard
+    of nkError:
+      reportId*: ReportId
+      kids*: TNodeSeq
     else:
       sons*: TNodeSeq
 

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -1643,7 +1643,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
     if renderWithoutErrorPrefix notin g.flags:
       putWithSpace(g, tkSymbol, "error")
     #gcomma(g, n, c)
-    gsub(g, n[0], c)
+    gsub(g, n.kids[0], c)
   else:
     #nkNone, nkExplicitTypeListCall:
     g.config.localReport InternalReport(

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -16,7 +16,15 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode]): bool =
   if n == nil: return
   for v in visited:
     if v == n: return true
-  if not (n.kind in {nkEmpty..nkNilLit}):
+  case n.kind
+  of nkEmpty..nkNilLit:
+    discard
+  of nkError:
+    visited.add(n)
+    for kid in n.kids:
+      if cyclicTreeAux(kid, visited): return true
+    discard visited.pop()
+  else:
     visited.add(n)
     for nSon in n.sons:
       if cyclicTreeAux(nSon, visited): return true

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -121,6 +121,9 @@ proc sexp*(node: PNode): SexpNode =
     of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)
     of nkSym:                     result.add newSSymbol(node.sym.name.s)
     of nkIdent:                   result.add newSSymbol(node.ident.s)
+    of nkError:
+      for node in node.kids:
+        result.add sexp(node)
     else:
       for node in node.sons:
         result.add sexp(node)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1806,7 +1806,7 @@ proc pragmaRec(c: PContext, sym: PSym, n: PNode, validPragmas: TSpecialWords;
 
     if p.isErrorLike:
       assert not cyclicTree(result)
-      if p.isError and p[0] == result:
+      if p.isError and p.kids[0] == result:
         # This can happen because processPush for example may
         # return the whole pragma node wrapped in an error.
         # We don't want to accidently create a cycle in that case.

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -516,8 +516,12 @@ include hlo, seminst, semcall
 proc resetSemFlag(n: PNode) =
   if n != nil:
     excl n.flags, nfSem
-    for i in 0..<n.safeLen:
-      resetSemFlag(n[i])
+    case n.kind
+    of nkError:
+      discard
+    else:
+      for i in 0..<n.safeLen:
+        resetSemFlag(n[i])
 
 proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
                        s: PSym, flags: TExprFlags): PNode =

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -792,13 +792,17 @@ proc getGenSym*(c: PContext; s: PSym): PSym =
 proc considerGenSyms*(c: PContext; n: PNode) =
   if n == nil:
     discard "can happen for nkFormalParams/nkArgList"
-  elif n.kind == nkSym:
-    let s = getGenSym(c, n.sym)
-    if n.sym != s:
-      n.sym = s
   else:
-    for i in 0..<n.safeLen:
-      considerGenSyms(c, n[i])
+    case n.kind
+    of nkSym:
+      let s = getGenSym(c, n.sym)
+      if n.sym != s:
+        n.sym = s
+    of nkError:
+      discard
+    else:
+      for i in 0..<n.safeLen:
+        considerGenSyms(c, n[i])
 
 proc newOptionEntry*(conf: ConfigRef): POptionEntry =
   new(result)

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -824,6 +824,8 @@ proc hasUnresolvedArgs(c: PContext, n: PNode): bool =
       return isUnresolvedSym(sym)
     else:
       return false
+  of nkError:
+    return false
   else:
     for i in 0..<n.safeLen:
       if hasUnresolvedArgs(c, n[i]): return true

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -189,8 +189,11 @@ proc instGenericContainer(c: PContext, info: TLineInfo, header: PType,
   closeScope(c)
 
 proc referencesAnotherParam(n: PNode, p: PSym): bool =
-  if n.kind == nkSym:
+  case n.kind
+  of nkSym:
     return n.sym.kind == skParam and n.sym.owner == p
+  of nkError:
+    return false
   else:
     for i in 0..<n.safeLen:
       if referencesAnotherParam(n[i], p): return true

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -3373,12 +3373,12 @@ proc reportIfError(config: ConfigRef, n: PNode) =
   ## `nkError`
   if n.isError:
     # Errors from direct vmgen invocations don't have a stack-trace
-    if n.len == 4 and n[3].kind == nkIntLit:
+    if n.kids.len == 4 and n.kids[3].kind == nkIntLit:
       # XXX: testing for the presence of a stack-trace report like this is
       #      not a good idea. Error node layout might change, making the test
       #      invalid. VM errors should get their own report object with the
       #      stack-trace embedded as part of it.
-      config.handleReport(n[3].intVal.ReportId, instLoc(-1)) # stack-trace
+      config.handleReport(n.kids[3].intVal.ReportId, instLoc(-1)) # stack-trace
     config.localReport(n)
 
 


### PR DESCRIPTION
## Summary
`nkError` has a dedicate branch in `TNode`

## Details
- `reportId` is now in the branch
- nkError has a `kids` node sequences instead of `sons`

The separation of the sequence requires some direct access to `kids`.
This surfaced compiler bugs where traversals went into error nodes.

Next we can replace `reportId` the report and remove gc/memory pressure.

---

## Notes for Reviewers
* getting a weird VM Runner error, not sure how it's happening, tips?
* will rebase after CI is passing
* will handle `reportId` change separately