### PR TITLE
sem: refactor `semConstExpr`

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3504,11 +3504,11 @@ proc reportBody*(conf: ConfigRef, r: VMReport): string =
   of rvmUnsupportedNonNil:
     case r.typ.kind
     of tyRef:
-      result = "static expressions yielding non-nil 'ref' values that are" &
-              " not of 'object'-type are not supported"
+      result = "static expressions where the result contains non-nil 'ref'" &
+              " values are not supported"
     of tyPtr, tyPointer:
-      result = "static expressions yielding non-nil pointer values are " &
-              "not supported"
+      result = "static expressions where the result contains non-nil pointer" &
+              " values are not supported"
     else:
       assert false
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -899,7 +899,7 @@ func astDiagToLegacyReport*(diag: PAstDiag): Report {.inline.} =
       sym: diag.formal,
       ast: diag.wrongNode)
   of adVmUnsupportedNonNil:
-    semRep = SemReport(
+    vmRep = VMReport(
       location: std_options.some diag.location,
       reportInst: diag.instLoc.toReportLineInfo,
       kind: rvmUnsupportedNonNil,

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -164,8 +164,13 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     elif kind in {skVar, skLet}:
       result = t[1]
   of tyRef:
-    if kind == skConst: result = t
-    else: result = typeAllowedAux(marker, t.lastSon, kind, c, flags+{taHeap})
+    if kind == skConst:
+      # allow ``ref`` types for ``skConst``, as whether they're allowed in that
+      # context depends on the *value* (i.e. nil is okay, but everything else
+      # is not)
+      result = nil
+    else:
+      result = typeAllowedAux(marker, t.lastSon, kind, c, flags+{taHeap})
   of tyPtr:
     result = typeAllowedAux(marker, t.lastSon, kind, c, flags+{taHeap})
   of tySet:

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -635,7 +635,7 @@ proc myOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext 
 proc myProcess(c: PPassContext, n: PNode): PNode =
   let c = PCtx(c)
   # don't eval errornous code:
-  if c.oldErrorCount == c.config.errorCounter:
+  if c.oldErrorCount == c.config.errorCounter and not n.isError:
     let r = evalStmt(c[], n)
     reportIfError(c.config, r)
     # TODO: use the node returned by evalStmt as the result and don't report

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -993,10 +993,6 @@ proc genAsgnPatch(c: var TCtx; le: PNode, value: TRegister) =
       let dest = c.genx(le, {gfNodeAddr})
       c.gABC(le, opcWrDeref, dest, 0, value)
       c.freeTemp(dest)
-  of nkError:
-    # XXX: do a better job with error generation
-    fail(le.info, vmGenDiagCannotGenerateCode, le)
-
   else:
     discard
 
@@ -1770,7 +1766,6 @@ proc canElimAddr(n: PNode): PNode =
       # addr ( nkConv ( deref ( x ) ) ) --> nkConv(x)
       result = copyNode(n[0])
       result.add m[0]
-  of nkError: result = nil
   else:
     if n[0].kind in {nkDerefExpr, nkHiddenDeref}:
       # addr ( deref ( x )) --> x
@@ -1978,10 +1973,6 @@ proc genFieldAsgn(c: var TCtx, obj: TRegister; le, ri: PNode) =
 
 proc genAsgn(c: var TCtx; le, ri: PNode; requiresCopy: bool) =
   case le.kind
-  of nkError:
-    # XXX: do a better job with error generation
-    fail(le.info, vmGenDiagCannotGenerateCode, le)
-
   of nkBracketExpr:
     let typ = le[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind
     let dest = c.genx(le[0], {gfNode})
@@ -2480,10 +2471,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
   when defined(nimCompilerStacktraceHints):
     setFrameMsg c.config$n.info & " " & $n.kind & " " & $flags
   case n.kind
-  of nkError:
-    # XXX: do a better job with error generation
-    fail(n.info, vmGenDiagCannotGenerateCode, n)
-
   of nkSym:
     let s = n.sym
     checkCanEval(c, n)

--- a/tests/errmsgs/t5870.nim
+++ b/tests/errmsgs/t5870.nim
@@ -1,6 +1,6 @@
 discard """
-errormsg: "invalid type: 'SomeRefObj' in this context: 'seq[SomeRefObj]' for const"
-line: 14
+errormsg: "static expressions where the result contains non-nil 'ref' values are not supported"
+line: 18
 """
 
 # bug #5870
@@ -11,6 +11,10 @@ proc createSomeRefObj(v: int): SomeRefObj=
     result.new()
     result.someIntMember = v
 
+# embedded nil values work:
+const seqOfNilRefs = @[SomeRefObj(nil), SomeRefObj(nil)]
+
+# but embedded non-nil values don't:
 const compileTimeSeqOfRefObjs = @[createSomeRefObj(100500), createSomeRefObj(2)]
 
 for i in 0..1:


### PR DESCRIPTION
## Summary
- split the evaluation part into a separate procedure (`evalConstExpr`)
- use `nkError` nodes for reporting errors from `evalConstExpr`
- for a `const` definition, the expression is now not evaluated if
  its type is illegal in a `const` context

## Details
- `nkError` nodes are now prevented from reaching `vmgen`
- the `typeAllowed` check doesn't reject `ref` types for `const`s
  anymore
- disallowed non-nil values (such as for `ref`s) are now rejected via
  `ensureNilOnly` (which also looks at the *values*, not only at the
   *types*)
---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* the main motivation here is to prevent `nkError` nodes from reaching `vmgen`. If they do, they'd have to be passed through `mirgen`, which is not intended to be possible.

<!-- Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
