### PR TITLE
lexer: smaller diag type and drop internal error

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -197,6 +197,7 @@ type
     rlexNumberNotInRange
     rlexExpectedHex
     rlexInvalidIntegerLiteral
+    rlexInvalidNumericLiteral
 
     # char
     rlexInvalidCharLiteral

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2843,7 +2843,7 @@ proc reportBody*(conf: ConfigRef, r: LexerReport): string =
       result.addf("expected a hex digit, but found: '$1'; maybe prefix with 0",
                   r.msg)
 
-    of rlexInvalidIntegerLiteral:
+    of rlexInvalidNumericLiteral, rlexInvalidIntegerLiteral:
       result.addf("invalid number: '$1'", r.msg)
 
     of rlexInvalidCharLiteral:

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -1499,7 +1499,6 @@ from compiler/ast/reports_lexer import LexerReport
 
 func lexDiagToLegacyReportKind*(diag: LexerDiagKind): ReportKind {.inline.} =
   case diag
-  of lexDiagInternalError: rintIce
   of lexDiagMalformedUnderscores: rlexMalformedUnderscores
   of lexDiagMalformedTrailingUnderscre: rlexMalformedTrailingUnderscre
   of lexDiagInvalidToken: rlexInvalidToken
@@ -1510,6 +1509,7 @@ func lexDiagToLegacyReportKind*(diag: LexerDiagKind): ReportKind {.inline.} =
   of lexDiagNumberNotInRange: rlexNumberNotInRange
   of lexDiagExpectedHex: rlexExpectedHex
   of lexDiagInvalidIntegerLiteral: rlexInvalidIntegerLiteral
+  of lexDiagInvalidNumericLiteral: rlexInvalidNumericLiteral
   of lexDiagInvalidCharLiteral: rlexInvalidCharLiteral
   of lexDiagInvalidCharLiteralConstant: rlexInvalidCharLiteralConstant
   of lexDiagInvalidCharLiteralPlatformNewline: rlexInvalidCharLiteralPlatformNewline
@@ -1533,9 +1533,8 @@ func lexerDiagToLegacyReport*(diag: LexerDiag): Report {.inline.} =
         LexerReport(
             location: std_options.some diag.location,
             reportInst: diag.instLoc.toReportLineInfo,
-            msg: diag.msg,
             kind: kind,
-            wanted: diag.wanted,
+            wanted: diag.msg,
             got: diag.got)
       else:
         LexerReport(

--- a/compiler/front/nimconf.nim
+++ b/compiler/front/nimconf.nim
@@ -30,7 +30,6 @@ import
   ],
   compiler/utils/[
     pathutils,
-    idioms,
   ]
 
 type
@@ -165,7 +164,6 @@ proc ppGetTok(N: var NimConfParser, tok: var Token) =
                                       of LexDiagsError:   cekLexerErrorDiag
                                       of LexDiagsWarning: cekLexerWarningDiag
                                       of LexDiagsHint:    cekLexerHintDiag
-                                      of LexDiagsFatal:   unreachable()
                                       ),
                                 lexerDiag: d,
                                 instLoc: d.instLoc)


### PR DESCRIPTION
## Summary
Internal changes:
- `LexDiag` is now a smaller type
- removed the `lexDiagInternalError`

## Details

Smaller Diag Type:
- `lexDiagNameXShouldBeY` resuse the `msg` field for 'Y' (wanted)
- this reduces the variant by a `string`

Drop Internal Error:
- eliminated `lexDiagInternalError`
- all cases were guarded and are now handled by `unreachable`
- also removes the need to wrap token fetching in try/except

Misc:
- More specific diagnostic kinds for invalid integer vs numeric literals
- Messages remain unchanged, however
- Minor style clean-ups

This is made possible thanks to more specific diag kinds that have reduced or deferred many string allocs.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* more minor changes that made sense while poking at lexing/parsing