### PR TITLE
sem: fix crash import from a non-existent symbol

### DIFF
--- a/compiler/modules/importer.nim
+++ b/compiler/modules/importer.nim
@@ -405,6 +405,8 @@ proc evalImport*(c: PContext, n: PNode): PNode =
     result = c.config.wrapError(result)
 
 proc evalFrom*(c: PContext, n: PNode): PNode =
+  # TODO: this proc, `myImportModule`, and friends are all very convoluted in
+  #       how they work, far too much mutation
   checkMinSonsLen(n, 2, c.config)
   result = newNodeI(nkImportStmt, n.info)
   let m = myImportModule(c, n[0], result)
@@ -427,9 +429,9 @@ proc evalFrom*(c: PContext, n: PNode): PNode =
         case imported.kind
         of skError:
           hasError = true
-          result[i] = imported.ast
+          result.add imported.ast
         else:
-          discard
+          result.add newSymNode(imported)
     
     c.addImport im
     afterImport(c, m)

--- a/tests/modules/timportfromerr.nim
+++ b/tests/modules/timportfromerr.nim
@@ -1,0 +1,8 @@
+discard """
+description: "non-existent symbol in import from clause errors out"
+errormsg: "undeclared identifier: 'doesNotExist'"
+line: 8
+column: 25
+"""
+
+from definitions import doesNotExist


### PR DESCRIPTION
## Summary

evaluation of `from ... import x` statments would crash if `x` was
undefined.

## Details

This was due to an index out of bounds issue. Now an
undeclared identifier error is reported.

In the future the error message should be improved, but at least the
crash is fixed and a test exists.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* quick bug fix; improved message etc comes later