### PR TITLE
remove explict mention of WASM runtime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ create software (including itself) that is sustainable, it aims to be:
 - *Scalable:* target a variety of hardware architectures, with zero or low cost
   abstractions to run in constrained environments.
 - *Adaptable:* producing native executables, running via the built-in VM, or
-  with in a JS/WASM runtime.
+  with in a JS runtime.
 - *Evolving:* developed and maintained by its community of users, with a self-
   hosted compiler, support for metaprogramming to safely attempt language
   extension outside of the core, and support code migration to avoid legacy.


### PR DESCRIPTION
Rationale: while it is technically/factually correct we don't have *any* tests to back  up this claim. Not all GC runtimes work reliably with wasm (`refc` tends to break  completely on startup), it is not out-of-the-box experience in any way (it might be in the future, but right now it is not) and it is not documented anywhere.

Can be switched back on when we actually have this implemented properly
