### PR TITLE
sem: overload resolution ast corruption fixes

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -207,7 +207,7 @@ proc newIdentNode*(ident: PIdent, info: TLineInfo): PNode =
 proc newSymNode2*(sym: PSym): PNode =
   ## creates a new `nkSym` node, unless sym.kind is an skError where an nkError
   ## is extracted from the sym and returned instead.
-  # TODO replace newSymNode with this
+  ## NB: not a `newSymNode` replacement, it's for when symbol sem fails
   if sym.isError:
     result = sym.ast
   else:
@@ -220,8 +220,7 @@ proc newSymNode2*(sym: PSym, info: TLineInfo): PNode =
   ## creates a new `nkSym` node, unless sym.kind is an skError where an nkError
   ## is extracted from the sym and returned instead. In either case sets the
   ## node info to the one provided
-  
-  # TODO replace newSymNode with this
+  ## NB: not a `newSymNode` replacement, it's for when symbol sem fails
   if sym.isError:
     result = sym.ast
     result.info = info
@@ -533,6 +532,12 @@ proc transitionToLet*(s: PSym) =
   s.guard = obj.guard
   s.bitsize = obj.bitsize
   s.alignment = obj.alignment
+
+proc transitionToError*(s: PSym, err: PNode) =
+  ## transition `s`ymbol to an `skError` with `err`or node
+  assert err.kind == nkError
+  transitionSymKindCommon(skError)
+  s.ast = err
 
 proc shallowCopy*(src: PNode): PNode =
   # does not copy its sons, but provides space for them:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -55,7 +55,6 @@ type
     rintUnreachable ## State in the compiler code that must not be reached
     rintAssert ## Failed internal assert in the compiler
 
-
     rintIce ## Internal compilation error
     # fatal end
 
@@ -76,15 +75,15 @@ type
     rintSource = "Source" ## Show source in the report
                           # REFACTOR this is a global configuration option,
                           # not a hint.
-
+    rintMsgOrigin = "MsgOrigin" # REFACTOR this is a global option not a hint
+    rintErrKind = "ErrKind" ## Show report kind in error messages
+                            # REFACTOR this is a global option not a hint
 
     rintGCStats = "GCStats" ## Print GC statistics for the compiler run
     rintQuitCalled = "QuitCalled" ## `quit()` called by the macro code
     ## compilation error handling and similar
     rintMissingStackTrace ## Stack trace would've been generated in the
     ## debug compiler build
-    rintMsgOrigin = "MsgOrigin"
-    rintErrKind = "ErrKind" ## Show report kind in error messages
 
     rintSuccessX = "SuccessX" ## Succesfull compilation
     # hints END !! add reports BEFORE the last enum !!
@@ -607,6 +606,7 @@ type
     rsemUndeclaredIdentifier
     rsemExpectedIdentifier
     rsemExpectedIdentifierInExpr
+    rsemOnlyDeclaredIdentifierFoundIsError
 
     # Object and Object Construction
     rsemFieldNotAccessible

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -64,7 +64,6 @@ type
     sckInstantiationOf
     sckInstantiationFrom
 
-
   ReportContext* = object
     location*: TLineInfo ## Report context instantiation
     case kind*: ReportContextKind
@@ -234,14 +233,12 @@ type
         ]
 
       of rsemHasSideEffects:
-        sideEffectTrace*: seq[tuple[
-          isUnsafe: PSym,
-          unsafeVia: PSym,
-          trace: SemSideEffectCallKind,
-          location: TLineInfo,
-          level: int
-        ]]
-
+        sideEffectTrace*: seq[tuple[isUnsafe: PSym,
+                                    unsafeVia: PSym,
+                                    trace: SemSideEffectCallKind,
+                                    location: TLineInfo,
+                                    level: int
+                                  ]]
         sideEffectMutateConnection*: TLineInfo
 
       of rsemEffectsListingHint:
@@ -257,18 +254,14 @@ type
       of rsemWrongIdent:
         expectedIdents*: seq[string]
 
-
       of rsemStaticIndexLeqUnprovable, rsemStaticIndexGeProvable:
         rangeExpression*: tuple[a, b: PNode]
 
       of rsemExprHasNoAddress:
         isUnsafeAddr*: bool
 
-      of rsemUndeclaredIdentifier,
-         rsemCallNotAProcOrField,
-           :
+      of rsemUndeclaredIdentifier, rsemCallNotAProcOrField:
         potentiallyRecursive*: bool
-
         explicitCall*: bool ## Whether `rsemCallNotAProcOrField` error was
         ## caused by expression with explicit dot call: `obj.cal()`
         unexpectedCandidate*: seq[PSym] ## Symbols that are syntactically
@@ -310,7 +303,6 @@ type
          rsemDifferentTypeForReintroducedSymbol:
         typeMismatch*: seq[SemTypeMismatch]
 
-
       of rsemSymbolKindMismatch:
         expectedSymbolKind*: set[TSymKind]
 
@@ -328,8 +320,6 @@ type
 
       of rsemStaticOutOfBounds:
         indexSpec*: tuple[usedIdx, minIdx, maxIdx: Int128]
-
-
 
       of rsemProcessing:
         processing*: tuple[

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -676,9 +676,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
         result = "undeclared field: '$1'" % r.str & typeHint & suffix
 
-
-
-
     of rsemUndeclaredField:
       result =  "undeclared field: '$1' for type $2" % [
         $r.ast.ident.s, $getProcHeader(conf, r.sym)]
@@ -1828,6 +1825,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         result.add presentSpellingCandidates(
           conf, r.spellingCandidates)
 
+    of rsemOnlyDeclaredIdentifierFoundIsError:
+      result = "identifier '$1' found but it has errors, see: $2" %
+                [r.str, conf.toStr(r.ast.info)]
+
     of rsemXDeclaredButNotUsed:
       result = "'$1' is declared but not used" % r.symstr
 
@@ -2294,7 +2295,6 @@ proc reportShort*(conf: ConfigRef, r: SemReport): string =
     "."
   else:
     reportBody(conf, r) & suffixShort(conf, r)
-
 
 proc reportBody*(conf: ConfigRef, r: ParserReport): string =
   assertKind r

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -441,7 +441,7 @@ proc computeRequiresInit(c: PContext, t: PType): bool =
   let initResult = semConstructTypeAux(c, constrCtx, {})
   constrCtx.missingFields.len > 0
 
-proc defaultConstructionError2(c: PContext, t: PType, n: PNode): PNode =
+proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode =
   var objType = t
   
   while objType.kind notin {tyObject, tyDistinct}:
@@ -461,31 +461,6 @@ proc defaultConstructionError2(c: PContext, t: PType, n: PNode): PNode =
   
   of tyDistinct:
     result = c.config.newError(n, reportTyp(
-      rsemDistinctDoesNotHaveDefaultValue, t))
-  
-  else:
-    assert false, "Must not enter here."
-
-proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
-  var objType = t
-  
-  while objType.kind notin {tyObject, tyDistinct}:
-    objType = objType.lastSon
-    assert objType != nil
-  
-  case objType.kind
-  of tyObject:
-    var constrCtx = initConstrContext(objType, newNodeI(nkObjConstr, info))
-    let initResult = semConstructTypeAux(c, constrCtx, {})
-    if constrCtx.missingFields.len > 0:
-      localReport(
-        c.config, info,
-        reportSymbols(
-          rsemObjectRequiresFieldInitNoDefault,
-          constrCtx.missingFields, typ = t))
-  
-  of tyDistinct:
-    localReport(c.config, info, reportTyp(
       rsemDistinctDoesNotHaveDefaultValue, t))
   
   else:

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -1044,7 +1044,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   var allUntyped = true
   case n[paramsPos].kind
   of nkFormalParams:
-    semParamList(c, result[paramsPos], result[genericParamsPos], s)
+    s.typ = semParamList(c, result[paramsPos], result[genericParamsPos], s.kind)
     # a template's parameters are not gensym'ed even if that was originally the
     # case as we determine whether it's a template parameter in the template
     # body by the absence of the sfGenSym flag:

--- a/tests/generics/tpointerprocs.nim
+++ b/tests/generics/tpointerprocs.nim
@@ -2,11 +2,10 @@ discard """
 cmd: "nim check $options --hints:off $file"
 action: "reject"
 nimout:'''
-tpointerprocs.nim(27, 11) Error: cannot instantiate: 'foo[int]'; got 1 typeof(s) but expected 2
-tpointerprocs.nim(15, 11) Error: 'foo' doesn't have a concrete type, due to unspecified generic parameters.
-tpointerprocs.nim(16, 11) Error: expression has no type: bar
-tpointerprocs.nim(27, 14) Error: expression has no type: foo[int]
-tpointerprocs.nim(28, 11) Error: expression has no type: bar
+tpointerprocs.nim(14, 11) Error: 'foo' doesn't have a concrete type, due to unspecified generic parameters.
+tpointerprocs.nim(15, 11) Error: identifier 'bar' found but it has errors, see: tpointerprocs.nim(14, 5)
+tpointerprocs.nim(26, 11) Error: cannot instantiate: 'foo[int]'; got 1 typeof(s) but expected 2
+tpointerprocs.nim(27, 11) Error: identifier 'bar' found but it has errors, see: tpointerprocs.nim(26, 5)
 '''
 """
 block:


### PR DESCRIPTION
## Summary
- signature matching no longer corrupts symbol table

## Details

core changes:
- matchesAux and friends in sigmatch no longer merge broken symbols
  - this means defensive ast copies during overload resolution
  - procs are also more nkError aware and will short circuit
- lookups no longer puts error symbols in the top level
  - this was a hack to stop "cascading errors"
  - mildly better error message for ident lookups resolving to errors
- required fixes in semLetOrVar and semConst:
  - const/let/var symbol definition tracks errors better
  - consolidated top level semLetOrVar and semConst

miscellaneous:
- due to nkError branch changes (`kids`), fixes were required in astrepr
- renamed old error proc `defaultConstructionError2`, dropped the `2`
- `semParamList` now returns a `PType` instead of unnecessarily mutating
