### PR TITLE
Internals: Lexer and Nimconf Output and Reporting

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -11,13 +11,13 @@
 
 import
   compiler/ast/[
-    lineinfos, # Positional information
-    idents,    # Ast identifiers
-    ast_types, # Main ast type definitions
-    ast_idgen, # Per module Id generation
-    ast_query, # querying/reading the ast
+    lineinfos,        # Positional information
+    idents,           # Ast identifiers
+    ast_types,        # Main ast type definitions
+    ast_idgen,        # Per module Id generation
+    ast_query,        # querying/reading the ast
     ast_parsed_types, # Data types for the parsed node
-    lexer, # NumericalBase
+    numericbase       # NumericalBase
   ],
   compiler/front/[
     options

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -3,7 +3,8 @@
 import
   compiler/ast/[
     ast_types, # For the node kinds
-    lexer # For the token type definition
+    lexer,     # For the token type definition
+    lineinfos  # For TLineInfo
   ]
 
 # NOTE further refactoring considerations for the parser:

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1,3 +1,4 @@
+import compiler/ast/lineinfos
 import compiler/utils/ropes
 import std/[hashes]
 
@@ -5,21 +6,6 @@ from compiler/front/in_options import TOption, TOptions # Stored in `PSym`
 
 const maxInstantiation* = 100
   ## maximum number of nested generic instantiations or macro pragma expansions
-
-type
-  FileIndex* = distinct int32
-  TLineInfo* = object          ## This is designed to be as small as
-    ## possible, because it is used in syntax nodes. We save space here by
-    ## using two int16 and an int32. On 64 bit and on 32 bit systems this
-    ## is only 8 bytes.
-
-    line*: uint16
-    col*: int16
-    fileIndex*: FileIndex
-
-const
-  InvalidFileIdx* = FileIndex(-1)
-  unknownLineInfo* = TLineInfo(line: 0, col: -1, fileIndex: InvalidFileIdx)
 
 type
   TCallingConvention* = enum

--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -22,11 +22,11 @@ import
     pathutils,
   ],
   compiler/ast/[
+    numericbase,
     wordrecg,
     nimlexbase,
     llstream,
     lineinfos,
-    reports,
     idents
   ],
   std/[
@@ -35,8 +35,7 @@ import
     strutils
   ],
   compiler/front/[
-    options,
-    msgs
+    options
   ]
 
 const
@@ -52,7 +51,7 @@ const
 
 type
   TokType* = enum
-    tkInvalid = "tkInvalid", tkEof = "[EOF]", # order is important here!
+    tkInvalid = "tkInvalid", tkError = "tkError", tkEof = "[EOF]", # order is important here!
     tkSymbol = "tkSymbol", # keywords:
     tkAddr = "addr", tkAnd = "and", tkAs = "as", tkAsm = "asm",
     tkBind = "bind", tkBlock = "block", tkBreak = "break", tkCase = "case", tkCast = "cast",
@@ -96,6 +95,69 @@ type
 
   TokTypes* = set[TokType]
 
+  LexerDiagKind* = enum
+    # internal errors begin
+    lexDiagInternalError ## lexer programming error
+    # internal errors end
+    
+    # users errors begin
+
+    # spacing
+    lexDiagMalformedUnderscores
+    lexDiagMalformedTrailingUnderscre
+    lexDiagInvalidToken
+    lexDiagNoTabs
+
+    # numbers
+    lexDiagInvalidIntegerPrefix
+    lexDiagInvalidIntegerSuffix
+    lexDiagNumberNotInRange
+    lexDiagExpectedHex
+    lexDiagInvalidIntegerLiteral
+
+    # char
+    lexDiagInvalidCharLiteral
+    lexDiagMissingClosingApostrophe
+    lexDiagInvalidUnicodeCodepoint
+    # xxx: differentiate between invalid codepoint empty vs out of range, but
+    #      still be treated within the invalidUnicodeCodepoint "family"
+
+    # string
+    lexDiagUnclosedTripleString
+    lexDiagUnclosedSingleString
+
+    # comments
+    lexDiagUnclosedComment
+
+    # user errors end
+
+    # warnings begin
+    lexDiagDeprecatedOctalPrefix = "OctalEscape"
+    # warnings end
+
+    # linting hints begin
+    lexDiagLineTooLong = "LineTooLong"
+    lexDiagNameXShouldBeY = "Name"
+    # linting hints end
+
+  LexerDiag* = object
+    ## `Diag`nostic data from the Lexer, mostly errors
+    msg*: string
+    location*: TLineInfo        ## diagnostic location
+    instLoc*: InstantiationInfo ## instantiation in lexer's source
+    case kind*: LexerDiagKind:
+    of lexDiagNameXShouldBeY:
+      wanted*: string
+      got*: string
+    else:
+      discard
+
+const
+  LexDiagsFatal*   = {lexDiagInternalError}
+  LexDiagsError*   = {lexDiagMalformedUnderscores..lexDiagUnclosedComment}
+  LexDiagsWarning* = {lexDiagDeprecatedOctalPrefix}
+  LexDiagsHint*    = {lexDiagLineTooLong..lexDiagNameXShouldBeY}
+
 when defined(nimsuggest):
   const weakTokens = {tkComma, tkSemiColon, tkColon,
                       tkParRi, tkParDotRi, tkBracketRi, tkBracketDotRi,
@@ -106,12 +168,8 @@ const
   tokKeywordLow* = succ(tkSymbol)
   tokKeywordHigh* = pred(tkIntLit)
 
-type
-  NumericalBase* = enum
-    base10,                   ## base10 is listed as the first element,
-                              ## so that it is the correct default value
-    base2, base8, base16
 
+type
   Token* = object             ## a Nim token
     tokType*: TokType         ## the type of the token
     indent*: int              ## the indentation; != -1 if the token has been
@@ -126,6 +184,13 @@ type
     literal*: string          ## the parsed (string) literal; and
                               ## documentation comments are here too
     line*, col*: int
+    error*: LexerDiag         ## error diagnostic if `tokType` is `tkError`
+
+  LexerError = object of ValueError
+    ## internal error used to signal the lexer can no longer proceed given the
+    ## input and has aborted
+    diagId: int      ## index into `Lexer.diags`, used to fetch the diag and
+                     ## insert into the error token
 
   Lexer* = object of TBaseLexer
     fileIdx*: FileIndex
@@ -138,6 +203,22 @@ type
     when defined(nimsuggest):
       previousToken: TLineInfo
     config*: ConfigRef
+    diags: seq[LexerDiag]
+
+func diagOffset*(L: Lexer): int {.inline.} =
+  ## return value represents a point in time where all existing diagnostics are
+  ## considered in the past, used in conjunction with `errorsHintsAndWarnings`
+  L.diags.len
+
+iterator errorsHintsAndWarnings*(L: Lexer, diagOffset = 0): LexerDiag =
+  ## iterate over all diagnostics (excluding fatal) from the beginning, or from
+  ## the point in time specificed via `diagOffset`
+  for d in L.diags.toOpenArray(diagOffset, L.diags.high):
+    case d.kind
+    of LexDiagsFatal:
+      continue         # fatals are reported via tkError
+    else:
+      yield d
 
 proc getLineInfo*(L: Lexer, tok: Token): TLineInfo {.inline.} =
   result = newLineInfo(L.fileIdx, tok.line, tok.col)
@@ -170,6 +251,7 @@ proc `$`*(tok: Token): string =
   of tkFloatLit..tkFloat64Lit: $tok.fNumber
   of tkInvalid, tkStrLit..tkCharLit, tkComment: tok.literal
   of tkParLe..tkColon, tkEof, tkAccent: $tok.tokType
+  of tkError: tok.error.msg
   else:
     if tok.ident != nil:
       tok.ident.s
@@ -223,9 +305,10 @@ proc openLexer*(lex: var Lexer, filename: AbsoluteFile, inputstream: PLLStream;
 proc closeLexer*(lex: var Lexer) =
   if lex.config != nil:
     inc(lex.config.linesCompiled, lex.lineNumber)
+  lex.diags.setLen(0)
   closeBaseLexer(lex)
 
-proc getLineInfo(L: Lexer): TLineInfo =
+proc getLineInfo*(L: Lexer): TLineInfo =
   result = newLineInfo(L.fileIdx, L.lineNumber, getColNumber(L, L.bufpos))
 
 proc matchTwoChars(L: Lexer, first: char, second: set[char]): bool =
@@ -272,17 +355,70 @@ template eatChar(L: var Lexer, t: var Token) =
   t.literal.add(L.buf[L.bufpos])
   inc(L.bufpos)
 
-template localReport*(L: Lexer, report: ReportTypes): untyped =
-  L.config.handleReport(wrap(report, instLoc(), getLineInfo(L)), instLoc())
 
-template localReportTok*(L: Lexer, report: ReportTypes, tok: Token): untyped =
-  L.config.handleReport(wrap(
-    report, instLoc(), newLineInfo(L.fileIdx, tok.line, tok.col)), instLoc())
+func handleDiag(L: var Lexer, diag: LexerDiagKind, instLoc = instLoc(-1)) =
+  doAssert diag notin {lexDiagNameXShouldBeY}
+  L.diags.add LexerDiag(
+                location: L.getLineInfo, 
+                instLoc: instLoc,
+                kind: diag
+              )
 
-template localReportPos*(L: Lexer, report: ReportTypes, pos: int): untyped =
-  L.config.handleReport(wrap(
-    report, instLoc(), newLineInfo(
-      L.fileIdx, L.lineNumber, pos - L.lineStart)), instLoc())
+func handleDiag(L: var Lexer,
+                diag: LexerDiagKind, 
+                message: string, 
+                instLoc = instLoc(-1)) =
+  doAssert diag notin {lexDiagNameXShouldBeY}
+  L.diags.add LexerDiag(
+                msg: message, 
+                location: L.getLineInfo, 
+                instLoc: instLoc, 
+                kind: diag
+              )
+
+func handleDiagPos(L: var Lexer,
+                   diag: LexerDiagKind,
+                   pos: int,
+                   instLoc = instLoc(-1)) =
+  L.diags.add LexerDiag(
+                msg: "",
+                location: newLineInfo(L.fileIdx,
+                                      L.lineNumber,
+                                      pos - L.lineStart),
+                instLoc: instLoc,
+                kind: diag
+              )
+
+func diagLineTooLong(L: var Lexer, pos: int, instLoc = instLoc(-1)) =
+  L.diags.add LexerDiag(
+                msg: "",
+                location: newLineInfo(L.fileIdx,
+                                      L.lineNumber,
+                                      pos - L.lineStart),
+                instLoc: instLoc,
+                kind: lexDiagLineTooLong
+              )
+
+func diagLintName(L: var Lexer,
+                  wantedName, gotName: string,
+                  instLoc = instLoc(-1)) =
+  L.diags.add LexerDiag(
+                location: L.getLineInfo, 
+                instLoc: instLoc, 
+                kind: lexDiagNameXShouldBeY, 
+                wanted: wantedName,
+                got: gotName
+              )
+
+func internalError(L: var Lexer, message: string, instLoc = instLoc(-1)) =
+  ## Causes an internal error
+  L.diags.add LexerDiag(
+                msg: message,
+                location: L.getLineInfo,
+                instLoc: instLoc,
+                kind: lexDiagInternalError
+              )
+  raise (ref LexerError)(diagId: L.diags.high)
 
 
 proc getNumber(L: var Lexer, result: var Token) =
@@ -298,7 +434,7 @@ proc getNumber(L: var Lexer, result: var Token) =
         break
       if L.buf[pos] == '_':
         if L.buf[pos+1] notin chars:
-          L.localReport(LexerReport(kind: rlexMalformedUnderscores))
+          L.handleDiag(lexDiagMalformedUnderscores)
           break
         tok.literal.add('_')
         inc(pos)
@@ -311,10 +447,11 @@ proc getNumber(L: var Lexer, result: var Token) =
       inc(pos)
     L.bufpos = pos
 
-  proc lexMessageLitNum(L: var Lexer, msg: string, startpos: int, msgKind: LexerReportKind) =
+  proc lexMessageLitNum(L: var Lexer, msg: string, startpos: int, msgKind: LexerDiagKind) =
     # Used to get slightly human friendlier err messages.
     const literalishChars = {'A'..'Z', 'a'..'z', '0'..'9', '_', '.', '\''}
-    var msgPos = L.bufpos
+    # preserve the old pos so we can restore it later
+    let msgPos = L.bufpos 
     var t: Token
     t.literal = ""
     L.bufpos = startpos # Use L.bufpos as pos because of matchChars
@@ -329,8 +466,9 @@ proc getNumber(L: var Lexer, result: var Token) =
       t.literal.add(L.buf[L.bufpos])
       inc(L.bufpos)
       matchChars(L, t, {'0'..'9'})
+    # restore the old pos
     L.bufpos = msgPos
-    L.localReport(LexerReport(kind: msgKind, msg: msg % t.literal))
+    L.handleDiag(msgKind, msg % t.literal)
 
   var
     xi: BiggestInt
@@ -362,7 +500,7 @@ proc getNumber(L: var Lexer, result: var Token) =
     case L.buf[L.bufpos]
     of 'O':
       lexMessageLitNum(L, "$1 is an invalid int literal; For octal literals " &
-                          "use the '0o' prefix.", startpos, rlexInvalidIntegerPrefix)
+                          "use the '0o' prefix.", startpos, lexDiagInvalidIntegerPrefix)
     of 'x', 'X':
       eatChar(L, result, 'x')
       numDigits = matchUnderscoreChars(L, result, {'0'..'9', 'a'..'f', 'A'..'F'})
@@ -373,9 +511,9 @@ proc getNumber(L: var Lexer, result: var Token) =
       eatChar(L, result, 'b')
       numDigits = matchUnderscoreChars(L, result, {'0'..'1'})
     else:
-      L.config.internalError(getLineInfo(L), rintIce, "getNumber")
+      L.internalError("getNumber")
     if numDigits == 0:
-      lexMessageLitNum(L, "invalid number: '$1'", startpos, rlexInvalidIntegerLiteral)
+      lexMessageLitNum(L, "invalid number: '$1'", startpos, lexDiagInvalidIntegerLiteral)
   else:
     discard matchUnderscoreChars(L, result, {'0'..'9'})
     if (L.buf[L.bufpos] == '.') and (L.buf[L.bufpos + 1] in {'0'..'9'}):
@@ -428,14 +566,14 @@ proc getNumber(L: var Lexer, result: var Token) =
         result.literal.add suffix
         result.tokType = tkCustomLit
       else:
-        lexMessageLitNum(L, "invalid number suffix: '$1'", errPos, rlexInvalidIntegerSuffix)
+        lexMessageLitNum(L, "invalid number suffix: '$1'", errPos, lexDiagInvalidIntegerSuffix)
     else:
-      lexMessageLitNum(L, "invalid number suffix: '$1'", errPos, rlexInvalidIntegerSuffix)
+      lexMessageLitNum(L, "invalid number suffix: '$1'", errPos, lexDiagInvalidIntegerSuffix)
 
   # Is there still a literalish char awaiting? Then it's an error!
   if  L.buf[postPos] in literalishChars or
      (L.buf[postPos] == '.' and L.buf[postPos + 1] in {'0'..'9'}):
-    lexMessageLitNum(L, "invalid number: '$1'", startpos, rlexInvalidIntegerLiteral)
+    lexMessageLitNum(L, "invalid number: '$1'", startpos, lexDiagInvalidIntegerLiteral)
 
   if result.tokType != tkCustomLit:
     # Third stage, extract actual number
@@ -477,7 +615,7 @@ proc getNumber(L: var Lexer, result: var Token) =
             else:
               break
         else:
-          L.config.internalError(getLineInfo(L), rintIce, "getNumber")
+          L.internalError("getNumber")
 
         case result.tokType
         of tkIntLit, tkInt64Lit: setNumber result.iNumber, xi
@@ -494,9 +632,8 @@ proc getNumber(L: var Lexer, result: var Token) =
           # XXX: Test this on big endian machine!
         of tkFloat64Lit, tkFloatLit:
           setNumber result.fNumber, (cast[PFloat64](addr(xi)))[]
-
         else:
-          L.config.internalError(getLineInfo(L), rintIce, "getNumber")
+          L.internalError("getNumber")
 
         # Bounds checks. Non decimal literals are allowed to overflow the range of
         # the datatype as long as their pattern don't overflow _bitwise_, hence
@@ -514,7 +651,7 @@ proc getNumber(L: var Lexer, result: var Token) =
           if outOfRange:
             #echo "out of range num: ", result.iNumber, " vs ", xi
             lexMessageLitNum(
-              L, "number out of range: '$1'", startpos, rlexNumberNotInRange)
+              L, "number out of range: '$1'", startpos, lexDiagNumberNotInRange)
 
       else:
         case result.tokType
@@ -553,7 +690,7 @@ proc getNumber(L: var Lexer, result: var Token) =
           else: false
 
         if outOfRange:
-          lexMessageLitNum(L, "number out of range: '$1'", startpos, rlexNumberNotInRange)
+          lexMessageLitNum(L, "number out of range: '$1'", startpos, lexDiagNumberNotInRange)
 
       # Promote int literal to int64? Not always necessary, but more consistent
       if result.tokType == tkIntLit:
@@ -561,18 +698,17 @@ proc getNumber(L: var Lexer, result: var Token) =
           result.tokType = tkInt64Lit
 
     except ValueError:
-      lexMessageLitNum(L, "invalid number: '$1'", startpos, rlexInvalidIntegerLiteral)
+      lexMessageLitNum(L, "invalid number: '$1'", startpos, lexDiagInvalidIntegerLiteral)
     except OverflowDefect, RangeDefect:
-      lexMessageLitNum(L, "number out of range: '$1'", startpos, rlexNumberNotInRange)
+      lexMessageLitNum(L, "number out of range: '$1'", startpos, lexDiagNumberNotInRange)
   tokenEnd(result, postPos-1)
   L.bufpos = postPos
 
 proc handleHexChar(L: var Lexer, xi: var int; position: range[0..4]) =
   template invalid() =
-    L.localReport(LexerReport(
-      kind: rlexExpectedHex,
-      msg: "expected a hex digit, but found: " & L.buf[L.bufpos] &
-        "; maybe prepend with 0"))
+    L.handleDiag(lexDiagExpectedHex,
+                 "expected a hex digit, but found: " & L.buf[L.bufpos] &
+                 "; maybe prepend with 0")
 
   case L.buf[L.bufpos]
   of '0'..'9':
@@ -644,10 +780,8 @@ proc getEscapedChar(L: var Lexer, tok: var Token) =
     inc(L.bufpos)
   of 'p', 'P':
     if tok.tokType == tkCharLit:
-      L.localReport(LexerReport(
-        kind: rlexInvalidCharLiteral,
-        msg: "\\p not allowed in character literal"))
-
+      L.handleDiag(lexDiagInvalidCharLiteral,
+                   "\\p not allowed in character literal")
     tok.literal.add(L.config.target.tnl)
     inc(L.bufpos)
   of 'r', 'R', 'c', 'C':
@@ -688,26 +822,20 @@ proc getEscapedChar(L: var Lexer, tok: var Token) =
     tok.literal.add(chr(xi))
   of 'u', 'U':
     if tok.tokType == tkCharLit:
-      L.localReport(LexerReport(
-        kind: rlexInvalidCharLiteral,
-        msg: "\\u not allowed in character literal"))
+      L.handleDiag(lexDiagInvalidCharLiteral, "\\u not allowed in character literal")
     inc(L.bufpos)
     var xi = 0
     if L.buf[L.bufpos] == '{':
       inc(L.bufpos)
-      var start = L.bufpos
+      let start = L.bufpos
       while L.buf[L.bufpos] != '}':
         handleHexChar(L, xi, 0)
       if start == L.bufpos:
-        L.localReport(LexerReport(
-          kind: rlexInvalidUnicodeCodepoint,
-          msg: "Unicode codepoint cannot be empty"))
+        L.handleDiag(lexDiagInvalidUnicodeCodepoint, "Unicode codepoint cannot be empty")
       inc(L.bufpos)
       if xi > 0x10FFFF:
-        let hex = ($L.buf)[start..L.bufpos-2]
-        L.localReport(LexerReport(
-          kind: rlexInvalidUnicodeCodepoint,
-          msg: "Unicode codepoint must be lower than 0x10FFFF, but was: " & hex))
+        let hex = ($L.buf)[start..L.bufpos-1]
+        L.handleDiag(lexDiagInvalidUnicodeCodepoint, "Unicode codepoint must be lower than 0x10FFFF, but was: " & hex)
     else:
       handleHexChar(L, xi, 1)
       handleHexChar(L, xi, 2)
@@ -716,21 +844,20 @@ proc getEscapedChar(L: var Lexer, tok: var Token) =
     addUnicodeCodePoint(tok.literal, xi)
   of '0'..'9':
     if matchTwoChars(L, '0', {'0'..'9'}):
-      L.localReport(LexerReport(kind: rlexDeprecatedOctalPrefix))
+      L.handleDiag(lexDiagDeprecatedOctalPrefix)
     var xi = 0
     handleDecChars(L, xi)
     if (xi <= 255):
       tok.literal.add(chr(xi))
     else:
-      L.localReport(LexerReport(kind: rlexInvalidCharLiteral))
+      L.handleDiag(lexDiagInvalidCharLiteral)
   else:
-    L.localReport(LexerReport(kind: rlexInvalidCharLiteral))
+      L.handleDiag(lexDiagInvalidCharLiteral)
 
 proc handleCRLF(L: var Lexer, pos: int): int =
   template registerLine =
     if L.getColNumber(pos) > MaxLineLength:
-      L.localReportPos(
-        LexerReport(kind: rlexLineTooLong), pos)
+      L.diagLineTooLong(pos)
 
   case L.buf[pos]
   of CR:
@@ -779,8 +906,7 @@ proc getString(L: var Lexer, tok: var Token, mode: StringMode) =
         tokenEndIgnore(tok, pos)
         var line2 = L.lineNumber
         L.lineNumber = line
-        L.localReportPos(LexerReport(
-          kind: rlexUnclosedTripleString), L.lineStart)
+        L.handleDiagPos(lexDiagUnclosedTripleString, L.lineStart)
         L.lineNumber = line2
         L.bufpos = pos
         break
@@ -803,7 +929,7 @@ proc getString(L: var Lexer, tok: var Token, mode: StringMode) =
           break
       elif c in {CR, LF, nimlexbase.EndOfFile}:
         tokenEndIgnore(tok, pos)
-        L.localReport LexerReport(kind: rlexUnclosedSingleString)
+        L.handleDiag(lexDiagUnclosedSingleString)
         break
       elif (c == '\\') and mode == normal:
         L.bufpos = pos
@@ -821,7 +947,7 @@ proc getCharacter(L: var Lexer; tok: var Token) =
   var c = L.buf[L.bufpos]
   case c
   of '\0'..pred(' '), '\'':
-    L.localReport LexerReport(kind: rlexInvalidCharLiteral)
+    L.handleDiag(lexDiagInvalidCharLiteral)
     tok.literal = $c
   of '\\': getEscapedChar(L, tok)
   else:
@@ -835,7 +961,7 @@ proc getCharacter(L: var Lexer; tok: var Token) =
       tok.literal = "'"
       L.bufpos = startPos+1
     else:
-      L.localReport LexerReport(kind: rlexMissingClosingApostrophe)
+      L.handleDiag(lexDiagMissingClosingApostrophe)
     tokenEndIgnore(tok, L.bufpos)
 
 const
@@ -899,7 +1025,7 @@ proc getSymbol(L: var Lexer, tok: var Token) =
       suspicious = true
     of '_':
       if L.buf[pos+1] notin SymChars:
-        L.localReport LexerReport(kind: rlexMalformedTrailingUnderscre)
+        L.handleDiag(lexDiagMalformedTrailingUnderscre)
         break
       inc(pos)
       suspicious = true
@@ -921,10 +1047,7 @@ proc getSymbol(L: var Lexer, tok: var Token) =
   else:
     tok.tokType = TokType(tok.ident.id + ord(tkSymbol))
     if suspicious and {optStyleHint, optStyleError} * L.config.globalOptions != {}:
-      L.localReport LexerReport(
-        kind: rlexLinterReport,
-        wanted: tok.ident.s.normalize,
-        got: tok.ident.s)
+      L.diagLintName(tok.ident.s.normalize, tok.ident.s)
   L.bufpos = pos
 
 
@@ -1079,9 +1202,7 @@ proc skipMultiLineComment(L: var Lexer; tok: var Token; start: int;
           dec c
     of nimlexbase.EndOfFile:
       tokenEndIgnore(tok, pos)
-      L.localReportPos(
-        LexerReport(kind: rlexUnclosedComment), pos)
-
+      L.handleDiagPos(lexDiagUnclosedComment, pos)
       break
     else:
       if isDoc: tok.literal.add L.buf[pos]
@@ -1153,9 +1274,7 @@ proc skip(L: var Lexer, tok: var Token) =
       inc(tok.strongSpaceA)
     of '\t':
       if not L.allowTabs:
-        L.localReportPos(
-          LexerReport(kind: rlexNoTabs), pos)
-
+        L.handleDiagPos(lexDiagNoTabs, pos)
       inc(pos)
     of CR, LF:
       tokenEndPrevious(tok, pos)
@@ -1193,7 +1312,7 @@ proc skip(L: var Lexer, tok: var Token) =
   tokenEndPrevious(tok, pos-1)
   L.bufpos = pos
 
-proc rawGetTok*(L: var Lexer, tok: var Token) =
+proc rawGetTokInner(L: var Lexer, tok: var Token) =
   template atTokenEnd() {.dirty.} =
     when defined(nimsuggest):
       # we attach the cursor to the last *strong* token
@@ -1311,9 +1430,9 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
       else:
         tok.literal = $c
         tok.tokType = tkInvalid
-        L.localReport LexerReport(
-          kind: rlexInvalidToken,
-          msg: "invalid token: " & c & " (\\" & $(ord(c)) & ')')
+        L.handleDiag(
+          lexDiagInvalidToken,
+          "invalid token: " & c & " (\\" & $(ord(c)) & ')')
     of '\"':
       # check for generalized raw string literal:
       let mode = if L.bufpos > 0 and L.buf[L.bufpos-1] in SymChars: generalized else: normal
@@ -1334,9 +1453,9 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
             unicodeOprLen(L.buf, L.bufpos)[0] != 0:
           discard
         else:
-          L.localReport LexerReport(
-            kind: rlexInvalidToken,
-            msg: "invalid token: no whitespace between number and identifier")
+          L.handleDiag(
+            lexDiagInvalidToken,
+            "invalid token: no whitespace between number and identifier")
     of '-':
       if L.buf[L.bufpos+1] in {'0'..'9'} and
           (L.bufpos-1 == 0 or L.buf[L.bufpos-1] in UnaryMinusWhitelist):
@@ -1351,9 +1470,9 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
               unicodeOprLen(L.buf, L.bufpos)[0] != 0:
             discard
           else:
-            L.localReport LexerReport(
-              kind: rlexInvalidToken,
-              msg: "invalid token: no whitespace between number and identifier")
+            L.handleDiag(
+              lexDiagInvalidToken,
+              "invalid token: no whitespace between number and identifier")
       else:
         getOperator(L, tok)
     else:
@@ -1365,11 +1484,17 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
       else:
         tok.literal = $c
         tok.tokType = tkInvalid
-        L.localReport LexerReport(
-          kind: rlexInvalidToken,
-          msg: "invalid token: " & c & " (\\" & $(ord(c)) & ')')
+        L.handleDiag(
+          lexDiagInvalidToken,
+          "invalid token: " & c & " (\\" & $(ord(c)) & ')')
         inc(L.bufpos)
   atTokenEnd()
+
+proc rawGetTok*(L: var Lexer, tok: var Token) =
+  try:
+    rawGetTokInner(L, tok)
+  except LexerError as e:
+    tok = Token(tokType: tkError, error: L.diags[e.diagId])
 
 proc getIndentWidth*(fileIdx: FileIndex, inputstream: PLLStream;
                      cache: IdentCache; config: ConfigRef): int =

--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -11,154 +11,57 @@
 ## ``TLineInfo`` object.
 
 import
-  std/[tables, hashes],
+  std/hashes,
   compiler/utils/[ropes, pathutils]
 
-from ast_types import
-  PSym,     # Contextual details of the instantnation stack optionally refer to
-            # the used symbol
-  TLineInfo,
-  FileIndex # Forward-declared to avoid cyclic dependencies
+type
+  FileIndex* = distinct int32
 
-export FileIndex, TLineInfo
+  TLineInfo* = object          ## This is designed to be as small as
+    ## possible, because it is used in syntax nodes. We save space here by
+    ## using two int16 and an int32. On 64 bit and on 32 bit systems this
+    ## is only 8 bytes.
 
-import reports
+    line*: uint16
+    col*: int16
+    fileIndex*: FileIndex
+
+const
+  InvalidFileIdx* = FileIndex(-1)
+  unknownLineInfo* = TLineInfo(line: 0, col: -1, fileIndex: InvalidFileIdx)
+  trackPosInvalidFileIdx* = FileIndex(-2) ## special marker so that no
+  ## suggestions are produced within comments and string literals
+  commandLineIdx* = FileIndex(-3)
+
+proc newLineInfo*(fileInfoIdx: FileIndex, line, col: int): TLineInfo =
+  result.fileIndex = fileInfoIdx
+  if line < int high(uint16):
+    result.line = uint16(line)
+  else:
+    result.line = high(uint16)
+  if col < int high(int16):
+    result.col = int16(col)
+  else:
+    result.col = -1
+
+proc `==`*(a, b: FileIndex): bool {.borrow.}
+
+proc hash*(i: TLineInfo): Hash =
+  hash (i.line.int, i.col.int, i.fileIndex.int)
+
+func isKnown*(info: TLineInfo): bool =
+  ## Check if `info` represents valid source file location
+  info != unknownLineInfo
+
 
 type
-  CompilerVerbosity* = enum
-    ## verbosity of the compiler, number is used as an array index and the
-    ## string matches what's passed on the CLI.
-    compVerbosityMin = (0, "0")
-    compVerbosityDefault = (1, "1")
-    compVerbosityHigh = (2, "2")
-    compVerbosityMax = (3, "3")
+  InstantiationInfo* = typeof(instantiationInfo())
 
-const
-  explanationsBaseUrl* = "https://nim-lang.github.io/Nim"
-    # was: "https://nim-lang.org/docs" but we're now usually showing devel docs
-    # instead of latest release docs.
-
-proc createDocLink*(urlSuffix: string): string =
-  # os.`/` is not appropriate for urls.
-  result = explanationsBaseUrl
-  if urlSuffix.len > 0 and urlSuffix[0] == '/':
-    result.add urlSuffix
-  else:
-    result.add "/" & urlSuffix
-
-proc computeNotesVerbosity(): tuple[
-    main: array[CompilerVerbosity, ReportKinds],
-    foreign: ReportKinds,
-    base: ReportKinds
-  ] =
-  ## Create configuration sets for the default compilation report verbosity
-
-  # Mandatory reports - cannot be turned off, present in all verbosity
-  # settings
-  result.base = (repErrorKinds + repInternalKinds)
-
-
-  # Somewhat awkward handing - stack trace report cannot be error (because
-  # actual error report must follow), so it is a hint-level report (can't
-  # be debug because it is a user-facing, can't be "trace" because it is
-  # not for compiler developers use only)
-  result.base.incl {rvmStackTrace}
-
-  when defined(debugOptions):
-    # debug report for transition of the configuration options
-    result.base.incl {rdbgOptionsPush, rdbgOptionsPop}
-
-  when defined(nimVMDebugExecute):
-    result.base.incl {
-      rdbgVmExecTraceFull # execution of the generated code listings
-    }
-
-  when defined(nimVMDebugGenerate):
-    result.base.incl {
-      rdbgVmCodeListing    # immediately generated code listings
-    }
-
-  when defined(nimDebugUtils):
-    # By default enable only semantic debug trace reports - other changes
-    # might be put in there *temporarily* to aid the debugging.
-    result.base.incl repDebugTraceKinds
-
-  result.main[compVerbosityMax] =
-    result.base + repWarningKinds + repHintKinds - {
-    rsemObservableStores,
-    rsemResultUsed,
-    rsemAnyEnumConvert,
-    rbackLinking,
-
-    rbackLinking,
-    rbackCompiling,
-    rcmdLinking,
-    rcmdCompiling,
-
-    rintErrKind
-  }
-
-  if defined(release):
-    result.main[compVerbosityMax].excl rintStackTrace
-
-  result.main[compVerbosityHigh] = result.main[compVerbosityMax] - {
-    rsemUninit,
-    rsemExtendedContext,
-    rsemProcessingStmt,
-    rsemWarnGcUnsafe,
-    rextConf,
-  }
-
-  result.main[compVerbosityDefault] = result.main[compVerbosityHigh] -
-    repPerformanceHints -
-    {
-      rsemProveField,
-      rsemErrGcUnsafe,
-      rsemHintLibDependency,
-      rsemGlobalVar,
-
-      rintGCStats,
-      rintMsgOrigin,
-
-      rextPath,
-
-      rlexSourceCodeFilterOutput,
-    }
-
-  result.main[compVerbosityMin] = result.main[compVerbosityDefault] - {
-    rintSuccessX,
-    rextConf,
-    rsemProcessing,
-    rsemPattern,
-    rcmdExecuting,
-    rbackLinking,
-  }
-
-  result.foreign = result.base + {
-    rsemProcessing,
-    rsemUserHint,
-    rsemUserWarning,
-    rsemUserHint,
-    rsemUserWarning,
-    rsemUserError,
-    rintQuitCalled,
-    rsemImplicitObjConv
-  }
-
-  for idx, n in @[
-    result.foreign,
-    # result.base,
-    result.main[compVerbosityMax],
-    result.main[compVerbosityHigh],
-    result.main[compVerbosityDefault],
-    result.main[compVerbosityMin],
-  ]:
-    assert rbackLinking notin n
-    assert rsemImplicitObjConv in n, $idx
-    assert rvmStackTrace in n, $idx
-
-const
-  NotesVerbosity* = computeNotesVerbosity()
+template instLoc*(depth: int = -2): InstantiationInfo =
+  ## grabs where in the compiler an error was instanced to ease debugging.
+  ##
+  ## whether to use full paths depends on --excessiveStackTrace compiler option.
+  instantiationInfo(depth, fullPaths = compileOption"excessiveStackTrace")
 
 
 type
@@ -190,59 +93,36 @@ type
   ERecoverableError* = object of ValueError
   ESuggestDone* = object of ValueError
 
-proc `==`*(a, b: FileIndex): bool {.borrow.}
-
-proc hash*(i: TLineInfo): Hash =
-  hash (i.line.int, i.col.int, i.fileIndex.int)
-
 proc raiseRecoverableError*(msg: string) {.noinline.} =
   raise newException(ERecoverableError, msg)
 
-func isKnown*(info: TLineInfo): bool =
-  ## Check if `info` represents valid source file location
-  info != unknownLineInfo
+
+# Refactor: miscellaneous stuff bellow, not sure where to put this yet
+
+type
+  CompilerVerbosity* = enum
+    ## verbosity of the compiler, number is used as an array index and the
+    ## string matches what's passed on the CLI.
+    compVerbosityMin = (0, "0")
+    compVerbosityDefault = (1, "1")
+    compVerbosityHigh = (2, "2")
+    compVerbosityMax = (3, "3")
+
 
 type
   Severity* {.pure.} = enum ## VS Code only supports these three
     Hint, Warning, Error
 
+
 const
-  trackPosInvalidFileIdx* = FileIndex(-2) ## special marker so that no
-  ## suggestions are produced within comments and string literals
-  commandLineIdx* = FileIndex(-3)
+  explanationsBaseUrl* = "https://nim-works.github.io/nimskull"
+    # was: "https://nim-lang.org/docs" but we're now usually showing devel docs
+    # instead of latest release docs.
 
-type
-  MsgConfig* = object ## does not need to be stored in the incremental cache
-    trackPos*: TLineInfo
-    trackPosAttached*: bool ## whether the tracking position was attached to
-                            ## some close token.
-
-    errorOutputs*: TErrorOutputs ## Allowed output streams for messages.
-    # REFACTOR this field is mostly touched in sem for 'performance'
-    # reasons - don't write out error messages when compilation failed,
-    # don't generate list of call candidates when `compiles()` fails and so
-    # on. This should be replaced with `.inTryExpr` or something similar,
-    # and let the reporting hook deal with all the associated heuristics.
-
-    msgContext*: seq[tuple[info: TLineInfo, detail: PSym]] ## \ Contextual
-    ## information about instantiation stack - "template/generic
-    ## instantiation of" message is constructed from this field. Right now
-    ## `.detail` field is only used in the `sem.semMacroExpr()`,
-    ## `seminst.generateInstance()` and `semexprs.semTemplateExpr()`. In
-    ## all other cases this field is left empty (SemReport is `skUnknown`)
-    reports*: ReportList ## Intermediate storage for the
-    writtenSemReports*: ReportSet
-    lastError*: TLineInfo
-    filenameToIndexTbl*: Table[string, FileIndex]
-    fileInfos*: seq[TFileInfo] ## Information about all known source files
-    ## is stored in this field - full/relative paths, list of line etc.
-    ## (For full list see `TFileInfo`)
-    systemFileIdx*: FileIndex
-
-proc initMsgConfig*(): MsgConfig =
-  result.msgContext = @[]
-  result.lastError = unknownLineInfo
-  result.filenameToIndexTbl = initTable[string, FileIndex]()
-  result.fileInfos = @[]
-  result.errorOutputs = {eStdOut, eStdErr}
-  result.filenameToIndexTbl["???"] = FileIndex(-1)
+proc createDocLink*(urlSuffix: string): string =
+  # os.`/` is not appropriate for urls.
+  result = explanationsBaseUrl
+  if urlSuffix.len > 0 and urlSuffix[0] == '/':
+    result.add urlSuffix
+  else:
+    result.add "/" & urlSuffix

--- a/compiler/ast/numericbase.nim
+++ b/compiler/ast/numericbase.nim
@@ -1,0 +1,8 @@
+## This module doesn't do much beyond store a common type between the `lexer` &
+## `ast` called `NumericalBase` to break cyclic dependencies
+
+type
+  NumericalBase* = enum
+    base10,                   ## base10 is listed as the first element,
+                              ## so that it is the correct default value
+    base2, base8, base16

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -51,17 +51,17 @@ import
   ]
 
 type
-  Parser* = object            # A Parser object represents a file that
-                              # is being parsed
-    currInd: int              # current indentation level
-    firstTok: bool            # Has the first token been read?
-    hasProgress: bool         # some while loop requires progress ensurance
-    lex*: Lexer               # The lexer that is used for parsing
-    tok*: Token               # The current token
+  Parser* = object            ## A Parser object represents a file that
+                              ## is being parsed
+    currInd: int              ## current indentation level
+    firstTok: bool            ## Has the first token been read?
+    hasProgress: bool         ## some while loop requires progress ensurance
+    lex*: Lexer               ## The lexer that is used for parsing
+    tok*: Token               ## The current token
     lineStartPrevious*: int
     lineNumberPrevious*: int
     bufposPrevious*: int
-    inPragma*: int            # Pragma level
+    inPragma*: int            ## Pragma level
     inSemiStmtList*: int
     emptyNode: ParsedNode
 
@@ -104,7 +104,17 @@ proc getTok(p: var Parser) =
   p.lineNumberPrevious = p.lex.lineNumber
   p.lineStartPrevious = p.lex.lineStart
   p.bufposPrevious = p.lex.bufpos
+  
+  let lexDiagOffset = p.lex.diagOffset # capture before using the lexer
+
   p.lex.rawGetTok(p.tok)
+
+  if p.tok.tokType == tkError:
+    p.lex.config.handleReport(p.tok.error, instLoc(-1), doAbort)
+  
+  for d in p.lex.errorsHintsAndWarnings(lexDiagOffset):
+    p.lex.config.handleReport(d, instLoc(-1))
+  
   p.hasProgress = true
 
 proc openParser*(p: var Parser, fileIdx: FileIndex, inputStream: PLLStream,
@@ -360,7 +370,6 @@ proc parseSymbol(p: var Parser, mode = smNormal): ParsedNode =
         break
 
     p.eat(tkAccent)
-
   else:
     p.localError ParserReport(kind: rparIdentExpected)
     # BUGFIX: We must consume a token here to prevent endless loops!
@@ -2253,6 +2262,9 @@ proc parseTopLevelStmt(p: var Parser): ParsedNode =
         p.localError ParserReport(kind: rparInvalidIndentation)
       p.firstTok = true
     of tkEof: break
+    # of tkError:
+    #   p.lex.config.handleReport(p.tok.error, instLoc(-1))
+    #   break
     else:
       result = complexOrSimpleStmt(p)
       if result.kind == nkEmpty:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -179,6 +179,8 @@ type
     rlexUnclosedTripleString
     rlexUnclosedSingleString
 
+    # xxx: expected token and invalid direct are not really "lexer" errors, it
+    #      is `nimconf` module abusing error reporting facilities
     rlexExpectedToken
     rlexCfgInvalidDirective
 

--- a/compiler/backend/ccgutils.nim
+++ b/compiler/backend/ccgutils.nim
@@ -20,7 +20,6 @@ import
     trees
   ],
   compiler/front/[
-    msgs,
     options
   ],
   compiler/utils/[

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -21,7 +21,8 @@ import
     ast,
     renderer,
     types,
-    reports
+    reports,
+    lineinfos,
   ],
   compiler/modules/[
     magicsys,

--- a/compiler/front/depfiles.nim
+++ b/compiler/front/depfiles.nim
@@ -11,7 +11,7 @@ import
 import
   compiler/utils/[pathutils],
   compiler/modules/[modulegraphs],
-  compiler/ast/[ast_types],
+  compiler/ast/[lineinfos],
   compiler/front/[msgs, options]
 
 proc writeDepsFile*(g: ModuleGraph) =

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -27,6 +27,7 @@ import
     options,
     condsyms,
     msgs,
+    cmdlinehelper,
     nimconf,     # Configuration file reading
     depfiles
   ],
@@ -377,7 +378,6 @@ proc mainCommand*(graph: ModuleGraph) =
     else:
       globalReport(conf, ExternalReport(
         kind: rextExpectedTinyCForRun))
-
   of cmdDoc:
     docLikeCmd():
       conf.setNoteDefaults(rsemLockLevelMismatch, false) # issue #13218

--- a/compiler/front/nimconf.nim
+++ b/compiler/front/nimconf.nim
@@ -17,279 +17,405 @@ import
   ],
   compiler/front/[
     commands,
-    msgs,
     options,
     scriptconfig
   ],
   compiler/ast/[
     lexer,
-    reports,
     idents,
     wordrecg,
     llstream,
+    lineinfos,
     ast
   ],
   compiler/utils/[
     pathutils,
+    idioms,
   ]
+
+type
+  ConfigEventKind* = enum
+    ## events/errors arising from parsing and processing a compiler config file
+
+    # fatal errors begin
+    cekInternalError
+    # fatal errors end
+
+    # users errors begin
+
+    # lexer generated
+    cekLexerErrorDiag        ## lexer error being forwarded
+
+    # expected token
+    cekParseExpectedX        ## expected some token
+    cekParseExpectedCloseX   ## expected closing ')', ']', etc
+    cekParseExpectedIdent    ## expected an identifier
+
+    # invalid input
+    cekInvalidDirective
+    # user errors end
+
+    # warning begin
+    cekLexerWarningDiag      ## warning from the lexer
+    # warning end
+
+    # hint begin
+    cekLexerHintDiag         ## hint from the lexer
+    # hint end
+
+    # user output start
+    cekWriteConfig           ## write out the config
+    # user output end
+
+    # debug start
+    cekDebugTrace            ## config debug trace
+    cekDebugReadStart        ## start config file read
+    cekDebugReadStop         ## stop config file read
+    # debug end
+
+    # progress begin
+    cekProgressConfStart
+    # progress end
+
+  ConfigFileEvent* = object
+    case kind*: ConfigEventKind:
+      of cekParseExpectedX, cekParseExpectedCloseX, cekParseExpectedIdent,
+         cekInvalidDirective, cekWriteConfig, cekDebugTrace:
+        location*: TLineInfo         ## diagnostic location
+      of cekInternalError, cekLexerErrorDiag, cekLexerWarningDiag,
+         cekLexerHintDiag:
+        lexerDiag*: LexerDiag
+      of cekDebugReadStart, cekDebugReadStop, cekProgressConfStart:
+        discard
+    instLoc*: InstantiationInfo ## instantiation in lexer's source
+    msg*: string
+  
+  NimConfEvtHandler* = proc(config: ConfigRef,
+                            evt: ConfigFileEvent,
+                            reportFrom: InstantiationInfo,
+                            eh: TErrorHandling = doNothing): void
+  NimConfParser = object
+    lexer: Lexer
+    condStack: seq[bool]
+    config: ConfigRef
+    cfgEvtHandler: NimConfEvtHandler
+
 
 # ---------------- configuration file parser -----------------------------
 # we use Nim's lexer here to save space and work
 
-proc ppGetTok(L: var Lexer, tok: var Token) =
+proc handleError(N: NimConfParser,
+                 ev: range[cekParseExpectedX..cekInvalidDirective],
+                 errMsg: string, 
+                 instLoc = instLoc(-1)) =
+    let e = ConfigFileEvent(kind: ev,
+                            location: N.lexer.getLineInfo,
+                            instLoc: instLoc,
+                            msg: errMsg)
+    N.cfgEvtHandler(N.lexer.config, e, instLoc)
+
+proc handleExpectedX(N: NimConfParser, missing: string, instLoc = instLoc(-1)) =
+    let e = ConfigFileEvent(kind: cekParseExpectedX, 
+                            location: N.lexer.getLineInfo, 
+                            instLoc: instLoc, 
+                            msg: missing)
+    N.cfgEvtHandler(N.lexer.config, e, instLoc)
+
+proc handleWriteConf(N: NimConfParser, cfg: string, instLoc = instLoc(-1)) =
+    let e = ConfigFileEvent(kind: cekWriteConfig,
+                            instLoc: instLoc,
+                            msg: cfg)
+    N.cfgEvtHandler(N.lexer.config, e, instLoc)
+
+proc handleTrace(N: NimConfParser, trace: string, instLoc = instLoc(-1)) =
+    let e = ConfigFileEvent(kind: cekDebugTrace,
+                            location: N.lexer.getLineInfo,
+                            instLoc: instLoc,
+                            msg: trace)
+    N.cfgEvtHandler(N.lexer.config, e, instLoc)
+
+proc handleRead(N: NimConfParser,
+                evt: range[cekDebugReadStart..cekProgressConfStart],
+                filename: string,
+                instLoc = instLoc(-1)) =
+    let e = ConfigFileEvent(kind: evt,
+                            instLoc: instLoc,
+                            msg: filename)
+    N.cfgEvtHandler(N.config, e, instLoc)
+
+proc ppGetTok(N: var NimConfParser, tok: var Token) =
+  var firstLine = true
+    ## used to force at least one attempt
+
   # simple filter
-  rawGetTok(L, tok)
-  while tok.tokType in {tkComment}: rawGetTok(L, tok)
+  while firstLine or tok.tokType in {tkComment}:
+    firstLine = false # first attempt started, now only comment skipping
 
-proc parseExpr(L: var Lexer, tok: var Token; config: ConfigRef): bool
-proc parseAtom(L: var Lexer, tok: var Token; config: ConfigRef): bool =
+    rawGetTok(N.lexer, tok)
+
+    if tok.tokType == tkError:
+      let e = ConfigFileEvent(kind: cekInternalError,
+                              lexerDiag: tok.error,
+                              instLoc: tok.error.instLoc)
+      N.cfgEvtHandler(N.lexer.config, e, instLoc(-1), doAbort)
+    
+    for d in N.lexer.errorsHintsAndWarnings():
+      {.cast(uncheckedAssign).}:
+        let e = ConfigFileEvent(kind: (case d.kind
+                                      of LexDiagsError:   cekLexerErrorDiag
+                                      of LexDiagsWarning: cekLexerWarningDiag
+                                      of LexDiagsHint:    cekLexerHintDiag
+                                      of LexDiagsFatal:   unreachable()
+                                      ),
+                                lexerDiag: d,
+                                instLoc: d.instLoc)
+      N.cfgEvtHandler(N.lexer.config, e, instLoc(-1), doNothing)
+
+proc parseExpr(N: var NimConfParser, tok: var Token): bool
+proc parseAtom(N: var NimConfParser, tok: var Token): bool =
   if tok.tokType == tkParLe:
-    ppGetTok(L, tok)
-    result = parseExpr(L, tok, config)
+    ppGetTok(N, tok)
+    result = parseExpr(N, tok)
     if tok.tokType == tkParRi:
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
     else:
-      localReport(L, LexerReport(kind: rlexExpectedToken, msg: ")"))
-
+      handleError(N, cekParseExpectedCloseX, ")")
   elif tok.tokType == tkNot:
-    ppGetTok(L, tok)
-    result = not parseAtom(L, tok, config)
+    ppGetTok(N, tok)
+    result = not parseAtom(N, tok)
   else:
-    result = isDefined(config, tok.ident.s)
-    ppGetTok(L, tok)
+    result = isDefined(N.config, tok.ident.s)
+    ppGetTok(N, tok)
 
-proc parseAndExpr(L: var Lexer, tok: var Token; config: ConfigRef): bool =
-  result = parseAtom(L, tok, config)
+proc parseAndExpr(N: var NimConfParser, tok: var Token): bool =
+  result = parseAtom(N, tok)
   while tok.tokType == tkAnd:
-    ppGetTok(L, tok)          # skip "and"
-    var b = parseAtom(L, tok, config)
+    ppGetTok(N, tok)          # skip "and"
+    var b = parseAtom(N, tok)
     result = result and b
 
-proc parseExpr(L: var Lexer, tok: var Token; config: ConfigRef): bool =
-  result = parseAndExpr(L, tok, config)
+proc parseExpr(N: var NimConfParser, tok: var Token): bool =
+  result = parseAndExpr(N, tok)
   while tok.tokType == tkOr:
-    ppGetTok(L, tok)          # skip "or"
-    var b = parseAndExpr(L, tok, config)
+    ppGetTok(N, tok)          # skip "or"
+    var b = parseAndExpr(N, tok)
     result = result or b
 
-proc evalppIf(L: var Lexer, tok: var Token; config: ConfigRef): bool =
-  ppGetTok(L, tok)            # skip 'if' or 'elif'
-  result = parseExpr(L, tok, config)
+proc evalppIf(N: var NimConfParser, tok: var Token): bool =
+  ppGetTok(N, tok)            # skip 'if' or 'elif'
+  result = parseExpr(N, tok)
   if tok.tokType == tkColon:
-    ppGetTok(L, tok)
-
+    ppGetTok(N, tok)
   else:
-    localReport(L, LexerReport(kind: rlexExpectedToken, msg: ":"))
+    handleExpectedX(N, ":")
 
-#var condStack: seq[bool] = @[]
+proc doEnd(N: var NimConfParser, tok: var Token) =
+  if high(N.condStack) < 0:
+    handleExpectedX(N, "@if")
 
-proc doEnd(L: var Lexer, tok: var Token; condStack: var seq[bool]) =
-  if high(condStack) < 0:
-    localReport(L, LexerReport(kind: rlexExpectedToken, msg: "@if"))
-
-  ppGetTok(L, tok)            # skip 'end'
-  setLen(condStack, high(condStack))
+  ppGetTok(N, tok)            # skip 'end'
+  setLen(N.condStack, high(N.condStack))
 
 type
   TJumpDest = enum
     jdEndif, jdElseEndif
 
-proc jumpToDirective(L: var Lexer, tok: var Token, dest: TJumpDest; config: ConfigRef;
-                     condStack: var seq[bool])
-proc doElse(L: var Lexer, tok: var Token; config: ConfigRef; condStack: var seq[bool]) =
-  if high(condStack) < 0:
-    localReport(L, LexerReport(kind: rlexExpectedToken, msg: "@if"))
+proc jumpToDirective(N: var NimConfParser, tok: var Token, dest: TJumpDest)
+proc doElse(N: var NimConfParser, tok: var Token) =
+  if high(N.condStack) < 0:
+    handleExpectedX(N, "@if")
 
-  ppGetTok(L, tok)
+  ppGetTok(N, tok)
+
   if tok.tokType == tkColon:
-    ppGetTok(L, tok)
+    ppGetTok(N, tok)
 
-  if condStack[high(condStack)]:
-    jumpToDirective(L, tok, jdEndif, config, condStack)
+  if N.condStack[high(N.condStack)]:
+    jumpToDirective(N, tok, jdEndif)
 
-proc doElif(L: var Lexer, tok: var Token; config: ConfigRef; condStack: var seq[bool]) =
-  if high(condStack) < 0:
-    localReport(L, LexerReport(kind: rlexExpectedToken, msg: "@if"))
+proc doElif(N: var NimConfParser, tok: var Token) =
+  if high(N.condStack) < 0:
+    handleExpectedX(N, "@if")
 
-  var res = evalppIf(L, tok, config)
-  if condStack[high(condStack)] or not res:
-    jumpToDirective(L, tok, jdElseEndif, config, condStack)
-
+  var res = evalppIf(N, tok)
+  if N.condStack[high(N.condStack)] or not res:
+    jumpToDirective(N, tok, jdElseEndif)
   else:
-    condStack[high(condStack)] = true
+    N.condStack[high(N.condStack)] = true
 
-proc jumpToDirective(L: var Lexer, tok: var Token, dest: TJumpDest; config: ConfigRef;
-                     condStack: var seq[bool]) =
+proc jumpToDirective(N: var NimConfParser, tok: var Token, dest: TJumpDest) =
   var nestedIfs = 0
   while true:
     if tok.ident != nil and tok.ident.s == "@":
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
       case whichKeyword(tok.ident)
       of wIf:
         inc(nestedIfs)
       of wElse:
         if dest == jdElseEndif and nestedIfs == 0:
-          doElse(L, tok, config, condStack)
+          doElse(N, tok)
           break
       of wElif:
         if dest == jdElseEndif and nestedIfs == 0:
-          doElif(L, tok, config, condStack)
+          doElif(N, tok)
           break
       of wEnd:
         if nestedIfs == 0:
-          doEnd(L, tok, condStack)
+          doEnd(N, tok)
           break
         if nestedIfs > 0: dec(nestedIfs)
       else:
         discard
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
     elif tok.tokType == tkEof:
-      localReport(L, LexerReport(kind: rlexExpectedToken, msg: "@end"))
+      handleExpectedX(N, "@end")
     else:
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
 
-proc parseDirective(L: var Lexer, tok: var Token; config: ConfigRef; condStack: var seq[bool]) =
-  ppGetTok(L, tok)            # skip @
+proc parseDirective(N: var NimConfParser, tok: var Token) =
+  ppGetTok(N, tok)            # skip @
   case whichKeyword(tok.ident)
   of wIf:
-    setLen(condStack, condStack.len + 1)
-    let res = evalppIf(L, tok, config)
-    condStack[high(condStack)] = res
-    if not res: jumpToDirective(L, tok, jdElseEndif, config, condStack)
-  of wElif: doElif(L, tok, config, condStack)
-  of wElse: doElse(L, tok, config, condStack)
-  of wEnd: doEnd(L, tok, condStack)
+    setLen(N.condStack, N.condStack.len + 1)
+    let res = evalppIf(N, tok)
+    N.condStack[high(N.condStack)] = res
+    if not res: jumpToDirective(N, tok, jdElseEndif)
+  of wElif: doElif(N, tok)
+  of wElse: doElse(N, tok)
+  of wEnd: doEnd(N, tok)
   of wWrite:
-    ppGetTok(L, tok)
-    L.localReport(InternalReport(
-      kind: rintNimconfWrite,
-      msg: strtabs.`%`($tok, config.configVars, {useEnvironment, useKey})))
-
-    ppGetTok(L, tok)
+    ppGetTok(N, tok)
+    N.handleWriteConf:
+      strtabs.`%`($tok, N.config.configVars, {useEnvironment, useKey})
+    ppGetTok(N, tok)
   else:
     case tok.ident.s.normalize
     of "putenv":
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
       var key = $tok
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
       os.putEnv(key, $tok)
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
 
     of "prependenv":
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
       var key = $tok
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
       os.putEnv(key, $tok & os.getEnv(key))
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
 
     of "appendenv":
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
       var key = $tok
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
       os.putEnv(key, os.getEnv(key) & $tok)
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
 
     of "trace":
-      ppGetTok(L, tok)
-      localReport(L, DebugReport(kind: rdbgCfgTrace, str: $tok))
-      ppGetTok(L, tok)
+      ppGetTok(N, tok)
+      N.handleTrace($tok)
+      ppGetTok(N, tok)
 
     else:
-      localReport(L, LexerReport(kind: rlexCfgInvalidDirective, msg: $tok))
+      handleError(N, cekInvalidDirective, $tok)
 
-proc confTok(L: var Lexer, tok: var Token; config: ConfigRef; condStack: var seq[bool]) =
-  ppGetTok(L, tok)
+proc confTok(N: var NimConfParser, tok: var Token) =
+  ppGetTok(N, tok)
   while tok.ident != nil and tok.ident.s == "@":
-    parseDirective(L, tok, config, condStack)    # else: give the token to the parser
+    parseDirective(N, tok)    # else: give the token to the parser
 
-proc checkSymbol(L: Lexer, tok: Token) =
+proc checkSymbol(N: NimConfParser, tok: Token) =
   if tok.tokType notin {tkSymbol..tkInt64Lit, tkStrLit..tkTripleStrLit}:
-    localReport(L, ParserReport(kind: rparIdentExpected, msg: $tok))
+    handleError(N, cekParseExpectedIdent, $tok)
 
-proc parseAssignment(L: var Lexer, tok: var Token;
-                     config: ConfigRef; condStack: var seq[bool]) =
+proc parseAssignment(N: var NimConfParser, tok: var Token) =
   if tok.ident != nil:
     if tok.ident.s == "-" or tok.ident.s == "--":
-      confTok(L, tok, config, condStack)           # skip unnecessary prefix
-  var info = getLineInfo(L, tok) # save for later in case of an error
-  checkSymbol(L, tok)
+      confTok(N, tok)           # skip unnecessary prefix
+  var info = getLineInfo(N.lexer, tok) # save for later in case of an error
+  checkSymbol(N, tok)
   var s = $tok
-  confTok(L, tok, config, condStack)             # skip symbol
+  confTok(N, tok)             # skip symbol
   var val = ""
   while tok.tokType == tkDot:
     s.add('.')
-    confTok(L, tok, config, condStack)
-    checkSymbol(L, tok)
+    confTok(N, tok)
+    checkSymbol(N, tok)
     s.add($tok)
-    confTok(L, tok, config, condStack)
+    confTok(N, tok)
   if tok.tokType == tkBracketLe:
     # BUGFIX: val, not s!
-    confTok(L, tok, config, condStack)
-    checkSymbol(L, tok)
+    confTok(N, tok)
+    checkSymbol(N, tok)
     val.add('[')
     val.add($tok)
-    confTok(L, tok, config, condStack)
-    if tok.tokType == tkBracketRi:
-      confTok(L, tok, config, condStack)
+    confTok(N, tok)
 
+    if tok.tokType == tkBracketRi:
+      confTok(N, tok)
     else:
-      localReport(L, LexerReport(kind: rlexExpectedToken, msg: "]"))
+      handleError(N, cekParseExpectedCloseX, "]")
 
     val.add(']')
   let percent = tok.ident != nil and tok.ident.s == "%="
   if tok.tokType in {tkColon, tkEquals} or percent:
     if val.len > 0: val.add(':')
-    confTok(L, tok, config, condStack)           # skip ':' or '=' or '%'
-    checkSymbol(L, tok)
+    confTok(N, tok)           # skip ':' or '=' or '%'
+    checkSymbol(N, tok)
     val.add($tok)
-    confTok(L, tok, config, condStack)           # skip symbol
+    confTok(N, tok)           # skip symbol
     if tok.tokType in {tkColon, tkEquals}:
       val.add($tok) # add the :
-      confTok(L, tok, config, condStack)           # skip symbol
-      checkSymbol(L, tok)
+      confTok(N, tok)           # skip symbol
+      checkSymbol(N, tok)
       val.add($tok) # add the token after it
-      confTok(L, tok, config, condStack)           # skip symbol
+      confTok(N, tok)           # skip symbol
     while tok.ident != nil and tok.ident.s == "&":
-      confTok(L, tok, config, condStack)
-      checkSymbol(L, tok)
+      confTok(N, tok)
+      checkSymbol(N, tok)
       val.add($tok)
-      confTok(L, tok, config, condStack)
+      confTok(N, tok)
   if percent:
-    processSwitch(s, strtabs.`%`(val, config.configVars,
-                                {useEnvironment, useEmpty}), passPP, info, config)
+    processSwitch(s, strtabs.`%`(val, N.config.configVars,
+                                {useEnvironment, useEmpty}), passPP, info,
+                                N.config)
   else:
-    processSwitch(s, val, passPP, info, config)
+    processSwitch(s, val, passPP, info, N.config)
 
-proc readConfigFile*(filename: AbsoluteFile; cache: IdentCache;
-                    config: ConfigRef): bool =
+proc readConfigFile(N: var NimConfParser, filename: AbsoluteFile,
+                    cache: IdentCache): bool =
+  ## assumes `cfgEvtHandler` has already been set, do not export
   var
-    L: Lexer
     tok: Token
     stream: PLLStream
 
   stream = llStreamOpen(filename, fmRead)
   if stream != nil:
-    config.localReport DebugReport(
-      kind: rdbgStartingConfRead,
-      filename: filename.string
-    )
+    N.handleRead(cekDebugReadStart, filename.string)
 
     initToken(tok)
-    openLexer(L, filename, stream, cache, config)
+    openLexer(N.lexer, filename, stream, cache, N.config)
     tok.tokType = tkEof       # to avoid a pointless warning
-    var condStack: seq[bool] = @[]
-    confTok(L, tok, config, condStack)           # read in the first token
-    while tok.tokType != tkEof: parseAssignment(L, tok, config, condStack)
-    if condStack.len > 0:
-      localReport(L, LexerReport(kind: rlexExpectedToken, msg: "@end"))
-    closeLexer(L)
+    confTok(N, tok)           # read in the first token
 
-    config.localReport DebugReport(
-      kind: rdbgFinishedConfRead,
-      filename: filename.string
-    )
+    while tok.tokType != tkEof:
+      parseAssignment(N, tok)
+
+    if N.condStack.len > 0:
+      handleError(N, cekParseExpectedX, "@end")
+
+    closeLexer(N.lexer)
+
+    N.handleRead(cekDebugReadStop, filename.string)
 
     return true
+
+proc readConfigFile*(filename: AbsoluteFile, cache: IdentCache,
+                     config: ConfigRef, evtHandler: NimConfEvtHandler
+): bool {.inline.} =
+  # set the event handler so we can report
+  var parser = NimConfParser(config: config, cfgEvtHandler: evtHandler)
+  readConfigFile(parser, filename, cache)
 
 proc getUserConfigPath*(filename: RelativeFile): AbsoluteFile =
   result = getConfigDir().AbsoluteDir / RelativeDir"nim" / filename
@@ -303,93 +429,102 @@ proc getSystemConfigPath*(conf: ConfigRef; filename: RelativeFile): AbsoluteFile
     if not fileExists(result): result = p / RelativeDir"etc/nim" / filename
     if not fileExists(result): result = AbsoluteDir"/etc/nim" / filename
 
-proc loadConfigs*(
-    cfg: RelativeFile; cache: IdentCache;
-    conf: ConfigRef; idgen: IdGenerator
+proc loadConfigs(
+    N: var NimConfParser, cfg: RelativeFile, cache: IdentCache,
+    idgen: IdGenerator
   ) =
+  setDefaultLibpath(N.config)
 
-
-  setDefaultLibpath(conf)
-  proc readConfigFile(path: AbsoluteFile) =
+  proc readConfigFile(N: var NimConfParser, path: AbsoluteFile) =
     let configPath = path
-    if readConfigFile(configPath, cache, conf):
-      conf.configFiles.add(configPath)
+    if readConfigFile(N, configPath, cache):
+      N.config.configFiles.add(configPath)
 
-  proc runNimScriptIfExists(path: AbsoluteFile, isMain = false) =
+  proc runNimScriptIfExists(N: var NimConfParser, path: AbsoluteFile,
+                            isMain = false) =
     let p = path # eval once
     var s: PLLStream
-    if isMain and optWasNimscript in conf.globalOptions:
-      if conf.projectIsStdin:
+    if isMain and optWasNimscript in N.config.globalOptions:
+      if N.config.projectIsStdin:
         s = stdin.llStreamOpen
-
-      elif conf.projectIsCmd:
-        s = llStreamOpen(conf.cmdInput)
+      elif N.config.projectIsCmd:
+        s = llStreamOpen(N.config.cmdInput)
 
     if s == nil and fileExists(p):
       s = llStreamOpen(p, fmRead)
 
     if s != nil:
-      conf.configFiles.add(p)
-      runNimScript(cache, p, idgen, freshDefines = false, conf, s)
+      N.config.configFiles.add(p)
+      runNimScript(cache, p, idgen, freshDefines = false, N.config, s)
 
-
-  if optSkipSystemConfigFile notin conf.globalOptions:
-    readConfigFile(getSystemConfigPath(conf, cfg))
-
-    if cfg == DefaultConfig:
-      runNimScriptIfExists(getSystemConfigPath(conf, DefaultConfigNims))
-
-
-  if optSkipUserConfigFile notin conf.globalOptions:
-    readConfigFile(getUserConfigPath(cfg))
+  if optSkipSystemConfigFile notin N.config.globalOptions:
+    N.readConfigFile(getSystemConfigPath(N.config, cfg))
 
     if cfg == DefaultConfig:
-      runNimScriptIfExists(getUserConfigPath(DefaultConfigNims))
+      N.runNimScriptIfExists(getSystemConfigPath(N.config, DefaultConfigNims))
 
-  let pd = if not conf.projectPath.isEmpty:
-             conf.projectPath
+  if optSkipUserConfigFile notin N.config.globalOptions:
+    N.readConfigFile(getUserConfigPath(cfg))
+
+    if cfg == DefaultConfig:
+      N.runNimScriptIfExists(getUserConfigPath(DefaultConfigNims))
+
+  let pd = if not N.config.projectPath.isEmpty:
+             N.config.projectPath
            else:
              AbsoluteDir(getCurrentDir())
 
-
-  if optSkipParentConfigFiles notin conf.globalOptions:
+  if optSkipParentConfigFiles notin N.config.globalOptions:
     for dir in parentDirs(pd.string, fromRoot=true, inclusive=false):
-      readConfigFile(AbsoluteDir(dir) / cfg)
-
+      N.readConfigFile(AbsoluteDir(dir) / cfg)
       if cfg == DefaultConfig:
-        runNimScriptIfExists(AbsoluteDir(dir) / DefaultConfigNims)
+        N.runNimScriptIfExists(AbsoluteDir(dir) / DefaultConfigNims)
 
-  if optSkipProjConfigFile notin conf.globalOptions:
-    readConfigFile(pd / cfg)
+  if optSkipProjConfigFile notin N.config.globalOptions:
+    N.readConfigFile(pd / cfg)
     if cfg == DefaultConfig:
-      runNimScriptIfExists(pd / DefaultConfigNims)
+      N.runNimScriptIfExists(pd / DefaultConfigNims)
 
-    if conf.projectName.len != 0:
+    if N.config.projectName.len != 0:
       # new project wide config file:
-      var projectConfig = changeFileExt(conf.projectFull, "nimcfg")
+      var projectConfig = changeFileExt(N.config.projectFull, "nimcfg")
       if not fileExists(projectConfig):
-        projectConfig = changeFileExt(conf.projectFull, "nim.cfg")
-      readConfigFile(projectConfig)
+        projectConfig = changeFileExt(N.config.projectFull, "nim.cfg")
+      N.readConfigFile(projectConfig)
 
-
-  let scriptFile = conf.projectFull.changeFileExt("nims")
-  let scriptIsProj = scriptFile == conf.projectFull
+  let
+    scriptFile = N.config.projectFull.changeFileExt("nims")
+    scriptIsProj = scriptFile == N.config.projectFull
+  
   template showHintConf =
-    for filename in conf.configFiles:
+    for filename in N.config.configFiles:
       # delayed to here so that `hintConf` is honored
-      localReport(conf, ExternalReport(kind: rextConf, msg: filename.string))
-  if conf.cmd == cmdNimscript:
+      N.handleRead(cekProgressConfStart, filename.string)
+
+  if N.config.cmd == cmdNimscript:
     showHintConf()
-    conf.configFiles.setLen 0
-  if conf.cmd != cmdIdeTools:
-    if conf.cmd == cmdNimscript:
-      runNimScriptIfExists(conf.projectFull, isMain = true)
+    N.config.configFiles.setLen 0
+  
+  if N.config.cmd != cmdIdeTools:
+    if N.config.cmd == cmdNimscript:
+      N.runNimScriptIfExists(N.config.projectFull, isMain = true)
     else:
-      runNimScriptIfExists(scriptFile, isMain = true)
+      N.runNimScriptIfExists(scriptFile, isMain = true)
   else:
     if not scriptIsProj:
-      runNimScriptIfExists(scriptFile, isMain = true)
+      N.runNimScriptIfExists(scriptFile, isMain = true)
     else:
       # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
       discard
+  
   showHintConf()
+
+proc loadConfigs*(
+    cfg: RelativeFile; cache: IdentCache;
+    conf: ConfigRef; idgen: IdGenerator;
+    evtHandler: NimConfEvtHandler
+  ) {.inline.} =
+  var parser = NimConfParser(config: conf, cfgEvtHandler: evtHandler)
+  parser.loadConfigs(cfg, cache, idgen)
+
+  

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -212,7 +212,7 @@ proc toLitId(x: FileIndex; c: var PackedEncoder; m: var PackedModule): LitId =
   assert result != LitId(0)
 
 proc toFileIndex*(x: LitId; m: PackedModule; config: ConfigRef): FileIndex =
-  result = msgs.fileInfoIdx(config, AbsoluteFile m.strings[x])
+  result = options.fileInfoIdx(config, AbsoluteFile m.strings[x])
 
 proc includesIdentical(m: var PackedModule; config: ConfigRef): bool =
   for it in mitems(m.includes):

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -447,6 +447,8 @@ proc nodeToHighlightedHtml(d: PDoc; n: PNode; result: var string;
     case kind
     of tkEof:
       break
+    of tkError:
+      d.conf.internalError(n.info, "encountered unhandled tkError")
     of tkComment:
       dispA(d.conf, result, "<span class=\"Comment\">$1</span>", "\\spanComment{$1}",
             [escLit])

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -20,7 +20,8 @@ import
   ],
   compiler/ast/[
     ast_query,
-    ast_types
+    ast_types,
+    lineinfos
   ],
   compiler/ic/[
     bitabs,

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -21,6 +21,7 @@ import
   compiler/ast/[
     ast,
     ast_types,
+    lineinfos,
     astalgo, # for `getModule`
     reports
   ],

--- a/compiler/vm/vmerrors.nim
+++ b/compiler/vm/vmerrors.nim
@@ -10,7 +10,8 @@
 
 import
   compiler/ast/[
-    reports
+    reports,
+    lineinfos,
   ],
   compiler/front/[
     msgs

--- a/tests/compiler/tvmbackend.nim
+++ b/tests/compiler/tvmbackend.nim
@@ -8,7 +8,7 @@ discard """
 
 import std/[os, tables]
 
-import compiler/ast/ast_types
+import compiler/ast/[ast_types, lineinfos]
 import compiler/ic/bitabs
 import compiler/utils/pathutils
 import compiler/vm/vmdef


### PR DESCRIPTION
## Summary

Lexing and Nim Config File Handling no longer depend upon the legacy
report infrastructure. This is part of a large effort to fix compiler
diagnostics and output, see this issue for more information:
https://github.com/nim-works/nimskull/issues/443

## Details

Before `lexer` and `nimconf` modules' "reports" were comingled as lexer
reports in the `report_enums` modules under the `rlex` prefix.
Additionally, the `lexer` and `nimconf` module had odd cylic
dependencies with `reports` and `msgs` modules. Lastly, the `reports`
module owned the error/event/output data types when those should be
under `lexer` and `nimconf`.

Now, `lexer` and `nimconf` define "diagnostic" data types that the
caller deals with including integrating output handling. Now they no
longer depend upon the `reports` module.

Changes to Lexer:
- lexer only throws on fatal/internal error
- all other cases (errors, warnings, hints) are diagnostics (LexerDiags)
- the lexer stores all diags in a field for its lifetime
- diags are traversed via an interator `errorsHintsAndWarnings`
- `diagOffset` is used to demarcate "when" the last diags came from

Changes to Nim Config handler:
- similar to Lexer above, wrt diagnostics
- legacy reporting bridge for `nimconf` is in `cmdlinehelper`

Simplifications, Code Clean-up, and Responsibility Changes:
- `options` module:
  - moved `MsgConfig` here was misplaced in `lineinfos`
  - moved helper procs for file path and other handling bits specific to
    options and used by other modules from `msgs`
- `msgs` hanldes `lexer` diagnostic to report mapping as it is the
  compiler messages framework code
- `lineinfos` now contains the `TLineInfo` type as it should, was not
  possible before because `MsgConfig` was misplaced
- introduced `numericbase` to break a cycle between `ast_types` and
  `lexer` modules
- `reports` module cleanup:
  - `ReportBase` no longer contains `ReportContext`, which is a sem/vm
    only issue; longer term all this data should never be here in the
    first place
  - minor: removed some unnecessary new lines and cleaned up formatting
- `cmdlinehelper` handles nimconf diagnostic to report mapping, then
  callers like `main` module can use that

---

## Notes for Reviewers

* this is going to be a big change, that ship has sailed
* the code already feels more modular

### Strategy
* I'm going to create a number of clean-ish commits in this branch
* they might go in one at a time, or get squashed
* rough order of operations:
  * extract all lexer related diagnostics out
  * make the above work:
    * including sorting declarations into better modules
    * break apart cyclic dependencies
    * don't introduce too many bridges
  * repeat for all other report types
* if the above yields clean chunks then they'll merge in one at a time, otherwise they'll get squashed

### Questions

Cycle breaking without introducing function pointers is a useful trick. The problem is
reporting/error handling are tied tightly and it's hard to see how to tease them apart.
Thoughts? Good place to see the issue is the `handleDiag` stuff in `lexer`. They can't
simply fire and forget because the errorhandling strategy as configured injects itself
into the lexer's execution in cases where we abort. So how do we break this while still
using static dispatch (code and no function pointers)?
