### PR TITLE
publisher: update output format

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -75,8 +75,13 @@ jobs:
           # Create a new release manifest
           ./release_manifest add *.json
 
-          toUpload=$(./release_manifest files-to-upload --format:github-actions)
-          echo "result=$toUpload" >> $GITHUB_OUTPUT
+          toUpload=$(./release_manifest files-to-upload)
+          delimiter=EOF-$(uuidgen)
+          cat <<EOF >> $GITHUB_OUTPUT
+          result<<$delimiter
+          $toUpload
+          $delimiter
+          EOF
           echo "version=$(./release_manifest version)" >> $GITHUB_OUTPUT
         working-directory: release-staging
 


### PR DESCRIPTION
## Summary
With the switch to `GITHUB_OUTPUT`, it seems that they no longer uses the old escaping style but rather a new bash-like method documented here:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

However, we were outputting the old escaped format, making the output unusable by later jobs.

This commit fixes the output format to restore publishing functionality to publisher.

Verified working: https://github.com/alaviss/nimskull/actions/runs/4121576271/jobs/7117396986