### PR TITLE
test organization

### DIFF
--- a/.github/contributing.rst
+++ b/.github/contributing.rst
@@ -84,6 +84,27 @@ forward:
 .. note:: Progress of the test suite improvements is tracked in the github
           `project <https://github.com/nim-works/nimskull/projects/2>`_.
 
+Running test suite locally
+--------------------------
+
+You can use `./koch.py` tool to execute tests:
+
+- `./koch.py test all`: run all available tests from scratch.
+
+- `./koch.py test cat <directory>`: run all tests in the tests
+  subdirectory. Tests are sorted into different directories based on their
+  categories so command itself is documented as "execute test category".
+
+After running specific test category you can generate *retry cache* to
+avoid re-running tests that are already ok. In order to generate the cache
+run `./koch.py test cache` after which you can use `./koch.py test --retry`
+to only execute failing tests.
+
+.. note:: Cache re-generation happens automatically when "all" tests are
+          executed.
+
+
+
 Cleaning up existing tests
 --------------------------
 

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -26,6 +26,6 @@ The standard distribution ships with the following tools:
 - | `nimgrep <nimgrep.html>`_
   | Nim search and replace utility.
 
-- | nimpretty
-  | `nimpretty`:cmd: is a |NimSkull| source code beautifier,
-    to format code according to the official style guide.
+- | `testament <testament.html>`_
+  | Compiler test execution tools
+

--- a/testament/backend.nim
+++ b/testament/backend.nim
@@ -128,18 +128,26 @@ proc open*() =
   thisMachine = getMachine()
   thisCommit = getCommit()
 
+const testResults = "testresults"
+
 proc close*() =
   if currentCategory.len > 0:
-    var resFile = open("testresults" / currentCategory.addFileExt"json", fmWrite)
+    # To handle `testament cat stdlib/os` testing. There is no reason to
+    # ban this because (surprise!) test directory can actually have more
+    # than one level of nesting.
+    createDir(joinPath(testResults, parentDir(currentCategory)))
+
+    var resFile = open(testResults / currentCategory.addFileExt"json", fmWrite)
     resFile.write pretty(results)
     close resFile
 
 proc cacheResults*() =
   ## Traverses the testresults directory and extracts any failed json entries
   ## and inserts them into a new file within the cacheresults directory.
-  createDir("testresults/cacheresults")
+  createDir(joinPath(testResults, "cacheresults"))
   # We will ignore any entries that have this as their result
-  const passResults = ["reJoined", "reSuccess", "reDisabled", "reKnownIssue", ""] # "" is defaulted to if result field not found
+  const passResults = [
+    "reJoined", "reSuccess", "reDisabled", "reKnownIssue", ""] # "" is defaulted to if result field not found
   let searchPattern = "testresults" / "*.json"
   # Prepare json array which will be written to our new cache file
   var fresults = newJArray()

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -494,7 +494,7 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string, options: st
 proc processCategory(r: var TResults, cat: Category,
                      options, testsDir: string,
                      runJoinableTests: bool) =
-  let cat2 = cat.string.normalize
+  let cat2 = cat.string.split("/")[0].normalize
   case cat2
   of "js":
     # only run the JS tests on Windows or Linux because some CI and other OSes


### PR DESCRIPTION
Follow-up for https://github.com/nim-works/nimskull/pull/461, mostly for imports and some docs

- Replace `import tables`  and `import sets` in tests  (replacement is done using `fd | sd`, so it is not exhaustive yet).
- Handle `testament  cat stdlib/os` properly --  there is no reason  to ban this as  (surprise!) test  directory might  have more  than one  level. I guess level of  orderliness of the core maintainers shows  in that pretty well.  After fifteen  years nobody  had ever  thought that  tests can  be placed into something other than 133+ entries on the same level.
- Add  small entry  for  using  `koch.py` for  test  running  tests in  the documentation.
- Add missing testament link from the documentation
- Comment out `nimpretty` link as it was removed earlier.

