### PR TITLE
sem: restructure call application handling

### DIFF
--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -135,25 +135,23 @@ proc pickBestCandidate(c: PContext,
 
 proc maybeResemArgs*(c: PContext, n: PNode, startIdx: int = 1): seq[PNode] =
   # HACK original implementation of the `describeArgs` used `semOperand`
-  # here, but until there is a clear understanding /why/ is it necessary to
-  # additionall call sem on the arguments I will leave this as it is now.
+  # here and it's unclear /why/ it's necessary, leaving it as is for now.
   # This was introduced in commit 5b0d8246f79730a473a869792f12938089ecced6
   # that "made some tests green" (+98/-77)
   for i in startIdx ..< n.len:
     var arg = n[i]
     case n[i].kind
     of nkExprEqExpr:
-      if arg.typ.isNil and arg.kind notin {nkStmtList, nkDo}:
+      if arg.typ.isNil: # and arg.kind notin {nkStmtList, nkDo}:
         # XXX we really need to 'tryExpr' here!
         arg = c.semOperand(c, n[i][1])
         arg = n[i][1]
         n[i].typ = arg.typ
         n[i][1] = arg
+    of nkStmtList, nkDo, nkElse, nkOfBranch, nkElifBranch, nkExceptBranch:
+      discard "`semOperand` is not required... for some reason?"
     else:
-      if arg.typ.isNil and arg.kind notin {
-           nkStmtList, nkDo, nkElse, nkOfBranch, nkElifBranch, nkExceptBranch
-         }:
-
+      if arg.typ.isNil:
         arg = c.semOperand(c, n[i])
         n[i] = arg
 

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -346,6 +346,10 @@ proc semGenericStmt(c: PContext, n: PNode,
     result = semGenericStmt(c, result, flags, ctx)
     if result.isError: return
   of nkBracketExpr:
+    # xxx: screwing up `nkBracketExpr` nodes like this does no one any favours.
+    #      instead, just pass them on and figure out what to do _later_ when
+    #      there is more context to make a decision. Instead, `semExpr` now has
+    #      to crudely recreate this information.
     result = newNodeI(nkCall, n.info)
     result.add newIdentNode(getIdent(c.cache, "[]"), n.info)
     for i in 0..<n.len: result.add(n[i])

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -811,6 +811,10 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       else:
         discard
   of nkBracketExpr:
+    # xxx: screwing up `nkBracketExpr` nodes like this does no one any favours.
+    #      instead, just pass them on and figure out what to do _later_ when
+    #      there is more context to make a decision. Instead, `semExpr` now has
+    #      to crudely recreate this information.
     result = newNodeI(nkCall, n.info)
     result.add newIdentNode(getIdent(c.c.cache, "[]"), n.info)
     for i in 0..<n.len: result.add(n[i])

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -188,7 +188,7 @@ dot operators
 .. note:: Dot operators are still experimental and so need to be enabled
   via `{.experimental: "dotOperators".}`.
 
-Nim offers a special family of dot operators that can be used to
+|NimSkull| offers a special family of dot operators that can be used to
 intercept and rewrite proc call and field access attempts, referring
 to previously undeclared symbol names. They can be used to provide a
 fluent interface to objects lying outside the static confines of the
@@ -240,10 +240,10 @@ This operator will be matched against assignments to missing fields.
 
 Call operator
 -------------
-The call operator, `()`, matches all kinds of unresolved calls and takes
-precedence over dot operators, however it does not match missing overloads
-for existing routines. The experimental `callOperator` switch must be enabled
-to use this operator.
+The call operator, `()`, matches all kinds of unresolved calls and has lower
+precedence than dot operators, and matches missing overloads for existing
+routines. The experimental `callOperator` switch must be enabled to use this
+operator.
 
 .. code-block:: nim
 

--- a/tests/errmsgs/twrongcolon.nim
+++ b/tests/errmsgs/twrongcolon.nim
@@ -1,9 +1,9 @@
 discard """
-errormsg: "in expression '(890)"
+errormsg: "in expression ' do:"
 nimout: '''
-twrongcolon.nim(10, 12) Error: in expression '(890)': identifier expected, but found ''
+twrongcolon.nim(10, 12) Error: in expression ' do:
+  890': identifier expected, but found ''
 '''
-
 
 """
 

--- a/tests/specialops/tcallops.nim
+++ b/tests/specialops/tcallops.nim
@@ -1,6 +1,12 @@
+discard """
+description: "Tests for the experimental call operator `()` overloading"
+"""
+
 import macros
 
 {.experimental: "callOperator".}
+
+# setup - declare up front so we can ensure overloading works
 
 type Foo[T: proc] = object
   callback: T
@@ -10,30 +16,61 @@ macro `()`(foo: Foo, args: varargs[untyped]): untyped =
   for a in args:
     result.add(a)
 
-var f1Calls = 0
-var f = Foo[proc()](callback: proc() = inc f1Calls)
-doAssert f1Calls == 0
-f()
-doAssert f1Calls == 1
-var f2Calls = 0
-f.callback = proc() = inc f2Calls
-doAssert f2Calls == 0
-f()
-doAssert f2Calls == 1
-
-let g = Foo[proc (x: int): int](callback: proc (x: int): int = x * 2 + 1)
-doAssert g(15) == 31
-
 proc `()`(args: varargs[string]): string =
   result = "("
   for a in args: result.add(a)
   result.add(')')
 
-let a = "1"
-let b = "2"
-let c = "3"
+macro `()`(args: varargs[untyped]): untyped =
+  # this should be picked last... based on current rules
+  result = newNimNode(nnkTupleConstr)
+  for i, a in args.pairs:
+    result.add(a.toStrLit)
 
-doAssert a(b) == "(12)"
-doAssert a.b(c) == `()`(b, a, c)
-doAssert (a.b)(c) == `()`(a.b, c)
-doAssert `()`(a.b, c) == `()`(`()`(b, a), c)
+block macro_over_some_foo:
+  var f1Calls = 0
+  var f = Foo[proc()](callback: proc() = inc f1Calls)
+  doAssert f1Calls == 0
+  f()
+  doAssert f1Calls == 1
+
+  # what if we change the callable?
+  var f2Calls = 0
+  f.callback = proc() = inc f2Calls
+  doAssert f2Calls == 0
+  f()
+  doAssert f2Calls == 1
+  doAssert f1Calls == 1 # `f1Calls` remains unscathed from our shenanigans
+
+  let g = Foo[proc (x: int): int](callback: proc (x: int): int = x * 2 + 1)
+  doAssert g(15) == 31
+
+block we_can_even_use_a_regular_proc:
+  # note it still dispatches correctly on params of type string
+
+  let a = "1"
+  let b = "2"
+  let c = "3"
+
+  doAssert a(b) == "(12)"
+  doAssert a.b(c) == `()`(b, a, c)
+  doAssert (a.b)(c) == `()`(a.b, c)
+  doAssert `()`(a.b, c) == `()`(`()`(b, a), c)
+
+block works_with_untyped_input:
+  # previously an error was reported for `doesNotExist` being undeclared
+  let something = 10
+
+  doAssert something(doesNotExist) == ("something", "doesNotExist")
+
+block does_not_interfere_with_ambiguous_lookups_requiring_overload_resolution:
+  # this was a regression
+  proc floop(input: string, len: int): string =
+    if input.len == len: # here the `len` proc must go through overload
+                         # resolution, instead of the call operator
+      "same length"
+    else:
+      "different lengths"
+
+  doAssert floop("test", 4) == "same length"
+  doAssert "test".floop(4) == "same length"

--- a/tests/specialops/tcallprecedence.nim
+++ b/tests/specialops/tcallprecedence.nim
@@ -23,17 +23,17 @@ macro `()`(args: varargs[typed]): untyped =
 macro `.`(args: varargs[typed]): untyped =
   result = newLit(". " & args.treeRepr)
 
-block:
+block dot_operators_precede_call_operator:
   let a = 1
   let b = 2
-  doAssert a.b == `()`(b, a)
+  doAssert a.b == `.`(a, b)
 
-block:
+block not_confused_by_overloads:
   let a = 1
   proc b(): int {.used.} = 2
   doAssert a.b == `.`(a, b)
 
-block:
+block existing_proc_vs_special_ops_fallback:
   let a = 1
   proc b(x: int): int = x + 1
   let c = 3


### PR DESCRIPTION
Summary
=======

- call operator now tries after failed overload resolution
- lower call operator `()` precedence

Major Fixes:
- overload resolution before call operator dispatch
- `()` overloads unable to receive untyped params
- `semIndirectOps` NPE (nil pointer exception)

Details
=======

Call Operator Precedence
------------------------

Lowered the `()` call operators precedence below the dot operators (`.`
and `.()`). Additionally, a number of associated changes resulted in
minor changes to error msg output. Along with additional tests, docs,
and the like. Many other fixes we

As of now the `()` will match last, and will also be a catchall for
unmatched overload resolutions -- previously a short coming.

This makes far more sense given the simple example `foo.bar()`. Here the
expectation is that `foo.bar` is:
1. a fully qualified identifier to a callable
2. a field access to a callable
3. method call syntax, requiring a dot transform
4. finally a fall back case via special operators

*Design Thinking*

The special operators are analoguous to Scala's `apply`/`unapply`. Long-
term this is the design direction, to enable fall backs for callables.

Presently, `()` receives `foo.bar`, implying that the expression
`foo.bar` should have already been evaluated. In which case, we should
have already attempted dot operator fallback. This is why the precedence
has been lowered. Alternatively, and not in keeping with the language,
the call operator should receive `bar`instead.

NB: The current behaviour is more correct, but unlikely "final".

Fixes
-----

*lower call operator precedence*
In some cases, where a call symbol was ambiguous, call operator dispath
would happen before overload resoltuion. This change now fixes that and
adds tests see `tests/specialops/tcallops`.

*untyped params for `()` overloads*
In addition, call operator (`()`) overloading couldn't receive untyped
arguments as they would be prematurely semantically analysed. This has
since been fixed, and the `tcallops` test been expanded to cover it.

*`semIndirectOps` NPE*
There was an NPE in `semDirectOps` logic, it's long standing, which is
indicative of this being a "pile of conditions" that sorta work, the
logic is entirely unsound.

Misc
====

Minor Improvements
------------------

- logic error `semOpAux`, some semantic errors in call operands would
  get overwrriten -- not sure how to reproduce this one
- `semExpr` now detects call errors sooner, slightly faster compiler
- clean-up misleading code in `maybeResemArgs` in `semcall`
- added additional call operator tests
- variety of docs for some of the procs, removal of dead code, and
  necessary stylistic clean-ups

"Fun Facts" Learned
-------------------

`nfDotField` and `nkSymChoices` are mutually exclusive for
`dotTransformations` (`nkDotExpr -> nkDotCall`)

Generic & template analysis both mangle `nkBranchExpr`. The current
implementation foolishly mangles `nkBracketExpr` to `nkCall` with a `[]`
callee symbol. This simply creates greater complexity within `semexprs`
module as it has to hackily reconstruct information and compensate for
this.

Closing Remark
--------------

As usual a big takeaway is that the existing implementation and
resulting language lack taste. By ~solving~ half-assing solutions in the
wrong places complexity and mistakes have spread throughout the code
base. This is just one small clean-up of many.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers

* largely speaking, the old code, design, ideas, are all objectively bad
* changes to behaviour are pretty much guarantees
* with that in mind, the new code should be:
  * easier to reason about
  * preserve many/most things, at least in spirit

### Personal Note:

The existing code genuinely upsets me, this rework isn't a "fun" process, though
I'm looking forward to the outcome. I don't intend to mollify anyone upset about
some esoteric, half-baked, unsound, or objectively bad thing being changed or
removed.