### PR TITLE
`finally` block passing with same indent as expr

### DIFF
--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -1263,7 +1263,7 @@ proc postExprBlocks(p: var Parser, x: ParsedNode): ParsedNode =
     result = makeCall(result)
     p.getTok
     p.skipComment(result)
-    if p.tok.tokType notin {tkOf, tkElif, tkElse, tkExcept}:
+    if p.tok.tokType notin {tkOf, tkElif, tkElse, tkExcept, tkFinally}:
       var stmtList = p.newNode(nkStmtList, @[parseStmt(p)])
       # to keep backwards compatibility (see tests/vm/tstringnil)
       if stmtList[0].kind == nkStmtList: stmtList = stmtList[0]

--- a/tests/compiler_integration/parser/tpostexprblocks.nim
+++ b/tests/compiler_integration/parser/tpostexprblocks.nim
@@ -166,6 +166,62 @@ StmtList
       StmtList
         DiscardStmt
           Empty
+  Call
+    Ident "foo181"
+    StmtList
+      DiscardStmt
+        Empty
+    OfBranch
+      StmtList
+        DiscardStmt
+          Empty
+  Call
+    Ident "foo182"
+    StmtList
+      DiscardStmt
+        Empty
+    ElifBranch
+      Ident "bar"
+      StmtList
+        DiscardStmt
+          Empty
+  Call
+    Ident "foo183"
+    StmtList
+      DiscardStmt
+        Empty
+    Else
+      StmtList
+        DiscardStmt
+          Empty
+  Call
+    Ident "foo184"
+    StmtList
+      DiscardStmt
+        Empty
+    ExceptBranch
+      StmtList
+        DiscardStmt
+          Empty
+  Call
+    Ident "foo185"
+    StmtList
+      DiscardStmt
+        Empty
+    ExceptBranch
+      Ident "bar"
+      StmtList
+        DiscardStmt
+          Empty
+  Call
+    Ident "foo186"
+    StmtList
+      DiscardStmt
+        Empty
+    Finally
+      StmtList
+        DiscardStmt
+          Empty
   Command
     Ident "foo190"
     Call
@@ -498,6 +554,12 @@ StmtList
         StmtList
           DiscardStmt
             Empty
+  Call
+    Ident "foo400"
+    Finally
+      StmtList
+        DiscardStmt
+          Empty
 '''
 """
 
@@ -561,6 +623,36 @@ dumpTree:
   do:
     discard
   else:
+    discard
+
+  foo181 do:
+    discard
+  of:
+    discard
+
+  foo182 do:
+    discard
+  elif bar:
+    discard
+
+  foo183 do:
+    discard
+  else:
+    discard
+
+  foo184 do:
+    discard
+  except:
+    discard
+
+  foo185 do:
+    discard
+  except bar:
+    discard
+
+  foo186 do:
+    discard
+  finally:
     discard
 
   foo190 x do (y):
@@ -653,5 +745,9 @@ dumpTree:
     discard
   except (a, b):
     discard
+  finally:
+    discard
+
+  foo400:
   finally:
     discard


### PR DESCRIPTION
Previously, `of`, `else`, `elif`, and `except` could be used to pass the branch and contents as a param on the same level of a call expression ending with a `:`, like so:

```
foo:
else:
  discard
```

Now `finally` can be used just like `else`.

This inconsistency was discovered by @Clyybber while reviewing: https://github.com/nim-works/nimskull/pull/533

---

## Notes for Reviewers
* this came out of the parser rework PR
* the `compiler_integration` test category doesn't make sense, will move separately