### PR TITLE
vm: make `opcExpandToAst` more flexible

### DIFF
--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -129,6 +129,7 @@ type
     opcGetImpl,
     opcGetImplTransf,
 
+    opcDataToAst,   ## deserialize data to NimNode AST
     opcExpandToAst,
 
     opcEcho,


### PR DESCRIPTION
## Summary

The `ExpandToAst` operation was previously responsible for turning each arguments' value into `PNode` AST in order for them to be passed to `evalTemplate`. For providing the `PType` of each argument, the AST of the original template call expression was passed as the first operand.

Since this approach would become a problem once `vmgen` no longer operates on `PNode` AST, a different one is required: the deserialization logic is moved to a dedicated operation (`opcDataToAst`) taking the value and the destination type as input, with `vmgen` emitting the instruction for arguments to template calls.

## Details

- add the `opcDataToAst` operation
- clean up the `opcExpandToAst` implementation
- adjust the logic for `mExpandToAst` and clean up / improve the code

### Misc

- fix `regToNode` not initializing the resulting node's line information

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* split off from #551

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
