### PR TITLE
lexer: more specific diags, fewer strings

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -188,10 +188,11 @@ type
     rlexMalformedUnderscores
     rlexMalformedTrailingUnderscre
     rlexInvalidToken
+    rlexInvalidTokenSpaceBetweenNumAndIdent
     rlexNoTabs
 
     # numbers
-    rlexInvalidIntegerPrefix
+    rlexInvalidIntegerLiteralOctalPrefix
     rlexInvalidIntegerSuffix
     rlexNumberNotInRange
     rlexExpectedHex
@@ -199,8 +200,12 @@ type
 
     # char
     rlexInvalidCharLiteral
+    rlexInvalidCharLiteralConstant
+    rlexInvalidCharLiteralPlatformNewline
+    rlexInvalidCharLiteralUnicodeCodepoint
     rlexMissingClosingApostrophe
-    rlexInvalidUnicodeCodepoint
+    rlexInvalidUnicodeCodepointEmpty
+    rlexInvalidUnicodeCodepointGreaterThan0x10FFFF
 
     # string
     rlexUnclosedTripleString

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2762,7 +2762,6 @@ To create a stacktrace, rerun compilation with './koch temp $1 <file>'
         for (a, state) in s.hints:
           hints[$a] = %(state)
 
-
         var warnings = newJObject()
         for (a, state) in s.warnings:
           warnings[$a] = %(state)
@@ -2797,11 +2796,10 @@ To create a stacktrace, rerun compilation with './koch temp $1 <file>'
 proc reportFull*(conf: ConfigRef, r: InternalReport): string =
   assertKind r
   case r.kind:
-    of rintCannotOpenFile, rintWarnCannotOpenFile:
-      result.add(conf.prefix(r), conf.reportBody(r), conf.suffix(r))
-
-    else:
-      result = reportBody(conf, r)
+  of rintCannotOpenFile, rintWarnCannotOpenFile:
+    result.add(conf.prefix(r), conf.reportBody(r), conf.suffix(r))
+  else:
+    result = reportBody(conf, r)
 
 proc reportShort*(conf: ConfigRef, r: InternalReport): string =
   # mostly created for nimsuggest
@@ -2822,34 +2820,53 @@ proc reportBody*(conf: ConfigRef, r: LexerReport): string =
         "end with an underscore: e.g. '1__1' and '1_' are invalid"
 
     of rlexInvalidToken:
-      result.add r.msg
+      result.add "invalid token: $1 (\\$2)" % [r.msg, $ord(r.msg[0])]
+
+    of rlexInvalidTokenSpaceBetweenNumAndIdent:
+      result.add "invalid token: no whitespace between number and identifier"
 
     of rlexNoTabs:
       result.add "tabs are not allowed, use spaces instead"
 
-    of rlexInvalidIntegerPrefix:
-      result.add r.msg
+    of rlexInvalidIntegerLiteralOctalPrefix:
+      result.addf(
+        "$1 is an invalid int literal; For octal literals use the '0o' prefix",
+        r.msg)
 
     of rlexInvalidIntegerSuffix:
-      result.add r.msg
+      result.addf("invalid number suffix: '$1'", r.msg)
 
     of rlexNumberNotInRange:
-      result.add r.msg
+      result.addf("number out of range: '$1'", r.msg)
 
     of rlexExpectedHex:
-      result.add r.msg
+      result.addf("expected a hex digit, but found: '$1'; maybe prefix with 0",
+                  r.msg)
 
     of rlexInvalidIntegerLiteral:
-      result.add r.msg
+      result.addf("invalid number: '$1'", r.msg)
 
     of rlexInvalidCharLiteral:
-      result.add r.msg
+      result.add "invalid character literal"
+
+    of rlexInvalidCharLiteralConstant:
+      result.add "invalid character constant"
+
+    of rlexInvalidCharLiteralPlatformNewline:
+      result.add "\\p not allowed in character literal"
+
+    of rlexInvalidCharLiteralUnicodeCodepoint:
+      result.add "\\u not allowed in character literal"
 
     of rlexMissingClosingApostrophe:
       result.add "missing closing ' for character literal"
 
-    of rlexInvalidUnicodeCodepoint:
-      result.add r.msg
+    of rlexInvalidUnicodeCodepointEmpty:
+      result.add "Unicode codepoint cannot be empty"
+
+    of rlexInvalidUnicodeCodepointGreaterThan0x10FFFF:
+      result.addf("Unicode codepoint must be 0x10FFFF or lower, but was: $1",
+                  r.msg)
 
     of rlexUnclosedTripleString:
       result.add "closing \"\"\" expected, but end of file reached"
@@ -2867,7 +2884,7 @@ proc reportBody*(conf: ConfigRef, r: LexerReport): string =
       result.add "end of multiline comment expected"
 
     of rlexDeprecatedOctalPrefix:
-      result.add r.msg
+      result.add "octal escape sequences do not exist; leading zero is ignored"
 
     of rlexLinterReport:
       result.addf("'$1' should be: '$2'", r.got, r.wanted)

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -1503,15 +1503,20 @@ func lexDiagToLegacyReportKind*(diag: LexerDiagKind): ReportKind {.inline.} =
   of lexDiagMalformedUnderscores: rlexMalformedUnderscores
   of lexDiagMalformedTrailingUnderscre: rlexMalformedTrailingUnderscre
   of lexDiagInvalidToken: rlexInvalidToken
+  of lexDiagInvalidTokenSpaceBetweenNumAndIdent: rlexInvalidTokenSpaceBetweenNumAndIdent
   of lexDiagNoTabs: rlexNoTabs
-  of lexDiagInvalidIntegerPrefix: rlexInvalidIntegerPrefix
+  of lexDiagInvalidIntegerLiteralOctalPrefix: rlexInvalidIntegerLiteralOctalPrefix
   of lexDiagInvalidIntegerSuffix: rlexInvalidIntegerSuffix
   of lexDiagNumberNotInRange: rlexNumberNotInRange
   of lexDiagExpectedHex: rlexExpectedHex
   of lexDiagInvalidIntegerLiteral: rlexInvalidIntegerLiteral
   of lexDiagInvalidCharLiteral: rlexInvalidCharLiteral
+  of lexDiagInvalidCharLiteralConstant: rlexInvalidCharLiteralConstant
+  of lexDiagInvalidCharLiteralPlatformNewline: rlexInvalidCharLiteralPlatformNewline
+  of lexDiagInvalidCharLiteralUnicodeCodepoint: rlexInvalidCharLiteralUnicodeCodepoint
   of lexDiagMissingClosingApostrophe: rlexMissingClosingApostrophe
-  of lexDiagInvalidUnicodeCodepoint: rlexInvalidUnicodeCodepoint
+  of lexDiagInvalidUnicodeCodepointEmpty: rlexInvalidUnicodeCodepointEmpty
+  of lexDiagInvalidUnicodeCodepointGreaterThan0x10FFFF: rlexInvalidUnicodeCodepointGreaterThan0x10FFFF
   of lexDiagUnclosedTripleString: rlexUnclosedTripleString
   of lexDiagUnclosedSingleString: rlexUnclosedSingleString
   of lexDiagUnclosedComment: rlexUnclosedComment

--- a/tests/lang_syntax/lexer/tinvalidintegerliteral3.nim
+++ b/tests/lang_syntax/lexer/tinvalidintegerliteral3.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "0O5 is an invalid int literal; For octal literals use the '0o' prefix."
+  errormsg: "0O5 is an invalid int literal; For octal literals use the '0o' prefix"
   file: "tinvalidintegerliteral3.nim"
   line: 7
 """


### PR DESCRIPTION
Introduced new diagnostircs for various specific circumstances. This reduces the need to allocate strings for various messages in the lexer. Pushed this through into legacy `reports` so most string creation happens in `cli_reporter` when required.

A few messages were changed, mostly punctuation or became slightly more specific.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* nothing major, just saw things while examining the `lexer`