### PR TITLE
types: fix all non-primitve types being treated as cyclic

### DIFF
--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -1153,7 +1153,7 @@ proc genTypeInfoV2Impl(m: BModule, t, origType: PType, name: Rope; info: TLineIn
   let traceImpl = genHook(m, t, info, attachedTrace)
 
   var flags = 0
-  if not canFormAcycle(t): flags = flags or 1
+  if not isCyclePossible(t, m.g.graph): flags = flags or 1 # acyclic
 
   addf(m.s[cfsTypeInit3], "$1.destructor = (void*)$2; $1.size = sizeof($3); $1.align = NIM_ALIGNOF($3); $1.name = $4;$n; $1.traceImpl = (void*)$5; $1.flags = $6;", [
     name, destroyImpl, getTypeDesc(m, t), typeName,

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -227,6 +227,14 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
       arg = arg.base.skipTypes(skippedTypes + {tyGenericInst})
       if not rec: break
     result = getTypeDescNode(c, arg, operand.owner, traitCall.info)
+  of "isCyclical":
+    let r =
+      if operand.skipTypes(abstractInst).kind in ConcreteTypes:
+        isCyclePossible(operand, c.graph)
+      else:
+        false
+
+    result = newIntNodeT(toInt128(ord(r)), traitCall, c.idgen, c.graph)
   else:
     localReport(c.config, traitCall.info, reportSym(
       rsemUnknownTrait, trait.sym))

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -184,6 +184,22 @@ since (1, 3, 5):
 
     typeof(block: (for ai in a: ai))
 
+proc isCyclical*(t: typedesc): bool {.magic: "TypeTrait".} =
+  ## Returns whether the type `t` is *potentially* able to be part of a
+  ## reference cycle when used as the type of a managed heap location.
+  runnableExamples:
+    type
+      NoCycle = object
+        x: seq[NoCycle]
+      NoCycle2 {.acyclic.} = ref object
+        x: NoCycle2
+      Cycle = ref object
+        x: Cycle
+
+    doAssert not isCyclical(NoCycle)
+    doAssert not isCyclical(NoCycle2)
+    doAssert isCyclical(Cycle)
+
 import std/macros
 
 macro enumLen*(T: typedesc[enum]): int =

--- a/lib/system/orc.nim
+++ b/lib/system/orc.nim
@@ -116,15 +116,9 @@ template orcAssert(cond, msg) =
       cfprintf(cstderr, "[Bug!] %s\n", msg)
       quit 1
 
-when logOrc:
-  proc strstr(s, sub: cstring): cstring {.header: "<string.h>", importc.}
-
 proc nimTraceRef(q: pointer; desc: PNimTypeV2; env: pointer) {.compilerRtl, inline.} =
   let p = cast[ptr pointer](q)
   if p[] != nil:
-
-    orcAssert strstr(desc.name, "TType") == nil, "following a TType but it's acyclic!"
-
     var j = cast[ptr GcEnv](env)
     j.traceStack.add(p, desc)
 
@@ -415,8 +409,6 @@ proc registerCycle(s: Cell; desc: PNimTypeV2) =
     collectCycles()
   when logOrc:
     writeCell("[added root]", s, desc)
-
-  orcAssert strstr(desc.name, "TType") == nil, "added a TType as a root!"
 
 proc GC_runOrc* =
   ## Forces a cycle collection pass.

--- a/tests/typerel/tcyclic.nim
+++ b/tests/typerel/tcyclic.nim
@@ -1,0 +1,128 @@
+discard """
+  description: "Tests for the cyclic type detection"
+  action: compile
+"""
+
+import std/typetraits
+
+template test(t: untyped) =
+  {.line.}:
+    static: doAssert isCyclical(t)
+
+template testNot(t: untyped) =
+  {.line.}:
+    static: doAssert not isCyclical(t)
+
+# primitive types are never cyclic
+testNot int
+testNot float
+testNot void
+
+type
+  NonCyclicObj = object
+    x: seq[NonCyclicObj]
+  NonCyclicRef = ref object
+
+# no reference cycle is possible
+testNot NonCyclicObj
+testNot NonCyclicRef
+
+type Cyclic = ref object
+  x: Cyclic
+
+test    Cyclic
+# the tuple/seq/array is not part of the reference cycle, their elements are:
+testNot (Cyclic,)
+testNot seq[Cyclic]
+testNot array[1, Cyclic]
+
+type
+  AliasedInt = int
+  AliasedCyclic = Cyclic
+
+# type aliases use the aliased type
+testNot AliasedInt
+test    AliasedCyclic
+
+type Cyclic2 = object
+  x: ref (Cyclic2, int)
+
+# a container tuple/seq/etc. storing a ``ref`` type matching the container can
+# be part of a reference cycle
+test    (Cyclic2, int)
+test    (ref (Cyclic2, int))
+
+type
+  Acyclic[T] {.acyclic.} = object
+    # no cycles are possible through a location of type `Acyclic`
+    a: ref T
+
+  A = object
+    x: ref Acyclic[A] # indirect cycle through a different type
+    y: ref A
+
+  B = object
+    x: ref Acyclic[B]
+
+test    A
+testNot B
+
+type
+  WithCursor = object
+    x {.cursor.}: ref WithCursor
+
+testNot WithCursor
+
+# closures don't have a statically known environment type, so the analysis has
+# to be pessimistic and assume that the dynamic environment contains
+# `WithClosure` somewhere
+type
+  WithClosure = object
+    x: proc () {.closure.}
+
+test    WithClosure
+
+# same with types that can be inherited from
+type
+  Inheritable = object of RootObj
+  Final {.final.} = object of Inheritable
+  AcyclicBase {.acyclic.} = object of RootObj
+
+  Test[T] = object
+    x: ref T
+
+# inspecting a non-ref type that can be inherited from is also treated as cyclic
+
+test    Inheritable
+test    Test[Inheritable]
+
+testNot Final
+testNot Test[Final]
+
+# using acyclic for an inheritable type overrides both the super- and sub-types
+testNot AcyclicBase
+testNot Test[AcyclicBase]
+
+# `distinct` types are treated as their base type during the cyclic analysis
+type
+  DRef = distinct WithDRef
+  WithDRef = ref object
+    x: DRef
+
+  DRef2 = distinct WithDRef2
+  WithDRef2 = object
+    x: ref DRef2
+
+test    DRef
+test    WithDRef
+test    DRef2
+test    WithDRef2
+
+# ``UncheckedArray``s are not considered because their contents are not traced
+# by the cycle collector
+type
+  WithUncheckedArray = object
+    x: UncheckedArray[ref WithUncheckedArray]
+
+testNot WithUncheckedArray
+testNot (ref WithUncheckedArray)


### PR DESCRIPTION
## Summary

Due to a logic bug with `canFormAcycle`, *all* non-primitive types (such
as tuples, objects, `array`s, `seq`s, etc.) not explicitly marked with
`.acyclic` were detected as being cyclic.

Since `canFormAcycle` is used to decide whether a type is relevant to
the cycle collector when using `--gc:orc`, all heap locations of
non-primitive type were tracked and scanned by the cycle collector, and
unnecessary `=trace` hooks lifted for them.

As a consequence of the above, moving `ref` values between threads or
holding references to a (non-cyclic) heap location from multiple threads
was effectively impossible (without crashing) when using `--gc:orc`.

## Details

The logic for detecting types that can potentially act as the root in a
reference cycle is rewritten from scratch, now properly handling
structural types and generic instantiations. The `.cursor` annotation
is also taken into account.

Since `canFormAcycle` is still used by logic related to the legacy GCs it
is kept for now, in order to reduce the impact of the fix.

For testing the whether is potentially cyclic, the `isCyclical`
type-trait query procedure is added to `std/typetraits`.


### Misc

- remove leftover debug code from `orc.nim`

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this is a hard blocker for #547

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
