### PR TITLE
compiler: unify the backend processing

### DIFF
--- a/compiler/backend/backend2.nim
+++ b/compiler/backend/backend2.nim
@@ -299,6 +299,10 @@ proc generateCodeC*(graph: ModuleGraph) =
         if emulatedThreadVars(graph.config):
           dependOnCompilerProc(ctx, iter, gstate, ctx.modules[i], i, graph, "initThreadVarsEmulation")
 
+    if optStackTrace in ctx.modules[i].bmod.initProc.options and preventStackTrace notin ctx.modules[i].bmod.flags:
+      dependOnCompilerProc(ctx, iter, gstate, ctx.modules[i], i, graph, "nimFrame")
+      dependOnCompilerProc(ctx, iter, gstate, ctx.modules[i], i, graph, "popFrame")
+
   # discover and generate code for all alive procedures
   while hasNext(iter):
     let prc = next(iter, graph, ctx.list[])

--- a/compiler/backend/backend2.nim
+++ b/compiler/backend/backend2.nim
@@ -1,0 +1,332 @@
+## This module implements the code-generation orchestrator for the C backend.
+
+import
+  std/[
+    intsets,
+    tables,
+    sets
+  ],
+  compiler/ast/[
+    ast,
+    ast_types,
+    lineinfos
+  ],
+  compiler/backend/[
+    backends,
+    cgen,
+    cgendata
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/mir/[
+    mirgen,
+    mirbridge,
+    mirtrees,
+    astgen
+  ],
+  compiler/modules/[
+    magicsys,
+    modulegraphs
+  ],
+  compiler/sem/[
+    transf
+  ],
+  compiler/utils/[
+    containers,
+    ropes,
+    platform
+  ]
+
+export collectPass # TODO: remove
+
+type
+  InlineProc = object
+    info: TLineInfo
+      ## where the procedure was defined. Used by error reporting
+    sym: PSym
+    body: PNode
+      ## the fully processed body of the procedure
+
+    firstSeen: ModuleId ## the module in which the procedure was first seen
+      # TODO: make this work for inline procedure called from inside other inline procedures
+
+    deps: IntSet
+
+  GlobalData = object
+    ## Code-generator-related data shared across all modules
+    inlineProcs: Store[uint32, InlineProc]
+      ## stores the additional information plus the generated code for each
+      ## alive inline procedure
+    inlineMap: Table[int, uint32]
+      ## maps a procedure ID to the associated InlineProc ID
+
+  LocalModuleData = object
+    bmod: BModule
+
+    inlined: OrderedSet[uint32]
+      ## all procedures that need to be inlined into the module
+
+  GCodegenCtx*[T] = object
+    # TODO: move it to a module that is shared between all backends
+    list*: ModuleListRef
+    modules*: SeqMap[ModuleId, T]
+
+    # TODO: implement this differently
+    noMagics*: set[TMagic]
+
+    # TODO: this too
+    seen*: IntSet
+
+  CodegenCtx = GCodegenCtx[LocalModuleData]
+
+func isFilled(x: LocalModuleData): bool =
+  x.bmod != nil
+
+proc registerInline(g: var GlobalData, prc: PSym): uint32 =
+  ## If not already registered, registers the inline procedure `prc` with the
+  ## global code-generator context. This only sets up an ``InlineProc`` entry
+  ## stub -- the entry is not populated yet
+  if prc.id in g.inlineMap:
+    # XXX: ``getOrDefault`` can't be used to get around the double
+    #      table-lookup, as there doesn't exist a known unused symbol ID.
+    #      ``mgetOrPut`` could be used
+    result = g.inlineMap[prc.id]
+  else:
+    result = g.inlineProcs.add(InlineProc(sym: prc))
+    g.inlineMap[prc.id] = result
+
+proc getModuleOf(c: CodegenCtx, s: PSym): BModule =
+  ## Returns the module `prc` is attached to. Note that this is not
+  ## necessarily the symbol's owner
+  c.modules[c.list[].lookupModule(s)].bmod
+
+proc queueSingle(ctx: var CodegenCtx, iter: var ProcedureIter, g: var GlobalData, m: var LocalModuleData, mId: ModuleId, dep: PSym) =
+  let isInline = dep.typ.callConv == ccInline
+
+  if queue(iter, dep):
+    # a new procedure; fill in the `loc`. Pass the module the procedure is
+    # attached to, not the the one it's used from
+    fillProcLoc(ctx.getModuleOf(dep), dep.ast[namePos])
+
+    if isInline:
+      # remember the module we've first seen the procedure used in:
+      let id = registerInline(g, dep)
+      g.inlineProcs[id].firstSeen = mId
+
+  elif isInline:
+    # remember the dependency on an inline procedure
+    m.inlined.incl registerInline(g, dep)
+
+const CBackendNoMagics =
+  {mNewString, mNewStringOfCap, mExit, mParseBiggestFloat, mDotDot, mEqCString,
+   mIsolate}
+  ## Magic procedures that have use no dedicated code-generation logic but are instead normal calls
+
+const CBackendNimv2NoMagics =
+  {mNewSeq, mSetLengthSeq, mAppendSeqElem}
+
+proc queueAll(ctx: var CodegenCtx, iter: var ProcedureIter, g: var GlobalData, m: var LocalModuleData, mId: ModuleId, tree: MirTree) =
+  ## Processes the direct dependencies of the given `tree`.
+  for dep in deps(tree, ctx.noMagics):
+    case dep.kind
+    of routineKinds:
+      queueSingle(ctx, iter, g, m, mId, dep)
+    of skConst:
+      if not containsOrIncl(ctx.seen, dep.id):
+        # a complex constant might reference the symbols of further procedures --
+        # they too are alive
+        # TODO: this needs to work differently. inline procedures are not handled
+        #       properly
+        queueProcedureSyms(iter, astdef(dep))
+    else:
+      discard "a global; ignore"
+
+func selectedModule(ctx: CodegenCtx, gstate: var GlobalData, prc: Procedure): ModuleId =
+  # TODO: don't require a mutable gstate
+  let id = ctx.list[].lookupModule(prc.sym)
+  let isInline = prc.sym.typ.callConv == ccInline
+
+  if isInline and not prc.isImported:
+    # inline procedures might have late dependencies (i.e. those raised
+    # only during by ``cgen``) so, in order to know about them without
+    # requiring a nested loop, we generate and emit code for them in the
+    # module where they were first seen. This way, we can already collect
+    # the late dependencies during the main loop
+    gstate.inlineProcs[registerInline(gstate, prc.sym)].firstSeen
+  else:
+    id
+
+proc dependOnCompilerProc(ctx: var CodegenCtx, iter: var ProcedureIter,
+                          g: var GlobalData, m: var LocalModuleData,
+                          mId: ModuleId, graph: ModuleGraph, name: string) =
+  let sym = getCompilerProc(graph, name)
+  # guard against nil so that the procedure can be used in contexts where not
+  # all compilerprocs have been processed yet
+  if sym != nil:
+    # a compilerproc can also be marked as ``inline``, hence the usage of
+    # ``queueSingle`` and not just ``queue``
+    queueSingle(ctx, iter, g, m, mId, sym)
+
+proc generateCodeC*(graph: ModuleGraph) =
+  echo "codegen"
+
+  var ctx = CodegenCtx(list: ModuleListRef(graph.backend))
+  var clist = newModuleList(graph)
+  var iter: ProcedureIter
+  var gstate: GlobalData
+
+  reserve(ctx.modules, ctx.list.modules)
+
+  ctx.noMagics = CBackendNoMagics
+  if optSeqDestructors in graph.config.globalOptions:
+    ctx.noMagics.incl CBackendNimv2NoMagics
+
+  # first create a ``BModule`` instance for all modules that we know about:
+  for i, m in ctx.list.modules.pairs:
+    var local = LocalModuleData(bmod: newModule(clist, m.sym, graph.config))
+    local.bmod.idgen = m.idgen
+    ctx.modules[i] = local
+
+  # process the top-level statements. Since dependency processing might
+  # requires access to modules other than the one for which the top-level
+  # statements are code-gen'ed, it can't happen as part of the above loop
+  for i, m in ctx.list.modules.pairs:
+    let top = transformStmt(graph, m.idgen, m.sym, m.stmts)
+    var (tree, source) = generateCode(graph, m.sym, {}, top)
+
+    # exported procedures always need to be code-gen'ed, irrespective of
+    # whether they're actually used
+    for def in procDefs(tree):
+      # don't queue compilerprocs here. They're only included in code
+      # generation if they're used
+      if {sfExportc, sfCompilerProc} * def.flags == {sfExportc}:
+        queueSingle(ctx, iter, gstate, ctx.modules[i], i, def)
+
+    processTopLevel(m, tree, source, graph)
+
+    # process and queue the dependencies:
+    queueAll(ctx, iter, gstate, ctx.modules[i], i, tree)
+
+    let stmts = generateAST(graph, m.idgen, m.sym, tree, source)
+    echoOutput(graph.config, m.sym, stmts)
+
+    genTopLevelStmt2(ctx.modules[i].bmod, stmts) # might raise late dependencies
+
+    for it in ctx.modules[i].bmod.extra.items:
+      queueSingle(ctx, iter, gstate, ctx.modules[i], i, it)
+
+    # we processed/consumed all elements
+    ctx.modules[i].bmod.extra.setLen(0)
+
+    # there are some dependencies raised during ``finalCodegenActions``, but
+    # at that point, the iterator can now longer be notified about them. As a
+    # workaround, we raise these dependencies here
+    # work around
+    # XXX: in the future, code generator should no longer be be allowed to
+    #      introduce new dependencies
+    if sfMainModule in m.sym.flags:
+      if graph.config.exc == excGoto:
+        dependOnCompilerProc(ctx, iter, gstate, ctx.modules[i], i, graph, "nimTestErrorFlag")
+
+      if graph.config.target.targetOS != osStandalone:
+        if graph.config.selectedGC != gcNone:
+          dependOnCompilerProc(ctx, iter, gstate, ctx.modules[i], i, graph, "initStackBottomWith")
+
+        if emulatedThreadVars(graph.config):
+          dependOnCompilerProc(ctx, iter, gstate, ctx.modules[i], i, graph, "initThreadVarsEmulation")
+
+  # discover and generate code for all alive procedures
+  while hasNext(iter):
+    let prc = next(iter, graph, ctx.list[])
+    let id = selectedModule(ctx, gstate, prc)
+    let m {.cursor.} = ctx.list.modules[id]
+    let bmod = ctx.modules[id].bmod
+    let isInline = prc.sym.typ.callConv == ccInline
+    case prc.isImported
+    of false:
+      if isInline:
+        # FIXME: this is inefficient. The dependencies are already iterated in
+        #        ``queueAll``. Find a way to merge both traversals
+        let iid = registerInline(gstate, prc.sym)
+        for dep in deps(prc.tree, ctx.noMagics):
+          if dep.kind in routineKinds and dep.typ.callConv == ccInline:
+            let other = registerInline(gstate, dep)
+            gstate.inlineProcs[iid].deps.incl other.int
+
+      # FIXME: argument aliasing rule violation
+      queueAll(ctx, iter, gstate, ctx.modules[id], id, prc.tree)
+
+      let body = generateAST(graph, m.idgen, prc.sym, prc.tree, prc.source)
+      echoOutput(graph.config, m.sym, body)
+
+      genProcPrototype(bmod, prc.sym)
+      let r = genProcAux(bmod, prc.sym, body)
+      bmod.declaredThings.incl(prc.sym.id)
+
+      if isInline:
+        #echo "emit ", prc.sym.name.s, " in ", bmod.module.name.s
+        # remember the generated body:
+        gstate.inlineProcs[registerInline(gstate, prc.sym)].body = body
+
+      # add the C function to the procedure section of the module it is
+      # attached to, or, in the case of inline procedures, we're it's first
+      # used
+      bmod.s[cfsProcs].add(r)
+
+    of true:
+      # XXX: code generation for dynamically imported procedures should also
+      #      be managed here. Due to the fact that code generation for them has
+      #      to happen *before* their name is first accessed (otherwise the
+      #      original name would be used, and not the internal one, e.g.
+      #      ``Dl_XXX``) we still let ``cgen`` take care of that for now
+      if lfDynamicLib notin prc.sym.loc.flags:
+        genProcNoForward(bmod, prc.sym)
+
+    # calls to procedures part of the compiler's runtime (i.e.
+    # ``.compilerproc``s) are still emitted by the code-generators for now.
+    # So that we know about which ones are used, the code-generator collects
+    # them to a list that we process here
+    for it in bmod.extra.items:
+      queueSingle(ctx, iter, gstate, ctx.modules[id], id, it)
+      if isInline and it.typ.callConv == ccInline:
+        let other = registerInline(gstate, it)
+        gstate.inlineProcs[registerInline(gstate, prc.sym)].deps.incl other.int
+
+    # we processed/consumed all elements
+    bmod.extra.setLen(0)
+
+  echo "pass 1 done"
+
+  # pass 2: emit all inlined procedures. Due to how ``cgen`` currently works,
+  # this means generating code for them again
+  for i, m in ctx.modules.pairs:
+    proc emit(m: BModule, map: Store[uint32, InlineProc], prc: InlineProc, mId: ModuleId, r: var Rope) =
+      if m.declaredThings.containsOrIncl(prc.sym.id):
+        return
+
+      for dep in prc.deps.items:
+        emit(m, map, map[dep.uint32], mId, r)
+
+      genProcPrototype(m, prc.sym)
+      r.add(genProcAux(m, prc.sym, prc.body))
+
+    var r: Rope
+    for it in m.inlined.items:
+      emit(m.bmod, gstate.inlineProcs, gstate.inlineProcs[it], i, r)
+
+    m.bmod.s[cfsProcs].add(r)
+
+  echo "pass 2 done"
+
+  # generate the code for the init procedures and close the modules. This has
+  # to happen in the order the modules were closed:
+  for m in ctx.list[].modulesClosed:
+    finalCodegenActions(graph, ctx.modules[m].bmod, newNode(nkStmtList))
+
+    #echo "flags: ", whichInitProcs(it.bmod), " in ", it.bmod.module.name.s
+    #registerInitProcs(clist, it.bmod.module, whichInitProcs(it.bmod))
+
+  echo "pass 3 done"
+
+  cgenWriteModules(clist, graph.config)

--- a/compiler/backend/backend2.nim
+++ b/compiler/backend/backend2.nim
@@ -248,6 +248,10 @@ proc generateCodeC*(graph: ModuleGraph) =
     let top = transformStmt(graph, m.idgen, m.sym, m.stmts)
     var (tree, source) = generateCode(graph, m.sym, {}, top)
 
+    # we no longer need the original module body, so as a memory usage
+    # optimization, we free it already:
+    ctx.list.modules[i].stmts = nil
+
     # exported procedures always need to be code-gen'ed, irrespective of
     # whether they're actually used
     for def in procDefs(tree):

--- a/compiler/backend/backend2.nim
+++ b/compiler/backend/backend2.nim
@@ -308,7 +308,7 @@ proc generateCodeC*(graph: ModuleGraph) =
       dependOnCompilerProc(ctx, iter, gstate, ctx.modules[i], i, graph, "popFrame")
 
   # discover and generate code for all alive procedures
-  while hasNext(iter):
+  while hasNext(iter, graph):
     let prc = next(iter, graph, ctx.list[])
     let id = selectedModule(ctx, gstate, prc)
     let m {.cursor.} = ctx.list.modules[id]

--- a/compiler/backend/backend2.nim
+++ b/compiler/backend/backend2.nim
@@ -274,6 +274,17 @@ proc generateCodeC*(graph: ModuleGraph) =
             let other = registerInline(gstate, dep)
             gstate.inlineProcs[iid].deps.incl other.int
 
+      block:
+        # queue all procedures used by the initialization logic for the
+        # procedure-level globals. They need to be queued from the module to
+        # which the procedure is *attached*, not from the one it's *first used*
+        # from
+        let mId = ctx.list[].lookupModule(prc.sym)
+        queueAll(ctx, iter, gstate, ctx.modules[mId], mId, prc.extra.tree)
+
+        for it in prc.globals.items:
+          ctx.modules[mId].struct.privateFields.add it
+
       # FIXME: argument aliasing rule violation
       queueAll(ctx, iter, gstate, ctx.modules[id], id, prc.tree)
 

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -67,9 +67,10 @@ type
     # XXX: ``modulesClosed`` and ``moduleMap`` should be split off into a
     #      separate object. They're relevant until the end of ``generateCode``,
     #      while ``modules`` gets processed at the start and is then discarded
-    modulesClosed: seq[ModuleId] ## the modules in the order they were closed.
+    modulesClosed*: seq[ModuleId] ## the modules in the order they were closed.
                                  ## The first closed module comes first, then
                                  ## the next, etc.
+      # TODO: try to not export ```modulesClosed``
     moduleMap: Table[int32, ModuleId] ## maps the module IDs used by semantic
                                       ## analysis to the ones used in the
                                       ## back-end

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -121,7 +121,7 @@ type
 
     # configuration state:
     options: set[GenOption]
-    processOptions: set[ProcessOption]
+    processOptions*: set[ProcessOption]
     noImported*: bool
       ## if ``true``, indicates that a procedure with a body should not be
       ## treated as imported, even if it's marked as such

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -40,9 +40,9 @@ import
   ]
 
 type
-  CodeFragment = object
-    tree: MirTree
-    sourceMap: SourceMap
+  CodeFragment* = object
+    tree*: MirTree
+    sourceMap*: SourceMap
 
   Module* = object
     stmts*: PNode ## the top level statements in the order they were parsed

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -1,0 +1,429 @@
+import
+  std/[
+    deques,
+    intsets,
+    tables,
+  ],
+  compiler/ast/[
+    ast,
+    ast_types,
+    astalgo, # for `getModule`,
+    idents,
+    lineinfos
+  ],
+  compiler/backend/[
+    cgmeth
+  ],
+  compiler/front/[
+    msgs,
+    options
+  ],
+  compiler/mir/[
+    mirchangesets,
+    mirgen,
+    mirtrees,
+    sourcemaps,
+    mirbridge # for the echoX procedures
+  ],
+  compiler/modules/[
+    modulegraphs
+  ],
+  compiler/sem/[
+    injectdestructors,
+    passes,
+    transf,
+    varpartitions
+  ],
+  compiler/utils/[
+    containers,
+    idioms
+  ]
+
+type
+  CodeFragment = object
+    tree: MirTree
+    sourceMap: SourceMap
+
+  Module* = object
+    stmts*: PNode ## the top level statements in the order they were parsed
+    sym*: PSym ## module symbol
+    idgen*: IdGenerator
+
+    preInitFragment: CodeFragment
+      ## the in-flight code fragment of the module's pre-initialization procedure
+
+  ModuleDataExtra = object
+    ## Extra data associated with a module
+    # XXX: since this is data that's somewhat relevant to all targets, it
+    #      might be a good idea to merge ``ModuleDataExtra`` with
+    #      ``ModuleData``. The way in which the data for modules is organized
+    #      needs an overhaul in general.
+    fileIdx: FileIndex
+    flags: TSymFlags
+
+  ModuleId* = distinct uint32 ## The ID of a module in the back-end
+
+  ModuleListRef* = ref ModuleList
+  ModuleList* = object of RootObj
+    modules*: Store[ModuleId, Module]
+
+    # XXX: ``modulesClosed`` and ``moduleMap`` should be split off into a
+    #      separate object. They're relevant until the end of ``generateCode``,
+    #      while ``modules`` gets processed at the start and is then discarded
+    modulesClosed: seq[ModuleId] ## the modules in the order they were closed.
+                                 ## The first closed module comes first, then
+                                 ## the next, etc.
+    moduleMap: Table[int32, ModuleId] ## maps the module IDs used by semantic
+                                      ## analysis to the ones used in the
+                                      ## back-end
+    # TODO: use a ``seq`` instead of a ``Table``
+
+  ModuleRef = ref object of TPassContext
+    ## The pass context for the VM backend. Represents a reference to a
+    ## module in the module list
+    list: ModuleListRef
+    id: ModuleId
+
+  Procedure* = object
+    sym*: PSym
+    case isImported*: bool
+    of false:
+      tree*: MirTree # TODO: rename to `body`
+      source*: SourceMap
+    of true:
+      discard
+
+  ProcessOption* = enum
+    ## The processing options are only meant as a temporary solution until the
+    ## code generators work similar enough for the options to no longer be
+    ## necessary
+    poLiftGlobals ## extract the globals defined inside inside procedures
+
+  ProcedureIter* = object
+    # general state:
+    seen: IntSet
+      ## remembers the IDs of procedures that were queued at one point already
+    queued: Deque[PSym]
+      ## procedures that are queued for code-generation
+
+    queuedInner: seq[Procedure]
+      ## pre-processed inner procedures. They take precedence before other
+      ## queued procedures, that is, ``queuedInner`` is first drained before
+      ## new procedures are processed
+    nextInner: int
+
+    generatedDispatchers: bool
+
+    noMagics: set[TMagic] # warning: very large
+
+    # TODO: restructure
+    globalDestructors: Changeset
+
+    # configuration state:
+    options: set[GenOption]
+    processOptions: set[ProcessOption]
+    noImported*: bool
+      ## if ``true``, indicates that a procedure with a body should not be
+      ## treated as imported, even if it's marked as such
+
+proc get(m: ModuleRef): var Module =
+  m.list.modules[m.id]
+
+template add*[T](x: Deque[T], elem: T) =
+  x.addLast elem
+
+func collect[T](list: var T, s: sink PSym, marker: var IntSet) {.inline.} =
+  ## If `s.id` is not present in `marker`, adds `s` to `list` and remember it
+  ## in `markers`
+  if not marker.containsOrIncl(s.id):
+    list.add s
+
+func moduleId(o: PIdObj): int32 {.inline.} =
+  ## Returns the ID of the module `o` is *attached* to. Do note that in the
+  ## case of generic instantiations, this is not the necessarily the same
+  ## module as the one returned by ``getModule(o)``
+  o.itemId.module
+
+func lookupModule*(mlist: ModuleList, s: PSym): ModuleId =
+  mlist.moduleMap[getModule(s).moduleId]
+
+iterator modulesClosed*(m: ModuleList): ModuleId =
+  for it in m.modulesClosed.items:
+    yield it
+
+func queue*(iter: var ProcedureIter, prc: PSym): bool {.discardable.} =
+  ## If the procedure `prc` is not queued already, adds it to the iterators
+  ## processing queue. Assuming that two procedures queued this way weren't
+  ## queued already, they are returned from `next<#next; ProcedureIter>`_ in
+  ## the same order in which they were queued
+  assert prc.kind in routineKinds
+  # don't queue
+  if not containsOrIncl(iter.seen, prc.id) and sfDispatcher notin prc.flags:
+    iter.queued.add prc
+    true
+  else:
+    false
+
+func queueProcedureSyms*(iter: var ProcedureIter, ast: PNode) =
+  ## Traverses the `ast` and collects all referenced symbols of procedure kind
+  ## to `syms` and `marker`
+  case ast.kind
+  of nkSym:
+    let s = ast.sym
+    if s.kind in routineKinds:
+      queue(iter, s)
+  of nkWithSons:
+    for n in ast.items:
+      queueProcedureSyms(iter, n)
+  of nkWithoutSons - {nkSym}:
+    discard "nothing to do"
+
+iterator deps*(tree: MirTree; includeMagics: set[TMagic] = {}): PSym {.noSideEffect.} =
+  ## Returns all external entities (procedures, globals, etc.) that `tree`
+  ## references *directly* in an unspecified order
+  var i = NodePosition(0)
+  while i < NodePosition(tree.len):
+    let n {.cursor.} = tree[i]
+    case n.kind
+    of mnkDef:
+      # make sure to not process the entity inside a 'def'
+      i = sibling(tree, i)
+      continue
+    of mnkProc:
+      # don't treat magics as dependencies. They're (in most but not all) cases
+      # no "real" procedures
+      # TODO: this is a workaround. Magics should be lowered or encoded as
+      #       ``mnkMagic`` nodes when reaching here
+      if n.sym.magic == mNone or n.sym.magic in includeMagics:
+        yield n.sym
+    of mnkConst, mnkGlobal:
+      yield n.sym
+    else:
+      discard "nothing to do"
+
+    inc i
+
+iterator procDefs*(tree: MirTree): PSym =
+  var i = NodePosition(0)
+  while i < NodePosition(tree.len):
+    let n {.cursor.} = tree[i]
+    case n.kind
+    of mnkDef:
+      inc i
+      if tree[i].kind == mnkProc:
+        yield tree[i].sym
+      # make sure to not process the entity inside a 'def'
+      i = parentEnd(tree, i)
+    else:
+      discard "nothing to do"
+
+    inc i
+
+func takeInner*(iter: var ProcedureIter): seq[Procedure] =
+  ## Removes all queued closure procedures from `iter` and returns them
+  result = move iter.queuedInner
+
+proc hasNext*(iter: ProcedureIter): bool =
+  result = iter.queued.len > 0 or iter.nextInner < iter.queuedInner.len
+
+
+type InnerProc = PSym
+
+## The (not yet implemented) new lambda-lifting pass needs access to the MIR
+## bodies of multiple procedures at once. We first acquire the MIR code for the
+## entry procedure (i.e. the one from which the pass starts) and then
+## iteratively collect all transitive relevant inner procedures. Once done, we
+## run the lambda-lifting pass
+
+proc extractGlobals(iter: var ProcedureIter, m: var Module, graph: ModuleGraph, body: PNode) =
+    ## Extract globals defined in `body` into the pre-init procedure of `m`.
+    ## Also registers destructor calls for them, if necessary. `body` is
+    ## mutated.
+    var globals: seq[PNode]
+    extractGlobals(body, globals, isNimVm = false)
+    # note: we're modifying the procedure's cached transformed body above,
+    # meaning that globals defiend inside ``inline`` procedures are also only
+    # extracted once
+
+    # first pass: register the destructors
+    for it in globals.items:
+      let sym = it[0].sym
+      # NOTE: thread-local variables are currently never destroyed
+      if sfThread notin sym.flags and hasDestructor(sym.typ):
+        iter.globalDestructors.insert(NodeInstance 0, buf):
+          genDestroy(buf, graph, sym.typ, MirNode(kind: mnkGlobal, sym: sym, typ: sym.typ))
+
+    # second pass: generate the initialization code. This is done here already,
+    # as it might depend on other procedures. Deferring this to ``genInitCode``
+    # is not possible, because then it's too late to raise further dependencies.
+    # Also, generate the code in the pre-init procedure of the module where the
+    # procedure is *defined*, not where it's first *used* (this is only relevant
+    # for ``inline`` procedures, as they're generated multiple times)
+    for it in globals.items:
+      # since the identdefs are extracted from the transformed AST, the
+      # initializer expression isn't canonicalized yet
+      if it[2].kind != nkEmpty:
+        let n = newTreeI(nkFastAsgn, it.info, it[0], it[2])
+
+        # generate the MIR code for the assignment and append it to the
+        # pre-init fragment
+        generateCode(graph, iter.options, n, m.preInitFragment.tree, m.preInitFragment.sourceMap)
+
+        # TODO: run the destructor injection pass for the pre-init fragment
+
+        # the expression of the initial value might reference procedures
+        # TODO: don't scan the whole fragment each time
+        for dep in deps(m.preInitFragment.tree, iter.noMagics):
+          if dep.kind in routineKinds:
+            queue(iter, dep)
+
+proc preprocess(iter: var ProcedureIter, prc: PSym, graph: ModuleGraph, m: var Module): Procedure =
+  ## Transforms the body of the given procedure and translates it to MIR code.
+  ## No MIR passes are applied yet
+  var body = transformBody(graph, m.idgen, prc, cache = false)
+
+  if poLiftGlobals in iter.processOptions:
+    extractGlobals(iter, m, graph, body)
+
+  # TODO: turn cursor inference into a MIR pass and remove the logic below
+  if optCursorInference in graph.config.options and
+     shouldInjectDestructorCalls(prc):
+    computeCursors(prc, body, graph)
+
+  #echo prc, " at ", graph.config.toFileLineCol(prc.info)
+  if sfImportc in prc.flags and not (iter.noImported and getBody(graph, prc).kind == nkEmpty):
+    # the procedure is imported
+    result = Procedure(sym: prc, isImported: true)
+  else:
+    echoInput(graph.config, prc, body)
+
+    result = Procedure(sym: prc, isImported: false)
+    (result.tree, result.source) = generateCode(graph, prc, iter.options, body)
+
+    echoMir(graph.config, prc, result.tree)
+
+proc collectInner(iter: var ProcedureIter, prc: PSym, body: MirTree, inner: var seq[InnerProc], marker: var IntSet) =
+  ## Collects all transitive inner routines of `prc` that might capture something
+  for dep in deps(body):
+    if dep.kind in routineKinds and dep.skipGenericOwner.kind in routineKinds and dep.typ.callConv == ccClosure and not containsOrIncl(marker, dep.id):
+      # it's an inner procedure; remember it
+      inner.add dep
+
+proc processInner(iter: var ProcedureIter, prc: Procedure, graph: ModuleGraph, m: var Module) =
+  var list: seq[InnerProc]
+  var marker: IntSet
+  # first, scan the procedure for inner routines that might capture
+  # something:
+  collectInner(iter, prc.sym, prc.tree, list, marker)
+
+  # then, pre-process the collected inner routines (if any) and collect the
+  # inner routines referenced by them. This is repeated until we've discovered
+  # all of them
+  var i = 0
+  while i < list.len:
+    let
+      sym = list[i]
+      inner = preprocess(iter, sym, graph, m)
+
+    collectInner(iter, sym, inner.tree, list, marker)
+
+    # queue the pre-processed routine and remember that we've seen it:
+    iter.seen.incl inner.sym.id
+    iter.queuedInner.add inner
+
+    inc i
+
+proc process(iter: var ProcedureIter, prc: var Procedure, graph: ModuleGraph, m: Module) =
+  # apply all applicable MIR passes:
+  if shouldInjectDestructorCalls(prc.sym):
+    injectDestructorCalls(graph, m.idgen, prc.sym, prc.tree, prc.source)
+
+proc processTopLevel*(module: Module, tree: var MirTree, source: var SourceMap, graph: ModuleGraph) =
+  # apply all applicable MIR passes:
+  if shouldInjectDestructorCalls(module.sym):
+    injectDestructorCalls(graph, module.idgen, module.sym, tree, source)
+
+proc next*(iter: var ProcedureIter, graph: ModuleGraph, mlist: var ModuleList): Procedure =
+  # TODO: don't require the whole `mlist` to be mutable, we only to modify the
+  #       data of the module the next procedure belongs to
+  assert hasNext(iter)
+  if iter.nextInner < iter.queuedInner.len:
+    # there are some pre-processed routines
+    result = move iter.queuedInner[iter.nextInner]
+    inc iter.nextInner
+  elif iter.queued.len > 0:
+    let sym = iter.queued.popFirst()
+    let m = addr mlist.modules[mlist.lookupModule(sym)]
+    #echo "process: ", sym.name.s
+    result = preprocess(iter, sym, graph, m[])
+    if not result.isImported:
+      processInner(iter, result, graph, m[])
+  elif not iter.generatedDispatchers:
+    # no more queued routines and method dispatchers haven't been generated yet.
+    # We assume that this means that all normal routines have been processed
+    # and that we should now process all methods
+
+    # XXX: instead of processing and returning *all* methods, we could collect
+    #      all used buckets and then only process these. Methods only used
+    #      inside other methods would be a small problem, however
+    for disp in generateMethodDispatchers2(graph):
+      iter.queued.add disp
+
+    iter.generatedDispatchers = true
+
+    # pick the first dispatcher:
+    let sym = iter.queued.popFirst()
+    let m = addr mlist.modules[mlist.lookupModule(sym)]
+    result = preprocess(iter, sym, graph, m[])
+    processInner(iter, result, graph, m[])
+  else:
+    unreachable("hasNext == false")
+
+  if not result.isImported:
+    # now apply all MIR passes:
+    process(iter, result, graph, mlist.modules[mlist.lookupModule(result.sym)])
+
+# Below is the `passes` interface implementation
+
+proc myOpen(graph: ModuleGraph, module: PSym, idgen: IdGenerator): PPassContext =
+  if graph.backend == nil:
+    graph.backend = ModuleListRef()
+
+  let
+    mlist = ModuleListRef(graph.backend)
+    id = module.itemId.module
+
+  assert id >= 0 and id == module.position # sanity check
+
+  # create an entry in the store and add an ID mapping:
+  let mId =
+    mlist.modules.add Module(sym: module, stmts: newNode(nkStmtList),
+                             idgen: idgen)
+  mlist.moduleMap[id] = mId
+
+  result = ModuleRef(list: mlist, id: mId)
+
+proc myProcess(b: PPassContext, n: PNode): PNode =
+  result = n
+  let m = ModuleRef(b)
+
+  if n.kind == nkStmtList:
+    # append all statements to the top-level list:
+    for it in n.items:
+      m.get.stmts.add(it)
+  else:
+    m.get.stmts.add(n)
+
+proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
+  result = myProcess(b, n)
+
+  let m = ModuleRef(b)
+  # prevent empty statement lists from reaching the code-generators
+  if m.get.stmts.len == 0:
+    m.get.stmts = newNode(nkEmpty)
+
+  # remember the order relative to the other modules in which the current one
+  # is closed
+  m.list.modulesClosed.add(m.id)
+
+const collectPass* = makePass(myOpen, myProcess, myClose)

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -8,18 +8,15 @@ import
     ast,
     ast_types,
     astalgo, # for `getModule`,
-    idents,
     lineinfos
   ],
   compiler/backend/[
     cgmeth
   ],
   compiler/front/[
-    msgs,
     options
   ],
   compiler/mir/[
-    mirchangesets,
     mirgen,
     mirtrees,
     sourcemaps,

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2390,6 +2390,10 @@ proc genSlice(p: BProc; e: PNode; d: var TLoc) =
 proc genEnumToStr(p: BProc, e: PNode, d: var TLoc) =
   let t = e[1].typ.skipTypes(abstractInst+{tyRange})
   let toStrProc = getToStringProc(p.module.g.graph, t)
+
+  # it's a late dependency and we thus need to notify the orchestrator:
+  p.module.extra.add(toStrProc)
+
   # XXX need to modify this logic for IC.
   var n = copyTree(e)
   n[0] = newSymNode(toStrProc)

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -906,6 +906,8 @@ proc genTryGoto(p: BProc; t: PNode; d: var TLoc) =
           genTypeInfo2Name(p.module, t[i][j].typ)
         else:
           genTypeInfoV1(p.module, t[i][j].typ, t[i][j].info)
+
+        discard cgsym(p.module, "Exception")
         let memberName = "Sup.m_type"
         appcg(p.module, orExpr, "#isObj(#nimBorrowCurrentException()->$1, $2)", [memberName, checkFor])
 

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -764,7 +764,6 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet; kind: TSymKin
   excl(check, t.id)
 
 proc getTypeDesc(m: BModule, typ: PType; kind = skParam): Rope =
-  m.usedTypes.add typ
   var check = initIntSet()
   result = getTypeDescAux(m, typ, check, kind)
 
@@ -1173,9 +1172,6 @@ proc genTypeInfoV2Impl(m: BModule, t, origType: PType, name: Rope; info: TLineIn
     discard genTypeInfoV1(m, t, info)
 
 proc genTypeInfoV2*(m: BModule, t: PType; info: TLineInfo): Rope =
-  # track the dependency:
-  m.usedTypes.add t
-
   let origType = t
   # distinct types can have their own destructors
   var t = skipTypes(origType, irrelevantForBackend + tyUserTypeClasses - {tyDistinct})
@@ -1248,9 +1244,6 @@ proc typeToC(t: PType): string =
       result.addInt ord(c)
 
 proc genTypeInfoV1(m: BModule, t: PType; info: TLineInfo): Rope =
-  # track the dependency:
-  m.usedTypes.add t
-
   let origType = t
   var t = skipTypes(origType, irrelevantForBackend + tyUserTypeClasses)
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1839,9 +1839,9 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
     if m.config.exc == excGoto and getCompilerProc(graph, "nimTestErrorFlag") != nil:
       discard cgsym(m, "nimTestErrorFlag")
 
-    if {optGenStaticLib, optGenDynLib, optNoMain} * m.config.globalOptions == {}:
-      for i in countdown(high(graph.globalDestructors), 0):
-        n.add graph.globalDestructors[i]
+    # if {optGenStaticLib, optGenDynLib, optNoMain} * m.config.globalOptions == {}:
+    #   for i in countdown(high(graph.globalDestructors), 0):
+    #     n.add graph.globalDestructors[i]
   if passes.skipCodegen(m.config, n): return
   if moduleHasChanged(graph, m.module):
     # if the module is cached, we don't regenerate the main proc

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -60,7 +60,6 @@ import
   compiler/backend/[
     extccomp,
     ccgutils,
-    cgmeth,
     cgendata
   ],
   compiler/plugins/[
@@ -1860,8 +1859,8 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
 
       if m.g.forwardedProcs.len == 0:
         incl m.flags, objHasKidsValid
-      let disp = generateMethodDispatchers(graph)
-      for x in disp: genProcAux2(m, x.sym)
+      # let disp = generateMethodDispatchers(graph)
+      # for x in disp: genProcAux2(m, x.sym)
 
   let mm = m
   m.g.modulesClosed.add mm

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -193,7 +193,6 @@ type
       ## back to the caller. The caller is responsible for clearing the list
       ## after it's done with processing it. The code-generator only ever
       ## appends to it
-    usedTypes*: seq[PType]
 
 template config*(m: BModule): ConfigRef = m.g.config
 template config*(p: BProc): ConfigRef = p.module.g.config

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -188,6 +188,13 @@ type
     g*: BModuleList
     ndi*: NdiFile
 
+    extra*: seq[PSym]
+      ## used to communicate dependencies introduced by the code-generator
+      ## back to the caller. The caller is responsible for clearing the list
+      ## after it's done with processing it. The code-generator only ever
+      ## appends to it
+    usedTypes*: seq[PType]
+
 template config*(m: BModule): ConfigRef = m.g.config
 template config*(p: BProc): ConfigRef = p.module.g.config
 

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -317,6 +317,18 @@ proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet): PS
   nilchecks.flags.incl nfTransf # should not be further transformed
   result.ast[bodyPos] = nilchecks
 
+iterator generateMethodDispatchers2*(g: ModuleGraph): PSym =
+  for bucket in 0..<g.methods.len:
+    var relevantCols = initIntSet()
+    for col in 1..<g.methods[bucket].methods[0].typ.len:
+      if relevantCol(g.methods[bucket].methods, col): incl(relevantCols, col)
+      if optMultiMethods notin g.config.globalOptions:
+        # if multi-methods are not enabled, we are interested only in the first field
+        break
+
+    sortBucket(g.methods[bucket].methods, relevantCols)
+    yield genDispatcher(g, g.methods[bucket].methods, relevantCols)
+
 proc generateMethodDispatchers*(g: ModuleGraph): PNode =
   result = newNode(nkStmtList)
   for bucket in 0..<g.methods.len:

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -1,0 +1,164 @@
+
+import
+  std/[
+    intsets,
+    tables,
+    json
+  ],
+  compiler/ast/[
+    ast,
+    ast_types,
+  ],
+  compiler/backend/[
+    backends,
+    jsgen,
+    backend2
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/mir/[
+    mirgen,
+    mirtrees,
+    astgen,
+  ],
+  compiler/modules/[
+    modulegraphs
+  ],
+  compiler/sem/[
+    transf,
+    sourcemap,
+  ],
+  compiler/utils/[
+    containers,
+    ropes,
+  ]
+
+type
+  LocalModuleData = object
+    bmod: BModule
+    init: PProc
+
+  CodegenCtx = GCodegenCtx[LocalModuleData]
+
+proc queueAll(ctx: var CodegenCtx, iter: var ProcedureIter, tree: MirTree) =
+  ## Processes the direct dependencies of the given `tree`.
+  for dep in deps(tree, ctx.noMagics):
+    case dep.kind
+    of routineKinds:
+      queue(iter, dep)
+    of skConst:
+      if not containsOrIncl(ctx.seen, dep.id):
+        # a complex constant might reference the symbols of further procedures --
+        # they too are alive
+        queueProcedureSyms(iter, astdef(dep))
+    else:
+      discard "a global; ignore"
+
+proc generateCode*(graph: ModuleGraph) =
+  echo "codegen"
+
+  var ctx = CodegenCtx(list: ModuleListRef(graph.backend))
+  var g = newGlobals()
+
+  reserve(ctx.modules, ctx.list.modules)
+
+  var main: BModule
+  var iter: ProcedureIter
+
+  # first create a ``BModule`` instance for all modules that we know about:
+  for i, m in ctx.list.modules.pairs:
+    var local = newModule(graph, m.sym)
+    local.idgen = m.idgen
+    ctx.modules[i] = LocalModuleData(bmod: local)
+
+    if sfMainModule in m.sym.flags:
+      main = local
+
+  # process the top-level statements. Since dependency processing potentially
+  # requires access to modules other than the one for which the top-level
+  # statements are code-gen'ed, it can't happen as part of the above loop
+  for i, m in ctx.list.modules.pairs:
+    let top = transformStmt(graph, m.idgen, m.sym, m.stmts)
+    var (tree, source) = generateCode(graph, m.sym, {}, top)
+
+    # exported procedures always need to be code-gen'ed, irrespective of
+    # whether they're actually used
+    for def in procDefs(tree):
+      # don't queue compilerprocs here. They're only included in code
+      # generation if they're used
+      if {sfExportc, sfCompilerProc} * def.flags == {sfExportc}:
+        queue(iter, def)
+
+    processTopLevel(m, tree, source, graph)
+
+    # process and queue the dependencies:
+    queueAll(ctx, iter, tree)
+
+    let stmts = generateAST(graph, m.idgen, m.sym, tree, source)
+
+    var p = setupInitProc(g, ctx.modules[i].bmod)
+    genModule(p, stmts) # might raise late dependencies
+    ctx.modules[i].init = p
+
+    for it in g.extra.items:
+      queue(iter, it)
+
+    # we processed/consumed all elements
+    g.extra.setLen(0)
+
+  while hasNext(iter):
+    let prc = next(iter, graph, ctx.list[])
+    let id = ctx.list[].lookupModule(prc.sym)
+    let m {.cursor.} = ctx.list.modules[id]
+    let bmod = ctx.modules[id].bmod
+
+    case prc.isImported
+    of false:
+      queueAll(ctx, iter, prc.tree)
+
+      # lambda-lifting is disabled for the JS backend, which means that we
+      # require special handling for closure procedures
+      let inner = iter.takeInner()
+
+      for it in inner.items:
+        g.innerProcs[it.sym.id] =
+          generateAST(graph, m.idgen, it.sym, it.tree, it.source)
+
+      let body = generateAST(graph, m.idgen, prc.sym, prc.tree, prc.source)
+      let r = genProc(ctx.modules[id].init, prc.sym, body)
+
+      if sfCompilerProc in prc.sym.flags:
+        # compilerprocs go into the constants section ...
+        g.constants.add(r)
+      else:
+        # ... other procedures into the normal code section
+        g.code.add(r)
+
+    of true:
+      discard "nothing to do"
+
+    # queue the late dependencies:
+    for it in g.extra.items:
+      queue(iter, it)
+
+    # we processed/consumed all elements
+    g.extra.setLen(0)
+
+  # all procedures are generated. Emit the top-level code for all modules in
+  # the order they were closed:
+  for i in ctx.list[].modulesClosed:
+    g.code.add ctx.modules[i].init.locals
+    g.code.add ctx.modules[i].init.body
+
+  var code = genHeader() & wholeCode(g)
+  let outFile = graph.config.prepareToWriteOutput()
+
+  # generate and write out the source map, if requested:
+  if optSourcemap in graph.config.globalOptions:
+    var map: SourceMap
+    (code, map) = genSourceMap($(code), outFile.string)
+    writeFile(outFile.string & ".map", $(%map))
+
+  # write the generated code to disk:
+  discard writeRopeIfNotEqual(code, outFile)

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -107,7 +107,9 @@ proc generateCode*(graph: ModuleGraph) =
   # Since dependency processing potentially requires access to modules other
   # than the one for which the top-level statements are code-gen'ed, it can't
   # happen as part of the above loop
-  for i, m in ctx.list.modules.pairs:
+  # TODO: don't use the module-closed order here. Either setup the name for
+  #       globals in ``jsgen`` or, better yet, use a different appraoch
+  for id in ctx.list.modulesClosed:
     processModule(ctx, ctx.list.modules[id], graph, g, ctx.modules[id], iter)
 
   while hasNext(iter):

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -140,7 +140,7 @@ proc generateCode*(graph: ModuleGraph) =
   for id in ctx.list.modulesClosed:
     processModule(ctx, ctx.list.modules[id], graph, g, ctx.modules[id], iter)
 
-  while hasNext(iter):
+  while hasNext(iter, graph):
     let prc = next(iter, graph, ctx.list[])
     let id = ctx.list[].lookupModule(prc.sym)
     let m {.cursor.} = ctx.list.modules[id]

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -339,7 +339,7 @@ proc makeJSString(s: string, escapeNonAscii = true): Rope =
 include jstypes
 
 proc gen(p: PProc, n: PNode, r: var TCompRes)
-proc genStmt(p: PProc, n: PNode)
+proc genStmt*(p: PProc, n: PNode)
 proc genProc(oldProc: PProc, prc: PSym): Rope
 proc genConstant(p: PProc, c: PSym)
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1819,10 +1819,11 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
     s: Rope
     varCode: string
     varName = mangleName(p.module, v)
-    useGlobalPragmas = sfGlobal in v.flags and ({sfPure, sfThread} * v.flags != {})
+    isThreadVar = sfGlobal in v.flags and sfThread in v.flags
 
   if v.constraint.isNil:
-    if useGlobalPragmas:
+    # TODO: move threadvar handling out of the code generator
+    if isThreadVar:
       lineF(p, "if (globalThis.$1 === undefined) {$n", varName)
       varCode = "globalThis." & $varName
       inc p.extraIndent
@@ -1878,7 +1879,7 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
     else:
       line(p, runtimeFormat(varCode & " = $3;$n", [returnType, v.loc.r, s]))
 
-  if useGlobalPragmas:
+  if isThreadVar:
     dec p.extraIndent
     lineF(p, "}$n")
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -59,7 +59,6 @@ import
     ropes
   ],
   compiler/sem/[
-    passes,
     lowerings,
     rodutils,
     sourcemap
@@ -67,10 +66,6 @@ import
   compiler/backend/[
     backends,
     ccgutils,
-  ],
-  compiler/plugins/[
-  ],
-  compiler/vm/[
   ]
 
 # xxx: reports are a code smell meaning data types are misplaced

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -59,21 +59,21 @@ let reprConfig = block:
 # and outputs in the context of compiler debugging until a more
 # structured/integrated solution is implemented
 
-proc echoInput(config: ConfigRef, owner: PSym, body: PNode) =
+proc echoInput*(config: ConfigRef, owner: PSym, body: PNode) =
   ## If requested via the define, renders the input AST `body` and writes the
   ## result out through ``config.writeLine``.
   if config.getStrDefine("nimShowMirInput") == owner.name.s:
     writeBody(config, "-- input AST: " & owner.name.s):
       config.writeln(treeRepr(config, body, reprConfig))
 
-proc echoMir(config: ConfigRef, owner: PSym, tree: MirTree) =
+proc echoMir*(config: ConfigRef, owner: PSym, tree: MirTree) =
   ## If requested via the define, renders the `tree` and writes the result out
   ## through ``config.writeln``.
   if config.getStrDefine("nimShowMir") == owner.name.s:
     writeBody(config, "-- MIR: " & owner.name.s):
       config.writeln(print(tree))
 
-proc echoOutput(config: ConfigRef, owner: PSym, body: PNode) =
+proc echoOutput*(config: ConfigRef, owner: PSym, body: PNode) =
   ## If requested via the define, renders the output AST `body` and writes the
   ## result out through ``config.writeLine``.
   if config.getStrDefine("nimShowMirOutput") == owner.name.s:

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -131,7 +131,7 @@ type
     cacheCounters*: Table[string, BiggestInt] # IC: implemented
     cacheTables*: Table[string, BTree[string, PNode]] # IC: implemented
     passes*: seq[TPass]
-    globalDestructors*: seq[PNode]
+    globalDestructors*: seq[PNode] ## TODO: remove
     strongSemCheck*: proc (graph: ModuleGraph; owner: PSym; body: PNode) {.nimcall.}
     compatibleProps*: proc (graph: ModuleGraph; formal, actual: PType): bool {.nimcall.}
     idgen*: IdGenerator

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -683,7 +683,7 @@ template genWasMoved(buf: var MirNodeSeq, graph: ModuleGraph, body: untyped) =
                   magic: mWasMoved)
   buf.add MirNode(kind: mnkVoid)
 
-proc genDestroy(buf: var MirNodeSeq, graph: ModuleGraph, t: PType,
+proc genDestroy*(buf: var MirNodeSeq, graph: ModuleGraph, t: PType,
                 target: sink MirNode) =
   let destr = getOp(graph, t, attachedDestructor)
 

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -1396,13 +1396,6 @@ func shouldInjectDestructorCalls*(owner: PSym): bool =
      {sfInjectDestructors, sfGeneratedOp} * owner.flags == {sfInjectDestructors} and
      (owner.kind != skIterator or not isInlineIterator(owner.typ))
 
-proc deferGlobalDestructor*(g: ModuleGraph, idgen: IdGenerator, owner: PSym,
-                            global: PNode) =
-  ## If the global has a destructor, emits a call to it at the end of the
-  ## section of global destructors.
-  if sfThread notin global.sym.flags and hasDestructor(global.typ):
-    g.globalDestructors.add genDestroy(g, idgen, owner, global)
-
 proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
                             tree: var MirTree, sourceMap: var SourceMap) =
   ## The ``injectdestructors`` pass entry point. The pass is made up of

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -683,7 +683,7 @@ template genWasMoved(buf: var MirNodeSeq, graph: ModuleGraph, body: untyped) =
                   magic: mWasMoved)
   buf.add MirNode(kind: mnkVoid)
 
-proc genDestroy*(buf: var MirNodeSeq, graph: ModuleGraph, t: PType,
+proc genDestroy(buf: var MirNodeSeq, graph: ModuleGraph, t: PType,
                 target: sink MirNode) =
   let destr = getOp(graph, t, attachedDestructor)
 


### PR DESCRIPTION
Summary
-------

Right now, each code generator / backend works differently. Both `cgen` and `jsgen` use a recursive approach, where the code for a procedure is generated when it's first used. While `cgen` emits the generated code into multiple C files (one corresponding to each NimSkull module), `jsgen` emits all of it into a single file, and also requires special handling for inner procedures (lambda lifting is disabled for the JS backend).

For the VM, code generation works significantly different: the code generator (`vmgen`) is, for the most part, only responsible for generating code. Invoking the code generator to generate the bytecode for all alive procedures is left to the callsite. During compile-time execution, this is the responsibility of the JIT logic (`vmjit`), and for the VM backend it's that of `vmbackend`. The latter uses, supported by `vmgen`, an iterative approach for discovering all alive procedures and passing them to the code generator.

The problem with the recursive approach is that it's inflexible: how discovery of alive procedures happens is an intrinsic property of it and can't be easily changed. In addition, transforming a procedure's code and applying the MIR passes to it has to happen from *inside* the code generators, meaning that they have to carry the necessary state around, further complicating the whole implementation.

This PR implements a facility for collecting the AST of the whole program and applying the pre-processing (e.g. `transf`, applying eligible MIR passes) to all code passed to it, making the resulting procedures accessible as a *stream*.

The approach is an evolution of how the processing is implemented in https://github.com/nim-works/nimskull/pull/424 (which itself evolved from `vmbackend`), with the difference that it's more general and that the procedures are, except for inner `closure` procedures, only processed one-by-one instead of all at once. This change makes the layer more flexible, allowing it to be used with both interleaved and non-interleaved compilation (interleaved here meaning: alternating between semantic analysis and code generation).

The C, JS, and VM code generators are now no longer responsible for discovering dependencies, and, in the case of `cgen`/`jsgen`, processing them. Both things are now implemented by a dedicated orchestrator (which used the aforementioned processing facilities) for each backend, similar to `vmbackend`.

For the first revision, the orchestrators are only concerned with *procedures*, but will eventually also manage code generation for constants and globals.

---

## Notes for reviewers
- the PR is an early proof-of-concept. The focus so far was only to make it work
- once finalized, this PR will only include the new processing facilities -- changing each code generator to make use of them will all be separate PRs
- removing the IC backend would make the `cgen` transition easier
