### PR TITLE
semexprs: improve `semYieldVarResult`

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -573,6 +573,9 @@ type
     rsemCannotInferReturnType
     rsemExpectedValueForYield
     rsemUnexpectedYield
+    rsemYieldExpectedTupleConstr
+      ## a literal tuple constructor is required when the iterator returns a
+      ## tuple containing a view
     rsemCannotReturnTypeless
     rsemExpectedMacroOrTemplate
     rsemAmbiguousGetAst

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1469,6 +1469,13 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemUnexpectedYield:
       result = "'yield' only allowed in an iterator"
 
+    of rsemYieldExpectedTupleConstr:
+      # TODO: make the error message more helpful by also showing which
+      #       elements are of view type
+      result = "literal tuple constructor expected for 'yield', as the " &
+               "iterator returns a tuple directly containing a view. Got: " &
+               r.ast.render
+
     of rsemCannotReturnTypeless:
       result = "current routine cannot return an expression"
 

--- a/tests/errmsgs/tyield_view_tuple.nim
+++ b/tests/errmsgs/tyield_view_tuple.nim
@@ -1,0 +1,27 @@
+discard """
+  nimoutFormat: sexp
+  cmd: "nim check --msgFormat=sexp --filenames=canonical --hints:off $options $file"
+  action: reject
+"""
+
+block tuple_with_var:
+  proc make(x: var int): (int, var int) =
+    ## Helper procedure -- not relevant to the test
+    (0, x)
+
+  iterator iter(): (int, var int) =
+    var x = 0
+    # this doesn't compile because the expression is not a literal tuple
+    # constructor
+    yield make(x) #[tt.Error
+            ^ (SemYieldExpectedTupleConstr) ]#
+
+block tuple_with_lent:
+  proc make2(x: int): (int, lent int) =
+    (0, x)
+
+  iterator iter2(): (int, lent int) =
+    var x = 0
+    # same as for the previous test case
+    yield make2(x) #[tt.Error
+              ^ (SemYieldExpectedTupleConstr) ]#


### PR DESCRIPTION
## Summary
- replace `localReport` with `nkError` in `takeImplicitAddr`
- make `semYieldVarResult` `nkError` aware
- fix the `nkHiddenAddr` produced by `takeImplicitAddr` for tuple
  elements having the wrong type (i.e. `tyPtr`)
- use a dedicated error report for when a literal tuple constructor is
  expected, instead of the rather meaningless `illformed AST` error

## Details
- add a test for the introduced report
- improve documentation

In addition, a `nkHiddenAddr(nkDerefExpr(x))` expression is no longer
collapsed to just `x`. Doing so is unsound and produces expressions of
the wrong type, which causes problems for the MIR. In general, such
transformations/optimizations are better done in the backend.

The aforementioned change is also visible to macros operating on typed
AST:
```nim
proc p(x: ptr int): var int =
  result = x[]
  # the AST of the right-hand side is now:
  # ``nnkHiddenAddr(nnkDerefExpr(nnkSym))``
  # instead of:
  # ``nnkSym``

iterator iter(x: ptr int): var int =
  yield x[]
  # the AST differs in the same way as for the `result` assignment.

iterator iter2(x: ptr int): (int, var int) =
  yield (0, x[]) # the AST for `x[]` is also affected in the same way
```