### PR TITLE
vm: properly handle `quit` in const/standalone mode

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -289,6 +289,7 @@ type
     rvmNoType
     rvmNotAField
     rvmUnsupportedNonNil
+    rvmQuit
 
     rvmTooManyIterations
 

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -420,6 +420,9 @@ type
       of rvmIndexError:
         indexSpec*: tuple[usedIdx, minIdx, maxIdx: Int128]
 
+      of rvmQuit:
+        exitCode*: BiggestInt
+
       else:
         discard
 

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3543,6 +3543,9 @@ proc reportBody*(conf: ConfigRef, r: VMReport): string =
       else:
         result = "index " & $i & " not in " & $a & " .. " & $b
 
+    of rvmQuit:
+      result = "`quit` called with exit-code: " & $r.exitCode
+
 
 proc reportFull*(conf: ConfigRef, r: VMReport): string =
   assertKind r

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -10,7 +10,8 @@ import
 
   compiler/ast/[
     ast_types,
-    ast
+    ast,
+    report_enums
   ],
   compiler/front/[
     cli_reporter,
@@ -264,10 +265,15 @@ proc main*(args: seq[string]): int =
     result = r.unsafeGet.intVal.int
   else:
     let err = r.takeErr
-    # an uncaught error occurred
-    c.config.localReport(err.stackTrace)
-    c.config.localReport(err.report)
-    result = 1
+    case err.report.kind
+    of rvmQuit:
+      # abnormal exit via ``quit``
+      result = err.report.exitCode.int
+    else:
+      # an uncaught error occurred
+      c.config.localReport(err.stackTrace)
+      c.config.localReport(err.report)
+      result = 1
 
 when isMainModule:
   programResult = main(commandLineParams())

--- a/tests/stdlib/tquit_exitcode.nim
+++ b/tests/stdlib/tquit_exitcode.nim
@@ -1,0 +1,11 @@
+discard """
+  description: "The program must exit with the code passed to `quit`"
+  output: "quit called"
+  exitcode: 1
+
+  targets: "c cpp vm js"
+"""
+
+quit("quit called", 1)
+
+doAssert false # must not be reached

--- a/tests/vm/tconst_quit.nim
+++ b/tests/vm/tconst_quit.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    Calling `quit` when inside the computation of a const value is an
+    error.
+  '''
+
+  target: native
+  action: reject
+  errormsg: "`quit` called with exit-code: 2"
+"""
+
+proc compute(): int =
+  quit(2)
+
+const Value = compute()


### PR DESCRIPTION
## Summary
The previous behaviour of `opcQuit` was to abort the execution loop
without any clean-up (and without reporting the user-provided
exit-code). Since this looked like a normal exit to the caller of
`rawExecute`, the VM was left in an invalid state, causing an internal
compiler error when `quit` was called in the context of a `const`
evaluation.

When being run in `emConst` or `emStandalone` mode, `opcQuit` now
performs an abnormal exit by raising an error that also stores the
exit-code.

---

@saem reported the issue [here](https://github.com/nim-works/nimskull/pull/440#issuecomment-1250479840) .