### PR TITLE
arc: fix code-gen error when copying pure sub-objects

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1390,4 +1390,12 @@ proc isCharArrayPtr*(t: PType; allowPointerToChar: bool): bool =
       discard
 
 proc lacksMTypeField*(typ: PType): bool {.inline.} =
+  ## Tests if `typ` has a type field *itself* . Doesn't consider base types
   (typ.sym != nil and sfPure in typ.sym.flags) or tfFinal in typ.flags
+
+proc isObjLackingTypeField*(typ: PType): bool {.inline.} =
+  ## Tests if `typ` has no type field (header). The only types that store a
+  ## type header are non-final ``object`` types where the inheritance root
+  ## is not marked as ``.pure`` (the ``sfPure`` flags is not present on it)
+  result = (typ.kind == tyObject) and ((tfFinal in typ.flags) and
+      (typ[0] == nil) or isPureObject(typ))

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -211,10 +211,6 @@ proc isImportedCppType(t: PType): bool =
 
 proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet; kind: TSymKind): Rope
 
-proc isObjLackingTypeField(typ: PType): bool {.inline.} =
-  result = (typ.kind == tyObject) and ((tfFinal in typ.flags) and
-      (typ[0] == nil) or isPureObject(typ))
-
 proc isInvalidReturnType(conf: ConfigRef; rettype: PType): bool =
   # Arrays and sets cannot be returned by a C procedure, because C is
   # such a poor programming language.

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -1001,7 +1001,8 @@ proc produceSym(g: ModuleGraph; c: PContext; typ: PType; kind: TTypeAttachedOp;
       fillStrOp(a, typ, result.ast[bodyPos], d, src)
     else:
       fillBody(a, typ, result.ast[bodyPos], d, src)
-      if tk == tyObject and a.kind in {attachedAsgn, attachedSink, attachedDeepCopy} and not lacksMTypeField(typ):
+      if tk == tyObject and a.kind in {attachedAsgn, attachedSink, attachedDeepCopy} and
+         not isObjLackingTypeField(typ):
         # bug #19205: Do not forget to also copy the hidden type field:
         genTypeFieldCopy(a, typ, result.ast[bodyPos], d, src)
 

--- a/tests/assign/tassign.nim
+++ b/tests/assign/tassign.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "; --gc:arc"
   output:
 '''
 TEMP=C:\Programs\xyz\bin
@@ -216,3 +217,21 @@ block tgeneric_assign_varargs:
     stdout.write('\n')
 
   fatal "abc", "123"
+
+block assign_pure_subobject:
+
+  type
+    PureBase {.pure, inheritable.} = object
+    PureSub = object of PureBase
+      # for this test, it's important that ``PureSub`` is not annotated with
+      # ``.pure`` itself
+      r: ref int
+      # the type of `r`doesn't matter as long as it makes ``PureSub`` require
+      # a complex assignment (either via a lifted ``=copy`` hook or via
+      # ``genericAssign``)
+
+  var x = PureSub(r: new int)
+  var y = x
+  doAssert x.r != nil # prevent a sink for the assignment by using `x`
+                      # afterwards
+  doAssert y.r != nil


### PR DESCRIPTION
## Summary
To decide whether a type-field copy is needed, `liftdestructors` used `lackMTypeField` which doesn't consider base types, thus erroneously generating a type-field copy for sub-object types not annotated as `.pure` where the root is `.pure`. This then caused an error at the C compilation stage.

`liftdestructors` now uses the same procedure (`isObjLackingTypeField`) as is used by `cgen` to detect the presence of a type header.

## Details
* move `isObjLackingTypeField` from `ccgtypes` to `types` and document it