### PR TITLE
cgen: fix IC-backend crash with `inline` procedures

### DIFF
--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1012,7 +1012,8 @@ proc genProcAux(m: BModule, prc: PSym) =
     # meaning that globals defiend inside ``inline`` procedures are also only
     # extracted once
 
-    let m2 = findPendingModule(m, prc)
+    let m2 = if m.config.symbolFiles != disabledSf: m
+             else: findPendingModule(m, prc)
 
     # first pass: register the destructors
     for it in globals.items:


### PR DESCRIPTION
## Summary
Using an `inline` procedure in a different module from where it was defined lead to a compiler crash when the defining module was not pending. As a workaround, procedure-level globals are generated into the module where the parent procedure is first *used* instead of where it's *defined*.

The above means that procedure-level globals are now initialized in a different order when using symbol files (i.e. incremental compilation) compared to when not.

## Details
The fundamental problem is that procedure-level globals are not attached to their owning routines early enough and in a way that they can be properly special-cased by the code generators.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
This is the last remaining blocker for #547 -- the crash also happens with `refc`, but only when not using `-d:danger`. Due to the unstable nature of the IC-backend plus its uncertain future, I think the divergence in semantics is okay.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
