### PR TITLE
disable flakey http test

### DIFF
--- a/tests/stdlib/web/thttpclient.nim
+++ b/tests/stdlib/web/thttpclient.nim
@@ -1,5 +1,6 @@
 discard """
   cmd: "nim c --threads:on -d:ssl $file"
+  knownIssue: "this test exemplifies stupidity"
   disabled: "openbsd"
   disabled: "freebsd"
   disabled: "windows"


### PR DESCRIPTION
It keeps breaking CI as it's attempting to use services like google.
This is of course a bad idea in the first place, marked it as a known
issue very firmly. Just so people are aware how ridiculous the whole
thing is.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* do not be afraid to remove junk like this