### PR TITLE
semstmts: produce an `skError` for erroneous constants

### DIFF
--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -806,7 +806,7 @@ func astDiagToLegacyReport*(diag: PAstDiag): Report {.inline.} =
         location: std_options.some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: rsemOnlyDeclaredIdentifierFoundIsError,
-        str: diag.name,
+        str: diag.identName,
         ast: diag.wrongNode,
         wrongNode: diag.err)
   of adSemCannotImportItself:


### PR DESCRIPTION
## Summary
If the type or initializer expression has an error, the produced symbol is
now an `skError`. This prevents the `nkError` node that represents the
content of the constant from being inlined, which would cause the compiler
to crash, as `nkError` nodes are not expected when inlining constants.

## Details
- fix a compiler crash when using tuple unpacking for a `const` and either
  the type or the init expression is erroneous
- remove the check for `nkEmpty` init expressions. They're already handled
  earlier when evaluating the expression

## Misc
- fix a `FieldDefect` crash when converting
  `adSemOnlyDeclaredIdentifierFoundIsError` to a legacy report