### PR TITLE
cgen: make `.global.`s work more according to spec

### DIFF
--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -75,6 +75,10 @@ from compiler/ast/reports_sem import SemReport,
   reportTyp
 from compiler/ast/report_enums import ReportKind
 
+# XXX: the code-generator should not need to know about the existance of
+#      destructor injections (or destructors, for that matter)
+from compiler/sem/injectdestructors import deferGlobalDestructor
+
 import std/strutils except `%` # collides with ropes.`%`
 
 from compiler/ic/ic import ModuleBackendFlag
@@ -1028,6 +1032,37 @@ proc genProcAux(m: BModule, prc: PSym) =
   assert(prc.ast != nil)
 
   var procBody = transformBody(m.g.graph, m.idgen, prc, cache = false)
+  block:
+    # process globals defined by the procedure's body
+    var globals: seq[PNode]
+    extractGlobals(procBody, globals, isNimVm = false)
+    # note: we're modifying the procedure's cached transformed body above,
+    # meaning that globals defiend inside ``inline`` procedures are also only
+    # extracted once
+
+    let m2 = findPendingModule(m, prc)
+
+    # first pass: register the destructors
+    for it in globals.items:
+      deferGlobalDestructor(m2.g.graph, m2.idgen, prc, it[0])
+
+    # second pass: generate the initialization code. This is done here already,
+    # as it might depend on other procedures. Deferring this to ``genInitCode``
+    # is not possible, because then it's too late to raise further dependencies.
+    # Also, generate the code in the pre-init procedure of the module where the
+    # procedure is *defined*, not where it's first *used* (this is only relevant
+    # for ``inline`` procedures, as they're generated multiple times)
+    for it in globals.items:
+      # since the identdefs are extracted from the transformed AST, the
+      # initializer expression isn't canonicalized yet
+      let value =
+        if it[2].kind != nkEmpty:
+          canonicalizeSingle(m2.g.graph, m2.idgen, prc, it[2], {})
+        else:
+          it[2]
+
+      genSingleVar(m2.preInitProc, it[0].sym, it[0], value)
+
   procBody = canonicalizeWithInject(m.g.graph, m.idgen, prc, procBody, {})
 
   if sfPure notin prc.flags and prc.typ[0] != nil:

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -1103,6 +1103,14 @@ func shouldInjectDestructorCalls*(owner: PSym): bool =
      {sfInjectDestructors, sfGeneratedOp} * owner.flags == {sfInjectDestructors} and
      (owner.kind != skIterator or not isInlineIterator(owner.typ))
 
+proc deferGlobalDestructor*(g: ModuleGraph, idgen: IdGenerator, owner: PSym,
+                            global: PNode) =
+  ## If the global has a destructor, emits a call to it at the end of the
+  ## section of global destructors.
+  if sfThread notin global.sym.flags and hasDestructor(global.typ):
+    var c = Con(owner: owner, graph: g, idgen: idgen)
+    g.globalDestructors.add genDestroy(c, global)
+
 proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym; n: PNode): PNode =
   when toDebug.len > 0:
     shouldDebug = toDebug == owner.name.s or toDebug == "always"

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -493,8 +493,6 @@ type
     cgfAllowMeta ## If not present, type or other meta expressions are
                  ## disallowed in imperative contexts and code-gen for meta
                  ## function arguments (e.g. `typedesc`) is suppressed
-    cgfCollectGlobals ## If present, the ident defs of `{.global.}` variables
-                      ## are collected instead of code-gen'ed
 
   LinkIndex* = uint32 ## Depending on the context: `FunctionIndex`; index
     ## into `TCtx.globals`; index into `TCtx.complexConsts`
@@ -518,10 +516,6 @@ type
     nextProc*: LinkIndex
     nextGlobal*: LinkIndex
     nextConst*: LinkIndex
-
-    globalDefs*: seq[PNode] ## output; collected `{.global.}` definitions.
-                            ## They're only collected if `cgfCollectGlobals`
-                            ## is active
 
     flags*: set[CodeGenFlag] ## input
   

--- a/tests/global/globalaux.nim
+++ b/tests/global/globalaux.nim
@@ -13,3 +13,12 @@ proc globalInstance*[T]: var TObj[T] =
   var g {.global.} = when T is int: makeObj(10) else: makeObj("hello")
   result = g
 
+proc testInline*(cmp: int) {.inline.} =
+  # initialization of the global needs to happen at the start of ``globalaux``
+  var v {.global.} = 1
+  doAssert v == cmp
+  # modify the global. The other module from which ``testInline`` is called
+  # must be able to observe this modification:
+  v = 2
+
+testInline(1) # change the `v` to '2'

--- a/tests/global/tglobal.nim
+++ b/tests/global/tglobal.nim
@@ -1,7 +1,14 @@
 discard """
+  description: '''
+    Tests for globals defined inside procedures via the `.global.` pragma
+  '''
+  targets: "c !vm"
   output: "in globalaux2: 10\ntotal globals: 2\nint value: 100\nstring value: second"
-
 """
+
+## knownIssue: the VM backend initializes the globals in the pre-init procedure
+##             of the module where the generic is defined, not where it's
+##             instantiated
 
 import globalaux, globalaux2
 
@@ -14,3 +21,7 @@ globalInstance[string]().val = "first"
 globalInstance[string]().val = "second"
 echo "string value: ", globalInstance[string]().val
 
+block inline_procedure_with_global:
+  # call the inline procedure and make sure that the global was not
+  # re-initialized at the start of the current module
+  testInline(2)

--- a/tests/lang_objects/destructor/tdestructor_in_initializer.nim
+++ b/tests/lang_objects/destructor/tdestructor_in_initializer.nim
@@ -1,0 +1,29 @@
+discard """
+  description: '''
+    Regression test to make sure that locals inside the initializer of a global
+    defined inside a procedure's body are properly destroyed
+  '''
+  targets: "c"
+  knownIssue: "the `injectdestructors` pass is not for the initializer"
+"""
+
+var wasDestroyed: bool
+# don't initialize the global; doing so might override the value assgined
+# during pre-initialization
+
+# initialization of ``.global.``s currently happens *before* the code part
+# of the module is executed, so if the destructor was called, ``wasDestroyed``
+# has to be true here
+doAssert wasDestroyed
+
+type Resource = object
+
+proc `=destroy`(x: var Resource) =
+  wasDestroyed = true
+
+proc prc() =
+  var v {.global.} = block:
+    var r = Resource() # `r` needs to be destroyed at the end of the block
+    1
+
+prc() # use the procedure so that the global is part of the alive code


### PR DESCRIPTION
## Summary
For the C target, globals defined inside procedures that are resource- like (i.e. have a user-defined or lifted destructor) are now initialized in a module's pre-init procedure, instead of each time control-flow reaches the definition. This mirrors what already happened for non-resource-like globals.

In addition, globals defined in `inline` procedures no longer cause linking errors because of duplicated definitions in the generated C code.

## Details
The globals are extracted before translating the AST to MIR code, making the workaround in `mirgen` (that didn't work anyway) obsolete. In order to work towards unifying the architecture of the back-ends, `vmbackend` now also makes use of the pre-extraction, no longer requiring extra logic in the code-generator.

### Known Issues
- the destructor-injection pass is not run for the initializer expression of globals defined inside procedures
- `.global.`s on the JS target still don't work according to specification

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
The PR is meant to unblock #450 with the least amount of work and changes to semantics. I think that the introduced regression (no destructor injection for initializers of procedure-level globals) is acceptable until the implementation gets an overhaul.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
