### PR TITLE
vmgen: move `mIs` folding into `semfold`

### DIFF
--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1526,17 +1526,6 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
       c.gABC(n, opcOf, dest, tmp, idx)
       c.freeTemp(tmp)
       c.freeTemp(idx)
-  of mIs:
-    # XXX: instead of performing the operation inside the VM, we're doing it
-    #      here now. The `is` operator should be handled in `semfold`, never
-    #      reaching the VM
-    if dest.isUnset: dest = c.getTemp(n.typ)
-
-    let t1 = n[1].typ.skipTypes({tyTypeDesc})
-    let t2 = n[2].typ
-    let match = if t2.kind == tyUserTypeClass: true
-                else: sameType(t1, t2)
-    c.gABx(n, opcLdImmInt, dest, ord(match))
   of mHigh:
     if dest.isUnset: dest = c.getTemp(n.typ)
     let tmp = c.genx(n[1])


### PR DESCRIPTION
## Summary
The logic is copied verbatim, and while it is still incorrect, it is now
applied earlier and no longer reaches into the code-generator. In other
words, the issue (type expression that is erroneously not materialized)
is worked around at a point that is closer (in the time sense) to the
origin of the problem than it was previously.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

While it would be better to fix the underlying issue, I currently don't have the bandwidth to do so. Moving the folding to `semfold` means that `mirgen` doesn't have to employ special handling for the `mIs` magic.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
