### PR TITLE
Skip "failing known issue" in CI post-failing

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -434,13 +434,16 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string, options: st
     ##
     ## We expect the program to exit soon after
     if backendLogging:
-      backend.writeTestResult(name = MegaTestCat,
-                              category = MegaTestCat,
-                              target = "c",
-                              action = "run",
-                              result = $res,
-                              expected = "",
-                              given = errorOutput)
+      backend.writeTestResult(ReportParams(
+        name: MegaTestCat,
+        cat: MegaTestCat,
+        targetStr: "c",
+        action: actionRun,
+        success: res,
+        expected: "",
+        given: errorOutput,
+        knownIssues: @[]
+      ))
 
       # Flush all buffers
       backend.close()

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -7,8 +7,18 @@
 #    distribution, for details about the copyright.
 #
 
-import sequtils, parseutils, strutils, os, streams, parsecfg,
-  tables, hashes, sets
+import
+  std/[
+    sequtils,
+    parseutils,
+    strutils,
+    os,
+    streams,
+    parsecfg,
+    tables,
+    hashes,
+    sets
+  ]
 
 type TestamentData* = ref object
   # better to group globals under 1 object; could group the other ones here too

--- a/tools/ci_testresults.nim
+++ b/tools/ci_testresults.nim
@@ -1,8 +1,24 @@
 ## Print summary of failed tests for CI
 
-import os, json, sets, strformat, strutils
+import
+  std/[
+    os,
+    json,
+    sets,
+    strformat,
+    strutils
+  ]
 
-const skip = toHashSet(["reDisabled", "reIgnored", "reSuccess", "reJoined"])
+const skip = toHashSet([
+  "reDisabled",
+  "reIgnored",
+  "reSuccess",
+  "reJoined",
+  "reKnownIssue"
+  # The test is a known issue that failed to execute, to avoud
+  # cluttering the CI output they are skipped.
+])
+
 let githubActions = existsEnv"GITHUB_ACTIONS"
 
 func formatResult(j: JsonNode): string =


### PR DESCRIPTION
- Clean  up implementation  of the  backend reporting:  pass around  proper report object that we already have instead of taking it apart into half a dozen string  arguments that need  to be pieced  back into a  JSON object anyway.
- Add information about known issues to the testament JSON cache so they can be used in later PR for tracking known issues that no longer fail
- Skip failing issues  in the CI post-processing in order  to reduce visual clutter.
