### PR TITLE
utils: introduce the `idioms` module

### DIFF
--- a/compiler/utils/idioms.nim
+++ b/compiler/utils/idioms.nim
@@ -1,0 +1,40 @@
+## This module implements various helper routines for idioms used throughout
+## the compiler. Dependencies on other modules should be kept as minimal as
+## possible
+
+from std/private/miscdollars import toLocation
+
+type
+  IInfo = typeof(instantiationInfo())
+
+func unreachableImpl(str: string, loc: IInfo) {.noinline, noreturn.} =
+  var msg: string
+  msg.toLocation(loc.filename, loc.line, loc.column + 1)
+  msg.add:
+    if str.len > 0: " unreachable: "
+    else:           " unreachable"
+  msg.add str
+  raiseAssert(msg)
+
+func unreachableImpl(e: enum, loc: IInfo) {.noinline, noreturn.} =
+  ## A bit more efficient than ``unreachable($e)``, due to the stringication
+  ## logic being located inside a separate procedure instead of at the
+  ## callsite
+  unreachableImpl($e, loc)
+
+template unreachable*() =
+  ## Use ``unreachable`` to mark a point in the program as unreachable. That
+  ## is, execution must never reach said point and if it does, the event is
+  ## treated as an unrecoverable fatal error.
+  ## As the intent is clearer, it's preferred to use ``unreachable`` is
+  ## over ``doAssert false``
+  unreachableImpl("", instantiationInfo(-1))
+
+template unreachable*(msg: string) =
+  ## Similar to `#unreachable <#unreachable>`_, but reports an additional
+  ## `msg` when reached
+  unreachableImpl(msg, instantiationInfo(-1))
+
+template unreachable*(e: enum) =
+  ## More efficient than using ``unreachable($e)``
+  unreachableImpl(e, instantiationInfo(-1))

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -27,6 +27,7 @@ import
     rodfiles
   ],
   compiler/utils/[
+    idioms,
     pathutils # for `AbsoluteFile`
   ],
   compiler/vm/[

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -40,6 +40,7 @@ import
   ],
   compiler/utils/[
     debugutils,
+    idioms,
     int128,
     btrees,
     bitsets

--- a/compiler/vm/vmchecks.nim
+++ b/compiler/vm/vmchecks.nim
@@ -11,6 +11,9 @@
 ## disciminator(s) there.
 
 import
+  compiler/utils/[
+    idioms
+  ],
   compiler/vm/[
     vmdef,
     vmmemory

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -19,6 +19,9 @@ import
   compiler/front/[
     msgs
   ],
+  compiler/utils/[
+    idioms
+  ],
   compiler/vm/[
     vmaux,
     vmdef,

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -32,8 +32,6 @@ import
 import vm_enums
 export vm_enums
 
-from std/private/miscdollars import toLocation
-
 type TInstrType* = uint64
 
 const
@@ -874,33 +872,3 @@ func safeZeroMem*(dest: var openArray[byte], numBytes: Natural) =
   if numBytes > 0:
     # Calling `safeZeroMem` with empty `dest` would erroneously raise without this check
     zeroMem(addr dest[0], numBytes)
-
-
-# XXX: `unreachable` and it's implementation details don't really belong here.
-#      They're also useful outside of VM related code
-type IInfo = typeof(instantiationInfo())
-
-func unreachableImpl(str: string, loc: IInfo) {.noinline, noreturn.} =
-  var msg: string
-  msg.toLocation(loc.filename, loc.line, loc.column + 1)
-  msg.add:
-    if str.len > 0: " unreachable: "
-    else: " unreachable"
-  msg.add str
-  raiseAssert(msg)
-
-func unreachableImpl(e: enum, loc: IInfo) {.noinline, noreturn.} =
-  ## More efficient than `unreachable($e)`, as the stringification code is
-  ## placed in a different function, reducing I-cache pressure at the callsite
-  unreachableImpl($e, loc)
-
-template unreachable*() =
-  unreachableImpl("", instantiationInfo(-1))
-
-template unreachable*(msg: string) =
-  unreachableImpl(msg, instantiationInfo(-1))
-
-template unreachable*(e: enum) =
-  ## More efficient than `unreachable($e)`. See `unreachableImpl` for more
-  ## info
-  unreachableImpl(e, instantiationInfo(-1))

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -51,6 +51,9 @@ import
   compiler/sem/[
     lowerings
   ],
+  compiler/utils/[
+    idioms
+  ],
   compiler/vm/[
     vmaux,
     vmdef,

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -11,6 +11,9 @@ import
   compiler/front/[
     options
   ],
+  compiler/utils/[
+    idioms
+  ],
   compiler/vm/[
     vmdef,
     vmmemory,

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -31,6 +31,7 @@ import
     bitabs
   ],
   compiler/utils/[
+    idioms,
     pathutils,
     bitsets
   ],

--- a/compiler/vm/vmtypegen.nim
+++ b/compiler/vm/vmtypegen.nim
@@ -15,6 +15,9 @@ import
   compiler/front/[
     options
   ],
+  compiler/utils/[
+    idioms
+  ],
   compiler/vm/[
     vmdef
   ],

--- a/compiler/vm/vmtypes.nim
+++ b/compiler/vm/vmtypes.nim
@@ -2,6 +2,9 @@
 ## `VmType`s and working with them in general.
 
 import
+  compiler/utils/[
+    idioms
+  ],
   compiler/vm/[
     vmdef
   ]


### PR DESCRIPTION
## Summary
- the module is meant for the helper routines of idioms used throughout the compiler
- move the `unreachable` template from `vm/vmdef` to `utils/idioms` and adjust usage sites

---

As suggested by @saem [here](https://github.com/nim-works/nimskull/pull/424#discussion_r991525324).