### PR TITLE
vmgen: small refactoring

### DIFF
--- a/tests/vm/tslow_tables.nim
+++ b/tests/vm/tslow_tables.nim
@@ -1,5 +1,5 @@
 discard """
-  timeout: "18"
+  timeout: "4"
   action: "compile"
   nimout: '''create
 search


### PR DESCRIPTION
## Summary
- refactor and improve the code in multiple places, with a focus on removing usages of `TGenFlag`
- don't materialize a full copy when passing locals to immutable parameters

This is as precursor to reworking address handling in the VM and `vmgen`.

## Details
- split `genRdVar` into `genSym` and `genSymAddr`
- don't propagate the `gfNodeAddr` flag; handle the operands to `nkAddr`/`nkHiddenAddr` directly in `genAddr`
- remove leftover type expression handling
- clean up `genArrAccess`
- de-duplicate object access logic
- remove the unused `genUnaryStmt` procedure

Use the "direct assignment" path for all locals -- `skTemp` symbols no longer reach `vmgen` anymore, so the path was taken for all locals anyway. This allows for always using a register copy in `genSym`, which in turn removes the need for the `gfIsParam` flag and greatly improves the run-time efficiency of passing complex locals to immutable parameters.

The `tslow_tables.nim` test now compiles in ~3 instead of ~17.5 seconds.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

As noted in the commit message, this is the first part of a sequence of commits that I'm splitting off from a more far-reaching `vmgen` refactoring. In the end, I abandoned it because of the amount and complexity of the changes becoming too large/unmanageable, but the address handling rework was already finished, so I figured that it'd make sense to split the related changes out.

## Notes for reviewers:
- while this PR could be subdivided further, I think that the changes are neither large nor complex enough to warrant separate PRs (especially right now with the CI issues) 