### PR TITLE
vmgen/vm: conversion-related improvements

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -941,6 +941,7 @@ type
     adVmNodeNotASymbol
     adVmNodeNotAProcSymbol
     adVmIllegalConv
+    adVmIllegalConvFromXToY
     adVmMissingCacheKey
     adVmCacheKeyAlreadyExists
     adVmFieldNotFound
@@ -961,7 +962,7 @@ type
         callName*: string
         argAst*: PNode
         argPos*: int
-      of adVmCannotCast:
+      of adVmCannotCast, adVmIllegalConvFromXToY:
         formalType*: PType
         actualType*: PType
       of adVmIndexError:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -309,6 +309,7 @@ type
     rvmNodeNotASymbol
     rvmNodeNotAProcSymbol
     rvmIllegalConv
+    rvmIllegalConvFromXToY
     rvmMissingCacheKey
     rvmCacheKeyAlreadyExists
     rvmFieldNotFound

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -317,7 +317,7 @@ template wrap*(rep: ReportTypes): Report =
 func `$`*(point: ReportLineInfo): string =
   point.file & "(" & $point.line & ", " & $point.col & ")"
 
-func actualType*(r: SemReport | VMReport): PType = r.typeMismatch[0].actualType
-func formalType*(r: SemReport | VMReport): PType = r.typeMismatch[0].formalType
+func actualType*(r: SemReport): PType = r.typeMismatch[0].actualType
+func formalType*(r: SemReport): PType = r.typeMismatch[0].formalType
 func formalTypeKind*(r: SemReport): set[TTypeKind] = r.typeMismatch[0].formalTypeKind
 func symstr*(r: SemReport | VMReport): string = r.sym.name.s

--- a/compiler/ast/reports_vm.nim
+++ b/compiler/ast/reports_vm.nim
@@ -24,8 +24,8 @@ type
         stacktrace*: seq[tuple[sym: PSym, location: TLineInfo]]
         skipped*: int
 
-      of rvmCannotCast:
-        typeMismatch*: seq[SemTypeMismatch]
+      of rvmCannotCast, rvmIllegalConvFromXToY:
+        actualType*, formalType*: PType
 
       of rvmIndexError:
         indexSpec*: tuple[usedIdx, minIdx, maxIdx: Int128]

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3501,6 +3501,10 @@ proc reportBody*(conf: ConfigRef, r: VMReport): string =
   of rvmIllegalConv:
     result = r.str
 
+  of rvmIllegalConvFromXToY:
+    result = "illegal conversion from '$1' to '$2'" %
+             [$r.actualType, $r.formalType]
+
   of rvmFieldNotFound:
     result = "node lacks field: " & r.str
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -431,6 +431,7 @@ func astDiagVmToLegacyReportKind*(
   of adVmNodeNotASymbol: rvmNodeNotASymbol
   of adVmNodeNotAProcSymbol: rvmNodeNotAProcSymbol
   of adVmIllegalConv: rvmIllegalConv
+  of adVmIllegalConvFromXToY: rvmIllegalConvFromXToY
   of adVmMissingCacheKey: rvmMissingCacheKey
   of adVmCacheKeyAlreadyExists: rvmCacheKeyAlreadyExists
   of adVmFieldNotFound: rvmFieldNotFound
@@ -1212,14 +1213,13 @@ func astDiagToLegacyReport*(diag: PAstDiag): Report {.inline.} =
       location = diag.location
 
     case kind
-    of rvmCannotCast:
+    of rvmCannotCast, rvmIllegalConvFromXToY:
       vmRep = VMReport(
         kind: kind,
         location: std_options.some location,
         reportInst: diag.instLoc.toReportLineInfo,
-        typeMismatch:
-          @[SemTypeMismatch(actualType: diag.vmErr.actualType,
-                            formalType: diag.vmErr.formalType)])
+        actualType: diag.vmErr.actualType,
+        formalType: diag.vmErr.formalType)
     of rvmIndexError:
       vmRep = VMReport(
         location: std_options.some location,
@@ -1285,9 +1285,8 @@ func astDiagToLegacyReport*(diag: PAstDiag): Report {.inline.} =
         location: std_options.some location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: rvmCannotCast,
-        typeMismatch:
-          @[SemTypeMismatch(actualType: diag.vmGenErr.actualType,
-                            formalType: diag.vmGenErr.formalType)])
+        actualType: diag.vmGenErr.actualType,
+        formalType: diag.vmGenErr.formalType)
     of adVmGenCodeGenUnhandledMagic,
         adVmGenMissingImportcCompleteStruct:
       vmRep = VMReport(

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -83,7 +83,7 @@ type
     opcMulSet, opcPlusSet, opcMinusSet, opcConcatStr,
     opcContainsSet, opcRepr, opcSetLenStr, opcSetLenSeq,
     opcIsNil, opcOf,
-    opcParseFloat, opcConv, opcCast,
+    opcParseFloat, opcConv, opcObjConv, opcCast
     opcQuit, opcInvalidField,
     opcNarrowS, opcNarrowU,
     opcSignExtend,
@@ -179,5 +179,5 @@ type
 const
   firstABxInstr* = opcTJmp
   largeInstrs* = { # instructions which use 2 int32s instead of 1:
-    opcConv, opcCast, opcNewSeq, opcOf}
+    opcConv, opcObjConv, opcCast, opcNewSeq, opcOf}
   relativeJumps* = {opcTJmp, opcFJmp, opcJmp, opcJmpBack}

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -664,6 +664,7 @@ type
     vmEvtNodeNotASymbol
     vmEvtNodeNotAProcSymbol
     vmEvtIllegalConv
+    vmEvtIllegalConvFromXToY
     vmEvtMissingCacheKey
     vmEvtCacheKeyAlreadyExists
     vmEvtFieldNotFound
@@ -688,7 +689,7 @@ type
         callName*: string
         argAst*: PNode
         argPos*: int
-      of vmEvtCannotCast:
+      of vmEvtCannotCast, vmEvtIllegalConvFromXToY:
         typeMismatch*: VmTypeMismatch
       of vmEvtIndexError:
         indexSpec*: tuple[usedIdx, minIdx, maxIdx: Int128]
@@ -981,7 +982,8 @@ template regBx*(x: TInstr): int = (x.TInstrType shr regBxShift and regBxMask).in
 template jmpDiff*(x: TInstr): int = regBx(x) - wordExcess
 
 template isNil*(p: VmMemPointer | CellPtr): bool = p.rawPointer == nil
-template isNil*(h: HeapSlotHandle): bool = int(h) == 0
+template isNil*(h: HeapSlotHandle): bool = ord(h) == 0
+template isNotNil*(h: HeapSlotHandle): bool = ord(h) != 0
 
 const noneType*: PVmType = nil
 

--- a/compiler/vm/vmlegacy.nim
+++ b/compiler/vm/vmlegacy.nim
@@ -54,9 +54,8 @@ func vmGenDiagToLegacyVmReport*(diag: VmGenDiag): VMReport {.inline.} =
         location: std_options.some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: rvmCannotCast,
-        typeMismatch:
-          @[SemTypeMismatch(actualType: diag.typeMismatch.actualType,
-                            formalType: diag.typeMismatch.formalType)])
+        actualType: diag.typeMismatch.actualType,
+        formalType: diag.typeMismatch.formalType)
     of vmGenDiagCodeGenUnhandledMagic,
         vmGenDiagMissingImportcCompleteStruct:
       VMReport(

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -269,6 +269,7 @@ func vmEventToLegacyReportKind(evt: VmEventKind): ReportKind {.inline.} =
   of vmEvtNodeNotASymbol: rvmNodeNotASymbol
   of vmEvtNodeNotAProcSymbol: rvmNodeNotAProcSymbol
   of vmEvtIllegalConv: rvmIllegalConv
+  of vmEvtIllegalConvFromXToY: rvmIllegalConvFromXToY
   of vmEvtMissingCacheKey: rvmMissingCacheKey
   of vmEvtCacheKeyAlreadyExists: rvmCacheKeyAlreadyExists
   of vmEvtFieldNotFound: rvmFieldNotFound
@@ -287,14 +288,13 @@ func vmEventToLegacyVmReport(
   let kind = evt.kind.vmEventToLegacyReportKind()
   result =
     case kind
-    of rvmCannotCast:
+    of rvmCannotCast, rvmIllegalConvFromXToY:
       VMReport(
         kind: kind,
         location: location,
         reportInst: evt.instLoc.toReportLineInfo,
-        typeMismatch:
-          @[SemTypeMismatch(actualType: evt.typeMismatch.actualType,
-                            formalType: evt.typeMismatch.formalType)])
+        actualType: evt.typeMismatch.actualType,
+        formalType: evt.typeMismatch.formalType)
     of rvmIndexError:
       VMReport(
         location: location,

--- a/tests/lang_defs/distinct/tdistinct.nim
+++ b/tests/lang_defs/distinct/tdistinct.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c js"
+  targets: "c js vm"
   output: '''
 tdistinct
 25

--- a/tests/lang_exprs/tlvalue_conv_assignment.nim
+++ b/tests/lang_exprs/tlvalue_conv_assignment.nim
@@ -1,0 +1,101 @@
+discard """
+  labels: "subtyping conversion distinct"
+  description: '''
+    Assigning to the result of an lvalue conversion must modify the underlying
+    location
+  '''
+  targets: "c js vm"
+  matrix: "--gc:refc; --gc:orc"
+"""
+
+type
+  Base = object of RootObj
+  A = object of Base
+  B = object of A
+
+  Obj[T] = object
+    field: T
+
+block ref_and_ptr_conversion:
+  proc test[A, B, C](def: C) =
+    block down_conv_local:
+      var x = def
+      # assignment to down-converted local:
+      B(x) = nil
+      doAssert x == nil
+
+      x = def
+
+      # assignment to down-converted local (nested):
+      A(B(x)) = nil
+      doAssert x == nil
+
+    block up_conv_local:
+      var x = A(def)
+      # assignment to up-converted local:
+      B(x) = nil
+      doAssert x == nil
+
+      x = A(def)
+
+      # assignment to up-converted local (nested):
+      C(B(x)) = nil
+      doAssert x == nil
+
+    block down_conv_field:
+      # assignment to down-converted field:
+      var x = Obj[C](field: def)
+      B(x.field) = nil
+      doAssert x.field == nil
+
+      # assignment to down-converted field (nested):
+      x = Obj[C](field: def)
+      A(B(x.field)) = nil
+      doAssert x.field == nil
+
+    block up_conv_field:
+      # assignment to up-converted field:
+      var x = Obj[C](field: def)
+      B(x.field) = nil
+      doAssert x.field == nil
+
+      # assignment to up-converted field (nested):
+      x = Obj[C](field: def)
+      C(B(x.field)) = nil
+      doAssert x.field == nil
+
+  # conversions involving refs:
+  test[ref Base, ref A, ref B](new(B))
+
+  # conversions involving ptrs:
+  when not defined(vm): # XXX: not yet supported by ``vmgen``
+    var obj = B()
+    test[ptr Base, ptr A, ptr B](addr obj)
+
+block distinct_conversion:
+  proc test[T, Base](a: T, b: Base) =
+    block to_base:
+      var x = a
+      Base(x) = b
+      doAssert Base(x) == b
+
+    block from_base:
+      var x = b
+      T(x) = a
+      doAssert x == Base(a)
+
+    block to_base_field:
+      var x = Obj[T](field: a)
+      Base(x.field) = b
+      doAssert Base(x.field) == b
+
+    block from_base_field:
+      var x = Obj[Base](field: b)
+      T(x.field) = a
+      doAssert x.field == Base(a)
+
+  type DInt = distinct int
+
+  when not defined(vm):
+    # XXX: crashes the compiler
+    test(DInt(1), 2)


### PR DESCRIPTION
## Summary

Refactor the conversion-related parts in `vmgen`, which fixes multiple bugs and issues with code running in the VM:
- conversions where the source was of `sink` or `static` type always created a full copy
- lvalue-ness was not preserved for conversions to or from `distinct T` types was not always preserved
- assignments where the left-hand side is an lvalue conversion didn't update the destination location in some cases (such as for `ref`s or field assignments)

In addition, the VM access checks are now less strict: accessing a `ref|ptr T` location with a handle of `ref|ptr X` is allowed, as long as `X` is either a sub- or super-type of `T`.

## Details

Move the conversion logic for `ref`s and `objects` to a new instruction (`opcObjConv`). Compared to the previously used `opcConv`, using a dedicated conversion operator has the benefits that:
- only one type argument is required instead of two, meaning that the instruction can be encoded with two instead of three instruction words
- no full RTTI is required

For `opConv`:
- remove the `initLocReg` calls -- making sure that the destination location is set-up is now the responsibility of the code generator
- remove the catch-all branch

### Other

- fold `PointerLike(nil)` expressions into correctly typed `nkNilLit`s during `transf`

### Misc

- move the rendering of VM type conversion diagnostics to `cli_reporter` by introducing the dedicated `vmEvtIllegalConvFromXToY` event/diagnostic
- store the formal and actual type for VM type conversion reports directly, instead of as a `seq[TypeMismatch]`

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this is a split-off from #548, with additional improvements and fixes 

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
