### PR TITLE
vm: better `LocHandle` design

### DIFF
--- a/compiler/vm/vmchecks.nim
+++ b/compiler/vm/vmchecks.nim
@@ -1,10 +1,9 @@
 ## This module implements the handle validation logic.
 ##
-## Handles are validate by first making sure that they point to VM owned
-## memory. After finding the allocation the handle points into, the
-## allocation's layout is walked in order to verify that there exists a valid
-## location of the handle's type at the offset relative to the start of
-## the allocation.
+## After making making sure that the handle references a valid cell (it's an
+## error otherwise), the layout of cell is traversed in order to verify that
+## there exists a valid location of the handle's type at the offset relative to
+## the start of the cell.
 ##
 ## Special handling is required for variant objects, since whether a
 ## sub-location is valid depends on the run-time value of the respective
@@ -15,14 +14,13 @@ import
     idioms
   ],
   compiler/vm/[
-    vmdef,
-    vmmemory
+    vmdef
   ]
 
 from compiler/vm/vmobjects import variantFieldIndices
 from compiler/vm/vmtypes import alignedSize
 
-iterator fields(p: MemRegionPtr, t: PVmType): FieldIndex =
+iterator fields(p: VmMemoryRegion, t: PVmType): FieldIndex =
   ## Iterates and yields the indices of all active fields in the object at the
   ## given location
   if t.branches.len == 0:
@@ -33,10 +31,10 @@ iterator fields(p: MemRegionPtr, t: PVmType): FieldIndex =
       yield i
 
 
-func searchInObject(h: MemRegionPtr, otyp, t: PVmType, o: int): AccessViolationReason
+func searchInObject(h: VmMemoryRegion, otyp, t: PVmType, o: int): AccessViolationReason
 func testLocationType(locType: PVmType, t: PVmType): AccessViolationReason
 
-func searchInArray(h: MemRegionPtr, etyp: PVmType, t: PVmType, len, stride, o: int): AccessViolationReason =
+func searchInArray(h: VmMemoryRegion, etyp: PVmType, t: PVmType, len, stride, o: int): AccessViolationReason =
   let i = o /% stride
   assert i < len
 
@@ -47,12 +45,11 @@ func searchInArray(h: MemRegionPtr, etyp: PVmType, t: PVmType, len, stride, o: i
     of realAtomKinds:
       avrNoLocation
     of akObject:
-      searchInObject(h.getSubHandle(i*stride), etyp, t, o - (i*stride))
+      searchInObject(h.subView(i*stride), etyp, t, o - (i*stride))
     of akArray:
-      searchInArray(h.getSubHandle(i*stride), etyp.elementType, t, etyp.elementCount, etyp.elementStride, o - (i*stride))
+      searchInArray(h.subView(i*stride), etyp.elementType, t, etyp.elementCount, etyp.elementStride, o - (i*stride))
 
-
-func searchInObject(h: MemRegionPtr, otyp, t: PVmType, o: int): AccessViolationReason =
+func searchInObject(h: VmMemoryRegion, otyp, t: PVmType, o: int): AccessViolationReason =
   assert uint(o) < otyp.sizeInBytes
   assert otyp.kind == akObject
   for i in fields(h, otyp):
@@ -62,9 +59,9 @@ func searchInObject(h: MemRegionPtr, otyp, t: PVmType, o: int): AccessViolationR
     elif o < f.offset + int(f.typ.sizeInBytes):
       case f.typ.kind
       of akObject:
-        return searchInObject(h.getSubHandle(f.offset), f.typ, t, o - f.offset)
+        return searchInObject(h.subView(f.offset), f.typ, t, o - f.offset)
       of akArray:
-        return searchInArray(h.getSubHandle(f.offset), f.typ.elementType, t, f.typ.elementCount, f.typ.elementStride, o - f.offset)
+        return searchInArray(h.subView(f.offset), f.typ.elementType, t, f.typ.elementCount, f.typ.elementStride, o - f.offset)
       else:
         return avrNoLocation
 
@@ -90,41 +87,30 @@ func testLocationType(locType: PVmType, t: PVmType): AccessViolationReason =
     else:
       return avrTypeMismatch
 
-func checkValid*(al: VmAllocator, a: MemRegionPtr, typ: PVmType): AccessViolationReason =
-  ## Tests if the handle with address `a` and type `typ` refers to a valid
-  ## location of type `typ`
-  let rp = cast[int](a.rawPointer)
 
-  result = avrOutOfBounds
+func checkValid(p: VmMemPointer, typ: PVmType, cell: VmCell): AccessViolationReason =
+  assert p.rawPointer >= cell.p, "memory not part of `cell`"
 
-  for x in al.regions.items:
-    if rp in x.start..<(x.start+x.len):
-      let rtyp = x.typ
-      let off = rp - x.start
-      if off > 0:
-        if x.count == 0:
-          let mp = makeMemPtr(cast[pointer](x.start), x.typ.sizeInBytes)
-          case x.typ.kind
-          of akObject:
-            result = searchInObject(mp, x.typ, typ, off)
-          of akArray:
-            result = searchInArray(mp, x.typ.elementType, typ, x.typ.elementCount, x.typ.elementStride, off)
-          else:
-            result = avrTypeMismatch
-        else:
-          if typ != nil:
-            let stride = rtyp.alignedSize.int
-            result = searchInArray(makeMemPtr(cast[pointer](x.start), uint(stride * x.count)), rtyp, typ, x.count, stride, off)
-          else:
-            unreachable()
-            #[
-            # untyped memory
-            if uint(off) + typ.sizeInBytes < uint(x.len):
-              result = avrNoError
-            else:
-              discard "size is past the region"
-            ]#
-      else:
-        result = testLocationType(rtyp, typ)
+  let off = cast[int](p) - cast[int](cell.p)
+  if off > 0:
+    # `p` is an interior pointer
+    if typ != nil:
+      # the cell stores either a single- or a contiguous sequence of locations
+      let stride = cell.typ.alignedSize.int
+      result = searchInArray(toOpenArray(cell.p, 0, int(cell.sizeInBytes-1)), cell.typ, typ, cell.count, stride, off)
+    else:
+      # untyped memory; not yet supported
+      unreachable()
+  else:
+    # `p` points to the start of the cell -- the most simple case. We only
+    # need to perform a type comparision
+    result = testLocationType(cell.typ, typ)
 
-      break
+func checkValid*(al: VmAllocator, h: LocHandle): AccessViolationReason =
+  ## Tests and returns whether the handle `h` is valid. That is, whether it
+  ## points to a valid memory cell and location and whether the handle's type
+  ## is compatible with that of the location.
+  if h.cell != -1:
+    checkValid(h.p, h.typ, al.cells[h.cell])
+  else:
+    avrOutOfBounds

--- a/compiler/vm/vmconv.nim
+++ b/compiler/vm/vmconv.nim
@@ -53,7 +53,7 @@ proc tryWriteTo*[T: seq](v: T, dest: LocHandle, mm: var VmMemoryManager): bool =
 
     let s = deref(dest).seqVal # shallow copy
     for i in 0..<v.len:
-      if tryWriteTo(v[i], s.getItemHandle(dest.typ, i), mm): discard
+      if tryWriteTo(v[i], s.getItemHandle(dest.typ, i, mm.allocator), mm): discard
       else: return false
 
     result = true

--- a/compiler/vm/vmhooks.nim
+++ b/compiler/vm/vmhooks.nim
@@ -91,4 +91,6 @@ proc getVar*(a: VmArgs; i: Natural): LocHandle =
   assert a.slots[si].kind == rkAddress
 
   # The address was validate by the VM prior the invoking the callback
-  makeLocHandle(a.slots[si].addrVal, a.slots[si].addrTyp)
+  # TODO: while currently always the case, an address register is not required
+  #       to store an address into guest memory, so casting is unsafe here
+  makeLocHandle(a.mem.allocator, a.slots[si].addrVal, a.slots[si].addrTyp)

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -158,7 +158,7 @@ template wrapIteratorInner(a: VmArgs, iter: untyped) =
   var i = 0
   for x in iter:
     s[].growBy(rh.typ, 1, a.mem[])
-    writeTo(x, getItemHandle(s[], rh.typ, i), a.mem[])
+    writeTo(x, getItemHandle(s[], rh.typ, i, a.mem.allocator), a.mem[])
     inc i
 
 template wrapIterator(fqname: string, iter: untyped) =
@@ -334,7 +334,7 @@ proc registerBasicOps*(c: var TCtx) =
     let n = writeFloatToBufferSprintf(temp, x)
     let oldLen = deref(p).strVal.len
     deref(p).strVal.setLen(oldLen + n, a.mem.allocator)
-    safeCopyMem(deref(p).strVal.data.subView(oldLen, n), temp, n)
+    safeCopyMem(deref(p).strVal.data.slice(oldLen, n), temp, n)
 
 proc registerIoReadOps*(c: var TCtx) =
   ## Registers callbacks for read operations from the ``io`` module

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -91,7 +91,7 @@ proc loadConst(s: PackedEnv, idx: int, dst: LocHandle,
 
     var i = 0
     while i < L:
-      result += loadConst(s, idx+1+result, getItemHandle(dst, i), mem)
+      result += loadConst(s, idx+1+result, getItemHandle(dst, i, mem.allocator), mem)
       inc i
 
   of akString:


### PR DESCRIPTION
Use a significantly more efficient design around handles, made possible by improvements to the VM's allocator:
1) assign allocated cells a stable ID that doesn't change until they're freed
2) store the ID of the underlying cell in `LocHandle` 3) when creating a `LocHandle` from a random address, the address is mapped to a cell ID
4) seqs and strings only store a `CellPtr` for their data, reducing their in-memory from 24 to 16 byte

As a consequence:
- the access check logic knows directly in which cell the location is located (or if at all) -- mapping the pointer to a cell via a linear search is no longer required
- freeing a cell identified by a `LocHandle` has O(1) complexity instead of O(n), where `n` is the number of in-use cells. Right now, all cells are identified by `LocHandle`s

This results in a significant speed up for code running in the VM, especially if it uses a large number of long-living cells (both stack and heap). For example, with a `-d:release` compiler, the `tunidecode.nim` test now takes ~14 seconds to compile, compared to the ~40 seconds it took previously.

## Details

### General changes

- remove `MemRegionPtr` and associated routines. It's usages are replaced with either `VmMemoryRegion` or `VmMemPointer`. Since the former is an `openArray`, this also make it easier for the compiler to reason about the code
- use more consistent naming and terminology

### Changes to `vmmemory`

- deduplicate logic across the `allocX` procedures
- remove the unused `allocAtomLocation`
- disable stack-traces for the allocator related routines
- use an intrusive linked-list to efficiently remember free cells, replacing the usage of `seq.del` and making cell IDs stable

### Access checks

- remove the never taken `count == 0` branch
- remove all pointer-to-cell-id mapping logic from `vmchecks`

### Other

- introduce `VmSlice`. While also an important preparation for full `openArray` support, it's current use is to simplify some logic

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this puts the VM on a good trajectory towards reaching the performance it had before the VM rework
* #548 will further speed up the VM, as with the PR, handles in the context of `var|lent T` stay as handles and are not unnecessarily turned into raw addresses.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
