### PR TITLE
compiler/installer.ini: reduce csources list to common platforms

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -8,17 +8,9 @@ Commit: "$commit"
 CommitDate: "$commitdate"
 Platforms: """
   windows: i386;amd64
-  linux: i386;hppa;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv32;riscv64
-  macosx: i386;amd64;powerpc64;arm64
-  solaris: i386;amd64;sparc;sparc64
-  freebsd: i386;amd64;powerpc64;arm;arm64;riscv64;sparc64;mips;mipsel;mips64;mips64el;powerpc;powerpc64el
-  netbsd: i386;amd64
-  openbsd: i386;amd64;arm;arm64
-  dragonfly: i386;amd64
-  crossos: amd64
-  haiku: i386;amd64
-  android: i386;arm;arm64
-  nintendoswitch: arm64
+  linux: i386;amd64;arm;arm64
+  macosx: amd64;arm64
+  android: arm64
 """
 
 Authors: "Andreas Rumpf"


### PR DESCRIPTION
## Summary
Currently the large list take a huge toll on CI time. Trim this down to common platforms to speed CI up.

For platforms removed from this list, bootstrapping from a source archive would require either cross-compilation or via an older archive with the platform included to generate the bootstrap compiler.