### PR TITLE
tests: disable the `realtimeGC` test

### DIFF
--- a/tests/realtimeGC/tmain.nim
+++ b/tests/realtimeGC/tmain.nim
@@ -1,6 +1,7 @@
 discard """
   matrix: "--threads:on -d:release -d:useRealtimeGC"
   joinable:false
+  knownIssue: "the test dependens on the GC not running at the wrong time"
 """
 
 #[
@@ -8,6 +9,15 @@ Test the realtime GC without linking nimrtl.dll/so.
 
 To build by hand and run the test for 35 minutes:
 `nim r --threads:on -d:runtimeSecs:2100 tests/realtimeGC/tmain.nim`
+
+EDIT: the test as it currently is can't work, and only by accident didn't
+crash in the past. Without linking to the "nimrtl" dynlib, two instance of the
+GC (one for the executable and one for the dynlib) are created. The GC instance
+used for the dynlib is initialized with an incorrect stack-bottom value (due to
+it being initialized from the dynlibs entry point), leading to some stack cells
+not being detected, causing the referenced heap location to be garbage
+collected.
+
 ]#
 
 import times, os, strformat, strutils


### PR DESCRIPTION
## Summary

The test depends on the GC not running at the wrong time, which can happen if allocation behaviour changes (as is the case with https://github.com/nim-works/nimskull/pull/488)

This is caused by the GC instance used for the shared library being initialized with an incorrect stack-bottom value, leading to valid stack cells located below the wrong bottom not being considered during stack scanning. If a heap location is only referenced from said stack cells, it is garbage collected, making further access to it invalid and potentially causing crashes due to heap corruption.

For programs using both shared libraries and `refc`, the `nimrtl` (Nim run-time library) has to be used in order for there to only be a single GC instance per thread, but the test explicitly states that it tests the realtime GC *without* using the `nimrtl`. This can't work, and only did so in the past by accident.

The test is only disabled instead of removed, so that it can be, if desired, corrected in the future without losing the associated history.