### PR TITLE
fix backend & ex/internal errors handling

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -148,6 +148,7 @@ type
     ## or 'list' value.
     rextExpectedCmdArgument ## Command-line option expected argument
     rextExpectedNoCmdArgument ## Command-line option expected no arguments
+    rextCmdDisallowsAdditionalArguments ## command disallows additional args
     rextInvalidNumber ## Command-line switch expected a number
     rextInvalidValue
     rextUnexpectedValue ## Command-line argument had value, but it did not
@@ -918,7 +919,7 @@ type
     #---------------------------  Backend reports  ---------------------------#
     # errors start
     rbackCannotWriteScript ## Cannot write build script to a cache file
-    rbackCannotWriteMappingFile ## Canot write module compilation mapping
+    rbackCannotWriteMappingFile ## Cannot write module compilation mapping
     ## file to cache directory
     rbackTargetNotSupported ## C compiler does not support requested target
     rbackJsTooCaseTooLarge

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2951,7 +2951,12 @@ proc reportBody*(conf: ConfigRef, r: ExternalReport): string =
       result = "argument for command line option expected: '$1'" % r.cmdlineSwitch
 
     of rextExpectedNoCmdArgument:
-      result = "invalid argument for command line option: '$1'" % r.cmdlineSwitch
+      result = "invalid argument ('$1') for command line option: '$2'" %
+                  [r.cmdlineProvided, r.cmdlineSwitch]
+
+    of rextCmdDisallowsAdditionalArguments:
+      result = "$1 command does not support additional arguments: '$2'" %
+                  [r.cmdlineSwitch, r.cmdlineProvided]
 
     of rextInvalidNumber:
       result = "$1 is not a valid number" % r.cmdlineProvided
@@ -3753,44 +3758,48 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
   # be written.
   if wkind == writeDisabled:
     return
-  elif r.kind in rdbgTracerKinds and conf.isDefined(traceDir):
-    rotatedTrace(conf, r)
-  elif wkind == writeForceEnabled:
-    echo conf.reportFull(r)
-  elif r.kind == rsemProcessing and conf.hintProcessingDots:
-    # xxx: the report hook is handling processing dots output, why? this whole
-    #      infrastructure is overwrought. seriously, they're not hints, they're
-    #      progress indicators.
-    conf.write(".")
-    lastDot = true
   else:
-    var msg: seq[string]
-    if lastDot:
-      msg.add("")
-      lastDot = false
+    if r.kind in rdbgTracerKinds and conf.isDefined(traceDir):
+      rotatedTrace(conf, r)
+    elif wkind == writeForceEnabled:
+      echo conf.reportFull(r)
+    elif r.kind == rsemProcessing and conf.hintProcessingDots:
+      # xxx: the report hook is handling processing dots output, why? this whole
+      #      infrastructure is overwrought. seriously, they're not hints, they're
+      #      progress indicators.
+      conf.write(".")
+      lastDot = true
+    else:
+      var msg: seq[string]
+      if lastDot:
+        msg.add("")
+        lastDot = false
 
-    if conf.hack.reportInTrace:
-      var indent {.global.}: int
-      if r.kind == rdbgTraceStep:
-        indent = r.dbgTraceReport.semstep.level
+      if conf.hack.reportInTrace:
+        var indent {.global.}: int
 
-      case r.kind:
+        case r.kind:
         of rdbgTracerKinds:
+          if r.kind == rdbgTraceStep:
+            indent = r.dbgTraceReport.semstep.level
           msg.add(conf.reportFull(r))
         of repSemKinds:
-          if 0 < indent:
+          if indent > 0:
             for line in conf.reportFull(r).splitLines():
               msg.add("  ]" & repeat("  ", indent) & " ! " & line)
           else:
             msg.add(conf.reportFull(r))
         else:
           msg.add(conf.reportFull(r))
-    else:
-      msg.add(conf.reportFull(r))
+      else:
+        msg.add(conf.reportFull(r))
 
-    if conf.hack.bypassWriteHookForTrace:
-      for item in msg:
-        echo item
-    else:
-      for item in msg:
-        conf.writeln(item)
+      if conf.hack.bypassWriteHookForTrace:
+        for item in msg:
+          echo item
+      else:
+        for item in msg:
+          conf.writeln(item)
+  if r.category in {repInternal, repExternal, repBackend} and
+      conf.severity(r) in {rsevFatal, rsevError}:
+    result = doAbort

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -257,12 +257,12 @@ proc processOnOffSwitchG(conf: ConfigRef; op: TGlobalOptions, arg: string, pass:
 proc expectArg(conf: ConfigRef; switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
   if arg == "":
     conf.localReport ExternalReport(
-      kind: rextExpectedCmdArgument, cmdlineProvided: switch, cmdlineSwitch: switch)
+      kind: rextExpectedCmdArgument, cmdlineSwitch: switch)
 
 proc expectNoArg(conf: ConfigRef; switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
   if arg != "":
     conf.localReport ExternalReport(
-      kind: rextExpectedNoCmdArgument, cmdlineProvided: switch, cmdlineSwitch: switch)
+      kind: rextExpectedNoCmdArgument, cmdlineProvided: arg, cmdlineSwitch: switch)
 
 proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
                          info: TLineInfo; orig: string; conf: ConfigRef) =

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -297,20 +297,17 @@ proc errorActions(
   if conf.isCompilerFatal(report):
     # Fatal message such as ICE (internal compiler), errFatal,
     result = (doAbort, true)
-
   elif conf.isCodeError(report):
     # Regular code error
     inc(conf.errorCounter)
     conf.exitcode = 1'i8
 
-    if conf.errorMax <= conf.errorCounter:
+    if conf.errorCounter >= conf.errorMax:
       # only really quit when we're not in the new 'nim check --def' mode:
       if conf.ideCmd == ideNone:
         result = (doAbort, false)
-
     elif eh == doAbort and conf.cmd != cmdIdeTools:
       result = (doAbort, false)
-
     elif eh == doRaise:
       result = (doRaise, false)
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -115,18 +115,18 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
         # `The parameter is incorrect`
       execExternalProgram(
         conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments, rcmdExecuting)
-
     of cmdDocLike, cmdRst2html, cmdRst2tex: # bugfix(cmdRst2tex was missing)
       if conf.arguments.len > 0:
         # reserved for future use
         localReport(conf, ExternalReport(
-          kind: rextExpectedNoCmdArgument, cmdlineSwitch: $conf.cmd))
-
+          kind: rextCmdDisallowsAdditionalArguments,
+          cmdlineSwitch: $conf.command,
+          cmdlineProvided: conf.arguments))
       openDefaultBrowser($output)
     else:
       # support as needed
       localReport(conf, ExternalReport(
-        kind: rextUnexpectedRunOpt, cmdlineSwitch: $conf.cmd))
+        kind: rextUnexpectedRunOpt, cmdlineSwitch: $conf.command))
 
 when declared(GC_setMaxPause):
   GC_setMaxPause 2_000


### PR DESCRIPTION
## Summary

Backend, external, and internal errors abort on fatal/error severities. Also
some error message clean-up.

## Details

Error Message Clean-up:

- cli options getting an unexpected value shows value in error message
- clearer error message when extra arguments provided to `doc` command

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* noticed this issue when looking to remove more reports stuff
* it's not perfect and meant mostly as a stop gap