### PR TITLE
Internals: breakup reports and prep for redesign

### DIFF
--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -34,16 +34,22 @@
 import
   compiler/ast/[
     ast,
-    reports,
-    lineinfos
+    lineinfos,
   ],
   compiler/utils/[
     debugutils,
   ],
   compiler/front/[
     msgs,
-    options
+    options,
   ]
+
+from compiler/ast/reports_sem import SemReport, reportSem
+from compiler/ast/report_enums import ReportKind,
+  SemOrVMReportKind,
+  repSemKinds,
+  repVMKinds
+from compiler/ast/reports import wrap
 
 when defined(nimDebugUnreportedErrors):
   import std/tables

--- a/compiler/ast/filter_tmpl.nim
+++ b/compiler/ast/filter_tmpl.nim
@@ -25,8 +25,10 @@ import
     ast,
     filters,
     lineinfos,
-    reports
   ]
+
+from compiler/ast/reports_parser import ParserReport
+from compiler/ast/report_enums import ReportKind
 
 type
   TParseState = enum

--- a/compiler/ast/filters.nim
+++ b/compiler/ast/filters.nim
@@ -14,7 +14,6 @@ import
     llstream,
     ast,
     renderer,
-    reports
   ],
   std/[
     strutils,
@@ -27,8 +26,13 @@ import
     options,
   ]
 
+# TODO: abusing `reportSem`, this isn't event a semantic analysis error
+from compiler/ast/reports_sem import reportAst
+from compiler/ast/report_enums import ReportKind
+
 
 proc invalidPragma(conf: ConfigRef; n: PNode) =
+  # TODO: this isn't a semantic analysis error, we're in a _source filter_.
   conf.localReport(n.info, reportAst(rsemNodeNotAllowed, n))
 
 proc getArg(conf: ConfigRef; n: PNode, name: string, pos: int): PNode =

--- a/compiler/ast/linter.nim
+++ b/compiler/ast/linter.nim
@@ -23,6 +23,8 @@ import
     msgs
   ]
 
+# TODO: linter should have it's own diag/event/telemetry types
+from compiler/ast/reports_sem import SemReport
 
 const
   Letters* = {'a'..'z', 'A'..'Z', '0'..'9', '\x80'..'\xFF', '_'}

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -36,7 +36,7 @@ import
     idents,
     ast,
     lineinfos,
-    reports
+    reports_parser,
   ],
   std/[
     strutils,
@@ -49,6 +49,12 @@ import
     pathutils,
     astrepr
   ]
+
+# TODO: switch to internalError/Assert or better yet emit the appropriate
+#       diagnostic/event/telemetry data instead, then drop this dependency
+from compiler/ast/reports_internal import InternalReport
+
+from compiler/ast/reports import wrap
 
 type
   Parser* = object            ## A Parser object represents a file that
@@ -145,7 +151,7 @@ template localError(p: Parser, report: ParserReport): untyped =
     wrap(rep, instLoc(), p.lex.getLineInfo(p.tok)), instLoc())
 
 
-template localError(p: Parser, report: ReportTypes): untyped =
+template localError(p: Parser, report: InternalReport): untyped =
   p.lex.config.handleReport(
     wrap(report, instLoc(), p.lex.getLineInfo(p.tok)), instLoc())
 

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -20,7 +20,6 @@ import
     idents,
     ast,
     lineinfos,
-    reports
   ],
   std/[
     strutils,
@@ -29,6 +28,11 @@ import
     options,
     msgs,
   ]
+
+# TODO: switch to internalError/Assert or better yet emit the appropriate
+#       diagnostic/event/telemetry data instead, then drop this dependency
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/report_enums import ReportKind
 
 type
   TRenderFlag* = enum

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -19,9 +19,11 @@ type
 
     repVM = "VM" ## Report related to embedded virtual machine
 
-    repDebug = "Debug" ## Side channel for the compiler debug report. Sem
-    ## expansion traces and other helper messages designed specifically to
-    ## aid development of the compiler
+    repDbgTrace = "Trace" ## compiler execution expansion traces for debugging
+    ## or understaning the compiler
+
+    repDebug = "Debug" ## Side channel for the compiler debug report. Helper
+    ## messages designed specifically to aid development of the compiler
 
     repInternal = "Internal" ## Reports constructed during hanling of the
     ## internal compilation errors. Separate from debugging reports since
@@ -322,6 +324,7 @@ type
 
     rsemNodeNotAllowed
       ## Generated in `filters.nim`
+      ## TODO: this is not a sem error, it's a source filters error
 
     rsemCannotProveNotNil
     rsemProvablyNil
@@ -858,18 +861,19 @@ type
     rcmdRunnableExamplesSuccess
     # hints END !! add reports BEFORE the last enum !!
 
+    #----------------------------  Trace reports  ----------------------------#
+
+    rdbgTraceDefined # first ! trace begin
+    rdbgTraceUndefined
+    rdbgTraceStart
+    rdbgTraceStep
+    rdbgTraceLine
+    rdbgTraceEnd # last ! trace end
 
     #----------------------------  Debug reports  ----------------------------#
     rdbgVmExecTraceFull
     rdbgVmExecTraceMinimal
     rdbgVmCodeListing
-
-    rdbgTraceDefined # first ! tracer begin
-    rdbgTraceUndefined
-    rdbgTraceStart
-    rdbgTraceStep
-    rdbgTraceLine
-    rdbgTraceEnd # last ! tracer end
 
     rdbgStartingConfRead
     rdbgFinishedConfRead
@@ -939,6 +943,8 @@ type
 
   CmdReportKind* = range[rcmdFailedExecution .. rcmdRunnableExamplesSuccess]
 
+  DbgTraceReportKind* = range[rdbgTraceDefined .. rdbgTraceEnd]
+  
   DebugReportKind* = range[rdbgVmExecTraceFull .. rdbgOptionsPop]
 
   BackendReportKind* = range[rbackCannotWriteScript .. rbackLinking]
@@ -989,17 +995,11 @@ const
   rcmdWarningKinds* = default(set[ReportKind])
   rcmdHintKinds* = {rcmdCompiling .. rcmdRunnableExamplesSuccess}
 
+  #--------------------------------  trace  --------------------------------#
+  repDbgTraceKinds* = {low(DbgTraceReportKind) .. high(DbgTraceReportKind)}
+
   #--------------------------------  debug  --------------------------------#
   repDebugKinds* = {low(DebugReportKind) .. high(DebugReportKind)}
-  repDebugTraceKinds* = {
-    rdbgTraceStart, # Begin report
-    rdbgTraceStep, # in/out
-    rdbgTraceLine,
-    rdbgTraceEnd, # End report
-    rdbgTraceUndefined, # `.undef` triggered in code
-    rdbgTraceDefined, # `.define` triggered in code
-  }
-
 
   #-------------------------------  backend  -------------------------------#
   repBackendKinds* = {low(BackendReportKind) .. high(BackendReportKind)}
@@ -1040,6 +1040,7 @@ const
 
   repTraceKinds*: ReportKinds =
     {rvmStackTrace, rintStackTrace} +
+    repDbgTraceKinds +
     repDebugKinds
 
   repHintKinds*: ReportKinds    =
@@ -1093,6 +1094,7 @@ static:
       set[ReportKind](repParserKinds) +
       set[ReportKind](repInternalKinds) +
       set[ReportKind](repExternalKinds) +
+      set[ReportKind](repDbgTraceKinds) +
       set[ReportKind](repDebugKinds) +
       set[ReportKind](repBackendKinds) +
       set[ReportKind](repCmdKinds) +

--- a/compiler/ast/reports_backend.nim
+++ b/compiler/ast/reports_backend.nim
@@ -1,0 +1,40 @@
+## module with backend legacy reports definitions
+##
+## TODO: even though it's legacy backend reports should not be in the ast
+##       package.
+
+import
+  compiler/ast/[
+    reports_base,
+  ]
+
+type
+  BackendReport* = object of ReportBase
+    msg*: string
+    usedCompiler*: string
+    case kind*: ReportKind
+      of rbackCannotWriteScript,
+         rbackProducedAssembly,
+         rbackCannotWriteMappingFile:
+        filename*: string
+
+      of rbackTargetNotSupported:
+        requestedTarget*: string
+
+      of rbackJsonScriptMismatch:
+        jsonScriptParams*: tuple[
+          outputCurrent, output, jsonFile: string
+        ]
+
+      of rbackVmFileWriteFailed:
+        outFilename*: string
+        failureMsg*: string ## string rep of the ``RodFileError``, so that
+                            ## ``rodfiles`` doesn't need to be imported here
+      else:
+        discard
+
+func severity*(report: BackendReport): ReportSeverity =
+  case BackendReportKind(report.kind):
+    of rbackErrorKinds: rsevError
+    of rbackHintKinds: rsevHint
+    of rbackWarningKinds: rsevWarning

--- a/compiler/ast/reports_base.nim
+++ b/compiler/ast/reports_base.nim
@@ -1,0 +1,53 @@
+## module with base legacy reports definitions
+
+import
+  compiler/ast/[
+    lineinfos,
+    report_enums,
+  ]
+
+import std/[options]
+
+export report_enums, lineinfos
+
+type
+  ReportLineInfo* = object
+    ## Location expressed in terms of a single point in the file
+    file*: string
+    line*: uint16
+    col*: int16
+
+  ReportSeverity* = enum
+    rsevDebug = "Debug" ## Internal compiler debug information
+
+    rsevHint = "Hint" ## User-targeted hint
+    rsevWarning = "Warning" ## User-targeted warnings
+    rsevError = "Error" ## User-targeted error
+
+    rsevFatal = "Fatal"
+    rsevTrace = "Trace" ## Additional information about compiler actions -
+    ## external commands mostly.
+
+  # TODO: the need to inherit should be the first clue that things are wrong,
+  #       thanks to that all the data type declaration dependencies are still
+  #       stuck being inverted. Rip this stuff out.
+
+  ReportBase* = object of RootObj
+    location*: Option[TLineInfo] ## Location associated with report. Some
+    ## reports do not have any locations associated with them (most (but
+    ## not all, due to `gorge`) of the external command executions, sem
+    ## tracing etc). Some reports might have additional associated location
+    ## information (view type sealing reasons) - those are handled on the
+    ## per-report-kind basis.
+
+    reportInst*: ReportLineInfo ## Information about instantiation location
+    ## of the reports - present for all reports in order to track their
+    ## origin withing the compiler.
+
+    reportFrom*: ReportLineInfo ## Information about submit location of the
+    ## report. Contains information about the place where report was
+    ## /submitted/ to the system - sometimes a report is created, modified
+    ## to add new information, and only then put into the pipeline.
+  
+  DebugReportBase* = object of ReportBase
+    ## Inherit various debugging related reports from this object

--- a/compiler/ast/reports_base_sem.nim
+++ b/compiler/ast/reports_base_sem.nim
@@ -1,0 +1,34 @@
+## module with base sem-like reports definitions
+
+import compiler/ast/[
+    ast_types,
+    reports_base,
+  ]
+
+export reports_base
+
+type
+  SemishReportBase* = object of ReportBase
+    ## Base for Sem and VM reports which may require additional contextual
+    ## data. Created as part of a refactor to extract diagnostic data out of
+    ## `reports` and put it back into the appropriate modules. The name is
+    ## temporary and ideally we no longer will need inheritance.
+    ## 
+    ## For refactor info: https://github.com/nim-works/nimskull/issues/443
+    context*: seq[ReportContext]
+
+  ReportContextKind* = enum
+    sckInstantiationOf
+    sckInstantiationFrom
+
+  ReportContext* = object
+    location*: TLineInfo ## Report context instantiation
+    case kind*: ReportContextKind
+      of sckInstantiationOf:
+        entry*: PSym ## Instantiated entry symbol
+      of sckInstantiationFrom:
+        discard
+
+  SemTypeMismatch* = object
+    formalTypeKind*: set[TTypeKind]
+    actualType*, formalType*: PType

--- a/compiler/ast/reports_cmd.nim
+++ b/compiler/ast/reports_cmd.nim
@@ -1,0 +1,27 @@
+## module with CLI legacy reports definitions
+##
+## TODO: even though it's legacy, it's highly unlike that this should be
+##       included in the ast package
+
+import
+  compiler/ast/[
+    reports_base,
+  ]
+
+type
+  CmdReport* = object of ReportBase
+    cmd*: string
+    msg*: string
+    code*: int
+    case kind*: ReportKind
+      of rcmdFailedExecution:
+        exitOut*, exitErr*: string
+      else:
+        discard
+
+
+func severity*(report: CmdReport): ReportSeverity =
+  case CmdReportKind(report.kind):
+    of rcmdHintKinds: rsevHint
+    of rcmdWarningKinds: rsevWarning
+    of rcmdErrorKinds: rsevError

--- a/compiler/ast/reports_debug.nim
+++ b/compiler/ast/reports_debug.nim
@@ -1,0 +1,71 @@
+## module with Debug legacy reports definitions
+##
+## TODO: even though it's legacy we shouldn't group "debug" reports like this,
+##       that's what severity or some other categorization is for. Instead,
+##       break these up into additional report types within reports_sem/vm/etc
+
+import
+  compiler/ast/[
+    ast_types,
+    lineinfos,
+    reports_base,
+  ],
+  compiler/front/[
+    in_options,
+  ],
+  compiler/vm/vm_enums
+
+type
+  DebugVmCodeEntry* = object
+    isTarget*: bool
+    info*: TLineInfo
+    pc*: int
+    idx*: int
+    case opc*: TOpcode:
+      of opcConv, opcCast:
+        types*: tuple[tfrom, tto: PType]
+      of opcLdConst, opcAsgnConst:
+        ast*: PNode
+      else:
+        discard
+    ra*: int
+    rb*: int
+    rc*: int
+
+  DebugReport* = object of DebugReportBase
+    case kind*: ReportKind
+      of rdbgOptionsPush, rdbgOptionsPop:
+        optionsNow*: TOptions
+
+      of rdbgVmExecTraceFull:
+        vmgenExecFull*: tuple[
+          pc: int,
+          opc: TOpcode,
+          info: TLineInfo,
+          ra, rb, rc: TRegisterKind
+        ]
+
+      of rdbgStartingConfRead, rdbgFinishedConfRead:
+        filename*: string
+
+      of rdbgCfgTrace:
+        str*: string
+
+      of rdbgVmCodeListing:
+        vmgenListing*: tuple[
+          sym: PSym,
+          ast: PNode,
+          entries: seq[DebugVmCodeEntry]
+        ]
+
+      of rdbgVmExecTraceMinimal:
+        vmgenExecMinimal*: tuple[
+          info: TLineInfo,
+          opc: TOpcode
+        ]
+
+      else:
+        discard
+
+func severity*(report: DebugReport): ReportSeverity =
+  rsevDebug

--- a/compiler/ast/reports_external.nim
+++ b/compiler/ast/reports_external.nim
@@ -1,0 +1,41 @@
+## module with external legacy reports definitions
+##
+## TODO: even though it's legacy external reports should not be in the ast
+##       package.
+
+import
+  compiler/ast/[
+    reports_base,
+  ]
+
+type
+  ExternalReport* = object of ReportBase
+    ## Report about external environment reads, passed configuration
+    ## options etc.
+    msg*: string
+
+    case kind*: ReportKind
+      of rextInvalidHint .. rextInvalidPath:
+        cmdlineSwitch*: string ## Switch in processing
+        cmdlineProvided*: string ## Value passed to the command-line
+        cmdlineAllowed*: seq[string] ## Allowed command-line values
+        cmdlineError*: string ## Textual description of the cmdline failure
+
+      of rextUnknownCCompiler:
+        knownCompilers*: seq[string]
+        passedCompiler*: string
+
+      of rextInvalidPackageName:
+        packageName*: string
+
+      of rextPath:
+        packagePath*: string
+
+      else:
+        discard
+
+func severity*(report: ExternalReport): ReportSeverity =
+  case ExternalReportKind(report.kind):
+    of rextErrorKinds: rsevError
+    of rextWarningKinds: rsevWarning
+    of rextHintKinds: rsevHint

--- a/compiler/ast/reports_internal.nim
+++ b/compiler/ast/reports_internal.nim
@@ -1,0 +1,99 @@
+## module with internal legacy reports definitions
+##
+## TODO: even though it's legacy internal reports should not be in the ast
+##       package.
+## TODO: This module needs to be broken and those parts placed correctly:
+##       1. Internal assertion/error related bits
+##       2. Internal state/user input types
+##       3. Help/CLI messages, etc
+##       4. General report cruft
+
+
+import
+  compiler/ast/[
+    reports_base,
+  ],
+  compiler/utils/[
+    platform,
+  ]
+
+
+type
+  UsedBuildParams* = object
+    project*: string
+    output*: string
+    linesCompiled*: int
+    mem*: int
+    isMaxMem*: bool
+    sec*: float
+    case isCompilation*: bool
+      of true:
+        threads*: bool
+        backend*: string
+        buildMode*: string
+        optimize*: string
+        gc*: string
+
+      of false:
+        discard
+
+  InternalStateDump* = ref object
+    version*: string
+    nimExe*: string
+    prefixdir*: string
+    libpath*: string
+    projectPath*: string
+    definedSymbols*: seq[string]
+    libPaths*: seq[string]
+    lazyPaths*: seq[string]
+    nimbleDir*: string
+    outdir*: string
+    `out`*: string
+    nimcache*: string
+    hints*, warnings*: seq[tuple[name: string, enabled: bool]]
+
+  InternalCliData* = object
+    ## Information used to construct messages for CLI reports - `--help`,
+    ## `--fullhelp`
+    version*: string ## Language version
+    sourceHash*: string ## Compiler source code git hash
+    sourceDate*: string ## Compiler source code date
+    boot*: seq[string] ## nim compiler boot flags
+    cpu*: TSystemCPU ## Target CPU
+    os*: TSystemOS ## Target OS
+
+  InternalReport* = object of ReportBase
+    ## Report generated for the internal compiler workings
+    msg*: string
+    case kind*: ReportKind
+      of rintStackTrace:
+        trace*: seq[StackTraceEntry] ## Generated stack trace entries
+
+      of rintDumpState:
+        stateDump*: InternalStateDump
+
+      of rintAssert:
+        expression*: string
+
+      of rintSuccessX:
+        buildParams*: UsedBuildParams
+
+      of rintCannotOpenFile .. rintWarnFileChanged:
+        file*: string
+
+      of rintListWarnings, rintListHints:
+        enabledOptions*: set[ReportKind]
+
+      of rintCliKinds:
+        cliData*: InternalCliData
+
+      else:
+        discard
+
+func severity*(report: InternalReport): ReportSeverity =
+  case InternalReportKind(report.kind)
+  of rintFatalKinds:    rsevFatal
+  of rintHintKinds:     rsevHint
+  of rintWarningKinds:  rsevWarning
+  of rintErrorKinds:    rsevError
+  of rintDataPassKinds: rsevTrace

--- a/compiler/ast/reports_lexer.nim
+++ b/compiler/ast/reports_lexer.nim
@@ -1,0 +1,22 @@
+## module with lexer legacy reports definitions
+
+import
+  compiler/ast/[
+    reports_base,
+  ]
+
+type
+  LexerReport* = object of ReportBase
+    msg*: string
+    case kind*: ReportKind
+      of rlexLinterReport:
+        wanted*: string
+        got*: string
+      else:
+        discard
+
+func severity*(rep: LexerReport): ReportSeverity =
+  case LexerReportKind(rep.kind):
+    of rlexHintKinds: rsevHint
+    of rlexErrorKinds: rsevError
+    of rlexWarningKinds: rsevWarning

--- a/compiler/ast/reports_parser.nim
+++ b/compiler/ast/reports_parser.nim
@@ -1,0 +1,29 @@
+## module with parser legacy reports definitions
+
+import
+  compiler/ast/[
+    ast_types,
+    reports_base,
+  ]
+
+export reports_base.ReportKind
+
+type
+  ParserReport* = object of ReportBase
+    msg*: string
+    found*: string
+    case kind*: ReportKind
+      of rparIdentExpected .. rparUnexpectedToken:
+        expected*: seq[string]
+
+      of rparInvalidFilter:
+        node*: PNode
+
+      else:
+        discard
+
+func severity*(parser: ParserReport): ReportSeverity =
+  case ParserReportKind(parser.kind):
+    of rparHintKinds: rsevHint
+    of rparWarningKinds: rsevWarning
+    of rparErrorKinds: rsevError

--- a/compiler/ast/reports_vm.nim
+++ b/compiler/ast/reports_vm.nim
@@ -1,0 +1,42 @@
+## module with VM legacy reports definitions
+
+import
+  compiler/ast/[
+    ast_types,
+    reports_base_sem,
+  ],
+  compiler/utils/[
+    int128,
+  ]
+
+
+type
+  VMReport* = object of SemishReportBase
+    ast*: PNode
+    typ*: PType
+    str*: string
+    sym*: PSym
+    case kind*: ReportKind
+      of rvmStackTrace:
+        currentExceptionA*, currentExceptionB*: PNode
+        traceReason*: ReportKind
+        stacktrace*: seq[tuple[sym: PSym, location: TLineInfo]]
+        skipped*: int
+
+      of rvmCannotCast:
+        typeMismatch*: seq[SemTypeMismatch]
+
+      of rvmIndexError:
+        indexSpec*: tuple[usedIdx, minIdx, maxIdx: Int128]
+
+      of rvmQuit:
+        exitCode*: BiggestInt
+
+      else:
+        discard
+
+
+func severity*(vm: VMReport): ReportSeverity =
+  case VMReportKind(vm.kind):
+  of rvmStackTrace: rsevTrace
+  else: rsevError

--- a/compiler/ast/syntaxes.nim
+++ b/compiler/ast/syntaxes.nim
@@ -21,7 +21,6 @@ import
     filter_tmpl,
     renderer,
     lineinfos,
-    reports
   ],
   compiler/front/[
     options,
@@ -30,6 +29,16 @@ import
   compiler/utils/[
     pathutils,
   ]
+
+# TODO: reporting lexer and parser errors tangles it up with filters, break
+#       this up into it's own diag/event/telemetry
+from compiler/ast/reports_lexer import LexerReport
+from compiler/ast/reports_parser import ParserReport
+
+# TODO: replace with internalError/Assert, at the very least, its own
+#       diag/event/telemetry is better
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/report_enums import ReportKind
 
 export Parser, parseAll, parseTopLevelStmt, closeParser
 

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -21,7 +21,6 @@ import
     renderer,
     lineinfos,
     errorhandling,
-    reports
   ],
   compiler/front/[
     msgs,
@@ -34,6 +33,15 @@ import
   compiler/modules/[
     modulegraphs,
   ]
+
+# TODO: switch to internalError/Assert or better yet emit the appropriate
+#       diagnostic/event/telemetry data instead, then drop this dependency
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/report_enums import ReportKind
+
+from compiler/ast/reports_sem import SemReport,
+  SemTypeMismatch,
+  reportSem
 
 export EffectsCompat, TTypeRelation, ProcConvMismatch
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -29,7 +29,6 @@ import
     wordrecg,
     treetab,
     renderer,
-    reports,
     lineinfos,
     astmsgs,
     ndi
@@ -64,6 +63,16 @@ import
   ],
   compiler/plugins/[
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced...
+#      like the backend report sem errors.
+from compiler/ast/reports_sem import SemReport,
+  reportSem,
+  reportStr,
+  reportSym,
+  reportTyp
+from compiler/ast/reports_backend import BackendReport
+from compiler/ast/report_enums import ReportKind
 
 import std/strutils except `%` # collides with ropes.`%`
 

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -21,7 +21,6 @@ import
     ast,
     renderer,
     types,
-    reports,
     lineinfos,
   ],
   compiler/modules/[
@@ -31,6 +30,14 @@ import
   compiler/sem/[
     sempass2,
   ]
+
+# TODO: reporting semantic errors from the backend... awesome
+from compiler/ast/reports_sem import SemReport,
+  reportAst,
+  reportSem,
+  reportSym,
+  reportSymbols
+from compiler/ast/report_enums import ReportKind
 
 proc genConv(n: PNode, d: PType, downcast: bool; conf: ConfigRef): PNode =
   var dest = skipTypes(d, abstractPtrs)

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -40,8 +40,13 @@ import
     sugar
   ]
 
-# import ropes, platform, condsyms, options, msgs, lineinfos, pathutils, reports
-
+# TODO: does it really make sense that this module should produce all these
+#       types of "reports"? Unlikely, it's probably creating a bunch of false
+#       dependencies with other modules... yay!
+#       Also, diagnostic, telemetry, and event are better terms
+from compiler/ast/reports_external import ExternalReport
+from compiler/ast/reports_cmd import CmdReport
+from compiler/ast/reports_backend import BackendReport
 
 
 type

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -45,7 +45,6 @@ import
     renderer,
     lineinfos,
     astmsgs,
-    reports
   ],
   compiler/modules/[
     magicsys,
@@ -76,6 +75,13 @@ import
   ],
   compiler/vm/[
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportSem,
+  reportStr,
+  reportSym
+from compiler/ast/reports_backend import BackendReport
+from compiler/ast/report_enums import ReportKind
 
 
 type

--- a/compiler/front/cmdlinehelper.nim
+++ b/compiler/front/cmdlinehelper.nim
@@ -17,7 +17,6 @@ import
   compiler/ast/[
     ast_idgen,
     idents,
-    reports
   ],
   compiler/modules/[
     modulegraphs
@@ -36,6 +35,17 @@ import
   compiler/backend/[
     extccomp
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_lexer import LexerReport
+from compiler/ast/reports_parser import ParserReport
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/reports_external import ExternalReport
+from compiler/ast/reports_debug import DebugReport
+from compiler/ast/report_enums import ReportKind
+from compiler/ast/reports import Report,
+  ReportCategory,
+  toReportLineInfo
 
 proc prependCurDir*(f: AbsoluteFile): AbsoluteFile =
   when defined(unix):

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -20,7 +20,6 @@ import
     lexer,
     idents,
     syntaxes,
-    reports,     # Error report information
     lineinfos    # Positional data
   ],
   compiler/front/[
@@ -62,6 +61,15 @@ import compiler/ic/[
     navigator
   ]
 from compiler/ic/ic import rodViewer
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_internal import InternalReport,
+  InternalStateDump
+from compiler/ast/reports_external import ExternalReport
+from compiler/ast/report_enums import ReportKind,
+  repHintKinds,
+  repWarningKinds,
+  rstWarnings
 
 when not defined(leanCompiler):
   import
@@ -190,8 +198,11 @@ proc commandCompileToJS(graph: ModuleGraph) =
       msg: "Compiler was not build with js support"))
   else:
     conf.exc = excNative
-    conf.target = conf.target.withIt do:
-      setTarget(it, osJS, cpuJS)
+    conf.target =
+      block:
+        var t = conf.target
+        setTarget(t, osJS, cpuJS)
+        t
 
     defineSymbol(conf, "ecmascript") # For backward compatibility
     semanticPasses(graph)

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -16,8 +16,18 @@ import
 
 import
   compiler/utils/[ropes, pathutils],
-  compiler/ast/[reports, lineinfos],
+  compiler/ast/[reports, lineinfos, reports_internal],
   compiler/front/[options]
+
+# TODO: `ReportContext` is used for "context setting", it happening in `msgs`
+#       and it involving `ConfigRef`, all seems off. Likely a dependency that
+#       can be simplified out, also the functionality itself could be ill
+#       conceived.
+from compiler/ast/reports_base_sem import ReportContext, ReportContextKind
+
+# when you have data where it belongs, it's easy to see this stuff... should
+# `msgs` really depend upon `SemReport`?
+from compiler/ast/reports_sem import SemReport 
 
 from compiler/ast/ast_types import PSym
 
@@ -448,6 +458,7 @@ template localReport*(conf: ConfigRef, report: Report) =
 #      code below is a temporary bridge to work around this until fixed.
 
 from compiler/ast/lexer import LexerDiag, LexerDiagKind
+from compiler/ast/reports_lexer import LexerReport
 
 func lexDiagToLegacyReportKind*(diag: LexerDiagKind): ReportKind {.inline.} =
   case diag

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -589,6 +589,10 @@ template store*(
   ## Add report with given location information to the postponed list
   conf.addReport(wrap(report, instLoc(), linfo))
 
+# REFACTOR: we shouldn't need to dig into the internalReport and query severity
+#           directly
+from compiler/ast/reports_internal import severity
+
 func isCompilerFatal*(conf: ConfigRef, report: Report): bool =
   ## Check if report stores fatal compilation error
   report.category == repInternal and
@@ -732,7 +736,7 @@ type
 func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
   const forceWrite = {
     rsemExpandArc, # Not considered a hint for now
-  } + repDebugTraceKinds # Unconditionally write debug tracing information
+  } + repDbgTraceKinds # Unconditionally write debug tracing information
 
   let tryhack = conf.m.errorOutputs == {}
   # REFACTOR this check is an absolute hack, `errorOutputs` need to be
@@ -868,7 +872,7 @@ proc computeNotesVerbosity(): tuple[
   when defined(nimDebugUtils):
     # By default enable only semantic debug trace reports - other changes
     # might be put in there *temporarily* to aid the debugging.
-    result.base.incl repDebugTraceKinds
+    result.base.incl repDbgTraceKinds
 
   result.main[compVerbosityMax] =
     result.base + repWarningKinds + repHintKinds - {

--- a/compiler/front/scriptconfig.nim
+++ b/compiler/front/scriptconfig.nim
@@ -21,7 +21,6 @@ import
     ast,
     idents,
     wordrecg,
-    reports,
     llstream,
   ],
   compiler/modules/[
@@ -46,6 +45,10 @@ import
   compiler/utils/[
     pathutils
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_debug import DebugReport
+from compiler/ast/report_enums import ReportKind
 
 # we support 'cmpIgnoreStyle' natively for efficiency:
 from std/strutils import cmpIgnoreStyle, contains

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -168,10 +168,9 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
       of repSem:
         if r.kind == rsemProcessingStmt:
           s.addFields(r.semReport, f & "node")
-
         else:
           s.addFields(r.semReport, f)
-
+      of repDbgTrace: s.addFields(r.dbgTraceReport, f)
       of repDebug:    s.addFields(r.debugReport, f)
       of repInternal: s.addFields(r.internalReport, f)
       of repBackend:  s.addFields(r.backendReport, f)

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -19,7 +19,6 @@ import
     ast,
     idents,
     lineinfos,
-    reports
   ],
   compiler/front/[
     msgs,
@@ -29,6 +28,11 @@ import
     ropes,
     pathutils
   ]
+
+# TODO: at least switch to internalAssert/Error or better have its own
+#       diag/event/telemetry types
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/report_enums import ReportKind
 
 from std/os import removeFile, isAbsolute
 

--- a/compiler/ic/navigator.nim
+++ b/compiler/ic/navigator.nim
@@ -14,7 +14,6 @@
 import
   compiler/ast/[
     ast,
-    reports
   ],
   compiler/modules/[
     modulegraphs
@@ -24,6 +23,11 @@ import
     options
   ],
   std/sets
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport
+from compiler/ast/reports_external import ExternalReport
+from compiler/ast/report_enums import ReportKind
 
 
 from std/os import nil

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -15,7 +15,6 @@ import
   compiler/ast/[
     ast,
     trees,
-    reports,
   ],
   compiler/modules/[
     modulegraphs,
@@ -32,6 +31,9 @@ import
     extccomp,
     cgmeth
   ]
+
+from compiler/ast/reports_sem import reportStr
+from compiler/ast/report_enums import ReportKind
 
 import std/tables
 

--- a/compiler/modules/importer.nim
+++ b/compiler/modules/importer.nim
@@ -21,7 +21,6 @@ import
     idents,
     lineinfos,
     wordrecg,
-    reports,
     errorhandling,
     errorreporting,
   ],
@@ -37,6 +36,12 @@ import
     lookups,
     semdata,
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportAst,
+  reportSem,
+  reportSym
+from compiler/ast/report_enums import ReportKind
 
 proc declarePureEnumField*(c: PContext; s: PSym) =
   # XXX Remove the outer 'if' statement and see what breaks.

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -29,6 +29,16 @@ import
     options
   ]
 
+# TODO: `reportStr` is being abused, it's not quite a sem error
+from compiler/ast/reports_sem import reportStr,
+  reportSymbols,
+  reportTyp
+
+# TODO: at least use internalAssert/Error better still have its own data type
+#       for diag/event/telemetry
+from compiler/ast/reports_internal import InternalReport
+# from compiler/ast/report_enums import ReportKind
+
 export createMagic
 
 proc nilOrSysInt*(g: ModuleGraph): PType = g.sysTypes[tyInt]
@@ -150,7 +160,7 @@ proc registerNimScriptSymbol*(g: ModuleGraph; s: PSym) =
       rsemConflictingExportnims, @[s, conflict]))
 
 proc registerNimScriptSymbol2*(g: ModuleGraph; s: PSym): PNode =
-  # Nimscript symbols must be al unique:
+  # Nimscript symbols must be all unique:
   result = g.emptyNode
   let conflict = strTableGet(g.exposed, s.name)
   if conflict == nil:

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -27,7 +27,6 @@ import
     astalgo,
     lineinfos,
     idents,
-    reports
   ],
   compiler/utils/[
     pathutils,
@@ -38,6 +37,10 @@ import
     packed_ast,
     ic
   ]
+
+# xxx: all this to output '.' on the command line... it's not even sem
+from compiler/ast/reports_sem import SemReport
+from compiler/ast/report_enums import ReportKind
 
 type
   SigHash* = distinct MD5Digest

--- a/compiler/modules/modulepaths.nim
+++ b/compiler/modules/modulepaths.nim
@@ -16,7 +16,6 @@ import
     ast,
     lineinfos,
     renderer,
-    reports,
   ],
   compiler/utils/[
     pathutils,
@@ -26,6 +25,10 @@ import
     options,
   ]
 
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportAst
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/report_enums import ReportKind
 
 when false:
   const

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -20,7 +20,6 @@ import
     lexer,
     llstream,
     lineinfos,
-    reports,
     syntaxes,
   ],
   compiler/front/[
@@ -41,6 +40,10 @@ import
     replayer
   ]
 
+# TODO: `modules` shouldn't report "semantic analysis" errors
+from compiler/ast/reports_sem import reportSym
+from compiler/ast/reports_external import ExternalReport
+from compiler/ast/report_enums import ReportKind
 
 proc resetSystemArtifacts*(g: ModuleGraph) =
   magicsys.resetSysTypes(g)
@@ -52,14 +55,16 @@ template packageId(): untyped {.dirty.} = ItemId(module: PackageModuleId, item: 
 
 proc getPackage(graph: ModuleGraph; fileIdx: FileIndex): PSym =
   ## returns package symbol (skPackage) for yet to be defined module for fileIdx
-  let filename = AbsoluteFile toFullPath(graph.config, fileIdx)
-  let name = getModuleIdent(graph, filename)
-  let info = newLineInfo(fileIdx, 1, 1)
   let
+    filename = AbsoluteFile toFullPath(graph.config, fileIdx)
+    name = getModuleIdent(graph, filename)
+    info = newLineInfo(fileIdx, 1, 1)
     pck = getPackageName(graph.config, filename.string)
     pck2 = if pck.len > 0: pck else: "unknown"
     pack = getIdent(graph.cache, pck2)
+  
   result = graph.packageSyms.strTableGet(pack)
+  
   if result == nil:
     result = newSym(skPackage, getIdent(graph.cache, pck2), packageId(), nil, info)
     #initStrTable(packSym.tab)

--- a/compiler/modules/nimblecmd.nim
+++ b/compiler/modules/nimblecmd.nim
@@ -30,6 +30,9 @@ import
     pathutils
   ]
 
+# TODO: implement this modules own diag/event/telemetry types
+from compiler/ast/reports_external import ExternalReport
+from compiler/ast/report_enums import ReportKind
 
 proc addPath*(conf: ConfigRef; path: AbsoluteDir, info: TLineInfo) =
   if not conf.searchPaths.contains(path):

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -37,14 +37,14 @@ import
     pathutils
   ],
   compiler/ast/[
-    reports, idents
+    idents
   ]
 
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/reports_external import ExternalReport
+from compiler/ast/report_enums import ReportKind
 
-# import
-#   cli_reporter,
-#   commands, options, msgs,  main, idents, cmdlinehelper,
-#   pathutils, modulegraphs, reports
 
 from std/browsers import openDefaultBrowser
 from compiler/utils/nodejs import findNodeJs

--- a/compiler/plugins/itersgen.nim
+++ b/compiler/plugins/itersgen.nim
@@ -11,7 +11,6 @@
 
 import
   compiler/ast/[
-    reports,
     ast
   ],
   compiler/modules/[
@@ -25,6 +24,10 @@ import
     semdata,
     lambdalifting
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportAst
+from compiler/ast/report_enums import ReportKind
 
 proc iterToProcImpl*(c: PContext, n: PNode): PNode =
   result = newNodeI(nkStmtList, n.info)

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -16,7 +16,6 @@ import
     lineinfos,
     idents,
     renderer,
-    reports,
     errorhandling,
     errorreporting
   ],
@@ -27,6 +26,12 @@ import
   compiler/utils/[
     debugutils
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
+  reportAst,
+  reportSem
+from compiler/ast/report_enums import ReportKind
 
 type
   TemplCtx = object

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -19,7 +19,6 @@ import
     trees,
     types,
     lineinfos,
-    reports
   ],
   compiler/utils/[
     saturate,
@@ -34,7 +33,9 @@ import
     options,
   ]
 
-
+from compiler/ast/reports_sem import reportAst,
+  reportTyp
+from compiler/ast/report_enums import ReportKind
 
 const
   someEq = {mEqI, mEqF64, mEqEnum, mEqCh, mEqB, mEqRef, mEqProc,

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -28,7 +28,6 @@ import
     typesrenderer,
     idents,
     lineinfos,
-    reports
   ],
   compiler/modules/[
     magicsys,
@@ -47,6 +46,14 @@ import
     optimizer,
     varpartitions
   ]
+
+from std/options as std_options import some, none
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
+  reportAst,
+  reportSem
+from compiler/ast/report_enums import ReportKind
 
 from compiler/ast/trees import exprStructuralEquivalent, getRoot
 
@@ -550,9 +557,10 @@ proc cycleCheck(n: PNode; c: var Con) =
       break
     if exprStructuralEquivalent(x, value, strictSymEquality = true):
       localReport(c.graph.config, n.info):
-        reportAst(rsemUncollectableRefCycle, field).withIt do:
-          it.cycleField = field
-
+        block:
+          var r = reportAst(rsemUncollectableRefCycle, field)
+          r.cycleField = field
+          r
 
       break
 

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -17,7 +17,6 @@ import
   compiler/ast/[
     ast,
     astalgo,
-    reports,
     idents,
     renderer,
     types,
@@ -37,6 +36,12 @@ import
     transf,
     lowerings
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
+  reportSem,
+  reportSymbols
+from compiler/ast/report_enums import ReportKind
 
 discard """
   The basic approach is that captured vars need to be put on the heap and

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -20,7 +20,6 @@ import
     ast,
     renderer,
     types,
-    reports,
     trees
   ],
   compiler/modules/[
@@ -41,6 +40,12 @@ import
   compiler/backend/[
     ccgutils
   ]
+
+from compiler/ast/reports_sem import reportAst,
+  reportSem,
+  reportSym,
+  reportTyp
+from compiler/ast/report_enums import ReportKind
 
 type
   TLiftCtx = object

--- a/compiler/sem/lowerings.nim
+++ b/compiler/sem/lowerings.nim
@@ -19,7 +19,6 @@ import
     types,
     idents,
     lineinfos,
-    reports
   ],
   compiler/modules/[
     modulegraphs,
@@ -29,6 +28,9 @@ import
     msgs,
     options
   ]
+
+from compiler/ast/reports_sem import reportStr
+from compiler/ast/report_enums import ReportKind
 
 proc newDeref*(n: PNode): PNode {.inline.} =
   result = newTreeIT(nkHiddenDeref, n.info, n.typ[0]): n

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -23,7 +23,6 @@ import
     renderer,
     lineinfos,
     idents,
-    reports,
     treetab,
   ],
   compiler/modules/[
@@ -36,6 +35,12 @@ import
   compiler/sem/[
     nilcheck_enums
   ]
+
+# TODO: the `SemNilHistory` data type was put into reporting even though it
+#       _clearly_ belongs here, in the module that makes it.
+from compiler/ast/reports_sem import SemNilHistory,
+  SemReport
+from compiler/ast/report_enums import ReportKind
 
 # IMPORTANT: notes not up to date, i'll update this comment again
 #

--- a/compiler/sem/parampatterns.nim
+++ b/compiler/sem/parampatterns.nim
@@ -20,12 +20,15 @@ import
     renderer,
     wordrecg,
     trees,
-    reports
   ],
   compiler/front/[
     msgs,
     options
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportAst
+from compiler/ast/report_enums import ReportKind
 
 # we precompile the pattern here for efficiency into some internal
 # stack based VM :-) Why? Because it's fun; I did no benchmarks to see if that

--- a/compiler/sem/passaux.nim
+++ b/compiler/sem/passaux.nim
@@ -12,7 +12,6 @@
 import
   compiler/ast/[
     ast,
-    reports
   ],
   compiler/modules/[
     modulegraphs
@@ -24,6 +23,10 @@ import
   compiler/sem/[
     passes
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportSem
+from compiler/ast/report_enums import ReportKind
 
 type
   VerboseRef = ref object of PPassContext

--- a/compiler/sem/passes.nim
+++ b/compiler/sem/passes.nim
@@ -22,12 +22,16 @@ import
     ast,
     llstream,
     syntaxes,
-    reports,
     lineinfos,
   ],
   compiler/utils/[
     pathutils
   ]
+
+# TODO: `reportStr` is being abused, it's not quite a sem error
+from compiler/ast/reports_sem import reportStr
+from compiler/ast/report_enums import ReportKind
+
 
 type
   TPassData* = tuple[input: PNode, closeOutput: PNode]
@@ -37,11 +41,9 @@ proc makePass*(open: TPassOpen = nil,
                process: TPassProcess = nil,
                close: TPassClose = nil,
                isFrontend = false): TPass =
-
   ## a pass is a tuple of procedure vars ``TPass.close`` may produce additional
   ## nodes. These are passed to the other close procedures.
   ## This mechanism used to be used for the instantiation of generics.
-
   result.open = open
   result.close = close
   result.process = process
@@ -138,7 +140,6 @@ proc prepareConfigNotes(graph: ModuleGraph; module: PSym) =
   # don't be verbose unless the module belongs to the main package:
   if module.getnimblePkgId == graph.config.mainPackageId:
     graph.config.asgn(cnCurrent, cnMainPackage)
-
   else:
     # QUESTION what are the exact conditions that lead to this branch being
     # executed? For example, if I compile `tests/arc/thard_alignment.nim`,
@@ -185,9 +186,7 @@ proc processModule*(
       localReport(
         graph.config,
         reportStr(rsemCannotOpenFile, filename.string))
-
       return false
-
   else:
     stream = defaultStream
 

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -24,7 +24,6 @@ import
     trees,
     linter,
     errorhandling,
-    reports,
     lineinfos
   ],
   compiler/modules/[
@@ -47,7 +46,18 @@ import
     extccomp
   ]
 
-
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
+  reportAst,
+  reportSem,
+  reportStr,
+  reportSym,
+  reportTyp
+from compiler/ast/reports_debug import DebugReport
+from compiler/ast/report_enums import ReportKind,
+  ReportKinds,
+  repHintKinds,
+  repWarningKinds
 
 from compiler/ic/ic import addCompilerProc
 

--- a/compiler/sem/procfind.nim
+++ b/compiler/sem/procfind.nim
@@ -16,7 +16,6 @@ import
     astalgo,
     types,
     trees,
-    reports
   ],
   compiler/front/[
      msgs,
@@ -25,6 +24,10 @@ import
      semdata,
      lookups,
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportSym
+from compiler/ast/report_enums import ReportKind
 
 proc equalGenericParams(procA, procB: PNode): bool =
   if procA.len != procB.len: return false

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -29,7 +29,6 @@ import
     errorreporting,
     errorhandling,
     astmsgs,
-    reports,
     lineinfos,
     idents,
     enumtostr,
@@ -83,6 +82,29 @@ import
     vmdef,
     vm
   ]
+
+from std/options as std_options import some, none
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
+  SemCallMismatch, # xxx: used by `semcall` at least
+  MismatchInfo,    # xxx: used by `semcall` at least
+  reportAst,
+  reportSem,       # xxx: used by `semcall` at least
+  reportStr,       # xxx: used by `semtypes` at least
+  reportSym,
+  reportSymbols,   # xxx: used by `semcall` at least
+  reportTyp        # xxx: used by `semtypes` at least
+
+# TODO: `semtypes` misuses `VMReport` to indicate a compile time error, it's a
+#       semantic analysis error born of compile time evaluation
+from compiler/ast/reports_vm import VMReport
+from compiler/ast/report_enums import ReportKind
+
+when defined(nimsuggest):
+  # TODO: used in `semexprs.tryIt` for the report hook, it's far too broad and
+  #       it's silly that the compiler hook looks so broadly
+  from compiler/ast/reports import Report
 
 import compiler/tools/suggest
 

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -200,7 +200,7 @@ proc notFoundError(c: PContext, n: PNode, errors: seq[SemCallMismatch]): PNode =
 
   if f.kind in {nkSym, nkIdent}:
     report.spellingCandidates = fixSpelling(
-      c, tern(f.kind == nkSym, f.sym.name, f.ident))
+      c, if f.kind == nkSym: f.sym.name else: f.ident)
 
   discard maybeResemArgs(c, n, 1)
   report.callMismatches = errors

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -27,7 +27,6 @@ import
     renderer,
     lineinfos,
     linter,
-    reports,
     trees,
     wordrecg,
   ],
@@ -45,6 +44,13 @@ import
     pathutils,
     astrepr,
   ]
+
+from compiler/ast/reports_sem import reportAst,
+  reportSym
+
+# TODO: `ReportKinds` is being abused for notes again, it covers far too much
+from compiler/ast/report_enums import ReportKinds,
+  ReportKind
 
 export TExprFlag, TExprFlags
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -688,7 +688,10 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
       if not isOrdinalType(idx.typ):
         result = n
         result[0][0] = c.config.newError(x[0]):
-          reportTyp(rsemExpectedOrdinal, idx.typ, ast = result).withIt: it.wrongNode = idx
+          block:
+            var r = reportTyp(rsemExpectedOrdinal, idx.typ, ast = result)
+            r.wrongNode = idx
+            r
         result = c.config.wrapError(result)
         return
 
@@ -1632,8 +1635,10 @@ proc dotTransformation(c: PContext, n: PNode): PNode =
       else:
         # we have an error, set it in the first pos handle on return
         c.config.newError(n):
-          reportAst(rsemIdentExpectedInExpr, n[1]).withIt do:
-                      it.wrongNode = n
+          block:
+            var r = reportAst(rsemIdentExpectedInExpr, n[1])
+            r.wrongNode = n
+            r
 
   result.add copyTree(n[0])
 

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -23,7 +23,6 @@ import
     ast,
     trees,
     lineinfos,
-    reports
   ],
   compiler/modules/[
     magicsys,
@@ -37,6 +36,12 @@ import
   compiler/utils/[
     platform,
   ]
+
+from compiler/ast/reports_sem import SemReport,
+  reportAst,
+  reportStr,
+  reportTyp
+from compiler/ast/report_enums import ReportKind
 
 from system/memory import nimCStrLen
 

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -21,9 +21,11 @@ proc semAddrArg(c: PContext; n: PNode; isUnsafeAddr = false): PNode =
   else:
     # Do not suggest the use of unsafeAddr if this expression already is a
     # unsafeAddr
-    result = newError(c.config, n,
-      reportSem(rsemExprHasNoAddress).withIt do:
-        it.isUnsafeAddr = true)
+    result = newError(c.config, n):
+      block:
+        var r = reportSem(rsemExprHasNoAddress)
+        r.isUnsafeAddr = true
+        r
 
 proc semTypeOf(c: PContext; n: PNode): PNode =
   var m = BiggestInt 1 # typeOfIter

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -117,12 +117,12 @@ proc semConstrField(c: PContext, flags: TExprFlags,
       result = newError(
         c.config,
         result,
-        reportSym(
-          rsemFieldOkButAssignedValueInvalid,
-          field,
-          ast = initValue
-        ).withIt do:
-          it.wrongNode = result
+        block:
+          var r = reportSym(rsemFieldOkButAssignedValueInvalid,
+                            field,
+                            ast = initValue)
+          r.wrongNode = result
+          r
       )
 
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1634,9 +1634,11 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
 
     if m.state != csMatch:
       localReport(c.config, n.info):
-        reportTyp(rsemCannotInstantiateWithParameter, t, ast = n).withIt do:
-          it.arguments.got = maybeResemArgs(c, n)
-          it.arguments.expected = maybeResemArgs(c, t.n, 0)
+        block:
+          var r = reportTyp(rsemCannotInstantiateWithParameter, t, ast = n)
+          r.arguments.got = maybeResemArgs(c, n)
+          r.arguments.expected = maybeResemArgs(c, t.n, 0)
+          r
 
       return newOrPrevType(tyError, prev, c)
 

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -23,7 +23,6 @@ import
     lineinfos,
     errorreporting,
     errorhandling,
-    reports,
   ],
   compiler/modules/[
     modulegraphs,
@@ -44,6 +43,22 @@ import
     debugutils,
   ]
 
+# xxx: reports are a code smell meaning data types are misplaced, for example
+#      SemCallMismatch, SemDiagnostics, MismatchInfo, and
+#      DebugCallableCandidate
+from compiler/ast/reports_sem import SemReport,
+  MismatchInfo,
+  SemCallMismatch,
+  SemDiagnostics,
+  DebugCallableCandidate,
+  reportAst,
+  reportSym
+from compiler/ast/report_enums import ReportKind,
+  repSem
+
+# TODO: this report hook is bonkers, we're looking at any possible "report" for
+#       errors to include in diagnostics, it's far too broad
+from compiler/ast/reports import Report
 
 type
   TCandidateState* = enum

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -23,7 +23,6 @@ import
     ast,
     astalgo,
     trees,
-    reports,
     idents,
     renderer,
     types,
@@ -45,6 +44,11 @@ import
   compiler/backend/[
     cgmeth
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
+  reportAst
+from compiler/ast/report_enums import ReportKind
 
 proc transformBody*(g: ModuleGraph; idgen: IdGenerator, prc: PSym, cache: bool): PNode
 

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -18,7 +18,6 @@ import
     ast,
     renderer,
     types,
-    reports,
     errorhandling,
   ],
   compiler/front/[
@@ -27,6 +26,9 @@ import
   compiler/sem/[
     semdata,
   ]
+
+from compiler/ast/reports_sem import SemReport
+from compiler/ast/report_enums import ReportKind
 
 export TTypeAllowedFlag, TTypeAllowedFlags
 

--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -34,7 +34,6 @@ import
     lineinfos,
     types,
     renderer,
-    reports
   ],
   compiler/front/[
     options,
@@ -46,6 +45,13 @@ import
   compiler/modules/[
     modulegraphs,
   ]
+
+
+from compiler/ast/reports_sem import SemReport,
+  reportAst,
+  reportSym,
+  reportSymbols
+from compiler/ast/report_enums import ReportKind
 
 from compiler/ast/trees import getMagic, isNoSideEffectPragma,
                                stupidStmtListExpr

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -35,7 +35,6 @@ import
     astalgo,
     lineinfos,
     renderverbatim,
-    reports
   ],
   compiler/modules/[
     nimpaths
@@ -47,6 +46,13 @@ import
   compiler/utils/[
     pathutils,
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportAst
+from compiler/ast/reports_backend import BackendReport
+from compiler/ast/reports_cmd import CmdReport
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/report_enums import ReportKind
 
 
 import

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -24,7 +24,6 @@ import
     renderer, # toStrLit implementation
     trees,
     idents,
-    reports,
     typesrenderer,
     types,
   ],
@@ -68,6 +67,21 @@ import
   experimental/[
     results
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_vm import VMReport
+from compiler/ast/reports_sem import SemReport,
+  reportAst,
+  reportSym
+from compiler/ast/reports_debug import DebugReport
+from compiler/ast/reports_internal import InternalReport
+from compiler/ast/report_enums import ReportKind
+
+# xxx: `Report` is faaaar too wide a type for what the VM needs, even with all
+#      the ground that can cover.
+from compiler/ast/reports import Report,
+  toReportLineInfo,
+  wrap
 
 when defined(nimVMDebugGenerate):
   import compiler/vm/vmutils

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -23,7 +23,6 @@ import
     ast_types,
     lineinfos,
     astalgo, # for `getModule`
-    reports
   ],
   compiler/front/[
     msgs,
@@ -49,6 +48,10 @@ import
   experimental/[
     results
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_backend import BackendReport
+from compiler/ast/report_enums import ReportKind
 
 import std/options as stdoptions
 

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -13,7 +13,6 @@ import
     errorhandling,
     lineinfos,
     nimsets,
-    reports,
     types
   ],
   compiler/front/[
@@ -36,6 +35,11 @@ import
   experimental/[
     results
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
+  reportAst
+from compiler/ast/report_enums import ReportKind
 
 # XXX: the function signatures are a bit cumbersome here
 

--- a/compiler/vm/vmconv.nim
+++ b/compiler/vm/vmconv.nim
@@ -2,9 +2,6 @@
 ## locations. These are useful when writing VM callbacks.
 
 import
-  compiler/ast/[
-    reports
-  ],
   compiler/front/[
     options
   ],
@@ -17,6 +14,10 @@ import
     vmobjects,
     vmmemory
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_vm import VMReport
+from compiler/ast/report_enums import ReportKind
 
 # XXX: A better approach than `tryWrite` is needed if the plan is to wrap
 #      large parts of the stdlib... (macros come to mind)

--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -17,7 +17,6 @@ import
     idents,
     lineinfos,
     parser,
-    reports
   ],
   compiler/front/[
     cli_reporter,
@@ -30,6 +29,17 @@ import
   experimental/[
     results
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportStr
+from compiler/ast/report_enums import ReportKind,
+  ReportCategory
+
+# xxx: `Report` is faaaar too wide a type for what the VM needs, even with all
+#      the ground that can cover.
+from compiler/ast/reports import Report,
+  ReportSeverity,
+  kind
 
 proc opSlurp*(file: string, info: TLineInfo, module: PSym; conf: ConfigRef): string =
   try:

--- a/compiler/vm/vmerrors.nim
+++ b/compiler/vm/vmerrors.nim
@@ -10,13 +10,16 @@
 
 import
   compiler/ast/[
-    reports,
     lineinfos,
   ],
   compiler/front/[
     msgs
-  ]
+  ],
+  std/options
 
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_vm import VMReport
+from compiler/ast/reports import toReportLineInfo
 
 type VmError* = object of CatchableError
   report*: VMReport

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -36,9 +36,8 @@ import
     renderer,
     types,
     ast,
-    reports,
     lineinfos,
-    astmsgs
+    astmsgs,
   ],
   compiler/modules/[
     magicsys,
@@ -64,6 +63,13 @@ import
   experimental/[
     results
   ]
+
+import std/options as std_options
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_vm import VMReport
+from compiler/ast/report_enums import ReportKind
+from compiler/ast/reports import toReportLineInfo
 
 from std/bitops import bitor
 

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -16,7 +16,6 @@ import
     ast_types,
     ast,
     idents,
-    reports,
   ],
   compiler/front/[
     options
@@ -37,6 +36,10 @@ import
   experimental/[
     results
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_vm import VMReport
+from compiler/ast/report_enums import ReportKind
 
 from std/math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
   arctan, arctan2, cos, cosh, hypot, sinh, sin, tan, tanh, pow, trunc,

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -23,7 +23,6 @@ import std/options as std_options
 
 import
   compiler/ast/[
-    reports,
     idents,
     lineinfos,
     ast
@@ -48,6 +47,18 @@ import
     passes,
     passaux,
   ]
+
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import reportSem
+from compiler/ast/report_enums import ReportCategory,
+  ReportKind
+
+# TODO: `Report` is far too broad a type, includes help messages (wtf), the
+#       structured report hook is overly broad and lost the plot
+from compiler/ast/reports import Report,
+  category,
+  kind,
+  location
 
 from compiler/tools/suggest import isTracked, listUsages, suggestSym, `$`
 
@@ -114,7 +125,7 @@ proc myLog(conf: ConfigRef, s: string, flags: MsgFlags = {}) =
 proc reportHook(conf: ConfigRef, report: Report): TErrorHandling =
   result = doNothing
   case report.category
-  of repCmd, repDebug, repInternal, repExternal:
+  of repCmd, repDebug, repDbgTrace, repInternal, repExternal:
     myLog(conf, $report)
   of repParser, repLexer, repSem, repVM:
     if report.category == repSem and

--- a/tests/compilerunits/confread/treport_filtering.nim
+++ b/tests/compilerunits/confread/treport_filtering.nim
@@ -34,6 +34,10 @@ import
     nimconf
   ]
 
+# xxx: all the `reports` bits are legacy
+from compiler/ast/reports_debug import DebugReport
+
+
 var reported: seq[Report]
 
 proc hook(conf: ConfigRef, report: Report): TErrorHandling =
@@ -67,7 +71,6 @@ proc cfgPass*(file: string, args: seq[string]): ConfigRef =
 
 proc assertInter[T](inters: set[T], want: set[T] = {}) =
   doAssert inters == want, $want
-
 block fist_pass_tests:
   block:
     let conf = firstPass(@["compile", "--hint=all:off"])
@@ -104,14 +107,10 @@ block first_and_cfg_pass:
       case r.kind:
         of rdbgStartingConfRead:
           result.reads.add r.debugReport
-
         of rdbgCfgTrace:
           result.trace.add r.debugReport
-
         else:
           discard
-
-
 
   block:
     var conf = cfgPass(file, @["compile"])


### PR DESCRIPTION
## Summary

- extracts specific report modules from `compiler/ast/reports`
- removes direct `reports` dependency from all over the compiler
- preparing rework of compiler diagnostics/events/output/telemetry

## Details

- extract `LexerReport`, `ParserReport`, etc types into separate modules
- split out compiler execution tracing into `TraceSemReport` (temp name)
- added `ReportCategory` for the traces (previous point)
- remove direct import of the `reports` module
- switched to narrow imports to highlight the scope of issues
- marked all reports imports to clarify we're moving away

### Misc

- fixed formatting
- removed `withIt` usage, not sure I want this to be an idiom (untyped)

Future Work/Observations:

- structured reporting hook
  - the original purpose is totally lost
  - `Report` covers far too much and the hook too
  - an any output hook wasn't the point, it needs to be split
- modules must own the data types they produce
- broad exports are a smell
- inheritance among the report data types is creating dependency cycles

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* unless there is a bug it's good to merge