### PR TITLE
Extract nkError diagnostics data

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -95,8 +95,13 @@ const
                    nkClosedSymChoice}
 
   nkPragmaCallKinds* = {nkExprColonExpr, nkCall, nkCallStrLit}
-  nkLiterals* = {nkCharLit..nkTripleStrLit}
+
+  nkIntLiterals*   = {nkCharLit..nkUInt64Lit}
   nkFloatLiterals* = {nkFloatLit..nkFloat128Lit}
+  nkStrLiterals*   = {nkStrLit..nkTripleStrLit}
+  # TODO: include `nkNilLit` as it's a literal, not the same as `nnkLiterals`
+  nkLiterals*      = nkIntLiterals + nkFloatLiterals + nkStrLiterals
+  
   nkLambdaKinds* = {nkLambda, nkDo}
   declarativeDefs* = {nkProcDef, nkFuncDef, nkMethodDef, nkIteratorDef, nkConverterDef}
   routineDefs* = declarativeDefs + {nkMacroDef, nkTemplateDef}
@@ -104,10 +109,11 @@ const
   callableDefs* = nkLambdaKinds + routineDefs
 
   nkSymChoices* = {nkClosedSymChoice, nkOpenSymChoice}
-  nkFloatKinds* = nkFloatLiterals # QUESTION remove float literals
-                                  # altogether?
-  nkStrKinds* = {nkStrLit..nkTripleStrLit}
-  nkIntKinds* = {nkCharLit .. nkUInt64Lit}
+
+  # TODO: replace with `nk*Literals`, see above
+  nkIntKinds*   = nkIntLiterals
+  nkFloatKinds* = nkFloatLiterals
+  nkStrKinds*   = nkStrLiterals
 
   skLocalVars* = {skVar, skLet, skForVar, skParam, skResult}
   skProcKinds* = {skProc, skFunc, skTemplate, skMacro, skIterator,
@@ -404,10 +410,7 @@ proc hasSubnodeWith*(n: PNode, kind: TNodeKind): bool =
   of nkEmpty..nkNilLit, nkFormalParams:
     result = n.kind == kind
   of nkError:
-    for i in 0..<n.kids.len:
-      if (n.kids[i].kind == kind) or hasSubnodeWith(n.kids[i], kind):
-        return true
-    result = false
+    result = hasSubnodeWith(n.diag.wrongNode, kind)
   else:
     for i in 0..<n.len:
       if (n[i].kind == kind) or hasSubnodeWith(n[i], kind):

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -36,7 +36,8 @@ import
     idents,
     ast,
     lineinfos,
-    reports_parser,
+    reports_parser, # legacy remove
+    report_enums,   # legacy remove
   ],
   std/[
     strutils,

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -1642,7 +1642,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
     if renderWithoutErrorPrefix notin g.flags:
       putWithSpace(g, tkSymbol, "error")
     #gcomma(g, n, c)
-    gsub(g, n.kids[0], c)
+    gsub(g, n.diag.wrongNode, c)
   of nkNimNodeLit:
     gsub(g, n.sons[0], c)
   else:

--- a/compiler/ast/reports_backend.nim
+++ b/compiler/ast/reports_backend.nim
@@ -6,6 +6,7 @@
 import
   compiler/ast/[
     reports_base,
+    report_enums,
   ]
 
 type

--- a/compiler/ast/reports_base.nim
+++ b/compiler/ast/reports_base.nim
@@ -3,12 +3,9 @@
 import
   compiler/ast/[
     lineinfos,
-    report_enums,
   ]
 
 import std/[options]
-
-export report_enums, lineinfos
 
 type
   ReportLineInfo* = object
@@ -16,17 +13,6 @@ type
     file*: string
     line*: uint16
     col*: int16
-
-  ReportSeverity* = enum
-    rsevDebug = "Debug" ## Internal compiler debug information
-
-    rsevHint = "Hint" ## User-targeted hint
-    rsevWarning = "Warning" ## User-targeted warnings
-    rsevError = "Error" ## User-targeted error
-
-    rsevFatal = "Fatal"
-    rsevTrace = "Trace" ## Additional information about compiler actions -
-    ## external commands mostly.
 
   # TODO: the need to inherit should be the first clue that things are wrong,
   #       thanks to that all the data type declaration dependencies are still

--- a/compiler/ast/reports_base_sem.nim
+++ b/compiler/ast/reports_base_sem.nim
@@ -3,9 +3,8 @@
 import compiler/ast/[
     ast_types,
     reports_base,
+    lineinfos,
   ]
-
-export reports_base
 
 type
   SemishReportBase* = object of ReportBase
@@ -28,7 +27,3 @@ type
         entry*: PSym ## Instantiated entry symbol
       of sckInstantiationFrom:
         discard
-
-  SemTypeMismatch* = object
-    formalTypeKind*: set[TTypeKind]
-    actualType*, formalType*: PType

--- a/compiler/ast/reports_cmd.nim
+++ b/compiler/ast/reports_cmd.nim
@@ -6,6 +6,7 @@
 import
   compiler/ast/[
     reports_base,
+    report_enums,
   ]
 
 type

--- a/compiler/ast/reports_debug.nim
+++ b/compiler/ast/reports_debug.nim
@@ -9,6 +9,7 @@ import
     ast_types,
     lineinfos,
     reports_base,
+    report_enums,
   ],
   compiler/front/[
     in_options,

--- a/compiler/ast/reports_external.nim
+++ b/compiler/ast/reports_external.nim
@@ -6,6 +6,7 @@
 import
   compiler/ast/[
     reports_base,
+    report_enums,
   ]
 
 type

--- a/compiler/ast/reports_internal.nim
+++ b/compiler/ast/reports_internal.nim
@@ -11,6 +11,7 @@
 
 import
   compiler/ast/[
+    report_enums,
     reports_base,
   ],
   compiler/utils/[

--- a/compiler/ast/reports_lexer.nim
+++ b/compiler/ast/reports_lexer.nim
@@ -3,6 +3,7 @@
 import
   compiler/ast/[
     reports_base,
+    report_enums,
   ]
 
 type

--- a/compiler/ast/reports_parser.nim
+++ b/compiler/ast/reports_parser.nim
@@ -4,9 +4,8 @@ import
   compiler/ast/[
     ast_types,
     reports_base,
+    report_enums,
   ]
-
-export reports_base.ReportKind
 
 type
   ParserReport* = object of ReportBase

--- a/compiler/ast/reports_vm.nim
+++ b/compiler/ast/reports_vm.nim
@@ -4,6 +4,8 @@ import
   compiler/ast/[
     ast_types,
     reports_base_sem,
+    report_enums,
+    lineinfos,
   ],
   compiler/utils/[
     int128,
@@ -19,7 +21,6 @@ type
     case kind*: ReportKind
       of rvmStackTrace:
         currentExceptionA*, currentExceptionB*: PNode
-        traceReason*: ReportKind
         stacktrace*: seq[tuple[sym: PSym, location: TLineInfo]]
         skipped*: int
 

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -21,8 +21,7 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode]): bool =
     discard
   of nkError:
     visited.add(n)
-    for kid in n.kids:
-      if cyclicTreeAux(kid, visited): return true
+    if cyclicTreeAux(n.diag.wrongNode, visited): return true
     discard visited.pop()
   else:
     visited.add(n)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -3018,7 +3018,8 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkGotoState:
     genGotoState(p, n)
   of nkMixinStmt, nkBindStmt: discard
-  else: internalError(p.config, n.info, "expr(" & $n.kind & "); unknown node kind")
+  else:
+    internalError(p.config, n.info, "expr(" & $n.kind & "); unknown node kind")
 
 proc genNamedConstExpr(p: BProc, n: PNode; isConst: bool): Rope =
   if n.kind == nkExprColonExpr: result = genBracedInit(p, n[1], isConst, n[0].typ)

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -20,7 +20,6 @@ import
   ],
   compiler/ast/[
     lineinfos,
-    reports
   ],
   compiler/front/[
     options,
@@ -44,6 +43,7 @@ import
 #       types of "reports"? Unlikely, it's probably creating a bunch of false
 #       dependencies with other modules... yay!
 #       Also, diagnostic, telemetry, and event are better terms
+from compiler/ast/report_enums import ReportKind
 from compiler/ast/reports_external import ExternalReport
 from compiler/ast/reports_cmd import CmdReport
 from compiler/ast/reports_backend import BackendReport

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -83,7 +83,7 @@ when defined(nimDebugUnreportedErrors):
   proc echoAndResetUnreportedErrors(conf: ConfigRef) =
     if conf.unreportedErrors.len > 0:
       echo "Unreported errors:"
-      for reportId, node in conf.unreportedErrors:
+      for nodeId, node in conf.unreportedErrors:
         var reprConf = defaultTReprConf
         reprConf.flags.incl trfShowNodeErrors
         echo conf.treeRepr(node)

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -43,6 +43,7 @@ proc sexp*[T](s: seq[T]): SexpNode = sexpItems(s)
 proc sexp*[R, T](s: array[R, T]): SexpNode = sexpItems(s)
 proc sexp*[I](s: set[I]): SexpNode = sexpItems(s)
 proc sexp*(s: cstring): SexpNode = sexp($s)
+proc sexp*(n: NodeId): SexpNode = sexp(n.int)
 
 proc sexp*(v: SomeInteger): SexpNode = newSInt(BiggestInt(v))
 proc sexp*(id: FileIndex): SexpNode =
@@ -121,9 +122,7 @@ proc sexp*(node: PNode): SexpNode =
     of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)
     of nkSym:                     result.add newSSymbol(node.sym.name.s)
     of nkIdent:                   result.add newSSymbol(node.ident.s)
-    of nkError:
-      for node in node.kids:
-        result.add sexp(node)
+    of nkError:                   result.add sexp(node.diag.wrongNode)
     else:
       for node in node.sons:
         result.add sexp(node)
@@ -142,7 +141,6 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
 
   if wkind == writeDisabled:
     return
-
   else:
     var s = newSList()
     s.add newSSymbol(multiReplace($r.kind, {
@@ -178,6 +176,5 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
 
     if wkind == writeForceEnabled:
       echo s.toLine().toString(conf.useColor)
-
     else:
       conf.writeln(s.toLine().toString(conf.useColor))

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -21,8 +21,6 @@ type
   ModuleId* = distinct int32
   NodePos* = distinct int
 
-  NodeId* = distinct int32
-
   PackedItemId* = object
     module*: LitId       # 0 if it's this module
     item*: int32         # same as the in-memory representation
@@ -106,7 +104,6 @@ proc hash*(a: SymId): Hash {.borrow.}
 
 proc `==`*(a, b: NodePos): bool {.borrow.}
 #proc `==`*(a, b: PackedItemId): bool {.borrow.}
-proc `==`*(a, b: NodeId): bool {.borrow.}
 
 proc newTreeFrom*(old: PackedTree): PackedTree =
   result.nodes = @[]

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -161,15 +161,14 @@ proc registerNimScriptSymbol*(g: ModuleGraph; s: PSym) =
 
 proc registerNimScriptSymbol2*(g: ModuleGraph; s: PSym): PNode =
   # Nimscript symbols must be all unique:
-  result = g.emptyNode
   let conflict = strTableGet(g.exposed, s.name)
-  if conflict == nil:
+  if conflict.isNil:
     strTableAdd(g.exposed, s)
+    g.emptyNode
   else:
-    result = g.config.newError(
+    g.config.newError(
       newSymNode(s),
-      reportSymbols(rsemConflictingExportnims, @[s, conflict]),
-      posInfo = s.info)
+      PAstDiag(kind: adSemConflictingExportnims, conflict: conflict))
 
 proc getNimScriptSymbol*(g: ModuleGraph; name: string): PSym =
   strTableGet(g.exposed, getIdent(g.cache, name))

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -153,7 +153,7 @@ proc evalTemplateArgs(n: PNode, s: PSym; conf: ConfigRef; fromHlo: bool): PNode 
     
     if default.isNil or default.kind == nkEmpty:
       result.add newNodeI(nkEmpty, n.info)
-      return newError(conf, result, reportSem rsemWrongNumberOfArguments)
+      return newError(conf, result, PAstDiag(kind: adSemWrongNumberOfArguments))
     else:
       result.add default.copyTree
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -50,7 +50,8 @@ import
     nversion,
     debugutils,
     int128,
-    astrepr
+    astrepr,
+    idioms
   ],
   compiler/sem/[
     semfold,
@@ -88,8 +89,6 @@ from std/options as std_options import some, none
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_sem import SemReport,
-  SemCallMismatch, # xxx: used by `semcall` at least
-  MismatchInfo,    # xxx: used by `semcall` at least
   reportAst,
   reportSem,       # xxx: used by `semcall` at least
   reportStr,       # xxx: used by `semtypes` at least
@@ -583,12 +582,11 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
       if result.kind == nkStmtList: result.transitionSonsKind(nkStmtListType)
       var typ = semTypeNode(c, result, nil)
       if typ == nil:
-        let err = newError(c.config, result, reportSem rsemExpressionHasNoType)
+        let err = newError(c.config, result, PAstDiag(kind: adSemExpressionHasNoType))
         localReport(c.config, err)
         result = newSymNode(errorSym(c, result, err))
       else:
         result.typ = makeTypeDesc(c, typ)
-      #result = symNodeFromType(c, typ, n.info)
     else:
       if s.ast[genericParamsPos] != nil and retType.isMetaType:
         # The return type may depend on the Macro arguments
@@ -604,7 +602,6 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
 
       result = semExpr(c, result, flags)
       result = fitNode(c, retType, result, result.info)
-      #globalReport(s.info, errInvalidParamKindX, typeToString(s.typ[0]))
   dec(c.config.evalTemplateCounter)
   discard c.friendModules.pop()
 

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -483,7 +483,7 @@ type
       ## read:
       ##  - suggest: `markOwnerModuleAsUsed`, used beyond suggestions, query
       ##             export indirections to track usage info
-    recursiveDep*: seq[tuple[importer, importee: string]]
+    recursiveDep*: seq[tuple[importer, importee: FileIndex]]
       ## used to detect recursive `importer` issues populated by importer and
       ## used by `lookups`
       ## 

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -731,7 +731,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
     else:
       g.config.localReport(n.info, SemReport(
         kind: rsemSemfoldInvalidConversion,
-        typeMismatch: @[typeMismatch(g.config, n[0].typ, n.typ)]))
+        typeMismatch: @[typeMismatch(n[0].typ, n.typ)]))
 
   of nkStringToCString, nkCStringToString:
     var a = getConstExpr(m, n[0], idgen, g)

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1576,10 +1576,9 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
         var report = reportSem(rsemHasSideEffects)
         listSideEffects(report, s, g.config, t.c)
         localReport(g.config, s.info, report)
-
       else:
         # simple error for `system.compiles` context
-        localReport(g.config, s.info, reportSem(rsemCompilesError))
+        localReport(g.config, s.info, reportSem rsemCompilesHasSideEffects)
 
   if not t.gcUnsafe:
     s.typ.flags.incl tfGcSafe

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -555,8 +555,7 @@ proc transformConv(c: PTransf, n: PNode): PNode =
         # presently hints on `proc(thing)` where thing converts to non var base.
         localReport(c.graph.config, n[1], SemReport(
           kind: rsemImplicitObjConv,
-          typeMismatch: @[c.graph.config.typeMismatch(
-            formal = dest, actual = source)]))
+          typeMismatch: @[typeMismatch(formal = dest, actual = source)]))
 
     let diff = inheritanceDiff(dest, source)
     if diff == 0 or diff == high(int):

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -27,9 +27,6 @@ import
     semdata,
   ]
 
-from compiler/ast/reports_sem import SemReport
-from compiler/ast/report_enums import ReportKind
-
 export TTypeAllowedFlag, TTypeAllowedFlags
 
 proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind;
@@ -210,8 +207,8 @@ proc typeAllowedOrError*(t: PType, kind: TSymKind, c: PContext,
   else:
     newTypeError(t, nextTypeId(c.idgen)):
               c.config.newError(def,
-                                SemReport(
-                                  kind: rsemTypeNotAllowed,
+                                PAstDiag(
+                                  kind: adSemTypeNotAllowed,
                                   allowedType: (
                                     allowed: temp,
                                     actual: t,

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -23,8 +23,7 @@ import
 from compiler/ast/reports_sem import TraceSemReport,
   DebugSemStep, 
   DebugSemStepKind, 
-  DebugSemStepDirection,
-  SemCallMismatch
+  DebugSemStepDirection
 
 from compiler/ast/report_enums import ReportKind
 

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -172,6 +172,7 @@ type
     avrNoLocation   ## Address points to valid VM memory. but not to the start
                     ## of a location
 
+
 const
   firstABxInstr* = opcTJmp
   largeInstrs* = { # instructions which use 2 int32s instead of 1:

--- a/compiler/vm/vmerrors.nim
+++ b/compiler/vm/vmerrors.nim
@@ -22,8 +22,15 @@ type VmError* = object of CatchableError
 
 func raiseVmError*(
   event: sink VmEvent;
-  inst:  InstantiationInfo = instLoc()
+  inst:  InstantiationInfo
   ) {.noinline, noreturn.} =
   ## Raises a `VmError`.
   event.instLoc = inst
   raise (ref VmError)(event: event)
+
+# templates below are required as InstantiationInfo isn't captured otherwise
+
+template raiseVmError*(event: VmEvent) =
+  ## Raises a `VmError`, using the source code position of the callsite as the
+  ## `inst` value.
+  raiseVmError(event, instLoc(-2))

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -15,8 +15,8 @@
 
 import
   compiler/ast/[
+    ast_types,
     ast_query,
-    reports
   ],
   compiler/sem/[
     transf

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -354,7 +354,7 @@ proc main() =
   else:
     let files = toSeq(walkFiles(tpath / "t*.nim"))
     for i, x in files:
-      echo "$#/$# test: $#" % [$i, $files.len, x]
+      echo "$#/$# test: $#" % [$(i+1), $files.len, x]
       when defined(i386):
         if x == "nimsuggest/tests/tmacro_highlight.nim":
           echo "skipping" # workaround bug #17945

--- a/nimsuggest/tests/tchk1.nim
+++ b/nimsuggest/tests/tchk1.nim
@@ -17,11 +17,11 @@ proc main =
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Error;;$file;;12;;0;;"identifier expected, but got \'template\'";;0
+chk;;skUnknown;;;;Error;;$file;;12;;0;;"identifier expected, but found \'template\'";;0
 chk;;skUnknown;;;;Error;;$file;;14;;0;;"nestable statement requires indentation";;0
 chk;;skUnknown;;;;Error;;$file;;12;;0;;"implementation of \'foo\' expected";;0
 chk;;skUnknown;;;;Error;;$file;;17;;0;;"invalid indentation";;0
-chk;;skUnknown;;;;Hint;;$file;;20;;85;;"Hint: line too long [LineTooLong]";;0
+chk;;skUnknown;;;;Hint;;$file;;20;;87;;"Hint: line too long [LineTooLong]";;0
 chk;;skUnknown;;;;Hint;;$file;;21;;83;;"Hint: line too long [LineTooLong]";;0
 chk;;skUnknown;;;;Hint;;$file;;28;;97;;"Hint: line too long [LineTooLong]";;0
 chk;;skUnknown;;;;Hint;;$file;;29;;98;;"Hint: line too long [LineTooLong]";;0

--- a/tests/compiler_integration/parser/twhen_in_enum.nim
+++ b/tests/compiler_integration/parser/twhen_in_enum.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "identifier expected, but got 'keyword when'"
+  errormsg: "identifier expected, but found 'keyword when'"
 """
 
 # bug #2123

--- a/tests/errmsgs/t9768.nim
+++ b/tests/errmsgs/t9768.nim
@@ -1,6 +1,6 @@
 discard """
-  errormsg: "unhandled exception:"
-  file: "system/fatal.nim"
+  errormsg: "unhandled exception: t9768.nim(23, 12) `a < 4`"
+  file: "fatal.nim"
   nimout: '''
 stack trace: (most recent call last)
 t9768.nim(28, 33) main

--- a/tests/errmsgs/tmisc.nim
+++ b/tests/errmsgs/tmisc.nim
@@ -3,7 +3,7 @@ cmd: "nim check $file"
 action: reject
 nimout: '''
 tmisc.nim(25, 13) Error: object construction uses ':', not '='
-tmisc.nim(27, 5) Error: wrong number of arguments
+tmisc.nim(27, 5) Error: 'is' operator takes 2 arguments
 tmisc.nim(31, 9) Error: expression has no type: foo
 tmisc.nim(39, 5) Error: type mismatch: got <int, uint>
 but expected one of:

--- a/tests/lang_experimental/concepts/t3330.nim
+++ b/tests/lang_experimental/concepts/t3330.nim
@@ -1,5 +1,6 @@
 discard """
 description: "From https://github.com/nim-lang/Nim/issues/3330"
+knownIssue: "Requires Report/SemReport removal, see: https://github.com/nim-works/nimskull/issues/443"
 errormsg: "type mismatch: got <Bar[system.int]>"
 nimout: '''
 t3330.nim(70, 4) Error: type mismatch: got <Bar[system.int]>

--- a/tests/lang_experimental/concepts/texplain.nim
+++ b/tests/lang_experimental/concepts/texplain.nim
@@ -1,5 +1,6 @@
 discard """
   description: "Tests {.explain.} attached to concept types, to expressions, and diagnostics reporting on failed overload resolution"
+  knownIssue: "Requires Report/SemReport removal, see: https://github.com/nim-works/nimskull/issues/443"
   nimout: '''
 texplain.nim(144, 10) Hint: Non-matching candidates for e(y)
 proc e(i: int): int

--- a/tests/lang_experimental/concepts/twrapconcept.nim
+++ b/tests/lang_experimental/concepts/twrapconcept.nim
@@ -1,6 +1,7 @@
 discard """
   errormsg: "type mismatch: got <string>"
   nimout: "twrapconcept.nim(10, 13) Foo: concept predicate failed"
+  knownIssue: "Requires Report/SemReport removal, see: https://github.com/nim-works/nimskull/issues/443"
 """
 
 # https://github.com/nim-lang/Nim/issues/5127

--- a/tests/lang_objects/objvariant/temptycaseobj.nim
+++ b/tests/lang_objects/objvariant/temptycaseobj.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "identifier expected, but got 'keyword of'"
+  errormsg: "identifier expected, but found 'keyword of'"
   line: 11
 """
 

--- a/tests/misc/tsizeof2.nim
+++ b/tests/misc/tsizeof2.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: "'sizeof' requires '.importc' types to be '.completeStruct'"
+errormsg: "'sizeOf' requires '.importc' types to be '.completeStruct'"
 line: 9
 """
 


### PR DESCRIPTION
`nkError` has a `reportId` which unfortunately opens any possible "report" crawling its way in there. With the current approach, the idea is to create a data type for `nkError` alone. Then rework the code base for just that data type, once free of all the `ReportId` cruft.

The intermediate logical conclusion isn't pretty but it should allow:
- AST/Sem to drop `ReportId` and associated memory leak
- AST/Sem to evolve independently of Report cruft
- Allow throwing out all but the necessary bits of `Reports`

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
- happy to hear alternatives to remove `ReportId`
- the overall plan is to get `nkError` free of `Report` and `ReportId` etc:
  - try to get DOD AST right after this gets merged
  - break things up further, `ast_types` in particular, as we can use handles without incurring data type deps

## TODO
- [x] finish first pass conversion of all `newError`/`nkError`
- [x] compiler bootstrap
- [x] tools tests pass
- [x] full test suite passes
- [x] add code to start deleting reports and stop the space leak
- [x] remove all the commented out code left for quick reference
- [x] simplify `VmEvent` and `VmGenDiag` types and enums (more can be done)
- [x] module data type break-up quick wins