### PR TITLE
internals: `P/TIdent` moved to the `idents` module

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -2,9 +2,14 @@ import compiler/ast/lineinfos
 import compiler/utils/ropes
 import std/[hashes]
 
+from compiler/ast/idents import PIdent, TIdent
+
 from compiler/front/in_options import TOption, TOptions # Stored in `PSym`
 
 from compiler/utils/int128 import Int128
+
+# xxx: is there a way to/worth eliminate the exports?
+export PIdent, TIdent
 
 const maxInstantiation* = 100
   ## maximum number of nested generic instantiations or macro pragma expansions
@@ -780,13 +785,6 @@ type
   TNodeSeq* = seq[PNode]
   PType* = ref TType
   PSym* = ref TSym
-
-  PIdent* = ref TIdent
-  TIdent*{.acyclic.} = object
-    id*: int ## unique id; use this for comparisons and not the pointers
-    s*: string
-    next*: PIdent ## for hash-table chaining
-    h*: Hash ## hash value of `s`
 
   SemTypeMismatch* = object
     formalTypeKind*: set[TTypeKind]

--- a/compiler/ast/idents.nim
+++ b/compiler/ast/idents.nim
@@ -17,13 +17,17 @@ import
     hashes
   ],
   compiler/ast/[
-    ast_types,
     wordrecg
   ]
 
-export PIdent
-
 type
+  PIdent* = ref TIdent
+  TIdent*{.acyclic.} = object
+    id*: int ## unique id; use this for comparisons and not the pointers
+    s*: string
+    next*: PIdent ## for hash-table chaining
+    h*: Hash ## hash value of `s`
+
   IdentCache* = ref object
     buckets: array[0..4096 * 2 - 1, PIdent]
     wordCounter: int


### PR DESCRIPTION
## Summary

`PIdent` and `TIdent` were in the `ast_types` module. Moved them into `idents`. This now places the data type in the correct module (`idents`) and also drops the number of dependencies in `idents` module, `ast_types`.

There is an export in `ast_types` for the types with a comment to consider if there is a way or even worth eliminuating it.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* quick win come out of the parser refactoring