### PR TITLE
testament documentation cleanup

### DIFF
--- a/.github/contributing.rst
+++ b/.github/contributing.rst
@@ -110,7 +110,7 @@ Cleaning up existing tests
 
 Original collection of tests in the test suite contained a lot of files
 that did not conform to the requirements listed above, and should
-eventually be fixed. List of known issues that should be fixed includes,
+eventually be fixed. A list of known issues that should be fixed includes,
 but not limited to:
 
 - Check if test name makes sense - `t123123_b.nim` does not make sense,
@@ -131,16 +131,18 @@ but not limited to:
   Huge number of original tests "referred" to issue numbers using file
   names or highly illegible comments such as `# XYZ123` placed at arbitrary
   locations all over the code. You should replace them with actual `url`
-  links so people can see the context quickly.
+  links from https://github.com/nim-lang/Nim/issues so people can see the
+  context quickly.
 
 
 
-- If possible, provide explanation to the test logic. You can use
-  explanation to the linked issues as a basis for explanation.
+- If possible, provide explanation to the test logic. You can use the description of the linked issue as a basis.
 
 - Adding labels to existing tests. For guidelines on test label usage and
   list of existing tags with documentation please see testament
-  documentation `Labels` section.
+  documentation `Labels
+  <https://nim-works.github.io/nimskull/testament.html#writing-tests-labels>`_
+  section.
 
 If you write new tests make sure they don't have these issues. Entries from
 this list should be *removed* from old tests and should *not be introduced*
@@ -171,6 +173,13 @@ different methods one can use to write a new test.
 - *Test for specific values*: Either use `doAssert <given> == <expected>`
   or `check` from `std/unittest`
 
+.. tip:: If the test already uses `std/unittest` or you plan to rewrite it
+         to use the library you should prefer `check` and `expect` macros,
+         otherwise you can stick to `try..except` and `doAssert`.
+
+         Another reason why might opt to use simpler solution is reducing
+         number of dependencies for the test -- if you want your test to
+         include as little additional details as possible.
 
 Improving Language specification
 --------------------------------

--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -230,22 +230,26 @@ If you notice any seemingly duplicate tags (e.g. `error_compile` and
 
 .. code-block:: cmd
 
-    rg --no-filename  -g "*.nim" "labels: " | sd 'labels:\s+"(.*?)"' '$1' | tr ' ' '\n' | sort | uniq -c
+    grep -R "labels: " |
+        sed -r 's/labels:\s+"(.*?)"/\1/' |
+        tr ' ' '\n' |
+        sort |
+        uniq -c
+
 
 - Type-related
   - ``array``: Array type is tested
   - ``distinct``: `distinct` type is involved
-  - ``enum``: Enumeration type is involved
+  - ``enum``: `enum` type is involved
   - ``ptr``: Default `ptr T` type
   - ``range``: Default `range[low..high]` type
   - ``ref``: Default `ref T` type
   - ``char``: Character type is involved
   - ``seq``: Default `seq[T]` type
-  - ``int``: Integer or other integral type is used
+  - ``int``: `int` or other integral type is used
   - ``float``: `float` or other floating point type is used
 - Compiler diagnostics
-  - ``error_compilation``:
-  - ``error_compile``:
+  - ``error_compile``: Test is expecting compilation error.
   - ``error_message``: Test is specifically targeting formatting or content
     of the error message.
 - Code detail
@@ -261,7 +265,6 @@ If you notice any seemingly duplicate tags (e.g. `error_compile` and
     - ``union``:
     - ``macro``:
     - ``iterator``:
-
   - Code detail
     - ``overload``:
     - ``exception``:
@@ -272,9 +275,13 @@ If you notice any seemingly duplicate tags (e.g. `error_compile` and
   - Other
     - ``pragma``:
     - ``subtyping``:
-    - ``resolution``: Overloading resolution
+    - ``resolution``: Overloading resolution for procedure calls.
     - ``typedesc``:
-    - ``var``: Mutable variable declaration
+    - ``var``: Mutable variable declaration -- variable declaration
+      statement, not to be confused with ``var_arg`` tag which refers to
+      the mutable argument in a callable declaration.
+    - ``var_arg``: Mutable argument to in a callable declaration
+      (procedure, method, convert, iterator etc.)
     - ``conversion``:
     - ``alias``:
     - ``constructor``:
@@ -287,7 +294,9 @@ If you notice any seemingly duplicate tags (e.g. `error_compile` and
   - ``backend_c``: Testing something directly related or requiring C backend
   - ``codegen``: Code generation is involved
   - ``mode_release``: Compiled in release mode
+  - ``mode_danger``
   - ``js``:
+  - ``cpp``
 - Standard library
   - ``stdlib``: Standard library module
   - ``system``: Types and procedures imported by default in every compiled

--- a/tests/ccgbugs/tcodegen_template_with_generic.nim
+++ b/tests/ccgbugs/tcodegen_template_with_generic.nim
@@ -1,5 +1,5 @@
 discard """
-labels: "codegen error_compilation generics template"
+labels: "codegen error_compile generics template"
 description: '''
   . From https://github.com/nim-lang/Nim/issues/6756
     Error in template when using the type of the parameter inside it


### PR DESCRIPTION
- wording and formatting of the label descriptions
- add missing links in the documentation
- use gnu =coreutils= solutions for getting list of tags
