### PR TITLE
vmbackend: fix crash related to `nkEmpty` nodes

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1009,7 +1009,10 @@ const
     {nkStrLit..nkTripleStrLit} +
     {nkSym} +
     {nkIdent} +
+    {nkError} +
     {nkEmpty, nkNone}
+
+  nkWithSons* = {low(TNodeKind) .. high(TNodeKind)} - nkWithoutSons
 
 type
   EffectsCompat* = enum

--- a/tests/compiler/tpacked_env.nim
+++ b/tests/compiler/tpacked_env.nim
@@ -1,0 +1,42 @@
+discard """
+  target: native
+  description: "Unit tests for the `packed_env` module"
+"""
+
+import
+  compiler/ast/[
+    ast_types
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/vm/[
+    packed_env,
+    vmdef
+  ]
+
+block empty_nodes:
+  # make sure that storing and loading an `nkEmpty` node works
+  let
+    placeholder = PVmType(kind: akInt) # content is not relevant
+    typ = PType(n: PNode(kind: nkEmpty))
+
+  var
+    ctx: TCtx
+    env: PackedEnv
+    enc: PackedEncoder
+
+  # creating a ``ConfigRef`` is unfortunately required for now
+  ctx.config = ConfigRef()
+
+  ctx.types.add placeholder
+  ctx.rtti.add VmTypeInfo(internal: placeholder, nimType: typ)
+
+  # store the rtti. Must not fail:
+  init(enc, ctx.types)
+  storeEnv(enc, env, ctx)
+
+  # load the rtti:
+  let infos = loadTypeInfos(env, ctx.types)
+  doAssert infos.len == 1
+  doAssert infos[0].nimType.n.kind == nkEmpty


### PR DESCRIPTION
## Summary
During both serialization and deserialization of `PNode`s used for the
VM's RTTI, `nkEmpty` nodes were not explicitly handled, leading to them
being treated as nodes with children. This caused a `FieldDefect` when
trying to access their (inaccessible) `sons` field.

The problem rendered a large amount of programs unusable with the VM
backend, as either the compiler or the runner would crash when RTTI that
contained empty nodes somewhere was used.

## Details
- add `nkError` to the `nkWithoutSons` set
- add the `nkWithSons` set
- make `case` statements in `storeNode` and `loadNode` exhaustive.
  `nkNone` and `nkError` are now also detected (and rejected)
- add a test to make sure `nkEmpty` nodes are handled correctly

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

As mentioned in the commit message, the issue blocked a lot of tests in the test suite from working with the VM target.

## Notes for Reviewers
* the `nkWithoutSons` set wasn't used until now, so extending it with `nkError` can't break any existing code

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
