### PR TITLE
compiler: improve `for`-loop tuple unpacking

### DIFF
--- a/tests/errmsgs/t17460.nim
+++ b/tests/errmsgs/t17460.nim
@@ -1,6 +1,7 @@
 discard """
-  cmd: "nim check $options $file"
-  errormsg: "wrong number of variables"
+  cmd: "nim check --msgFormat=sexp --filenames=canonical $options $file"
+  nimoutFormat: sexp
+  action: reject
 """
 
 iterator xclusters*[T](a: openarray[T]; s: static[int]): array[s, T] {.inline.} =
@@ -13,7 +14,8 @@ iterator xclusters*[T](a: openarray[T]; s: static[int]): array[s, T] {.inline.} 
     inc(i)
 
 proc m =
-  for (i, j, k) in xclusters([1, 2, 3, 4, 5], 3):
+  for (i, j, k) in xclusters([1, 2, 3, 4, 5], 3): #[tt.Error
+     ^ (SemWrongNumberOfVariables) ]#
     echo i, j, k
 
 m()

--- a/tests/lang_stmts/for_stmt/tforloop_tuple_unpacking.nim
+++ b/tests/lang_stmts/for_stmt/tforloop_tuple_unpacking.nim
@@ -1,0 +1,150 @@
+discard """
+  description: "Tests for tuple unpacking done by for-loops"
+  targets: "c !js !vm"
+"""
+
+# knownIssue: fails for the JS back-end with an internal compiler error
+# knownIssue: fails for the VM back-end because `=copy` hooks are not
+#             supported there
+
+type
+  Tup = tuple
+    a, b: int
+
+  Copyable = object
+    valid: bool
+
+var numCopies = 0
+
+proc `=copy`(a: var Copyable, b: Copyable) =
+  if b.valid:
+    inc numCopies
+    a.valid = true
+
+iterator single[T](item: T): T =
+  yield item
+
+iterator singleVar[T](item: var T): var T =
+  yield item
+
+iterator nestedVar[T](item: var T): (int, var T) =
+  yield (0, item)
+
+iterator nestedLent[T](item: T): (int, lent T) =
+  yield (0, item)
+
+iterator singleLent[T](item: T): lent T =
+  yield item
+
+block not_mutable:
+  # without the iterator returning the tuple as a ``var``, the unpacked
+  # elements are not mutable
+  var item: Tup = (1, 2)
+
+  for x, y in single(item):
+    doAssert not compiles(x = 1)
+    doAssert not compiles(y = 1)
+    doAssert x == 1
+    doAssert y == 2
+
+  for (x, y) in single(item):
+    doAssert not compiles(x = 1)
+    doAssert not compiles(y = 1)
+    doAssert x == 1
+    doAssert y == 2
+
+block var_access:
+  # if an unpacked tuple is of ``var`` type, so are its fields
+  var item: Tup = (1, 2)
+  for x, y in singleVar(item):
+    x = 3
+    y = 4
+
+  doAssert item.a == 3
+  doAssert item.b == 4
+
+  for (x, y) in singleVar(item):
+    x = 1
+    y = 2
+
+  doAssert item.a == 1
+  doAssert item.b == 2
+
+  # this is also true for nested unpacking
+  for _, (x, y) in nestedVar(item):
+    x = 3
+    y = 4
+
+  doAssert item.a == 3
+  doAssert item.b == 4
+
+block no_copy_lent:
+  # unpacking a ``lent`` tuple doesn't copy its elements
+  numCopies = 0
+  var item = (1, Copyable(valid: true))
+
+  for x, y in singleLent(item):
+    doAssert x == 1
+    doAssert y.valid == true
+
+  for (x, y) in singleLent(item):
+    doAssert x == 1
+    doAssert y.valid == true
+
+  # this is also true for nested unpacking
+  for _, (x, y) in nestedLent(item):
+    doAssert x == 1
+    doAssert y.valid == true
+
+  doAssert numCopies == 0
+
+block copy_no_lent:
+  # if it's safe to borrow, the copy *may* be elided -- otherwise it is
+  # required for when the item is not yielded as ``lent``
+  numCopies = 0
+  var item = (1, Copyable(valid: true))
+
+  for x, y in single(item):
+    item[1].valid = false # it's not safe to borrow (or to use a cursor)
+    doAssert y.valid
+
+  doAssert numCopies == 1
+  item[1].valid = true
+
+  for (x, y) in single(item):
+    item[1].valid = false
+    doAssert y.valid
+
+{.experimental: "views".}
+
+# the below doesn't work due to an unrelated view bug that creates invalid
+# code for the ``(1, x)`` expression
+when false: #block nested_var_in_lent:
+  # NOTE: the behaviour of this test is questionable
+
+  proc make(x: var int): (int, var int) =
+    ## A helper required to create a tuple with a ``var`` element
+    (1, x)
+
+  var a = 2
+  let item = make(a)
+
+  for x, y in singleLent(item):
+    doAssert y == 2
+    y = 3
+
+  doAssert a == 3
+
+  for (x, y) in singleLent(item):
+    doAssert y == 3
+    y = 2
+
+  doAssert a == 2
+
+  # the same also applies to nested unpacking
+
+  for _, (x, y) in nestedLent(item):
+    doAssert y == 2
+    y = 3
+
+  doAssert a == 3

--- a/tests/lang_stmts/for_stmt/tforloop_unpacking_bug.nim
+++ b/tests/lang_stmts/for_stmt/tforloop_unpacking_bug.nim
@@ -1,0 +1,25 @@
+discard """
+  description: '''
+    This is a regression test for a semantic analysis issue that was caused by
+    a direct type modification
+  '''
+  action: compile
+  target: native
+"""
+
+proc p1() =
+  var x: seq[(bool, bool)]
+  for _, a in x.mpairs: # doesn't mutate the type
+    a[0] = true # works
+
+proc p2() =
+  var x: seq[(bool, bool)]
+  for _, (_, _) in x.mpairs:
+    # mutates the type of the instantiated ``mpairs`` iterator (turns the
+    # return type from ``(int, var (bool, bool))`` into ``(int, (bool, bool))``
+    discard
+
+proc p3() =
+  var x: seq[(bool, bool)]
+  for _, a in x.mpairs:
+    a[0] = true # fails to compile: ``a[0]`` cannot be assigned to


### PR DESCRIPTION
## Summary
- fix an issue with `semForVar` where types were modified, leading to unrelated valid code being rejected by semantic analysis (see `tforloop_unpacking_bug.nim`)
- always use a full copy instead of a shallow copy for `for` variables
- refactor `semForVar`
- refactor `transformYield`
- make `semForVar` `nkError` aware

## Details
- fix the `nkHiddenAddr` nodes produced by `transformYield` having the wrong type (the type of the accessed tuple was used)
- split up `semForVar` into multiple procedures in order to reduce code duplication
- add debug-tracing calls to the `for`-loop related procedures
- improve the documentation of the refactored code
- add tests for `for`-loop tuple unpacking

Unconditionally using `nkFastAsgn` (i.e. a shallow assignment) for local variables is unsound without proving that doing so is safe (which did not happen). Figuring out where to use shallow copies should be left to the cursor inference step.

The `nkFastAsgn` change negatively impacts performance when of the compiled code when using `--gc:refc` (or other legacy GCs), because a full copy is materialized where it previously wasn't. This is not the case for `--gc:arc|orc`, as `nkFastAsgn` was/is treated the same as `nkAsgn` (i.e. as a full copy) for locations with destructors.

---

This PR depends on #487 to be merged first.