### PR TITLE
clean-up warnings and hints during bootstrap

### DIFF
--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -308,6 +308,10 @@ proc closeLexer*(lex: var Lexer) =
   lex.diags.setLen(0)
   closeBaseLexer(lex)
 
+template getColNumber(L: Lexer, pos: int): int =
+  # supresses the hint on the CLI
+  getColNumber(TBaseLexer L, pos)
+
 proc getLineInfo*(L: Lexer): TLineInfo =
   result = newLineInfo(L.fileIdx, L.lineNumber, getColNumber(L, L.bufpos))
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -73,7 +73,6 @@ from compiler/ast/reports_sem import SemReport,
   reportStr,
   reportSym,
   reportTyp
-from compiler/ast/reports_backend import BackendReport
 from compiler/ast/report_enums import ReportKind
 
 import std/strutils except `%` # collides with ropes.`%`

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -64,7 +64,6 @@ import
   compiler/sem/[
     passes,
     lowerings,
-    sighashes,
     rodutils,
     transf,
     sourcemap

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -81,7 +81,6 @@ import
   compiler/vm/[
     compilerbridge,
     vmdef,
-    vmhooks
   ]
 
 from std/options as std_options import some, none

--- a/lib/experimental/sexp_parse.nim
+++ b/lib/experimental/sexp_parse.nim
@@ -79,7 +79,7 @@ proc kind*(parser: SexpParser): SexpEventKind {.inline.} =
 
 proc getColumn*(parser: SexpParser): int {.inline.} =
   ## get the current column the parser has arrived at.
-  result = getColNumber(parser, parser.bufpos)
+  result = getColNumber(BaseLexer parser, parser.bufpos)
 
 proc getLine*(parser: SexpParser): int {.inline.} =
   ## get the current line the parser has arrived at.

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -140,7 +140,7 @@ proc kind*(my: JsonParser): JsonEventKind {.inline.} =
 
 proc getColumn*(my: JsonParser): int {.inline.} =
   ## get the current column the parser has arrived at.
-  result = getColNumber(my, my.bufpos)
+  result = getColNumber(BaseLexer my, my.bufpos)
 
 proc getLine*(my: JsonParser): int {.inline.} =
   ## get the current line the parser has arrived at.


### PR DESCRIPTION
## Summary

- remove unused imports
- supress value object param up conversion not passing sub-type fields

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* minor clean-up, just less console spam so actual issues can standout