### PR TITLE
entry-level docs for improving tests

### DIFF
--- a/.github/contributing.rst
+++ b/.github/contributing.rst
@@ -89,15 +89,73 @@ Cleaning up existing tests
 
 Original collection of tests in the test suite contained a lot of files
 that did not conform to the requirements listed above, and should
-eventually be fixed. See `Clean up and reorder tests #41
-<https://github.com/nim-works/nimskull/issues/41>`_ issue on github for
-more context and relevant discussion.
+eventually be fixed. List of known issues that should be fixed includes,
+but not limited to:
+
+- Check if test name makes sense - `t123123_b.nim` does not make sense,
+  change it to something matching what is being tested. File names usually
+  refer to the numbers of issues in the original repository.
+
+- Reduce number of echo-based error testing. If you see direct echo in test
+  consider changing it to the `doAssert` check instead.
+
+  Added assertions should replace original sequence of checks with
+  `doAssert a == <expected>` expression. If original check printed multiple
+  values in sequence (for example in a for loop) you can collect them into
+  a `seq[string]` variable and compare using `==` later.
+
+- Link relevant issues in the test description (`description` field) or in
+  comments.
+
+  Huge number of original tests "referred" to issue numbers using file
+  names or highly illegible comments such as `# XYZ123` placed at arbitrary
+  locations all over the code. You should replace them with actual `url`
+  links so people can see the context quickly.
+
+
+
+- If possible, provide explanation to the test logic. You can use
+  explanation to the linked issues as a basis for explanation.
+
+- Adding labels to existing tests. For guidelines on test label usage and
+  list of existing tags with documentation please see testament
+  documentation `Labels` section.
+
+If you write new tests make sure they don't have these issues. Entries from
+this list should be *removed* from old tests and should *not be introduced*
+into new ones.
+
+Writing new tests
+-----------------
+
+Short list of common patters for text implementation. Documentation for
+usage of specific features can be found in the `testament` tool and
+`std/unittest` module docs: this list provides a brief overview of
+different methods one can use to write a new test.
+
+- *Test that is supposed to fail*: There are several different ways a test
+  can "fail":
+
+  - *Known issue that should be fixed later*: Write a test for code as it
+    *should* work and annotate the specification using `knownIssue` with
+    provided explanation.
+
+  - *Exception must be thrown*: Either use `try ... except` construct and
+    check for type/field of the exception captured or use `expect` macro
+    from `std/unittest`
+
+  - *Specific compilation error*: Use `errormsg: "<error>"` and `line:
+    <line>` fields in the specification.
+
+- *Test for specific values*: Either use `doAssert <given> == <expected>`
+  or `check` from `std/unittest`
+
 
 Improving Language specification
 --------------------------------
 
 In order to have the confidence in the compiler implementation and it's
-behaviour we must provide a comprehensive suite of checks for the compiler
+behavior we must provide a comprehensive suite of checks for the compiler
 behavior. This is a complex undertaking as a whole, but it can be easily
 split in a smaller contributions.
 

--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -123,7 +123,9 @@ Test execution options
     disabled: "i386"
     disabled: true    # ...or can disable the test entirely
 
-- ``knownIssue``
+- ``knownIssue`` description of the test that currently fails but should
+  execute successfully; it is a known bug that must be fixed in the future.
+  Can be used several times in specification.
 
 Compiler output assertions
 --------------------------
@@ -197,6 +199,110 @@ Binary output assertions
 * `This is not the full spec of Testament, check the Testament Spec on GitHub, see parseSpec(). <https://github.com/nim-works/nimskull/blob/devel/testament/specs.nim#L238>`_
 * `Nim itself uses Testament, so there are plenty of test examples. <https://github.com/nim-works/nimskull/tree/devel/tests>`_
 * `Testament supports inlined error messages on tests, basically comments with the expected error directly on the code. <https://github.com/nim-works/nimskull/blob/9a110047cbe2826b1d4afe63e3a1f5a08422b73f/tests/effects/teffects1.nim>`_
+
+Labels
+------
+
+Testament specification supports a `labels:` tag that allows for
+non-hierarchical categorization of tests. Things can be split in different
+directories, but still properly mention involved language features.
+
+Tags should be added if the test specifically targets one of the features
+(such as code generation failure in certain case that was added as a text)
+or involves high-level language feature (such as macros, procedures, enums
+etc). For example -- unless the test specifically deals with some for-loop
+feature there is no need to add `for_loop` tag.
+
+General rule of tag construction is -- avoid long and overly specific tags,
+since it would be impossible to break down every single tests accordingly.
+There is a clear need to balance out precision and usability. Use your best
+judgement and don't hesitate to ask for clarification if you are stuck.
+
+Tag names can consist *one or more lowercase words in a singular form*
+separated by underscores, each word either narrowing down the scope
+(`interop_c`, `interop_cpp`, `backend_c`, `gc`, `gc_orc` etc.) or simply
+being a part of a longer phrase (`top_level`).
+
+Please do check whether the tag is already present before adding new one.
+To generate a new list of all tags used in the code you can run code below.
+If you notice any seemingly duplicate tags (e.g. `error_compile` and
+`error_compilation`) please correct the code to leave the most common one.
+
+.. code-block:: cmd
+
+    rg --no-filename  -g "*.nim" "labels: " | sd 'labels:\s+"(.*?)"' '$1' | tr ' ' '\n' | sort | uniq -c
+
+- Type-related
+  - ``array``: Array type is tested
+  - ``distinct``: `distinct` type is involved
+  - ``enum``: Enumeration type is involved
+  - ``ptr``: Default `ptr T` type
+  - ``range``: Default `range[low..high]` type
+  - ``ref``: Default `ref T` type
+  - ``char``: Character type is involved
+  - ``seq``: Default `seq[T]` type
+  - ``int``: Integer or other integral type is used
+  - ``float``: `float` or other floating point type is used
+- Compiler diagnostics
+  - ``error_compilation``:
+  - ``error_compile``:
+  - ``error_message``: Test is specifically targeting formatting or content
+    of the error message.
+- Code detail
+  - ``local``:
+  - ``top_level``: Language construct is specifically tested when it is
+    placed in the top level of the module -- and not inside
+    procedure/method definition.
+  - ``32_bit``: Test explicitly involves 32-bit data handling
+- Language feature
+  - Definitions
+    - ``proc``:
+    - ``template``:
+    - ``union``:
+    - ``macro``:
+    - ``iterator``:
+
+  - Code detail
+    - ``overload``:
+    - ``exception``:
+    - ``generic``:
+    - ``const``:
+    - ``import``:
+    - ``module``:
+  - Other
+    - ``pragma``:
+    - ``subtyping``:
+    - ``resolution``: Overloading resolution
+    - ``typedesc``:
+    - ``var``: Mutable variable declaration
+    - ``conversion``:
+    - ``alias``:
+    - ``constructor``:
+    - ``identifier``:
+    - ``scope``:
+- Expectations
+  - ``error_runtime``: Runtime error expected
+- Compilation details
+  - ``gc``: Garbage collector is involved
+  - ``backend_c``: Testing something directly related or requiring C backend
+  - ``codegen``: Code generation is involved
+  - ``mode_release``: Compiled in release mode
+  - ``js``:
+- Standard library
+  - ``stdlib``: Standard library module
+  - ``system``: Types and procedures imported by default in every compiled
+    module
+  - ``table``: Standard library `std/table` module tested
+  - ``macro_API``: Publicly exposed macro API for operations on the AST
+- Other:
+  - ``alignment``:
+  - ``arithmetic``:
+  - ``atomics``:
+  - ``bitwise``:
+  - ``gensym``:
+  - ``index``:
+  - ``inline``:
+  - ``shift``:
 
 Reading test outputs
 ====================


### PR DESCRIPTION
- Added entry-level documentation  for writing new tests; this  is not 100% complete and should be iteratively improved later on.
- Mostly complete  list of  tags present  in the  test suite  together with guidelines on how to add new tags.
- Move todo  list for cleaning up  existing tests from github  issue to the documentation.

