### PR TITLE
bootstrap the compiler and tools with ORC

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -211,7 +211,8 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
 
       if a.len == 2 and a[0].kind == nkBracket:
         # rewrite ``except [a, b, c]: body`` -> ```except a, b, c: body```
-        a.sons[0..0] = a[0].sons
+        let x = move a[0]
+        a.sons[0..0] = x.sons
 
       if a.len == 2 and a[0].isInfixAs():
         # support ``except Exception as ex: body``

--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -1,6 +1,6 @@
 # Special configuration file for the Nim project
 
-gc:markAndSweep
+gc:orc
 
 hint[XDeclaredButNotUsed]:off
 

--- a/testament/testament.nim.cfg
+++ b/testament/testament.nim.cfg
@@ -5,3 +5,5 @@ path = "."    # to allow for package qualified imports
 -d:ssl # For some CI (previously Azure)
 # my SSL doesn't have this feature and I don't care:
 -d:nimDisableCertificateValidation
+
+--gc:orc


### PR DESCRIPTION
## Summary

All tools built as part of `koch tools` as well as the second and third
iteration of bootstrapping now use ORC as the memory management
strategy. The first iteration does not, as the current csources compiler
fails to compile the compiler.

This is the first step towards making ORC the default and removing all
legacy GC options.

## Details

The tools that are now built with `--gc:orc` are:
- `nimsuggest`
- `nimgrep`
- `vccexe`
- `vmrunner`
- `nim_dbg`
- `testament`

As a side-effect of the change, the compiler and the VM (both built-in
and standalone) are now significantly faster. For compiling itself,
the `--gc:orc`-built compiler is ~30% faster in `-d:release` mode than
the `--gc:refc` counterpart.

### Other

- fix a parameter passing aliasing violation in `semTry` that lead to
  memory corruption

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
- in order to still have a test for a full bootstrap run with `--gc:orc`, I didn't remove CI steps just now (though since the result from the third and second iteration are tested to be equal, this is probably redundant)