### PR TITLE
stdlib: split sexp module into sexp and sexp_parse

### DIFF
--- a/lib/experimental/sexp.nim
+++ b/lib/experimental/sexp.nim
@@ -7,7 +7,24 @@
 #    distribution, for details about the copyright.
 #
 
-## **Note:** Import ``nimsuggest/sexp`` to use this module
+## **Note:** Import ``experimental/sexp`` to use this module
+##
+## Symbolic Expressions, S-Expressions, s-expresssions, s-exp, sexp, whatever
+## someone might call them are woefully underspecified. There aren't too many
+## places too screw-up, but edge cases matter.
+##
+## This modules allows for s-exp handling and is "flavoured" by remaining
+## largely compatible with emacs' EPC specification. As such it's meant for
+## serdes (serializing and deserializing) data and will likely fall short for
+## forgiving/precise parsing that a high quality lisp like language interpreter
+## may require.
+##
+## Future Direction:
+## - Keyword support (:someKeyWord) might be removed or reworked to not require
+##     a key/value pair approach
+## - cons vs list separation and nil handling
+
+import experimental/sexp_parse
 
 import
   std/[hashes, strutils, lexbase, streams, unicode, macros, algorithm]
@@ -15,46 +32,42 @@ import
 import std/private/decode_helpers
 
 type
-  SexpEventKind* = enum  ## enumeration of all events that may occur when
-                         ## parsing
-    sexpError,           ## an error occurred during parsing
-    sexpEof,             ## end of file reached
-    sexpString,          ## a string literal
-    sexpSymbol,          ## a symbol
-    sexpKeyword,         ## `:keyword` event
-    sexpInt,             ## an integer literal
-    sexpFloat,           ## a float literal
-    sexpNil,             ## the value ``nil``
-    sexpDot,             ## the dot to separate car/cdr
-    sexpListStart,       ## start of a list: the ``(`` token
-    sexpListEnd,         ## end of a list: the ``)`` token
+  SexpNodeKind* = enum ## possible s-exp node types
+    SNil,
+    SInt,
+    SFloat,
+    SString,
+    SSymbol,
+    SKeyword,
+    SList,
+    SCons
 
-  TTokKind = enum        # must be synchronized with SexpEventKind!
-    tkError,
-    tkEof,
-    tkString,
-    tkSymbol,
-    tkKeyword,
-    tkInt,
-    tkFloat,
-    tkNil,
-    tkDot,
-    tkParensLe,
-    tkParensRi
-    tkSpace
+  SexpNode* = ref SexpNodeObj ## s-exp node
+  SexpNodeObj* {.acyclic.} = object
+    case kind*: SexpNodeKind
+    of SString:
+      str*: string
+    of SSymbol:
+      symbol*: string
+    of SInt:
+      num*: BiggestInt
+    of SFloat:
+      fnum*: float
+    of SList:
+      elems*: seq[SexpNode]
+    of SKeyword:             # xxx: might remove keywords, at least the forced
+                             #      key/value aspect.
+      key*: string
+      value*: SexpNode
+    of SCons:
+      car*: SexpNode
+      cdr*: SexpNode
+    of SNil:
+      discard
 
-  SexpError* = enum        ## enumeration that lists all errors that can occur
-    errNone,               ## no error
-    errInvalidToken,       ## invalid token
-    errParensRiExpected,    ## ``)`` expected
-    errQuoteExpected,      ## ``"`` expected
-    errEofExpected,        ## EOF expected
+  Cons = tuple[car: SexpNode, cdr: SexpNode]
 
-  SexpParser* = object of BaseLexer ## the parser object.
-    str: string
-    tok: TTokKind ## Current token that lexer has processed
-    kind: SexpEventKind
-    err: SexpError
+  SexpParsingError* = object of ValueError ## is raised for a s-exp error
 
 const
   errorMessages: array[SexpError, string] = [
@@ -77,42 +90,12 @@ const
     "(", ")", "space"
   ]
 
-proc close*(parser: var SexpParser) {.inline.} =
-  ## closes the parser `parser` and its associated input stream.
-  lexbase.close(parser)
-
-proc str*(parser: SexpParser): string {.inline.} =
-  ## returns the character data for the events: ``sexpInt``, ``sexpFloat``,
-  ## ``sexpString``
-  assert(parser.kind in {sexpInt, sexpFloat, sexpString})
-  result = parser.str
-
-proc getInt*(parser: SexpParser): BiggestInt {.inline.} =
-  ## returns the number for the event: ``sexpInt``
-  assert(parser.kind == sexpInt)
-  result = parseBiggestInt(parser.str)
-
-proc getFloat*(parser: SexpParser): float {.inline.} =
-  ## returns the number for the event: ``sexpFloat``
-  assert(parser.kind == sexpFloat)
-  result = parseFloat(parser.str)
-
-proc kind*(parser: SexpParser): SexpEventKind {.inline.} =
-  ## returns the current event type for the SEXP parser
-  result = parser.kind
-
-proc getColumn*(parser: SexpParser): int {.inline.} =
-  ## get the current column the parser has arrived at.
-  result = getColNumber(parser, parser.bufpos)
-
-proc getLine*(parser: SexpParser): int {.inline.} =
-  ## get the current line the parser has arrived at.
-  result = parser.lineNumber
-
 proc errorMsg*(parser: SexpParser): string =
   ## returns a helpful error message for the event ``sexpError``
   assert(parser.kind == sexpError)
-  result = "($1, $2) Error: $3" % [$getLine(parser), $getColumn(parser), errorMessages[parser.err]]
+  result = "($1, $2) Error: $3" % [$getLine(parser),
+                                   $getColumn(parser),
+                                   errorMessages[parser.error]]
 
 proc errorMsgExpected*(parser: SexpParser, e: string): string =
   ## returns an error message "`e` expected" in the same format as the
@@ -121,207 +104,19 @@ proc errorMsgExpected*(parser: SexpParser, e: string): string =
     $getLine(parser),
     $getColumn(parser),
     e & " expected",
-    $parser.str,
-    $parser.tok
+    $parser.currString,
+    $parser.currToken
   ]
 
-proc parseString(parser: var SexpParser): TTokKind =
-  result = tkString
-  var pos = parser.bufpos + 1
-  while true:
-    case parser.buf[pos]
-    of '\0':
-      parser.err = errQuoteExpected
-      result = tkError
-      break
-    of '"':
-      inc(pos)
-      break
-    of '\\':
-      case parser.buf[pos+1]
-      of '\\', '"', '\'', '/':
-        add(parser.str, parser.buf[pos+1])
-        inc(pos, 2)
-      of 'b':
-        add(parser.str, '\b')
-        inc(pos, 2)
-      of 'f':
-        add(parser.str, '\f')
-        inc(pos, 2)
-      of 'n':
-        add(parser.str, '\L')
-        inc(pos, 2)
-      of 'r':
-        add(parser.str, '\C')
-        inc(pos, 2)
-      of 't':
-        add(parser.str, '\t')
-        inc(pos, 2)
-      of 'u':
-        inc(pos, 2)
-        var r: int
-        if handleHexChar(parser.buf[pos], r): inc(pos)
-        if handleHexChar(parser.buf[pos], r): inc(pos)
-        if handleHexChar(parser.buf[pos], r): inc(pos)
-        if handleHexChar(parser.buf[pos], r): inc(pos)
-        add(parser.str, toUTF8(Rune(r)))
-      else:
-        # don't bother with the error
-        add(parser.str, parser.buf[pos])
-        inc(pos)
-    of '\c':
-      pos = lexbase.handleCR(parser, pos)
-      add(parser.str, '\c')
-    of '\L':
-      pos = lexbase.handleLF(parser, pos)
-      add(parser.str, '\L')
-    else:
-      add(parser.str, parser.buf[pos])
-      inc(pos)
-  parser.bufpos = pos # store back
-
-proc parseNumber(parser: var SexpParser) =
-  var pos = parser.bufpos
-  if parser.buf[pos] == '-':
-    add(parser.str, '-')
-    inc(pos)
-  if parser.buf[pos] == '.':
-    add(parser.str, "0.")
-    inc(pos)
-  else:
-    while parser.buf[pos] in Digits:
-      add(parser.str, parser.buf[pos])
-      inc(pos)
-    if parser.buf[pos] == '.':
-      add(parser.str, '.')
-      inc(pos)
-  # digits after the dot:
-  while parser.buf[pos] in Digits:
-    add(parser.str, parser.buf[pos])
-    inc(pos)
-  if parser.buf[pos] in {'E', 'e'}:
-    add(parser.str, parser.buf[pos])
-    inc(pos)
-    if parser.buf[pos] in {'+', '-'}:
-      add(parser.str, parser.buf[pos])
-      inc(pos)
-    while parser.buf[pos] in Digits:
-      add(parser.str, parser.buf[pos])
-      inc(pos)
-  parser.bufpos = pos
-
-proc parseSymbol(parser: var SexpParser) =
-  # Using symbol definition from
-  # http://www.lispworks.com/documentation/HyperSpec/Body/02_cd.htm
-  var pos = parser.bufpos
-  while parser.buf[pos] notin Whitespace + {')', '('}:
-    add(parser.str, parser.buf[pos])
-    inc(pos)
-  parser.bufpos = pos
-
-proc getTok(parser: var SexpParser): TTokKind =
-  # echo ">> ", parser.tok, " ", parser.bufpos, " @ ", parser.buf[parser.bufpos]
-  setLen(parser.str, 0)
-  case parser.buf[parser.bufpos]
-  of '-', '0'..'9': # numbers that start with a . are not parsed
-                    # correctly.
-    parseNumber(parser)
-    if {'.', 'e', 'E'} in parser.str:
-      result = tkFloat
-    else:
-      result = tkInt
-  of '"': #" # gotta fix nim-mode
-    result = parseString(parser)
-  of '(':
-    inc(parser.bufpos)
-    result = tkParensLe
-  of ')':
-    inc(parser.bufpos)
-    result = tkParensRi
-  of '\0':
-    result = tkEof
-  of ':':
-    parseSymbol(parser)
-    result = tkKeyword
-  of {'\x01' .. '\x1F'} - Whitespace:
-    inc(parser.bufpos)
-    result = tkError
-  of Whitespace:
-    result = tkSpace
-    if parser.buf[parser.bufpos] in lexbase.NewLines:
-      parser.bufpos = parser.handleRefillChar(parser.bufpos)
-
-    else:
-      inc(parser.bufpos)
-
-    while parser.bufpos < parser.buf.len and
-          parser.buf[parser.bufpos] in Whitespace:
-      if parser.buf[parser.bufpos] in lexbase.NewLines:
-        parser.bufpos = parser.handleRefillChar(parser.bufpos)
-
-      else:
-        inc parser.bufpos
-
-  of '.':
-    result = tkDot
-    inc(parser.bufpos)
-  else:
-    parseSymbol(parser)
-    if parser.str == "nil":
-      result = tkNil
-    else:
-      result = tkSymbol
-  parser.tok = result
-  # echo " << ", parser.tok, " ", parser.bufpos
-
-# ------------- higher level interface ---------------------------------------
-
-type
-  SexpNodeKind* = enum ## possible SEXP node types
-    SNil,
-    SInt,
-    SFloat,
-    SString,
-    SSymbol,
-    SKeyword,
-    SList,
-    SCons
-
-  SexpNode* = ref SexpNodeObj ## SEXP node
-  SexpNodeObj* {.acyclic.} = object
-    case kind*: SexpNodeKind
-    of SString:
-      str*: string
-    of SSymbol:
-      symbol*: string
-    of SInt:
-      num*: BiggestInt
-    of SFloat:
-      fnum*: float
-    of SList:
-      elems*: seq[SexpNode]
-    of SKeyword:
-      key*: string
-      value*: SexpNode
-    of SCons:
-      car*: SexpNode
-      cdr*: SexpNode
-    of SNil:
-      discard
-
-  Cons = tuple[car: SexpNode, cdr: SexpNode]
-
-  SexpParsingError* = object of ValueError ## is raised for a SEXP error
-
 proc raiseParseErr*(p: SexpParser, msg: string) {.noinline, noreturn.} =
-  ## raises an `ESexpParsingError` exception.
+  ## raises an `SexpParsingError` exception.
   raise newException(SexpParsingError, errorMsgExpected(p, msg))
 
 proc newSString*(s: string): SexpNode =
   ## Creates a new `SString SexpNode`.
   result = SexpNode(kind: SString, str: s)
 
-proc newSStringMove(s: string): SexpNode =
+proc newSStringMove(s: sink string): SexpNode =
   result = SexpNode(kind: SString)
   shallowCopy(result.str, s)
 
@@ -339,15 +134,16 @@ proc newSNil*(): SexpNode =
 
 proc newSCons*(car, cdr: SexpNode): SexpNode =
   ## Creates a new `SCons SexpNode`
+  ## NB: this will not evaluate the arguments, eg: 'nil . nil' -> 'nil'
   result = SexpNode(kind: SCons, car: car, cdr: cdr)
 
 proc newSKeyword*(key: string, value: SexpNode): SexpNode =
   ## Create new `SKeyword` node with `key` and `value` specified
   result = SexpNode(kind: SKeyword, key: key, value: value)
 
-proc newSList*(): SexpNode =
+proc newSList*(items: varargs[SexpNode]): SexpNode =
   ## Creates a new `SList SexpNode`
-  result = SexpNode(kind: SList, elems: @[])
+  result = SexpNode(kind: SList, elems: @items)
 
 proc newSSymbol*(s: string): SexpNode =
   result = SexpNode(kind: SSymbol, symbol: s)
@@ -425,6 +221,8 @@ proc sexp*(n: float): SexpNode =
 proc sexp*(b: bool): SexpNode =
   ## Generic constructor for SEXP data. Creates a new `SSymbol
   ## SexpNode` with value t or `SNil SexpNode`.
+  ##
+  ## Future Direction: the t/nil behaviour may change unless required by EPC
   if b:
     result = SexpNode(kind: SSymbol, symbol: "t")
   else:
@@ -445,13 +243,10 @@ proc toSexp(x: NimNode): NimNode {.compileTime.} =
     result = newNimNode(nnkBracket)
     for i in 0 ..< x.len:
       result.add(toSexp(x[i]))
-
     result = prefix(result, "sexp")
-
   of nnkExprEqExpr:
     result = prefix(nnkTupleConstr.newTree(
       newLit(x[0].strVal()), toSexp(x[1])), "sexp")
-
   else:
     result = prefix(x, "sexp")
 
@@ -463,12 +258,11 @@ macro convertSexp*(x: untyped): untyped =
 proc `==`* (a, b: SexpNode): bool {.noSideEffect.} =
   ## Check two nodes for equality
   if a.isNil:
-    if b.isNil: return true
-    return false
+    b.isNil
   elif b.isNil or a.kind != b.kind:
-    return false
+    false
   else:
-    return case a.kind
+    case a.kind
     of SString:
       a.str == b.str
     of SInt:
@@ -641,15 +435,14 @@ proc toPretty(result: var string, node: SexpNode, indent = 2, ml = true,
         true, newIndent(currIndent, indent, ml))
     result.add(")")
 
-
 proc pretty*(node: SexpNode, indent = 2): string =
-  ## Converts `node` to its Sexp Representation, with indentation and
+  ## Converts `node` to its S-Expression representation, with indentation and
   ## on multiple lines.
   result = ""
   toPretty(result, node, indent)
 
 proc `$`*(node: SexpNode): string =
-  ## Converts `node` to its SEXP Representation on one line.
+  ## Converts `node` to its s-expression representation on one line.
   result = ""
   toPretty(result, node, 0, false)
 
@@ -658,7 +451,6 @@ iterator items*(node: SexpNode): SexpNode =
   assert node.kind == SList
   for i in items(node.elems):
     yield i
-
 
 iterator pairs*(node: SexpNode): (int, SexpNode) =
   ## Iterator for the pairs of `node`. `node` has to be a SList.
@@ -681,115 +473,92 @@ iterator mpairs*(node: var SexpNode): (int, var SexpNode) =
     yield (i, node)
 
 proc treeRepr*(node: SexpNode): string =
-  ## Generate uncolored tree repr string for the S-expression AST.
+  ## Generate uncolored tree repr string for the S-Expression AST.
   proc aux(node: SexpNode, level: int, res: var string) =
     res.add repeat("  ", level)
     res.add $node.kind
-    case node.kind:
-      of SInt:
-        res.add " "
-        res.add $node.getNum()
-
-      of SFloat:
-        res.add " "
-        res.add $node.getFNum()
-
-      of SString:
-        res.add " \""
-        res.add node.getStr()
-        res.add "\""
-
-      of SList:
-        for item in node:
-          res.add "\n"
-          aux(item, level + 1, res)
-
-      of SKeyword:
-        res.add " :"
-        res.add node.key
+    case node.kind
+    of SInt:
+      res.add " "
+      res.add $node.getNum()
+    of SFloat:
+      res.add " "
+      res.add $node.getFNum()
+    of SString:
+      res.add " \""
+      res.add node.getStr()
+      res.add "\""
+    of SList:
+      for item in node:
         res.add "\n"
-        aux(node.value, level + 1, res)
-
-      of SNil:
-        res.add " null"
-
-      of SSymbol:
-        res.add " " & node.symbol
-
-      of SCons:
-        res.add "\n" & repeat("  ", level + 1) & "car"
-        aux(node.car, level + 2, res)
-        res.add "\n" & repeat("  ", level + 1) & "cdr"
-        aux(node.cdr, level + 2, res)
-
+        aux(item, level + 1, res)
+    of SKeyword:
+      res.add " :"
+      res.add node.key
+      res.add "\n"
+      aux(node.value, level + 1, res)
+    of SNil:
+      res.add " null"
+    of SSymbol:
+      res.add " " & node.symbol
+    of SCons:
+      res.add "\n" & repeat("  ", level + 1) & "car"
+      aux(node.car, level + 2, res)
+      res.add "\n" & repeat("  ", level + 1) & "cdr"
+      aux(node.cdr, level + 2, res)
 
   aux(node, 0, result)
 
-
-
 proc eat(p: var SexpParser, tok: TTokKind) =
-  if p.tok == tok: discard getTok(p)
+  if p.isTok(tok): discard getTok(p)
   else: raiseParseErr(p, tokToStr[tok])
 
-proc space(p: var SexpParser) =
-  ## Skip all space tokens from the current point onwards
-  while p.tok == tkSpace:
-    discard getTok(p)
-
 proc parseSexp(p: var SexpParser): SexpNode =
-  ## Parses SEXP from a SEXP Parser `p`.
+  ## Parses S-Expression from the given S-Expression Parser `p`.
   p.space()
-  case p.tok
+  case p.currToken
   of tkString:
-    # we capture 'p.str' here, so we need to give it a fresh buffer afterwards:
-    result = newSStringMove(p.str)
-    p.str = ""
+    result = newSStringMove(captureCurrString(p))
     discard getTok(p)
   of tkInt:
-    result = newSInt(parseBiggestInt(p.str))
+    result = newSInt(parseBiggestInt(p.currString))
     discard getTok(p)
   of tkFloat:
-    result = newSFloat(parseFloat(p.str))
+    result = newSFloat(parseFloat(p.currString))
     discard getTok(p)
   of tkNil:
     result = newSNil()
     discard getTok(p)
   of tkSymbol:
-    result = newSSymbolMove(p.str)
-    p.str = ""
+    result = newSSymbolMove(captureCurrString(p))
     discard getTok(p)
-
   of tkParensLe:
     result = newSList()
     discard getTok(p)
-    while p.tok notin {tkParensRi, tkDot}:
+    p.space()         # remove spaces in case of empty list such as: '(   )',
+                      # or the `parseSexp` loop below errors on `tkParensRi`.
+
+    while p.currToken notin {tkParensRi, tkDot}:
       result.add(parseSexp(p))
       # Account for possible space in the list elements.
       p.space()
 
-    if p.tok == tkDot:
+    if p.currToken == tkDot:
       eat(p, tkDot)
       eat(p, tkSpace)
       result.add(parseSexp(p))
       result = newSCons(result[0], result[1])
     eat(p, tkParensRi)
-
   of tkKeyword:
     # `:key (value)`
-    let key = p.str[1 .. ^1]
+    let key = p.currString[1 .. ^1]
     discard getTok(p)
+
     eat(p, tkSpace)
     result = newSKeyword(key, parseSexp(p))
-
   of tkSpace, tkDot, tkError, tkParensRi, tkEof:
     raiseParseErr(p,
       "':key', '(', 'symbol', '<float>', '<string>' or '<int>'")
-
-proc open*(parser: var SexpParser, input: Stream) =
-  ## initializes the parser with an input stream.
-  lexbase.open(parser, input)
-  parser.kind = sexpError
-  parser.str = ""
 
 proc parseSexp*(s: Stream): SexpNode =
   ## Parses from a buffer `s` into a `SexpNode`.
@@ -800,10 +569,13 @@ proc parseSexp*(s: Stream): SexpNode =
   p.close()
 
 proc parseSexp*(buffer: string): SexpNode =
-  ## Parses Sexp from `buffer`.
+  ## Parses an s-expression from `buffer`.
   result = parseSexp(newStringStream(buffer))
 
 when isMainModule:
+  # These tests have been replicated and largely superceded in `tsexp` unit
+  # tests. After some confirmation I think it's reasonable to remove these.
+
   discard parseSexp("(\"foo\")")
   let testSexp = parseSexp("""(1 (98 2) nil (2) foobar "foo" 9.234)""")
   doAssert testSexp[0].getNum == 1

--- a/lib/experimental/sexp_parse.nim
+++ b/lib/experimental/sexp_parse.nim
@@ -1,0 +1,275 @@
+## **Note:** Import ``experimental/sexp_parse`` to use this module
+
+import
+  std/[lexbase, streams]
+
+from std/strutils import
+  parseBiggestInt, parseFloat,
+  `%`,
+  Digits, Whitespace,
+  contains
+from std/unicode import toUTF8, Rune
+from std/private/decode_helpers import handleHexChar
+
+type
+  SexpEventKind* = enum  ## enumeration of all events that may occur when
+                         ## parsing
+    sexpError,           ## an error occurred during parsing
+    sexpEof,             ## end of file reached
+    sexpString,          ## a string literal
+    sexpSymbol,          ## a symbol
+    sexpKeyword,         ## `:keyword` event
+    sexpInt,             ## an integer literal
+    sexpFloat,           ## a float literal
+    sexpNil,             ## the value ``nil``
+    sexpDot,             ## the dot to separate car/cdr
+    sexpListStart,       ## start of a list: the ``(`` token
+    sexpListEnd,         ## end of a list: the ``)`` token
+
+  TTokKind* = enum        # must be synchronized with SexpEventKind!
+    tkError,
+    tkEof,
+    tkString,
+    tkSymbol,
+    tkKeyword,
+    tkInt,
+    tkFloat,
+    tkNil,
+    tkDot,
+    tkParensLe,
+    tkParensRi
+    tkSpace
+
+  SexpError* = enum        ## enumeration that lists all errors that can occur
+    errNone,               ## no error
+    errInvalidToken,       ## invalid token
+    errParensRiExpected,   ## ``)`` expected
+    errQuoteExpected,      ## ``"`` expected
+    errEofExpected,        ## EOF expected
+
+  SexpParser* = object of BaseLexer ## the parser object.
+    str: string
+    tok: TTokKind ## Current token that lexer has processed
+    kind: SexpEventKind
+    err: SexpError
+
+proc close*(parser: var SexpParser) {.inline.} =
+  ## closes the parser `parser` and its associated input stream.
+  lexbase.close(parser)
+
+proc str*(parser: SexpParser): string {.inline.} =
+  ## returns the character data for the events: ``sexpInt``, ``sexpFloat``,
+  ## ``sexpString``
+  assert(parser.kind in {sexpInt, sexpFloat, sexpString})
+  result = parser.str
+
+proc getInt*(parser: SexpParser): BiggestInt {.inline.} =
+  ## returns the number for the event: ``sexpInt``
+  assert(parser.kind == sexpInt)
+  result = parseBiggestInt(parser.str)
+
+proc getFloat*(parser: SexpParser): float {.inline.} =
+  ## returns the number for the event: ``sexpFloat``
+  assert(parser.kind == sexpFloat)
+  result = parseFloat(parser.str)
+
+proc kind*(parser: SexpParser): SexpEventKind {.inline.} =
+  ## returns the current event type for the SEXP parser
+  result = parser.kind
+
+proc getColumn*(parser: SexpParser): int {.inline.} =
+  ## get the current column the parser has arrived at.
+  result = getColNumber(parser, parser.bufpos)
+
+proc getLine*(parser: SexpParser): int {.inline.} =
+  ## get the current line the parser has arrived at.
+  result = parser.lineNumber
+
+proc parseString(parser: var SexpParser): TTokKind =
+  result = tkString
+  var pos = parser.bufpos + 1
+  while true:
+    case parser.buf[pos]
+    of '\0':
+      parser.err = errQuoteExpected
+      result = tkError
+      break
+    of '"':
+      inc(pos)
+      break
+    of '\\':
+      case parser.buf[pos+1]
+      of '\\', '"', '\'', '/':
+        add(parser.str, parser.buf[pos+1])
+        inc(pos, 2)
+      of 'b':
+        add(parser.str, '\b')
+        inc(pos, 2)
+      of 'f':
+        add(parser.str, '\f')
+        inc(pos, 2)
+      of 'n':
+        add(parser.str, '\L')
+        inc(pos, 2)
+      of 'r':
+        add(parser.str, '\C')
+        inc(pos, 2)
+      of 't':
+        add(parser.str, '\t')
+        inc(pos, 2)
+      of 'u':
+        inc(pos, 2)
+        var r: int
+        if handleHexChar(parser.buf[pos], r): inc(pos)
+        if handleHexChar(parser.buf[pos], r): inc(pos)
+        if handleHexChar(parser.buf[pos], r): inc(pos)
+        if handleHexChar(parser.buf[pos], r): inc(pos)
+        add(parser.str, toUTF8(Rune(r)))
+      else:
+        # don't bother with the error
+        add(parser.str, parser.buf[pos])
+        inc(pos)
+    of '\c':
+      pos = lexbase.handleCR(parser, pos)
+      add(parser.str, '\c')
+    of '\L':
+      pos = lexbase.handleLF(parser, pos)
+      add(parser.str, '\L')
+    else:
+      add(parser.str, parser.buf[pos])
+      inc(pos)
+  parser.bufpos = pos # store back
+
+proc parseNumber(parser: var SexpParser) =
+  template pos(): var int = parser.bufpos
+
+  # sign, positive, negative, or implicitly positive
+  if parser.buf[pos] in ['-', '+']:
+    add(parser.str, parser.buf[pos])
+    inc(pos)
+
+  # the decimal point or integer digits prior to
+  if parser.buf[pos] == '.':
+    add(parser.str, "0.")
+    inc(pos)
+  else:
+    while parser.buf[pos] in Digits:
+      add(parser.str, parser.buf[pos])
+      inc(pos)
+    if parser.buf[pos] == '.':
+      add(parser.str, '.')
+      inc(pos)
+
+  # digits after the dot:
+  while parser.buf[pos] in Digits:
+    add(parser.str, parser.buf[pos])
+    inc(pos)
+
+  # exponentiation
+  if parser.buf[pos] in {'E', 'e'}:
+    add(parser.str, parser.buf[pos])
+    inc(pos)
+    if parser.buf[pos] in {'+', '-'}:
+      add(parser.str, parser.buf[pos])
+      inc(pos)
+    while parser.buf[pos] in Digits:
+      add(parser.str, parser.buf[pos])
+      inc(pos)
+
+proc parseSymbol(p: var SexpParser) =
+  ## Using symbol definition from
+  ## http://www.lispworks.com/documentation/HyperSpec/Body/02_cd.htm
+  ## 
+  ## Note: presently escaping such as '\.' for the dot character or blank
+  ##       spaces is not yet supported. Unclear whether this will be accepted
+  ##       or not in the future.
+  var pos = p.bufpos
+  while p.buf[pos] notin Whitespace + {')', '(', '\0'}:
+    add(p.str, p.buf[pos])
+    inc(pos)
+  p.bufpos = pos
+
+proc open*(parser: var SexpParser, input: Stream) =
+  ## initializes the parser with an input stream.
+  lexbase.open(parser, input)
+  parser.kind = sexpError
+  parser.str = ""
+
+proc getTok*(parser: var SexpParser): TTokKind =
+  # echo ">> ", parser.tok, " ", parser.bufpos, " @ ", parser.buf[parser.bufpos]
+  setLen(parser.str, 0)
+  case parser.buf[parser.bufpos]
+  of '-', '+', '0'..'9': # numbers that start with a . are handled below.
+    parseNumber(parser)
+    if {'.', 'e', 'E'} in parser.str:
+      result = tkFloat
+    else:
+      result = tkInt
+  of '"': #" # gotta fix nim-mode
+    result = parseString(parser)
+  of '(':
+    inc(parser.bufpos)
+    result = tkParensLe
+  of ')':
+    inc(parser.bufpos)
+    result = tkParensRi
+  of '\0':
+    result = tkEof
+  of ':':
+    parseSymbol(parser)
+    result = tkKeyword
+  of {'\x01' .. '\x1F'} - Whitespace:
+    inc(parser.bufpos)
+    result = tkError
+  of Whitespace:
+    result = tkSpace
+    if parser.buf[parser.bufpos] in lexbase.NewLines:
+      parser.bufpos = parser.handleRefillChar(parser.bufpos)
+    else:
+      inc(parser.bufpos)
+
+    while parser.bufpos < parser.buf.len and
+          parser.buf[parser.bufpos] in Whitespace:
+      if parser.buf[parser.bufpos] in lexbase.NewLines:
+        parser.bufpos = parser.handleRefillChar(parser.bufpos)
+      else:
+        inc parser.bufpos
+  of '.':
+    inc(parser.bufpos)
+    if parser.bufpos < parser.buf.len and
+        parser.buf[parser.bufpos] in '0' .. '9':
+      dec(parser.bufpos)
+      result = tkFloat
+      parseNumber(parser)
+    else:
+      result = tkDot
+  else:
+    parseSymbol(parser)
+    if parser.str == "nil":
+      result = tkNil
+    else:
+      result = tkSymbol
+  parser.tok = result
+  # echo " << ", parser.tok, " ", parser.bufpos
+
+proc space*(p: var SexpParser) =
+  ## Skip all space tokens from the current point onwards
+  while p.tok == tkSpace:
+    discard getTok(p)
+
+func error*(p: SexpParser): SexpError {.inline.} =
+  ## most recent error kind
+  p.err
+func currString*(p: SexpParser): string {.inline.} =
+  ## the last string that was parsed
+  p.str
+func currToken*(p: SexpParser): TTokKind {.inline.} =
+  ## the last token that was parsed
+  p.tok
+
+proc captureCurrString*(p: var SexpParser): string =
+  result = p.str
+  p.str = ""
+
+func isTok*(p: SexpParser, tok: TTokKind): bool {.inline.} =
+  p.tok == tok

--- a/tests/stdlib/experimental/tsexp.nim
+++ b/tests/stdlib/experimental/tsexp.nim
@@ -1,0 +1,220 @@
+discard """
+description: "Tests for the sexp module"
+joinable: false
+"""
+
+import experimental/sexp
+import std/unittest
+from std/strutils import repeat
+
+# Parsing
+
+suite "parse s-expressions - empty/invalid strings":
+  test "parse empty raises an error":
+    expect(SexpParsingError):
+      discard parseSexp("")
+
+  test "parse empty, blank space only strings raises an error":
+    expect(SexpParsingError):
+      discard parseSexp(" ")
+
+    expect(SexpParsingError):
+      discard parseSexp("   ")
+
+    expect(SexpParsingError):
+      discard parseSexp("\n")
+
+  test "parse dot '.' only raises an error":
+    expect(SexpParsingError):
+      discard parseSexp(".")
+
+    expect(SexpParsingError):
+      discard parseSexp("..")
+
+  test "parse close/right paren ')', without an open/left paran is an error":
+    expect(SexpParsingError):
+      discard parseSexp(")")
+
+    expect(SexpParsingError):
+      discard parseSexp(")(")
+
+suite "parse s-expressions - string atoms":
+  test "an empty string atom, is two double quotes":
+    let parsed = parseSexp("\"\"")
+    check parsed == newSString("")
+
+  test "a string atom is any characters surrounded by double quotes '\"'":
+    let parsed = parseSexp("\"string\"")
+    check parsed == newSString("string")
+
+  test "a string atom can have spaces within":
+    let parsed = parseSexp("\"this is a string\"")
+    check parsed == newSString("this is a string")
+
+  test "you can even have double quote characters through escaping '\\\"'":
+    let parsed = parseSexp("\"look at me \\\"escaping\\\"\"")
+    check parsed == newSString("look at me \"escaping\"")
+
+suite "parse s-expressions - numeric atoms":
+  test "integers are parsed into an integer cell":
+    # xxx: not sure if BiggestInt should be part of the spec
+    let parsed = parseSexp("0")
+    check parsed == newSInt(0)
+  
+  test "integers can be negative":
+    let parsed = parseSexp("-1")
+    check parsed == newSInt(-1)
+
+  test "integers or explicitly positive":
+    let parsed = parseSexp("+1")
+    check parsed == newSInt(1)
+
+  test "floats are parsed into float cell":
+    let parsed = parseSexp("0.0")
+    check parsed == newSFloat(0.0)
+
+  test "floats can start with a '.' dropping the need for a leading '0'":
+    let parsed = parseSexp(".0")
+    check parsed == newSFloat(0.0)
+
+  test "floats can be negative numbers":
+    let parsed = parseSexp("-.1")
+    check parsed == newSFloat(-0.1)
+
+suite "parse s-expressions - symbol atoms":
+  test "symbols unquoted character strings, uninterrupted by space or parens":
+    let parsed = parseSexp("test")
+    check parsed == newSSymbol("test")
+
+  test "symbols can have hyphens, underscores, and other punctuation":
+    let parsed = parseSexp("with-hyphens_and|other!things,too?")
+    check parsed == newSSymbol("with-hyphens_and|other!things,too?")
+
+  test "symbols can be single punctuation marks":
+      let parsed = parseSexp("(> 12 2)")
+      check $parsed == "(> 12 2)"
+
+  test "with escaping a dot can be a symbol":
+    let parsed = parseSexp("\\.")
+    skip()
+    when false: # not supported at present, unsure if we should
+      check parsed.kind == SSymbol
+      check parsed == newSSymbol(".")
+
+suite "parse s-expressions - keyword atoms":
+  # Note: might remove keywords or at least drop the key/value requirement
+  test "keywords are symbols prefixed with a ':', followed by a sexp":
+    let expected = newSList(newSKeyword("key", newSSymbol("val")))
+    check parseSexp("(:key val)") == expected
+    check parseSexp("(:key\n\n\nval)") == expected
+    check parseSexp("(:key\n\n\nval  )") == expected
+    check parseSexp("(Sem:ExpandMacro :expression (___) :original (___))") ==
+            newSList(newSSymbol("Sem:ExpandMacro"),
+                     newSKeyword("expression", newSList(newSSymbol("___"))),
+                     newSKeyword("original", newSList(newSSymbol("___"))))
+
+suite "parse s-expression - nil atom":
+  test "nil s-expression is end of list, or a sort of empty list":
+    let parsed = parseSexp("nil")
+    check parsed == newSNil()
+
+suite "parse s-expressions - cons":
+  test "cons are created with a '.' and s-exprs on either side":
+    let parsed = parseSexp("(left . right)")
+    check parsed == newSCons(newSSymbol("left"), newSSymbol("right"))
+
+suite "parse s-expressions - lists":
+  test "an empty list is two parens":
+    let parsed = parseSexp("()")
+    check parsed == newSList()
+
+  test "spaces in an empty list don't matter":
+    let parsed = parseSexp("(     )")
+    check parsed == newSList()
+  
+  test "spaces between lists don't matter":
+    let parsed = parseSexp("((1)(2))")
+    check parsed == newSList(newSList(newSInt(1)), newSList(newSInt(2)))
+
+  test "lists don't have to start with symbols, this isn't lisp":
+    let parsed = parseSexp("((12) 2 (3))")
+    check parsed == newSList(newSList(newSInt(12)),
+                             newSInt(2),
+                             newSList(newSInt(3)))
+
+# SexpNode API - Traversing, Querying, Generating, Transforming, and Printing
+
+suite "working with parsed SexpNode output":
+  test "traversing and querying a SexpNode tree":
+    let parsed = parseSexp("""(1 (98 2) nil (2) foobar "foo" 9.234)""")
+    check parsed[0].getNum == 1
+    check parsed[1][0].getNum == 98
+    check parsed[2].getElems == newSeq[SexpNode]()
+    check parsed[4].getSymbol == "foobar"
+    check parsed[5].getStr == "foo"
+
+  test "working with cons":
+    let parsed = parseSexp("""((1 . 2) (2 . "foo"))""")
+    check parsed[0].getCons.car.getNum == 1
+    check parsed[0].getCons.cdr.getNum == 2
+    check parsed[1].getCons.cdr.getStr == "foo"
+
+suite "basic to string conversion":
+  test "`$` converts to string":
+    let parsed = parseSexp("(1 . 2)")
+    check $parsed == "(1 . 2)"
+
+  test "an empty list is printed as nil":
+    let parsed = parseSexp("()")
+    check $parsed == "nil"
+  
+  test "extra spaces are not preserved":
+    let parsed = parseSexp("(:key \n   \n val)")
+    check $parsed == "(:key val)"
+
+suite "generating SexpNode from data":
+  test "convertSexp takes syntax to sexp representation":
+    let generated = convertSexp([true, false, "foobar", [1, 2, "baz"]])
+    check $generated == """(t nil "foobar" (1 2 "baz"))"""
+
+  test "convertSexp takes literal bool syntax to SexpNode":
+    for b in [true, false]:
+      let
+        generated = convertSexp(b)
+        expected = if b: "t" else: "nil"
+      check $generated == expected
+
+  test "convertSexp takes literal integer syntax to SexpNode":
+    let generated = convertSexp(-11)
+    check $generated == "-11"
+
+  test "convertSexp takes literal float syntax to SexpNode":
+    let generated = convertSexp(-1.1)
+    check $generated == "-1.1"
+
+  test "convertSexp takes string syntax to SexpNode":
+    let generated = convertSexp("string")
+    check $generated == "\"string\""
+
+  test "convertSexp can also handle key value maps":
+    check $convertSexp([key = "value"]) == "(:key \"value\")"
+    check $convertSexp([k1 = 1, k2 = 3, "k3"]) == "(:k1 1 :k2 3 \"k3\")"
+
+# Miscellaneous
+
+suite "Regression Test suite":
+  test "ensure parsing works when input exceeds the lexer buffer":
+    # Apparently S-expression parser is having some mild troubles with
+    # expressions that are longer than a lexer buffer length, so its
+    # ability to parse things need to be checked as well.
+    for withNl in [true, false]:
+      let
+        count = 128
+        size = 64
+        nl = if withNl: "\n" else: ""
+        item = "(" & nl & repeat("t", size) & nl & ")"
+        items = "(" & repeat(item, count) & ")"
+        node = parseSexp(items)
+        nodeCount = node.len
+      check nodeCount == count
+      # checkpoint $node


### PR DESCRIPTION
## Summary

- `sexp` contains the high level interface with `SexpNode`
- `sexp_parse` provides the low level token straem interface

## Details

The low level event/stream based interface wasn't really useable by other modules. This separation allows for that. This should also ensure that we have small narrow public interfaces for modules.

A more accessible token/event stream based interface should allow for building fast sexp based IR serdes for simple test description and print debugging.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* suggestions that help narrow down the public API surface