### PR TITLE
introduce vm syscall - echo

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -53,6 +53,8 @@ import
 
 import std/options as std_options
 
+from std/strutils import join
+
 from compiler/vm/vmgen import vmGenDiagToAstDiagVmGenError
 
 # TODO: legacy report cruft remove from here
@@ -291,9 +293,18 @@ proc execute(c: var TCtx, start: int, frame: sink TStackFrame;
         result.initFailure:
           buildError(c, thread, res.takeErr)
         break
-
       # success! ``compile`` updated the procedure's entry, so we can
       # continue execution
+    of yrkEcho:
+      # vm yielded with an echo
+      # xxx: `localReport` and report anything needs to be replaced, this is
+      #      just output and it's ridiculous that it all funnles through
+      #      `cli_reporter`. Using it here only because I'm sure there is some
+      #      spooky action at a distance breakage without. at least it's pushed
+      #      out to the edge.
+      localReport(c.config, InternalReport(msg: r.strs.join(""),
+                                           kind: rintEchoMessage))
+      # after echo continue executing, hence no `break`
 
   dispose(c, thread)
 


### PR DESCRIPTION
## Summary

Introduced a 'syscall' concept to the VM, starting with the "echo".

## Details

This is the first 'syscall' for the VM. Meaning the VM will yield control to the caller with the reason `yrkEcho`. The caller, the "system" in this case, is responsible for fullfilling the expectations of the echo, whatever that mean in the particular context, then resuming execution, if it chooses to. Baby CPS (Continuation Passing Style) for the win!

It's pretty simple right now, but it already drops more report related dependencies from the VM. A bit more of this and we'll have excised much of it in no time. :D

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* not looking to rework all the things, rather get a good start on them
* I'm not sure the precise shape of the "syscall" interface, so I didn't go nuts with documenting the concept
* if any quick wins stand out let me know, otherwise, I'll keep rolling with these and see what emerges.