### PR TITLE
report illegal branch switch during semantic analysis

### DIFF
--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -421,12 +421,6 @@ proc genDiscriminantAsgn(c: var Con; s: var Scope; n: PNode): PNode =
   let objType = leDotExpr[0].typ
 
   if hasDestructor(c, objType):
-    if getAttachedOp(c.graph, objType, attachedDestructor) != nil and
-        sfOverriden in getAttachedOp(c.graph, objType, attachedDestructor).flags:
-      localReport(c.graph.config, n, reportSem rsemCannotAssignToDiscriminantWithCustomDestructor)
-      result.add newTree(nkFastAsgn, le, tmp)
-      return
-
     # generate: if le != tmp: `=destroy`(le)
     let branchDestructor = produceDestructorForDiscriminator(c.graph, objType, leDotExpr[1].sym, n.info, c.idgen)
     let cond = newTreeIT(nkInfix, n.info, getSysType(c.graph, unknownLineInfo, tyBool)):

--- a/tests/lang_objects/destructor/tdisallow_branch_switch.nim
+++ b/tests/lang_objects/destructor/tdisallow_branch_switch.nim
@@ -1,0 +1,29 @@
+discard """
+  description: '''
+    Attempting to switch the branch of a variant object with an overridden
+    destructor produces an error
+  '''
+  cmd: "nim check --msgFormat=sexp --filenames=canonical $options $file"
+  nimoutFormat: sexp
+  action: reject
+"""
+
+type
+  Obj = object
+    case tag: bool
+    of false, true:
+      discard
+
+proc `=destroy`(x: var Obj) =
+  discard
+
+var o = Obj(tag: false)
+o.tag = false #[tt.Error
+     ^ (SemCannotAssignToDiscriminantWithCustomDestructor)]#
+
+# the error must also be diagnosed for code not part of the alive graph (i.e.
+# for unused procedures)
+proc unused() {.used.} = # suppress the warning
+  var o = Obj(tag: false)
+  o.tag = false #[tt.Error
+       ^ (SemCannotAssignToDiscriminantWithCustomDestructor)]#


### PR DESCRIPTION
## Summary
Assigning to a discriminant of a variant object (i.e. switching the active branch) that has a user-provided destructor is a semantic error, but it was checked for and reported during the `injectdestructors` pass, which, as of now, is part of the mid-/back-end phase.

It is now reported in `sempass2`, which also fixes the issue of no error being reported when the offending assignment is not part of the alive code.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->