### PR TITLE
dev cmd: add `scan` compiler command

### DIFF
--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -621,6 +621,7 @@ proc parseCommand*(command: string): Command =
   of "gendepend": cmdGendepend
   of "dump": cmdDump
   of "parse": cmdParse
+  of "scan": cmdScan
   of "rod": cmdRod
   of "secret": cmdInteractive
   of "nop", "help": cmdNop

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -146,6 +146,7 @@ type
     cmdTcc         ## run the project via TCC backend
     cmdCheck       ## semantic checking for whole project
     cmdParse       ## parse a single file (for debugging)
+    cmdScan        ## scan/lexically analyse a single file (for debugging)
     cmdRod         ## .rod to some text representation (for debugging)
     cmdIdeTools    ## ide tools (e.g. nimsuggest)
     cmdNimscript   ## evaluate nimscript

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -305,8 +305,9 @@ proc setOutFile*(conf: ConfigRef) =
 
 proc mainCommand*(graph: ModuleGraph) =
   ## Execute main compiler command
-  let conf = graph.config
-  let cache = graph.cache
+  let
+    conf = graph.config
+    cache = graph.cache
 
   # In "nim serve" scenario, each command must reset the registered passes
   clearPasses(graph)
@@ -450,6 +451,10 @@ proc mainCommand*(graph: ModuleGraph) =
     reprConf.flags.excl trfShowNodeIds
     reprConf.flags.incl trfShowNodeLineInfo
     echo conf.treeRepr(parseFile(conf.projectMainIdx, cache, conf), reprConf)
+
+  of cmdScan:
+    wantMainModule(conf)
+    commandScan(cache, conf)
 
   of cmdRod:
     wantMainModule(conf)


### PR DESCRIPTION
Outputs the tokens scanned from a single file, this is useful for developing and debugging lexical analysis and in the future get stats about files.

Left undocumented as it's very rough.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* useful for me, but also @zevv asked how to get this info