### PR TITLE
compiler: introduce a mid-end IR (MIR)

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -768,3 +768,21 @@ proc `[]`*(node: PNode, slice: NodeSliceName): seq[PNode] =
     of SliceAllIdents: node.sons[0..^3]
     of SliceAllArguments, SliceAllBranches: node.sons[1..^1]
     of SliceBranchExpressions: node.sons[0 .. ^2]
+
+iterator branches*(node: PNode): tuple[position: int, n: PNode] =
+  ## Returns all branches of the ``case`` statement or expression `node` in
+  ## order of occurrence. `position` is the 0-based position of the branch,
+  ## not the index of the sub-node
+  assert node.kind in {nkRecCase, nkCaseStmt}
+  for i in 1..<node.len:
+    yield (i-1, node[i])
+
+iterator branchLabels*(node: PNode): (int, PNode) =
+  ## Returns all labels of the branch-like constructs (i.e. ``of``, ``if``,
+  ## ``elif``) that `node` represents, together with their position. For
+  ## convenience, ``else`` branches are also allowed: they're treated as having
+  ## no labels
+  assert node.kind in {nkOfBranch, nkElifBranch, nkElse, nkElifExpr,
+                       nkElseExpr, nkExceptBranch}
+  for i in 0..<node.len-1:
+    yield (i, node[i])

--- a/compiler/mir/astgen.nim
+++ b/compiler/mir/astgen.nim
@@ -1,0 +1,1268 @@
+## This module implements the MIR -> ``PNode`` AST translation. The translation
+## preserves the semantics and uses the smallest ``PNode`` constructs that best
+## match the respective MIR construct. Note that not all constructs in the MIR
+## have a direct ``PNode`` counterpart: those require more complex translation
+## logic.
+##
+## The translation is implemented via recursive application of the correct
+## translation procedure, where each procedure processes a sub-tree either
+## directly or via further recursion. Instead of one uber procedure, multiple
+## smaller ones that closely match the grammer are used. This allows for
+## validating that the input MIR code is grammatically correct with effectively
+## no overhead and without requiring extra contextual data or a separate pass.
+##
+## ============
+## MIR sections
+## ============
+##
+## There exists no equivalent to MIR sections in the ``PNode`` AST, so a more
+## complex translation has to be used. At the start of the section, each
+## section argument is assigning to a temporary, using either a ``var`` /
+## ``lent`` view or shallow copy depending on the argument's mode and
+## type. A section parameter reference (``mnkOpParam``) is then translated to
+## accessing the temporary introduce for the parameter's argument.
+
+import
+  compiler/ast/[
+    ast,
+    ast_types,
+    ast_idgen,
+    ast_query,
+    idents,
+    lineinfos,
+    types
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/mir/[
+    mirtrees,
+    sourcemaps
+  ],
+  compiler/modules/[
+    magicsys,
+    modulegraphs
+  ],
+  compiler/sem/[
+    lowerings
+  ],
+  compiler/utils/[
+    containers,
+    idioms
+  ]
+
+from compiler/sem/semdata import makeVarType
+from compiler/sem/typeallowed import directViewType, noView
+
+# TODO: move the procedure somewhere common
+from compiler/vm/vmaux import findRecCase
+
+type
+  ValuesKind = enum
+    vkNone, vkSingle, vkMulti
+
+  ArgumentMode = enum
+    amValue
+    amName
+    amConsume
+
+  ValueTag = enum
+    ## ``ValueTag``s are used to propgate some information forward to the
+    ## value's consumer (e.g. a procedure call)
+    vtMutable ## the value is a mutable lvalue meant to be passed to a ``var``
+              ## parameter
+    vtVariant
+
+  ValueTags = set[ValueTag]
+
+  Values = object
+    ## Represents the inputs to an operation. A container of zero-or-more
+    ## values, where each value is represented by a ``PNode`` expression
+    case kind: ValuesKind
+    of vkNone:
+      discard
+    of vkSingle:
+      single: PNode
+      tag: ValueTags
+    of vkMulti:
+      list: seq[PNode]
+      modeAndTags: seq[tuple[mode: ArgumentMode, tags: ValueTags]]
+        ## a separate sequence is used so that the whole ``PNode`` list can
+        ## be moved into the destination node at once
+
+  TranslateCl = object
+    graph: ModuleGraph
+    cache: IdentCache
+    idgen: IdGenerator
+
+    owner: PSym
+
+    tempMap: SeqMap[TempId, PSym]
+      ## maps a ``TempId`` to ``PSym`` created for it
+    labelMap: SeqMap[uint32, PSym]
+      ## maps a block-label name to the ``PSym`` created for it
+
+    params: Values
+
+    # While in the MIR only a ``mnkScope`` opens a new scope, in ``PNode``-AST
+    # both ``nkStmtList`` and ``nkStmtListExpr`` do - the latter being used by
+    # the arg-block translation. A 'def'-like can appear inside an arg-block
+    # and the defined entity be used outside of it, which would thus result
+    # in the definition being placed in an ``nkStmtListExpr``, producing
+    # semantically invalid code that later results in code-gen errors.
+    # To solve the problem, if a 'def'-like appears nested inside an arg-block,
+    # only an assignment (if necessary) is produced and the symbol node is
+    # added to the `def` list, which is then used to create a var section that
+    # is prepended to the statement list produced for the current enclosing
+    # ``mnkScope``
+    inArgBlock: int ## keeps track of the current arg-block nesting
+    defs: seq[PSym]
+
+  TreeWithSource = object
+    ## Combines a ``MirTree`` with its associated ``SourceMap`` for
+    ## convenience. It's only meant to be used as parameter type
+    # TODO: the fields don't need ownership and should thus be turned into
+    #       views as soon as possible
+    tree: MirTree
+    map: SourceMap
+
+  TreeCursor = object
+    ## A cursor into a ``TreeWithSource``
+    pos: uint32 ## the index of the currently pointed to node
+    origin {.cursor.}: PNode ## the node
+
+template isFilled(x: ref): bool = not x.isNil
+
+template `^^`(s, i: untyped): untyped =
+  # XXX: copied from ``system.nim`` because it's not exported
+  (when i is BackwardsIndex: s.len - int(i) else: int(i))
+
+func toValues(x: sink PNode): Values {.inline.} =
+  # note: having ``toValues`` be an implicit converter lead to an overload
+  # resolution issue where the converter was incorrectly chosen, making
+  # otherwise correct code not compile
+  assert x != nil
+  Values(kind: vkSingle, single: x)
+
+func `[]`(v: Values, i: Natural): PNode =
+  if i > 0 or v.kind == vkMulti:
+    v.list[i]
+  else:
+    v.single
+
+func len(v: Values): int =
+  case v.kind
+  of vkNone:   0
+  of vkSingle: 1
+  of vkMulti:  v.list.len
+
+func add(v: var Values, n: sink PNode, tag: ValueTags, mode: ArgumentMode) =
+  v.list.add n
+  v.modeAndTags.add (mode, tag)
+
+func getCalleeMagic(n: PNode): TMagic =
+  if n.kind == nkSym: n.sym.magic
+  else:               mNone
+
+proc createMagic(cl: var TranslateCl, magic: TMagic): PSym =
+  createMagic(cl.graph, cl.idgen, "op", magic)
+
+func get(t: TreeWithSource, cr: var TreeCursor): lent MirNode {.inline.} =
+  cr.origin = sourceFor(t.map, cr.pos.NodeInstance)
+  result = t.tree[cr.pos]
+
+  inc cr.pos
+
+func enter(t: TreeWithSource, cr: var TreeCursor): lent MirNode {.inline.} =
+  assert t.tree[cr.pos].kind in SubTreeNodes, "not a sub-tree"
+  result = get(t, cr)
+
+func leave(t: TreeWithSource, cr: var TreeCursor) =
+  assert t.tree[cr.pos].kind == mnkEnd, "not at the end of sub-tree"
+  inc cr.pos
+
+template info(cr: TreeCursor): TLineInfo =
+  cr.origin.info
+
+template `[]`(t: TreeWithSource, cr: TreeCursor): untyped =
+  t.tree[cr.pos]
+
+template hasNext(cr: TreeCursor, t: TreeWithSource): bool =
+  cr.pos.int < t.tree.len
+
+func toMode(kind: range[mnkArg..mnkConsume]): ArgumentMode =
+  case kind
+  of mnkArg:     amValue
+  of mnkName:    amName
+  of mnkConsume: amConsume
+
+proc copySubTree[A, B](source: PNode, slice: HSlice[A, B], to: PNode) =
+  ## Copies all sub-nodes from the `slice` in `source` to the end of `to`,
+  ## using a full sub-tree copy (i.e. ``copyTree``)
+  # XXX: using an ``openArray`` instead of a ``PNode`` + ``HSlice`` pair
+  #      would simplify this procedure a lot. As of the time of this comment
+  #      being written, creating an openArray from a node is rather cumbersome
+  #      however
+  let
+    a = source ^^ slice.a
+    b = source ^^ slice.b
+
+  if a > b:
+    return
+
+  # resize the node list first:
+  let start = to.len
+  to.sons.setLen(start + (b - a) + 1)
+
+  # then copy all nodes:
+  for i in a..b:
+    to[start + (i - a)] = source[i]
+
+func addIfNotEmpty(stmts: var seq[PNode], n: sink PNode) =
+  ## Only adds the node to the list if it's not an empty node. Used to prevent
+  ## the creation of statement-list expression that only consist of empty
+  ## nodes + the result-expression (a statement-list expression is unnecessary
+  ## in that case)
+  if n.kind != nkEmpty:
+    stmts.add n
+
+func toSingleNode(stmts: sink seq[PNode]): PNode =
+  ## Creates a single ``PNode`` from a list of *statements*
+  case stmts.len
+  of 0:
+    result = newNode(nkEmpty)
+  of 1:
+    result = move stmts[0]
+  else:
+    result = newNode(nkStmtList)
+    result.sons = move stmts
+
+proc wrapArg(stmts: seq[PNode], info: TLineInfo, val: PNode): PNode =
+  ## If there are extra statements (i.e. `stmts` is not empty), wraps the
+  ## statements + result-expression into an ``nkStmtListExpr``. Otherwise,
+  ## returns `val` as is
+  if stmts.len == 0:
+    result = val
+  else:
+    assert val.kind != nkStmtListExpr
+    result = newTreeIT(nkStmtListExpr, info, val.typ, stmts)
+    result.add val
+
+func unwrap(expr: PNode, stmts: var seq[PNode]): PNode =
+  if expr.kind == nkStmtListExpr:
+    for i in 0..<expr.len-1:
+      stmts.add expr[i]
+
+    result = expr[^1]
+  else:
+    result = expr
+
+proc makeVarSection(syms: openArray[PSym], info: TLineInfo): PNode =
+  ## Creates a var section with all symbols from `syms`
+  result = newNodeI(nkVarSection, info)
+  result.sons.newSeq(syms.len)
+  for i, s in syms.pairs:
+    result[i] = newIdentDefs(newSymNode(s))
+
+proc newTemp(cl: var TranslateCl, info: TLineInfo, typ: PType): PSym =
+  ## Creates and returns a new ``skTemp`` symbol
+  newSym(skTemp, cl.cache.getIdent(genPrefix),
+         cl.idgen.nextSymId(), cl.owner, info, typ)
+
+func findBranch(c: ConfigRef, rec: PNode, field: PIdent): int =
+  ## Computes the 0-based position of the branch that `field` is part of. Only
+  ## the direct child nodes of `rec` are searched, nested record-cases are
+  ## ignored
+  assert rec.kind == nkRecCase
+  template cmpSym(s: PSym): bool =
+    s.name.id == field.id
+
+  for i, b in branches(rec):
+    assert b.kind in {nkOfBranch, nkElse}
+    case b.lastSon.kind
+    of nkSym:
+      if cmpSym(b.lastSon.sym):
+        return i
+
+    of nkRecList:
+      for it in b.lastSon.items:
+        let sym =
+          case it.kind
+          of nkSym: it.sym
+          of nkRecCase: it[0].sym
+          else: nil
+
+        if sym != nil and cmpSym(sym):
+          return i
+
+    of nkRecCase:
+      if cmpSym(b[0].sym):
+        return i
+
+    else:
+      unreachable()
+
+  unreachable("field is not part of the record-case")
+
+proc buildCheck(cl: var TranslateCl, recCase: PNode, pos: Natural,
+                info: TLineInfo): PNode =
+  ## Builds the boolean expression testing if `discr` is part of the branch
+  ## with position `pos`
+  assert recCase.kind == nkRecCase
+  let
+    discr = recCase[0] ## the node holding the discriminant symbol
+    branch = recCase[1 + pos]
+    setType = newType(tySet, nextTypeId(cl.idgen), cl.owner)
+
+  rawAddSon(setType, discr.typ) # the set's element type
+
+  var
+    lit = newNodeIT(nkCurly, info, setType)
+    invert = false
+
+  case branch.kind
+  of nkOfBranch:
+    # use the branch labels as the set to test against
+    copySubTree(branch, 0..^2, lit)
+  of nkElse:
+    # iterate over all branches except the ``else`` branch and collect their
+    # labels
+    for i in 1..<recCase.len-1:
+      let b = recCase[i]
+      copySubTree(b, 0..^2, lit)
+
+    invert = true
+  else:
+    unreachable()
+
+  # create a ``contains(lit, discr)`` expression:
+  let inExpr =
+    newTreeIT(nkCall, info, getSysType(cl.graph, info, tyBool), [
+      newSymNode(getSysMagic(cl.graph, info, "contains", mInSet), info),
+      lit,
+      copyTree(discr)
+    ])
+
+  if invert:
+    result =
+      newTreeIT(nkCall, info, getSysType(cl.graph, info, tyBool), [
+        newSymNode(getSysMagic(cl.graph, info, "not", mNot), info),
+        inExpr
+      ])
+  else:
+    result = inExpr
+
+proc addToVariantAccess(cl: var TranslateCl, dest: PNode, field: PSym,
+                        info: TLineInfo): PNode =
+  ## Appends a field access for a field inside a record branch to `dest`
+  ## (transforming it into a ``nkCheckedFieldExpr`` if it isn't one already)
+  ## and returns the resulting expression
+  let node =
+    case dest.kind
+    of nkDotExpr: dest
+    of nkCheckedFieldExpr: dest[0]
+    else: unreachable()
+
+  # TODO: generating a field check (i.e. ``nkCheckedFieldExpr``) should not
+  #       done by the code-generators, but instead happen at the MIR level as
+  #       a MIR pass. In other words, a MIR pass should insert an 'if' +
+  #       'raise' for each access to a field inside a record branch (but only
+  #       if ``optFieldCheck`` is enabled) and no ``nkCheckedFieldExpr`` should
+  #       be generated here
+
+  assert node.kind == nkDotExpr
+
+  let
+    # the symbol of the discriminant is on the right-side of the dot-expr
+    discr = node[1].sym
+    recCase = findRecCase(node[0].typ.skipTypes(abstractInst+tyUserTypeClasses), discr)
+    check = buildCheck(cl, recCase, findBranch(cl.graph.config, recCase, field.name),
+                       info)
+
+  node[1] = newSymNode(field)
+  node.typ = field.typ
+
+  case dest.kind
+  of nkDotExpr:
+    newTreeIT(nkCheckedFieldExpr, info, field.typ, [node, check])
+  of nkCheckedFieldExpr:
+    # a field is accessed that is inside a nested record-case. Don't wrap the
+    # ``nkCheckedFieldExpr`` in another one -- append the check instead.
+    # While the order of the checks *should* be irrelevant, we still emit them
+    # in the order they were generated originally (i.e. innermost to outermost)
+    dest.sons.insert(check, 1)
+    # update the type of the expression:
+    dest.typ = field.typ
+    dest
+  else:
+    unreachable()
+
+# FIXME: duplicated from mirgen
+func isSimple(n: PNode): bool =
+  ## Computes if the l-value expression `n` always names the same valid
+  ## location
+  var n = n
+  while true:
+    case n.kind
+    of nkSym, nkLiterals:
+      return true
+    of nkDotExpr:
+      # ``nkCheckedFieldExpr`` is deliberately not included here because it
+      # means the location is part of a variant-object-branch
+      n = n[0]
+    of nkBracketExpr:
+      if n[0].typ.skipTypes(abstractVarRange).kind in {tyTuple, tyArray} and
+          n[1].kind in nkLiterals:
+        # tuple access and arrays indexed by a constant value are
+        # allowed -- they always name the same location
+        n = n[0]
+      else:
+        return false
+    else:
+      return false
+
+func underlyingLoc(n: PNode): tuple[underlying: PNode, firstConv: PNode] =
+  ## Returns the lvalue expression stripped from any trailing lvalue
+  ## conversion. For convenience, the node representing the first
+  ## applied conversion is also returned. If no conversion exists, `firstConv`
+  ## is equal to `underlying`
+  var
+    n = n
+    orig = n
+
+  while n.kind in {nkObjDownConv, nkObjUpConv}:
+    orig = n
+    n = n.lastSon
+
+  result = (n, orig)
+
+proc useLvalueRef(n: PNode, mutable: bool, cl: var TranslateCl,
+                  stmts: var seq[PNode]): PNode =
+  ## Generates a temporary view into the location named by the lvalue
+  ## expression `n` and returns the deref expression for accessing the
+  ## location
+  let
+    (locExpr, conv) = underlyingLoc(n)
+    typ = makeVarType(cl.owner, locExpr.typ, cl.idgen,
+                      (if mutable: tyVar else: tyLent))
+
+    sym = newTemp(cl, n.info, typ)
+
+  # for the "undo conversion" logic to work, the expression needs to end in a
+  # conversion. Creating a view from the location *after* lvalue conversion
+  # would break this, so instead, a view is created from the unconverted
+  # location and the conversion is applied at each usage site
+  stmts.add newTreeI(nkVarSection, n.info,
+                     [newIdentDefs(newSymNode(sym),
+                                   newTreeIT(nkHiddenAddr, n.info, typ, [locExpr]))
+                     ])
+
+  if locExpr != conv:
+    # a conversion exists. Rewrite the conversion operation to apply to the
+    # dereferenced view
+    conv[0] = newTreeIT(nkHiddenDeref, n.info, locExpr.typ, [newSymNode(sym)])
+    result = n
+  else:
+    result = newTreeIT(nkHiddenDeref, n.info, n.typ, [newSymNode(sym)])
+
+proc useTemporary(n: PNode, cl: var TranslateCl, stmts: var seq[PNode]): PNode =
+  let sym = newTemp(cl, n.info, n.typ)
+
+  stmts.add newTreeI(nkVarSection, n.info, [newIdentDefs(newSymNode(sym), n)])
+  result = newSymNode(sym)
+
+proc canUseView(n: PNode): bool =
+  ## Computes whether the expression `n` computes to something for which a
+  ## view can be created
+  var n {.cursor.} = n
+  while true:
+    case n.kind
+    of nkAddr, nkHiddenAddr, nkBracketExpr, nkObjUpConv, nkObjDownConv,
+       nkCheckedFieldExpr, nkDotExpr:
+      n = n[0]
+    of nkHiddenStdConv, nkHiddenSubConv, nkConv:
+      if skipTypes(n.typ, abstractVarRange).kind in {tyOpenArray, tyTuple, tyObject} or
+         compareTypes(n.typ, n[1].typ, dcEqIgnoreDistinct):
+        # lvalue conversion
+        n = n[1]
+      else:
+        return false
+
+    of nkSym:
+      # don't use a view if the location is part of a constant
+      return n.sym.kind in {skVar, skLet, skForVar, skResult, skParam, skTemp}
+    of nkHiddenDeref, nkDerefExpr:
+      return true
+    of nkCallKinds:
+      # if the call yields a view, use an lvalue reference (view) -- otherwise,
+      # do not
+      return directViewType(n.typ) != noView
+    else:
+      return false
+
+proc prepareParameter(expr: PNode, tag: ValueTags, mode: ArgumentMode,
+                      cl: var TranslateCl, stmts: var seq[PNode]): PNode =
+  let expr = unwrap(expr, stmts)
+  if isSimple(expr):
+    # if it's an independent expression with no side-effects, a temporary is
+    # not needed and the expression can be used directly
+    result = expr
+  elif mode == amName or
+       (skipTypes(expr.typ, abstractVarRange).kind notin IntegralTypes and
+        canUseView(expr)):
+    # using an lvalue reference (view) is preferred for complex values
+    result = useLvalueRef(expr, vtMutable in tag, cl, stmts)
+  else:
+    # assign to a temporary first
+    result = useTemporary(expr, cl, stmts)
+
+proc prepareParameters(params: var Values, stmts: var seq[PNode],
+                       cl: var TranslateCl) =
+  ## Pre-processes the given arguments so that they can be used (referenced)
+  ## as region parameters. A region can be seen as an inlined procedure
+  ## call, where each reference to a parameter is replaced with the
+  ## corresponding argument. Argument expressions that have side-effects or
+  ## depend on mutable state are first assigned to a temporary.
+  case params.kind
+  of vkNone:
+    unreachable()
+  of vkSingle:
+    # arguments passed without an arg-block use the 'consume' argument mode
+    params.single = prepareParameter(params.single, {}, amConsume, cl, stmts)
+  of vkMulti:
+    for i, param in params.list.mpairs:
+      let (mode, tags) = params.modeAndTags[i]
+      param = prepareParameter(param, tags, mode, cl, stmts)
+
+proc wrapInHiddenAddr(cl: TranslateCl, n: PNode): PNode =
+  ## Restores the ``nkHiddenAddr`` around lvalue expressions passed to ``var``
+  ## parameters. The code-generators operating on ``PNode``-AST depend on the
+  ## hidden addr to be present
+  let inner =
+    if n.kind == nkStmtListExpr: n.lastSon else: n
+
+  result =
+    if n.typ.skipTypes(abstractInst).kind != tyVar:
+      newTreeIT(nkHiddenAddr, n.info, makeVarType(cl.owner, n.typ, cl.idgen), n)
+    elif inner.kind == nkObjDownConv and
+         inner[0].typ.kind != tyVar:
+      # TODO: ``nkHiddenSubConv`` nodes for objects (which are later
+      #       transformed into ``nkObjDownConv`` nodes) are in some cases
+      #       incorrectly typed as ``var`` somewhere in the compiler
+      #       (presumably during sem). Fix the underlying problem and remove
+      #       the special case here
+      newTreeIT(nkHiddenAddr, n.info, n.typ, n)
+    else:
+      n
+
+proc genObjConv(n: PNode, a, b, t: PType): PNode =
+  ## Depending on the relationship between `a` and `b`, wraps `n` in either an
+  ## up- or down-conversion. `t` is the type to use for the resulting
+  ## expression
+  let diff = inheritanceDiff(b, a)
+  #echo "a: ", a.sym.name.s, "; b: ", b.sym.name.s
+  #assert diff != 0 and diff != high(int), "redundant or illegal conversion"
+  if diff == 0:
+    return nil
+  result = newTreeIT(
+    if diff < 0: nkObjUpConv else: nkObjDownConv,
+    n.info, t): n
+
+# forward declarations:
+proc tbSeq(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): Values
+
+proc tbStmt(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): PNode {.inline.}
+proc tbList(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): PNode
+
+proc tbScope(tree: TreeWithSource, cl: var TranslateCl, n: MirNode, cr: var TreeCursor): PNode
+
+proc tbRegion(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
+              cr: var TreeCursor): PNode
+
+proc handleSpecialConv(c: ConfigRef, n: PNode, info: TLineInfo,
+                       dest: PType): PNode =
+  ## Checks if a special conversion operator is required for a conversion
+  ## between the source type (i.e. that of `n`) and the destination type.
+  ## If it is, generates the conversion operation AST and returns it -- nil
+  ## otherwise
+  let
+    orig = dest
+    source = n.typ.skipTypes(abstractVarRange)
+    dest = dest.skipTypes(abstractVarRange)
+
+  case dest.kind
+  of tyObject:
+    assert source.kind == tyObject
+    result = genObjConv(n, source, dest, orig)
+  of tyRef, tyPtr, tyVar, tyLent:
+    assert source.kind == dest.kind
+
+    if source.base.kind == tyObject:
+      if n.kind in {nkObjUpConv, nkObjDownConv} and sameType(dest, n[0].typ):
+        # this one and the previous conversion cancel each other out. Both
+        # ``nkObjUpConv`` and ``nkObjDownConv`` are not treated as lvalue
+        # conversions when the source/dest operands are pointer/reference-like,
+        # so the collapsing here is required in order to generate correct
+        # code
+        result = n[0]
+      else:
+        result = genObjConv(n, source.base, dest.base, orig)
+
+  of tyInt..tyInt64, tyEnum, tyChar, tyUInt8..tyUInt32:
+    # TODO: including ``tyUInt64`` here causes rvmIllegalConv errors for code
+    #       that is run in the VM. ``transf`` (from where the logic was copied
+    #       from) also doesn't include it. Find out what the underlying problem
+    #       is, fix it, and include ``tyUInt64`` here
+    # TODO: introducing and lowering range checks into an if + raise should
+    #       happen at the MIR level as a MIR pass (maybe even earlier) instead
+    #       of requiring the code-generators to implement this logic
+    if isOrdinalType(source) and               # is it a float-to-int conversion?
+       (firstOrd(c, orig) > firstOrd(c, n.typ) or
+        lastOrd(c, n.typ) > lastOrd(c, orig)): # is dest not a sub-range of source?
+      # generate a range check:
+      let
+        rangeDest = skipTypes(orig, abstractVar)
+        kind =
+          if tyInt64 in {dest.kind, source.kind}: nkChckRange64
+          else:                                   nkChckRange
+
+      result = newTreeIT(kind, info, orig):
+        [n,
+         newIntTypeNode(firstOrd(c, rangeDest), rangeDest),
+         newIntTypeNode(lastOrd(c, rangeDest), rangeDest)]
+  of tyFloat..tyFloat128:
+    let rangeDest = skipTypes(orig, abstractVar)
+    if rangeDest.kind == tyRange:
+      # a conversion to a float range (e.g. ``range[0.0 .. 1.0]``)
+      result = newTreeIT(nkChckRangeF, info, orig):
+        [n, copyTree(rangeDest.n[0]), copyTree(rangeDest.n[1])]
+
+  else:
+    result = nil
+
+proc tbConv(cl: TranslateCl, n: PNode, info: TLineInfo, dest: PType): PNode =
+  ## Generates the AST for an expression that performs a type conversion for
+  ## `n` to type `dest`
+  result = handleSpecialConv(cl.graph.config, n, info, dest)
+  if result == nil:
+    # no special conversion is used
+    result = newTreeIT(nkConv, info, dest): [newNodeIT(nkType, info, dest), n]
+
+proc tbSingle(n: MirNode, cl: TranslateCl, info: TLineInfo): PNode =
+  case n.kind
+  of mnkProc, mnkConst, mnkParam, mnkGlobal, mnkLocal:
+    newSymNodeIT(n.sym, info, n.sym.typ)
+  of mnkTemp:
+    newSymNode(cl.tempMap[n.temp], info)
+  of mnkLiteral:
+    n.lit
+  of mnkType:
+    newNodeIT(nkType, info, n.typ)
+  else:
+    unreachable("not an atom: " & $n.kind)
+
+proc tbExceptItem(tree: TreeWithSource, cl: TranslateCl, cr: var TreeCursor
+                 ): PNode =
+  let n {.cursor.} = get(tree, cr)
+  case n.kind
+  of mnkPNode: n.node
+  of mnkType:  newNodeIT(nkType, cr.info, n.typ)
+  else:        unreachable()
+
+
+proc tbDef(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
+           n: MirNode, cr: var TreeCursor): PNode =
+  ## Translates a 'def'-like construct
+  assert n.kind in DefNodes
+  let
+    entity {.cursor.} = get(tree, cr) # the name of the defined entity
+    info = cr.info
+
+  var def: PNode
+
+  case entity.kind
+  of SymbolLike:
+    def = tbSingle(entity, cl, info)
+    case def.sym.kind
+    of skVar, skLet, skForVar:
+      discard "pass through"
+    of skParam:
+      # has no ``PNode`` counterpart
+      def = newNode(nkEmpty)
+    of routineKinds:
+      # the original procdef is stored as the second sub-node
+      def = get(tree, cr).node
+    else:
+      unreachable()
+
+  of mnkTemp:
+    # for temporaries, we create an ``skTemp`` symbol and associate it with
+    # the ``TempId`` so that it can be looked up later
+    assert entity.typ != nil
+    let sym = newTemp(cl, info, entity.typ)
+
+    assert entity.temp notin cl.tempMap, "re-definition of temporary"
+    cl.tempMap[entity.temp] = sym
+
+    def = newSymNode(sym, info)
+  else:
+    unreachable()
+
+  leave(tree, cr)
+
+  if def.kind == nkSym:
+    assert def.sym.kind in {skVar, skLet, skForVar, skTemp}
+    # it's a definition that needs to be put into a var section
+    if cl.inArgBlock > 0:
+      # if we're inside an arg-block, the var section is generated later and
+      # placed at an earlier position. We just produce an assignment to the
+      # entity here (if the def has an input)
+      cl.defs.add def.sym
+
+      result =
+        case prev.kind
+        of vkNone:   newNodeI(nkEmpty, info)
+        of vkSingle: newTreeI(nkAsgn, info, def, prev.single)
+        of vkMulti:  unreachable()
+
+    else:
+      result = newTreeI(nkVarSection, info):
+        case prev.kind
+        of vkNone:   newIdentDefs(def)
+        of vkSingle: newIdentDefs(def, prev.single)
+        of vkMulti:  unreachable()
+
+  else:
+    result = def
+
+proc tbSingleStmt(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
+                  cr: var TreeCursor): PNode =
+  template body(): PNode =
+    tbStmt(tree, cl, cr)
+
+  let info = cr.info ## the source information of `n`
+
+  case n.kind
+  of DefNodes:
+    # a definition of an entity with no initial value
+    result = tbDef(tree, cl, Values(kind: vkNone), n, cr)
+  of mnkScope:
+    result = tbScope(tree, cl, n, cr)
+    leave(tree, cr)
+  of mnkRepeat:
+    # translated into ``while true: body``
+    result =
+      newTreeI(nkWhileStmt, info,
+               newIntTypeNode(1, cl.graph.getSysType(info, tyBool)), # condition
+               body()) # body
+
+    leave(tree, cr)
+  of mnkBlock:
+    let sym = newSym(skLabel, cl.cache.getIdent("label"), cl.idgen.nextSymId(),
+                     cl.owner, info)
+    cl.labelMap[n.label[]] = sym
+
+    result = newTreeI(nkBlockStmt, info,
+                      newSymNode(sym), # the label
+                      body())
+    leave(tree, cr)
+  of mnkTry:
+    result = newTreeIT(nkTryStmt, info, n.typ, [body()])
+    assert n.len <= 2
+
+    for _ in 0..<n.len:
+      let it {.cursor.} = enter(tree, cr)
+
+      case it.kind
+      of mnkExcept:
+        for _ in 0..<it.len:
+          let br {.cursor.} = enter(tree, cr)
+          assert br.kind == mnkBranch
+
+          let excpt = newTreeI(nkExceptBranch, cr.info)
+          for j in 0..<br.len:
+            excpt.add tbExceptItem(tree, cl, cr)
+
+          excpt.add body()
+          result.add excpt
+
+          leave(tree, cr)
+
+      of mnkFinally:
+        result.add newTreeI(nkFinally, cr.info, body())
+      else:
+        unreachable(it.kind)
+
+      leave(tree, cr)
+
+    leave(tree, cr)
+  of mnkBreak:
+    let label =
+      if n.label.isSome: newSymNode(cl.labelMap[n.label[]])
+      else:              newNode(nkEmpty)
+
+    result = newTreeI(nkBreakStmt, info, [label])
+  of mnkReturn:
+    result = newTreeI(nkReturnStmt, info, [newNode(nkEmpty)])
+  of mnkPNode:
+    result = n.node
+  of AllNodeKinds - StmtNodes:
+    unreachable(n.kind)
+
+proc tbStmt(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
+            cr: var TreeCursor): PNode =
+  case n.kind
+  of mnkStmtList:
+    result = tbList(tree, cl, cr)
+    leave(tree, cr)
+  else:
+    result = tbSingleStmt(tree, cl, n, cr)
+
+proc tbSingleStmt(tree: TreeWithSource, cl: var TranslateCl,
+                  cr: var TreeCursor): PNode {.inline.} =
+  tbSingleStmt(tree, cl, get(tree, cr), cr)
+
+proc tbStmt(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor
+           ): PNode {.inline.} =
+  tbStmt(tree, cl, get(tree, cr), cr)
+
+proc tbCaseStmt(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
+                prev: sink Values, cr: var TreeCursor): PNode =
+  result = newTreeI(nkCaseStmt, cr.info, [prev.single])
+  for j in 0..<n.len:
+    let br {.cursor.} = enter(tree, cr)
+
+    if br.len == 0:
+      result.add newTreeI(nkElse, cr.info)
+    else:
+      result.add newTreeI(nkOfBranch, cr.info)
+      for x in 0..<br.len:
+        result[^1].add get(tree, cr).lit
+
+    result[^1].add tbStmt(tree, cl, cr)
+    leave(tree, cr)
+
+  leave(tree, cr)
+
+proc tbOut(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
+           cr: var TreeCursor): PNode =
+  let n {.cursor.} = get(tree, cr)
+  case n.kind
+  of DefNodes:
+    tbDef(tree, cl, prev, n, cr)
+  of mnkRegion:
+    tbRegion(tree, cl, prev, cr)
+  of mnkFastAsgn:
+    assert prev.list.len == 2
+    newTreeI(nkFastAsgn, cr.info, [prev[0], prev[1]])
+  of mnkInit, mnkAsgn:
+    assert prev.list.len == 2
+    newTreeI(nkAsgn, cr.info, [prev[0], prev[1]])
+  of mnkSwitch:
+    assert prev.list.len == 2
+    newTreeI(nkFastAsgn, cr.info, [prev[0], prev[1]])
+    # TODO: use a MIR pass to lower 'switch' operations into assignments and
+    #       make reaching here an error
+    #unreachable("unlowered switch")
+  of mnkIf:
+    assert prev.kind == vkSingle
+    let n = newTreeI(nkIfStmt, cr.info):
+      [newTreeI(nkElifBranch, cr.info, [prev.single, tbStmt(tree, cl, cr)])]
+    leave(tree, cr)
+
+    n
+  of mnkVoid:
+    # it's a void sink
+    assert prev.kind == vkSingle
+    if prev.single.typ.isEmptyType():
+      # a void call doesn't need to be discarded
+      prev.single
+    else:
+      newTreeI(nkDiscardStmt, cr.info, [prev.single])
+
+  of mnkRaise:
+    newTreeI(nkRaiseStmt, cr.info, [prev.single])
+  of mnkCase:
+    tbCaseStmt(tree, cl, n, prev, cr)
+  of AllNodeKinds - OutputNodes:
+    unreachable(n.kind)
+
+
+proc tbArgBlock(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor
+               ): Values =
+  var stmts: seq[PNode]
+  result = Values(kind: vkMulti)
+
+  inc cl.inArgBlock
+
+  while true:
+    case tree[cr].kind
+    of InputNodes:
+      let v = tbSeq(tree, cl, cr)
+      case tree[cr].kind
+      of ArgumentNodes:
+        let n {.cursor.} = get(tree, cr)
+        # bundle the statements (if any) and the direct expression together,
+        # and reset the collected statements:
+        let expr = wrapArg(stmts, cr.info, v.single)
+        stmts.setLen(0)
+
+        result.add(expr, v.tag, toMode(n.kind))
+      of OutputNodes:
+        stmts.add tbOut(tree, cl, v, cr)
+      else:
+        unreachable()
+
+    of StmtNodes:
+      stmts.addIfNotEmpty tbSingleStmt(tree, cl, cr)
+    of mnkEnd:
+      break
+    else:
+      unreachable(tree[cr].kind)
+
+  leave(tree, cr)
+  dec cl.inArgBlock
+
+  assert stmts.len == 0, "argument block has trailing statements"
+
+proc tbInput(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor
+            ): Values =
+  let n {.cursor.} = get(tree, cr)
+  case n.kind
+  of mnkProc..mnkTemp, mnkLiteral, mnkType:
+    toValues tbSingle(n, cl, cr.info)
+  of mnkOpParam:
+    # we need a full copy since the parameter may be referenced multiple times
+    let node = copyTree(cl.params[n.param])
+    node.info = cr.info
+    toValues node
+  of mnkNone:
+    # it's a 'none' (i.e. empty) input
+    toValues newNodeIT(nkEmpty, cr.info, n.typ)
+  of mnkArgBlock:
+    tbArgBlock(tree, cl, cr)
+  of AllNodeKinds - InputNodes:
+    unreachable(n.kind)
+
+proc tbArgs(v: var Values, m: TMagic, cl: TranslateCl) =
+  ## The operands to some magics (those in the ``FakeVarParams`` set) must
+  ## not be wrapped in ``nkHiddenAddr`` nodes.
+  if m notin FakeVarParams:
+    case v.kind
+    of vkSingle:
+      if vtMutable in v.tag:
+        v.single = wrapInHiddenAddr(cl, v.single)
+
+    of vkMulti:
+      for i, n in v.list.mpairs:
+        if vtMutable in v.modeAndTags[i].tags:
+          n = wrapInHiddenAddr(cl, n)
+
+    of vkNone:
+      discard "nothing to do"
+
+proc tbInOut(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
+             cr: var TreeCursor): Values =
+  ## Handles the translation of operations that accept input and produce
+  ## a value (a 'in-out-op' in the grammar)
+  let
+    n {.cursor.} = get(tree, cr)
+    info = cr.info
+
+  case n.kind
+  of mnkMagic:
+    assert n.typ != nil
+    tbArgs(prev, n.magic, cl)
+
+    var node = newTreeIT(nkCall, info, n.typ)
+    node.sons.newSeq(1 + prev.len)
+    # the ``PNode`` AST requires a symbol for magics, so we have to create one
+    node.sons[0] = newSymNode(createMagic(cl, n.magic))
+
+    case prev.kind
+    of vkNone: discard
+    of vkSingle: node.sons[1] = move prev.single
+    of vkMulti:
+      for i, v in prev.list.mpairs:
+        node.sons[1 + i] = move v
+
+    toValues node
+  of mnkCall:
+    assert n.typ != nil
+    var node = newNodeIT(nkCall, info, n.typ)
+    case prev.kind
+    of vkMulti:
+      # pre-process the argument expressions:
+      tbArgs(prev, getCalleeMagic(prev.list[0]), cl)
+
+      node.sons = move prev.list
+    of vkSingle:
+      # the procedure is called with no arguments
+      node.sons = @[prev.single]
+    of vkNone:
+      unreachable()
+
+    toValues node
+  of mnkCast:
+    toValues newTreeIT(nkCast, info, n.typ, newNodeIT(nkType, info, n.typ), prev.single)
+  of mnkConv:
+    toValues tbConv(cl, prev.single, info, n.typ)
+  of mnkStdConv:
+    let
+      opr = prev.single
+      source = opr.typ.skipTypes(abstractVarRange)
+      dest = n.typ.skipTypes(abstractVarRange)
+
+    var adjusted = PNode(nil)
+
+    case dest.kind
+    of tyCstring:
+      if source.kind == tyString:
+        adjusted = newTreeIT(nkStringToCString, info, n.typ): opr
+
+    of tyString:
+      if source.kind == tyCstring:
+        adjusted = newTreeIT(nkCStringToString, info, n.typ): opr
+
+    of tyOpenArray, tyVarargs:
+      # the old code-generators depend on conversions to ``openArray`` to be
+      # omitted
+      adjusted = opr
+    else:
+      discard
+
+    if adjusted == nil:
+      # no special conversion is used
+      adjusted = newTreeIT(nkHiddenStdConv, info, n.typ,
+                           [newNodeIT(nkType, info, n.typ), opr])
+
+    toValues adjusted
+  of mnkPathVariant:
+    var node: PNode
+    if vtVariant in prev.tag:
+      node = addToVariantAccess(cl, prev.single, n.field, info)
+    else:
+      # the node's ``typ`` is the type of the enclosing object not of the
+      # discriminant, so we have to explicitly use the field's type here
+      node = newTreeIT(nkDotExpr, info, n.field.typ, [prev.single, newSymNode(n.field)])
+
+    # mark the value as being a variant object. Depending on which context the
+    # resulting value is used, it's either kept as is, turned  into a
+    # ``nkCheckedFieldExpr``, or, if it already is one, appended to
+    Values(kind: vkSingle, single: node, tag: {vtVariant})
+  of mnkPathNamed:
+    if vtVariant in prev.tag:
+      toValues addToVariantAccess(cl, prev.single, n.field, info)
+    else:
+      toValues newTreeIT(nkDotExpr, info, n.typ, [prev.single, newSymNode(n.field)])
+
+  of mnkPathPos:
+    # try to use a dot access where possible
+    # TODO: this is done so that ``sizeof(tup.f)`` works for the C back-end
+    #       where ``tup`` is an imported tuple type, because ``cgen``'s
+    #       implementation of the ``mSizeOf`` magic doesn't support
+    #       bracket-access. Make the implementation support bracket-access and
+    #       then only emit ``nkBracketExpr`` here
+    let t = prev.single.typ.skipTypes(abstractInst + tyUserTypeClasses)
+    if t.n != nil:
+      # it's a named tuple
+      toValues newTreeIT(nkDotExpr, info, n.typ,
+        [prev.single, t.n.sons[n.position]])
+    else:
+      # a tuple with unnamed fields
+      toValues newTreeIT(nkBracketExpr, info, n.typ,
+        [prev.single, newIntNode(nkIntLit, n.position.BiggestInt)])
+
+  of mnkPathArray:
+    let node = newNodeIT(nkBracketExpr, info, n.typ)
+    node.sons = move prev.list
+    toValues node
+  of mnkAddr:
+    toValues newTreeIT(nkAddr, info, n.typ, [prev.single])
+  of mnkDeref:
+    toValues newTreeIT(nkDerefExpr, info, n.typ, [prev.single])
+  of mnkView:
+    toValues newTreeIT(nkHiddenAddr, info, n.typ, [prev.single])
+  of mnkDerefView:
+    toValues newTreeIT(nkHiddenDeref, info, n.typ, [prev.single])
+  of mnkObjConstr:
+    assert n.typ.skipTypes(abstractVarRange).kind in {tyObject, tyRef}
+    var node = newTreeIT(nkObjConstr, info, n.typ, newNodeIT(nkType, info, n.typ))
+    for j in 0..<n.len:
+      let f {.cursor.} = get(tree, cr)
+      node.add newTreeI(nkExprColonExpr, cr.info, [newSymNode(f.field), prev[j]])
+
+    leave(tree, cr)
+    toValues node
+  of mnkConstr:
+    let typ = n.typ.skipTypes(abstractVarRange)
+
+    let kind =
+      case typ.kind
+      of tySet:               nkCurly
+      of tyArray, tySequence: nkBracket
+      of tyTuple:             nkTupleConstr
+      of tyProc:
+        assert typ.callConv == ccClosure
+        nkClosure
+      else:
+        unreachable(typ.kind)
+
+    var node = newNodeIT(kind, info, n.typ)
+    node.sons = move prev.list
+
+    toValues node
+  of mnkTag:
+    if n.effect in {ekMutate, ekReassign, ekInvalidate, ekKill}:
+      prev.tag.incl vtMutable
+
+    prev
+  of AllNodeKinds - InOutNodes:
+    unreachable(n.kind)
+
+proc tbSeq(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): Values =
+  ## Translate a 'sequence' MIR syntax construct
+  result = tbInput(tree, cl, cr)
+  while tree[cr].kind notin OutputNodes + ArgumentNodes:
+    result = tbInOut(tree, cl, result, cr)
+
+  assert result.kind != vkNone
+
+
+proc tbList(tree: TreeWithSource, cl: var TranslateCl, stmts: var seq[PNode],
+            cr: var TreeCursor) =
+  while true:
+    case tree[cr].kind
+    of InputNodes:
+      let v = tbSeq(tree, cl, cr)
+      stmts.add tbOut(tree, cl, v, cr)
+    of StmtNodes:
+      stmts.addIfNotEmpty tbSingleStmt(tree, cl, cr)
+    of mnkEnd:
+      # don't consume the end node
+      break
+    else:
+      unreachable(tree[cr].kind)
+
+proc tbList(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): PNode =
+  ## Translates a 'stmt-list' MIR structure into AST
+  var stmts: seq[PNode]
+  tbList(tree, cl, stmts, cr)
+  result = toSingleNode(stmts)
+
+proc tbScope(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
+             cr: var TreeCursor): PNode =
+  let
+    prev = cl.defs.len
+    info = cr.info
+
+  var stmts: seq[PNode]
+  tbList(tree, cl, stmts, cr)
+
+  if cl.defs.len > prev:
+    # create a var section for the collected symbols:
+    stmts.insert(
+      makeVarSection(cl.defs.toOpenArray(prev, cl.defs.high), info), 0)
+
+    # "pop" the elements that were added as part of this scope:
+    cl.defs.setLen(prev)
+
+  result = toSingleNode(stmts)
+
+proc tbRegion(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
+              cr: var TreeCursor): PNode =
+  var stmts: seq[PNode]
+  prepareParameters(prev, stmts, cl)
+
+  swap(cl.params, prev)
+  # `cl.params` now stores the prepared parameters (and `prev` the ones of the
+  # enclosing region, if any)
+
+  # translate the body of the region:
+  tbList(tree, cl, stmts, cr)
+  leave(tree, cr)
+
+  # restore the parameters of the enclosing region (if any):
+  swap(cl.params, prev)
+
+  result = toSingleNode(stmts)
+
+
+proc tbExpr(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor
+           ): tuple[node: PNode, atEnd: bool] =
+  ## Translates the expression located at the current cursor position `cr` to
+  ## ``PNode`` AST
+  template hasNext(): bool =
+    cr.pos.int < tree.tree.len
+
+  # translate the operation sequence while taking into account that we might
+  # reach the end of the tree:
+  var values = tbInput(tree, cl, cr)
+  while hasNext() and tree[cr].kind notin OutputNodes + ArgumentNodes:
+    values = tbInOut(tree, cl, values, cr)
+
+  # also translate the output (if one exists):
+  if not hasNext() or tree[cr].kind in ArgumentNodes:
+    (values.single, true)
+  elif tree[cr].kind in OutputNodes:
+    (tbOut(tree, cl, values, cr), false)
+  else:
+    unreachable("illformed MIR")
+
+proc tbMulti(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): PNode =
+  ## Translates expressions/statements until the cursor either reaches the end
+  ## or a top-level argument node is encountered
+  var nodes: seq[PNode]
+  while cr.hasNext(tree):
+    case tree[cr].kind
+    of InputNodes:
+      let (n, atEnd) = tbExpr(tree, cl, cr)
+      nodes.add n
+
+      if atEnd:
+        # we also abort if we reach an argument node, so the loop condition
+        # alone is not enough
+        break
+    of StmtNodes:
+      nodes.addIfNotEmpty tbSingleStmt(tree, cl, cr)
+    else:
+      unreachable("illformed MIR code")
+
+  # insert the var section for the collected defs at the start:
+  if cl.defs.len > 0:
+    nodes.insert(makeVarSection(cl.defs, unknownLineInfo), 0)
+
+  case nodes.len
+  of 0: newNode(nkEmpty)
+  of 1: nodes[0]
+  else:
+    let r =
+      if nodes[^1].typ.isEmptyType():
+        # it's a statement list
+        newNode(nkStmtList)
+      else:
+        newNodeIT(nkStmtListExpr, unknownLineInfo, nodes[^1].typ)
+
+    r.sons = move nodes
+    r
+
+proc tb(tree: TreeWithSource, cl: var TranslateCl, start: NodePosition): PNode =
+  ## Translate `tree` back to a ``PNode`` AST
+  var cr = TreeCursor(pos: start.uint32)
+  assert tree[cr].kind in InputNodes + StmtNodes,
+         "start must point to the start of expression or statement"
+  tbMulti(tree, cl, cr)
+
+
+proc generateAST*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
+                  tree: sink MirTree, sourceMap: sink SourceMap): PNode =
+  ## Generates a ``PNode`` AST that is semantically equivalent to `tree`,
+  ## using the `idgen` to provide new IDs when creating symbols. `sourceMap`
+  ## must be the ``SourceMap`` corresponding to `tree` and is used as the
+  ## provider for source position information
+  # TODO: `tree` and `sourceMap` are only consumed because of efficiency
+  #       reasons (to get around a full copy for both). Remove ``sink`` for
+  #       both once the fields of ``TreeWithSource`` are views
+  var cl = TranslateCl(graph: graph, idgen: idgen, cache: graph.cache,
+                       owner: owner)
+  tb(TreeWithSource(tree: tree, map: sourceMap), cl, NodePosition 0)

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -1,0 +1,122 @@
+## A temporary module that implements convenience routines for the ``PNode``
+## AST <-> ``MirTree`` translation.
+##
+## With the current implementation, the code-generators are responsible for
+## running both translation steps (plus any MIR passes), but this is the wrong
+## approach -- the code reaching the code-generators should have already been
+## processed (i.e. MIR translation and passes done).
+
+import
+  compiler/ast/[
+    ast_types,
+    ast_idgen,
+    ast
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/mir/[
+    astgen,
+    mirtrees,
+    mirgen,
+    sourcemaps,
+    utils
+  ],
+  compiler/modules/[
+    modulegraphs
+  ],
+  compiler/sem/[
+    injectdestructors,
+    varpartitions
+  ],
+  compiler/utils/[
+    astrepr
+  ]
+
+export GenOption
+
+proc getStrDefine(config: ConfigRef, name: string): string =
+  if config.isDefined(name):
+    result = config.getDefined(name)
+  else:
+    result = ""
+
+template writeBody(config: ConfigRef, header: string, body: untyped) =
+  # NOTE: if the debug traces should be kept, they should be properly
+  #       integrated into the tracing pipeline
+  config.writeln(header)
+  body
+  config.writeln("-- end")
+
+let reprConfig = block:
+  var rc = implicitTReprConf
+  rc.flags.excl trfShowFullSymTypes
+  rc.flags.excl trfShowNodeTypes
+  rc.flags.incl trfShowSymKind
+  rc
+
+proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
+                   body: PNode, options: set[GenOption]): PNode =
+  ## No MIR passes exist yet, so the to-and-from translation is treated as a
+  ## canonicalization step. To be able to step-by-step rewrite
+  ## transformations done in ``transf`` and in the back-ends as MIR passes, it
+  ## is important that ``canonicalize`` is applied to *all* code reaching
+  ## the code-generators, so that they can depend on the shape of the
+  ## resulting AST
+  let config = graph.config
+  if config.getStrDefine("nimShowMirInput") == owner.name.s:
+    writeBody(config, "-- input AST: " & owner.name.s):
+      config.writeln(treeRepr(config, body, reprConfig))
+
+  # step 1: generate a ``MirTree`` from the input AST
+  let (tree, sourceMap) = generateCode(graph, owner, options, body)
+
+  if graph.config.getStrDefine("nimShowMir") == owner.name.s:
+    writeBody(config, "-- MIR: " & owner.name.s):
+      config.writeln(print(tree))
+
+  # step 2: translate it back
+  result = generateAST(graph, idgen, owner, tree, sourceMap)
+
+  if config.getStrDefine("nimShowMirOutput") == owner.name.s:
+    writeBody(config, "-- output AST: " & owner.name.s):
+      config.writeln(treeRepr(config, result, reprConfig))
+
+proc canonicalizeWithInject*(graph: ModuleGraph, idgen: IdGenerator,
+                             owner: PSym, body: PNode,
+                             options: set[GenOption]): PNode =
+  ## Performs either the canonicalization *or*  cursor inference plus
+  ## destructor injection
+
+  # the output of ``canonicalize`` confuses either ``computeCursors``,
+  # ``injectDestructorCalls``, or both enough for them to produce code
+  # where expected destructor calls are missing. As a temporary solution, the
+  # canonicalization step is skipped for bodies that require destructor
+  # injection
+  # FIXME: this is a severe problem, as it means that ``canonicalize`` is, in
+  #        fact, **not** run for all code that is reaching the code-generators.
+  #        The issue needs to be fixed before transformations and lowerings can
+  #        be turned into MIR passes
+  if shouldInjectDestructorCalls(owner):
+    if optCursorInference in graph.config.options:
+      computeCursors(owner, body, graph)
+
+    injectDestructorCalls(graph, idgen, owner, body)
+  else:
+    canonicalize(graph, idgen, owner, body, {})
+
+proc canonicalizeSingle*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
+                         n: PNode, options: set[GenOption]): PNode =
+  ## Similar to ``canonicalize``, but accepts a freestanding expression or
+  ## statement. The `owner` is used as the owner when generating the necessary
+  ## new symbols or types
+  var
+    tree: MirTree
+    sourceMap: SourceMap
+
+  # step 1: generate a ``MirTree`` from the input AST
+  generateCode(graph, options, n, tree, sourceMap)
+  # step 2: translate it back, but only if there is something to translate
+  result =
+    if tree.len > 0: generateAST(graph, idgen, owner, tree, sourceMap)
+    else:            newNode(nkEmpty)

--- a/compiler/mir/mirchangesets.nim
+++ b/compiler/mir/mirchangesets.nim
@@ -1,0 +1,321 @@
+## This module implements the ``Changeset`` API, which is the main way of
+## applying changes to a ``MirTree``.
+##
+## Instead of modifying a ``MirTree`` directly, the changes (which can be
+## insertions, replacements, or removals) are first recorded into a
+## ``Changeset``. This allows for recording changes independent of each other
+## concurrently and later apply the changes all at once.
+##
+## A cursor-like API is used. One has to first move the ``Changeset`` to the
+## position that the to-be-recorded change applies to via ``seek``.
+##
+## Before applying a ``Changeset`` to a ``MirTree``, it has to be prepared via
+## a call to ``prepare`` first, after which the ``Changeset`` is sealed an no
+## further changes can be recorded. ``prepare`` is responsible from normalizing
+## the internal representation of the ``Changeset`` and is required for the
+## later application to work.
+##
+## Applying the ``PreparedChangeset`` is done via ``apply`` -- updating the
+## ``MirTree``'s corresponding ``SourceMap`` via ``updateSourceMap``. For
+## efficiency, ``apply`` consumes the changeset, so it is advised to call
+## ``updateSourceMap`` first.
+##
+## Order of application
+## --------------------
+##
+## Nodes are inserted *before* the node at the insertion position, meaning that
+## it is allowed for an insertion to overlap with a removal/replacement at the
+## *start* position. All other forms of overlapping changes are disallowed.
+## If there exist two or more insertion at the same position, they are applied
+## in the order the changes were recorded. That is, the nodes from the insertion
+## recorded first are inserted first, then that of the second recorded, then
+## the third one's, etc.
+
+
+import
+  std/[
+    algorithm
+  ],
+  compiler/mir/[
+    mirtrees,
+    sourcemaps
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+type
+  Row = object
+    ## A changeset row. This is the building block of a changeset. Each row
+    ## represents a modification, of which there are three kinds:
+    ## - removal: `orig` has a length > 0 and `src` is empty
+    ## - insertion: `orig` has a length of 0 and `src` hasn't
+    ## - replacement: both `orig` and `src` have a length > 0
+    orig: HOslice[NodeIndex] ## the slice of nodes this change affects
+    src:  HOslice[NodeIndex] ## a slice in the buffer of staged nodes
+
+    source: uint32 ## the meaning depends on whether or not this row is part
+                   ## of a ``PrepareChangeset``. If it is, `source` is a
+                   ## ``SourceId``, otherwise it's a ``NodeInstance``.
+                   ## The source information is only relevant for insertions
+
+  Changeset* = object
+    # TODO: split ``Changeset`` into two parts:
+    #       1. the core ``Changeset`` - stores the rows and the node buffer
+    #       2. an object storing the data needed to build the changeset (e.g.
+    #          ``Cursor``, ``ChangeBuilder``, etc.)
+    tree: MirTree
+      ## stored in the changeset so that it's not required to pass the tree to
+      ## each ``Changeset`` routine
+    # TODO: `tree` needs to either become a view as soon as possible, or the
+    #       API of ``Changeset`` adjusted in a way that it's no longer required
+    #       for the tree to be stored as part of ``Changeset``. The full copy
+    #       is not acceptable
+
+    nodes: seq[MirNode]
+    rows: seq[Row]
+
+    numTemps: uint32 ## the number of existing temporaries
+
+    pos: NodePosition ## the cursor position
+
+  PreparedChangeset* = object
+    nodes: seq[MirNode]
+    rows: seq[Row]
+
+    diff: int        ## the number of additions/removals
+    stagingSize: int ## the minimum amount of nodes the working area must be
+                     ## able to hold
+
+func single[T](x: T): HOslice[T] {.inline.} =
+  ## Utility for creating a slice with a single item
+  HOslice[T](a: x, b: succ(x))
+
+func span[T](a, b: T): HOslice[T] {.inline.} =
+  HOslice[T](a: a, b: b)
+
+func empty[T](x: typedesc[HOslice[T]]): HOslice[T] {.inline.} =
+  HOslice[T](a: default(T), b: default(T))
+
+func row(start, fin: NodePosition, src: HOSlice[NodeIndex];
+         source = NodePosition(0)): Row {.inline.} =
+  ## Convenience constructor for ``Row``
+  Row(orig: span(NodeIndex(start), NodeIndex(fin)),
+      src: src,
+      source: source.uint32)
+
+func addSingle(s: var MirNodeSeq, n: sink MirNode): HOSlice[NodeIndex] =
+  s.add n
+  result = single(s.high.NodeIndex)
+
+func initChangeset*(tree: MirTree): Changeset =
+  ## Initializes a new ``Changeset`` instance. Until the resulting
+  ## ``Changeset`` is applied, the associated tree must not be modified
+  result.tree = tree # warning: this creates a full copy
+
+  # count the number of existing temporaries:
+  for i, n in tree.pairs:
+    if n.kind in DefNodes and
+       (let ent = child(tree, i, 0); ent.kind == mnkTemp):
+      result.numTemps = max(ent.temp.uint32 + 1, result.numTemps)
+
+func getTemp*(c: var Changeset): TempId =
+  ## Allocates a slot for new temporary and returns its ID
+  result = TempId(c.numTemps)
+  inc c.numTemps
+
+template position*(cs: Changeset): NodePosition =
+  ## The current position of the cursor
+  cs.pos
+
+func seek*(c: var Changeset, dest: NodePosition) {.inline.} =
+  ## Moves the internal cursor position to `dest`
+  assert c.pos in c.tree
+  c.pos = dest
+
+func replace*(c: var Changeset, n: sink MirNode) =
+  ## Records a change that replaces the node at the current cursor position
+  ## with `n`, inheriting it origin information. If the cursor points to a
+  ## sub-tree, the whole sub-tree is replaced
+  let next = sibling(c.tree, c.pos)
+  c.rows.add row(c.pos, next, c.nodes.addSingle(n), c.pos)
+  c.pos = next
+
+func insert*(c: var Changeset, n: sink MirNode, source: NodeInstance) =
+  ## Inserts `n` at the current cursor position, using `source` as the
+  ## inserted node's origin
+  c.rows.add row(c.pos, c.pos, c.nodes.addSingle(n), source.NodePosition)
+
+template insert*(c: var Changeset, source: NodeInstance, name: untyped,
+                 body: untyped) =
+  ## Records an insertion at the current cursor position, providing direct
+  ## access to the internal node buffer inside `body` via an injected variable
+  ## of the name `name`. `source` is the node to inherit the source/origin
+  ## information from
+  block:
+    let
+      start = c.nodes.len.NodeIndex
+      # evaluate `source` before `body`, as the latter might change what
+      # `source` evaluates to:
+      i = NodePosition source
+
+    var name: MirNodeSeq
+    swap(c.nodes, name)
+    body
+    swap(c.nodes, name)
+
+    c.rows.add row(c.pos, c.pos, span(start, c.nodes.len.NodeIndex), i)
+
+template replaceMulti*(c: var Changeset, name, body: untyped) =
+  ## Records a repacement of the node or sub-tree at the current cursor
+  ## position, providing direct access to the internal node buffer
+  ## inside `body` via an injected variable of the name `name`
+  # TODO: rename to ``replace`` once the sem bug that currently prevents this
+  #       is fixed
+  block:
+    let start = c.nodes.len.NodeIndex
+    var name: MirTree
+    swap(c.nodes, name)
+    body
+    swap(c.nodes, name)
+
+    let next = sibling(tree(c), c.pos)
+    c.rows.add row(c.pos, next, span(start, c.nodes.len.NodeIndex), c.pos)
+    c.pos = next
+
+func remove*(c: var Changeset) =
+  ## Records the removal of the currently pointed to sub-tree
+  let next = sibling(c.tree, c.pos)
+  # use an empty source slice
+  c.rows.add row(c.pos, next, empty(HOSlice[NodeIndex]))
+  c.pos = next
+
+func skip*(c: var Changeset, num: Natural) =
+  # Skips `num` sub-trees
+  for _ in 0..<num:
+    c.pos = sibling(c.tree, c.pos)
+
+func prepare*(c: sink Changeset, sourceMap: SourceMap): PreparedChangeset =
+  ## Prepares `c` for being applied
+
+  # applying the changes can be done much more efficiently if they are ordered
+  # by ascending modification position
+  c.rows.sort proc(a, b: auto): int =
+    result = a.orig.a.int - b.orig.a.int
+    if result == 0:
+      # use the end position as the second-order, so that insertions sharing
+      # their start position with replacements/removals are applied first
+      result = a.orig.b.int - b.orig.b.int
+
+  # calcuate the difference in the amount of nodes plus the required size for
+  # the working/staging area:
+  for row in c.rows.items:
+    result.diff -= row.orig.len
+    result.diff += row.src.len
+    result.stagingSize = max(result.stagingSize, result.diff)
+
+  # the `source` column of each row currently refers to the node to inherit
+  # the source information from (but only if the row represents an insertion
+  # or removal). Since the source-information attachments will become stale
+  # once the source mappings are modified, `source` is translated to the
+  # ``SourceId`` here already
+  for r in c.rows.mitems:
+    r.source = sourceMap[r.source.NodeInstance].uint32
+
+  result.nodes = move c.nodes
+  result.rows = move c.rows
+
+func moveRight[T](x: var openArray[T], src, dest, len: Natural) =
+  assert src < dest
+  for i in countdown(len-1, 0):
+    x[dest + i] = move x[src + i]
+
+func moveLeft[T](x: var openArray[T], src, dest, len: Natural) =
+  assert dest <= src
+  for i in 0..<len:
+    x[dest + i] = move x[src + i]
+
+iterator apply[T](s: var seq[T], diff, stagingSize: int, rows: seq[Row]): tuple[row: lent Row, writePos: NodeIndex] =
+  ## Performs the surrounding actions for integrating changes into `s`
+  ## .. warning:: Exiting the iterator via ``return`` or ``break`` will leave
+  ##              `s` in an inconsistent state
+  let oldLen = s.len
+  var
+    writePos = rows[0].orig.a.int
+      ## the start position of the "staging" area
+    readPos = writePos
+      ## the start position of the "original" area
+    origPos = writePos
+      ## keeps track of the logical position in the original sequeunce where
+      ## we're copying from
+
+  if stagingSize > 0:
+    # make space for the temporary/staging partition
+    let start = rows[0].orig.a.int
+    s.setLen(oldLen + stagingSize)
+
+    readPos = start + stagingSize
+    moveRight(s, start, readPos, oldLen - start)
+
+  assert writePos <= readPos
+
+  # iterate over all changes and apply them. A change either adds, removes, or
+  # replaces nodes.
+  for i, row in rows.lpairs:
+    let start = row.orig.a.int
+
+    assert writePos <= readPos
+    assert start >= origPos, "overlapping changes"
+
+    # first move over the original nodes (if any):
+    if start > origPos:
+      # move the nodes from the "original" area to the "staging" area:
+      let L = start - origPos
+      if readPos != writePos:
+        moveLeft(s, readPos, writePos, L)
+      # commit the nodes to "done" area:
+      readPos += L
+      writePos += L
+      origPos += L
+
+    yield (row, writePos.NodeIndex)
+
+    # skip the nodes we're replacing or removing:
+    readPos += row.orig.len
+    origPos += row.orig.len
+
+    # commit:
+    writePos += row.src.len
+
+  assert origPos <= oldLen
+
+  # move the remaining nodes:
+  if oldLen > origPos and readPos != writePos:
+    moveLeft(s, readPos, writePos, oldLen - origPos)
+
+  if diff != stagingSize:
+    # resize to the correct number of items
+    s.setLen(oldLen + diff)
+
+func updateSourceMap*(m: var SourceMap, c: PreparedChangeset) =
+  ## Updates the source mappings stored by `m` according to the changes
+  ## recorded in `c`
+  if c.rows.len == 0:
+    # nothing to do
+    return
+
+  for row, writePos in apply(m.map, c.diff, c.stagingSize, c.rows):
+    # insert the new source mappings when performing insertions or replacements
+    for p in row.src.items:
+      m.map[writePos + (p - row.src.a)] = SourceId(row.source)
+
+func apply*(tree: var MirTree, c: sink PreparedChangeset) =
+  ## Applies the changeset `c` to the `tree`, modifying the tree in-place. The
+  ## tree's underlying sequence is resized 0 to 2 times.
+  if c.rows.len == 0:
+    # nothing to do
+    return
+
+  for row, writePos in apply(tree, c.diff, c.stagingSize, c.rows):
+    for p in row.src.items:
+      tree[writePos + (p - row.src.a)] = move c.nodes[p]

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -1,0 +1,79 @@
+## This module contains constructor procedures for the different kinds of
+## ``MirNode``s plus convenience procedures for generating expressions.
+
+import
+  compiler/ast/[
+    ast_types
+  ],
+  compiler/mir/[
+    mirtrees
+  ]
+
+type
+  Value* = distinct bool
+    ## Used to mark a procedure as generating code that yields a value
+  Sink* = distinct bool
+    ## Used to mark a procedure as generating code that acts as a sink
+  SinkAndValue* = distinct bool
+
+template `=>`*(v: Value, sink: Sink) =
+  discard v
+  discard sink
+
+template `=>`*(v: Value, sink: SinkAndValue): Value =
+  discard v
+  discard sink
+  Value(false)
+
+template `=>|`*(v: Value, sink: SinkAndValue) =
+  discard v
+  discard sink
+
+template `|=>`*(sink: Sink) =
+  discard sink
+
+template `|=>`*(sink: SinkAndValue): Value =
+  discard sink
+  Value(false)
+
+template previous*(): Value =
+  Value(false)
+
+template follows*(): Sink =
+  ## A pseudo-sink used to indicate that the actual output expression is
+  ## either generated separately next or is already present and, in the context
+  ## where ``follows`` is used, comes next
+  Sink(false)
+
+# --------- node constructors:
+
+func procNode*(s: PSym): MirNode {.inline.} =
+  assert s.kind in routineKinds
+  MirNode(kind: mnkProc, sym: s)
+
+func magic*(m: TMagic, typ: PType; n: PNode = nil): MirNode {.inline.} =
+  MirNode(kind: mnkMagic, typ: typ, magic: m)
+
+template endNode*(k: MirNodeKind): MirNode =
+  MirNode(kind: mnkEnd, start: k)
+
+# --------- tree generation utilities:
+
+template subTree*(tree: var MirTree, n: MirNode, body: untyped) =
+  let start = tree.len
+  tree.add n
+  body
+  # note: don't use `n.kind` here as that would evaluate `n` twice
+  tree.add endNode(tree[start].kind)
+
+template stmtList*(tree: var MirTree, body: untyped) =
+  tree.subTree MirNode(kind: mnkStmtList):
+    body
+
+template scope*(tree: var MirTree, body: untyped) =
+  tree.subTree MirNode(kind: mnkScope):
+    body
+
+template argBlock*(tree: var MirTree, body: untyped) =
+  tree.subTree MirNode(kind: mnkArgBlock):
+    body

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1,0 +1,2116 @@
+## ``mirgen`` is responsible for generating MIR code from ``PNode`` AST. The
+## input AST is expected to have already been transformed by ``transf``.
+##
+## Operation wise, the input AST is traversed via recursing into statements and
+## expressions, ignoring declarative constructs that are not relevant to nor
+## representable with the MIR.
+##
+## None of the MIR operations that imply structured control-flow produce a
+## value, so the input expression that do (``if``, ``case``, ``block``, and
+## ``try``) are translated into statements where the last expression in each
+## clause is turned into an assignment to, depending on the context where
+## they're used, either a temporary or existing lvalue expression. The latter
+## are forwarded to the generation procedures via ``Destination``.
+##
+## To shorten the emit code and also make it a bit easier to read and
+## understand, a mini DSL realised through templates is used.
+##
+## Origin information
+## ==================
+##
+## Each generated ``MirNode`` is associated with the ``PNode`` it originated
+## (referred to as "source information") from. Setting the ``PNode`` to use
+## as the origin is done by using the ``useSource`` template. It overrides the
+## active source information until the end of the scope it is called inside --
+## all nodes without explicitly attached source information added till
+## the end of the scope will store the provided ``PNode`` as their origin.
+##
+## The source information is set/attached lazily because:
+## 1. it allows for adding the attachments in a batch, reducing the amount of
+##    checks and potentially also ``seq`` resizings
+## 2. it decouples adding nodes from attaching source information to them,
+##    making changes to how source information is stored/attached a bit
+##    simpler
+##
+## A downside of the current implementation is that it's easy to forget
+## explicitly overriding the used source information. While this won't impact
+## the generated code, it'll impact the AST / line-information shown in e.g.
+## reports.
+##
+
+import
+  std/[
+    tables
+  ],
+  compiler/ast/[
+    ast,
+    lineinfos,
+    trees,
+    types,
+    wordrecg
+  ],
+  compiler/mir/[
+    mirconstr,
+    mirtrees,
+    sourcemaps
+  ],
+  compiler/modules/[
+    magicsys,
+    modulegraphs
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/sem/[
+    typeallowed
+  ],
+  compiler/utils/[
+    containers,
+    idioms
+  ],
+  experimental/[
+    dod_helpers
+  ]
+
+type
+  EValue = object
+    ## Encapsulates information about the abstract value that results from
+    ## an operation sequence. It's used as a way to transport said information
+    ## between the generator procedures for operators
+    # XXX: maybe rename to ``Computation``?
+    typ {.cursor.}: PType
+
+  NodeSpan = HOslice[NodeIndex]
+    ## Refers to a span of nodes in a ``Fragment``
+
+  DestinationKind = enum
+    dkNone ## no destination
+    dkFrag ## an lvalue expression
+    dkGen  ## an lvalue expression that is generated in-place
+
+  DestFlag = enum
+    ## Extra information about an assignment destination. The flags are used to
+    ## decide which kind of assignment to use
+    dfEmpty ## the destination doesn't store a value yet
+    dfOwns  ## the destination is an owning location
+
+  Destination = object
+    ## Stores the information necessary to generate the code for an assignment
+    ## to some lvalue expression
+    case kind: DestinationKind
+    of dkNone:
+      discard
+    of dkFrag:
+      nodes: NodeSpan ## references a slice of nodes in the staging buffer
+    of dkGen:
+      node {.cursor.}: PNode
+
+    flags: set[DestFlag]
+
+  ChainEnd = distinct bool
+    ## Sentinel type used to mark an operator in a chain as ending the chain.
+    ## No further operators can be chained after an operator marked as
+    ## ``ChainEnd``
+
+  Block = object
+    ## Information about a ``block``
+    label: PSym ## the symbol of the block's label. 'nil' if the block has no
+                ## label
+    id: LabelId ## the block's internal label ID
+
+  CodeFragment = object
+    ## A MIR code fragment that doesn't imply any further semantic meaning. The
+    ## code is not required to be complete (i.e. grammatically valid).
+    nodes: MirNodeSeq
+    source: seq[SourceId]
+      ## the ``SourceId`` for each ``MirNode` in `nodes`. The association
+      ## happens via their respective index in the ``seq``s. During
+      ## construction, `source` is allowed to temporarily have less items
+      ## than `nodes`
+
+  SourceProvider = object
+    ## Stores the active origin and the in-progress database of origin
+    ## ``PNode``s. Both are needed together in most cases, hence their bundling
+    ## into an object
+    active: tuple[n: PNode, id: opt(SourceId)]
+      ## the ``PNode`` to use as the origin for emitted ``MirNode``s (if none
+      ## is explicitly provided). If `id` is 'none', no database entry exists
+      ## for the ``PNode`` yet
+    store: Store[SourceId, PNode]
+      ## the in-progress database of origin ``PNode``s
+
+  GenOption* = enum
+    goIsNimvm     ## choose the ``nimvm`` branch for ``when nimvm`` statements
+    goGenTypeExpr ## don't omit type expressions
+
+  TCtx = object
+    # output:
+    stmts: CodeFragment
+
+    # working state:
+    staging: CodeFragment ## intermediate buffer for partially generated MIR
+                          ## code
+
+    blocks: seq[Block] ## the stack of active ``block``s. Used for looking up
+                       ## break targets
+
+    sp: SourceProvider
+
+    tmpMap: Table[ItemId, TempId]
+      ## maps the ID of ``skTemp`` symbols to the ``TempId`` used to refer to
+      ## them in output
+
+    numTemps: int  ## provides the ID for temporaries
+    numLabels: int ## provides the ID to use for the next label
+
+    # input:
+    context: TSymKind ## what entity the input AST is part of (e.g. procedure,
+                      ## macro, module, etc.). Used to allow or change how the
+                      ## AST is interpreted in some places
+    graph: ModuleGraph
+
+    options: set[GenOption]
+
+const
+  abstractInstTypeClass = abstractInst + tyUserTypeClasses
+  # TODO: this set shouldn't be needed. ``tyUserTypeClass`` and
+  #       ``tyUserTypeClassInst`` should be turned into either aliases or
+  #       ``tyGenericInst`` types when they're resolved
+  ComplexExprs = {nkIfExpr, nkCaseStmt, nkBlockExpr, nkTryStmt}
+    ## The expression that are treated as complex and which are transformed
+    ## into assignments-to-temporaries
+
+func halfOpen[T](x: Slice[T]): HOslice[T] {.inline.} =
+  ## Constructs a half-open slice from a normal slice. `x` is expected to
+  ## already represent a half-open slice
+  HOslice[T](a: x.a, b: x.b)
+
+template toOpenArray[T, I](x: seq[T], slice: Slice[I]): openArray[T] =
+  let s = slice
+  toOpenArray(x, s.a.int, s.b.int)
+
+template toOpenArray[T, I](x: seq[T], slice: HOslice[I]): openArray[T] =
+  let s = slice
+  toOpenArray(x, s.a.int, s.b.int - 1)
+
+func isHandleLike(t: PType): bool =
+  t.skipTypes(abstractInst).kind in {tyPtr, tyRef, tyLent, tyVar, tyOpenArray}
+
+# XXX: copied from ``injectdestructors``. Move somewhere common
+proc isCursor(n: PNode): bool =
+  ## Computes whether the expression `n` names a location that is a cursor
+  case n.kind
+  of nkSym:
+    sfCursor in n.sym.flags
+  of nkDotExpr:
+    isCursor(n[1])
+  of nkCheckedFieldExpr:
+    isCursor(n[0])
+  else:
+    false
+
+func endsInNoReturn(n: PNode): bool =
+  ## Tests and returns whether the simple or compound statement `n` ends in a
+  ## no-return statement
+
+  # TODO: this is a patched version of ``sem.endsInNoReturn`` that also
+  #       considers ``nkPragmaBlock``. Move this procedure somewhere common and
+  #       replace ``sem.endsInNoReturn`` with it
+  const SkipSet = {nkStmtList, nkStmtListExpr, nkPragmaBlock}
+  var it {.cursor.} = n
+  while it.kind in SkipSet and it.len > 0:
+    it = it.lastSon
+
+  result = it.kind in nkLastBlockStmts or
+    (it.kind in nkCallKinds and it[0].kind == nkSym and
+     sfNoReturn in it[0].sym.flags)
+
+func canonicalExpr(n: PNode): PNode =
+  ## Returns the canonical expression, i.e. the expression without leading
+  ## pragma blocks or empty statement lists
+  func skipped(n: PNode): PNode =
+    case n.kind
+    of nkPragmaBlock:
+      n.lastSon
+    of nkStmtListExpr:
+      if stupidStmtListExpr(n):
+        # the statement-list expression is redundant (i.e. only has a single
+        # item or only leading empty nodes) -> skip it
+        n.lastSon
+      else:
+        # the list needs to be kept
+        n
+    else:
+      n
+
+  var n {.cursor.} = n
+  while (let it = skipped(n); it != n):
+    n = it
+
+  result = n
+
+func selectWhenBranch(n: PNode, isNimvm: bool): PNode =
+  assert n.kind == nkWhen
+  if isNimvm: n[0][1]
+  else:       n[1][0]
+
+func selectDefKind(s: PSym): range[mnkDef..mnkDefCursor] =
+  ## Returns the kind of definition to use for the given entity
+  if sfCursor in s.flags: mnkDefCursor
+  else:                   mnkDef
+
+func isSome(x: Destination): bool {.inline.} =
+  x.kind != dkNone
+
+func initDestination(n: PNode, isFirst: bool): Destination =
+  var flags: set[DestFlag]
+  if isFirst:
+    flags.incl dfEmpty
+  if not isCursor(n):
+    flags.incl dfOwns
+
+  Destination(kind: dkGen, node: n, flags: flags)
+
+proc typeOrVoid(g: ModuleGraph, t: PType): PType =
+  ## Returns `t` if it's not 'nil' - the ``void`` type otherwise
+  if t != nil: t
+  else:        g.getSysType(unknownLineInfo, tyVoid)
+
+proc typeOrVoid(c: TCtx, t: PType): PType {.inline.} =
+  ## Returns `t` if it's not 'nil' - the ``void`` type otherwise
+  # TODO: cache the void type
+  typeOrVoid(c.graph, t)
+
+func tempNode(typ: PType, id: TempId): MirNode {.inline.} =
+  MirNode(kind: mnkTemp, typ: typ, temp: id)
+
+
+func nextTempId(c: var TCtx): TempId =
+  result = TempId(c.numTemps)
+  inc c.numTemps
+
+func nextLabel(c: var TCtx): LabelId =
+  result = LabelId(c.numLabels + 1)
+  inc c.numLabels
+
+# ----------- CodeFragment API -------------
+
+template add(f: var CodeFragment, n: MirNode) =
+  f.nodes.add n
+
+template subTree(f: var CodeFragment, n: MirNode, body: untyped) =
+  f.nodes.subTree n:
+    body
+
+func apply(frag: var CodeFragment, id: SourceId) =
+  ## Associates all nodes added since the previous call to ``apply`` with the
+  ## origin information identified by `id`
+  assert frag.nodes.len > frag.source.len
+  let start = frag.source.len
+  frag.source.setLen(frag.nodes.len)
+
+  for i in start..<frag.source.len:
+    frag.source[i] = id
+
+func prepareForUse(sp: var SourceProvider): SourceId =
+  if sp.active.id.isNone:
+    sp.active.id = someOpt sp.store.add(sp.active.n)
+
+  result = sp.active.id[]
+
+func applySource(frag: var CodeFragment, sp: var SourceProvider) =
+  ## Associates all ``MirNode``s that don't yet have a source association with
+  ## the currently active source information
+  if frag.nodes.len > frag.source.len:
+    apply(frag, prepareForUse(sp))
+
+func addWithSource(frag: var CodeFragment, sp: var SourceProvider,
+                   n: sink MirNode, src: PNode) =
+  ## Adds `n` to `frag` and associates the node with `src`
+  applySource(frag, sp)
+  frag.nodes.add n
+  frag.source.add sp.store.add(src)
+
+template useSource(frag: var CodeFragment, sp: var SourceProvider,
+                   origin: PNode) =
+  ## Pushes `origin` to be used as the source for the rest of the scope that
+  ## ``useSource`` is used inside. When the scope is left, the previous origin
+  ## is restored
+  applySource(frag, sp)
+
+  # setup the new source information and swap it with the active one
+  var prev = (origin, noneOpt(SourceId))
+  swap(prev, sp.active)
+
+  defer:
+    # apply the still active source information first and then restore the
+    # the source information that was previously active:
+    applySource(frag, sp)
+    swap(prev, sp.active)
+
+template buildSlice(frag: var CodeFragment, sp: var SourceProvider,
+                    body: untyped): NodeSpan =
+  ## Creates a ``NodeSpan`` containing all code emitted into `frag` during the
+  ## execution of `body`
+  let nodeStart = frag.nodes.len.NodeIndex
+
+  body
+
+  applySource(frag, sp)
+  halfOpen(nodeStart .. frag.nodes.len.NodeIndex)
+
+func popSlice(frag: var CodeFragment, span: NodeSpan) =
+  ## Pops (removes) the nodes part of `span` from `frag`
+  assert span.b == frag.nodes.len.NodeIndex
+  assert span.b == frag.source.len.NodeIndex
+
+  frag.nodes.setLen(span.a)
+  frag.source.setLen(span.a)
+
+# -------------- DSL routines -------------
+
+template genValueAdapter(name: untyped) {.dirty.} =
+  template `name`(c: var TCtx): SinkAndValue =
+    mixin value
+    `name`(c, value)
+    SinkAndValue(false)
+
+template genValueAdapter1(name, arg1: untyped) {.dirty.} =
+  template `name`(c: var TCtx, arg1: untyped): SinkAndValue =
+    mixin value
+    `name`(c, arg1, value)
+    SinkAndValue(false)
+
+template genValueAdapter2(name, arg1, arg2: untyped) {.dirty.} =
+  template `name`(c: var TCtx, arg1, arg2: untyped): SinkAndValue =
+    mixin value
+    `name`(c, arg1, arg2, value)
+    SinkAndValue(false)
+
+template genSinkAdapter(name: untyped) {.dirty.} =
+  template `name`(c: var TCtx): Sink =
+    mixin value
+    `name`(c, value)
+    Sink(false)
+
+template `=>`(a: EValue, b: SinkAndValue): Value =
+  mixin value
+  value = a
+  discard b
+  Value(false)
+
+template `=>`(a: Value, b: Sink): ChainEnd =
+  discard a
+  discard b
+  ChainEnd(false)
+
+template `=>`(a: EValue, b: Sink): ChainEnd =
+  mixin value
+  value = a
+  discard b
+  ChainEnd(false)
+
+template discardTypeCheck[T](x: T) =
+  ## Helper to discard the expression `x` while still requiring it to be of
+  ## the given type. The templates making use of this helper can't use typed
+  ## parameters directly, as the arguments (which require a ``value`` symbol
+  ## to exist) would be sem'-checked before the `value` symbol is injected
+  discard x
+
+template chain(x: untyped) =
+  ## Provides the context for chaining operators together via ``=>`` that end
+  ## in a value sink
+  block:
+    var value {.inject, used.}: EValue
+    discardTypeCheck[ChainEnd](x)
+
+template forward(x: untyped) =
+  ## Provides the context for chaining operators together via ``=>`` that end
+  ## in *value*. This is used in places where the consuming operator can't be
+  ## expressed as part of the chain and is expected to be emitted immediately
+  ## after
+  block:
+    var value {.inject, used.}: EValue
+
+    type T = Value or EValue
+    discardTypeCheck[T](x)
+
+template eval(x: untyped): EValue =
+  ## Similar to ``forward``, but returns the resulting ``EValue`` to be used
+  ## as the input to another generator chain
+  block:
+    var value {.inject, used.}: EValue
+    discardTypeCheck[Value](x)
+    value
+
+
+template argBlock(f: var CodeFragment, body: untyped) =
+  f.nodes.argBlock:
+    body
+
+template scope(f: var CodeFragment, body: untyped) =
+  f.nodes.scope:
+    body
+
+template stmtList(f: var CodeFragment, body: untyped) =
+  f.nodes.stmtList:
+    body
+
+func arg(c: var TCtx, val: EValue) =
+  c.stmts.add MirNode(kind: mnkArg, typ: val.typ)
+
+func consume(c: var TCtx, val: EValue) =
+  c.stmts.add MirNode(kind: mnkConsume, typ: val.typ)
+
+func name(c: var TCtx, val: EValue) =
+  c.stmts.add MirNode(kind: mnkName, typ: val.typ)
+
+func genVoid(c: var TCtx, val: EValue) =
+  c.stmts.add MirNode(kind: mnkVoid)
+
+func tag(c: var TCtx, effect: EffectKind, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkTag, effect: effect, typ: val.typ)
+
+func modify(c: var TCtx, val: var EValue) =
+  tag(c, ekMutate, val)
+
+func outOp(c: var TCtx, val: var EValue) =
+  tag(c, ekReassign, val)
+
+func castOp(c: var TCtx, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkCast, typ: typ)
+  val.typ = typ
+
+func stdConvOp(c: var TCtx, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkStdConv, typ: typ)
+  val.typ = typ
+
+func convOp(c: var TCtx, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkConv, typ: typ)
+  val.typ = typ
+
+func addrOp(c: var TCtx, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkAddr, typ: typ)
+  # don't change ownership. If the l-value is owned so is the resulting
+  # pointer
+  val.typ = typ
+
+func viewOp(c: var TCtx, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkView, typ: typ)
+  val.typ = typ
+
+func derefOp(c: var TCtx, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkDeref, typ: typ)
+  val.typ = typ
+
+func derefViewOp(c: var TCtx, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkDerefView, typ: typ)
+  val.typ = typ
+
+func pathObj(c: var TCtx, field: PSym, val: var EValue) =
+  assert field.kind == skField
+  c.stmts.add MirNode(kind: mnkPathNamed, typ: field.typ, field: field)
+  val.typ = field.typ
+
+func pathPos(c: var TCtx, elemType: PType, position: uint32, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkPathPos, typ: elemType, position: position)
+  val.typ = elemType
+
+func pathVariant(c: var TCtx, objType: PType, field: PSym, val: var EValue) =
+  let objType = objType.skipTypes(abstractInstTypeClass)
+  c.stmts.add MirNode(kind: mnkPathVariant,
+                      typ: objType,
+                      field: field)
+  val.typ = objType
+
+func unaryMagicCall(c: var TCtx, m: TMagic, typ: PType, val: var EValue) =
+  assert typ != nil
+  c.stmts.add MirNode(kind: mnkMagic, typ: typ, magic: m)
+  val.typ = typ
+
+func magicCall(c: var TCtx, m: TMagic, typ: PType): EValue =
+  assert typ != nil
+  c.stmts.add MirNode(kind: mnkMagic, typ: typ, magic: m)
+  result = EValue(typ: typ)
+
+proc notOp(c: var TCtx, val: var EValue) =
+  unaryMagicCall(c, mNot, getSysType(c.graph, c.sp.active.n.info, tyBool), val)
+
+func tupleAccess(c: var TCtx, pos: uint32, typ: PType, val: var EValue) =
+  c.stmts.add MirNode(kind: mnkPathPos, typ: typ, position: pos)
+  val.typ = typ
+
+# generate the adapters:
+genSinkAdapter(arg)
+genSinkAdapter(name)
+genSinkAdapter(consume)
+genSinkAdapter(genVoid)
+
+genValueAdapter(modify)
+genValueAdapter(outOp)
+genValueAdapter(notOp)
+
+genValueAdapter1(castOp, typ)
+genValueAdapter1(stdConvOp, typ)
+genValueAdapter1(convOp, typ)
+genValueAdapter1(addrOp, typ)
+genValueAdapter1(viewOp, typ)
+genValueAdapter1(derefOp, typ)
+genValueAdapter1(derefViewOp, typ)
+genValueAdapter1(pathObj, field)
+genValueAdapter1(tag, effect)
+
+genValueAdapter2(pathPos, typ, pos)
+genValueAdapter2(pathVariant, typ, field)
+genValueAdapter2(tupleAccess, pos, typ)
+# currently unused:
+#genValueAdapter2(unaryMagicCall, m, typ)
+
+func constr(c: var TCtx, typ: PType): EValue =
+  c.stmts.add MirNode(kind: mnkConstr, typ: typ)
+  result = EValue(typ: typ)
+
+func tempNode(c: var TCtx, typ: PType, id: TempId): EValue =
+  c.stmts.add tempNode(typ, id)
+  result = EValue(typ: typ)
+
+func procLit(c: var TCtx, s: PSym): EValue =
+  c.stmts.add MirNode(kind: mnkProc, typ: s.typ, sym: s)
+  result = EValue(typ: s.typ)
+
+func genTypeLit(c: var TCtx, t: PType): EValue =
+  c.stmts.add MirNode(kind: mnkType, typ: t)
+  result = EValue(typ: t)
+
+proc genEmpty(c: var TCtx, n: PNode): EValue =
+  c.stmts.add MirNode(kind: mnkNone, typ: n.typ)
+  result = EValue(typ: c.graph.getSysType(n.info, tyVoid))
+
+func nameNode(s: PSym, n: PNode): MirNode =
+  if sfGlobal in s.flags:
+    MirNode(kind: mnkGlobal, typ: s.typ, sym: s)
+  elif s.kind in {skParam, skGenericParam}:
+    MirNode(kind: mnkParam, typ: s.typ, sym: s)
+  elif s.kind == skConst:
+    MirNode(kind: mnkConst, typ: s.typ, sym: s)
+  elif s.kind in {skVar, skLet, skForVar, skResult}:
+    MirNode(kind: mnkLocal, typ: s.typ, sym: s)
+  else:
+    unreachable(s.kind)
+
+func genLocation(c: var TCtx; n: PNode): EValue =
+  let mn = nameNode(n.sym, n)
+  c.stmts.add mn
+
+  result = EValue(typ: mn.typ)
+
+proc genLit(c: var TCtx; n: PNode): EValue =
+  c.stmts.add MirNode(kind: mnkLiteral, typ: n.typ, lit: n)
+  result = EValue(typ: n.typ)
+
+func emit(dest: var CodeFragment, sp: var SourceProvider, src: CodeFragment,
+          span: NodeSpan): EValue =
+  ## Copies the nodes denoted by `span` from `src` to the end of `dest`
+  assert span.len > 0, "empty source fragment"
+
+  # make sure that the source information in `dest` is up-to-date before
+  # appending
+  applySource(dest, sp)
+
+  dest.nodes.add toOpenArray(src.nodes, span)
+  dest.source.add toOpenArray(src.source, span)
+
+  result = EValue(typ: dest.nodes[^1].typ)
+
+func genDefault(c: var TCtx, typ: PType): EValue =
+  ## Emits a call to the ``default`` operator for the given `typ`
+  argBlock(c.stmts): discard
+  magicCall(c, mDefault, typ)
+
+proc gen(c: var TCtx; n: PNode)
+proc genx(c: var TCtx; n: PNode, consume: bool = false): EValue
+proc genComplexExpr(c: var TCtx, n: PNode, dest: Destination)
+
+proc genAsgn(c: var TCtx, dest: Destination, rhs: PNode)
+proc genWithDest(c: var TCtx; n: PNode; dest: Destination)
+
+template selectArg(c: var TCtx, useConsume: bool): Sink {.dirty.} =
+  if useConsume: consume(c)
+  else:          arg(c)
+
+func getTemp(c: var TCtx, typ: PType): TempId =
+  ## Allocates a new name for a temporary and emits a definition for it
+  result = nextTempId(c)
+  c.stmts.subTree MirNode(kind: mnkDef):
+    c.stmts.add MirNode(kind: mnkTemp, temp: result, typ: typ)
+
+proc genAndOr(c: var TCtx, n: PNode, dest: Destination) =
+  ## Generates the code for an ``and|or`` operation:
+  ##
+  ## .. code-block:: nim
+  ##
+  ##   block label:
+  ##     dest = a
+  ##
+  ##     # for `or`:
+  ##     if dest: break label
+  ##     # for `and`:
+  ##     if not dest: break label
+  ##
+  ##     dest = b
+  ##
+  # TODO: inefficient code is generated for nested ``and|or`` operations, e.g.
+  #       ``a or b or c``. Sequences of the same operation should be merged
+  #       into a single one before and the logic here adjusted to handle them.
+  #       With the aforementioned transformation, the previously mentioned
+  #       example would become: ``or(a, b, c)``
+  let label = nextLabel(c)
+  c.stmts.subTree MirNode(kind: mnkBlock, label: label):
+    stmtList(c.stmts):
+      genAsgn(c, dest, n[1])
+
+      # condition:
+      let v = emit(c.stmts, c.sp, c.staging, dest.nodes)
+      if n[0].sym.magic == mAnd:
+        forward: v => notOp(c)
+
+      c.stmts.subTree MirNode(kind: mnkIf, len: 1):
+        # then:
+        c.stmts.add MirNode(kind: mnkBreak, label: label)
+
+      genAsgn(c, dest, n[2])
+
+proc genBracketExpr(c: var TCtx, n: PNode): EValue =
+  let typ = n[0].typ.skipTypes(abstractInstTypeClass - {tyTypeDesc})
+  case typ.kind
+  of tyTuple:
+    let i = n[1].intVal.int
+    # due to all the type-related modifications done by ``transf``, it's safer
+    # to lookup query the type from the tuple instead of using `n.typ`
+    eval: genx(c, n[0]) => pathPos(c, typ[i], i.uint32)
+  of tyArray, tySequence, tyOpenArray, tyVarargs, tyUncheckedArray, tyString,
+     tyCstring:
+    argBlock(c.stmts):
+      chain: genx(c, n[0]) => name(c)
+      chain: genx(c, n[1]) => arg(c)
+    c.stmts.add MirNode(kind: mnkPathArray, typ: elemType(typ))
+
+    EValue(typ: elemType(typ))
+  else: unreachable()
+
+proc genVariantAccess(c: var TCtx, n: PNode): (EValue, PNode) =
+  assert n.kind == nkCheckedFieldExpr
+
+  let access = n[0]
+  assert access.kind == nkDotExpr
+
+  var val = genx(c, access[0])
+  # iterate the checks in reverse, as the outermost discriminator check is
+  # rightmost
+  # XXX: the "rightmost" part is an implementation detail of how
+  #      ``nkCheckedFieldExpr`` nodes are generated by ``sem.nim``,
+  #      depending on it here is brittle. It's okay for now and
+  #      ``nkCheckedFieldExpr`` should ideally be removed anyways
+  for i in countdown(n.len-1, 1):
+    let check = n[i]
+    assert check.kind in nkCallKinds
+    # the check can be wrapped in a ``not`` call -- unwrap it first
+    let inCall =
+      if check[0].sym.magic == mNot: check[1]
+      else:                          check
+
+    pathVariant(c, access[0].typ, inCall[2].sym, val)
+
+  result = (val, access[1])
+
+proc genTypeExpr(c: var TCtx, n: PNode): EValue =
+  ## Generates the code for an expression that yields a type. These are only
+  ## valid in metaprogramming contexts. If it's a static type expression, we
+  ## evaluate it directly and store the result as a type literal in the MIR
+  assert n.typ.kind == tyTypeDesc
+  c.stmts.useSource(c.sp, n)
+  case n.kind
+  of nkStmtListType, nkStmtListExpr:
+    # FIXME: a ``nkStmtListExpr`` shouldn't reach here, but it does. See
+    #        ``tests/lang_callable/generics/t18859.nim`` for a case where it
+    #        does
+    if n[^1].typ.kind == tyTypeDesc:
+      genTypeExpr(c, n.lastSon)
+    else:
+      # HACK: this is big hack. Consider the following case:
+      #
+      #       .. code-block:: nim
+      #
+      #         type Obj[T] = object
+      #           p: T not nil
+      #
+      #         var x: Obj[ref int]
+      #
+      #       The ``T not nil`` is a ``nkStmtListType`` node with a single
+      #       ``nkInfix`` sub-node, where the latter doesn't use a
+      #       ``tyTypeDesc`` type but a ``tyRef`` instead. For now, we work
+      #       around this by using the type of the ``nkStmtListType``
+      genTypeLit(c, n.typ)
+  of nkBlockType:
+    genTypeExpr(c, n.lastSon)
+  of nkSym:
+    case n.sym.kind
+    of skType:
+      genTypeLit(c, n.sym.typ)
+    of skVar, skLet, skForVar, skTemp, skParam:
+      # a first-class type value stored in a location
+      genLocation(c, n)
+    else:
+      unreachable()
+  of nkBracketExpr:
+    # the type description of a generic type, e.g. ``seq[int]``
+    genTypeLit(c, n.typ)
+  of nkTupleTy, nkStaticTy, nkRefTy, nkPtrTy, nkVarTy, nkDistinctTy, nkProcTy,
+     nkIteratorTy, nkSharedTy, nkTupleConstr:
+    genTypeLit(c, n.typ)
+  of nkTypeOfExpr, nkType:
+    genTypeLit(c, n.typ)
+  else:
+    unreachable("not a type expression")
+
+proc genCallee(c: var TCtx, n: PNode): EValue =
+  ## Generates and emits the code for a callee expression
+  if n.kind == nkSym and n.sym.kind in routineKinds:
+    c.stmts.useSource(c.sp, n)
+    procLit(c, n.sym)
+  else:
+    # an indirect call
+    genx(c, n)
+
+proc genArgExpression(c: var TCtx, formal: PType, n: PNode): EValue =
+  ## Generates the code for an expression appearing in the context of an
+  ## argument
+  const OpenArrayLike = {tyOpenArray, tyVarargs}
+  let
+    t = formal.skipTypes(abstractVarRange)
+    # skip the hidden addr - it's not needed by the IR
+    n = if n.kind == nkHiddenAddr: n[0] else: n
+
+  c.stmts.useSource(c.sp, n)
+
+  result = c.genx(n, consume = formal.kind == tySink)
+
+  if t.kind in OpenArrayLike and
+     n.typ.skipTypes(abstractVarRange).kind notin OpenArrayLike:
+    # restore the conversion that was eliminated by ``transf``
+    result = eval: result => stdConvOp(c, formal.skipTypes(abstractVar))
+
+proc genArg(c: var TCtx, formal: PType, n: PNode) =
+  ## Generates and emits the MIR code for an argument expression plus the
+  ## required argument sink. The `formal` type is needed for figuring out
+  ## which sink to use
+  let v = genArgExpression(c, formal, n)
+
+  case formal.skipTypes(abstractRange-{tySink}).kind
+  of tyVar:
+    chain: v => modify(c) => name(c)
+  of tySink:
+    chain: v => consume(c)
+  else:
+    chain: v => arg(c)
+
+proc finishCall(c: var TCtx, callee: PNode, fntyp: PType): EValue =
+  # compute the effects the call has:
+  var effects: set[GeneralEffect]
+  if canRaiseConservative(callee):
+    effects.incl geRaises
+
+  if tfNoSideEffect notin fntyp.flags:
+    effects.incl geMutateGlobal
+
+  # to ease further return-type queries, a non-existing return-type (i.e. the
+  # type is 'nil') is replaced with the ``void`` type
+  let rtyp = typeOrVoid(c, fntyp[0])
+  c.stmts.add MirNode(kind: mnkCall, typ: rtyp, effects: effects)
+
+  result = EValue(typ: rtyp)
+
+proc genCall(c: var TCtx, n: PNode): EValue =
+  ## Generates and emits the MIR code for a call expression
+  let fntyp = skipTypes(n[0].typ, abstractInst)
+
+  c.stmts.add MirNode(kind: mnkArgBlock)
+
+  chain: genCallee(c, n[0]) => arg(c)
+
+  for i in 1..<n.len:
+    # for procedures with unsafe varargs, the type of the argument expression
+    # is used as the formal type (because it's the only type-related
+    # information about the argument we have access to here)
+    let t =
+      if i < fntyp.len: fntyp[i]
+      else:             n[i].typ
+
+    if t.kind == tyTypeDesc and goGenTypeExpr in c.options:
+      # generation of type expressions is requested. It's important that this
+      # branch comes before the ``isCompileTimeOnly`` one, as a ``tyTypeDesc``
+      # is treated as a compile-time-only type and would be omitted then
+      chain: genTypeExpr(c, n[i]) => arg(c)
+    elif t.isCompileTimeOnly:
+      # don't translate arguments to compile-time-only parameters. To ease the
+      # translation back to ``PNode``, we don't omit them completely but only
+      # replace them with a node holding their type
+      chain: genEmpty(c, n[i]) => arg(c)
+    elif t.kind == tyVoid:
+      # a ``void`` argument. We can't just generate an ``mnkNone`` node, as the
+      # statement used as the argument can still have side-effects
+      gen(c, n[i])
+      chain: genEmpty(c, n[i]) => arg(c)
+    elif i == 1 and not fntyp[0].isEmptyType() and
+         not isHandleLike(t) and
+         directViewType(fntyp[0]) != noView:
+      # the procedure returns a view, but the first parameter is not something
+      # that resembles a handle. We need to make sure that the first argument
+      # (which the view could be created from), is passed by reference in that
+      # case.
+      chain: genArgExpression(c, t, n[i]) => name(c)
+    else:
+      genArg(c, t, n[i])
+
+  c.stmts.add endNode(mnkArgBlock)
+
+  finishCall(c, n[0], fntyp)
+
+proc genMacroCall(c: var TCtx, n: PNode): EValue =
+  ## Generates the code for a macro/template call expression. These can only
+  ## occur in a ``getAst`` context.
+  ##
+  ## The argument expressions require special handling, so a dedicated
+  ## procedure is used in order to encapsulate the required workarounds in a
+  ## single place, making it easier to spot, document, and eventually fix them.
+  assert n[0].kind == nkSym and n[0].sym.kind in {skMacro, skTemplate}
+
+  # XXX: ``genAst(templ(x))`` (where `templ` is a template) should be turned
+  #      into:
+  #
+  #        mExpandToAst( NimNodeLit(Sym "templ"), Call( Sym "toNimNode", Sym "x") )
+  #
+  #      during semantic analysis. The above expression is semantically
+  #      equivalent to what currently happens, but it would move decision
+  #      making out of both ``mirgen``, ``vmgen``, and the VM. ``toNimNode`` is
+  #      a magic procedure that does the same thing as ``vm.regToNode`` (i.e.
+  #      turn a run-time value into its ``NimNode`` representation)
+
+  # XXX: if each macro had a corresponding internal procedure symbol that
+  #      represents the macro during compile-time execution, then
+  #      ``getAst(macroCall(x)`` could be translated to
+  #      ``macroCall(toNimNode(x))`` during semantic analysis. That would
+  #      simplify both ``mirgen`` and ``vmgen``. For example, the macro:
+  #
+  #      .. code-block:: nim
+  #
+  #        macro m[A, B](x: int, y: untyped, z: static string) = ...
+  #
+  #      would have an internal represetation that is equivalent to:
+  #
+  #      .. code-block:: nim
+  #
+  #        proc m(x: NimNode, y: NimNode, A: typeDesc, B: typeDesc,
+  #               z: string) {.compileTime.}
+  #
+  #      This matches with how macro calls are already invoked by the
+  #      VM/``compilerbridge``. The ``skMacro`` symbol would be the one
+  #      used during overload resolution, while the ``skProc`` symbol would
+  #      be used when executing the macro in the VM.
+
+  c.stmts.add MirNode(kind: mnkArgBlock)
+  chain: genCallee(c, n[0]) => arg(c)
+
+  let fntyp = n[0].typ
+  for i in 1..<n.len:
+    let
+      t = fntyp[i]
+      argTyp = n[i].typ.skipTypes(abstractInst - {tyTypeDesc})
+
+    if t.kind == tyStatic:
+      # an argument to a static parameter. Treat as a normal argument
+      # expression
+      # QUESTION: what about ``static[var int]``? How should those work?
+      genArg(c, t, n[i])
+    elif argTyp.sym != nil and argTyp.sym.magic == mPNimrodNode:
+      # the argument is a ``NimNode`` value. Treat them as normal arguments
+      chain: genArgExpression(c, t, n[i]) => arg(c)
+    elif argTyp.kind == tyTypeDesc:
+      # the expression is a type expression, explicitly handle it there so that
+      # ``genx`` doesn't has to it here
+      chain: genTypeExpr(c, n[i]) => arg(c)
+    elif n[i].kind == nkSym and n[i].sym.kind in {skMacro, skTemplate}:
+      # special case them here so that ``genx`` doesn't have to
+      # note: do not use ``genProcLit`` here. These are *not* procedural
+      #       values
+      let
+        typ = sysTypeFromName(c.graph, n.info, "NimNode")
+        lit = newTreeIT(nkNimNodeLit, n[i].info, typ): n[i]
+
+      chain: genLit(c, lit) => arg(c)
+    else:
+      chain: genx(c, n[i]) => arg(c)
+
+  c.stmts.add endNode(mnkArgBlock)
+  finishCall(c, n[0], fntyp)
+
+proc genMagic(c: var TCtx, n: PNode; m: TMagic): EValue =
+  ## Generates the MIR code for the magic call expression/statement `n`. `m` is
+  ## the magic's enum value and must match with that of the callee.
+  ##
+  ## Some magics are inserted by the compiler, in which case the corresponding
+  ## symbols are incomplete: only the ``magic`` and ``name`` field can be
+  ## treated as valid. These magic calls are manually translated and don't go
+  ## through ``genCall``
+  c.stmts.useSource(c.sp, n)
+
+  proc argExpr(c: var TCtx, n: PNode): EValue =
+    ## Generates an argument expression in a context where information about
+    ## the formal type is missing -- the type of the expression is used as the
+    ## formal type instead. This only works for arguments where the parameter is
+    ## known to neither be of ``var`` nor ``sink`` type
+    # make sure to skip types such as ``sink``, as the expression would be
+    # erroneously treated as used in a consume context otherwise
+    genArgExpression(c, n.typ.skipTypes(abstractVar), n)
+
+  case m
+  of mAnd, mOr:
+    let tmp = getTemp(c, n.typ)
+    let slice = buildSlice(c.staging, c.sp):
+      c.staging.add tempNode(n.typ, tmp)
+
+    genAndOr(c, n, Destination(kind: dkFrag, nodes: slice))
+
+    c.staging.popSlice(slice)
+
+    tempNode(c, n.typ, tmp)
+  of mDefault:
+    # use the canonical form:
+    genDefault(c, n.typ)
+  of mNew, mNewFinalize:
+    # ``new`` has 3 variants. The standard one with a single argument, the
+    # unsafe version that also takes a ``size`` argument, and the finalizer
+    # version
+    assert n.len == 3 or n.len == 2
+    argBlock(c.stmts):
+      # the first argument is the location storing the ``ref``. A new value is
+      # assigned to it by ``new``, so the 'out' tag is used
+      chain: genArgExpression(c, n[0].typ[1], n[1]) => outOp(c) => name(c)
+      if n.len == 3:
+        # the finalizer or size argument
+        chain: genArgExpression(c, n[0].typ[2], n[2]) => arg(c)
+
+    magicCall(c, m, typeOrVoid(c, n.typ))
+  of mWasMoved:
+    # ``wasMoved`` has an effect that is not encoded by the parameter's type
+    # (it kills the location), so we need to manually translate it
+    argBlock(c.stmts):
+      chain: argExpr(c, n[1]) => tag(c, ekKill) => name(c)
+
+    magicCall(c, mWasMoved, typeOrVoid(c, n.typ))
+  of mConStrStr:
+    # the `mConStrStr` magic is very special. Nested calls to it are flattened
+    # into a single call in ``transf``. It can't be passed on to ``genCall``
+    # since the number of arguments doesn't match with the number of parameters
+    argBlock(c.stmts):
+      for i in 1..<n.len:
+        chain: argExpr(c, n[i]) => arg(c)
+
+    magicCall(c, mConStrStr, n.typ)
+  of mRunnableExamples:
+    # omit the ``runnableExamples`` call. The callsite of ``genMagic`` expects
+    # that we emit something, so we emit an ``mnkEmpty`` node
+    # TODO: call to ``runnableExamples`` shouldn't reach into ``mirgen``. If
+    #       they do, it means that simple expression might sometimes not be
+    #       detected as such, because ``canonicalExpr`` doesn't consider
+    #       ``runnableExamples``
+    genEmpty(c, n)
+
+  # magics that use incomplete symbols (most of them are generated by
+  # ``liftdestructors``):
+  of mDestroy:
+    # ``mDestroy`` magic calls might be incomplete symbols, so we have to
+    # translate them manually
+    argBlock(c.stmts):
+      chain: argExpr(c, n[1]) => tag(c, ekMutate) => name(c)
+    magicCall(c, m, typeOrVoid(c, n.typ))
+  of mMove:
+    # there exist two different types of ``mMove`` magic calls:
+    # 1. normal move calls: ``move(x)``
+    # 2. special move calls inserted by ``liftdestructors``, used for ``seq``s
+    #    and ``string``s: ``move(dst, src, stmt)``
+    case n.len
+    of 2:
+      # the first version
+      genCall(c, n)
+    of 4:
+      # HACK: the ``stmt`` statement is not always evaluated, so treating it as
+      #       a ``void`` argument is wrong. We also can't lower the call here
+      #       already, since we don't have access to the ``seq``s
+      #       implementation details and the lowering is also only required for
+      #       the C target.
+      #       Treating the statement as a ``void`` argument only works because,
+      #       at the time of writing this comment, there are no MIR passes that
+      #       inspect code in which a special ``move`` occurs.
+      #       A more proper solution is to add a new magic (something like
+      #       ``mMoveSeq``) that then gets lowered into the expected
+      #       comparision + destructor call by a MIR pass that is only enabled
+      #       for the C target
+
+      argBlock(c.stmts):
+        chain: argExpr(c, n[1]) => tag(c, ekReassign) => name(c)
+        chain: argExpr(c, n[2]) => arg(c)
+
+        gen(c, n[3])
+        chain: genEmpty(c, n[3]) => arg(c)
+      magicCall(c, m, typeOrVoid(c, n.typ))
+    else:
+      unreachable()
+  of mNewSeq:
+    # XXX: the first parameter is actually an ``out`` parameter -- the
+    #      ``ekReassign`` effect could be used
+    if n[0].typ == nil:
+      argBlock(c.stmts):
+        chain: argExpr(c, n[1]) => tag(c, ekMutate) => name(c)
+        chain: argExpr(c, n[2]) => arg(c)
+      magicCall(c, m, typeOrVoid(c, n.typ))
+    else:
+      genCall(c, n)
+  of mInc, mSetLengthStr:
+    if n[0].typ == nil:
+      argBlock(c.stmts):
+        chain: argExpr(c, n[1]) => tag(c, ekMutate) => name(c)
+        chain: argExpr(c, n[2]) => arg(c)
+      magicCall(c, m, typeOrVoid(c, n.typ))
+    else:
+      genCall(c, n)
+  of mLtI, mSubI, mLengthSeq, mLengthStr, mAccessEnv, mAccessTypeField:
+    if n[0].typ == nil:
+      # simple translation. None of the arguments need to be passed by lvalue
+      argBlock(c.stmts):
+        for i in 1..<n.len:
+          chain: argExpr(c, n[i]) => arg(c)
+
+      magicCall(c, m, n.typ)
+    else:
+      genCall(c, n)
+  of mAlignOf:
+    # instances of the magic inserted by ``liftdestructors`` and ``alignof(x)``
+    # calls where ``x`` is of an imported type with unknown alignment reach
+    # here. The code-generators only care about the types in both cases, so
+    # that's what we emit
+    argBlock(c.stmts):
+      # skip the surrounding typedesc
+      chain: genTypeLit(c, n[1].typ.skipTypes({tyTypeDesc})) => arg(c)
+    magicCall(c, m, n.typ)
+  of mGetTypeInfoV2:
+    if n[0].typ == nil:
+      # the compiler-generated version always uses a type as the argument
+      argBlock(c.stmts):
+        chain: genTypeLit(c, n[1].typ) => arg(c)
+      magicCall(c, m, n.typ)
+    else:
+      # only the compiler-generated version of the magic has a type parameter.
+      # The normal one doesn't (see ``cyclebreaker.getDynamicTypeInfo``), so we
+      # can safely use ``genCall``
+      genCall(c, n)
+
+  # special macro related magics:
+  of mExpandToAst:
+    if n[0].typ == nil:
+      # has no type information -- we need to manually tranlate it
+      argBlock(c.stmts):
+        for i in 1..<n.len:
+          assert n[i].typ == nil
+          # even the argument expressions don't have types in this case, so we
+          # can't use ``argExpr``
+          # FIXME: this happens in the context of ``quote`` (i.e.
+          #        ``semQuoteAst``), because the quoted expressions are not
+          #        semantically analysed.
+          #        The arguments (quoted expressions) should be analysed and
+          #        the call should also use a complete symbol.
+          chain: genx(c, n[i]) => arg(c)
+
+    else:
+      argBlock(c.stmts):
+        chain: genMacroCall(c, n[1]) => arg(c)
+
+    magicCall(c, m, n.typ)
+  else:
+    # no special transformation for the other magics:
+    genCall(c, n)
+
+proc genCallOrMagic(c: var TCtx, n: PNode): EValue =
+  if n[0].kind == nkSym and (let s = n[0].sym; s.magic != mNone):
+    genMagic(c, n, s.magic)
+  else:
+    genCall(c, n)
+
+proc genSetConstr(c: var TCtx, n: PNode): EValue =
+  argBlock(c.stmts):
+    for it in n.items:
+      chain: genx(c, it) => arg(c)
+
+  result = constr(c, n.typ)
+
+proc genArrayConstr(c: var TCtx, n: PNode, isConsume: bool): EValue =
+  argBlock(c.stmts):
+    for it in n.items:
+      chain: genx(c, it, isConsume) => selectArg(c, isConsume)
+
+  result = constr(c, n.typ)
+
+proc genTupleConstr(c: var TCtx, n: PNode, isConsume: bool): EValue =
+  assert n.typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind == tyTuple
+
+  argBlock(c.stmts):
+    for it in n.items:
+      chain: genx(c, skipColon(it), isConsume) => selectArg(c, isConsume)
+
+  result = constr(c, n.typ)
+
+proc genClosureConstr(c: var TCtx, n: PNode, isConsume: bool): EValue =
+  argBlock(c.stmts):
+    chain: genx(c, n[0]) => arg(c) # the procedure
+
+    let v =
+      if n[1].kind == nkNilLit:
+        # it can happen that a ``nkNilLit`` has no type (i.e. its typ is nil) -
+        # we ensure that the nil literal has the correct type
+        # TODO: prevent a ``nkNilLit`` with no type information from being
+        #       created instead
+        genLit(c, newNodeIT(nkNilLit, n[1].info, c.graph.getSysType(n[1].info, tyNil)))
+      else:
+        genx(c, n[1], isConsume)
+
+    chain: v => selectArg(c, isConsume) # the environment
+
+  result = constr(c, n.typ)
+
+proc genObjConstr(c: var TCtx, n: PNode, isConsume: bool): EValue =
+  let isRef = n.typ.skipTypes(abstractInst).kind == tyRef
+
+  # generate the argument block:
+  argBlock(c.stmts):
+    for i in 1..<n.len:
+      let it = n[i]
+      assert it.kind == nkExprColonExpr
+
+      # only require require a unique value when constructing a ``ref`` and the
+      # destination is not a ``.cursor`` field
+      let useConsume =
+        (isRef or isConsume) and
+        sfCursor notin lookupFieldAgain(n.typ.skipTypes(abstractInst), it[0].sym).flags
+
+      chain: genx(c, it[1], useConsume) => selectArg(c, useConsume)
+
+  # emit the constructor:
+  c.stmts.subTree MirNode(kind: mnkObjConstr, typ: n.typ, len: n.len-1):
+    for i in 1..<n.len:
+      let it = n[i]
+
+      c.stmts.add MirNode(kind: mnkField, field: it[0].sym)
+
+  result = EValue(typ: n.typ)
+
+
+proc genRaise(c: var TCtx, n: PNode) =
+  assert n.kind == nkRaiseStmt
+  forward:
+    if n[0].kind != nkEmpty: c.genx(n[0])
+    else:                    c.genEmpty(n[0])
+
+  c.stmts.add MirNode(kind: mnkRaise)
+
+proc genReturn(c: var TCtx, n: PNode) =
+  assert n.kind == nkReturnStmt
+  if n[0].kind != nkEmpty:
+    gen(c, n[0])
+
+  c.stmts.add MirNode(kind: mnkReturn)
+
+proc genAsgn(c: var TCtx, dest: Destination, rhs: PNode) =
+  assert dest.isSome
+  let owns = dfOwns in dest.flags
+  argBlock(c.stmts):
+    let v =
+      case dest.kind
+      of dkGen:  genx(c, dest.node)
+      of dkFrag: emit(c.stmts, c.sp, c.staging, dest.nodes)
+      else:      unreachable()
+
+    chain: v => outOp(c) => name(c) # lhs
+    chain: c.genx(rhs, consume = owns) => selectArg(c, owns) # rhs
+
+  let kind =
+    if owns:
+      if dfEmpty in dest.flags: mnkInit
+      else:                     mnkAsgn
+    else:                       mnkFastAsgn
+
+  c.stmts.add MirNode(kind: kind)
+
+proc unwrap(c: var TCtx, n: PNode): PNode =
+  ## If `n` is a statement-list expression, generates the code for all
+  ## statements and returns the unwrapped expression. Returns the canonicalized
+  ## `n` otherwise
+  result = canonicalExpr(n)
+  if result.kind == nkStmtListExpr:
+    for i in 0..<(result.len-1):
+      gen(c, result[i])
+
+    result = canonicalExpr(result.lastSon)
+    assert result.kind != nkStmtListExpr
+
+proc genAsgn(c: var TCtx, isFirst: bool, lhs, rhs: PNode) =
+  ## Generates the code for an assignment. `isFirst` indicates if this is the
+  ## first assignment to the location named by `lhs`.
+  ##
+  ## If the expression on the right is complex and the location the left-hand
+  ## names might be invalidated by the expression on the right, the value
+  ## resulting from the expression on the right is first stored in a temporary
+
+  # generate everything part of the left-hand-side that is not the relevant
+  # l-value expression:
+  let
+    lhs = unwrap(c, lhs)
+    isCursor = isCursor(lhs)
+
+  func isSimple(n: PNode): bool =
+    ## Computes if the l-value expression `n` always names the same valid
+    ## location
+    var n {.cursor.} = n
+    while true:
+      case n.kind
+      of nkSym:
+        return true
+      of nkDotExpr:
+        # ``nkCheckedFieldExpr`` is deliberately not included here because it
+        # means the location is part of a variant-object-branch
+        n = n[0]
+      of nkBracketExpr:
+        if n[0].typ.skipTypes(abstractVarRange).kind in {tyTuple, tyArray} and
+           n[1].kind in nkLiterals:
+          # tuple access and arrays indexed by a constant value are
+          # allowed -- they always name the same location
+          n = n[0]
+        else:
+          return false
+      else:
+        return false
+
+  if isSimple(lhs):
+    # the rhs cannot change the location the lhs names, so we can assign
+    # directly
+    genWithDest(c, rhs, initDestination(lhs, isFirst))
+  else:
+    argBlock(c.stmts):
+      chain: genx(c, lhs) => outOp(c) => name(c)
+      # only use 'consume' if the we're not assigning to a cursor
+      chain: genx(c, rhs, consume=not isCursor) => selectArg(c, not isCursor)
+
+    let kind =
+      if isCursor:  mnkFastAsgn
+      else:
+        if isFirst: mnkInit
+        else:       mnkAsgn
+
+    c.stmts.add MirNode(kind: kind)
+
+proc genFastAsgn(c: var TCtx, lhs, rhs: PNode) =
+  argBlock(c.stmts):
+    chain: genx(c, lhs) => outOp(c) => name(c)
+    chain: genx(c, rhs) => arg(c)
+
+  c.stmts.add MirNode(kind: mnkFastAsgn)
+
+proc genLocDef(c: var TCtx, n: PNode) =
+  ## Generates the 'def' construct for the entity provided by the symbol node
+  ## `n`
+  let s = n.sym
+
+  c.stmts.useSource(c.sp, n)
+  c.stmts.subTree MirNode(kind: selectDefKind(s)):
+    case s.kind
+    of skTemp:
+      let id = nextTempId(c)
+      c.tmpMap[s.itemId] = id
+
+      c.stmts.add MirNode(kind: mnkTemp, typ: s.typ, temp: id)
+    else:
+      let kind =
+        if sfGlobal in s.flags: mnkGlobal
+        else:                   mnkLocal
+
+      {.cast(uncheckedAssign).}:
+        c.stmts.add MirNode(kind: kind, sym: s)
+
+proc genLocInit(c: var TCtx, symNode: PNode, initExpr: PNode) =
+  ## Generates the code for a location definition. `sym` is the symbol of the
+  ## location and `initExpr` the initializer expression
+  let
+    sym = symNode.sym
+    hasInitExpr = initExpr.kind != nkEmpty
+    wantsOwnership = sfCursor notin sym.flags and
+                     hasDestructor(sym.typ)
+    isProcGlobal = sfGlobal in sym.flags and
+                   c.context in routineKinds
+
+  assert sym.kind in {skVar, skLet, skTemp, skForVar}
+
+  # if there's an initial value and the destination is non-owning, we pass the
+  # value directly to the def
+  # HACK: we rely on an implementation detail of ``astgen`` (namely that a
+  #       'def' with an initializer is translated to a single ``nkVarSection``
+  #       node) for globals defined at procedure scope. This is not the way
+  #       to go. It makes sense for these globals to be part of a procedure's
+  #       AST during the sem phase, but past this point, it's actually harmful.
+  #       They should be lifted into a separate list that is stored with the
+  #       module the procedure is attached to, which the back-end then queries
+  if hasInitExpr and (not wantsOwnership or isProcGlobal):
+    # TODO: add a test for using a constructor expression for initializing a
+    #       cursor
+    forward: genx(c, initExpr, consume = isProcGlobal)
+
+  genLocDef(c, symNode)
+
+  if hasInitExpr and wantsOwnership and not isProcGlobal:
+    # a copy or sink can't be expressed via a pass-to-def -- we need to use
+    # the assignment operator
+    genAsgn(c, true, symNode, initExpr)
+
+proc genVarTuple(c: var TCtx, n: PNode) =
+  ## Generates the code for a ``let/var (a, b) = c`` statement
+  assert n.kind == nkVarTuple
+  c.stmts.useSource(c.sp, n)
+
+  let
+    numDefs = n.len - 2
+    initExpr = n[^1]
+
+  # then, generate the initialization
+  case initExpr.kind
+  of nkEmpty:
+    unreachable("missing initializer")
+  of nkPar, nkTupleConstr:
+    # skip constructing a temporary and assign directly
+    assert numDefs == initExpr.len
+    for i in 0..<numDefs:
+      let
+        lhs = n[i]
+        rhs = initExpr[i].skipColon
+
+      case lhs.kind
+      of nkSym:     genLocInit(c, lhs, rhs)
+      of nkDotExpr: genAsgn(c, true, lhs, rhs) # part of a closure environment
+      else:         unreachable(lhs.kind)
+
+  else:
+    let
+      typ = initExpr.typ
+      tmp = nextTempId(c)
+
+    # XXX: ``mnkDefUnpack`` was meant as a workaround and shouldn't be used
+    #      here. Passing each destination plus the tuple expression as
+    #      arguments to a region that performs the unpacking would be a much
+    #      cleaner solution and also speed up the move analysis a bit, because
+    #      the lifetime of the temporary ends much earlier. The problem: the
+    #      move analyser is not capable of analysing section parameters yet.
+    #      Using a region would also mean an increase in the amount of nodes --
+    #      ``mnkDefUnpack``, while a hack, is much more concise
+    # generate the definition for the temporary:
+    forward: genx(c, initExpr, consume = true)
+    c.stmts.subTree MirNode(kind: mnkDefUnpack):
+      c.stmts.add MirNode(kind: mnkTemp, typ: typ, temp: tmp)
+
+    # generate the unpack logic:
+    for i in 0..<numDefs:
+      let lhs = n[i]
+
+      if lhs.kind == nkSym:
+        genLocDef(c, lhs)
+
+      # generate the assignment:
+      argBlock(c.stmts):
+        chain: genx(c, lhs) => outOp(c) => name(c)
+        chain: tempNode(c, typ, tmp) => tupleAccess(c, i.uint32, lhs.sym.typ) => consume(c)
+      c.stmts.add MirNode(kind: mnkInit)
+
+proc genVarSection(c: var TCtx, n: PNode) =
+  for a in n:
+    case a.kind
+    of nkCommentStmt: discard
+    of nkVarTuple:
+      genVarTuple(c, a)
+    of nkIdentDefs:
+      c.stmts.useSource(c.sp, a)
+      case a[0].kind
+      of nkSym:
+        genLocInit(c, a[0], a[2])
+      of nkDotExpr:
+        # initialization of a variable that was lifted into a closure
+        # environment
+        if a[2].kind != nkEmpty:
+          genAsgn(c, false, a[0], a[2])
+        else:
+          # no intializer expression -> assign the default value
+          argBlock(c.stmts):
+            chain: genx(c, a[0]) => tag(c, ekReassign) => name(c)
+            chain: genDefault(c, a[0].typ) => arg(c)
+          c.stmts.add MirNode(kind: mnkInit)
+      else:
+        unreachable()
+
+    else:
+      unreachable(a.kind)
+
+
+proc genWhile(c: var TCtx, n: PNode) =
+  ## Generates the code for a ``nkWhile`` node. Because no conditional loops
+  ## exist in the MIR, the the condition is translated to a ``break`` statement
+  ## inside an ``if``
+  c.stmts.add MirNode(kind: mnkRepeat)
+
+  scope(c.stmts):
+    # don't emit a branch for ``while true: ...``
+    if not isTrue(n[0]):
+      forward: genx(c, n[0]) => notOp(c) # condition
+      c.stmts.subTree MirNode(kind: mnkIf):
+        c.stmts.add MirNode(kind: mnkBreak)
+
+    # use a nested scope for the body. This is important for scope finalizers,
+    # as exiting the loop via the ``break`` emitted above (i.e. the loop
+    # condition is false) must not run the finalizers (if present) for the
+    # loop's body
+    scope(c.stmts):
+      c.gen(n[1])
+
+  c.stmts.add endNode(mnkRepeat)
+
+proc genBlock(c: var TCtx, n: PNode, dest: Destination) =
+  ## Generates and emits the MIR code for a ``block`` expression or statement
+  let id = nextLabel(c)
+
+  # push the block to the stack:
+  var oldLen = c.blocks.len
+  c.blocks.add Block(label: n[0].sym, id: id)
+
+  # generate the body:
+  c.stmts.subTree MirNode(kind: mnkBlock, label: id):
+    scope(c.stmts):
+      c.genWithDest(n[1], dest)
+
+  # pop the block:
+  assert c.blocks.len == oldLen + 1
+  c.blocks.setLen(oldLen)
+
+proc genBranch(c: var TCtx, n: PNode, dest: Destination) =
+  ## Generates the body of a branch. Here, a branch refers to either an
+  ## ``if|elif|else``, ``of``, or ``except`` clause
+
+  # if the branch ends in a no-return statement, it has no type. We generate a
+  # normal statement (without an assignment to `dest`) in that case
+  if dest.kind != dkNone and not n.typ.isEmptyType():
+    genWithDest(c, n, dest)
+  else:
+    gen(c, n)
+
+proc genIf(c: var TCtx, n: PNode, dest: Destination) =
+  ## Generates the code for an ``if`` statement (``nkIf(Stmt|Expr)``). It's
+  ## translated to the ``mnkIf`` MIR construct (which can be seen as a
+  ## predicate over a region of code).
+  ##
+  ## The translation works as follows:
+  ##
+  ## .. code-block:: nim
+  ##
+  ##   if (let a = x; a == 0):
+  ##     stmt
+  ##   elif (let b = x; b == 1):
+  ##     stmt2
+  ##   else:
+  ##     stmt3
+  ##
+  ## is mapped to MIR code that is equivalent to
+  ##
+  ## .. code-block:: nim
+  ##
+  ##   block label:
+  ##     let a = x
+  ##     if a == 0:
+  ##       stmt1
+  ##       break label
+  ##     let b = x
+  ##     if x == 1:
+  ##       stmt2
+  ##       break label
+  ##     stmt3
+  ##
+  let hasValue = not isEmptyType(n.typ)
+  assert hasValue == dest.isSome
+
+  template genElifBranch(branch: PNode, extra: untyped) =
+    ## Generates the code for a single ``nkElif(Branch|Expr)``
+    forward: genx(c, branch[0])
+    c.stmts.subTree MirNode(kind: mnkIf):
+      scope(c.stmts):
+        genBranch(c, branch.lastSon, dest)
+        extra
+
+  if n.len == 1:
+    # an ``if`` statement/expression with a single branch. Don't emit the
+    # unnecessary 'block' and 'break'
+    genElifBranch(n[0]):
+      discard
+
+  else:
+    # a multi-clause ``if`` statement/expression
+    let label = nextLabel(c)
+    c.stmts.subTree MirNode(kind: mnkBlock, label: label):
+      stmtList(c.stmts):
+        for it in n.items:
+          case it.kind
+          of nkElifBranch, nkElifExpr:
+            genElifBranch(it):
+              # don't emit the 'break' if the branch doesn't have a structured
+              # exit
+              if not endsInNoReturn(it.lastSon):
+                c.stmts.add MirNode(kind: mnkBreak, label: label)
+
+          of nkElse, nkElseExpr:
+            scope(c.stmts):
+              genBranch(c, it[0], dest)
+
+            # since this is the last branch, a 'break' is not needed
+          else:
+            unreachable(it.kind)
+
+proc genCase(c: var TCtx, n: PNode, dest: Destination) =
+  ## Generates the MIR code for an ``nkCaseStmt`` node. Since the ``mnkCase``
+  ## MIR construct works in a very similar way, the translation logic is
+  ## straightforward
+  assert isEmptyType(n.typ) == not dest.isSome
+
+  forward: genx(c, n[0])
+
+  let start = c.stmts.nodes.len
+  c.stmts.add MirNode(kind: mnkCase)
+
+  # the number of processed branches is not necessarily equal to the amount
+  # we're going to emit (in case we skip some), so we have to count them
+  # manually
+  var num = 0
+  # iterate of/else branches:
+  for (_, branch) in branches(n):
+    if branch.len == 1 and branch.kind == nkOfBranch:
+      # an 'of' branch that has no labels (e.g. ``of {}:``). We omit the whole
+      # branch and don't generate any code for it
+      continue
+
+    c.stmts.add MirNode(kind: mnkBranch, len: branch.len - 1)
+
+    case branch.kind
+    of nkElse:
+      discard
+    of nkOfBranch:
+      # emit the lables:
+      for (_, lit) in branchLabels(branch):
+        c.stmts.add MirNode(kind: mnkLiteral, lit: lit)
+    else:
+      unreachable(branch.kind)
+
+    # the branch's body:
+    scope(c.stmts):
+      genBranch(c, branch.lastSon, dest)
+
+    c.stmts.add endNode(mnkBranch)
+    inc num
+
+  c.stmts.add endNode(mnkCase)
+
+  # set the number of actually emitted branches:
+  c.stmts.nodes[start].len = num
+
+proc genExceptBranch(c: var TCtx, n: PNode, dest: Destination) =
+  assert n.kind == nkExceptBranch
+  c.stmts.useSource(c.sp, n)
+
+  c.stmts.subTree MirNode(kind: mnkBranch, len: n.len - 1):
+    # emit the exception types the branch covers:
+    for _, tn in branchLabels(n):
+      case tn.kind
+      of nkType:
+        c.stmts.add MirNode(kind: mnkType, typ: tn.typ)
+      of nkInfix:
+        # ``x as T`` doesn't get transformed to just ``T`` if ``T`` is the
+        # type of an imported exception. We don't care about the type of
+        # exceptions at the MIR-level, so we just use carry it along as is
+        c.stmts.add MirNode(kind: mnkPNode, node: tn)
+      else:
+        unreachable()
+
+    # generate the body of the branch:
+    scope(c.stmts):
+      genBranch(c, n.lastSon, dest)
+
+proc genTry(c: var TCtx, n: PNode, dest: Destination) =
+  let
+    hasFinally = n.lastSon.kind == nkFinally
+    hasExcept = n[1].kind == nkExceptBranch
+
+  c.stmts.add MirNode(kind: mnkTry, len: ord(hasFinally) + ord(hasExcept))
+  scope(c.stmts):
+    c.genBranch(n[0], dest)
+
+  let len =
+    if hasFinally: n.len-1
+    else: n.len
+    ## the number of sub-nodes excluding ``nkFinally``
+
+  if hasExcept:
+    c.stmts.subTree MirNode(kind: mnkExcept, len: len-1):
+      for i in 1..<len:
+        genExceptBranch(c, n[i], dest)
+
+  if hasFinally:
+    c.stmts.useSource(c.sp, n.lastSon)
+    c.stmts.subTree MirNode(kind: mnkFinally):
+      scope(c.stmts):
+        c.gen(n.lastSon[0])
+
+  c.stmts.add endNode(mnkTry)
+
+proc genComplexExpr(c: var TCtx, n: PNode, dest: Destination) =
+  ## Generates and emits the MIR code for assigning the value resulting from
+  ## the complex expression `n` to destination `dest`
+  assert not n.typ.isEmptyType()
+  assert dest.isSome
+  c.stmts.useSource(c.sp, n)
+
+  case n.kind
+  of nkIfExpr:
+    genIf(c, n, dest)
+  of nkCaseStmt:
+    genCase(c, n, dest)
+  of nkTryStmt:
+    genTry(c, n, dest)
+  of nkBlockExpr:
+    genBlock(c, n, dest)
+  else:
+    # not a complex expression
+    unreachable(n.kind)
+
+
+proc genx(c: var TCtx, n: PNode, consume: bool): EValue =
+  ## Generate and emits the MIR for the given expression `n`.
+  ##
+  ## `consume` indicates whether the expression is used in a 'consume' context,
+  ## that is, whether ownership is requested over the resulting value. This
+  ## information is used to decide whether or not constructor expressions yield
+  ## a *unique* value (one that has single ownership over its content)
+  c.stmts.useSource(c.sp, n)
+
+  case n.kind
+  of nkSym:
+    let s = n.sym
+    case s.kind
+    of skVar, skForVar, skLet, skResult, skParam, skConst:
+      genLocation(c, n)
+    of skTemp:
+      tempNode(c, s.typ, c.tmpMap[s.itemId])
+    of skProc, skFunc, skConverter, skMethod, skIterator:
+      procLit(c, s)
+    of skGenericParam:
+      case c.context
+      of skMacro:
+        genLocation(c, n)
+      of skUnknown:
+        # HACK: during parameter type matching, sigmatch (``paramTypesMatchAux``)
+        #       uses ``tryConstExpr`` in order to find out whether the argument
+        #       expression to a ``static`` parameter is evaluatable at
+        #       compile-time. If the expression contains a reference to an
+        #       unresolved generic parameter, ``vmgen`` is expected to fail.
+        #       The problem: ``mirgen`` is unable to report any errors, so we
+        #       have to push the original ``skGenericParam`` symbol through
+        #       the MIR stage to ``vmgen``
+        #       The likely best solution is to introduce a dedicated analysis
+        #       layer that makes sure that the AST passed to it is valid in the
+        #       context of compile-time execution (i.e. does the checks that
+        #       ``vmgen`` currently has to do). It would take place after
+        #       ``semfold``.
+        genLit(c, n)
+      else:
+        unreachable()
+
+    else:
+      unreachable(s.kind)
+
+  of nkCallKinds:
+    genCallOrMagic(c, n)
+  of nkCharLit..nkNilLit, nkRange, nkNimNodeLit:
+    genLit(c, n)
+  of nkCheckedFieldExpr:
+    let (val, rhs) = genVariantAccess(c, n)
+    eval: val => pathObj(c, rhs.sym)
+  of nkDotExpr:
+    let
+      v = genx(c, n[0])
+      typ = n[0].typ.skipTypes(abstractInstTypeClass)
+      sym = n[1].sym
+
+    assert sym.kind == skField
+
+    case typ.kind
+    of tyObject:
+      eval: v => pathObj(c, sym)
+    of tyTuple:
+      # always use lookup-by-position for tuples, even when they're accessed
+      # with via name
+      eval: v => pathPos(c, typ[sym.position], sym.position.uint32)
+    else:
+      unreachable(typ.kind)
+
+  of nkBracketExpr:
+    genBracketExpr(c, n)
+  of nkObjDownConv, nkObjUpConv:
+    eval: genx(c, n[0], consume) => convOp(c, n.typ)
+  of nkAddr:
+    eval: genx(c, n[0]) => addrOp(c, n.typ)
+  of nkHiddenAddr:
+    let v = genx(c, n[0])
+    if directViewType(n.typ) != noView:
+      # a view into the source operand is created
+      eval: v => viewOp(c, n.typ)
+    else:
+      # a normal address-of operation
+      eval: v => addrOp(c, n.typ)
+
+  of nkDerefExpr:
+    eval: genx(c, n[0]) => derefOp(c, n.typ)
+  of nkHiddenDeref:
+    let v = genx(c, n[0])
+    if directViewType(n[0].typ) != noView:
+      # it's a deref of a view
+      eval: v => derefViewOp(c, n.typ)
+    else:
+      # it's a ``ref`` or ``ptr`` deref
+      eval: v => derefOp(c, n.typ)
+
+  of nkHiddenStdConv:
+    eval: genx(c, n[1], consume) => stdConvOp(c, n.typ)
+  of nkHiddenSubConv, nkConv:
+    eval: genx(c, n[1], consume) => convOp(c, n.typ)
+  of nkLambdaKinds:
+    procLit(c, n[namePos].sym)
+  of nkChckRangeF, nkChckRange64, nkChckRange:
+    # turn the conversion back into an unchecked conversion
+    # TODO: remove the ``nkConv|nkHiddenStdConv|nkHiddenSubConv`` ->
+    #       ``nkChckRange`` transformation logic from ``transf`` -- it's
+    #       unnecessary now
+    eval: genx(c, n[0]) => convOp(c, n.typ)
+  of nkStringToCString, nkCStringToString:
+    # undo the transformation done by ``transf``
+    # TODO: turn both of them into operators
+    eval: genx(c, n[0]) => stdConvOp(c, n.typ)
+  of nkBracket:
+    let consume =
+      if n.typ.skipTypes(abstractVarRange).kind == tySequence:
+        # don't propagate the `consume` flag through sequence constructors.
+        # A sequence constructor is only used for constant seqs
+        false
+      else:
+        consume
+
+    if n.typ.skipTypes(abstractRange).kind == tySequence and n.len == 0:
+      genLit(c, n)
+    else:
+      genArrayConstr(c, n, consume)
+  of nkCurly:
+    # a ``set``-constructor never owns
+    genSetConstr(c, n)
+  of nkObjConstr:
+    genObjConstr(c, n, consume)
+  of nkTupleConstr:
+    genTupleConstr(c, n, consume)
+  of nkClosure:
+    genClosureConstr(c, n, consume)
+  of nkCast:
+    eval: c.genx(n[1]) => castOp(c, n.typ)
+  of nkWhenStmt:
+    # a ``when nimvm`` expression
+    genx(c, selectWhenBranch(n, goIsNimvm in c.options), consume)
+  of nkPragmaBlock:
+    genx(c, n.lastSon, consume)
+  of nkStmtListExpr:
+    for i in 0..<n.len-1:
+      gen(c, n[i])
+
+    genx(c, n[^1], consume)
+  of ComplexExprs:
+    # attempting to generate the code for a complex expression without a
+    # destination specified -> assign the value resulting from it to a
+    # temporary
+    let tmp = getTemp(c, n.typ)
+    let slice = buildSlice(c.staging, c.sp):
+      c.staging.add MirNode(kind: mnkTemp, typ: n.typ, temp: tmp)
+
+    genComplexExpr(c, n):
+      Destination(kind: dkFrag, nodes: slice, flags: {dfOwns, dfEmpty})
+
+    c.staging.popSlice(slice)
+
+    tempNode(c, n.typ, tmp)
+  else:
+    unreachable(n.kind)
+
+proc gen(c: var TCtx, n: PNode) =
+  ## Generates and emits the MIR code for the statement `n`
+  c.stmts.useSource(c.sp, n)
+
+  # because of ``.discardable`` calls, we can't require `n` to be of void
+  # type
+  #assert n.typ.isEmptyType()
+
+  # for the same reason as mentioned above, we also have to allow
+  # ``nkIfExpr|nkStmtListExpr`` here
+  case n.kind
+  of nkStmtList, nkStmtListExpr:
+    # statement-list expressions (``nkStmtListExpr``) reach here if they end
+    # in a no-return statement
+    for it in n.items:
+      gen(c, it)
+
+  of nkBlockStmt:
+    genBlock(c, n, Destination())
+  of nkIfStmt, nkIfExpr:
+    genIf(c, n, Destination())
+  of nkCaseStmt:
+    genCase(c, n, Destination())
+  of nkTryStmt:
+    genTry(c, n, Destination())
+  of nkWhileStmt:
+    genWhile(c, n)
+  of nkReturnStmt:
+    genReturn(c, n)
+  of nkRaiseStmt:
+    genRaise(c, n)
+  of nkPragmaBlock:
+    gen(c, n.lastSon)
+  of nkBreakStmt:
+    var id: LabelId
+    case n[0].kind
+    of nkSym:
+      let sym = n[0].sym
+      # find the block with the matching label and use its ``LabelId``:
+      for b in c.blocks.items:
+        if b.label.id == sym.id:
+          id = b.id
+          break
+
+      assert id.isSome, "break target missing"
+    of nkEmpty:
+      id = NoLabel
+    else:
+      unreachable()
+
+    c.stmts.add MirNode(kind: mnkBreak, label: id)
+  of nkVarSection, nkLetSection:
+    genVarSection(c, n)
+  of nkAsgn:
+    # get the unwrapped ``nkDotExpr`` on the left (if one exists):
+    let x =
+      case n[0].kind
+      of nkCheckedFieldExpr: n[0][0]
+      else: n[0]
+
+    if x.kind == nkDotExpr and sfDiscriminant in x[1].sym.flags:
+      # an assignment to a discriminant. In other words: a branch switch (but
+      # only if the new value refers to a different branch than the one that's
+      # currently active)
+      argBlock(c.stmts):
+        # for nested record-cases, the discriminant access is wrapped in a
+        # ``nkCheckedFieldExpr``, in which case it needs to be unwrapped
+        # first
+        let (val, rhs) =
+          case n[0].kind
+          of nkCheckedFieldExpr: genVariantAccess(c, n[0])
+          else:                  (genx(c, x[0]), x[1])
+
+        # the 'switch' operations expects a variant access as its input, so
+        # using ``genx(c, x)`` would be wrong
+        chain: val => pathVariant(c, x[0].typ, rhs.sym) => tag(c, ekInvalidate) => name(c)
+        chain: genx(c, n[1]) => arg(c)
+
+      c.stmts.add MirNode(kind: mnkSwitch)
+    else:
+      # a normal assignment
+      genAsgn(c, false, n[0], n[1])
+
+  of nkFastAsgn:
+    # for non-destructor-using types, ``nkFastAsgn`` means bitwise copy
+    # (i.e. ``mnkFastAsgn``), but for types having a destructor attached, it's
+    # a normal assignment
+    # XXX: this is confusing and unintuitive behaviour. ``transf`` shouldn't
+    #      insert ``nkFastAsgn`` as aggresively as it does now and instead
+    #      let the move-analyser and cursor-inference take care of optimizing
+    #      the copies away
+    if hasDestructor(n[0].typ):
+      genAsgn(c, false, n[0], n[1])
+    else:
+      genFastAsgn(c, n[0], n[1])
+
+  of nkCallKinds:
+    chain: genCallOrMagic(c, n) => genVoid(c)
+  of nkProcDef, nkFuncDef, nkIteratorDef, nkMethodDef, nkConverterDef:
+    c.stmts.subTree MirNode(kind: mnkDef):
+      c.stmts.add procNode(n[namePos].sym)
+      # XXX: this is a temporary solution. The current code-generators
+      #      require procdef nodes in some cases, and instead of
+      #      recreating them during ``astgen``, we carry the original nodes
+      #      over
+      c.stmts.add MirNode(kind: mnkPNode, node: n)
+
+  of nkDiscardStmt:
+    if n[0].kind != nkEmpty:
+      chain: genx(c, n[0]) => genVoid(c)
+
+  of nkNilLit:
+    # a 'nil' literals can be used as a statement, in which case it is treated
+    # as a ``discard``
+    assert n.typ.isEmptyType()
+  of nkCommentStmt, nkTemplateDef, nkMacroDef, nkImportStmt,
+     nkIncludeStmt, nkStaticStmt, nkExportStmt, nkExportExceptStmt,
+     nkTypeSection, nkMixinStmt, nkBindStmt, nkEmpty:
+    discard "ignore"
+  of nkConstSection:
+    # const sections are not relevant for the MIR, but the IC implementation
+    # needs them to be present
+    c.stmts.add MirNode(kind: mnkPNode, node: n)
+  of nkPragma:
+    # if the pragma statement contains an ``.emit`` or ``.computeGoto``, it is
+    # stored in the MIR as an ``mnkPNode`` -- otherwise it's discarded
+    var hasInteresting = false
+    for it in n:
+      case whichPragma(it)
+      of wEmit, wComputedGoto: hasInteresting = true; break
+      else:     discard
+
+    if hasInteresting:
+      c.stmts.add MirNode(kind: mnkPNode, node: n)
+
+  of nkGotoState, nkState, nkAsmStmt:
+    # these don't have a direct MIR counterpart
+    c.stmts.add MirNode(kind: mnkPNode, node: n)
+  of nkWhenStmt:
+    # a ``when nimvm`` statement
+    gen(c, selectWhenBranch(n, goIsNimvm in c.options))
+  else:
+    unreachable(n.kind)
+
+proc genWithDest(c: var TCtx, n: PNode; dest: Destination) =
+  ## Generates and emits the MIR code for an expression plus the code for
+  ## assigning the resulting value to the given destination `dest`. `dest` can
+  ## be 'none', in which case `n` is required to be a statement
+  if dest.isSome:
+    let n = canonicalExpr(n)
+    assert not endsInNoReturn(n)
+
+    case n.kind
+    of ComplexExprs:
+      genComplexExpr(c, n, dest)
+    of nkStmtListExpr:
+      for i in 0..<n.len-1:
+        gen(c, n[i])
+
+      genAsgn(c, dest, n[^1])
+    else:
+      genAsgn(c, dest, n)
+
+  else:
+    gen(c, n)
+
+
+proc generateCode*(graph: ModuleGraph, options: set[GenOption], n: PNode,
+                   code: var MirTree, source: var SourceMap) =
+  ## Generates MIR code that is semantically equivalent to the expression or
+  ## statement `n`, appending the resulting code and the corresponding origin
+  ## information to `code` and `source`, respectively.
+  assert code.len == source.map.len, "source map doesn't match with code"
+  var c = TCtx(context: skUnknown, graph: graph, options: options)
+
+  template swapState() =
+    swap(c.sp.store, source.source)
+    swap(c.stmts.source, source.map)
+    swap(c.stmts.nodes, code)
+
+  # for the duration of ``generateCode`` we move the state into ``TCtx``
+  swapState()
+
+  if n.typ.isEmptyType:
+    gen(c, n)
+  elif n.typ.kind == tyTypeDesc:
+    # FIXME: this shouldn't happen, but type expressions are sometimes
+    #        evaluated with the VM, such as the ``int`` in the type expression
+    #        ``static int``. While it makes to allow evaluating type expression
+    #        with the VM, in simple situtations like the example above, it's
+    #        simpler, faster, and more intuitive to either evaluate them directly
+    #        when analying the type expression or during ``semfold``
+    discard genTypeExpr(c, n)
+  elif n.typ.kind == tyFromExpr:
+    assert goGenTypeExpr in options
+    # a type expression that uses unresolved generic parameters. As we're unable
+    # to report errors here, we push the expression through to ``vmgen`` as an
+    # ``mnkLiteral``
+    # TODO: we shouldn't have to do this here. ``paramTypesMatchAux`` should
+    #       only try to run compile-time evaluation for expressions with no
+    #       unknowns (e.g. unresolved generic parameters)
+    c.stmts.useSource(c.sp, n)
+    discard genLit(c, n)
+  else:
+    discard genx(c, n)
+
+  assert c.stmts.nodes.len == c.stmts.source.len
+
+  # move the state back into the output parameters:
+  swapState()
+
+proc generateCode*(graph: ModuleGraph, owner: PSym, options: set[GenOption],
+                   body: PNode): tuple[code: MirTree, source: SourceMap] =
+  ## Generates MIR code that is semantically equivalent to `body` plus the
+  ## ``SourceMap`` that associates each ``MirNode`` with the ``PNode`` it
+  ## originated from.
+  ##
+  ## `owner` it the symbol of the entity (module or procedure) that `body`
+  ## belongs to. If the owner is a procedure, `body` is expected to be the
+  ## full body of the procedure.
+  ##
+  ## `isNimvm` indicates the branch of a ``when nimvm`` statement that code
+  ## should be generated code for
+  # XXX: this assertion can currently not be used, as the ``nfTransf`` flag
+  #      might no longer be present after the lambdalifting pass
+  #assert nfTransf in body.flags, "transformed AST is expected as input"
+
+  var c = TCtx(context: owner.kind, graph: graph, options: options)
+  c.sp = SourceProvider(active: (body, noneOpt(SourceId)))
+
+  c.stmts.add MirNode(kind: mnkScope)
+  if owner.kind in routineKinds:
+    # add a 'def' for each ``sink`` parameter. This simplifies further
+    # processing and analysis
+    let params = owner.typ.n
+    for i in 1..<params.len:
+      if params[i].sym.typ.isSinkTypeForParam():
+        c.stmts.subTree MirNode(kind: mnkDef):
+          c.stmts.add MirNode(kind: mnkParam, sym: params[i].sym)
+
+  gen(c, body)
+
+  c.stmts.add endNode(mnkScope)
+
+  # set the origin information for the 'end' node added above:
+  apply(c.stmts, prepareForUse(c.sp))
+
+  assert c.stmts.nodes.len == c.stmts.source.len
+
+  result[0] = move c.stmts.nodes
+  result[1] = SourceMap(source: move c.sp.store, map: move c.stmts.source)

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -1,0 +1,665 @@
+## This module contains the main definitions that make up the mid-end IR (MIR).
+##
+## See `MIR <mir.html>`_ for the grammar plus a high-level overview of the MIR.
+
+import
+  compiler/ast/[
+    ast_types
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+type
+  ## The MIR itself doesn't not care for how each of the following ID types is
+  ## interpreted. For example, a ``ParamId`` could be the index of the
+  ## parameter or it could be an index into a list of symbols.
+
+  LocalId = distinct uint32
+    ## Identifies a local inside a code fragment
+  GlobalId = distinct uint32
+    ## Identifies a global inside a code fragment
+  ConstId = distinct uint32
+    ## Identifies a named constant inside a code fragment
+  ParamId = distinct uint32
+    ## Identifies a parameter of the code fragment
+  FieldId = distinct uint32
+    ## Identifies the field of a record type
+  ProcedureId = distinct uint32
+    ## Identifies a procedure
+  LiteralId = distinct uint32
+    ## Identifies a literal
+
+  TypeInstance = distinct uint32
+    ## Refers to an existing type instance
+  TypeId = distinct uint32
+    ## The ID of a type instance or nil
+
+type
+  ## Different to the ID types above, how and what the following ID types
+  ## represent is dictated by the MIR
+  TempId* = distinct uint32
+    ## ID of a temporary location. A temporary location is created and
+    ## inserted by the compiler. The only difference to other named locations
+    ## is that temporaries are allowed to be elided (by an optimization pass,
+    ## for example) if it's deemed to have no effect on the codes' semantics
+  LabelId* = distinct uint32
+    ## ID of a label, used to identify a block (``mnkBlock``). The default
+    ## value is empty state and means "absence of label"
+
+  MirNodeKind* = enum
+    ## Users of ``MirNodeKind`` should not depend on the absolute or relative
+    ## order between the enum values
+    # when adding new enum values, make sure to adjust the sets below
+
+    # entity names:
+    mnkProc   ## procedure
+    mnkConst  ## named constant
+    mnkGlobal ## global location
+    mnkParam  ## parameter
+    mnkLocal  ## local location
+    mnkTemp   ## temporary; Semantics-wise, a ``mnkTemp`` is the same as a
+              ## ``mnkLocal``, but a different namespace is used (``TempId``
+              ## vs. ``PSym``). This allows for cheap introduction of locals
+
+    mnkOpParam ## references a parameter of the enclosing region
+               ## XXX: see if it's possible to merge this with ``mnkParam``,
+               ##      by treating a procedure's body as a region itself
+
+    mnkLiteral ## literal data. Currently represented via a ``PNode``
+    mnkType    ## a type literal
+
+    mnkNone    ## the "nothing" value. Represents the absence of a value.
+               ## To ease the back-to-``PNode`` translation, this node is
+               ## currently allowed to have a non-nil type.
+
+    mnkDef       ## defines an entity and, if the entity is a location, starts
+                 ## its lifetime (if the entity is a location). If the entity
+                 ## is a location, the ``def`` can be either a *sink* or a
+                 ## statement -- it must be a statement otherwise
+    mnkDefCursor ## starts the lifetime of a location that is non-owning. The
+                 ## location may or may not contain a value and is not
+                 ## responsible for destroying it
+                 ## inputs: either a single value (no arg-block) or none
+    mnkDefUnpack ## starts the lifetime of a location that owns a *tuple*
+                 ## value but is not responsible for destroying it, as all
+                 ## sub-values are moved out of it
+                 ## **Warning**: this is a hack and it should be relied on as
+                 ## little as possible. It's a workaround to support the
+                 ## temporary tuple values introduced for destructuring.
+
+    mnkFastAsgn ## ``fastAsgn(dst, src)``; assigns the `src` value to the location
+                ## named by the lvalue `dst`. Neither the previous value in the
+                ## destination location nor the source value are mutated in any
+                ## way. No transfer of ownership happens.
+    mnkAsgn     ## ``asgn(dst, src)``; assigns the `src` value to the location
+                ##  named by `dst`, also transferring onwership.
+    mnkInit     ## ``init(dst, src)``; similar to `asgn`, but with the
+                ## guarantee that the destination contains no value prior
+
+    mnkSwitch ## ``switch(x, y)``; changes the active branch of the record-case
+              ## identified by the result of the ``pathVariant`` operation used
+              ## as the `x` operand. `y` is the new discriminator value
+
+    mnkPathNamed ## access of a named field in a record
+    mnkPathPos   ## access of a field in record via its position
+    mnkPathArray ## ``pathArray(x, i)``; array-like access
+    mnkPathVariant ## access a field inside a tagged union
+                   ## XXX: this is likely only a temporary solution. Each
+                   ##      record-case part of an object should be its own
+                   ##      dedicated object type, which can then be addressed
+                   ##      as a normal field
+
+    mnkAddr   ## ``addr(x)``; creates a first-class unsafe alias/handle (i.e.
+              ## pointer) from the input lvalue `x`
+    mnkDeref  ## ``deref(x)``; dereferences the pointer-like `x` (this
+              ## *excludes* views), producing an lvalue that has same identity
+              ## as the pointed-to location
+              ## XXX: the possibility of invalid pointers (e.g. nil pointer) is
+              ##      currently ignored
+
+    # XXX: the exact semantics around views and their related operators are
+    #      not yet finalized. One should not rely on them too much at this
+    #      point
+    mnkView      ## ``view(x)``; creates a safe alias of the l-value 'x'
+    mnkDerefView ## ``derefView(x)``; dereferences a view, producing the lvalue
+                 ## named by it
+    # XXX: ``mnkDerefView`` is not used for ``openArray`` right now, due to
+    #      the latter's interactions with ``var`` and ``lent``
+
+    mnkStdConv    ## ``stdConv(x)``; a standard conversion. Depending on the
+                  ## source and target type, lvalue-ness is preserved
+    mnkConv       ## ``conv(x)``; a conversion. Depending on the source and
+                  ## target type, lvalue-ness is preserved
+    # XXX: distinguishing between ``stdConv`` and ``conv`` is only done to
+    #      make ``astgen`` a bit more efficient. Further progress should focus
+    #      on removing the need for it
+    mnkCast       ## ``cast(x)``; produces a new *instance* of the input value
+                  ## with a different type
+
+    mnkCall   ## ``call(p, ...)``; transfers control-flow (i.e. calls) the
+              ## procedure that `p` evaluates to and passes the provided
+              ## arguments
+    mnkMagic  ## ``magic(...)``; a call to a magic procedure
+
+    mnkRaise  ## ``raise(x)``; if `x` is a ``none`` node, reraises the
+              ## currently active exception. If `x` is a value, transfers the
+              ## ownership over it to the raise operation and transfers
+              ## control-flow to the respective exception handler
+
+    mnkTag    ## ``tag[T](x)``; must only appear directly as the input to
+              ## either a ``name`` sink. Marks evaluating the operator that
+              ## has the result of the tag operation as input as having the
+              ## specified effect on the location named by l-value `x`
+
+    # XXX: ``mnkObjConstr`` could be implemented as a user-op (which would
+    #      remove the need for ``mnkField``) at the cost of a larger amount
+    #      of nodes
+    mnkConstr     ## ``constr(...)``; constructs a new compound value made up of
+                  ## the input values. Whether the resulting value is owned
+                  ## depends on whether one the context it's used in
+    mnkObjConstr  ## ``objConstr(...)``; either heap-allocates and initializes
+                  ## a new managed location, or constructs a new compound value
+                  ## with named fields
+
+    # the following three are argument sinks. They must only appear directly
+    # inside an ``mnkArgBlock``
+    mnkArg    ## binds either an instance of the input value or the value
+              ## itself to an argument
+    mnkName   ## binds an lvalue to an argument
+    mnkConsume## similar to ``arg``, but also transfers ownership over the
+              ## value from the source to the operation taking the argument
+              ## as input. The source value *must* be an owned value.
+              ## **Note**: the transfer of ownership happens when the
+              ## value is bound to the argument, not when control-flow reaches
+              ## the target operation
+
+    mnkVoid   ## the 'void' sink. Discards the input value without doing
+              ## anything else with it
+
+    mnkField  ## may only appear as a sub-node to ``mnkObjConstr``. Identifies
+              ## the record field the corresponding argument is assigned to
+
+    mnkArgBlock ## an argument block groups the operands to an operation
+                ## together, and is required whenever an operation takes more
+                ## than one operand -- whether an argumnet block is required for
+                ## when there's only a single operand depends on the
+                ## corresponding operation
+    mnkRegion ## a region is something that accepts arguments (provided by a
+              ## mandatory arg-block) and performs some logic that is required
+              ## to only have the effects described by the argument tags. This
+              ## also includes control-flow effects, e.g. raising an exception
+              ## that is not handled inside the region. Right now, definitions
+              ## inside a region are allowed, but this might change in the
+              ## future
+
+    mnkStmtList ## groups statements together
+    mnkScope  ## the only way to introduce a scope. Scopes can be nested and
+              ## dictate the lifetime of the locals that are directly enclosed
+              ## by them
+
+    mnkIf     ## ``if(x)``; depending on the runtime value of `x`, transfers
+              ## control-flow to either the start or the end of the code, the
+              ## ``if`` spans
+    mnkCase   ## ``case(x)``; depending on the runtime value of `x`, transfers
+              ## control-flow to the start of one of its branches
+    mnkRepeat ## once control-flow reaches this statement, control-flow is
+              ## transfered to start of its body. Once control-flow reaches
+              ## the end of the body, it is transfered back to the start. In
+              ## other words, repeats its body an infinite number of times
+              # XXX: rename to ``mnkRepeat``?
+    mnkTry    ## associates one one or more statements (the first sub-node)
+              ## with: an exception handler, a finalizer, or both
+    mnkExcept ## defines and attaches an exception handler to a ``try`` block.
+              ## Only one handler can be attached to a ``try`` block
+    mnkFinally## defines a finalizer in the context of a ``try`` construct. All
+              ## control-flow that either leaves the body of the ``try`` and
+              ## does not target the exception handler (if one is present) or
+              ## that leaves the exception handler is redirected to inside the
+              ## finalizer first. Once control-flow reaches the end of a
+              ## finalizer, it is transferred to the original destination. Only
+              ## one finalizer can be attached to a ``try`` block
+    mnkBlock  ## attaches a label to a span of code. If control-flow reaches
+              ## this statement, it is transferred to the start of the body.
+              ## Once control-flow reaches the end of a ``block``, it is
+              ## transferred to the next statement/operation following the
+              ## block
+    mnkBreak  ## if a non-nil label is provided, transfers control-flow to the
+              ## statement/operation following after the ``block`` with the
+              ## given label. If no label is provided, control-flow is
+              ## transferred to the exit of the enclosing ``repeat`` (it is
+              ## required that there exists one)
+    mnkReturn ## if the code-fragment represents the body of a procedure,
+              ## transfers control-flow back to the caller
+
+    mnkBranch ## defines a branch of an ``mnkExcept`` or ``mnkCase``
+
+    mnkEnd    ## marks the physical end of a sub-tree. Has no semantic
+              ## meaning -- it's only required to know where a sub-tree ends
+
+    mnkPNode ## depending on the context, either statement or something else.
+             ## If it appears as a statement, it is expected to not have any
+             ## obsersvable effects
+             ## XXX: eventually, everything that currently requires
+             ##      ``mnkPNode`` (for example, ``nkGotoState``, ``nkAsmStmt``,
+             ##      emit, etc.) should be expressable directly in the IR
+
+  EffectKind* = enum
+    ekMutate    ## the value in the location is mutated
+    ekReassign  ## a new value is assigned to the location
+    ekKill      ## the value is removed from the location (without observing
+                ## it), leaving the location empty
+    ekInvalidate## all knowledge and assumptions about the location and its
+                ## value become outdated. The state of it is now completely
+                ## unknown
+
+  GeneralEffect* = enum
+    geMutateGlobal ## the operation mutates global state
+    geRaises       ## the operation is a source of exceptional control-flow
+
+  MirNode* = object
+    typ*: PType ## must be non-nil for operators, inputs, and sinks
+
+    case kind*: MirNodeKind
+    of mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal:
+      sym*: PSym
+    of mnkField, mnkPathNamed, mnkPathVariant:
+      field*: PSym
+    of mnkLiteral:
+      lit*: PNode
+    of mnkTemp:
+      temp*: TempId
+    of mnkPathPos:
+      position*: uint32 ## the 0-based position of the field
+    of mnkCall:
+      effects*: set[GeneralEffect]
+    of mnkMagic:
+      # XXX: with the current design, a magic call cannot have general effects,
+      #      which is a problem, as magic calls can indeed have general effects
+      #      (such as raising an exception). The ability to store information
+      #      about general effect ouf-of-band is likely required to properly
+      #      support this
+      magic*: TMagic
+    of mnkOpParam:
+      param*: uint32 ## the 0-based index of the enclosing region's parameter
+    of mnkBlock, mnkBreak:
+      label*: LabelId ## for a block, its label. A block always must always
+                      ## have a valid label ('none' is disallowed).
+                      ## for a break, the label of the block to break out of.
+                      ## May be 'none', in which case it means "exit the
+                      ## enclosing 'repeat'"
+    of mnkEnd:
+      start*: MirNodeKind ## the kind of the corresponding start node
+    of mnkPNode:
+      node*: PNode
+    of mnkTag:
+      effect*: EffectKind ## the effect that happens when the operator the
+                          ## tagged value is passed to is executed
+    else:
+      # XXX: now only used by ``mnkTry``, ``mnkCase``, and ``mnkObjConstr``. In
+      #      each case, the information is redundant. That is, the information
+      #      it stores can be compute from the tree itself
+      len*: int
+
+  MirTree* = seq[MirNode]
+  MirNodeSeq* = seq[MirNode]
+    ## A buffer of MIR nodes without any further meaning
+
+  # XXX: some of the distinct types below have a super/sub-type relation to
+  #      each other, but this can't be expressed in the language right now
+  #      (without turning the types into empty ``object``s)
+
+  NodeIndex* = uint32
+  NodeInstance* = distinct range[0'u32..high(uint32)-1]
+    ## refers to a node as just a node. Used to communicate that only the node
+    ## itself is of interest, not what it represents
+  NodePosition* = distinct int32
+    ## refers to a ``MirNode`` of which the position relative to other nodes
+    ## has meaning. Uses a signed integer as the base
+  Operation* = distinct uint32
+    ## refers to a ``MirNode`` that represents an operation
+  OpValue* = distinct uint32
+    ## refers to a value an operation produces
+
+const
+  AllNodeKinds* = {low(MirNodeKind)..high(MirNodeKind)}
+    ## Convenience set containing all existing node kinds
+
+  DefNodes* = {mnkDef, mnkDefCursor, mnkDefUnpack}
+
+  SubTreeNodes* = {mnkArgBlock..mnkBranch, mnkObjConstr} + DefNodes
+    ## Nodes that mark the start of a sub-tree. They're always matched with a
+    ## corrsponding ``mnkEnd`` node
+
+  AtomNodes* = AllNodeKinds - SubTreeNodes
+    ## Nodes that aren't sub-trees
+
+  InputNodes* = {mnkProc..mnkNone, mnkArgBlock}
+    ## Expression roots
+  InOutNodes* = {mnkMagic, mnkCall, mnkPathNamed..mnkPathVariant, mnkConstr,
+                 mnkObjConstr, mnkView,
+                 mnkTag, mnkCast, mnkDeref, mnkAddr,
+                 mnkDerefView, mnkStdConv, mnkConv}
+    ## Operations that act as both input and output
+  SourceNodes* = InputNodes + InOutNodes
+    ## Nodes than can appear in the position of inputs/operands
+
+  OutputNodes* = {mnkRaise, mnkFastAsgn..mnkInit, mnkSwitch, mnkVoid, mnkIf,
+                  mnkCase, mnkRegion} + DefNodes
+    ## Node kinds that are allowed in every output context
+    # TODO: maybe rename to SinkNodes
+
+  ArgumentNodes* = {mnkArg, mnkName, mnkConsume}
+    ## Node kinds only allowed in an output context directly inside an
+    ## arg-block
+
+  SingleInputNodes* = {mnkAddr, mnkDeref, mnkDerefView, mnkCast, mnkConv,
+                       mnkTag, mnkIf, mnkCase, mnkRaise, mnkVoid} +
+                      ArgumentNodes
+    ## Operators and statements that must not have argument-blocks as input
+
+  Operators* = {mnkFastAsgn..mnkMagic, mnkTag, mnkRaise..mnkDerefView,
+                mnkStdConv..mnkCast}
+
+  StmtNodes* = {mnkScope, mnkRepeat, mnkTry, mnkBlock, mnkBreak, mnkReturn,
+                mnkPNode} + DefNodes
+    ## Nodes that act as statements syntax-wise
+
+  SymbolLike* = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal}
+
+  NoLabel* = LabelId(0)
+
+func `==`*(a, b: TempId): bool {.borrow.}
+func `==`*(a, b: LabelId): bool {.borrow.}
+
+func isSome*(x: LabelId): bool {.inline.} =
+  x.uint32 != 0
+
+func isNone*(x: LabelId): bool {.inline.} =
+  x.uint32 == 0
+
+template `[]`*(x: LabelId): uint32 =
+  assert x.uint32 != 0
+  uint32(x) - 1
+
+# make ``NodeInstance`` available to be used with ``OptIndex``:
+template indexLike(_: typedesc[NodeInstance]) = discard
+
+# XXX: ideally, the arithmetic operations on ``NodePosition`` should not be
+#      exported. How the nodes are stored should be an implementation detail
+
+template `-`*(a: NodePosition, b: int): NodePosition =
+  NodePosition(ord(a) - b)
+
+template `+`*(a: NodePosition, b: int): NodePosition =
+  NodePosition(ord(a) + b)
+
+template `dec`*(a: var NodePosition) =
+  dec int32(a)
+
+template `inc`*(a: var NodePosition) =
+  inc int32(a)
+
+converter toOp*(x: OpValue): Operation {.inline.} =
+  ## For convenience, a converter is provided for this conversion. Each
+  ## ``OpValue`` is always backed by an ``Operation``
+  Operation(x)
+
+func `<`*(a, b: NodePosition): bool {.borrow, inline.}
+func `<=`*(a, b: NodePosition): bool {.borrow, inline.}
+func `==`*(a, b: NodePosition): bool {.borrow, inline.}
+
+func `==`*(a, b: Operation): bool {.borrow, inline.}
+
+func `in`*(p: NodePosition, tree: MirTree): bool {.inline.} =
+  ord(p) >= 0 and ord(p) < tree.len
+
+template `[]`*(tree: MirTree, i: NodePosition | NodeInstance | Operation | OpValue): untyped =
+  tree[ord(i)]
+
+func parent*(tree: MirTree, n: NodePosition): NodePosition =
+  result = n
+
+  var depth = 1
+  while depth > 0:
+    dec result
+
+    let kind = tree[result].kind
+    depth += ord(kind == mnkEnd) - ord(kind in SubTreeNodes)
+
+func parentEnd*(tree: MirTree, n: NodePosition): NodePosition =
+  # Computes the position of the ``mnkEnd`` node belonging to the sub-tree
+  # enclosing `n`
+  result = n
+
+  var depth = 1
+  while depth > 0:
+    inc result
+
+    let kind = tree[result].kind
+    depth += ord(kind in SubTreeNodes) - ord(kind == mnkEnd)
+
+func sibling*(tree: MirTree, n: NodePosition): NodePosition =
+  ## Computes the index of the next sibling node of `x`
+  # TODO: should return a option. Not all nodes have siblings
+  # TODO: since this doesn't consider 'end' nodes, the procedure should
+  #       probably be renamed to ``rawSibling``?
+  result = n + 1
+
+  var depth = ord(tree[n].kind in SubTreeNodes)
+  while depth > 0:
+    let kind = tree[result].kind
+    # to be more efficient, we don't use branching. We're incrementing
+    # `depth` whenever we encounter the start of a sub-tree and decrement
+    # it when an 'end' node is encountered
+    depth += ord(kind in SubTreeNodes) - ord(kind == mnkEnd)
+
+    inc result
+
+  if result.int == tree.len or tree[result].kind == mnkEnd:
+    # no sibling exists
+    discard
+
+func previous*(tree: MirTree, n: NodePosition): NodePosition =
+  ## Computes the index of the previous sibling node of `x`
+  # TODO: should return a option. Not all nodes have predecessors
+  var i = n - 1
+
+  var depth = ord(tree[n].kind == mnkEnd)
+  while depth > 0:
+    let kind = tree[i].kind
+    # to be more efficient, we don't use branching. We're incrementing
+    # `depth` whenever we encounter the start of a sub-tree and decrement
+    # it when an 'end' node is encountered
+    depth += ord(kind == mnkEnd) - ord(kind in SubTreeNodes)
+
+    dec i
+
+  assert ord(i) >= 0
+  result = i
+
+func computeSpan*(tree: MirTree, n: NodePosition): Slice[NodePosition] =
+  ## If `n` refers to a leaf node, returns a span with the `n` as the single
+  ## item.
+  ## Otherwise, computes and returns the span of nodes part of the sub-tree
+  ## at `n`. The 'end' node is included.
+  result = n .. (sibling(tree, n) - 1)
+
+func start*(tree: MirTree, n: NodePosition): NodePosition =
+  ## Find the corresponding start node for an ``mnkEnd`` node
+  assert tree[n].kind == mnkEnd
+  result = n
+
+  var depth = 1
+  while depth > 0:
+    dec result
+
+    let kind = tree[result].kind
+    depth += ord(kind == mnkEnd) - ord(kind in SubTreeNodes)
+
+func findEnd*(tree: MirTree, n: NodePosition): NodePosition =
+  ## Finds the corresponding ``end`` node for the node `n` that starts a
+  ## sub-tree
+  assert tree[n].kind in SubTreeNodes
+  result = sibling(tree, n) - 1
+
+func childIdx*(tree: MirTree, n: NodePosition, index: int): NodePosition =
+  ## Returns the position of the child node at index `index`. `index` *must*
+  ## refer to a valid sub-node -- no validation is performed
+  result = n + 1 # point `result` to the first child
+  for _ in 0..<index:
+    result = sibling(tree, result)
+
+func child*(tree: MirTree, n: NodePosition, index: int): lent MirNode =
+  ## Similar to ``childIndex`` but returns the node directly
+  tree[childIdx(tree, n, index)]
+
+func getStart*(tree: MirTree, n: NodePosition): NodePosition =
+  ## If `n` refers to an ``end`` node, returns the corresponding start node --
+  ## `n` otherwise
+  if tree[n].kind == mnkEnd:
+    start(tree, n)
+  else:
+    n
+
+func findParent*(tree: MirTree, start: NodePosition,
+                 kind: MirNodeKind): NodePosition =
+  ## Searches for the first enclosing sub-tree node of kind `kind` (which is
+  ## *required* to exist). The node at `start` is itself also considered
+  ## during the search
+  assert kind in SubTreeNodes
+  result = start
+  while tree[result].kind != kind:
+    result = parent(tree, result)
+
+func operand*(tree: MirTree, op: Operation, opr: Natural): OpValue =
+  ## Returns the `opr`th operand to the operation `op`. It is expected that
+  ## the operation has at least `opr` + 1 operands
+  let prev = NodePosition(op) - 1
+  if tree[prev].kind == mnkEnd and tree[prev].start == mnkArgBlock:
+    # start at the first sub-node of the argument block:
+    var pos = parent(tree, prev) + 1
+    # skip the sub-nodes until we've reached the `opr`-th arg node
+    var i = 0
+    while pos < prev:
+      if tree[pos].kind in {mnkArg, mnkName}:
+        if i == opr:
+          # return the input, not the 'arg' node itself
+          return OpValue getStart(tree, pos - 1)
+        inc i
+
+      pos = sibling(tree, pos)
+
+    unreachable("argument out of bounds: " & $opr)
+  else:
+    # there exists only a single operand
+    assert opr == 0
+    result = OpValue getStart(tree, prev)
+
+func operands*(tree: MirTree, op: Operation, slice: Slice[int],
+               result: var openArray[OpValue]) =
+  ## Collects the operands of `op` identified by `slice` to `result`
+  assert slice.len == result.len
+  let prev = NodePosition(op) - 1
+  if tree[prev].kind == mnkEnd and tree[prev].start == mnkArgBlock:
+    # start at the first sub-node of the argument block:
+    var pos = parent(tree, prev) + 1
+    # skip the sub-nodes until we've reached the `opr`-th arg node
+    var i = 0
+    while pos < prev:
+      if tree[pos].kind in ArgumentNodes:
+        if i >= slice.a:
+          # return the input, not the 'arg' node itself
+          result[i - slice.a] = OpValue getStart(tree, pos - 1)
+        if i == slice.b:
+          return
+
+        inc i
+
+      pos = sibling(tree, pos)
+
+    unreachable("argument out of bounds: " & $slice)
+  else:
+    # there exists only a single operand
+    assert slice.a == 0 and slice.b == 0
+    result[0] = OpValue getStart(tree, prev)
+
+func fetchArgs*(tree: MirTree, op: Operation, result: var openArray[NodePosition]) =
+  ## Collects all operands of `op` to `result`. The length of `result` must
+  ## match the number of operands
+  let prev = NodePosition(op) - 1
+  if tree[prev].kind == mnkEnd and tree[prev].start == mnkArgBlock:
+    var pos = prev - 1
+    # `pos` now points to the last argument sink inside the arg-block
+    var i = result.high
+    while tree[pos].kind != mnkArgBlock:
+      if tree[pos].kind in ArgumentNodes:
+        assert i >= 0, "not enough space for all argument nodes"
+        # return the input, not the 'arg' node itself
+        result[i] = pos
+        dec i
+
+      pos = previous(tree, pos)
+
+    assert i == -1, "not enough arguments"
+
+  else:
+    # there exists only a single operand
+    assert result.len == 1
+    result[0] = prev
+
+func numArgs*(tree: MirTree, op: Operation): int =
+  ## Computes the number of arguments in the argument-block used as the input
+  ## to `op`
+  let prev = NodePosition(op) - 1
+  if tree[prev].kind == mnkEnd and tree[prev].start == mnkArgBlock:
+    var pos = prev - 1
+    while tree[pos].kind != mnkArgBlock:
+      if tree[pos].kind in ArgumentNodes:
+        inc result
+
+      pos = previous(tree, pos)
+
+  else:
+    unreachable("no arg-block is used")
+
+func unaryOperand*(tree: MirTree, op: Operation): OpValue =
+  # XXX: a 'def' node is not an operation
+  assert tree[op].kind in SingleInputNodes + DefNodes
+  result = OpValue getStart(tree, NodePosition(op) - 1)
+
+func hasInput*(tree: MirTree, op: Operation): bool =
+  # XXX: a 'def' node is not an operation
+  assert tree[op].kind in DefNodes
+  let node = tree[NodePosition(op)-1]
+  case node.kind
+  # exclude sub-tree nodes here so that a dynamic operation appearing as the
+  # first child-node of, for example, an arg-block is not treated as having an
+  # input
+  of SourceNodes - SubTreeNodes: true
+  of mnkEnd:      node.start in SourceNodes
+  else:           false
+
+iterator pairs*(tree: MirTree): (NodePosition, lent MirNode) =
+  var i = 0
+  let L = tree.len
+  while i < L:
+    yield (i.NodePosition, tree[i])
+    inc i
+
+iterator subNodes*(tree: MirTree, n: NodePosition): NodePosition =
+  ## Iterates over and yields all direct child nodes of `n`
+  let L = tree[n].len
+  var r = n + 1
+  for _ in 0..<L:
+    yield r
+    r = sibling(tree, r)
+
+# XXX: ``lpairs`` is not at all related to the mid-end IR. The ``pairs``
+#      iterator from the stdlib should be changed to use ``lent`` instead
+iterator lpairs*[T](x: seq[T]): (int, lent T) =
+  var i = 0
+  let L = x.len
+  while i < L:
+    yield (i, x[i])
+    inc i

--- a/compiler/mir/sourcemaps.nim
+++ b/compiler/mir/sourcemaps.nim
@@ -1,0 +1,50 @@
+## This module implements the structures for associating ``MirNode``s with a
+## ``PNode`` origin.
+##
+## Information about which ``PNode`` a ``MirNode`` originated from is needed
+## for source-code position information and other reporting-related tasks.
+##
+## Origin information doesn't affect the semantics of MIR code and is thus
+## stored and implemented separately. This allows for using a different way
+## of storing such information without requiring adjustments to the core MIR
+## data structures.
+
+import
+  compiler/ast/[
+    ast_types
+  ],
+  compiler/mir/[
+    mirtrees
+  ],
+  compiler/utils/[
+    containers
+  ]
+
+type
+  SourceId* = distinct range[0'u32 .. high(uint32)-1]
+    ## The local ID of a source-mapping. The IDs are not unique across multiple
+    ## ``SourceMap``s
+
+  SourceMap* = object
+    ## Associates each ``MirNode`` with the ``PNode`` it originated from
+    source*: Store[SourceId, PNode]
+      ## stores the ``PNode``s used as the source/origin information
+    map*: seq[SourceId]
+      ## stores the ``SourceId`` for each ``MirNode``. The connection
+      ## happens via the index, that is, indexing `map` with a ``NodeIndex``
+      ## yields the ``SourceId`` attached to the node with the given
+      ## index. For this to work, `map` is required to always have the same
+      ## size as the associated ``MirNode`` seq
+
+# make ``SourceId`` available to be used with ``OptIndex``:
+template indexLike*(_: typedesc[SourceId]) = discard
+
+func `==`*(a, b: SourceId): bool {.borrow.}
+
+# ------- ``SourceMap``-related routines:
+
+func `[]`*(m: SourceMap, i: NodeInstance): SourceId {.inline.} =
+  m.map[ord(i)]
+
+func sourceFor*(m: SourceMap, i: NodeInstance): PNode {.inline.} =
+  m.source[m.map[ord(i)]]

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -1,0 +1,121 @@
+## Non-essential utilities for interacting with or inspecting MIR code. No
+## code should require any routines or types defined here in order to function.
+##
+## For maximum availability, the imports of compiler modules should be kept as
+## low as possible, so that the module can be imported without causing
+## circular dependencies.
+
+import
+  std/[
+    strutils
+  ],
+  compiler/ast/[
+    renderer
+  ],
+  compiler/mir/[
+    mirtrees
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+# TODO: improve the code
+
+func appendLine(s: var string, items: varargs[string, `$`]) =
+  for x in items:
+    s.add x
+  s.add "\n"
+
+func `$`(n: MirNode): string =
+  result.add "(kind: "
+  result.add $n.kind
+  case n.kind
+  of mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal:
+    result.add ", sym: "
+    result.add $n.sym.name.s
+  of mnkField, mnkPathNamed, mnkPathVariant:
+    result.add ", field:"
+    result.add $n.field.name.s
+  of mnkLiteral:
+    result.add ", lit: "
+    {.cast(noSideEffect).}:
+      result.add renderTree(n.lit)
+  of mnkTemp:
+    result.add ", temp: "
+    result.add $ord(n.temp)
+  of mnkPathPos:
+    result.add ", position: "
+    result.add $n.position
+  of mnkCall:
+    result.add ", effects: "
+    result.add $n.effects
+  of mnkMagic:
+    result.add ", magic: "
+    result.add $n.magic
+  of mnkOpParam:
+    result.add ", param: "
+    result.add $n.param
+  of mnkBlock, mnkBreak:
+    result.add ", block: "
+    result.add $ord(n.label)
+  of mnkEnd:
+    result.add ", start: "
+    result.add $n.start
+  of mnkPNode:
+    result.add ", node: "
+    result.add $n.node.kind
+  of mnkTag:
+    result.add ", effect: "
+    result.add $n.effect
+  else:
+    result.add ", len: "
+    result.add $n.len
+
+  if n.typ != nil:
+    result.add ", typ: "
+    result.add $n.typ.kind
+
+  result.add ")"
+
+proc print(result: var string, nodes: MirNodeSeq, indent: int, num: int, i: var uint32) =
+  if i >= nodes.len.uint32:
+    result.appendLine "error: missing node"
+    return
+
+  let n {.cursor.} = nodes[i]
+  inc i
+
+  result.appendLine repeat("  ", indent), num, ": ", n
+
+  case n.kind
+  of SubTreeNodes:
+    var sub = 0
+    while true:
+      if i >= nodes.len.uint32:
+        result.appendLine repeat("  ", indent), "out of bounds: end expected for ", n.kind
+        break
+      elif nodes[i].kind == mnkEnd:
+        if nodes[i].start == n.kind:
+          inc i
+          break
+        else:
+          result.appendLine repeat("  ", indent+1), "loose end: ", nodes[i].start
+          inc i
+
+      else:
+        print(result, nodes, indent+1, sub, i)
+
+      inc sub
+
+  of AtomNodes - {mnkEnd}:
+    discard
+  of mnkEnd:
+    unreachable()
+
+proc print*(nodes: MirTree, start = NodeIndex(0)): string =
+  var i = start.uint32
+  print(result, nodes, 0, 0, i)
+
+  while i < nodes.len.uint32:
+    result.appendLine "dangling node/sub-tree:"
+    print(result, nodes, 0, 0, i)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3204,7 +3204,13 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
             inferConceptStaticParam(c, x[2], x[1])
             continue
 
-        let verdict = semConstExpr(c, x)
+        let verdict = semConstExpr(c):
+          if x.kind in {nkStmtList, nkStmtListExpr}:
+            # only evaluate the last expression in a statement list resulting
+            # from a template expansion
+            x.lastSon
+          else:
+            x
         
         if verdict == nil or verdict.kind != nkIntLit or verdict.intVal == 0:
           result.add:

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -433,6 +433,9 @@ proc symFields(
     hfield("sym.id", trfShowSymName, $sym.id + style.number)
     hfield("name.id", trfShowSymName, $sym.name.id + style.number)
 
+  if trfShowSymKind in rconf:
+    field("kind", trfShowSymName, rconf.formatKind(sym.kind) + style.kind)
+
   if sym.flags.len > 0 or rconf.defaulted():
     field("flags", trfShowSymFlags, format(sym.flags, 2) + style.setIt)
 

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -1,0 +1,51 @@
+## This module contains ``seq``-based containers useful in contexts that make
+## use of data-oriented design
+
+type
+  SeqMap*[K: Ordinal, V] = object
+    ## Maps a 0-based integer-like key to a value, using a ``seq`` as the
+    ## underlying storage. The default value for `V` is expected to indicated
+    ## "empty" and an ``isFilled`` routine that returns a ``bool`` must
+    ## exist for ``V``
+    data: seq[V]
+
+  Store*[I; T] = object
+    ## Stores a sequence of `T` where each item is identified by an
+    ## integer-like ID. The container is append-only
+    data: seq[T]
+
+# ---------- SeqMap API ------------
+
+func contains*[K, V](m: SeqMap[K, V], key: K): bool {.inline.} =
+  ## Returns whether a value with key `key` exists in the map
+  mixin isFilled
+  result = ord(key) < m.data.len and isFilled(m.data[ord(key)])
+
+func `[]`*[K, V](m: SeqMap[K, V], key: K): lent V {.inline.} =
+  result = m.data[ord(key)]
+
+func `[]=`*[K, V](m: var SeqMap[K, V], key: K, val: sink V) =
+  let i = ord(key)
+  if m.data.len <= i:
+    m.data.setLen(i + 1)
+
+  m.data[i] = val
+
+
+# ---------- Store API ------------
+
+template `[]`*[I; T](x: Store[I, T], i: I): untyped =
+  # TODO: convert to ``distinctBase`` instead
+  x.data[int(i)]
+
+template `[]=`*[I; T](x: var Store[I, T], i: I, it: T): untyped =
+  ## Overwrites the item corresponding to `i` with `it`
+  # TODO: convert to ``distinctBase`` instead
+  x.data[int(i)] = it
+
+func add*[I; T](x: var Store[I, T], it: sink T): I {.inline.} =
+  ## Appends a new item to the Store and returns the ID assigned to
+  ## it
+  rangeCheck x.data.len.BiggestUInt < high(I).BiggestUInt
+  x.data.add it
+  result = I(x.data.high)

--- a/compiler/utils/idioms.nim
+++ b/compiler/utils/idioms.nim
@@ -7,6 +7,25 @@ from std/private/miscdollars import toLocation
 type
   IInfo = typeof(instantiationInfo())
 
+  HOslice*[T] = object
+    ## A half-open slice, that is, a slice where the end is excluded. These
+    ## are useful for use with unsigned integers, as, compared to ``Slice``,
+    ## no special handling is required for empty slices.
+    a*, b*: T
+
+# ----------------- HOslice -----------------
+
+func len*[T](x: HOslice[T]): int {.inline.} =
+  ## Returns the number of items in the slice
+  int(x.b - x.a)
+
+iterator items*[T](s: HOslice[T]): T =
+  ## Returns all items in the slice
+  for i in s.a..<s.b:
+    yield i
+
+# ----------------- unreachable -----------------
+
 func unreachableImpl(str: string, loc: IInfo) {.noinline, noreturn.} =
   var msg: string
   msg.toLocation(loc.filename, loc.line, loc.column + 1)

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -420,6 +420,29 @@ procedure.
      issues (god help you if you ever find yourself facing something like
      this) it might inhibit unexpected behavior.
 
+MIR Input and Output
+====================
+
+For debugging issues related to the MIR but also code-generator issues in
+general, one can print the input and output to the MIR canonicalization step
+plus the corresponding `PNode`-AST output.
+
+To print the `PNode`-AST that reaches `mirgen`, `--define:nimShowMirInput=name`
+is used. This will print out the `PNode`-AST of all procedures and modules of
+which the name is equal to the specified `name` in the console. Because of how
+dead-code-elimination works, only the AST of alive procedures (i.e. used ones)
+is printed. If a procedure is used at both compile- and run-time, it will be
+printed twice.
+
+To print the generated MIR code for a procedure, `--define:nimShowMir=name`
+can be used. The same limitation as for `nimShowMirInput` apply.
+
+`--define:nimShowMirOutput=name` prints the `PNode`-AST that is output by
+`astgen`. This is AST that the code-generators will operate on.
+
+While all of the defines listed above can be used simultaneously, only a single
+occurrence of each is considered. Each further occurrence will override the
+respective name.
 
 VM Codegen and Execution
 ========================

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -1,0 +1,161 @@
+===================================
+Mid-end intermediate representation
+===================================
+
+.. include:: rstcommon.rst
+.. default-role:: code
+
+.. note:: This document is a work in progress.
+
+Purpose
+=======
+
+The MIR is designed and meant to be used as a target-independent
+intermediate representation for analysis, transformations, and
+lowerings. It is centered around operations, control-flow, and locations.
+
+In the compilation pipeline, the MIR is located after semantic analysis and
+high-level transformation (``transf``) but before code-generation.
+
+Overview
+========
+
+For reasons of flexibility, modularity, and since the MIR eventually should
+support type lowering, it is itself type agnostic: no knowledge of the types
+is required in order to reason about the semantics of MIR code.
+
+.. note:: While this eventually should be the case, it is currently not
+          entirely true. To know whether a conversion is an lvalue
+          conversion or not, looking at both the source and destination type
+          is required
+
+Currently, ``PType``s are required for representing the type of nodes, but
+the plan is to use an ID (handle) centered design where what the ID refers
+to is up to the MIR's user.
+
+Even though the control-flow primitives are simpler and more regular than
+the ones used by the higher-level AST, they're still fairly high-level.
+For example, constructs like ``try`` and ``case`` statements still exist.
+The reason for this is twofold:
+- due to the code-generators still operating on ``PNode`` AST, the MIR code
+  has to be translated back to it. Translating low-level control-flow
+  primitives such as 'goto's back into 'if', 'block', and 'break' is fairly
+  involved and would also introduce additional overhead to the
+  back-translation
+- some transformation passes currently using the MIR are simpler to implement
+  with access to first-class control-flow constructs such as 'try-finally'
+
+The goal is to eventually also have low-level primitives like 'goto's as
+part the MIR, maybe replacing the current higher-level ones.
+
+Concepts
+========
+
+An *operator* (operation?) is something that takes zero or more *values* (operands) and
+produces an another value. An initial value is provided via what is
+referred to as an *input*. This is either: the name of a location, the name of
+a constant, or a nullary operation (one that has no operands). A value always
+has to be consumed by something. Note that "consume" here only means "used by
+something" and is not related to the higher-level concept of resource ownership
+in any way.
+
+An *operation sequence* starts with an input, is followed by zero or more
+operators, and ends in an output.
+
+An *output* is a special operator that accepts one or more operands but
+doesn't produce a value.
+
+Effects
+-------
+
+There are three kinds of *effects*: control-flow effects, location effects, and
+general effects. Applying an operator can have one or more of these
+effects.
+
+Location effects are encoded via a special parameterized operator: the `tag`
+operator. It takes a single *lvalue* as input and is purely declarative.
+Applying the operator that the tagged lvalue is an operand to then has the
+provided effect to the on the lvalue's underlying location.
+
+Structure
+=========
+
+Everything part of the MIR is stored in a `MirTree` (which is a single `seq` of
+`MirNode`s). This simplifies processing and applying changes, as all
+information is encoded with `MirNode`s. There are downside to this, however (which?).
+
+High-level
+----------
+
+On an abstract level, a tree/sequence-hybrid representation is used. That is,
+some constructs (mostly statements) use a node-tree tructure while others
+use a node *sequence*. Both are stored in the same underlying storage
+buffer -- they're not separated.
+
+Due to the focus on control-flow, the nodes are ordered in such as way as that
+a linear iteration over all nodes will yield them in an order that reflects how
+the operators the nodes represent are executed in the final program (ignoring
+loops and branching control-flow). This was an explicit design goal.
+
+Memory layout
+-------------
+
+Nodes are layed out as a flat contiguous sequence in memory. This allows for
+efficient linear traversal and random access, which is not possible with a
+pointer-based tree structure (such as the one currently used with the AST).
+
+Grammar
+=======
+
+The MIR grammar, represented in EBNF. It describes how the nodes are layed out
+in memory:
+
+.. code-block:: literal
+
+  obj-constr = "objConstr", {"field"}, "end"
+
+  name = "proc" | "const" | "global" | "param" | "local" | "temp" | "type" |
+         "literal"
+
+  def = "def", name, "end" {* note: not all names are semantically valid inside a 'def' *}
+
+  stmt-list  = "stmtList", {stmt-list-item}, "end"
+  stmt = stmt-list | single-stmt
+  if-stmt    = "if", stmt, "end"
+  while-stmt = "while", stmt, "end"
+  block-stmt = "block", stmt, "end"
+
+  branch-val = "literal" | "type"
+  branch = "branch", {branch-val}, stmt, "end"
+
+  case-stmt = "case", branch, {branch}, "end"
+
+  except-branch = "branch", {("type" | "pnode")}, stmt, "end"
+
+  except   = "except", except-branch, {except-branch}, "end"
+  finally  = "finally", stmt, "end"
+  try-stmt = "try", stmt, [except], [finally], "end"
+
+  scope = "scope", {stmt-list-item}, "end"
+
+  single-stmt = "break" | "return" | "pnode" | def | while-stmt | try-stmt |
+                block-stmt | scope
+
+  region = "region", {stmt-list-item}, "end"
+
+  arg = in-op, {in-out-op}, ("arg" | "name" | "consume")
+  arg-block-item = arg | stmt-list-item
+  arg-block = "argBlock", {arg-block-item}, arg, "end"
+
+  in-op     = "none" | name | arg-block | "opParam" {* may only appear inside a region *}
+  out-op    = "void" | "raise" | "init" | "fastAsgn" | "asgn" | "switch" |
+              def | if-stmt | case-stmt | region
+  in-out-op = "magic" | "call" | "pathNamed" | "pathPos" | "pathArray" |
+              "pathVariant" | "constr" | obj-constr | "cast" | "deref" |
+              "addr" | "stdConv" | "conv" | "view" | "derefView"
+
+  sequence = in-op, {in-out-op}, out-op
+
+  stmt-list-item = sequence | single-stmt
+
+  top-level = stmt-list-item {* the entry point *}

--- a/lib/experimental/dod_helpers.nim
+++ b/lib/experimental/dod_helpers.nim
@@ -1,4 +1,89 @@
-import std/[macros, strutils, options]
+import
+  std/[
+    macros,
+    options,
+    strutils,
+    typetraits
+  ]
+
+type
+  OptIndex[T] = distinct uint32
+    ## The nilable version of an index-like type. Concepts should be used to
+    ## restrict for which types ``OptIndex`` is usable, but because of their
+    ## not-yet stable nature, they aren't. Instead, the type-operator ``opt``
+    ## is used to construct the type.
+    ##
+    ## The zero-representation of ``OptIndex`` represents the 'nil' state --
+    ## this is achieved by shifting the index by 1. This allows for
+    ## ``OptIndex`` to have no size overhead compared to just using the
+    ## underlying type, but also means that not the whole range can be
+    ## used for the index values.
+    ##
+    ## Because of multiple compiler bugs, ``OptIndex`` right now only works for
+    ## index-like types that use ``uint32`` as the underlying type
+
+# XXX: instead of making ``OptIndex`` only available for ``uint32``-based
+#      types, the idea was to make ``OptIndex`` a ``distinct Underlying[T]``
+#      where ``Underlying`` is a type operator that is defined for each
+#      index-like type. Example:
+#
+#        type Underlying[T: NameOfIndexType] = uint32
+#
+#      Because of a severe compiler bug, that is currently not possible, as
+#      defining a generic alias of a primitive type results in the size
+#      information of the primitive type to become unknown. Using a template
+#      for the operator also fails to compile
+
+# ----------------- OptIndex implementation -----------------
+
+template opt*[T](t: typedesc[T]): untyped =
+  ## A type operator that returns the nilable version of the index-like type
+  ## `T`. To indicate that `T` represents an index-like, a tag routine
+  ## of the form ``indexLike(typedesc[T]): void`` has to be visible
+  mixin indexLike
+  when compiles(indexLike(t)):
+    when distinctBase(t) is uint32:
+      OptIndex[T]
+    else:
+      {.error: name(t) & " is not ``uint32``-based".}
+  else:
+    {.error: name(t) & " is not an index-like -- the tag routine is missing"}
+
+template `==`*[T](a, b: OptIndex[T]): bool =
+  ## Compares `a` and `b` for equality. If both are 'nil', they're are also
+  ## treated as equal
+  ord(a) == ord(b)
+
+func isSome*[T](i: OptIndex[T]): bool {.inline.} =
+  ## Tests if `i` stores a valid index-like value
+  ord(i) != 0
+
+func isNone*[T](i: OptIndex[T]): bool {.inline.} =
+  ## Tests if `i` is empty, i.e. doesn't store a valid index-like
+  ord(i) == 0
+
+template val[T](x: OptIndex[T]): untyped =
+  #(Underlying[T])(x)
+  uint32(x)
+
+func `[]`*[T](i: OptIndex[T]): T {.inline.} =
+  ## Returns the underlying index value. `i` is required to store a valid
+  ## value
+  bind val
+  assert val(i) != 0, "`i` is empty"
+  T(val(i) - 1)
+
+template noneOpt*[T](t: typedesc[T]): untyped =
+  ## Returns the value representing 'none' (or 'nil') for the index-like `T`
+  # XXX: the template can't be named ``none``, as that would create ambiguities
+  #      with the ``none`` routine for ``Option``
+  default(opt(t))
+
+func someOpt*[T](i: T): auto {.inline.} =
+  ## Returns the index-like value `i` as the corresponding nilable type
+  type Opt = opt(T)
+  #Opt((Underlying[T])(i) + 1)
+  Opt(uint32(i) + 1)
 
 template declareIdType*(
     Name: untyped,

--- a/tests/compiler/tmir_changesets.nim
+++ b/tests/compiler/tmir_changesets.nim
@@ -1,0 +1,176 @@
+discard """
+  description: "Tests for the MIR ``Changeset`` API"
+  matrix: "--gc:refc; --gc:orc"
+  targets: native
+"""
+
+# XXX: the test cases would benefit from a mini-DSL
+
+import
+  compiler/ast/ast_types,
+  compiler/mir/[mirtrees, mirchangesets, mirconstr, sourcemaps],
+  compiler/utils/containers
+
+proc temp(x: int): MirNode =
+  MirNode(kind: mnkTemp, temp: x.TempId)
+
+func `==`(a: TempId, b: int): bool =
+  a.int == b
+
+func seek(c: var Changeset, i: int) =
+  c.seek NodePosition(i)
+
+func insert(c: var Changeset, n: sink MirNode) =
+  c.insert(n, NodeInstance(0)) # inherit the origin information from node 0
+
+func `==`(a, b: MirNode): bool =
+  if a.kind != b.kind:
+    return false
+
+  # only implements the comparisons needed by the tests
+  case a.kind
+  of mnkTemp:
+    result = a.temp == b.temp
+  else:
+    doAssert false
+
+func setupSourceMap(tree: MirTree): SourceMap =
+  ## Sets up a minimal ``SourceMap`` instance for the given tree
+  let id = result.source.add PNode()
+  result.map.setLen(tree.len)
+
+template test(input, output: typed, body: untyped) =
+  ## Helper template to simplify writing test cases
+  block:
+    var
+      tree =
+        when input is array: @input
+        else:                input
+      c {.inject.} = initChangeset(tree)
+      sourceMap = setupSourceMap(tree)
+
+    body
+
+    let pc = prepare(c, sourceMap)
+    apply(tree, pc)
+    {.line.}:
+      doAssert tree == output
+
+# ------- beginning of tests --------
+
+block insert_same_position:
+  ## If there exists more than one 'insert' operation for a position, they're
+  ## applied in recording-order
+  test([temp(0), temp(1), temp(2)],
+       [temp(3), temp(4), temp(5), temp(6), temp(1), temp(2)]):
+    c.seek 1
+    c.insert temp(4)
+    c.insert temp(5)
+    c.seek 0
+    c.replace temp(3)
+    c.seek 1
+    c.insert temp(6)
+
+block insert_at_end:
+  test([temp(0), temp(1)],
+       [temp(0), temp(1), temp(2)]):
+    c.seek 2
+    c.insert temp(2)
+
+block insert_replace_same_position:
+  # Replacing a node and inserting at the same position has to work. The
+  # insertion always happens first...
+  test([temp(0), temp(1), temp(2)],
+       [temp(0), temp(3), temp(4), temp(2)]):
+    c.seek 1
+    c.replace temp(4)
+    c.seek 1 # `replace` moves the cursor, so we have to move it back
+    c.insert temp(3)
+
+  # ... independent of the order
+  test([temp(0), temp(1), temp(2)],
+       [temp(0), temp(3), temp(4), temp(2)]):
+    c.seek 1
+    c.insert temp(3)
+    c.replace temp(4)
+
+block insert_remove_same_position:
+  # Similar to the test above, but uses ``remove`` instead of ``replace``
+  test([temp(0), temp(1), temp(2)],
+       [temp(0), temp(3), temp(2)]):
+    c.seek 1
+    c.remove()
+    c.seek 1 # ``remove`` moves the cursor, so we have to move it back
+    c.insert temp(3)
+
+  test([temp(0), temp(1), temp(2)],
+       [temp(0), temp(3), temp(2)]):
+    c.seek 1
+    c.insert temp(3)
+    c.remove()
+
+block insert_shared_start:
+  # ``replace``/``remove`` operations are allowed to share their start node
+  # with an ``insert`` operation. The ``insert`` operation takes place *first*,
+  # independent of the order in which they're recorded
+  var tree: MirTree
+  tree.add temp(0)
+  tree.subTree MirNode(kind: mnkStmtList): discard
+  tree.add temp(3)
+
+  test(tree, [temp(0), temp(1), temp(2), temp(3)]):
+    c.seek 1
+    c.replace temp(2)
+    c.seek 1
+    c.insert temp(1)
+
+  test(tree, [temp(0), temp(1), temp(2), temp(3)]):
+    c.seek 1
+    c.insert temp(1)
+    c.seek 1
+    c.replace temp(2)
+
+  test(tree, [temp(0), temp(1), temp(3)]):
+    c.seek 1
+    c.remove()
+    c.seek 1
+    c.insert temp(1)
+
+  test(tree, [temp(0), temp(1), temp(3)]):
+    c.seek 1
+    c.insert temp(1)
+    c.seek 1
+    c.remove()
+
+block insert_shared_end:
+  # ``replace``/``remove`` operations are allowed to share their end node
+  # with an ``insert`` operation. The ``insert`` operation takes place
+  # *second*, independent of the order in which they're recorded
+  var tree: MirTree
+  tree.add temp(0)
+  tree.subTree MirNode(kind: mnkStmtList): discard
+  tree.add temp(3)
+
+  test(tree, [temp(0), temp(1), temp(2), temp(3)]):
+    c.seek 1
+    c.replace temp(1)
+    c.seek 3
+    c.insert temp(2)
+
+  test(tree, [temp(0), temp(1), temp(2), temp(3)]):
+    c.seek 3
+    c.insert temp(2)
+    c.seek 1
+    c.replace temp(1)
+
+  test(tree, [temp(0), temp(2), temp(3)]):
+    c.seek 1
+    c.remove()
+    c.seek 3
+    c.insert temp(2)
+
+  test(tree, [temp(0), temp(2), temp(3)]):
+    c.seek 3
+    c.insert temp(2)
+    c.seek 1
+    c.remove()

--- a/tests/compiler/tmir_trees.nim
+++ b/tests/compiler/tmir_trees.nim
@@ -1,0 +1,10 @@
+discard """
+  description: "Tests for the `mirtree` module"
+  targets: native
+"""
+
+import compiler/mir/mirtrees
+
+block last_sibling:
+  let tree = @[MirNode(kind: mnkStmtList), MirNode(kind: mnkEnd)]
+  doAssert sibling(tree, NodePosition 0) == NodePosition(tree.len)


### PR DESCRIPTION
Summary
=======

This PR introduces and integrates a **m**id-end **i**ntermediate
**r**epresentation (MIR) into the compiler. It is an IR for code and
meant to host target-independent transformations, analysis, and
lowerings, and is the first step towards implementing the plan detailed
in https://github.com/nim-works/nimskull/discussions/467.

Overview
--------

Before being processed by the code-generators, the `PNode` AST is
first passed to `mirgen`, which translates the AST into MIR code. In
the future, the MIR passes will take place after this step, but there
currently aren't any. After all eventual transformations are applied,
the MIR code is translated back into `PNode` AST. Rewriting the
code-generators to operate on the MIR directly is not feasible (at
least not as part of this commit), so the aforementioned translation is
required.

Until a proper pass management is implemented, `mirbridge` combines the
`mirgen`/`astgen` step into a single procedure, so that the logic can
be reused across all code-generators.

Passing the result of the MIR code -> `PNode`-AST translation to the
`injectdestructors` pass makes the latter produce code that fails the
current tests, so as a temporary workaround, the MIR processing is not
run at all for code for which the `injectdestructors` pass is enabled.

Lessons learned / Takeaways
===========================

`mirgen` has a similar structure to the other code-generators, in that
it also uses `genX` procedures that recursively call each other. It is
much more strict however, i.e. instead of using the top-level
dispatcher procedure everywhere, knowledge about the context is used in
order to call the correct procedure directly. For example, when
processing call arguments, the `gen` procedure for *expressions* is
called directly, as arguments are always (except for an explicitly
handled special-case) expressions. The consequences:
- more decisions happening at *compile-time* instead of at *run-time*.
  Decision making happens earlier -- it is moved outwards
- `mirgen` acts as a small validation layer for the input AST.
  Ill-formed or semantically invalid AST is (in some capacity) detected
  as a side-effect of how `mirgen` operates
- it is easier to reason about what AST forms are valid by only looking
  at the code (i.e. `mirgen` acts as a good overview of what is valid
  and what is not)

This helped uncovering a good amount of issues:
- the unsound collapsing of `HiddenAddr (HiddenDeref x)` node sequences
- `HiddenAddr` nodes having the wrong type in some cases
- when evaluating whether a `concept` applies and the last expression
  in the concept's body is the result of a template expansion, a
  `nkStmtListExpr` with expressions of which the result is not
  discarded is passed to `semConstExpr` (`vmgen` ignored this, but
  `mirgen` doesn't)
- when inserting boolean literals, `closureiters` used the symbol of
  the `bool` enum fields instead of integer literals. Past
  early-`transf` (where the `closureiters` transformation takes place)
  this is illegal, and only didn't fail code-generation because all
  code-generators still handled `skEnumField` symbols for robustness

Other findings:
- semantic analysis uses the VM to evaluate type expression in a lot of
  cases. For example, the expressions `static int` or `T not nil` are
  either partially or fully evaluated with the VM. The main work is
  done by `vmgen` here: an expression that has a `typeDesc` type is
  turned into a `nkType` node constant -- the VM only loads this
  constant into the result register and immediately exits again
- `vmgen` is being used by sem to detect and reject expressions
  containing unresolved generic parameters
- `closureiters` implements the same complex-expression-to-statement
  transformation as `mirgen`. Moving the `closureiters` transformation
  to operate on the MIR will likely simplify the logic there by a lot
- there are almost not tests for lifetime tracking hooks with the JS
  target
- cursor inference or the `injectdestructors` pass don't work with the
  output of `astgen`

MIR design
----------

What turned out to be a very good decision, was to separate the scoping
behaviour (in terms of both lifetime and visibility) from control-flow
constructs. That is, to make constructs like `if` (`mnkIf`) or `case`
(`mnkCase`) not affect the lifetime or visibility of definitions. This
simplified a lot of logic, made things clearer, and made important MIR
code possible that could not be represented before. The takeaway: if
there's no concrete reason to do so, don't combine/conflate unrelated
behaviour into a single construct.

Details
=======

This commit is for the most part self-contained, but multiple bugs and
issues in unrelated modules had to be fixed in order for `mirgen` to
work:
- `closureiters` now correctly emits `nkIntLit` nodes instead of
  `skEnumField` symbols for boolean literals
- `closureiters` now sets the type of a `case` expression to `nil`
  when transforming it into a statement
- cursor inference is separated from the `injectdestructors` pass.
  This is necessary in order for the MIR integration to happen
  in-between both
- prevent semantically invalid `nkStmtListExpr` AST from being
  evaluated with the VM during `concept` application

**General fixes:**
Fix `vmgen` raising an assertion for `x.len` where `x` was not directly
a string (e.g. a `sink string` or alias to `string`).

**Changes to `vmgen`:**
- since `mirgen` now handles type expressions, `vmgen` no longer has
  to. Only `nkType` (type literals) are code-gen'ed, everything else
  type related is rejected (an error is raised)
- the special handling for compile-time-only call arguments is
  removed - `mirgen` handles this now
- magics for which the instruction is selected based on the symbol
  name use exhaustive case statements now. This prevents magic symbol
  having an unexpected name from going unnoticed

**Other additions:**
- add a facility (`OptIndex`) for the ad-hoc creation of nilable
  versions of index-like types to the `dod_helpers` module
- add a simple half-open slice implementation to the `idioms` module
- add branch-related iterators to `ast_query`

**Added modules:**
- `mirtrees` contains the type definitions that make up the MIR, along
  with basic tree traversal routines
- `mirchangesets` implements the `Changeset` API, which is the primary
  way of modifying MIR code
- `mirconstr` contains some routines useful when generating MIR
  constructs. It's in an early stage of development, and the goal is to
  eventually generalize the mini DSL used by `mirgen` and move it here
- `sourcemaps` contains the `SourceMap` data type together with the
  outines for querying it. A `SourceMap` associates each `MirNode` with
  the `PNode` it originated from
- `mirgen` implements the `PNode` AST to MIR code translation
- `astgen` implements the MIR code to `PNode` AST translation
- `mir/utils` contains non-essential routines that are mainly meant to
  be used for inspection during debugging
- `utils/containers` implements various `seq`-based containers that are
  generally useful in DOD contexts

Misc
----

- implement printing the symbol kind in `astrepr`

Future directions
=================

The MIR processing is integrated into the C and JS backend the same way
as `transf` is: the code-generators have to explicitly invoke
both. When the body of a procedure or a top-level statement is
encountered:
1. `transf` is executed for the code
2. the transformed code is passed to the MIR processing step (if used)
3. the AST resulting from the previous step is passed on to the actual
   code-generation logic

This approach has the following problems:
- the code-generators need to know about the existence of both `transf`
  and the MIR processing step
- the logic for invoking both steps is duplicated into each backend
- should the `lambdalifting` pass become a MIR pass, the pass is likely
  going to require access to the MIR code of multiple procedures at
  once. With the current processing pipeline, the required state and
  logic for managing would, to some degree, also need to be duplicated
  into each backend/code-generator

Instead, using an approach similar to the one used by the VM backend
(`vmbackend`) for both the C and JS backend would make sense.
`vmbackend` is responsible for: figuring out which procedure to run
code-generation for, transforming the code (`transf`), applying the
MIR processing, and then passing the resulting AST to the
code-generator (`vmgen`). This could be generalized into a reusable
abstraction that is then used across all backends, removing the
duplication of logic and making backend processing more unified.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

### To-dos
- [x] integrate the to-and-from translation step into:
  - [x] `cgen`
  - [x] `vmgen`
  - [x] `jsgen`
- [x] implement the things still missing from `mirgen` 
- [x] refactor, cleanup, and document the added modules
- [x] write a proper commit/PR message