### PR TITLE
vm: prepare for the `var`/address rework

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1254,6 +1254,12 @@ proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): YieldReason
       checkHandle(regs[rc])
       writeLoc(h, regs[rc], c.memory)
 
+    of opcWrLoc:
+      # a = b
+      let rb = instr.regB
+      checkHandle(regs[ra])
+      checkHandle(regs[rb])
+      writeLoc(regs[ra].handle, regs[rb], c.memory)
     of opcWrStrIdx:
       # a[b] = c
       let rb = instr.regB

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -41,6 +41,9 @@ type
     opcLdObj,  # a = b.c
     opcLdObjAddr, # a = addr(b.c)
     opcWrObj,  # a.b = c
+    opcWrLoc,  ## ``a = b``; writes the value represented by register `b`
+               ## (either directly or indirectly) to the location identified
+               ## by register `a`. A full copy is performed.
 
     opcAddrReg,
     opcAddrNode,


### PR DESCRIPTION
## Summary
Introduce the `opcWrLoc` operation, which makes the `writeLoc` procedure available at the instruction level. This is a prerequisite for the rework of how `var` parameters and views are implemented by `vmgen`.

The introduction of `opcWrLoc` allows for generating more efficient code for `new` and `newSeq`, also fixing a double-evaluation bug with their arguments.

## Details
- add `opcWrLoc`. It is different from `opcAsgnComplex` in that the former is used for writing/assigning to a *location*, while the latter is used for assigning a value to a *register*
- don't generate a patch assignment for `opcSetLenStr` or `opcSetLengthSeq`. The operations already mutate the correct location

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* `genPatchAsgn` will eventually be removed completely, but the mentioned `var` rework is required for that

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
