### PR TITLE
vm: move the compiler interface into a separate module

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -677,7 +677,15 @@ proc canRaise*(fn: PNode): bool =
 proc skipAddr*(n: PNode): PNode {.inline.} =
   if n.kind == nkHiddenAddr: n[0] else: n
 
-
+iterator genericParamsInMacroCall*(macroSym: PSym, call: PNode): (PSym, PNode) =
+  ## For a macro call, yields the symbol for each generic parameter toghether
+  ## with the *argument* provided to it
+  let gp = macroSym.ast[genericParamsPos]
+  for i in 0..<gp.len:
+    let genericParam = gp[i].sym
+    let posInCall = macroSym.typ.len + i
+    if posInCall < call.len:
+      yield (genericParam, call[posInCall])
 
 type
   NodePosName* = enum

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -50,8 +50,8 @@ import
     pathutils    # Input file handling
   ],
   compiler/vm/[
-    vm,          # Configuration file evaluation, `nim e`
-    vmbackend,   # VM code generation
+    compilerbridge, # Configuration file evaluation, `nim e`
+    vmbackend,      # VM code generation
     vmprofiler
   ]
 

--- a/compiler/front/scriptconfig.nim
+++ b/compiler/front/scriptconfig.nim
@@ -32,9 +32,11 @@ import
     sem,
   ],
   compiler/vm/[
-    vm,
+    compilerbridge,
     vmconv,
     vmdef,
+    vmhooks,
+    vmops
   ],
   compiler/front/[
     msgs,

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -79,8 +79,9 @@ import
     active
   ],
   compiler/vm/[
+    compilerbridge,
     vmdef,
-    vm
+    vmhooks
   ]
 
 from std/options as std_options import some, none

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -915,7 +915,7 @@ proc semNormalizedLetOrVar(c: PContext, n: PNode, symkind: TSymKind): PNode =
     if not hasError and sfCompileTime in v.flags:
       var x = newNodeI(result.kind, v.info)
       x.add producedDecl
-      vm.setupCompileTimeVar(c.module, c.idgen, c.graph, x)
+      setupCompileTimeVar(c.module, c.idgen, c.graph, x)
 
     if v.flags * {sfGlobal, sfThread} == {sfGlobal}:
       # this is just logging, doesn't need to be converted to an error

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -1,0 +1,465 @@
+## This module implements the interface between the VM and the rest of the
+## compiler. The VM is only interacted with through this interface. Do note
+## that right now, the compiler still indirectly interacts with the VM through
+## the ``vmdef.PCtx`` object.
+##
+## The interface includes:
+## - the procedure that sets up a VM instance for use during compilation
+##   (``setupGlobalCtx``)
+## - the routines for executing expressions, statements, and macros with the VM
+## - an implementation of the ``passes`` interface that executes processed
+##   code with the VM (``evalPass``)
+## - the VM-related compilerapi
+
+import
+  std/[
+    tables
+  ],
+  compiler/ast/[
+    ast_types,
+    ast,
+    errorhandling,
+    errorreporting,
+    lineinfos,
+    trees
+  ],
+  compiler/front/[
+    msgs,
+    options
+  ],
+  compiler/modules/[
+    modulegraphs
+  ],
+  compiler/sem/[
+    passes,
+    transf
+  ],
+  compiler/utils/[
+    debugutils
+  ],
+  compiler/vm/[
+    vmcompilerserdes,
+    vmdef,
+    vmjit,
+    vmops,
+    vmtypegen,
+    vm
+  ],
+  experimental/[
+    results
+  ]
+
+from compiler/ast/reports import wrap
+from compiler/ast/reports_vm import VMReport
+from compiler/ast/reports_sem import SemReport
+from compiler/ast/report_enums import ReportKind
+
+# to prevent endless recursion in macro instantiation
+const evalMacroLimit = 1000
+
+proc putIntoReg(dest: var TFullReg; c: var TCtx, n: PNode, formal: PType) =
+  ## Put the value that is represented by `n` (but not the node itself) into
+  ## `dest`. Implicit conversion is also performed, if necessary.
+  let t = formal.skipTypes(abstractInst+{tyStatic}-{tyTypeDesc})
+
+  # XXX: instead of performing conversion here manually, sem could generate a
+  #      small thunk for macro invocations that sets up static arguments and
+  #      then invokes the macro. The thunk would be executed in the VM, making
+  #      the code here obsolete while also eliminating unnecessary
+  #      deserialize/serialize round-trips
+
+  case t.kind
+  of tyBool, tyChar, tyEnum, tyInt..tyInt64, tyUInt..tyUInt64:
+    assert n.kind in nkCharLit..nkUInt64Lit
+    dest.ensureKind(rkInt, c.memory)
+    dest.intVal = n.intVal
+  of tyFloat..tyFloat128:
+    assert n.kind in nkFloatLit..nkFloat128Lit
+    dest.ensureKind(rkFloat, c.memory)
+    dest.floatVal = n.floatVal
+  of tyNil, tyPtr, tyPointer:
+    dest.ensureKind(rkAddress, c.memory)
+    # XXX: it's currently forbidden to pass non-nil pointer to static
+    #      parameters. `deserialize` already reports an error, so an
+    #      assert is used here to make sure that it really got reported
+    #      earlier
+    assert n.kind == nkNilLit
+  of tyOpenArray:
+    # Handle `openArray` parameters the same way they're handled elsewhere
+    # in the VM: simply pass the argument without a conversion
+    let typ = c.getOrCreate(n.typ)
+    dest.initLocReg(typ, c.memory)
+    c.serialize(n, dest.handle)
+  of tyProc:
+    # XXX: a hack required to uphold some expectations. For example,
+    #      `genEnumCaseStmt` would fail without this. Procedural types as
+    #      static macro arguments are underspecified
+    let pt =
+      if t.callConv == ccClosure and n.kind == nkSym:
+        # Force the location to be of non-closure type. This breaks other
+        # assumptions!
+        n.sym.typ
+      else:
+        t
+
+    let typ = c.getOrCreate(pt)
+    dest.initLocReg(typ, c.memory)
+    c.serialize(n, dest.handle, pt)
+
+  else:
+    if t.kind == tyRef and t.sym != nil and t.sym.magic == mPNimrodNode:
+      # A NimNode
+      dest.ensureKind(rkNimNode, c.memory)
+      dest.nimNode = n
+    else:
+      let typ = c.getOrCreate(formal)
+      dest.initLocReg(typ, c.memory)
+      # XXX: overriding the type (passing `formal`), leads to issues (internal
+      #      compiler error) when passing an empty set to a static parameter
+      c.serialize(n, dest.handle)#, formal)
+
+proc unpackResult(res: sink ExecutionResult; config: ConfigRef, node: PNode): PNode =
+  ## Unpacks the execution result. If the result represents a failure, returns
+  ## a new `nkError` wrapping `node`. Otherwise, returns the value/tree result,
+  ## optionally filling in the node's `info` with that of `node`, if not
+  ## present already.
+  if res.isOk:
+    result = res.take
+    if node != nil and result.info.line < 0:
+      result.info = node.info
+  else:
+    let
+      err = res.takeErr
+      errKind = err.report.kind
+
+      stId = config.addReport(wrap(err.stackTrace))
+      rId = config.addReport(wrap(err.report))
+
+    result = config.newError(node, errKind, rId, instLoc(-1)):
+                             [newIntNode(nkIntLit, ord(stId))]
+
+proc execute(c: var TCtx, info: CodeInfo): ExecutionResult =
+  var tos = TStackFrame(prc: nil, comesFrom: 0, next: -1)
+  tos.slots.newSeq(info.regCount)
+  execute(c, info.start, tos,
+          proc(c: TCtx, r: TFullReg): PNode = c.graph.emptyNode)
+
+template returnOnErr(res: VmGenResult, config: ConfigRef, node: PNode): CodeInfo =
+  ## Unpacks the vmgen result. If the result represents an error, exits the
+  ## calling function by returning a new `nkError` wrapping `node`
+  let r = res
+  if r.isOk:
+    r.take
+  else:
+    let
+      report = r.takeErr
+      kind = report.kind
+      rid = config.addReport(wrap(report))
+
+    return config.newError(node, kind, rid, instLoc())
+
+proc reportIfError(config: ConfigRef, n: PNode) =
+  ## If `n` is a `nkError`, reports the error via `handleReport`. This is
+  ## only meant for errors from vm/vmgen invocations and is also only a
+  ## transition helper until all vm invocation functions properly propagate
+  ## `nkError`
+  if n.isError:
+    # Errors from direct vmgen invocations don't have a stack-trace
+    if n.kids.len == 4 and n.kids[3].kind == nkIntLit:
+      # XXX: testing for the presence of a stack-trace report like this is
+      #      not a good idea. Error node layout might change, making the test
+      #      invalid. VM errors should get their own report object with the
+      #      stack-trace embedded as part of it.
+      config.handleReport(n.kids[3].intVal.ReportId, instLoc(-1)) # stack-trace
+    config.localReport(n)
+
+
+template mkCallback(cn, rn, body): untyped =
+  let p = proc(cn: TCtx, rn: TFullReg): PNode = body
+  p
+
+proc evalStmt(c: var TCtx, n: PNode): PNode =
+  let n = transformExpr(c.graph, c.idgen, c.module, n)
+  let info = genStmt(c, n).returnOnErr(c.config, n)
+
+  # execute new instructions; this redundant opcEof check saves us lots
+  # of allocations in 'execute':
+  if c.code[info.start].opcode != opcEof:
+    result = execute(c, info).unpackResult(c.config, n)
+  else:
+    result = c.graph.emptyNode
+
+proc setupGlobalCtx*(module: PSym; graph: ModuleGraph; idgen: IdGenerator) =
+  addInNimDebugUtils(graph.config, "setupGlobalCtx")
+  if graph.vm.isNil:
+    let
+      ctx = newCtx(module, graph.cache, graph, idgen)
+      disallowDangerous =
+        defined(nimsuggest) or graph.config.cmd == cmdCheck or
+        vmopsDanger notin ctx.config.features
+
+    ctx.codegenInOut.flags = {cgfAllowMeta}
+    registerAdditionalOps(ctx[], disallowDangerous)
+
+    graph.vm = ctx
+  else:
+    let c = PCtx(graph.vm)
+    refresh(c[], module, idgen)
+
+proc evalConstExprAux(module: PSym; idgen: IdGenerator;
+                      g: ModuleGraph; prc: PSym, n: PNode,
+                      mode: TEvalMode): PNode =
+  addInNimDebugUtils(g.config, "evalConstExprAux", prc, n, result)
+  #if g.config.errorCounter > 0: return n
+  let n = transformExpr(g, idgen, module, n)
+  setupGlobalCtx(module, g, idgen)
+  let c = PCtx g.vm
+  let oldMode = c.mode
+  c.mode = mode
+  defer:
+    c.mode = oldMode
+
+  let requiresValue = mode!=emStaticStmt
+  let (start, regCount) = genExpr(c[], n, requiresValue).returnOnErr(c.config, n)
+
+  if c.code[start].opcode == opcEof: return newNodeI(nkEmpty, n.info)
+  assert c.code[start].opcode != opcEof
+  when defined(nimVMDebugGenerate):
+    c.config.localReport():
+      initVmCodeListingReport(c[], prc, n)
+
+  var tos = TStackFrame(prc: prc, comesFrom: 0, next: -1)
+  tos.slots.newSeq(regCount)
+  #for i in 0..<regCount: tos.slots[i] = newNode(nkEmpty)
+  let cb =
+    if requiresValue:
+      mkCallback(c, r): c.regToNode(r, n.typ, n.info)
+    else:
+      mkCallback(c, r): newNodeI(nkEmpty, n.info)
+
+  result = execute(c[], start, tos, cb).unpackResult(c.config, n)
+
+proc evalConstExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode): PNode {.inline.} =
+  result = evalConstExprAux(module, idgen, g, nil, e, emConst)
+
+proc evalStaticExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym): PNode {.inline.} =
+  result = evalConstExprAux(module, idgen, g, prc, e, emStaticExpr)
+
+proc evalStaticStmt*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym) {.inline.} =
+  let r = evalConstExprAux(module, idgen, g, prc, e, emStaticStmt)
+  # TODO: the node needs to be returned to the caller instead
+  reportIfError(g.config, r)
+
+proc setupCompileTimeVar*(module: PSym; idgen: IdGenerator; g: ModuleGraph; n: PNode) {.inline.} =
+  let r = evalConstExprAux(module, idgen, g, nil, n, emStaticStmt)
+  # TODO: the node needs to be returned to the caller instead
+  reportIfError(g.config, r)
+
+proc setupMacroParam(reg: var TFullReg, c: var TCtx, x: PNode, typ: PType) =
+  case typ.kind
+  of tyStatic:
+    putIntoReg(reg, c, x, typ)
+  else:
+    var n = x
+    if n.kind in {nkHiddenSubConv, nkHiddenStdConv}: n = n[1]
+    # TODO: is anyone on the callsite dependent on this modifiction of `x`?
+    n.typ = x.typ
+    reg = TFullReg(kind: rkNimNode, nimNode: n)
+
+proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph; templInstCounter: ref int;
+                    n: PNode, sym: PSym): PNode =
+  #if g.config.errorCounter > 0: return errorNode(idgen, module, n)
+
+  # XXX globalReport() is ugly here, but I don't know a better solution for now
+  inc(g.config.evalMacroCounter)
+  if g.config.evalMacroCounter > evalMacroLimit:
+    globalReport(g.config, n.info, VMReport(
+      kind: rsemMacroInstantiationTooNested, ast: n))
+
+  # immediate macros can bypass any type and arity checking so we check the
+  # arity here too:
+  if sym.typ.len > n.safeLen and sym.typ.len > 1:
+    globalReport(g.config, n.info, SemReport(
+      kind: rsemWrongNumberOfArguments,
+      ast: n,
+      countMismatch: (
+        expected: toInt128(sym.typ.len - 1),
+        got: toInt128(n.safeLen - 1))))
+
+  setupGlobalCtx(module, g, idgen)
+  let c = PCtx g.vm
+  let oldMode = c.mode
+  c.mode = emStaticStmt
+  c.comesFromHeuristic.line = 0'u16
+  c.callsite = n
+  c.templInstCounter = templInstCounter
+
+  defer:
+    # restore the previous state when exiting this procedure
+    # TODO: neither ``mode`` nor ``callsite`` should be stored as part of the
+    #       global execution environment (i.e. ``TCtx``). ``callsite`` is part
+    #       of the state that makes up a single VM invocation, and ``mode`` is
+    #       only needed for ``vmgen``
+    c.mode = oldMode
+    c.callsite = nil
+
+  let (start, regCount) = loadProc(c[], sym).returnOnErr(c.config, n)
+
+  var tos = TStackFrame(prc: sym, comesFrom: 0, next: -1)
+  tos.slots.newSeq(regCount)
+  # setup arguments:
+  var L = n.safeLen
+  if L == 0: L = 1
+  # This is wrong for tests/reject/tind1.nim where the passed 'else' part
+  # doesn't end up in the parameter:
+  #InternalAssert tos.slots.len >= L
+
+  # return value:
+  tos.slots[0] = TFullReg(kind: rkNimNode, nimNode: newNodeI(nkEmpty, n.info))
+
+  # put macro call arguments into registers
+  for i in 1..<sym.typ.len:
+    setupMacroParam(tos.slots[i], c[], n[i], sym.typ[i])
+
+  # put macro generic parameters into registers
+  let gp = sym.ast[genericParamsPos]
+  for i in 0..<gp.safeLen:
+    let idx = sym.typ.len + i
+    if idx < n.len:
+      setupMacroParam(tos.slots[idx], c[], n[idx], gp[i].sym.typ)
+    else:
+      # TODO: the decrement here is wrong, but the else branch is likely
+      #       currently not reached anyway
+      dec(g.config.evalMacroCounter)
+      localReport(c.config, n.info, SemReport(
+        kind: rsemWrongNumberOfGenericParams,
+        countMismatch: (
+          expected: toInt128(gp.len),
+          got: toInt128(idx))))
+
+  # temporary storage:
+  #for i in L..<maxSlots: tos.slots[i] = newNode(nkEmpty)
+
+  # n.typ == nil is valid and means that resulting NimNode represents
+  # a statement
+  let cb = mkCallback(c, r): r.nimNode
+  result = execute(c[], start, tos, cb).unpackResult(c.config, n)
+
+  if result.kind != nkError and cyclicTree(result):
+    globalReport(c.config, n.info, VMReport(
+      kind: rsemCyclicTree, ast: n, sym: sym))
+
+  dec(g.config.evalMacroCounter)
+
+
+# ----------- the VM-related compilerapi -----------
+
+# NOTE: it might make sense to move the VM-related compilerapi into
+#       ``nimeval.nim`` -- the compiler itself doesn't depend on or uses it
+
+proc execProc*(c: var TCtx; sym: PSym; args: openArray[PNode]): PNode =
+  # XXX: `localReport` is still used here since execProc is only used by the
+  # VM's compilerapi (`nimeval`) whose users don't know about nkError yet
+
+  c.loopIterations = c.config.maxLoopIterationsVM
+  if sym.kind in routineKinds:
+    if sym.typ.len-1 != args.len:
+      localReport(c.config, sym.info, SemReport(
+        kind: rsemWrongNumberOfArguments,
+        sym: sym,
+        countMismatch: (
+          expected: toInt128(sym.typ.len - 1),
+          got: toInt128(args.len))))
+
+    else:
+      let (start, maxSlots) = block:
+        # XXX: `returnOnErr` should be used here instead, but isn't for
+        #      backwards compatiblity
+        let r = loadProc(c, sym)
+        if unlikely(r.isErr):
+          localReport(c.config, r.takeErr)
+          return nil
+        r.unsafeGet
+
+      var tos = TStackFrame(prc: sym, comesFrom: 0, next: -1)
+      tos.slots.newSeq(maxSlots)
+
+      # setup parameters:
+      if not isEmptyType(sym.typ[0]) or sym.kind == skMacro:
+        let typ = c.getOrCreate(sym.typ[0])
+        if not tos.slots[0].loadEmptyReg(typ, sym.info, c.memory):
+          tos.slots[0].initLocReg(typ, c.memory)
+      # XXX We could perform some type checking here.
+      for i in 1..<sym.typ.len:
+        putIntoReg(tos.slots[i], c, args[i-1], sym.typ[i])
+
+      let cb =
+        if not isEmptyType(sym.typ[0]):
+          mkCallback(c, r): c.regToNode(r, sym.typ[0], sym.info)
+        elif sym.kind == skMacro:
+          # TODO: missing cyclic check
+          mkCallback(c, r): r.nimNode
+        else:
+          mkCallback(c, r): newNodeI(nkEmpty, sym.info)
+
+      let r = execute(c, start, tos, cb)
+      result = r.unpackResult(c.config, c.graph.emptyNode)
+      reportIfError(c.config, result)
+      if result.isError:
+        result = nil
+  else:
+    localReport(c.config, sym.info):
+      VMReport(kind: rvmCallingNonRoutine, sym: sym)
+
+# XXX: the compilerapi regarding globals (getGlobalValue/setGlobalValue)
+#      doesn't work the same as before. Previously, the returned PNode
+#      could be used to modify the actual global value, but this is not
+#      possible anymore
+
+proc getGlobalValue*(c: TCtx; s: PSym): PNode =
+  ## Does not perform type checking, so ensure that `s.typ` matches the
+  ## global's type
+  internalAssert(c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
+  let slotIdx = c.globals[c.symToIndexTbl[s.id]]
+  let slot = c.heap.slots[slotIdx]
+
+  result = c.deserialize(slot.handle, s.typ, s.info)
+
+proc setGlobalValue*(c: var TCtx; s: PSym, val: PNode) =
+  ## Does not do type checking so ensure the `val` matches the `s.typ`
+  internalAssert(c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
+  let slotIdx = c.globals[c.symToIndexTbl[s.id]]
+  let slot = c.heap.slots[slotIdx]
+
+  c.serialize(val, slot.handle)
+
+## what follows is an implementation of the ``passes`` interface that evaluates
+## the code directly inside the VM. It is used for NimScript execution and by
+## the ``nimeval`` interface
+
+proc myOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext {.nosinks.} =
+  #var c = newEvalContext(module, emRepl)
+  #c.features = {allowCast, allowInfiniteLoops}
+  #pushStackFrame(c, newStackFrame())
+
+  # XXX produce a new 'globals' environment here:
+  setupGlobalCtx(module, graph, idgen)
+  result = PCtx graph.vm
+
+proc myProcess(c: PPassContext, n: PNode): PNode =
+  let c = PCtx(c)
+  # don't eval errornous code:
+  if c.oldErrorCount == c.config.errorCounter:
+    let r = evalStmt(c[], n)
+    reportIfError(c.config, r)
+    # TODO: use the node returned by evalStmt as the result and don't report
+    #       the error here
+    result = newNodeI(nkEmpty, n.info)
+  else:
+    result = n
+  c.oldErrorCount = c.config.errorCounter
+
+proc myClose(graph: ModuleGraph; c: PPassContext, n: PNode): PNode =
+  result = myProcess(c, n)
+
+const evalPass* = makePass(myOpen, myProcess, myClose)

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -38,9 +38,12 @@ import
     passaux
   ],
   compiler/vm/[
+    compilerbridge,
     vmdef,
-    vm
+    vmops
   ]
+
+export compilerbridge
 
 type
   Interpreter* = ref object ## Use Nim as an interpreter with this object
@@ -81,16 +84,16 @@ proc selectRoutine*(i: Interpreter; name: string): PSym =
 proc callRoutine*(i: Interpreter; routine: PSym; args: openArray[PNode]): PNode =
   assert i != nil
   let c = PCtx(i.graph.vm)
-  result = vm.execProc(c[], routine, args)
+  result = execProc(c[], routine, args)
 
 proc getGlobalValue*(i: Interpreter; letOrVar: PSym): PNode =
   let c = PCtx(i.graph.vm)
-  result = vm.getGlobalValue(c[], letOrVar)
+  result = getGlobalValue(c[], letOrVar)
 
 proc setGlobalValue*(i: Interpreter; letOrVar: PSym, val: PNode) =
   ## Sets a global value to a given PNode, does not do any type checking.
   let c = PCtx(i.graph.vm)
-  vm.setGlobalValue(c[], letOrVar, val)
+  setGlobalValue(c[], letOrVar, val)
 
 proc implementRoutine*(i: Interpreter; pkg, module, name: string;
                        impl: proc (a: VmArgs) {.closure, gcsafe.}) =

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -18,7 +18,6 @@ import
   ],
   compiler/ast/[
     ast,
-    errorhandling,
     errorreporting,
     lineinfos,
     renderer, # toStrLit implementation
@@ -35,7 +34,6 @@ import
     msgs
   ],
   compiler/utils/[
-    debugutils,
     idioms,
     int128,
     btrees,
@@ -45,7 +43,6 @@ import
     sighashes,
     macrocacheimpl,
     transf,
-    passes,
     evaltempl
   ],
   compiler/vm/[
@@ -56,12 +53,9 @@ import
     vmdef,
     vmdeps,
     vmerrors,
-    vmhooks,
     vmjit,
     vmmemory,
     vmobjects,
-    vmops,
-    vmtypegen,
     vmtypes
   ],
   experimental/[
@@ -70,9 +64,7 @@ import
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_vm import VMReport
-from compiler/ast/reports_sem import SemReport,
-  reportAst,
-  reportSym
+from compiler/ast/reports_sem import SemReport
 from compiler/ast/reports_debug import DebugReport
 from compiler/ast/reports_internal import InternalReport
 from compiler/ast/report_enums import ReportKind
@@ -92,9 +84,6 @@ when defined(nimVMDebugGenerate):
 
 import std/options as stdoptions
 from std/math import round
-
-# these were includes previously, so they're re-exported for compatibility
-export vmhooks, vmops
 
 type
   ExecResultKind = enum
@@ -301,12 +290,12 @@ func cleanUpPending(mm: var VmMemoryManager) =
 # XXX: ensureKind (register transition) will be moved into a dedicated
 #      instruction
 
-func ensureKind(n: var TFullReg, k: TRegisterKind, mm: var VmMemoryManager) {.inline.} =
+func ensureKind*(n: var TFullReg, k: TRegisterKind, mm: var VmMemoryManager) {.inline.} =
   if n.kind != k:
     cleanUpReg(n, mm)
     n = TFullReg(kind: k)
 
-func initLocReg(r: var TFullReg, typ: PVmType, mm: var VmMemoryManager) =
+func initLocReg*(r: var TFullReg, typ: PVmType, mm: var VmMemoryManager) =
   ## Transitions `r` to a location register storing a location of type `typ`
   cleanUpReg(r, mm)
 
@@ -473,7 +462,7 @@ proc writeLoc(h: LocHandle, x: TFullReg, mm: var VmMemoryManager) =
     doAssert false, "Trying to write register address to location"
 
 
-proc regToNode(c: TCtx, x: TFullReg; typ: PType, info: TLineInfo): PNode =
+proc regToNode*(c: TCtx, x: TFullReg; typ: PType, info: TLineInfo): PNode =
   ## Deserializes the value stored by `x` to a `PNode` of type `typ`
   case x.kind
   of rkNone: unreachable()
@@ -798,69 +787,7 @@ func copyRegister(r: var TFullReg, other: TFullReg, mm: var VmMemoryManager) =
   cleanUpReg(r, mm)
   fastAsgnComplex(r, other)
 
-
-proc putIntoReg(dest: var TFullReg; c: var TCtx, n: PNode, formal: PType) =
-  ## Put the value that is represented by `n` (but not the node itself) into
-  ## `dest`. Implicit conversion is also performed, if necessary.
-  let t = formal.skipTypes(abstractInst+{tyStatic}-{tyTypeDesc})
-
-  # XXX: instead of performing conversion here manually, sem could generate a
-  #      small thunk for macro invocations that sets up static arguments and
-  #      then invokes the macro. The thunk would be executed in the VM, making
-  #      the code here obsolete while also eliminating unnecessary
-  #      deserialize/serialize round-trips
-
-  case t.kind
-  of tyBool, tyChar, tyEnum, tyInt..tyInt64, tyUInt..tyUInt64:
-    assert n.kind in nkCharLit..nkUInt64Lit
-    dest.ensureKind(rkInt, c.memory)
-    dest.intVal = n.intVal
-  of tyFloat..tyFloat128:
-    assert n.kind in nkFloatLit..nkFloat128Lit
-    dest.ensureKind(rkFloat, c.memory)
-    dest.floatVal = n.floatVal
-  of tyNil, tyPtr, tyPointer:
-    dest.ensureKind(rkAddress, c.memory)
-    # XXX: it's currently forbidden to pass non-nil pointer to static
-    #      parameters. `deserialize` already reports an error, so an
-    #      assert is used here to make sure that it really got reported
-    #      earlier
-    assert n.kind == nkNilLit
-  of tyOpenArray:
-    # Handle `openArray` parameters the same way they're handled elsewhere
-    # in the VM: simply pass the argument without an conversion
-    let typ = c.getOrCreate(n.typ)
-    dest.initLocReg(typ, c.memory)
-    c.serialize(n, dest.handle)
-  of tyProc:
-    # XXX: a hack required to uphold some expectations. For example,
-    #      `genEnumCaseStmt` would fail without this. Procedural types as
-    #      static macro arguments are underspecified
-    let pt =
-      if t.callConv == ccClosure and n.kind == nkSym:
-        # Force the location to be of non-closure type. This breaks other
-        # assumptions!
-        n.sym.typ
-      else:
-        t
-
-    let typ = c.getOrCreate(pt)
-    dest.initLocReg(typ, c.memory)
-    c.serialize(n, dest.handle, pt)
-
-  else:
-    if t.kind == tyRef and t.sym != nil and t.sym.magic == mPNimrodNode:
-      # A NimNode
-      dest.ensureKind(rkNimNode, c.memory)
-      dest.nimNode = n
-    else:
-      let typ = c.getOrCreate(formal)
-      dest.initLocReg(typ, c.memory)
-      # XXX: overriding the type (passing `formal`), leads to issues (internal
-      #      compiler error) when passing an empty set to a static parameter
-      c.serialize(n, dest.handle)#, formal)
-
-func loadEmptyReg(r: var TFullReg, typ: PVmType, info: TLineInfo, mm: var VmMemoryManager): bool =
+func loadEmptyReg*(r: var TFullReg, typ: PVmType, info: TLineInfo, mm: var VmMemoryManager): bool =
   ## If a value of `typ` fits into a register, transitions `r` to the correct
   ## state, loads the default value and returns true. Returns false otherwise
   case typ.kind
@@ -3243,10 +3170,6 @@ func `$`(e: ExecErrorReport): string {.error.}
 # XXX: the execution procs together with the result value processing needs
 #      some refactoring
 
-template mkCallback(cn, rn, body): untyped =
-  let p = proc(cn: TCtx, rn: TFullReg): PNode = body
-  p
-
 proc execute*(c: var TCtx, start: int, frame: sink TStackFrame; cb: proc(c: TCtx, r: TFullReg): PNode): ExecutionResult {.inline.} =
   assert c.sframes.len == 0
   c.sframes.add frame
@@ -3308,356 +3231,3 @@ proc execute*(c: var TCtx, start: int, frame: sink TStackFrame; cb: proc(c: TCtx
 
     # Free pending
     cleanUpPending(c.memory)
-
-# TODO: all code below is unrelated to the core VM and is instead part of the
-#       internal compiler-to-VM interface -- move it to a separate module
-
-proc unpackResult(res: sink ExecutionResult; config: ConfigRef, node: PNode): PNode =
-  ## Unpacks the execution result. If the result represents a failure, returns
-  ## a new `nkError` wrapping `node`. Otherwise, returns the value/tree result,
-  ## optionally filling in the node's `info` with that of `node`, if not
-  ## present already.
-  if res.isOk:
-    result = res.take
-    if node != nil and result.info.line < 0:
-      result.info = node.info
-  else:
-    let
-      err = res.takeErr
-      errKind = err.report.kind
-
-      stId = config.addReport(wrap(err.stackTrace))
-      rId = config.addReport(wrap(err.report))
-
-    result = config.newError(node, errKind, rId, instLoc(-1)):
-                             [newIntNode(nkIntLit, ord(stId))]
-
-proc execute(c: var TCtx, info: CodeInfo): ExecutionResult =
-  var tos = TStackFrame(prc: nil, comesFrom: 0, next: -1)
-  tos.slots.newSeq(info.regCount)
-  execute(c, info.start, tos,
-          proc(c: TCtx, r: TFullReg): PNode = c.graph.emptyNode)
-
-template returnOnErr(res: VmGenResult, config: ConfigRef, node: PNode): CodeInfo =
-  ## Unpacks the vmgen result. If the result represents an error, exits the
-  ## calling function by returning a new `nkError` wrapping `node`
-  let r = res
-  if r.isOk:
-    r.take
-  else:
-    let
-      report = r.takeErr
-      kind = report.kind
-      rid = config.addReport(wrap(report))
-
-    return config.newError(node, kind, rid, instLoc())
-
-proc reportIfError(config: ConfigRef, n: PNode) =
-  ## If `n` is a `nkError`, reports the error via `handleReport`. This is
-  ## only meant for errors from vm/vmgen invocations and is also only a
-  ## transition helper until all vm invocation functions properly propagate
-  ## `nkError`
-  if n.isError:
-    # Errors from direct vmgen invocations don't have a stack-trace
-    if n.kids.len == 4 and n.kids[3].kind == nkIntLit:
-      # XXX: testing for the presence of a stack-trace report like this is
-      #      not a good idea. Error node layout might change, making the test
-      #      invalid. VM errors should get their own report object with the
-      #      stack-trace embedded as part of it.
-      config.handleReport(n.kids[3].intVal.ReportId, instLoc(-1)) # stack-trace
-    config.localReport(n)
-
-
-proc execProc*(c: var TCtx; sym: PSym; args: openArray[PNode]): PNode =
-  # XXX: `localReport` is still used here since execProc is only used by the
-  # VM's compilerapi (`nimeval`) whose users don't know about nkError yet
-
-  c.loopIterations = c.config.maxLoopIterationsVM
-  if sym.kind in routineKinds:
-    if sym.typ.len-1 != args.len:
-      localReport(c.config, sym.info, SemReport(
-        kind: rsemWrongNumberOfArguments,
-        sym: sym,
-        countMismatch: (
-          expected: toInt128(sym.typ.len - 1),
-          got: toInt128(args.len))))
-
-    else:
-      let (start, maxSlots) = block:
-        # XXX: `returnOnErr` should be used here instead, but isn't for
-        #      backwards compatiblity
-        let r = loadProc(c, sym)
-        if unlikely(r.isErr):
-          localReport(c.config, r.takeErr)
-          return nil
-        r.unsafeGet
-
-      var tos = TStackFrame(prc: sym, comesFrom: 0, next: -1)
-      tos.slots.newSeq(maxSlots)
-
-      # setup parameters:
-      if not isEmptyType(sym.typ[0]) or sym.kind == skMacro:
-        let typ = c.getOrCreate(sym.typ[0])
-        if not tos.slots[0].loadEmptyReg(typ, sym.info, c.memory):
-          tos.slots[0].initLocReg(typ, c.memory)
-      # XXX We could perform some type checking here.
-      for i in 1..<sym.typ.len:
-        putIntoReg(tos.slots[i], c, args[i-1], sym.typ[i])
-
-      let cb =
-        if not isEmptyType(sym.typ[0]):
-          mkCallback(c, r): c.regToNode(r, sym.typ[0], sym.info)
-        elif sym.kind == skMacro:
-          # TODO: missing cyclic check
-          mkCallback(c, r): r.nimNode
-        else:
-          mkCallback(c, r): newNodeI(nkEmpty, sym.info)
-
-      let r = execute(c, start, tos, cb)
-      result = r.unpackResult(c.config, c.graph.emptyNode)
-      reportIfError(c.config, result)
-      if result.isError:
-        result = nil
-  else:
-    localReport(c.config, sym.info, reportSym(rvmCallingNonRoutine, sym))
-
-proc evalStmt(c: var TCtx, n: PNode): PNode =
-  let n = transformExpr(c.graph, c.idgen, c.module, n)
-  let info = genStmt(c, n).returnOnErr(c.config, n)
-
-  # execute new instructions; this redundant opcEof check saves us lots
-  # of allocations in 'execute':
-  if c.code[info.start].opcode != opcEof:
-    result = execute(c, info).unpackResult(c.config, n)
-  else:
-    result = c.graph.emptyNode
-
-proc evalExpr*(c: var TCtx, n: PNode): PNode =
-  # deadcode
-  # `nim --eval:"expr"` might've used it at some point for idetools; could
-  # be revived for nimsuggest
-  let n = transformExpr(c.graph, c.idgen, c.module, n)
-  let info = genExpr(c, n).returnOnErr(c.config, n)
-
-  assert c.code[info.start].opcode != opcEof
-  result = execute(c, info).unpackResult(c.config, n)
-
-# XXX: the compilerapi regarding globals (getGlobalValue/setGlobalValue)
-#      doesn't work the same as before. Previously, the returned PNode
-#      could be used to modify the actual global value, but this is not
-#      possible anymore
-
-proc getGlobalValue*(c: TCtx; s: PSym): PNode =
-  ## Does not perform type checking, so ensure that `s.typ` matches the
-  ## global's type
-  internalAssert(c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
-  let slotIdx = c.globals[c.symToIndexTbl[s.id]]
-  let slot = c.heap.slots[slotIdx]
-
-  result = c.deserialize(slot.handle, s.typ, s.info)
-
-proc setGlobalValue*(c: var TCtx; s: PSym, val: PNode) =
-  ## Does not do type checking so ensure the `val` matches the `s.typ`
-  internalAssert(c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
-  let slotIdx = c.globals[c.symToIndexTbl[s.id]]
-  let slot = c.heap.slots[slotIdx]
-
-  c.serialize(val, slot.handle)
-
-proc setupGlobalCtx*(module: PSym; graph: ModuleGraph; idgen: IdGenerator) =
-  addInNimDebugUtils(graph.config, "setupGlobalCtx")
-  if graph.vm.isNil:
-    let
-      ctx = newCtx(module, graph.cache, graph, idgen)
-      disallowDangerous =
-        defined(nimsuggest) or graph.config.cmd == cmdCheck or
-        vmopsDanger notin ctx.config.features
-
-    ctx.codegenInOut.flags = {cgfAllowMeta}
-    registerAdditionalOps(ctx[], disallowDangerous)
-
-    graph.vm = ctx
-  else:
-    let c = PCtx(graph.vm)
-    refresh(c[], module, idgen)
-
-proc myOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext {.nosinks.} =
-  #var c = newEvalContext(module, emRepl)
-  #c.features = {allowCast, allowInfiniteLoops}
-  #pushStackFrame(c, newStackFrame())
-
-  # XXX produce a new 'globals' environment here:
-  setupGlobalCtx(module, graph, idgen)
-  result = PCtx graph.vm
-
-proc myProcess(c: PPassContext, n: PNode): PNode =
-  let c = PCtx(c)
-  # don't eval errornous code:
-  if c.oldErrorCount == c.config.errorCounter:
-    let r = evalStmt(c[], n)
-    reportIfError(c.config, r)
-    # TODO: use the node returned by evalStmt as the result and don't report
-    #       the error here
-    result = newNodeI(nkEmpty, n.info)
-  else:
-    result = n
-  c.oldErrorCount = c.config.errorCounter
-
-proc myClose(graph: ModuleGraph; c: PPassContext, n: PNode): PNode =
-  result = myProcess(c, n)
-
-const evalPass* = makePass(myOpen, myProcess, myClose)
-
-proc evalConstExprAux(module: PSym; idgen: IdGenerator;
-                      g: ModuleGraph; prc: PSym, n: PNode,
-                      mode: TEvalMode): PNode =
-  addInNimDebugUtils(g.config, "evalConstExprAux", prc, n, result)
-  #if g.config.errorCounter > 0: return n
-  let n = transformExpr(g, idgen, module, n)
-  setupGlobalCtx(module, g, idgen)
-  let c = PCtx g.vm
-  let oldMode = c.mode
-  c.mode = mode
-  let requiresValue = mode!=emStaticStmt
-  let (start, regCount) = genExpr(c[], n, requiresValue).returnOnErr(c.config, n)
-
-  if c.code[start].opcode == opcEof: return newNodeI(nkEmpty, n.info)
-  assert c.code[start].opcode != opcEof
-  when defined(nimVMDebugGenerate):
-    c.config.localReport():
-      initVmCodeListingReport(c[], prc, n)
-
-  var tos = TStackFrame(prc: prc, comesFrom: 0, next: -1)
-  tos.slots.newSeq(regCount)
-  #for i in 0..<regCount: tos.slots[i] = newNode(nkEmpty)
-  let cb =
-    if requiresValue:
-      mkCallback(c, r): c.regToNode(r, n.typ, n.info)
-    else:
-      mkCallback(c, r): newNodeI(nkEmpty, n.info)
-
-  result = execute(c[], start, tos, cb).unpackResult(c.config, n)
-
-  c.mode = oldMode
-
-proc evalConstExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode): PNode =
-  result = evalConstExprAux(module, idgen, g, nil, e, emConst)
-
-proc evalStaticExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym): PNode =
-  result = evalConstExprAux(module, idgen, g, prc, e, emStaticExpr)
-
-proc evalStaticStmt*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym) =
-  let r = evalConstExprAux(module, idgen, g, prc, e, emStaticStmt)
-  # TODO: the node needs to be returned to the caller instead
-  reportIfError(g.config, r)
-
-proc setupCompileTimeVar*(module: PSym; idgen: IdGenerator; g: ModuleGraph; n: PNode) =
-  let r = evalConstExprAux(module, idgen, g, nil, n, emStaticStmt)
-  # TODO: the node needs to be returned to the caller instead
-  reportIfError(g.config, r)
-
-proc setupMacroParam(reg: var TFullReg, c: var TCtx, x: PNode, typ: PType) =
-  case typ.kind
-  of tyStatic:
-    putIntoReg(reg, c, x, typ)
-  else:
-    var n = x
-    if n.kind in {nkHiddenSubConv, nkHiddenStdConv}: n = n[1]
-    # TODO: is anyone on the callsite dependent on this modifiction of `x`?
-    n.typ = x.typ
-    reg = TFullReg(kind: rkNimNode, nimNode: n)
-
-iterator genericParamsInMacroCall*(macroSym: PSym, call: PNode): (PSym, PNode) =
-  let gp = macroSym.ast[genericParamsPos]
-  for i in 0..<gp.len:
-    let genericParam = gp[i].sym
-    let posInCall = macroSym.typ.len + i
-    if posInCall < call.len:
-      yield (genericParam, call[posInCall])
-
-# to prevent endless recursion in macro instantiation
-const evalMacroLimit = 1000
-
-#proc errorNode(idgen: IdGenerator; owner: PSym, n: PNode): PNode =
-#  result = newNodeI(nkEmpty, n.info)
-#  result.typ = newType(tyError, nextTypeId idgen, owner)
-#  result.typ.flags.incl tfCheckedForDestructor
-
-proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph; templInstCounter: ref int;
-                    n: PNode, sym: PSym): PNode =
-  #if g.config.errorCounter > 0: return errorNode(idgen, module, n)
-
-  # XXX globalReport() is ugly here, but I don't know a better solution for now
-  inc(g.config.evalMacroCounter)
-  if g.config.evalMacroCounter > evalMacroLimit:
-    globalReport(g.config, n.info, VMReport(
-      kind: rsemMacroInstantiationTooNested, ast: n))
-
-  # immediate macros can bypass any type and arity checking so we check the
-  # arity here too:
-  if sym.typ.len > n.safeLen and sym.typ.len > 1:
-    globalReport(g.config, n.info, SemReport(
-      kind: rsemWrongNumberOfArguments,
-      ast: n,
-      countMismatch: (
-        expected: toInt128(sym.typ.len - 1),
-        got: toInt128(n.safeLen - 1))))
-
-  setupGlobalCtx(module, g, idgen)
-  let c = PCtx g.vm
-  let oldMode = c.mode
-  c.mode = emStaticStmt
-  c.comesFromHeuristic.line = 0'u16
-  c.callsite = n
-  c.templInstCounter = templInstCounter
-
-  let (start, regCount) = loadProc(c[], sym).returnOnErr(c.config, n)
-
-  var tos = TStackFrame(prc: sym, comesFrom: 0, next: -1)
-  tos.slots.newSeq(regCount)
-  # setup arguments:
-  var L = n.safeLen
-  if L == 0: L = 1
-  # This is wrong for tests/reject/tind1.nim where the passed 'else' part
-  # doesn't end up in the parameter:
-  #InternalAssert tos.slots.len >= L
-
-  # return value:
-  tos.slots[0] = TFullReg(kind: rkNimNode, nimNode: newNodeI(nkEmpty, n.info))
-
-  # put macro call arguments into registers
-  for i in 1..<sym.typ.len:
-    setupMacroParam(tos.slots[i], c[], n[i], sym.typ[i])
-
-  # put macro generic parameters into registers
-  let gp = sym.ast[genericParamsPos]
-  for i in 0..<gp.safeLen:
-    let idx = sym.typ.len + i
-    if idx < n.len:
-      setupMacroParam(tos.slots[idx], c[], n[idx], gp[i].sym.typ)
-    else:
-      # TODO: the decrement here is wrong, but the else branch is likely
-      #       currently not reached anyway
-      dec(g.config.evalMacroCounter)
-      c.callsite = nil
-      localReport(c.config, n.info, SemReport(
-        kind: rsemWrongNumberOfGenericParams,
-        countMismatch: (
-          expected: toInt128(gp.len),
-          got: toInt128(idx))))
-
-  # temporary storage:
-  #for i in L..<maxSlots: tos.slots[i] = newNode(nkEmpty)
-
-  # n.typ == nil is valid and means that resulting NimNode represents
-  # a statement
-  let cb = mkCallback(c, r): r.nimNode
-  result = execute(c[], start, tos, cb).unpackResult(c.config, n)
-
-  if result.kind != nkError and cyclicTree(result):
-    globalReport(c.config, n.info, VMReport(
-      kind: rsemCyclicTree, ast: n, sym: sym))
-
-  dec(g.config.evalMacroCounter)
-  c.callsite = nil
-  c.mode = oldMode

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -22,6 +22,7 @@ import
     packed_env,
     vm,
     vmdef,
+    vmhooks,
     vmmemory,
     vmobjects,
     vmops,

--- a/tests/compilerapi/tcompilerapi.nim
+++ b/tests/compilerapi/tcompilerapi.nim
@@ -30,7 +30,7 @@ import
   ],
   compiler/vm/[
     vmdef,
-    vm,
+    vmhooks,
     nimeval,
   ]
 


### PR DESCRIPTION
## Summary
Move the parts that make up the direct interface between the compiler and the VM into a separate module, in order to reduce the amount of dependencies the `vm` module has on the rest of the compiler.

This is also a step towards completely separating the VM from `vmgen`.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

@saem If this PR interferes with #484 too much, I can also turn it into a draft PR and wait with merging until #484 is finished.

## Notes for Reviewers
* I'm not entirely sure of the name `compilerbridge`

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
