### PR TITLE
compiler: replace `Rope`s with plain strings

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -23,7 +23,6 @@ import
     in_options
   ],
   compiler/utils/[
-    ropes,
     idioms,
     int128 # Values for integer nodes
   ],
@@ -316,7 +315,7 @@ proc mergeLoc(a: var TLoc, b: TLoc) =
   if a.storage == low(typeof(a.storage)): a.storage = b.storage
   a.flags.incl b.flags
   if a.lode == nil: a.lode = b.lode
-  if a.r == nil: a.r = b.r
+  if a.r.len == 0: a.r = b.r
 
 proc newSons*(father: Indexable, length: int) =
   setLen(father.sons, length)

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -78,7 +78,7 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
   var typ = skipTypes(ri[0].typ, abstractInst)
   if typ[0] != nil:
     if isInvalidReturnType(p.config, typ[0]):
-      if params != nil: pl.add(~", ")
+      if params != "": pl.add(~", ")
       # beware of 'result = p(result)'. We may need to allocate a temporary:
       if d.k in {locTemp, locNone} or not preventNrvo(p, le, ri):
         # Great, we can use 'd':
@@ -356,10 +356,10 @@ proc genParams(p: BProc, ri: PNode, typ: PType): Rope =
       assert(typ.n[i].kind == nkSym)
       let paramType = typ.n[i]
       if not paramType.typ.isCompileTimeOnly:
-        if result != nil: result.add(~", ")
+        if result != "": result.add(", ")
         result.add(genArg(p, ri[i], paramType.sym, ri, needTmp[i-1]))
     else:
-      if result != nil: result.add(~", ")
+      if result != "": result.add(", ")
       result.add(genArgNoParam(p, ri[i], needTmp[i-1]))
 
 proc genPrefixCall(p: BProc, le, ri: PNode, d: var TLoc) =
@@ -380,7 +380,7 @@ proc genPrefixCall(p: BProc, le, ri: PNode, d: var TLoc) =
 proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
 
   proc addComma(r: Rope): Rope =
-    if r == nil: r else: r & ~", "
+    if r == "": r else: r & ", "
 
   const PatProc = "$1.ClE_0? $1.ClP_0($3$1.ClE_0):(($4)($1.ClP_0))($2)"
   const PatIter = "$1.ClP_0($3$1.ClE_0)" # we know the env exists

--- a/compiler/backend/ccgreset.nim
+++ b/compiler/backend/ccgreset.nim
@@ -24,7 +24,7 @@ proc specializeResetN(p: BProc, accessor: Rope, n: PNode;
   of nkRecCase:
     p.config.internalAssert(n[0].kind == nkSym, n.info, "specializeResetN")
     let disc = n[0].sym
-    if disc.loc.r == nil: fillObjectFields(p.module, typ)
+    if disc.loc.r == "": fillObjectFields(p.module, typ)
     p.config.internalAssert(disc.loc.t != nil, n.info, "specializeResetN()")
     lineF(p, cpsStmts, "switch ($1.$2) {$n", [accessor, disc.loc.r])
     for i in 1..<n.len:
@@ -41,7 +41,7 @@ proc specializeResetN(p: BProc, accessor: Rope, n: PNode;
   of nkSym:
     let field = n.sym
     if field.typ.kind == tyVoid: return
-    if field.loc.r == nil: fillObjectFields(p.module, typ)
+    if field.loc.r == "": fillObjectFields(p.module, typ)
     p.config.internalAssert(field.loc.t != nil, n.info, "specializeResetN()")
     specializeResetT(p, "$1.$2" % [accessor, field.loc.r], field.loc.t)
   else: internalError(p.config, n.info, "specializeResetN()")

--- a/compiler/backend/ccgthreadvars.nim
+++ b/compiler/backend/ccgthreadvars.nim
@@ -41,11 +41,11 @@ proc declareThreadVar(m: BModule, s: PSym, isExtern: bool) =
     m.s[cfsVars].addf(" $1;$n", [s.loc.r])
 
 proc generateThreadLocalStorage(m: BModule) =
-  if m.g.nimtv != nil and (usesThreadVars in m.flags or sfMainModule in m.module.flags):
+  if m.g.nimtv != "" and (usesThreadVars in m.flags or sfMainModule in m.module.flags):
     for t in items(m.g.nimtvDeps): discard getTypeDesc(m, t)
     finishTypeDescriptions(m)
     m.s[cfsSeqTypes].addf("typedef struct {$1} NimThreadVars;$n", [m.g.nimtv])
 
 proc generateThreadVarsSize(m: BModule) =
-  if m.g.nimtv != nil:
+  if m.g.nimtv != "":
     m.s[cfsProcs].addf("NI NimThreadVarsSize(){return (NI)sizeof(NimThreadVars);}$n", [])

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -148,7 +148,7 @@ proc createDispatcher(s: PSym; g: ModuleGraph; idgen: IdGenerator): PSym =
   if disp.typ.callConv == ccInline: disp.typ.callConv = ccNimCall
   disp.ast = copyTree(s.ast)
   disp.ast[bodyPos] = newNodeI(nkEmpty, s.info)
-  disp.loc.r = nil
+  disp.loc.r = ""
   if s.typ[0] != nil:
     if disp.ast.len > resultPos:
       disp.ast[resultPos].sym = copySym(s.ast[resultPos].sym, nextSymId(idgen))

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -635,7 +635,7 @@ proc getCompileCFileCmd*(conf: ConfigRef; cfile: Cfile,
           usedCompiler: CC[conf.cCompiler].name)
 
   result.add(' ')
-  result.addf(CC[c].compileTmpl, [
+  strutils.addf(result, CC[c].compileTmpl, [
     "dfile", dfile,
     "file", cfsh, "objfile", quoteShell(objfile),
     "options", options, "include", includeCmd,
@@ -726,7 +726,7 @@ proc getLinkCmd(conf: ConfigRef; output: AbsoluteFile,
         "buildgui", buildgui, "options", linkOptions, "objfiles", objfiles,
         "exefile", exefile, "nim", getPrefixDir(conf).string, "lib", conf.libpath.string])
     result.add ' '
-    result.addf(linkTmpl, ["builddll", builddll,
+    strutils.addf(result, linkTmpl, ["builddll", builddll,
         "mapfile", mapfile,
         "buildgui", buildgui, "options", linkOptions,
         "objfiles", objfiles, "exefile", exefile,
@@ -838,7 +838,7 @@ proc callCCompiler*(conf: ConfigRef) =
     return # speed up that call if only compiling and no script shall be
            # generated
   #var c = cCompiler
-  var script: Rope = nil
+  var script = ""
   var cmds: TStringSeq
   var prettyCmds: TStringSeq
   let prettyCb = proc (idx: int) = writePrettyCmdsStderr(prettyCmds[idx])
@@ -995,7 +995,7 @@ proc runJsonBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
 
 proc genMappingFiles(conf: ConfigRef; list: CfileList): Rope =
   for it in list:
-    result.addf("--file:r\"$1\"$N", [rope(it.cname.string)])
+    ropes.addf(result, "--file:r\"$1\"$N", [rope(it.cname.string)])
 
 proc writeMapping*(conf: ConfigRef; symbolMapping: Rope) =
   if optGenMapping notin conf.globalOptions: return
@@ -1011,7 +1011,7 @@ proc writeMapping*(conf: ConfigRef; symbolMapping: Rope) =
   code.add("\n[Environment]\nlibpath=")
   code.add(strutils.escape(conf.libpath.string))
 
-  code.addf("\n[Symbols]$n$1", [symbolMapping])
+  ropes.addf(code, "\n[Symbols]$n$1", [symbolMapping])
   let filename = getNimcacheDir(conf) / RelativeFile"mapping.txt"
   if not writeRope(code, filename):
     conf.localReport BackendReport(

--- a/compiler/backend/jstypes.nim
+++ b/compiler/backend/jstypes.nim
@@ -19,13 +19,13 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
     s, u: Rope
     field: PSym
     b: PNode
-  result = nil
+  result = ""
   case n.kind
   of nkRecList:
     if n.len == 1:
       result = genObjectFields(p, typ, n[0])
     else:
-      s = nil
+      s = ""
       for i in 0..<n.len:
         if i > 0: s.add(", \L")
         s.add(genObjectFields(p, typ, n[i]))
@@ -44,12 +44,12 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
     s = genTypeInfo(p, field.typ)
     for i in 1..<n.len:
       b = n[i]           # branch
-      u = nil
+      u = ""
       case b.kind
       of nkOfBranch:
         p.config.internalAssert(b.len >= 2, b.info, "genObjectFields; nkOfBranch broken")
         for j in 0..<b.len - 1:
-          if u != nil: u.add(", ")
+          if u != "": u.add(", ")
           if b[j].kind == nkRange:
             u.addf("[$1, $2]", [rope(getOrdValue(b[j][0])),
                                  rope(getOrdValue(b[j][1]))])
@@ -60,7 +60,7 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
       else:
         internalError(p.config, n.info, "genObjectFields(nkRecCase)")
 
-      if result != nil: result.add(", \L")
+      if result != "": result.add(", \L")
       result.addf("[setConstr($1), $2]",
            [u, genObjectFields(p, typ, lastSon(b))])
     result = ("{kind: 3, offset: \"$1\", len: $3, " &
@@ -85,7 +85,7 @@ proc genObjectInfo(p: PProc, typ: PType, name: Rope) =
          [name, genTypeInfo(p, typ[0].skipTypes(skipPtrs))])
 
 proc genTupleFields(p: PProc, typ: PType): Rope =
-  var s: Rope = nil
+  var s = ""
   for i in 0..<typ.len:
     if i > 0: s.add(", \L")
     s.addf("{kind: 1, offset: \"Field$1\", len: 0, " &
@@ -103,7 +103,7 @@ proc genTupleInfo(p: PProc, typ: PType, name: Rope) =
   p.g.typeInfo.addf("$1.node = NNI$2;$n", [name, rope(typ.id)])
 
 proc genEnumInfo(p: PProc, typ: PType, name: Rope) =
-  var s: Rope = nil
+  var s = ""
   for i in 0..<typ.n.len:
     p.config.internalAssert(typ.n[i].kind == nkSym, typ.n.info, "genEnumInfo")
     let field = typ.n[i].sym

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -9,7 +9,7 @@
 
 import
   std/[os, strutils, strtabs, sets, tables, packedsets],
-  compiler/utils/[prefixmatches, pathutils, platform, strutils2, ropes],
+  compiler/utils/[prefixmatches, pathutils, platform, strutils2],
   compiler/ast/[lineinfos],
   compiler/modules/nimpaths
 
@@ -1165,19 +1165,17 @@ proc toCChar*(c: char; result: var string) {.inline.} =
   else:
     result.add c
 
-proc makeCString*(s: string): Rope =
-  result = nil
-  var res = newStringOfCap(int(s.len.toFloat * 1.1) + 1)
-  res.add("\"")
+proc makeCString*(s: string): string =
+  result = newStringOfCap(int(s.len.toFloat * 1.1) + 1)
+  result.add("\"")
   for i in 0..<s.len:
     # line wrapping of string litterals in cgen'd code was a bad idea, e.g. causes: bug #16265
     # It also makes reading c sources or grepping harder, for zero benefit.
     # const MaxLineLength = 64
     # if (i + 1) mod MaxLineLength == 0:
     #   res.add("\"\L\"")
-    toCChar(s[i], res)
-  res.add('\"')
-  result.add(rope(res))
+    toCChar(s[i], result)
+  result.add('\"')
 
 proc newFileInfo(fullPath: AbsoluteFile, projPath: RelativeFile): TFileInfo =
   result.fullPath = fullPath

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -418,7 +418,7 @@ proc storeSym*(s: PSym; c: var PackedEncoder; m: var PackedModule): PackedItemId
       p.bitsize = s.bitsize
       p.alignment = s.alignment
 
-    p.externalName = toLitId(if s.loc.r.isNil: "" else: $s.loc.r, m)
+    p.externalName = toLitId(s.loc.r, m)
     p.locFlags = s.loc.flags
     c.addMissing s.typ
     p.typ = s.typ.storeType(c, m)

--- a/compiler/modules/depends.nim
+++ b/compiler/modules/depends.nim
@@ -75,7 +75,7 @@ proc myOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext 
   g.config = graph.config
   g.graph = graph
   if graph.backend == nil:
-    graph.backend = Backend(dotGraph: nil)
+    graph.backend = Backend(dotGraph: "")
   result = g
 
 const gendependPass* = makePass(open = myOpen, process = addDotDependency)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1331,7 +1331,7 @@ proc prepareSinglePragma(
         sym.flags.incl sfImportc
         sym.loc.flags.incl {lfHeader, lfNoDecl}
         # implies nodecl, because otherwise header would not make sense
-        if sym.loc.r == nil: sym.loc.r = rope(sym.name.s)
+        if sym.loc.r == "": sym.loc.r = sym.name.s
       of wNoSideEffect:
         result = noVal(c, it)
         if sym != nil:
@@ -1802,7 +1802,7 @@ proc implicitPragmas*(c: PContext, sym: PSym, info: TLineInfo,
         sfImportc in sym.flags and lib != nil:
       incl(sym.loc.flags, lfDynamicLib)
       addToLib(lib, sym)
-      if sym.loc.r == nil: sym.loc.r = rope(sym.name.s)
+      if sym.loc.r == "": sym.loc.r = sym.name.s
 
 proc pragma*(c: PContext, sym: PSym, n: PNode, validPragmas: TSpecialWords;
             isStatement: bool): PNode {.discardable.} =

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -909,7 +909,7 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
       f.options = c.config.options
       if fieldOwner != nil and
          {sfImportc, sfExportc} * fieldOwner.flags != {} and
-         not hasCaseFields and f.loc.r == nil:
+         not hasCaseFields and f.loc.r == "":
         f.loc.r = rope(f.name.s)
         f.flags.incl {sfImportc, sfExportc} * fieldOwner.flags
       inc(pos)

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -29,8 +29,6 @@ proc `&=`(c: var MD5Context, s: string) = md5Update(c, s, s.len)
 proc `&=`(c: var MD5Context, ch: char) =
   # XXX suspicious code here; relies on ch being zero terminated?
   md5Update(c, unsafeAddr ch, 1)
-proc `&=`(c: var MD5Context, r: Rope) =
-  for l in leaves(r): md5Update(c, l.cstring, l.len)
 proc `&=`(c: var MD5Context, i: BiggestInt) =
   md5Update(c, cast[cstring](unsafeAddr i), sizeof(i))
 proc `&=`(c: var MD5Context, f: BiggestFloat) =
@@ -154,7 +152,7 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
     # is actually safe without an infinite recursion check:
     if t.sym != nil:
       if {sfCompilerProc} * t.sym.flags != {}:
-        doAssert t.sym.loc.r != nil
+        doAssert t.sym.loc.r != ""
         # The user has set a specific name for this type
         c &= t.sym.loc.r
       elif CoOwnerSig in flags:

--- a/compiler/utils/ropes.nim
+++ b/compiler/utils/ropes.nim
@@ -7,56 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
-# Ropes for the C code generator
-#
-#  Ropes are a data structure that represents a very long string
-#  efficiently; especially concatenation is done in O(1) instead of O(N).
-#  Ropes make use a lazy evaluation: They are essentially concatenation
-#  trees that are only flattened when converting to a native Nim
-#  string or when written to disk. The empty string is represented by a
-#  nil pointer.
-#  A little picture makes everything clear:
-#
-#  "this string" & " is internally " & "represented as"
-#
-#             con  -- inner nodes do not contain raw data
-#            /   \
-#           /     \
-#          /       \
-#        con       "represented as"
-#       /   \
-#      /     \
-#     /       \
-#    /         \
-#   /           \
-#"this string"  " is internally "
-#
-#  Note that this is the same as:
-#  "this string" & (" is internally " & "represented as")
-#
-#             con
-#            /   \
-#           /     \
-#          /       \
-# "this string"    con
-#                 /   \
-#                /     \
-#               /       \
-#              /         \
-#             /           \
-#" is internally "        "represented as"
-#
-#  The 'con' operator is associative! This does not matter however for
-#  the algorithms we use for ropes.
-#
-#  Note that the left and right pointers are not needed for leaves.
-#  Leaves have relatively high memory overhead (~30 bytes on a 32
-#  bit machines) and we produce many of them. This is why we cache and
-#  share leaves across different rope trees.
-#  To cache them they are inserted in a `cache` array.
-
-import
-  std/hashes
+## An implemention of ropes for use by the C and JS code generators was
+## previously located here, but now ``Rope`` is only an alias for ``string``.
 
 from pathutils import AbsoluteFile
 
@@ -65,155 +17,46 @@ type
                        # performance of the code generator (assignments
                        # copy the format strings
                        # though it is not necessary)
-  Rope* = ref RopeObj
-  RopeObj*{.acyclic.} = object of RootObj # the empty rope is represented
-                                          # by nil to safe space
-    left, right: Rope
-    L: int                    # <= 0 if a leaf
-    data*: string
+  Rope* = string
 
-proc len*(a: Rope): int =
-  ## the rope's length
-  if a == nil: result = 0
-  else: result = abs a.L
-
-proc newRope(data: string = ""): Rope =
-  new(result)
-  result.L = -data.len
-  result.data = data
-
-when not compileOption("threads"):
-  var
-    cache: array[0..2048*2 - 1, Rope]
-
-  proc resetRopeCache* =
-    for i in low(cache)..high(cache):
-      cache[i] = nil
-
-proc ropeInvariant(r: Rope): bool =
-  if r == nil:
-    result = true
-  else:
-    result = true #
-                  #    if r.data <> snil then
-                  #      result := true
-                  #    else begin
-                  #      result := (r.left <> nil) and (r.right <> nil);
-                  #      if result then result := ropeInvariant(r.left);
-                  #      if result then result := ropeInvariant(r.right);
-                  #    end
-
-var gCacheTries* = 0
-var gCacheMisses* = 0
-var gCacheIntTries* = 0
-
-proc insertInCache(s: string): Rope =
-  when declared(cache):
-    inc gCacheTries
-    var h = hash(s) and high(cache)
-    result = cache[h]
-    if isNil(result) or result.data != s:
-      inc gCacheMisses
-      result = newRope(s)
-      cache[h] = result
-  else:
-    result = newRope(s)
-
-proc rope*(s: string): Rope =
-  ## Converts a string to a rope.
-  if s.len == 0:
-    result = nil
-  else:
-    result = insertInCache(s)
-  assert(ropeInvariant(result))
+template rope*(s: string): Rope =
+  ## A no-op -- the same as using `s` directly
+  s
 
 proc rope*(i: BiggestInt): Rope =
   ## Converts an int to a rope.
-  inc gCacheIntTries
-  result = rope($i)
+  result = $i
 
 proc rope*(f: BiggestFloat): Rope =
   ## Converts a float to a rope.
-  result = rope($f)
-
-proc `&`*(a, b: Rope): Rope =
-  if a == nil:
-    result = b
-  elif b == nil:
-    result = a
-  else:
-    result = newRope()
-    result.L = abs(a.L) + abs(b.L)
-    result.left = a
-    result.right = b
-
-proc `&`*(a: Rope, b: string): Rope =
-  ## the concatenation operator for ropes.
-  result = a & rope(b)
-
-proc `&`*(a: string, b: Rope): Rope =
-  ## the concatenation operator for ropes.
-  result = rope(a) & b
+  result = $f
 
 proc `&`*(a: openArray[Rope]): Rope =
   ## the concatenation operator for an openarray of ropes.
   for i in 0..high(a): result = result & a[i]
 
-proc add*(a: var Rope, b: Rope) =
-  ## adds `b` to the rope `a`.
-  a = a & b
-
-proc add*(a: var Rope, b: string) =
-  ## adds `b` to the rope `a`.
-  a = a & b
-
-iterator leaves*(r: Rope): string =
-  ## iterates over any leaf string in the rope `r`.
-  if r != nil:
-    var stack = @[r]
-    while stack.len > 0:
-      var it = stack.pop
-      while it.left != nil:
-        assert it.right != nil
-        stack.add(it.right)
-        it = it.left
-        assert(it != nil)
-      yield it.data
-
-iterator items*(r: Rope): char =
-  ## iterates over any character in the rope `r`.
-  for s in leaves(r):
-    for c in items(s): yield c
-
 proc writeRope*(f: File, r: Rope) =
   ## writes a rope to a file.
-  for s in leaves(r): write(f, s)
+  write(f, r)
 
 proc writeRope*(head: Rope, filename: AbsoluteFile): bool =
   var f: File
   if open(f, filename.string, fmWrite):
-    if head != nil: writeRope(f, head)
+    writeRope(f, head)
     close(f)
     result = true
   else:
     result = false
 
-proc `$`*(r: Rope): string =
-  ## converts a rope back to a string.
-  result = newString(r.len)
-  setLen(result, 0)
-  for s in leaves(r): result.add(s)
-
 proc ropeConcat*(a: varargs[Rope]): Rope =
   # not overloaded version of concat to speed-up `rfmt` a little bit
   for i in 0..high(a): result = result & a[i]
 
-proc prepend*(a: var Rope, b: Rope) = a = b & a
-proc prepend*(a: var Rope, b: string) = a = b & a
+func prepend*(a: var Rope, b: string) = a = b & a
 
 proc runtimeFormat*(frmt: FormatStr, args: openArray[Rope]): Rope =
   var i = 0
-  result = nil
+  result = ""
   var num = 0
   while i < frmt.len:
     if frmt[i] == '$':
@@ -266,7 +109,6 @@ proc runtimeFormat*(frmt: FormatStr, args: openArray[Rope]): Rope =
       else: break
     if i - 1 >= start:
       result.add(substr(frmt, start, i - 1))
-  assert(ropeInvariant(result))
 
 proc `%`*(frmt: static[FormatStr], args: openArray[Rope]): Rope =
   runtimeFormat(frmt, args)
@@ -277,19 +119,11 @@ template addf*(c: var Rope, frmt: FormatStr, args: openArray[Rope]) =
 
 when true:
   template `~`*(r: string): Rope = r % []
-else:
-  {.push stack_trace: off, line_trace: off.}
-  proc `~`*(r: static[string]): Rope =
-    # this is the new optimized "to rope" operator
-    # the mnemonic is that `~` looks a bit like a rope :)
-    var r {.global.} = r % []
-    return r
-  {.pop.}
 
 const
   bufSize = 1024              # 1 KB is reasonable
 
-proc equalsFile*(r: Rope, f: File): bool =
+proc equalsFile*(s: Rope, f: File): bool =
   ## returns true if the contents of the file `f` equal `r`.
   var
     buf: array[bufSize, char]
@@ -298,7 +132,7 @@ proc equalsFile*(r: Rope, f: File): bool =
     btotal = 0
     rtotal = 0
 
-  for s in leaves(r):
+  when true:
     var spos = 0
     rtotal += s.len
     while spos < s.len:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -51,8 +51,7 @@ import
     lowerings
   ],
   compiler/utils/[
-    idioms,
-    debugutils
+    idioms
   ],
   compiler/vm/[
     vmaux,
@@ -71,6 +70,7 @@ from std/bitops import bitor
 
 when defined(nimCompilerStacktraceHints):
   import std/stackframes
+  import compiler/utils/debugutils
 
 
 type


### PR DESCRIPTION
## Summary

The usage of `Rope`s is blocking the switch to `--gc:orc` for the compiler, as very long chains that can happen in some cases (such as `const` arrays with a very large number of items) lead to stack overflows on `Rope` destruction.

In addition, replacing `Rope`s with strings leads to a decrease in peak memory consumption (when building the compiler itself) by 400 MiB -- execution time is not affected for a compiler built with `refc`.

## Details

- make `Rope` an alias for `string`
- remove the now-unused routines from `ropes.nim`
- replace `nil` with `"" where `Rope` where previously used

### Misc

- fix the "Unused import" warnings with regarding `debugutils`

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* a refactoring without any functional change

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
