### PR TITLE
add a simple tracing framework

### DIFF
--- a/compiler/utils/trace_dump.nim
+++ b/compiler/utils/trace_dump.nim
@@ -1,0 +1,134 @@
+## This module implements a serializer for the trace data recorded with the
+## ``Tracer`` facility into the "Chrome Trace Event" JSON format, which is a
+## simple JSON-based format used for representing trace data. The format is
+## understood by Google Chrome's built-in "Trace Viewer" as well as other
+## trace/flamegraph visualizers, such as "Speedscope".
+##
+## For a specification, see `https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU`_
+##
+## "Complete" events (`X`) were used originally, as it meant less output to
+## write, but because of the issues it caused with visualizers in some cases,
+## "Begin" (`B`) and "End" (`E`) events are now used instead.
+##
+## While not strictly necessary, a manual JSON serializer is used instead of
+## ``std/json`` for efficiency.
+
+import
+  system/[
+    formatfloat
+  ],
+  std/[
+    monotimes,
+    times,
+    strutils,
+    streams
+  ],
+  compiler/utils/[
+    tracer
+  ]
+
+const
+  BeginPhase = "\"B\""
+  EndPhase = "\"E\""
+
+proc writeFloat(stream: Stream, val: float) =
+  var str = ""
+  str.addFloatRoundtrip(val)
+  stream.write str
+
+template fieldPart(name: untyped): untyped {.dirty.} =
+  '"' & astToStr(name) & "\":"
+
+template intField(name: untyped, val: SomeInteger) =
+  mixin stream
+  stream.write fieldPart(name)
+  stream.write $val
+
+template floatField(name: untyped, val: float) =
+  mixin stream
+  stream.write fieldPart(name)
+  stream.writeFloat val
+
+template stringField(name: untyped, val: string) =
+  mixin stream
+  stream.write fieldPart(name)
+  stream.write escape(val)
+
+template rawField(name: untyped, raw: string) =
+  mixin name
+  stream.write fieldPart(name)
+  stream.write raw
+
+template next() =
+  mixin name
+  stream.write ','
+
+proc writePayload(stream: Stream, pl: EventPayload) =
+  ## Serializes the payload's content to JSON and writes it to `stream`
+  case pl.kind
+  of tikModule:
+    stringField(name, pl.sym.name.s)
+  of tikInclude:
+    stringField(name, pl.str)
+  of tikSem:
+    stringField(kind, $pl.nk)
+    next()
+    intField(line, pl.loc.line)
+  of tikNimScript:
+    stringField(file, pl.str)
+  of tikCodegen, tikVmCodegen:
+    if pl.sym != nil:
+      stringField(name, pl.sym.name.s)
+    else:
+      intField(line, pl.loc.line)
+  of tikOther:
+    stringField(details, pl.str)
+  else:
+    if pl.sym != nil:
+      stringField(details, pl.sym.name.s)
+
+proc writeToStream*(t: Tracer, stream: Stream) =
+  ## Serializes all events and associated data recorded with `t` into the
+  ## "Chrome Trace Event" JSON Object format and outputs the result to `stream`
+  let start = t.start
+
+  # the JSON object format is used. All events are stored as an array in the
+  # 'traceEvents' field
+  stream.write """{"traceEvents": ["""
+
+  var first = true
+  for e in t.events.items:
+    let pl {.cursor.} = t.payloads[e.payload.int]
+
+    if not first:
+      stream.write ","
+    else:
+      first = false
+
+    let ph =
+      if e.begin: BeginPhase
+      else:       EndPhase
+
+    # make the timestamp a relative one and change the unit it's measured in
+    # to microseconds:
+    let ts = inNanoseconds(e.timeStamp - start).int / 1000
+
+    stream.write "{"
+    intField(pid, 0); next()   # process ID
+    intField(tid, 0); next()   # thread ID
+    rawField(ph, ph); next()   # the event phase
+    floatField(ts, ts); next() # the timestamp
+
+    # while it's not required by the specification for "End" events to store
+    # the "name" field, some visualizers won't work without
+    stringField(name, $pl.kind)
+
+    if e.begin:
+      stream.write ""","args":{"""
+      writePayload(stream, pl)
+      stream.write "}"
+
+    stream.write "}"
+
+  stream.write "]}"
+  stream.close()

--- a/compiler/utils/tracer.nim
+++ b/compiler/utils/tracer.nim
@@ -1,0 +1,151 @@
+## This module implements a simple framework for event-based tracing.
+##
+## A ``Tracer`` instance is used to record *events*. Each event is associated
+## with a payload, which stores user-provided information about the event. As
+## of now, there are only two types of events: begin and end events; but this
+## is meant to be expanded as needed.
+
+import
+  std/[
+    monotimes
+  ],
+  compiler/ast/[
+    ast_types,
+    lineinfos
+  ]
+
+type
+  TracedItemKind* = enum
+    ## Used to loosely group events together (the kind is used as the event name
+    ## in the output). This likely needs a complete redesign - the only goal so
+    ## far was to make the output readable
+    tikNimScript   = "NimScript" # an event related to NimScript processing
+    tikParser      = "Parser"
+    tikModule      = "Module"  # a module is imported
+    tikInclude     = "Include" # a module is included
+    tikSem         = "Sem"     # an event related to the semantic analysis
+                               # subsystem
+    tikVmCodegen   = "VmCodegen" # ``vmgen`` is invoked to generate bytecode in
+                                 # the context of compile-time execution
+    tikVm          = "Vm"      # the VM is invoked
+    tikTransform   = "Transform" # ``transf`` is invoked
+    tikCodegen     = "Codegen" # an event related to code-generation for the
+                               # target language
+    tikInjectDestr = "InjectDestructors"
+    tikBackend     = "Backend" # the backend is invoked (e.g. the C compiler or
+                               # linker)
+    tikOther       = "Other"   # an unspecified other event
+
+  PayloadId* = distinct uint32
+    ## The ID of a payload. Acts as the unique identifier of an event payload
+    ## in the context of a ``Tracer`` instance - they're not unique across
+    ## multiple instances
+
+  EventPayload* = object
+    ## Stores the data associated with a trace event. For simplicity and in
+    ## order to allow for figuring out the requirements, no object variant is
+    ## used and all field are available for all trace item kinds
+    kind*: TracedItemKind
+
+    nk*: TNodeKind
+
+    loc*: TLineInfo
+    sym*: PSym
+    str*: string
+
+  TraceEvent* = object
+    begin*: bool         ## whether this is a 'begin' or 'end' event
+    payload*: PayloadId  ## the ID of the associated payload
+    timeStamp*: MonoTime ## the timestamp of the event
+
+  Tracer* = object
+    start*: MonoTime         ## the point in time where the tracer became
+                             ## active. Used to turn the absolute timestamps of
+                             ## events into relative ones
+    events*: seq[TraceEvent] ## all recorded events
+    payloads*: seq[EventPayload] ## the payload data for events
+
+proc startTracer*(): Tracer =
+  ## Intializes a new ``Tracer`` instance and returns it. The start time is
+  ## initialized with the current time and the start event is recorded
+  let time = getMonoTime()
+  result = Tracer(start: time)
+  # add the payload for the top-level trace item and record a 'begin' event:
+  result.payloads.add EventPayload(kind: tikOther)
+  result.events.add TraceEvent(begin: true, payload: PayloadId 0,
+                               timeStamp: time)
+
+proc finish*(t: var Tracer) =
+  ## Records the stop event. No further events should be recorded with the
+  ## `t` after a call to ``finish``
+  let time = getMonoTime()
+  t.events.add TraceEvent(begin: false, payload: PayloadId 0, timeStamp: time)
+
+# disable stack-traces and runtime checks, so that the trace calls have less
+# overhead
+{.push stackTrace: off, checks: off.}
+
+proc addPayload*(t: var Tracer, payload: sink EventPayload): PayloadId =
+  ## Add `payload` to the tracer and returns the ID assigned to it, which can
+  ## then be used to
+  result = t.payloads.len.PayloadId
+  t.payloads.add payload
+
+proc record*(t: var Tracer, begin: bool, payload: PayloadId) {.inline.} =
+  ## Records an begin/end event with the given `payload`. A payload can
+  ## be associated with an unlimited amount of events
+  t.events.add TraceEvent(begin: begin, payload: payload,
+                          timeStamp: getMonoTime())
+
+{.pop.}
+
+# below are helper templates for instrumenting procedures or pieces of code:
+
+template traceStr*(t: var Tracer, k: TracedItemKind, s: string) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: k, str: s)
+
+  t.record(true, p)
+  defer: t.record(false, p)
+
+template traceStr*(t: var Tracer, s: string) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: tikOther, str: s)
+
+  t.record(true, p)
+  defer: t.record(false, p)
+
+template traceStr*(t: var Tracer, s: string, bloc) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: tikOther, str: s)
+  t.record(true, p)
+  bloc
+  t.record(false, p)
+
+template traceLoc*(t: var Tracer, k: TracedItemKind, l: TLineInfo) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: k, loc: l)
+
+  t.record(true, p)
+  defer: t.record(false, p)
+
+template traceSym*(t: var Tracer, k: TracedItemKind, s: PSym) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: k, sym: s)
+
+  t.record(true, p)
+  defer: t.record(false, p)
+
+template traceSym*(t: var Tracer, k: TracedItemKind, s: PSym, bloc) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: k, sym: s)
+  t.record(true, p)
+  bloc
+  t.record(false, p)
+
+template traceSem*(t: var Tracer, k: TNodeKind, l: TLineInfo) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: tikSem, nk: k, loc: l)
+
+  t.record(true, p)
+  defer: t.record(false, p)


### PR DESCRIPTION
## Summary
The goal is to provide the base for an event-based tracing framework
that can be incrementally improved/expanded upon. In its current form,
it's mainly meant for execution-time tracing.

While generally tailored towards being used as part of the compiler,
it's meant to be general enough to be used for both one-off temporary
instrumentation for use during debugging, and for building a persistent,
maybe even user-facing, compiler tracing facility. For example, it could
be expanded to also support the tracing done by `debugutils`.

This commit only adds the framework and a JSON serializer - both are not
used anywhere in the compiler yet.

## Details
The `tracer` module implements the data types and routines that make up
the framework.

The `trace_dump` module implements a serializer to the "Chrome Trace
Event" JSON Object format, which was chosen due to it being
simple-yet-powerful, with multiple visualizers already existing for it.