### PR TITLE
compiler: remove leftover `nimfind` integration

### DIFF
--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -131,9 +131,6 @@ type
     cacheCounters*: Table[string, BiggestInt] # IC: implemented
     cacheTables*: Table[string, BTree[string, PNode]] # IC: implemented
     passes*: seq[TPass]
-    onDefinition*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
-    onDefinitionResolveForward*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
-    onUsage*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
     globalDestructors*: seq[PNode]
     strongSemCheck*: proc (graph: ModuleGraph; owner: PSym; body: PNode) {.nimcall.}
     compatibleProps*: proc (graph: ModuleGraph; formal, actual: PType): bool {.nimcall.}
@@ -407,29 +404,6 @@ proc hash*(u: SigHash): Hash =
     result = (result shl 8) or u.MD5Digest[x].int
 
 proc hash*(x: FileIndex): Hash {.borrow.}
-
-when defined(nimfind):
-  template getPContext(): untyped =
-    when c is PContext: c
-    else: c.c
-
-  template onUse*(info: TLineInfo; s: PSym) =
-    let c = getPContext()
-    if c.graph.onUsage != nil: c.graph.onUsage(c.graph, s, info)
-
-  template onDef*(info: TLineInfo; s: PSym) =
-    let c = getPContext()
-    if c.graph.onDefinition != nil: c.graph.onDefinition(c.graph, s, info)
-
-  template onDefResolveForward*(info: TLineInfo; s: PSym) =
-    let c = getPContext()
-    if c.graph.onDefinitionResolveForward != nil:
-      c.graph.onDefinitionResolveForward(c.graph, s, info)
-
-else:
-  template onUse*(info: TLineInfo; s: PSym) = discard
-  template onDef*(info: TLineInfo; s: PSym) = discard
-  template onDefResolveForward*(info: TLineInfo; s: PSym) = discard
 
 proc stopCompile*(g: ModuleGraph): bool {.inline.} =
   result = g.doStopCompile != nil and g.doStopCompile()

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -363,7 +363,6 @@ proc considerAsgnOrSink(c: var TLiftCtx; t: PType; body, x, y: PNode;
         incl c.fn.flags, sfError
       #else:
       #  markUsed(c.g.config, c.info, op, c.g.usageSym)
-      onUse(c.info, op)
       body.add newHookCall(c, op, x, y)
       result = true
     elif op == nil and destructorOverriden:
@@ -387,7 +386,6 @@ proc considerAsgnOrSink(c: var TLiftCtx; t: PType; body, x, y: PNode;
       incl c.fn.flags, sfError
     #else:
     #  markUsed(c.g.config, c.info, op, c.g.usageSym)
-    onUse(c.info, op)
     # We also now do generic instantiations in the destructor lifting pass:
     if op.ast.isGenericRoutine:
       op = instantiateGeneric(c, op, t, t.typeInst)
@@ -417,7 +415,6 @@ proc addDestructorCall(c: var TLiftCtx; orig: PType; body, x: PNode) =
 
   if op != nil:
     #markUsed(c.g.config, c.info, op, c.g.usageSym)
-    onUse(c.info, op)
     body.add destructorCall(c, op, x)
   elif useNoGc(c, t):
     internalError(
@@ -435,7 +432,6 @@ proc considerUserDefinedOp(c: var TLiftCtx; t: PType; body, x, y: PNode): bool =
         setAttachedOp(c.g, c.idgen.module, t, attachedDestructor, op)
 
       #markUsed(c.g.config, c.info, op, c.g.usageSym)
-      onUse(c.info, op)
       body.add destructorCall(c, op, x)
       result = true
     #result = addDestructorCall(c, t, body, x)
@@ -455,7 +451,6 @@ proc considerUserDefinedOp(c: var TLiftCtx; t: PType; body, x, y: PNode): bool =
     let op = getAttachedOp(c.g, t, attachedDeepCopy)
     if op != nil:
       #markUsed(c.g.config, c.info, op, c.g.usageSym)
-      onUse(c.info, op)
       body.add newDeepCopyCall(c, op, x, y)
       result = true
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -614,7 +614,6 @@ proc semMacroExpr(c: PContext, n: PNode, sym: PSym,
 
   let info = getCallLineInfo(n)
   markUsed(c, info, sym)
-  onUse(info, sym)
   if sym == c.p.owner:
     globalReport(c.config, info, reportSym(rsemCyclicDependency, sym))
 

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -464,7 +464,6 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   var finalCallee = x.calleeSym
   let info = getCallLineInfo(n)
   markUsed(c, info, finalCallee)
-  onUse(info, finalCallee)
   assert finalCallee.ast != nil
   if x.hasFauxMatch:
     result = x.call
@@ -571,7 +570,6 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   newInst.typ.flags.excl tfUnresolved
   let info = getCallLineInfo(n)
   markUsed(c, info, s)
-  onUse(info, s)
   result = newSymNode(newInst, info)
 
 proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -84,14 +84,12 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
     result = symChoice(c, n, s, scOpen)
   of skTemplate:
     if macroToExpandSym(s):
-      onUse(n.info, s)
       result = semTemplateExpr(c, n, s, {efNoSemCheck})
       result = semGenericStmt(c, result, {}, ctx)
     else:
       result = symChoice(c, n, s, scOpen)
   of skMacro:
     if macroToExpandSym(s):
-      onUse(n.info, s)
       result = semMacroExpr(c, n, s, {efNoSemCheck})
       result = semGenericStmt(c, result, {}, ctx)
     else:
@@ -104,26 +102,21 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
         result = n
     else:
       result = newSymNodeTypeDesc(s, c.idgen, n.info)
-    onUse(n.info, s)
   of skParam:
     result = n
-    onUse(n.info, s)
   of skType:
     if (s.typ != nil) and
        (s.typ.flags * {tfGenericTypeParam, tfImplicitTypeParam} == {}):
       result = newSymNodeTypeDesc(s, c.idgen, n.info)
     else:
       result = n
-    onUse(n.info, s)
   of skEnumField:
     if overloadableEnums in c.features:
       result = symChoice(c, n, s, scOpen)
     else:
       result = newSymNode(s, n.info)
-      onUse(n.info, s)
   else:
     result = newSymNode(s, n.info)
-    onUse(n.info, s)
 
 proc lookup(c: PContext, n: PNode, flags: TSemGenericFlags,
             ctx: var GenericCtx): PNode =
@@ -203,7 +196,6 @@ proc addTempDecl(c: PContext; n: PNode; kind: TSymKind) =
   let s = newSymS(skUnknown, getIdentNode(c, n), c)
   addPrelimDecl(c, s)
   styleCheckDef(c.config, n.info, s, kind)
-  onDef(n.info, s)
 
 template captureError(conf: ConfigRef, n: PNode, body) =
   # Should this pattern arise more often, perhaps
@@ -285,7 +277,6 @@ proc semGenericStmt(c: PContext, n: PNode,
       case s.kind
       of skMacro:
         if macroToExpand(s) and sc.safeLen <= 1:
-          onUse(fn.info, s)
           result = semMacroExpr(c, n, s, {efNoSemCheck})
           result = semGenericStmt(c, result, flags, ctx)
           if result.isError: return
@@ -295,7 +286,6 @@ proc semGenericStmt(c: PContext, n: PNode,
         mixinContext = true
       of skTemplate:
         if macroToExpand(s) and sc.safeLen <= 1:
-          onUse(fn.info, s)
           result = semTemplateExpr(c, n, s, {efNoSemCheck})
           result = semGenericStmt(c, result, flags, ctx)
           if result.isError: return
@@ -319,13 +309,11 @@ proc semGenericStmt(c: PContext, n: PNode,
           first = result.safeLen # see trunnableexamples.fun3
       of skGenericParam:
         result[0] = newSymNodeTypeDesc(s, c.idgen, fn.info)
-        onUse(fn.info, s)
         first = 1
       of skType:
         # bad hack for generics:
         if (s.typ != nil) and (s.typ.kind != tyGenericParam):
           result[0] = newSymNodeTypeDesc(s, c.idgen, fn.info)
-          onUse(fn.info, s)
           first = 1
       of skError:
         if s.isError: # has the error ast
@@ -337,7 +325,6 @@ proc semGenericStmt(c: PContext, n: PNode,
           discard
       else:
         result[0] = newSymNode(s, fn.info)
-        onUse(fn.info, s)
         first = 1
     elif fn.kind == nkDotExpr:
       result[0] = fuzzyLookup(c, fn, flags, ctx, mixinContext)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -137,7 +137,6 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
 
     result.n.add symNode
     styleCheckDef(c.config, e)
-    onDef(e.info, e)
     if sfGenSym notin e.flags:
       if not isPure:
         if overloadableEnums in c.features:
@@ -426,13 +425,11 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
       result = qualifiedLookUp(c, n, {checkAmbiguity, checkUndeclared})
     if result.isError:
       markUsed(c, n.info, result)
-      onUse(n.info, result)
 
       # XXX: move to propagating nkError, skError, and tyError
       localReport(c.config, result.ast)
     elif result != nil:
       markUsed(c, n.info, result)
-      onUse(n.info, result)
 
       if result.kind == skParam and result.typ.kind == tyTypeDesc:
         # This is a typedesc param. is it already bound?
@@ -539,7 +536,6 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
         addSonSkipIntLit(result, typ, c.idgen)
 
       styleCheckDef(c.config, a[j].info, field)
-      onDef(field.info, field)
 
   if result.n.len == 0: result.n = nil
   if isTupleRecursive(result):
@@ -930,7 +926,6 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
         a.add newSymNode(f)
 
       styleCheckDef(c.config, f)
-      onDef(f.info, f)
     if a.kind != nkEmpty: father.add a
   of nkSym:
     # This branch only valid during generic object
@@ -1311,7 +1306,6 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
 
   of tyGenericParam:
     markUsed(c, paramType.sym.info, paramType.sym)
-    onUse(paramType.sym.info, paramType.sym)
     if tfWildcard in paramType.flags:
       paramType.flags.excl tfWildcard
       paramType.sym.transitionGenericParamToType()
@@ -1474,7 +1468,6 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       rawAddSon(result, finalType)
       addParamOrResult(c, arg, kind)
       styleCheckDef(c.config, a[j].info, arg)
-      onDef(a[j].info, arg)
       if {optNimV1Emulation, optNimV12Emulation} * c.config.globalOptions == {}:
         a[j] = newSymNode(arg)
 
@@ -2162,7 +2155,6 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         assignType(prev, t)
         result = prev
       markUsed(c, n.info, n.sym)
-      onUse(n.info, n.sym)
     else:
       if s.kind != skError:
         localReport(c.config, n.info, reportSym(rsemTypeExpected, s))

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2444,7 +2444,6 @@ proc paramTypesMatch*(
     else:
       # only one valid interpretation found, executing argument match
       markUsed(candidate.c, arg.info, arg[bestArg].sym)
-      onUse(arg.info, arg[bestArg].sym)
       result = paramTypesMatchAux(
         candidate, formal, arg[bestArg].typ, arg[bestArg])
 


### PR DESCRIPTION
## Summary
The `nimfind` tool was succeeded by a `nim check` subcommand and removed
as part of #957478ce264d0496f9a0c33de4af77ad0846b42d . This commit
removes the leftover `onDef`, `onUse`, and `onDefResolveForward` templates
plus usages.