### PR TITLE
semexprs: refactor 'var' parameter argument fixup

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -207,6 +207,17 @@ const
     nkUsingStmt,
   }
 
+  FakeVarParams* = {mNew, mNewFinalize, mInc, mDec, mIncl, mExcl,
+    mSetLengthStr, mSetLengthSeq, mAppendStrCh, mAppendStrStr, mSwap,
+    mAppendSeqElem, mNewSeq, mReset, mShallowCopy, mDeepCopy, mMove,
+    mWasMoved}
+    ## An arguments to these magics never uses ``nkHiddenAddr``, even if the
+    ## corresponding parameter is a 'var' parameter. The reason for this is
+    ## that these magics are lowered into code that, because it gets inlined
+    ## directly, doesn't mutate the arguments through indirection. This also
+    ## implies that the "is address taken" analysis (see ``sfAddrTaken``) must
+    ## not be performed for arguments to these magics.
+
 proc getPIdent*(a: PNode): PIdent {.inline.} =
   ## Returns underlying `PIdent` for `{nkSym, nkIdent}`, or `nil`.
   # xxx consider whether also returning the 1st ident for {nkOpenSymChoice, nkClosedSymChoice}

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -339,9 +339,8 @@ type
       ## read:
       ##  - sigmatch: islvalue
       ##  - semobjconstr: errors for case object/discriminator assignments
-      ##  - newHiddenAddrTaken: check to see if we're in an unsafe assignment
-      ##                        cast xxx: seems overly broad
-      ##  - analyseIfAddressTakenInCall: same check as newHiddenAddrTaken
+      ##  - analyseIfAddressTakenInCall: check to see if we're in an unsafe
+      ##                                 assignment block
 
     # using statement parameter tracking
     signatures*: TStrTable

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2031,7 +2031,8 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
                 if srca == isSubtype:
                   implicitConv(nkHiddenSubConv, src, copyTree(arg), m, c)
                 elif src.kind in {tyVar}:
-                  # Analyse the converter return type
+                  # create a mutable reference if the converter takes a 'var'
+                  # as input
                   newTreeIT(nkHiddenAddr, arg.info, conv.typ[1], copyTree(arg))
                 else:
                   copyTree(arg))


### PR DESCRIPTION
## Summary
This is mostly a refactoring and clean up, but it also adjusts the "is
address taken" analysis to no longer ignore l-value conversions and
statement list expressions. The operand to an `addr` operation now also
uses the same (more correct) analysis as the arguments to `var`
parameters.

`jsgen` depends on the `sfAddrTaken` flag in order to know whether a
location needs to support being modified via a "base + index" (the JS
back-end's way of implementing pointers), so this change fixes a
JS code-gen issue. Only in theory however, as the JS code-generator
implements the relevant bits incorrectly -- although in slightly
different way, wrong code is still generated.

## Details
- rename `analyseIfAddressTakenInCall` to `fixVarArgumentsAndAnalyse`,
  refactor and document it, and make it `nkError` aware
- remove the mutability check from `newHiddenAddrTaken` -- this is now
  the responsibility of the callsite
- move the "is address taken" analysis to a separate procedure
- move the `FakeVarParams` constant to the `ast_query` module
- make `semAddrArg` `nkError` aware, fixing `addr x` reporting an
  `expression has no address` error if expression `x` had an error
- fix the "has no address" error reported for  `addr` always suggesting
  the usage of `unsafeAddr`, even if it was already used
- remove leftover and unused `unsafeAddr`-related logic

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

As mentioned in the code comments, I don't think `jsgen` depending on `sfAddrTaken` is a good idea. The analysis itself should also not happen as part of the after-call actions, but rather during `sempass2`. Both are things that are better implemented in separate PRs, however.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
