### PR TITLE
 Saem exp sigmatch ast corruption

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -485,6 +485,10 @@ proc copyNode*(src: PNode): PNode =
 
 template transitionNodeKindCommon(k: TNodeKind) =
   let obj {.inject.} = n[]
+  when defined(useNodeIds):
+    if obj.id == nodeIdToDebug:
+      echo "TRANSITIONED TO ", k
+      writeStackTrace()
   n[] = TNode(id: obj.id, kind: k, typ: obj.typ, info: obj.info,
               flags: obj.flags)
   # n.comment = obj.comment # shouldn't be needed, the address doesnt' change

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2175,6 +2175,11 @@ proc semReturn(c: PContext, n: PNode): PNode =
 proc semProcBody(c: PContext, n: PNode): PNode =
   openScope(c)
   result = semExpr(c, n)
+
+  if result.isError:
+    closeScope(c)
+    return
+
   if c.p.resultSym != nil and not isEmptyType(result.typ):
     if result.kind == nkNilLit:
       # or ImplicitlyDiscardable(result):
@@ -3060,7 +3065,7 @@ proc semBlock(c: PContext, n: PNode; flags: TExprFlags): PNode =
     result.add lablRes
     result.add bodyRes
     result.typ = bodyRes.typ
-    
+
     # xxx: always transitions because nkError always(?) has an error type
     if isEmptyType(result.typ):
       result.transitionSonsKind(nkBlockStmt)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -894,7 +894,6 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
     if n[^2].kind == nkEmpty:
       localReport(c.config, n, reportSem rsemTypeExpected)
       typ = errorType(c)
-
     else:
       typ = semTypeNode(c, n[^2], nil)
       propagateToOwner(rectype, typ)
@@ -921,7 +920,6 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
 
       if a.kind == nkEmpty:
         father.add newSymNode(f)
-
       else:
         a.add newSymNode(f)
 
@@ -991,7 +989,6 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
     base = skipTypesOrNil(realBase, skipPtrs)
     if base.isNil:
       localReport(c.config, n, reportSem rsemExpectObjectForBase)
-
     else:
       var concreteBase = skipGenericInvocation(base)
       if concreteBase.kind in {tyObject, tyGenericParam,

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2174,7 +2174,7 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): YieldReason
 
           else:
             assert envPType == noneType # A programming error that should have
-                                        # already been caught by `opWrClosure`
+                                        # already been caught by `opcWrClosure`
 
         pushFrame(newFrame)
         # -1 for the following 'inc pc'

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2504,6 +2504,7 @@ proc genClosureConstr(c: var TCtx, n: PNode, dest: var TDest) =
 proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
   when defined(nimCompilerStacktraceHints):
     setFrameMsg c.config$n.info & " " & $n.kind & " " & $flags
+
   case n.kind
   of nkSym:
     let s = n.sym
@@ -2532,7 +2533,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
         let idx = c.registerConst(s)
         discard c.getOrCreate(s.typ)
         c.gABx(n, opcLdCmplxConst, dest, idx)
-
     of skEnumField:
       # we never reach this case - as of the time of this comment,
       # skEnumField is folded to an int in semfold.nim, but this code
@@ -2683,6 +2683,9 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       genCastIntFloat(c, n, dest)
   of nkType:
     genTypeLit(c, n.typ, dest)
+  of nkError:
+    c.config.internalError(n.info, $n.kind)
+    assert false
   else:
     echo "fail: ", n.kind
     fail(n.info, vmGenDiagCannotGenerateCode, n)

--- a/tests/errmsgs/tmake_tuple_visible.nim
+++ b/tests/errmsgs/tmake_tuple_visible.nim
@@ -1,6 +1,8 @@
 discard """
-  errormsg: '''Mixing types and values in tuples is not allowed.'''
-  line: 19
+  errormsg: '''type mismatch: got <(typedesc[NimEdAppWindow], int)>'''
+  line: 21
+  description: '''error message and hint if there is a space between the
+  routine name and the arguments at a call site.'''
 """
 
 type
@@ -17,4 +19,3 @@ template xxx*(tn: typeDesc, i: int) =
   discard
 
 xxx (NimEdAppWindow, 0)
-# bug #6776


### PR DESCRIPTION
## Summary

Previously `nkError` nodes were allowed to pass through to parameters, these now result in a match failure.

## Details

Besides the change stated above, `semProcBody` now is `nkError` aware. Removed creating callsite node copies during sigmatch. Finally, error message for a space between a routine call name and parameters now makes sense and fixed the associated test.

Although slow, CPS should now work.
---

## Notes for Reviewers
* feedback I'm mos interested in: glaring issues and quick wins
* if I'm not around please merge