### PR TITLE
Remove the `.deprecated` redirection feature

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -700,7 +700,6 @@ type
                           ## file (it is loaded on demand, which may
                           ## mean: never)
     skPackage             ## symbol is a package (used for canonicalization)
-    skAlias               ## an alias (needs to be resolved immediately)
 
   TSymKinds* = set[TSymKind]
 
@@ -708,7 +707,7 @@ type
 const
   routineKinds* = {skProc, skFunc, skMethod, skIterator,
                    skConverter, skMacro, skTemplate}
-  ExportableSymKinds* = {skVar, skLet, skConst, skType, skEnumField, skStub, skAlias} + routineKinds
+  ExportableSymKinds* = {skVar, skLet, skConst, skType, skEnumField, skStub} + routineKinds
 
   tfUnion* = tfNoSideEffect
   tfGcSafe* = tfThread
@@ -1078,7 +1077,6 @@ type
     adSemBorrowPragmaNonDot
     adSemInvalidExtern
     adSemBadDeprecatedArg
-    adSemBadDeprecatedArgs
     adSemMisplacedEffectsOf
     adSemMissingPragmaArg
     adSemCannotPushCast
@@ -1248,7 +1246,6 @@ type
         adSemLocksPragmaBadLevelString,
         adSemBorrowPragmaNonDot,
         adSemBadDeprecatedArg,
-        adSemBadDeprecatedArgs,
         adSemMisplacedEffectsOf,
         adSemMissingPragmaArg,
         adSemCannotPushCast,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -783,7 +783,6 @@ type
     rsemInvalidExtern
     rsemInvalidPragmaBlock
     rsemBadDeprecatedArg
-    rsemBadDeprecatedArgs
     rsemMisplacedEffectsOf
     rsemMissingPragmaArg
     rsemErrGcUnsafe

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -930,10 +930,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "invalid extern name: '" & r.externName & "'. (Forgot to escape '$'?)"
 
     of rsemBadDeprecatedArg:
-      result = "key:value pair expected"
-
-    of rsemBadDeprecatedArgs:
-      result = "list of key:value pairs expected"
+      result = "string literal expected"
 
     of rsemInvalidPragma:
       result = "invalid pragma: " & r.ast.render

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -507,7 +507,6 @@ func astDiagToLegacyReportKind*(
   of adSemBorrowPragmaNonDot: rsemBorrowPragmaNonDot
   of adSemInvalidExtern: rsemInvalidExtern
   of adSemBadDeprecatedArg: rsemBadDeprecatedArg
-  of adSemBadDeprecatedArgs: rsemBadDeprecatedArgs
   of adSemMisplacedEffectsOf: rsemMisplacedEffectsOf
   of adSemMissingPragmaArg: rsemMissingPragmaArg
   of adSemCannotPushCast: rsemCannotPushCast
@@ -710,7 +709,6 @@ func astDiagToLegacyReport*(diag: PAstDiag): Report {.inline.} =
       adSemLocksPragmaExpectsList,
       adSemBorrowPragmaNonDot,
       adSemBadDeprecatedArg,
-      adSemBadDeprecatedArgs,
       adSemMisplacedEffectsOf,
       adSemMissingPragmaArg,
       adSemCannotPushCast,

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -57,8 +57,6 @@ proc getSysSym*(g: ModuleGraph; info: TLineInfo; name: string): PSym =
     result = newSym(
       skError, getIdent(g.cache, name), nextSymId(g.idgen), g.systemModule, g.systemModule.info, {})
     result.typ = newType(tyError, nextTypeId(g.idgen), g.systemModule)
-  if result.kind == skAlias:
-    result = result.owner
 
 
 proc getSysMagic*(g: ModuleGraph; info: TLineInfo; name: string, m: TMagic): PSym =

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -960,44 +960,8 @@ proc deprecatedStmt(c: PContext; outerPragma: PNode): PNode =
     if c.module.constraint.kind == nkError:
       result = wrapError(c.config, outerPragma)
 
-    return
-  elif pragma.kind != nkBracket:
-    result = c.config.newError(pragma, PAstDiag(kind: adSemBadDeprecatedArgs))
-  
-    return
-
-  for n in pragma:
-    if n.kind in nkPragmaCallKinds and n.len == 2:
-      let dest = qualifiedLookUp(c, n[1], {checkUndeclared})
-  
-      if dest == nil or dest.kind in routineKinds or dest.kind == skError:
-        # xxx: warnings need to be figured out, also this is just silly, why
-        #      are they unreliable?
-        localReport(c.config, n.info, SemReport(kind: rsemUserWarning))
-  
-      let (src, err) = considerQuotedIdent(c, n[0])
-
-      if err.isNil:
-        let alias = newSym(skAlias, src, nextSymId(c.idgen), dest, n[0].info, c.config.options)
-        incl(alias.flags, sfExported)
-  
-        if sfCompilerProc in dest.flags:
-          let e = markCompilerProc(c, alias)
-  
-          if e != nil:
-            result = e
-            return
-  
-        addInterfaceDecl(c, alias)
-        n[1] = newSymNode(dest)
-      else:
-        result = err
-
-        return
-    else:
-      result = c.config.newError(n, PAstDiag(kind: adSemBadDeprecatedArgs))
-
-      return
+  else:
+    result = c.config.newError(pragma, PAstDiag(kind: adSemBadDeprecatedArg))
 
 proc pragmaGuard(c: PContext; it: PNode; kind: TSymKind): PSym =
   if it.kind notin nkPragmaCallKinds or it.len != 2:

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -126,7 +126,7 @@ proc lookup(c: PContext, n: PNode, flags: TSemGenericFlags,
     result = err
     return
   var amb = false
-  var s = searchInScopes(c, ident, amb).skipAlias(n, c.config)
+  var s = searchInScopes(c, ident, amb)
   if s == nil:
     s = strTableGet(c.pureEnumFields, ident)
     #if s != nil and contains(c.ambiguousSymbols, s.id):
@@ -171,7 +171,7 @@ proc fuzzyLookup(c: PContext, n: PNode, flags: TSemGenericFlags,
       result[1] = err
       result = c.config.wrapError(result)
       return
-    let candidates = searchInScopesFilterBy(c, ident, routineKinds) # .skipAlias(n, c.config)
+    let candidates = searchInScopesFilterBy(c, ident, routineKinds)
     if candidates.len > 0:
       let s = candidates[0] # XXX take into account the other candidates!
       isMacro = s.kind in {skTemplate, skMacro}

--- a/doc/nimfix.rst
+++ b/doc/nimfix.rst
@@ -12,12 +12,10 @@
 Nimfix is a tool to help you upgrade from Nimrod (<= version 0.9.6) to
 Nim (=> version 0.10.0).
 
-It performs 3 different actions:
+It performs 2 different actions:
 
 1. It makes your code case consistent.
-2. It renames every symbol that has a deprecation rule. So if a module has a
-   rule `{.deprecated: [TFoo: Foo].}` then `TFoo` is replaced by `Foo`.
-3. It can also check that your identifiers adhere to the official style guide
+2. It can also check that your identifiers adhere to the official style guide
    and optionally modify them to do so (via `--styleCheck:auto`).
 
 Note that `nimfix` defaults to **overwrite** your code unless you

--- a/lib/wrappers/mysql.nim
+++ b/lib/wrappers/mysql.nim
@@ -60,7 +60,6 @@ type
     COM_CONNECT_OUT, COM_REGISTER_SLAVE, COM_STMT_PREPARE, COM_STMT_EXECUTE,
     COM_STMT_SEND_LONG_DATA, COM_STMT_CLOSE, COM_STMT_RESET, COM_SET_OPTION,
     COM_STMT_FETCH, COM_END
-{.deprecated: [Tenum_server_command: Enum_server_command].}
 
 const
   SCRAMBLE_LENGTH* = 20 # Length of random string sent by server on handshake;
@@ -195,7 +194,6 @@ type
 
   NET* = St_net
   PNET* = ptr NET
-{.deprecated: [Tst_net: St_net, TNET: NET].}
 
 const
   packet_error* = - 1
@@ -209,7 +207,6 @@ type
     TYPE_TINY_BLOB = 249, TYPE_MEDIUM_BLOB = 250, TYPE_LONG_BLOB = 251,
     TYPE_BLOB = 252, TYPE_VAR_STRING = 253, TYPE_STRING = 254,
     TYPE_GEOMETRY = 255
-{.deprecated: [Tenum_field_types: Enum_field_types].}
 
 const
   CLIENT_MULTI_QUERIES* = CLIENT_MULTI_STATEMENTS
@@ -258,9 +255,6 @@ type
     CURSOR_TYPE_FOR_UPDATE = 2, CURSOR_TYPE_SCROLLABLE = 4
   Enum_mysql_set_option* = enum
     OPTION_MULTI_STATEMENTS_ON, OPTION_MULTI_STATEMENTS_OFF
-{.deprecated: [Tenum_shutdown_level: Enum_shutdown_level,
-              Tenum_cursor_type: Enum_cursor_type,
-              Tenum_mysql_set_option: Enum_mysql_set_option].}
 
 proc my_net_init*(net: PNET, vio: PVIO): my_bool{.cdecl, dynlib: lib,
     importc: "my_net_init".}
@@ -284,7 +278,6 @@ proc my_net_read*(net: PNET): int{.cdecl, dynlib: lib, importc: "my_net_read".}
 type
   Psockaddr* = ptr Sockaddr
   Sockaddr*{.final.} = object  # undefined structure
-{.deprecated: [Tsockaddr: Sockaddr].}
 
 proc my_connect*(s: my_socket, name: Psockaddr, namelen: cuint, timeout: cuint): cint{.
     cdecl, dynlib: lib, importc: "my_connect".}
@@ -321,9 +314,6 @@ type
 
   UDF_INIT* = St_udf_init
   PUDF_INIT* = ptr UDF_INIT   # Constants when using compression
-{.deprecated: [Trand_stuct: Rand_struct, TItem_result: Item_result,
-              Tst_udf_args: St_udf_args, TUDF_ARGS: UDF_ARGS,
-              Tst_udf_init: St_udf_init, TUDF_INIT: UDF_INIT].}
 
 const
   NET_HEADER_SIZE* = 4        # standard header size
@@ -427,8 +417,6 @@ type
   ROW* = cstringArray
   PFIELD_OFFSET* = ptr FIELD_OFFSET # offset to current field
   FIELD_OFFSET* = cuint
-{.deprecated: [Tst_mysql_field: St_mysql_field, TFIELD: FIELD, TROW: ROW,
-              TFIELD_OFFSET: FIELD_OFFSET].}
 
 proc IS_PRI_KEY*(n: int32): bool
 proc IS_NOT_NULL*(n: int32): bool
@@ -454,8 +442,6 @@ type
   PROWS* = ptr ROWS
   PROW_OFFSET* = ptr ROW_OFFSET # offset to current row
   ROW_OFFSET* = ROWS
-{.deprecated: [Tst_mysql_rows: St_mysql_rows, TROWS: ROWS,
-              TROW_OFFSET: ROW_OFFSET].}
 
 const
   ALLOC_MAX_BLOCK_TO_DROP* = 4096
@@ -485,8 +471,6 @@ type
 
   MEM_ROOT* = St_mem_root
   PMEM_ROOT* = ptr MEM_ROOT   #  ------------ Stop of declaration in "my_alloc.h"    ----------------------
-{.deprecated: [Tst_used_mem: St_used_mem, TUSED_MEM: USED_MEM,
-              Tst_mem_root: St_mem_root, TMEM_ROOT: MEM_ROOT].}
 
 type
   Pst_mysql_data* = ptr St_mysql_data
@@ -506,7 +490,6 @@ type
     OPT_WRITE_TIMEOUT, OPT_USE_RESULT, OPT_USE_REMOTE_CONNECTION,
     OPT_USE_EMBEDDED_CONNECTION, OPT_GUESS_CONNECTION, SET_CLIENT_IP,
     SECURE_AUTH, REPORT_DATA_TRUNCATION, OPT_RECONNECT
-{.deprecated: [Tst_mysql_data: St_mysql_data, TDATA: DATA, Toption: Option].}
 
 const
   MAX_MYSQL_MANAGER_ERR* = 256
@@ -803,19 +786,6 @@ type
 
   Enum_stmt_attr_type* = enum
     STMT_ATTR_UPDATE_MAX_LENGTH, STMT_ATTR_CURSOR_TYPE, STMT_ATTR_PREFETCH_ROWS
-{.deprecated: [Tst_dynamic_array: St_dynamic_array, Tst_mysql_options: St_mysql_options,
-              TDYNAMIC_ARRAY: DYNAMIC_ARRAY, Tprotocol_type: Protocol_type,
-              Trpl_type: Rpl_type, Tcharset_info_st: Charset_info_st,
-              TCHARSET_INFO: CHARSET_INFO, Tcharacter_set: Character_set,
-              TMY_CHARSET_INFO: MY_CHARSET_INFO, Tst_mysql: St_mysql,
-              Tst_mysql_methods: St_mysql_methods, TMySql: MySql,
-              Tst_mysql_res: St_mysql_res, TMETHODS: METHODS, TRES: RES,
-              Tst_mysql_manager: St_mysql_manager, TMANAGER: MANAGER,
-              Tst_mysql_parameters: St_mysql_parameters, TPARAMETERS: PARAMETERS,
-              Tenum_mysql_stmt_state: Enum_mysql_stmt_state,
-              Tst_mysql_bind: St_mysql_bind, TBIND: BIND, Tst_mysql_stmt: St_mysql_stmt,
-              TSTMT: STMT, Tenum_stmt_attr_type: Enum_stmt_attr_type,
-              Tstatus: Status].}
 
 proc server_init*(argc: cint, argv: cstringArray, groups: cstringArray): cint{.
     cdecl, dynlib: lib, importc: "mysql_server_init".}

--- a/tests/deprecated/tdeprecated.nim
+++ b/tests/deprecated/tdeprecated.nim
@@ -1,9 +1,7 @@
 discard """
   nimout: '''
-tdeprecated.nim(23, 3) Warning: a is deprecated [Deprecated]
-tdeprecated.nim(30, 11) Warning: asdf; enum 'Foo' which contains field 'a' is deprecated [Deprecated]
-tdeprecated.nim(40, 16) Warning: use fooX instead; fooA is deprecated [Deprecated]
-end
+tdeprecated.nim(21, 3) Warning: a is deprecated [Deprecated]
+tdeprecated.nim(28, 11) Warning: asdf; enum 'Foo' which contains field 'a' is deprecated [Deprecated]
 '''
 """
 
@@ -28,15 +26,3 @@ block t10111:
       a 
   
   var _ = a
-  
-
-block: # issue #8063
-  type
-    Foo = enum
-      fooX
-
-  {.deprecated: [fooA: fooX].}
-  let
-    foo: Foo = fooA
-  echo foo
-  static: echo "end"


### PR DESCRIPTION
## Summary

The `{.deprecated: [old, new].}` feature, originally introduced for providing information to `nimfix`, can be implemented as a library solution and doesn't need compiler support.

Since `skAlias` was only used for these redirections, the symbol kind is also removed, which simplifies lookup a bit, as alias symbols no longer need to be considered there.

## Details

The only user of the redirection feature was the `mysql` module; all usages there are now removed, meaning that code still using the deprecated enum names needs to be adjusted.

- remove the now unused `adSemBadDeprecatedArgs` and `rsemBadDeprecatedArgs` diagnostics
- update the `rsemBadDeprecatedArg` message

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* the removal was discussed [here](https://matrix.to/#/!MAXxvfCYnfYgZqSizw:matrix.org/$eig05VobpBjyZUrpNO5PN1N5a8Bs7hv88C1hxLV_clg?via=libera.chat&via=matrix.org&via=envs.net)

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
