### PR TITLE
internals: `useNodeIds` now tracks outgoing copies

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -466,6 +466,9 @@ template copyNodeImpl(dst, src, processSonsStmt) =
   when defined(useNodeIds):
     if dst.id == nodeIdToDebug:
       echo "COMES FROM ", src.id
+    elif src.id == nodeIdToDebug:
+      echo "GOES TO ", dst.id
+      writeStackTrace()
   case src.kind
   of nkCharLit..nkUInt64Lit: dst.intVal = src.intVal
   of nkFloatLiterals: dst.floatVal = src.floatVal


### PR DESCRIPTION
## Summary

`-d:useNodeIds` now tracks copies made from the observed node id

## Details

When the compiler is compiled with `-d:useNodeIds` it used to output a
"comes from" debug message when a node was created by copy with an id
matching `ast.nodeIdToDebug`. Now, it will also output a "goes to"
message when a node is created from a node with the matching id.

Hopefully it's more useful for compiler developers.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* quick win from the call application refactor