### PR TITLE
compiler: remove some unused routines and variables

### DIFF
--- a/compiler/backend/ccgliterals.nim
+++ b/compiler/backend/ccgliterals.nim
@@ -27,9 +27,6 @@ template detectVersion(field, corename) =
 proc detectStrVersion(m: BModule): int =
   detectVersion(strVersion, "nimStrVersion")
 
-proc detectSeqVersion(m: BModule): int =
-  detectVersion(seqVersion, "nimSeqVersion")
-
 # ----- Version 1: GC'ed strings and seqs --------------------------------
 
 proc genStringLiteralDataOnlyV1(m: BModule, s: string): Rope =
@@ -91,17 +88,6 @@ proc genStringLiteralV2Const(m: BModule; n: PNode; isConst: bool): Rope =
   result = "{$1, (NimStrPayload*)&$2}" % [rope(n.strVal.len), pureLit]
 
 # ------ Version selector ---------------------------------------------------
-
-proc genStringLiteralDataOnly(m: BModule; s: string; info: TLineInfo;
-                              isConst: bool): Rope =
-  case detectStrVersion(m)
-  of 0, 1: result = genStringLiteralDataOnlyV1(m, s)
-  of 2:
-    result = getTempName(m)
-    genStringLiteralDataOnlyV2(m, s, result, isConst)
-  else:
-    internalError(
-      m.config, info, "cannot determine how to produce code for string literal")
 
 proc genNilStringLiteral(m: BModule; info: TLineInfo): Rope =
   result = ropecg(m, "((#NimStringDesc*) NIM_NIL)", [])

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -222,10 +222,8 @@ func hash(x: PVmType): int {.inline.} =
   # the 4 or 8 byte alignment of `VmType`)
   hash(cast[int](x))
 
-func hash(x: TypeId): Hash {.borrow.}
 func `==`(a, b: TypeId): bool {.borrow.}
 
-func hash(x: SymId): Hash {.borrow.}
 func `==`(a, b: SymId): bool {.borrow.}
 
 template genAccessors(t: type, f: untyped, idTyp: type) {.dirty.} =

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -386,9 +386,6 @@ template decodeBx(k: AtomKind) {.dirty.} =
 template decodeBx() {.dirty.} =
   let rbx = instr.regBx - wordExcess
 
-template move(a, b: untyped) {.dirty.} = system.shallowCopy(a, b)
-# XXX fix minor 'shallowCopy' overloading bug in compiler
-
 
 template rawPointer(x: LocHandle): untyped =
   x.h.rawPointer
@@ -401,7 +398,6 @@ proc asgnValue(mm: var VmMemoryManager, dest: var TFullReg, src: TFullReg) =
   # Since vmgen doesn't take care of register/location lifetime management, it
   # has to be done here
 
-  var tmp: TFullReg
   case src.kind
   of rkNone, rkInt, rkFloat, rkAddress, rkNimNode, rkRegAddr:
     cleanUpReg(dest, mm)
@@ -754,7 +750,6 @@ proc opConv(c: var TCtx; dest: var TFullReg, src: TFullReg, dt, st: (PType, PVmT
       of tyArray, tyString:
         dest.initLocReg(dt[1], c.memory)
         let
-          stride = dt[1].seqElemStride
           t = dt[1].seqElemType
           L = arrayLen(src.handle)
 
@@ -861,12 +856,6 @@ template checkHandle(a: VmAllocator, handle: LocHandle) =
 
 when not defined(nimHasSinkInference):
   {.pragma: nosinks.}
-
-
-template source(c: TCtx, pc: PrgCtr): TLineInfo =
-  ## Gets the source-code information for the instruction the provided program
-  ## counter `pc` currently points to
-  c.debug[pc]
 
 proc rawExecute(c: var TCtx, pc: var int, tos: var StackFrameIndex): YieldReason =
   ## Runs the execution loop, starting in frame `tos` at program counter `pc`.

--- a/compiler/vm/vmchecks.nim
+++ b/compiler/vm/vmchecks.nim
@@ -97,7 +97,6 @@ func checkValid*(al: VmAllocator, a: MemRegionPtr, typ: PVmType): AccessViolatio
 
   result = avrOutOfBounds
 
-  var found = false
   for x in al.regions.items:
     if rp in x.start..<(x.start+x.len):
       let rtyp = x.typ

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -402,14 +402,6 @@ proc deserialize(c: TCtx, m: VmMemoryRegion, vt: PVmType, formal, t: PType, info
 proc deserialize*(c: TCtx, handle: LocHandle, asType: PType, info: TLineInfo): PNode =
   deserialize(c, handle.byteView(), handle.typ, asType, info)
 
-func findInConstr(n: PNode, pos: FieldPosition): PNode =
-  assert n.kind == nkObjConstr
-  for i in 1..<n.len:
-    if n[i][0].sym.position == pos.int:
-      return n[i]
-
-  return nil
-
 proc serialize*(c: var TCtx, n: PNode, dest: LocHandle, t: PType = nil)
 
 proc marshalFields*(c: var TCtx, nodes: openArray[PNode], dest: LocHandle) =

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -161,9 +161,6 @@ proc genLit(c: var TCtx; n: PNode; lit: int; dest: var TDest)
 
 template isUnset(x: TDest): bool = x < 0
 
-proc debugInfo(c: TCtx; info: TLineInfo): string =
-  result = toFileLineCol(c.config, info)
-
 func registerLinkItem(tbl: var Table[int, LinkIndex], list: var seq[PSym],
                       sym: PSym, next: var LinkIndex): int =
   let linkIdx = tbl.mgetOrPut(sym.id, next)
@@ -925,7 +922,6 @@ proc genCall(c: var TCtx; n: PNode; dest: var TDest) =
   c.freeTempRange(x, n.len)
 
 template isGlobal(s: PSym): bool = sfGlobal in s.flags and s.kind != skForVar
-proc isGlobal(n: PNode): bool = n.kind == nkSym and isGlobal(n.sym)
 
 func local(prc: PProc, sym: PSym): TDest {.inline.} =
   ## Returns the register associated with the local variable `sym` (or -1 if

--- a/compiler/vm/vmhooks.nim
+++ b/compiler/vm/vmhooks.nim
@@ -26,15 +26,6 @@ import
 # XXX: proper error handling is missing here. Since these functions are exposed
 # via the compilerapi, `doAssert` is used for pre-condition checking
 
-template kind(x: ptr TFullReg): untyped = x[].kind
-template atomVal(x: ptr TFullReg): untyped = x[].atomVal
-
-func setIntReg(x: var TFullReg, v: BiggestInt) {.inline.} =
-  x = TFullReg(kind: rkInt, intVal: v)
-
-func setFloatReg(x: var TFullReg, v: BiggestFloat) {.inline.} =
-  x = TFullReg(kind: rkFloat, floatVal: v)
-
 template setX(k, f) {.dirty.} =
   doAssert a.slots[a.ra].kind == k
   a.slots[a.ra].f = v

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -653,7 +653,6 @@ func asRegionPtr(x: VmMemoryRegion): MemRegionPtr {.inline.} =
 
 func resetLocation*(mm: var VmMemoryManager, loc: var VmMemoryRegion, typ: PVmType) =
   assert typ.sizeInBytes <= uint(loc.len)
-  let size = typ.sizeInBytes
   let a = cast[ptr Atom](addr loc[0])
 
   case typ.kind

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -44,7 +44,6 @@ proc dump*(conf: ConfigRef, pd: ProfileData): string =
   var data = pd.data
   echo "\nprof:     µs    #instr  location"
   for i in 0..<32:
-    var tMax: float
     var infoMax: ProfileInfo
     var flMax: TLineInfo
     for fl, info in data:


### PR DESCRIPTION
## Summary
Remove unused routines and variables from modules related to the VM and code generation. They were either never used or became unused as a side-effect of other removals / cleanup.