### PR TITLE
sem/transf: don't collapse implict addr/deref nodes

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -823,13 +823,9 @@ proc hasUnresolvedArgs(c: PContext, n: PNode): bool =
     return false
 
 proc newHiddenAddrTaken(c: PContext, n: PNode): PNode =
-  case n.kind
-  of nkHiddenDeref:
-    checkSonsLen(n, 1, c.config)
-    result = n[0]
-  else:
-    result = newNodeIT(nkHiddenAddr, n.info, makeVarType(c, n.typ))
-    result.add n
+  ## Wraps the expression `n` in an ``nkHiddenAddr`` and assigns a ``var`` type
+  ## derived from the source type to the resulting expression
+  result = newTreeIT(nkHiddenAddr, n.info, makeVarType(c, n.typ)): n
 
 func isVarParam(t: PType): bool =
   # watch out: ``typeDesc[var int]`` is **not** a 'var' parameter

--- a/tests/lang_types/var/tvar_arguments.nim
+++ b/tests/lang_types/var/tvar_arguments.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c js vm"
+  target: "c js !vm"
   labels: "var_arg"
   description: '''
     Tests to make sure arguments are properly passed to var parameter and that
@@ -7,6 +7,8 @@ discard """
     location
   '''
 """
+
+# knownIssue: ``vmgen`` generates incorrect code in some cases
 
 template disableIf(cond: bool, body: untyped) =
   when defined(tryBrokenSpecification) or not cond:


### PR DESCRIPTION
## Summary
The collapsing produces unsound AST in the case that the operand of the
`nkHiddenDeref` doesn't have the same type as the `nkHiddenAddr` node.
For example, if the `nkHiddenDeref` dereferences a `ptr` or `ref` value,
the collapsing would result in a `ptr` or `ref` value to be directly
passed to `var` parameter (because `nkHiddenAddr` nodes are generated
when passing something to a `var` parameter), which is incorrect.

The reason that this didn't cause many problems so far is that `var`,
`ref`, and `ptr` are all pointers underneath for the C target, and that
`cgen` doesn't inspect the type of nodes in many cases.

The collapsing done directly in `semexpr` is removed and the one done in
`transf` is adjusted:
- only `DerefExpr( Addr(x) )` and `Addr( DerefExpr(x) )`  (both are
  expressions explicitly provided by the user) are collapsed -- the
  latter one only when `x` is of `ptr` type.
- since collapsing `HiddenDeref( HiddenAddr(x) )` is always known to be
  safe, the behaviour is kept. Because of a `cgen` issue, it's currently
  also required.

Unconditional collapsing of all address-of + deref expression is now
performed inside the C code-generator, because it is known that the
operands to all dereference operations map to C pointers at that point.

## Details
The compiler targets C89, where dereferencing a pointer requires a
pointer to complete type, even when the result is immediately passed to
an address-of operation (i.e. `&(*x)`). `cgen` now requests the complete
type whenever emitting a deref.