### PR TITLE
tables: fix multiple `OrderedTable` bugs

### DIFF
--- a/tests/stdlib/types/collections/torderedtable_regression.nim
+++ b/tests/stdlib/types/collections/torderedtable_regression.nim
@@ -1,0 +1,57 @@
+discard """
+  description: "A regression test for lazily initialized `OrderedTable`s"
+  target: native
+"""
+
+include std/tables
+
+type Key = distinct int
+
+proc hash(x: Key): int = int(x)
+proc `==`(a, b: Key): bool {.borrow.}
+
+# choose the key so that the hash function yields a value `x` where
+# `x mod internalSlotCount` equals 0. Note that this depends on an
+# implementation detail of ``OrderedTable``
+let zeroKey = slotsNeeded(defaultInitialSize)
+
+block infinite_loop:
+  # ``initOrderedTable`` is explicitly **not** used 
+  var tbl: OrderedTable[Key, int]
+
+  # the key matters but the value doesn't 
+  tbl[Key zeroKey] = 3
+  var first = true
+  for k, v in tbl.pairs:
+    doAssert first # reaching this assert more than one time is an error
+    first = false
+
+block cut_off:
+  var tbl: OrderedTable[Key, int]
+  # insert multiple items that don't use slot 0
+  tbl[Key(zeroKey+1)] = 1
+  tbl[Key(zeroKey+2)] = 2
+  tbl[Key(zeroKey+3)] = 3
+  # now insert an item that uses slot 0
+  tbl[Key(zeroKey)] = 0
+
+  doAssert tbl.len == 4 # the length is correct
+
+  var c = 0
+  for _ in tbl.keys:
+    inc c
+  
+  doAssert c == tbl.len # but the number of items returned is not
+
+  # create a table with the same number of items
+  var tbl2: OrderedTable[Key, int]
+  # insert multiple items that don't use slot 0 and for which the value
+  # differs from the ones used in `tbl`
+  tbl2[Key(zeroKey+1)] = 4
+  tbl2[Key(zeroKey+2)] = 5
+  tbl2[Key(zeroKey+3)] = 6
+
+  # now insert an item that uses slot 0
+  tbl2[Key(zeroKey)] = 0
+
+  doAssert tbl != tbl2


### PR DESCRIPTION
## Summary
The fixed issues:
- for `OrderedTable`s with a single item, the iterators would get stuck in an infinite loop in some cases
- items would sometimes not be yielded when using any of the iterators
- comparing two `OrderedTable` would sometimes ignore items

These only happened for `OrdererdTable` not explicitly initialized via `initOrderedTable` - explicitly initialized ones were not affected.

## The problem
The underlying issue was the same in each case. An `OrderedTable` uses an intrusive linked list internally. Each slot stores a `next` pointer and the table itself the head (`first`) and tail (`last`) pointer.

Since the pointers are indices into the internal data `seq` and not memory addresses, the default value (i.e. 0) does not represent "none" (because the 0-th `seq` item is a valid item), meaning that the pointers have to be explicitly initialized to the "none" state (i.e. `-1`). This happens when using `initOrderedTable`, and at one point did also happen when inserting into a default-initialized table, but the latter behaviour got removed as part of
#161 (likely by accident).

When inserting an item into a default initialized `OrderedTable` and the selected slot is slot `0`, the slot's `next` pointer was set to point to the slot itself, due to the `last` pointer incorrectly pointing to slot `0` at that point. If any of the iterators were used directly after this insertion, they would loop forever (because of the self-cycle).

When inserting an item into a default initialized `OrderedTable` and the selected slot is not `0`, the `next` pointer of the unfilled slot `0` (which is treated as the head of the linked list) is set to the index of the newly filled slot. As most of the `OrderedTable` implementation checks for and skips unfilled slots, this doesn't cause any immediate problems, but once the slot at position `0` becomes used (before the table is first enlarged), all previously inserted items are effectively cut off. They're still part of the table, but are no longer returned by any of the iterators nor considered during comparisons or when using `sort`.

## Details
- add an overload of the `initImpl` template that correctly sets the `first` and `last` pointer to `-1` as part when initializing the `OrderedTable` (either explicitly or lazily)
- remove the `isFilled` guards from logic that traverses the linked list - they're unnecessary
- remove the `rawGetKnownHC`, `rawGetDeep`, and `rawGet` overloads for `OrderedTable`. They were either unused or the same as the more general implementation

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

The issue caused Nim-CPS to sometimes get stuck in an infinite loop at compile-time.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
