### PR TITLE
Parser: remove report dependency

### DIFF
--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -2,10 +2,15 @@
 
 import
   compiler/ast/[
-    ast_types, # For the node kinds
-    lexer,     # For the token type definition
-    lineinfos  # For TLineInfo
+    lineinfos,  # For TLineInfo
+    idents,     # For `PIdent`
+    numericbase
+  ],
+  compiler/utils/[
+    idioms
   ]
+
+from compiler/ast/lexer import Token, TokType
 
 # NOTE further refactoring considerations for the parser:
 #
@@ -17,44 +22,260 @@ import
 #   it should not be placed where it is now.
 
 type
-  ParsedNode* = ref object
-    # NOTE next two fields are very large combined, but further plans will
-    # deal with that problem - current implementation is easier to write
-    # and it is just a transition point.
-    info*: TLineInfo # TODO replace line and separate token with index to
-                     # the token, which in turn will store information
-                     # about global positioning (tuple made up of a token
-                     # id and a file ID)
-                     #
-                     # NOTE technically this is not really necessary even
-                     # with the current implementation, but the parser
-                     # consistently copies this information around anyway,
-                     # so I will let it stay this way for now.
-    token*: Token # TODO Replace full token value with an index information
-    kind*: TNodeKind # NOTE/QUESTION - for now the same kind of nodes is
-                     # reused as the main parser, to ease the transition,
-                     # but in the future two different sets of node kinds
-                     # might(?) be introduced.
+  ParseDiagKind* = enum
+    # internal errors begin
+    # pdkInternalError
+    # internal errors end
 
-    # TODO replace `ref` object tree with begin/end ranges for the nested
-    # trees in the linearized structure.
-    sons*: seq[ParsedNode]
-    comment*: string # TODO this should either be a token or a sequence of
-                     # tokens.
+    # TODO: likely incorporate lexer errors etc
+    
+    # errors begin
+    pdkInvalidIndentation
+    pdkInvalidIndentationWithForgotEqualSignHint
+    pdkNestableRequiresIndentation
+    pdkIdentExpected
+    pdkIdentExpectedEmptyAccQuote
+    pdkExprExpected
+    pdkMissingToken
+    pdkUnexpectedToken
+    pdkAsmStmtExpectsStrLit
+    pdkFuncNotAllowed   # xxx: bad name
+    pdkTupleTypeWithPar # xxx: bad name
+    pdkMisplacedParameterVar # xxx: bad name
+    pdkConceptNotInType
+    pdkMisplacedExport
+    pdkPragmaBeforeGenericParameters
+    # errors end
 
-    # HACK explicit flags in order to track down all 'extra' information
-    # that is collected during parsing.
-    isBlockArg*: bool # QUESTION add 'nkStmtListBlockArg' or similar node
-                      # and convert it to the `nkStmtList` + `nfBlocArg`
-                      # flags later on? Why do we need the `nfBlockArg`
-                      # flag in the first place?
+    # warnings being
+    pdkInconsistentSpacing # xxx: bad name
+    pdkPragmaDoesNotFollowTypeName
+    pdkEnablePreviewDotOps
+    # warnings end
+
+const
+  pdkWithExtraData* = {pdkInvalidIndentationWithForgotEqualSignHint,
+                        pdkUnexpectedToken,
+                        pdkMissingToken,
+                        pdkIdentExpected,
+                        pdkExprExpected,
+                        pdkAsmStmtExpectsStrLit,
+                        pdkInconsistentSpacing}
+  pdkWithoutExtraData* = {low(ParseDiagKind)..high(ParseDiagKind)} - 
+                          pdkWithExtraData
+
+type
+  ParseDiag* = object
+    instLoc*: InstantiationInfo
+    location*: TLineInfo        # xxx: can we get away with line/col only?
+    case kind*: ParseDiagKind:
+      of pdkInvalidIndentationWithForgotEqualSignHint:
+        eqLineInfo*: TLineInfo
+      of pdkUnexpectedToken:
+        expected*: TokType
+        actual*: Token
+      of pdkMissingToken:
+        missedToks*: seq[TokType]
+      of pdkIdentExpected,
+          pdkExprExpected,
+          pdkAsmStmtExpectsStrLit,
+          pdkInconsistentSpacing:
+        found*: Token
+      of pdkWithoutExtraData:
+        discard
+
+  ParsedNodeKind* = enum
+    pnkError        ## currently we don't produce error nodes
+    pnkEmpty
+    pnkIdent
+    pnkCharLit
+    pnkIntLit
+    pnkInt8Lit
+    pnkInt16Lit
+    pnkInt32Lit
+    pnkInt64Lit
+    pnkUIntLit
+    pnkUInt8Lit
+    pnkUInt16Lit
+    pnkUInt32Lit
+    pnkUInt64Lit
+    pnkFloatLit
+    pnkFloat32Lit
+    pnkFloat64Lit
+    pnkFloat128Lit
+    pnkStrLit
+    pnkRStrLit
+    pnkTripleStrLit
+    pnkNilLit
+    pnkCustomLit
+    pnkAccQuoted
+    pnkCall
+    pnkCommand
+    pnkCallStrLit
+    pnkInfix
+    pnkPrefix
+    pnkPostfix
+    pnkExprEqExpr
+    pnkExprColonExpr
+    pnkIdentDefs
+    pnkConstDef
+    pnkVarTuple
+    pnkPar
+    pnkSqrBracket
+    pnkCurly
+    pnkTupleConstr
+    pnkObjConstr
+    pnkTableConstr
+    pnkSqrBracketExpr
+    pnkCurlyExpr
+    pnkPragmaExpr
+    pnkPragma
+    pnkPragmaBlock
+    pnkDotExpr
+    pnkIfExpr
+    pnkIfStmt
+    pnkElifBranch
+    pnkElifExpr
+    pnkElse
+    pnkElseExpr
+    pnkCaseStmt
+    pnkOfBranch
+    pnkWhenExpr
+    pnkWhenStmt
+    pnkForStmt
+    pnkWhileStmt
+    pnkBlockExpr
+    pnkBlockStmt
+    pnkDiscardStmt
+    pnkContinueStmt
+    pnkBreakStmt
+    pnkReturnStmt
+    pnkRaiseStmt
+    pnkYieldStmt
+    pnkTryStmt
+    pnkExceptBranch
+    pnkFinally
+    pnkDefer
+    pnkLambda
+    pnkDo
+    pnkBind
+    pnkBindStmt
+    pnkMixinStmt
+    pnkCast
+    pnkStaticStmt
+    pnkAsgn
+    pnkGenericParams
+    pnkFormalParams
+    pnkStmtList
+    pnkStmtListExpr
+    pnkImportStmt
+    pnkImportExceptStmt
+    pnkImportAs
+    pnkFromStmt
+    pnkIncludeStmt
+    pnkExportStmt
+    pnkExportExceptStmt
+    pnkConstSection
+    pnkLetSection
+    pnkVarSection
+    pnkProcDef
+    pnkFuncDef
+    pnkMethodDef
+    pnkConverterDef
+    pnkIteratorDef
+    pnkMacroDef
+    pnkTemplateDef
+    pnkTypeSection
+    pnkTypeDef
+    pnkEnumTy
+    pnkEnumFieldDef
+    pnkObjectTy
+    pnkTupleTy
+    pnkProcTy
+    pnkIteratorTy
+    pnkRecList
+    pnkRecCase
+    pnkRecWhen
+    pnkTypeOfExpr
+    pnkRefTy
+    pnkVarTy
+    pnkPtrTy
+    pnkStaticTy
+    pnkDistinctTy
+    pnkMutableTy
+    pnkTupleClassTy
+    pnkTypeClassTy
+    pnkOfInherit
+    pnkArgList
+    pnkWith
+    pnkWithout
+    pnkAsmStmt
+    pnkCommentStmt
+    pnkUsingStmt
+  
+  ParsedKindWithSons* = range[pnkCall..pnkUsingStmt]
+  ParsedKindLiteral* = range[pnkCharLit..pnkCustomLit]
+  ParsedKindBracket* = range[pnkPar..pnkCurly]
+
+  ParsedToken* = object
+    ## Used instead of `Token` to save memory
+    line*: uint16
+    col*: int16
+    tokType*: TokType
+    ident*: PIdent
+    iNumber*: BiggestInt
+    fNumber*: BiggestFloat
+    base*: NumericalBase
+    literal*: string
+
+  ParsedNodeData*{.final, acyclic.} = object
+    # TODO: replace token fields with indexing into a token sequence, this
+    #       should also address line info tracking.
+    comment*: string       # TODO: replace with an index into a token stream
+    fileIndex*: FileIndex  # xxx: remove and have the caller handle it?
+    case kind*: ParsedNodeKind:
+      of pnkError:
+        diag*: ParseDiag
+      of pnkEmpty:
+        line*: uint16
+        col*: int16
+      of pnkIdent:
+        startToken*: ParsedToken
+      of pnkCharLit..pnkUInt64Lit,
+          pnkFloatLit..pnkFloat128Lit,
+          pnkStrLit..pnkTripleStrLit,
+          pnkNilLit,
+          pnkCustomLit:
+        lit*: ParsedToken
+      of pnkAccQuoted:
+        quote*: ParsedToken
+        idents*: seq[tuple[ident: PIdent, line: uint16, col: int16]]
+      of pnkCall..pnkUsingStmt:
+        token*: ParsedToken
+        isBlockArg*: bool       # TODO: rework ast to eliminate this flag,
+                                #       maybe with a `pnkStmtListArg` kind.
+        sons*: seq[ParsedNode]  # TODO: replace `ref` object graph with
+                                #       begin/end ranges for tracking the tree
+                                #       hierarchy in a linear data structure.
+
+  ParsedNode* = ref ParsedNodeData
+
+
+const
+  pnkParsedKindsWithSons* = {pnkCall..pnkUsingStmt}
+  pnkCallKinds* = {pnkCall, pnkInfix, pnkPrefix, pnkPostfix,
+                  pnkCommand, pnkCallStrLit}
 
 func len*(node: ParsedNode): int =
   ## Number of sons of the parsed node
   return node.sons.len()
 
 # NOTE added for the sake of API similarity between PNode
-proc safeLen*(node: ParsedNode): int = node.len()
+func safeLen*(node: ParsedNode): int =
+  if node.kind in pnkParsedKindsWithSons:
+    node.len()
+  else:
+    0
 
 proc `[]`*(node: ParsedNode, idx: int | BackwardsIndex): ParsedNode =
   return node.sons[idx]
@@ -74,39 +295,109 @@ proc add*(node: ParsedNode, other: ParsedNode) =
   ## append `other` to `node`'s `sons`
   node.sons.add(other)
 
-proc transitionSonsKind*(n: ParsedNode, kind: TNodeKind) =
-  n.kind = kind
+proc transitionSonsKind*(n: ParsedNode, kind: ParsedNodeKind) =
+  assert n.kind in pnkParsedKindsWithSons and kind in pnkParsedKindsWithSons,
+          "kind from: " & $n.kind & " to: " & $kind
+  let obj = n[]
+  {.cast(uncheckedAssign).}:
+    n[] = ParsedNodeData(kind: kind,
+                         token: obj.token,
+                         isBlockArg: obj.isBlockArg,
+                         sons: obj.sons,
+                         comment: obj.comment,
+                         fileIndex: obj.fileIndex)
 
-proc transitionIntKind*(n: ParsedNode, kind: TNodeKind) =
-  n.kind = kind
-
-proc transitionNoneToSym*(n: ParsedNode) =
-  n.kind = nkSym
-
-func newParsedNode*(kind: TNodeKind): ParsedNode =
-  ## Create a new parsed node without any location or token information
-  return ParsedNode(kind: kind, info: unknownLineInfo)
+func newEmptyParsedNode*(fileIndex: FileIndex,
+                         line = unknownLineInfo.line,
+                         col = unknownLineInfo.col): ParsedNode =
+  ## Create an empty ParsedNode
+  ParsedNode(kind: pnkEmpty, fileIndex: fileIndex, line: line, col: col)
 
 func newParsedNode*(
-  kind: TNodeKind, info: TLineInfo, sons: seq[ParsedNode] = @[]): ParsedNode =
+  kind: ParsedKindWithSons,
+  fileIndex: FileIndex,
+  token: ParsedToken,
+  sons: seq[ParsedNode] = @[]): ParsedNode =
   ## Create a new non-leaf parsed node with a specified location
   ## information and sons.
-  return ParsedNode(kind: kind, info: info, sons: sons)
+  ParsedNode(kind: kind, fileIndex: fileIndex, token: token, sons: sons)
 
-func newParsedNode*(kind: TNodeKind, info: TLineInfo, token: Token): ParsedNode =
-  ## Create a new leaf parsed node with the specified location information
-  ## and token kind.
-  return ParsedNode(kind: kind, info: info, token: token)
+func newParsedLitNode*(
+  kind: ParsedKindLiteral,
+  fileIndex: FileIndex,
+  token: ParsedToken): ParsedNode =
+  ## Create a new leaf literal parsed node.
+  ParsedNode(kind: kind, fileIndex: fileIndex, lit: token)
 
+func newParsedNodeIdent*(fileIndex: FileIndex, token: ParsedToken): ParsedNode =
+  ## Create a `pnkIdent` node
+  ParsedNode(kind: pnkIdent, fileIndex: fileIndex, startToken: token)
+
+proc getToken*(n: ParsedNode): ParsedToken =
+  case n.kind
+  of pnkError, pnkEmpty:
+    unreachable()
+  of pnkIdent:
+    n.startToken
+  of pnkCharLit..pnkUInt64Lit,
+      pnkFloatLit..pnkFloat128Lit,
+      pnkStrLit..pnkTripleStrLit,
+      pnkNilLit,
+      pnkCustomLit:
+    n.lit
+  of pnkAccQuoted:
+    n.quote
+  of pnkCall..pnkUsingStmt:
+    n.token
 
 proc newProcNode*(
-    kind: TNodeKind,
-    info: TLineInfo,
+    kind: ParsedNodeKind,
+    fileIndex: FileIndex,
+    token: ParsedToken,
     body, params, name, pattern, genericParams,
     pragmas, exceptions: ParsedNode
   ): ParsedNode =
-
-  result = newParsedNode(
+  newParsedNode(
     kind,
-    info,
+    fileIndex,
+    token,
     @[name, pattern, genericParams, params, pragmas, exceptions, body])
+
+func info*(p: ParsedNode): TLineInfo {.inline.} =
+  case p.kind
+  of pnkError:
+    unreachable("IMPLEMENT ME") # xxx: we don't produce pnkError nodes, yet
+  of pnkEmpty:
+    TLineInfo(fileIndex: p.fileIndex, line: p.line, col: p.col)
+  of pnkIdent:
+    TLineInfo(fileIndex: p.fileIndex,
+              line: p.startToken.line,
+              col: p.startToken.col)
+  of pnkCharLit..pnkUInt64Lit,
+      pnkFloatLit..pnkFloat128Lit,
+      pnkStrLit..pnkTripleStrLit,
+      pnkNilLit,
+      pnkCustomLit:
+    TLineInfo(fileIndex: p.fileIndex,
+              line: p.lit.line,
+              col: p.lit.col)
+  of pnkAccQuoted:
+    TLineInfo(fileIndex: p.fileIndex,
+              line: p.quote.line,
+              col: p.quote.col)
+  of pnkCall..pnkUsingStmt:
+    TLineInfo(fileIndex: p.fileIndex,
+              line: p.token.line,
+              col: p.token.col)
+
+proc toParsedToken*(t: Token): ParsedToken {.inline.} =
+  let (line, col) = clampLineCol(t.line, t.col)
+  result = ParsedToken(
+    line: line,
+    col: col,
+    tokType: t.tokType,
+    ident: t.ident,
+    iNumber: t.iNumber,
+    fNumber: t.fNumber,
+    base: t.base,
+    literal: t.literal)

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -10,9 +10,6 @@ import
     idents,    # Ast identifiers
     ast_types  # Main ast type definitions
   ],
-  compiler/front/[
-    options,
-  ],
   compiler/utils/[
     int128 # Values for integer nodes
   ]
@@ -122,95 +119,6 @@ const
   defaultSize* = -1
   defaultAlignment* = -1
   defaultOffset* = -1
-
-  nodeKindsProducedByParse* = {
-    nkError, nkEmpty,
-    nkIdent,
-
-    nkCharLit,
-    nkIntLit, nkInt8Lit, nkInt16Lit, nkInt32Lit, nkInt64Lit,
-    nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit,
-    nkFloatLit, nkFloat32Lit, nkFloat64Lit, nkFloat128Lit,
-    nkStrLit, nkRStrLit, nkTripleStrLit,
-    nkNilLit,
-
-    nkCall, nkCommand, nkCallStrLit, nkInfix, nkPrefix, nkPostfix,
-
-    nkExprEqExpr, nkExprColonExpr, nkIdentDefs, nkConstDef, nkVarTuple, nkPar,
-    nkBracket, nkCurly, nkTupleConstr, nkObjConstr, nkTableConstr,
-    nkBracketExpr, nkCurlyExpr,
-
-    nkPragmaExpr, nkPragma, nkPragmaBlock,
-
-    nkDotExpr, nkAccQuoted,
-
-    nkIfExpr, nkIfStmt, nkElifBranch, nkElifExpr, nkElse, nkElseExpr,
-    nkCaseStmt, nkOfBranch,
-    nkWhenStmt,
-
-    nkForStmt, nkWhileStmt,
-
-    nkBlockExpr, nkBlockStmt,
-
-    nkDiscardStmt, nkContinueStmt, nkBreakStmt, nkReturnStmt, nkRaiseStmt,
-    nkYieldStmt,
-
-    nkTryStmt, nkExceptBranch, nkFinally,
-
-    nkDefer,
-
-    nkLambda, nkDo,
-
-    nkBind, nkBindStmt, nkMixinStmt,
-
-    nkCast,
-    nkStaticStmt,
-
-    nkAsgn,
-
-    nkGenericParams,
-    nkFormalParams,
-
-    nkStmtList, nkStmtListExpr,
-
-    nkImportStmt, nkImportExceptStmt, nkImportAs, nkFromStmt,
-
-    nkIncludeStmt,
-
-    nkExportStmt, nkExportExceptStmt,
-
-    nkConstSection, nkLetSection, nkVarSection,
-
-    nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef, nkIteratorDef,
-    nkMacroDef, nkTemplateDef,
-
-    nkTypeSection, nkTypeDef,
-
-    nkEnumTy, nkEnumFieldDef,
-
-    nkObjectTy, nkTupleTy, nkProcTy, nkIteratorTy,
-
-    nkRecList, nkRecCase, nkRecWhen,
-
-    nkTypeOfExpr,
-
-    # nkConstTy,
-    nkRefTy, nkVarTy, nkPtrTy, nkStaticTy, nkDistinctTy,
-    nkMutableTy,
-
-    nkTupleClassTy, nkTypeClassTy,
-
-    nkOfInherit,
-
-    nkArgList,
-
-    nkWith, nkWithout,
-
-    nkAsmStmt,
-    nkCommentStmt,
-
-    nkUsingStmt,
-  }
 
   FakeVarParams* = {mNew, mNewFinalize, mInc, mDec, mIncl, mExcl,
     mSetLengthStr, mSetLengthSeq, mAppendStrCh, mAppendStrStr, mSwap,
@@ -603,17 +511,6 @@ proc skipStmtList*(n: PNode): PNode =
     result = n.lastSon
   else:
     result = n
-
-
-proc isImportedException*(t: PType; conf: ConfigRef): bool =
-  assert t != nil
-  if conf.exc != excNative:
-    return false
-
-  let base = t.skipTypes({tyAlias, tyPtr, tyDistinct, tyGenericInst})
-
-  if base.sym != nil and sfImportc in base.sym.flags:
-    result = true
 
 proc isInfixAs*(n: PNode): bool =
   return n.kind == nkInfix and n[0].kind == nkIdent and n[0].ident.s == "as"

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -246,6 +246,96 @@ type
 
   TNodeKinds* = set[TNodeKind]
 
+const
+  nodeKindsProducedByParse* = {
+    nkError, nkEmpty,
+    nkIdent,
+
+    nkCharLit,
+    nkIntLit, nkInt8Lit, nkInt16Lit, nkInt32Lit, nkInt64Lit,
+    nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit,
+    nkFloatLit, nkFloat32Lit, nkFloat64Lit, nkFloat128Lit,
+    nkStrLit, nkRStrLit, nkTripleStrLit,
+    nkNilLit,
+
+    nkCall, nkCommand, nkCallStrLit, nkInfix, nkPrefix, nkPostfix,
+
+    nkExprEqExpr, nkExprColonExpr, nkIdentDefs, nkConstDef, nkVarTuple, nkPar,
+    nkBracket, nkCurly, nkTupleConstr, nkObjConstr, nkTableConstr,
+    nkBracketExpr, nkCurlyExpr,
+
+    nkPragmaExpr, nkPragma, nkPragmaBlock,
+
+    nkDotExpr, nkAccQuoted,
+
+    nkIfExpr, nkIfStmt, nkElifBranch, nkElifExpr, nkElse, nkElseExpr,
+    nkCaseStmt, nkOfBranch,
+    nkWhenStmt,
+
+    nkForStmt, nkWhileStmt,
+
+    nkBlockExpr, nkBlockStmt,
+
+    nkDiscardStmt, nkContinueStmt, nkBreakStmt, nkReturnStmt, nkRaiseStmt,
+    nkYieldStmt,
+
+    nkTryStmt, nkExceptBranch, nkFinally,
+
+    nkDefer,
+
+    nkLambda, nkDo,
+
+    nkBind, nkBindStmt, nkMixinStmt,
+
+    nkCast,
+    nkStaticStmt,
+
+    nkAsgn,
+
+    nkGenericParams,
+    nkFormalParams,
+
+    nkStmtList, nkStmtListExpr,
+
+    nkImportStmt, nkImportExceptStmt, nkImportAs, nkFromStmt,
+
+    nkIncludeStmt,
+
+    nkExportStmt, nkExportExceptStmt,
+
+    nkConstSection, nkLetSection, nkVarSection,
+
+    nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef, nkIteratorDef,
+    nkMacroDef, nkTemplateDef,
+
+    nkTypeSection, nkTypeDef,
+
+    nkEnumTy, nkEnumFieldDef,
+
+    nkObjectTy, nkTupleTy, nkProcTy, nkIteratorTy,
+
+    nkRecList, nkRecCase, nkRecWhen,
+
+    nkTypeOfExpr,
+
+    # nkConstTy,
+    nkRefTy, nkVarTy, nkPtrTy, nkStaticTy, nkDistinctTy,
+    nkMutableTy,
+
+    nkTupleClassTy, nkTypeClassTy,
+
+    nkOfInherit,
+
+    nkArgList,
+
+    nkWith, nkWithout,
+
+    nkAsmStmt,
+    nkCommentStmt,
+
+    nkUsingStmt,
+  }
+
 type
   TSymFlag* = enum    # 48 flags!
     sfUsed            ## read access of sym (for warnings) or simply used

--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -565,6 +565,7 @@ proc getNumber(L: var Lexer, result: var Token) =
       elif customLitPossible:
         # remember the position of the `'` so that the parser doesn't
         # have to reparse the custom literal:
+        result.ident = L.cache.getIdent("'" & suffix)
         result.iNumber = len(result.literal)
         result.literal.add '\''
         result.literal.add suffix

--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -26,6 +26,10 @@ type
     col*: int16
     fileIndex*: FileIndex
 
+  LineColPair* = tuple
+    line: typeof(TLineInfo.line)
+    col: typeof(TLineInfo.col)
+
 const
   InvalidFileIdx* = FileIndex(-1)
   unknownLineInfo* = TLineInfo(line: 0, col: -1, fileIndex: InvalidFileIdx)
@@ -33,8 +37,7 @@ const
   ## suggestions are produced within comments and string literals
   commandLineIdx* = FileIndex(-3)
 
-proc newLineInfo*(fileInfoIdx: FileIndex, line, col: int): TLineInfo =
-  result.fileIndex = fileInfoIdx
+func clampLineCol*(line, col: int): LineColPair {.inline.} =
   if line < int high(uint16):
     result.line = uint16(line)
   else:
@@ -43,6 +46,10 @@ proc newLineInfo*(fileInfoIdx: FileIndex, line, col: int): TLineInfo =
     result.col = int16(col)
   else:
     result.col = -1
+
+proc newLineInfo*(fileIndex: FileIndex, line, col: int): TLineInfo {.inline.} =
+  result.fileIndex = fileIndex
+  (result.line, result.col) = clampLineCol(line, col)
 
 proc `==`*(a, b: FileIndex): bool {.borrow.}
 

--- a/compiler/ast/nimlexbase.nim
+++ b/compiler/ast/nimlexbase.nim
@@ -27,18 +27,18 @@ const
   BACKSPACE* = '\x08'
   VT* = '\x0B'
 
+## This diagram illustrates how the `buf`fer, length, position, sentinel, and
+## newline characters are considered:
+##
+## .. code-block:: nim
+##
+##   "Example Text\n ha!"   bufLen = 17
+##    ^pos = 0     ^ sentinel = 12
+##
+## NB: '\n' is one character/byte
+
 const
-  EndOfFile* = '\0' ##[
-end of file marker
-
-A little picture makes everything clear
-
-.. code-block:: nim
-
-  "Example Text\n ha!"   bufLen = 17
-    ^pos = 0     ^ sentinel = 12
-
-  ]##
+  EndOfFile* = '\0'    ## end of file marker
   NewLines* = {CR, LF}
 
 type
@@ -47,12 +47,12 @@ type
     buf*: cstring
     bufStorage: string
     bufLen: int
-    stream*: PLLStream        ## we read from this stream
-    lineNumber*: int          ## the current line number
-                              ## private data:
+    stream*: PLLStream ## we read from this stream
+    lineNumber*: int   ## the current line number
+    # private data:
     sentinel*: int
-    lineStart*: int           ## index of last line start in buffer
-    offsetBase*: int          ## use ``offsetBase + bufpos`` to get the offset
+    lineStart*: int    ## index of last line start in buffer
+    offsetBase*: int   ## use ``offsetBase + bufpos`` to get the offset
 
 
 proc openBaseLexer*(L: var TBaseLexer, inputstream: PLLStream,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -27,7 +27,7 @@ type
     repDebug = "Debug" ## Side channel for the compiler debug report. Helper
     ## messages designed specifically to aid development of the compiler
 
-    repInternal = "Internal" ## Reports constructed during hanling of the
+    repInternal = "Internal" ## Reports constructed during handling of
     ## internal compilation errors. Separate from debugging reports since
     ## they always exist - ICE, internal fatal errors etc.
 
@@ -233,29 +233,29 @@ type
     # errors begin
     # regular nim parser
     rparInvalidIndentation
+    rparInvalidIndentationWithForgotEqualSignHint
     rparNestableRequiresIndentation
 
     rparIdentExpected
-    rparIdentOrKwdExpected
+    rparIdentExpectedEmptyAccQuote
     rparExprExpected
-    rparMissingToken
+    rparMissingToken         # also used in filter_tmpl
     rparUnexpectedToken
-    rparUnexpectedTokenKind
+    rparAsmStmtExpectsStrLit
 
     rparFuncNotAllowed
     rparTupleTypeWithPar
     rparMisplacedParameterVar
     rparConceptNotinType
-    rparRotineExpected
-    rparPragmaAlreadyPresent
     rparMisplacedExport
 
     rparPragmaBeforeGenericParameters
 
-    # template parser `filter_tmpl.nim`
+    # source filter template parser `filter_tmpl.nim`
     rparTemplMissingEndClose
     rparTemplInvalidExpression
 
+    # source filter `syntaxes.nim`
     rparInvalidFilter
 
     # erorrs END !! add reports BEFORE the last enum !!

--- a/compiler/ast/reports_parser.nim
+++ b/compiler/ast/reports_parser.nim
@@ -7,13 +7,24 @@ import
     report_enums,
   ]
 
+from compiler/ast/lineinfos import TLineInfo
+
 type
   ParserReport* = object of ReportBase
     msg*: string
     found*: string
     case kind*: ReportKind
-      of rparIdentExpected .. rparUnexpectedToken:
+      of rparInvalidIndentationWithForgotEqualSignHint:
+        eqInfo*: TLineInfo
+
+      of rparIdentExpected .. rparMissingToken:
         expected*: seq[string]
+
+      of rparUnexpectedToken:
+        expectedKind*: string
+
+      of rparAsmStmtExpectsStrLit:
+        discard
 
       of rparInvalidFilter:
         node*: PNode

--- a/compiler/ast/syntaxes.nim
+++ b/compiler/ast/syntaxes.nim
@@ -14,6 +14,7 @@ import
   compiler/ast/[
     llstream,
     ast,
+    ast_parsed_types,
     idents,
     lexer,
     parser,
@@ -40,6 +41,7 @@ from compiler/ast/reports_parser import ParserReport
 from compiler/ast/reports_internal import InternalReport
 from compiler/ast/report_enums import ReportKind
 
+# TODO: see about getting rid of all these parser exports
 export Parser, parseAll, parseTopLevelStmt, closeParser
 
 type
@@ -79,7 +81,7 @@ proc parsePipe(filename: AbsoluteFile, inputStream: PLLStream; cache: IdentCache
       while i < line.len and line[i] in Whitespace: inc(i)
       var p: Parser
       openParser(p, filename, llStreamOpen(substr(line, i)), cache, config)
-      result = parseAll(p).toPNode()
+      result = toPNode(parseAll(p))
       closeParser(p)
     llStreamClose(s)
 
@@ -151,8 +153,8 @@ proc setupParser*(p: var Parser; fileIdx: FileIndex; cache: IdentCache;
   openParser(p, fileIdx, llStreamOpen(f), cache, config)
   result = true
 
-proc parseFile*(fileIdx: FileIndex; cache: IdentCache; config: ConfigRef): PNode =
+proc parseFile*(fileIdx: FileIndex, cache: IdentCache, config: ConfigRef): ParsedNode =
   var p: Parser
   if setupParser(p, fileIdx, cache, config):
-    result = parseAll(p).toPNode()
+    result = parseAll(p)
     closeParser(p)

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1398,3 +1398,14 @@ proc isObjLackingTypeField*(typ: PType): bool {.inline.} =
   ## is not marked as ``.pure`` (the ``sfPure`` flags is not present on it)
   result = (typ.kind == tyObject) and ((tfFinal in typ.flags) and
       (typ[0] == nil) or isPureObject(typ))
+
+proc isImportedException*(t: PType; conf: ConfigRef): bool =
+  ## true of the `Exception` described by type `t` was imported
+  assert t != nil
+  if conf.exc != excNative:
+    return false
+
+  let base = t.skipTypes({tyAlias, tyPtr, tyDistinct, tyGenericInst})
+
+  if base.sym != nil and sfImportc in base.sym.flags:
+    result = true

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -9,9 +9,6 @@
 
 # included from cgen.nim
 
-when defined(nimCompilerStacktraceHints):
-  import std/stackframes
-
 proc getNullValueAuxT(p: BProc; orig, t: PType; obj, constOrNil: PNode,
                       result: var Rope; count: var int;
                       isConst: bool, info: TLineInfo)
@@ -2776,7 +2773,7 @@ proc genConstStmt(p: BProc, n: PNode) =
 
 proc expr(p: BProc, n: PNode, d: var TLoc) =
   when defined(nimCompilerStacktraceHints):
-    setFrameMsg p.config$n.info & " " & $n.kind
+    frameMsg(p.config, n)
   p.currLineInfo = n.info
 
   case n.kind

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -48,7 +48,8 @@ import
     nversion,
     bitsets,
     ropes,
-    pathutils
+    pathutils,
+    debugutils
   ],
   compiler/sem/[
     passes,

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2318,74 +2318,80 @@ proc reportShort*(conf: ConfigRef, r: SemReport): string =
 
 proc reportBody*(conf: ConfigRef, r: ParserReport): string =
   assertKind r
-  case ParserReportKind(r.kind):
-    of rparInvalidIndentation:
-       result = "invalid indentation"
-       result.add r.msg
+  case ParserReportKind(r.kind)
+  of rparInvalidIndentation:
+    result = "invalid indentation"
 
-    of rparNestableRequiresIndentation:
-       result = "nestable statement requires indentation"
+  of rparInvalidIndentationWithForgotEqualSignHint:
+    result = "invalid indentation, maybe missing '=' at $1?" % conf$r.eqInfo
 
-    of rparIdentExpected, rparIdentOrKwdExpected:
-      result = "identifier expected, but found '$1'" % r.found
+  of rparNestableRequiresIndentation:
+    result = "nestable statement requires indentation"
 
-    of rparExprExpected:
-      result = "expression expected, but found '$1'" % r.found
+  of rparIdentExpected:
+    result = "identifier expected, but found '$1'" % r.found
 
-    of rparMissingToken:
-      result = "expected " & r.expected[0]
+  of rparIdentExpectedEmptyAccQuote:
+    result = "identifier expected, but got empty accent quotes"
 
-    of rparUnexpectedToken:
-      result = "expected: '" & $r.expected[0] & "', but got: '" & r.found & "'"
+  of rparExprExpected:
+    result = "expression expected, but found '$1'" % r.found
 
-    of rparUnexpectedTokenKind:
-      result = r.msg
+  of rparMissingToken:
+    result =
+      case r.expected.len
+      of 1:
+        "expected " & r.expected[0]
+      of 2:
+        "expected $1 or $2" % [r.expected[0], r.expected[1]]
+      else:
+        unreachable("only 1-2 expected tokesn allowed, update message to fix")
 
-    of rparFuncNotAllowed:
-      result = "func keyword is not allowed in type descriptions, " &
-        "use proc with {.noSideEffect.} pragma instead"
+  of rparUnexpectedToken:
+    result = "expected: '$1', but got: '$2'" % [r.expectedKind, r.found]
 
-    of rparTupleTypeWithPar:
-      result = "the syntax for tuple types is 'tuple[...]', not 'tuple(...)'"
+  of rparAsmStmtExpectsStrLit:
+    result = "the 'asm' statement takes a string literal, got: '$1'" % r.found
 
-    of rparMisplacedParameterVar:
-      result = "the syntax is 'parameter: var T', not 'var parameter: T'"
+  of rparFuncNotAllowed:
+    result = "func keyword is not allowed in type descriptions, " &
+      "use proc with {.noSideEffect.} pragma instead"
 
-    of rparConceptNotinType:
-      result = "the 'concept' keyword is only valid in 'type' sections"
+  of rparTupleTypeWithPar:
+    result = "the syntax for tuple types is 'tuple[...]', not 'tuple(...)'"
 
-    of rparRotineExpected:
-      result = r.msg
+  of rparMisplacedParameterVar:
+    result = "the syntax is 'parameter: var T', not 'var parameter: T'"
 
-    of rparPragmaAlreadyPresent:
-      result = "pragma already present"
+  of rparConceptNotinType:
+    result = "the 'concept' keyword is only valid in 'type' sections"
 
-    of rparMisplacedExport:
-      result = "invalid indentation; an export marker '*' " &
-        "follows the declared identifier"
+  of rparMisplacedExport:
+    result = "invalid indentation; an export marker '*' " &
+      "follows the declared identifier"
 
-    of rparTemplMissingEndClose:
-      result = "'end' does not close a control flow construct"
+  of rparTemplMissingEndClose:
+    result = "'end' does not close a control flow construct"
 
-    of rparTemplInvalidExpression:
-      result = "invalid expression"
+  of rparTemplInvalidExpression:
+    result = "invalid expression"
 
-    of rparInconsistentSpacing:
-      result = "Number of spaces around '$#' is not consistent"
+  of rparInconsistentSpacing:
+    result = "Number of spaces around '$1' is not consistent" % r.found
 
-    of rparEnablePreviewDotOps:
-      result = "dot-like operators will be parsed differently " &
-        "with `-d:nimPreviewDotLikeOps`"
+  of rparEnablePreviewDotOps:
+    result = "dot-like operators will be parsed differently " &
+      "with `-d:nimPreviewDotLikeOps`"
 
-    of rparPragmaNotFollowingTypeName:
-      result = "type pragmas follow the type name; this form of " &
-        "writing pragmas is deprecated"
+  of rparPragmaNotFollowingTypeName:
+    result = "type pragmas follow the type name; this form of " &
+      "writing pragmas is deprecated"
 
-    of rparPragmaBeforeGenericParameters:
-      result = "pragma must come after any generic parameter list"
+  of rparPragmaBeforeGenericParameters:
+    result = "pragma must come after any generic parameter list"
 
-    of rparInvalidFilter:
-      result = "invalid filter: $1" % r.node.renderTree
+  of rparInvalidFilter:
+    result = "invalid filter: $1" % r.node.renderTree
 
 proc reportFull*(conf: ConfigRef, r: ParserReport): string =
   assertKind r

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -343,7 +343,6 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
         conf.incl(cnModifiedy, n)
 
         if state in {wWarningAsError, wHintAsError}:
-          # xxx rename warningAsErrors to noteAsErrors
           conf.flip(cnWarnAsError, n, isOn)
         else:
           conf.flip(cnCurrent, n, isOn)

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -47,7 +47,8 @@ import
   compiler/utils/[
     platform,    # Target platform data
     nversion,
-    pathutils    # Input file handling
+    pathutils,   # Input file handling
+    astrepr,     # Output parsed data, for compiler development
   ],
   compiler/vm/[
     compilerbridge, # Configuration file evaluation, `nim e`
@@ -445,7 +446,10 @@ proc mainCommand*(graph: ModuleGraph) =
 
   of cmdParse:
     wantMainModule(conf)
-    discard parseFile(conf.projectMainIdx, cache, conf)
+    var reprConf = defaultTReprConf
+    reprConf.flags.excl trfShowNodeIds
+    reprConf.flags.incl trfShowNodeLineInfo
+    echo conf.treeRepr(parseFile(conf.projectMainIdx, cache, conf), reprConf)
 
   of cmdRod:
     wantMainModule(conf)

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -21,10 +21,13 @@ from times import utc, fromUnix, local, getTime, format, DateTime
 from std/private/globs import nativeToUnixPath
 
 from compiler/ast/ast_types import
-  NodeId, # used as a reportId/diagId proxy
-  PNode,  # because of reports, more leakage
-  PSym    # Contextual details of the instantiation stack optionally refer to
-          # the used symbol
+  TNodeKind,  # used in conversion from `ParsedNode` to `PNode`
+  TNodeFlag,  # used in conversion from `ParsedNode` to `PNode`
+  `comment=`, # used in conversion from `ParsedNode` to `PNode`
+  NodeId,     # used as a reportId/diagId proxy
+  PNode,      # because of reports, more leakage
+  PSym        # Contextual details of the instantiation stack optionally refers
+              # to the used symbol
 
 # xxx: legacy Reports to be removed
 import compiler/ast/report_enums

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -173,7 +173,7 @@ proc importModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
 
 
 proc includeModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PNode =
-  result = syntaxes.parseFile(fileIdx, graph.cache, graph.config)
+  result = syntaxes.parseFile(fileIdx, graph.cache, graph.config).toPNode()
   graph.addDep(s, fileIdx)
   graph.addIncludeDep(s.position.FileIndex, fileIdx)
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -60,7 +60,6 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
         # check if we got any errors and if so report them
         for e in ifErrorWalkErrors(c.config, n[i][0][1]):
           localReport(c.config, e)
-
       else:
         e = newSymS(skEnumField, n[i][0], c)
         identToReplace = addr n[i][0]
@@ -82,7 +81,6 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
             localReport(c.config, strVal, reportSem(rsemStringLiteralExpected))
         else:
           localReport(c.config, v, reportSem(rsemWrongNumberOfVariables))
-
       of tyString, tyCstring:
         strVal = v
         x = counter
@@ -96,7 +94,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
       if i != 1:
         if x != counter: incl(result.flags, tfEnumHasHoles)
         if x < counter:
-          localReport(c.config, n[i].info, SemReport(
+          localReport(c.config, v.info, SemReport(
             kind: rsemInvalidOrderInEnum,
             sym: e,
             expectedCount: toInt128 counter,

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -1541,8 +1541,8 @@ proc commandRst2TeX*(cache: IdentCache, conf: ConfigRef) =
   commandRstAux(cache, conf, conf.projectFull, TexExt)
 
 proc commandTags*(cache: IdentCache, conf: ConfigRef) =
-  var ast = parseFile(conf.projectMainIdx, cache, conf)
-  if ast == nil: return
+  let ast = parseFile(conf.projectMainIdx, cache, conf).toPNode()
+  if ast.isNil: return
   var d = newDocumentor(conf.projectFull, cache, conf)
   d.onTestSnippet = proc (d: var RstGenerator; filename, cmd: string;
                           status: int; content: string) =

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -237,9 +237,14 @@ template traceLeaveIt*(
   tmp.info = loc
   traceStepImpl(tmp, semstepLeave, body)
 
-template frameMsg(c: ConfigRef, n: PNode) =
+template frameMsg*(c: ConfigRef, n: PNode) =
   {.line.}:
-    setFrameMsg "$1 $2 $3" % [$n.kind, $n.id, c$n.info]
+    setFrameMsg "$1 $2 $3($4, $5)" % [
+      $n.kind,
+      $n.id,
+      c.toFullPath(n.info.fileIndex),
+      $n.info.line,
+      $n.info.col]
 
 const locOffset = -2
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -51,7 +51,8 @@ import
     lowerings
   ],
   compiler/utils/[
-    idioms
+    idioms,
+    debugutils
   ],
   compiler/vm/[
     vmaux,
@@ -2513,7 +2514,7 @@ proc genClosureConstr(c: var TCtx, n: PNode, dest: var TDest) =
 
 proc gen(c: var TCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
   when defined(nimCompilerStacktraceHints):
-    setFrameMsg c.config$n.info & " " & $n.kind & " " & $flags
+    frameMsg c.config, n
 
   case n.kind
   of nkSym:

--- a/nimsuggest/tests/tchk1.nim
+++ b/nimsuggest/tests/tchk1.nim
@@ -17,11 +17,11 @@ proc main =
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Error;;$file;;12;;0;;"identifier expected, but found \'template\'";;0
+chk;;skUnknown;;;;Error;;$file;;12;;0;;"identifier expected, but found \'keyword template\'";;0
 chk;;skUnknown;;;;Error;;$file;;14;;0;;"nestable statement requires indentation";;0
 chk;;skUnknown;;;;Error;;$file;;12;;0;;"implementation of \'foo\' expected";;0
 chk;;skUnknown;;;;Error;;$file;;17;;0;;"invalid indentation";;0
-chk;;skUnknown;;;;Hint;;$file;;20;;87;;"Hint: line too long [LineTooLong]";;0
+chk;;skUnknown;;;;Hint;;$file;;20;;95;;"Hint: line too long [LineTooLong]";;0
 chk;;skUnknown;;;;Hint;;$file;;21;;83;;"Hint: line too long [LineTooLong]";;0
 chk;;skUnknown;;;;Hint;;$file;;28;;97;;"Hint: line too long [LineTooLong]";;0
 chk;;skUnknown;;;;Hint;;$file;;29;;98;;"Hint: line too long [LineTooLong]";;0

--- a/tests/compilerfeatures/tstructured_parse_fail.nim
+++ b/tests/compilerfeatures/tstructured_parse_fail.nim
@@ -4,7 +4,7 @@ nimoutformat: "sexp"
 cmd: "nim c --filenames=canonical --msgFormat=sexp $file"
 action: reject
 nimout: '''
-(ParInvalidIndentation :severity Error :found "[EOF]" :location (_ 12 0))
+(ParInvalidIndentation :location ("tests/compilerfeatures/tstructured_parse_fail.nim" 12 0) :reportFrom ("parser.nim" _ _) :reportInst ("parser.nim" _ _) :severity Error)
 '''
 """
 

--- a/tests/lang_callable/macros/tvarargslen.nim
+++ b/tests/lang_callable/macros/tvarargslen.nim
@@ -9,11 +9,11 @@ done
 """
 ## line 10
 
+
+
 from std/macros import varargsLen
 
 template myecho*(a: varargs[untyped]) =
-  ## shows a useful debugging echo-like proc that is dependency-free (no dependency
-  ## on macros.nim) so can be used in more contexts
   const info = instantiationInfo(-1, false)
   const loc = info.filename & ":" & $info.line & ":" & $info.column & " "
   when varargsLen(a) > 0:

--- a/tests/lang_syntax/parser/tparse_confusing_identation.nim
+++ b/tests/lang_syntax/parser/tparse_confusing_identation.nim
@@ -3,11 +3,11 @@ discard """
   cmd: "nim check $options $file"
   action: "reject"
   nimout: '''
-tparse_confusing_identation.nim(23, 5) Error: invalid indentation, maybe you forgot a '=' at tparse_confusing_identation.nim(22, 13) ?
-tparse_confusing_identation.nim(28, 5) Error: invalid indentation, maybe you forgot a '=' at tparse_confusing_identation.nim(26, 13) ?
-tparse_confusing_identation.nim(33, 5) Error: invalid indentation, maybe you forgot a '=' at tparse_confusing_identation.nim(31, 25) ?
-tparse_confusing_identation.nim(42, 5) Error: invalid indentation, maybe you forgot a '=' at tparse_confusing_identation.nim(38, 12) ?
-tparse_confusing_identation.nim(56, 5) Error: invalid indentation, maybe you forgot a '=' at tparse_confusing_identation.nim(55, 13) ?
+tparse_confusing_identation.nim(23, 5) Error: invalid indentation, maybe missing '=' at tparse_confusing_identation.nim(22, 13)?
+tparse_confusing_identation.nim(28, 5) Error: invalid indentation, maybe missing '=' at tparse_confusing_identation.nim(26, 13)?
+tparse_confusing_identation.nim(33, 5) Error: invalid indentation, maybe missing '=' at tparse_confusing_identation.nim(31, 25)?
+tparse_confusing_identation.nim(42, 5) Error: invalid indentation, maybe missing '=' at tparse_confusing_identation.nim(38, 12)?
+tparse_confusing_identation.nim(56, 5) Error: invalid indentation, maybe missing '=' at tparse_confusing_identation.nim(55, 13)?
 tparse_confusing_identation.nim(61, 48) Error: expression expected, but found ','
 '''
 """


### PR DESCRIPTION
Summary
=======

This removes direct dependency on `reports`, but an indirect one still
exists via `msgs`. It's pretty trivial indirection at the moment, but
after dropping direct reports dependencies the API can be changed more
drastically.

A number of changes were required in order to make this possible, here
is an overview:

- smaller parser public API & simpler implementation
- added `parse` compiler command, for devs
- parser error message improvements
- fixes to `astrepr` logic and output
- lots of style clean-ups

Details
=======

Slimmer `parser` Public API
---------------------------

Previously the parser had many public procedures (eg: `isOperator`,
`getTok`, `skipComment`, etc) that would allow fine grained control for
other modules.

There are many issues with this:
- there are no consumers of this API
- lots of public API surface to test
- the API itself was bad, it conflated lexing and parsing

The public API surface for the parser has been reduced significantly,
now consisting of:
- `openParser`
- `parseTopLevelStmt`
- `parseAll`
- `closeParser`
- `parseString`

That's it, which frankly reads far more sensibly.

Simplified `parser` Implementation
----------------------------------

- removed `InternalReport`, `reports_parser`, and `reports_enum` imports
- introduced diagnostics for the parser, akin to the lexer, `ParseDiag`
- `ParseDiag` favours data over strings
- `ParsedNode` now has its own kind enum, mostly a subset of
   `TNodeKind`, but entirely compatible

Consolidated a pattern within the parser, where a node was created with
the current token's information, and then the token was immediately
consumed via `getTok` to advance the `lexer`. This is captured in the
newly introduced `newNodeConsumingTok`.

Long-term, itemizing these traversal/consumption patterns will make the
parser logic not only more regular, but also highlight oddities in the
grammar as the implementation will be convoluted.

Parsing/Diagnostics Performance
-------------------------------

`ParsedNode` uses a lightweight `ParsedToken`

Introduce `ParsedToken`, a smaller data type, storing the least amount
of data required from `lexer.Token` for `ParsedNode`. This not only
saves memory, but the runtime performance impact on my machine is
roughly 33% faster full compiler testament run for all targets

- before change: 3+ minutes
- after change:  2+ minutes

Added specialized diagnostic/report kinds for:
- empty accent quote when ident expected
- msg for asm statements without a string literal
These reduces the amount of string data carried around in the compiler.

Improved Custom Numeric Literal Handling
----------------------------------------

- the `lexer` still does silly things for lexing these
- it just does less work and produces better data
- fewer string operations and hacks are required by the `parser`

Parser Diagnostic/Reporting - Invalid Indentation
-------------------------------------------------

- now has correct source line information
- tracks instantiation and submission location
- has the appropriate severity
- improved phrasing for indent error from possible missed `=` character
- adjusted tests for the above

Parser Diagnostic/Reporting - Malformed Call Syntax
---------------------------------------------------

- `parser` detects malformed calls and sets better line info
- net-net the user will have a better chance to find the issues

Parser Diagnostic/Reporting - Misc
----------------------------------

- token rendering call out keywords via prefix, eg: `keyword template`
- inconsistent spacing style check shows the problematic source

Removed unused report kinds:
- `rparIdentOrKwdExpected`
- `rparRotineExpected`
- `rparPragmaAlreadyPresent`

Parse Compiler Command
----------------------

`parse` command:
- added `parse` command, which outputs the parsed ast for a file
- usage: `nim parse foo.nim`
- super useful for diffing parser output changes
- heavily leverages `astrepr`

`astrepr` module:
- `astrepr.treeRepr` now works for `ParsedNode`, was previously broken
- AST trasversal is now exhaustive and breakages less likely to pass CI

`astrepr` output improvements, mainly for `ParsedNode`:
- `astrepr` now shortens ParsedNodeKind enum
- output now includes line and column information
- comments no longer result in excessive new line output
- fixed many formatting issues for `ParsedNode` output
- improved `astrepr`'s output for custom numeric literals

Canonical Filenames Performance Issue
-------------------------------------

Also discovered a performance issue with canonical filenames option and
the `nimdebugstacktrace` option. Removed some of the pain, but canonical
file paths result in significant performance issues due to filesystem
IO. I've fixed part of it and filed an issue:
https://github.com/nim-works/nimskull/issues/546

Other Improvements
------------------

- introduced `debugutils.setFrame` template for frame msg hints
- above `setFrame` avoids the canonical path performance hit
- removed circular dependency between `ast` and `options` module
- document unused parser reports and other outliers
- move `isImportedException` to `ast/types`, whice drops `front/options`
  cyclic depencdency from `ast/ast_query`
- fixed docs in nimlexbase, also easier to understand
- `ast.toPNode` now handles `nil` input
- `syntaxes.parseFile` returns `ParsedNode`, allows avoiding unnecessary
  conversions in future use cases where only `ParsedNode` is required

Special Mentions
----------------

Thanks, clyybber and zerbina for the reviews!

Misc
----
- remove blank space characters from otherwise empty lines
- remove awful code style of `0 < foo.len`
- fixed a number of typos in comments
- adjusted a few tests to ensure they pass

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* done and good to go IMO
* Should be complementary to lexer DOD work

## TODO (non-exhausitive)
- [x] remove direct dependency on `reports` bits
- [x] `parser` sort out data internals approach
