### PR TITLE
pragmas: rework processing and application

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -591,13 +591,6 @@ type
     nfDefaultRefsParam ## a default param value references another parameter
                        ## the flag is applied to proc default values and to calls
     nfHasComment ## node has a comment
-    nfImplicitPragma ## node is a "singlePragma" this is a transition flag
-                  ## created as part of nkError refactoring for the pragmas
-                  ## module. an old proc, `singlePragma` did a lot of side-
-                  ## effects and returned a bool signal to callers typically to
-                  ## either break a loop and raise an error in
-                  ## `pragmas.implicitPragmas` or simply break a loop in
-                  ## `pragmas.pragmaRec`.
 
   TNodeFlags* = set[TNodeFlag]
   TTypeFlag* = enum   ## keep below 32 for efficiency reasons (now: 43)
@@ -1073,7 +1066,6 @@ type
     adSemLocksPragmaBadLevelString
     adSemBorrowPragmaNonDot
     adSemInvalidExtern
-    adSemBadDeprecatedArg
     adSemMisplacedEffectsOf
     adSemMissingPragmaArg
     adSemCannotPushCast
@@ -1255,7 +1247,6 @@ type
         adSemLocksPragmaBadLevelRange,
         adSemLocksPragmaBadLevelString,
         adSemBorrowPragmaNonDot,
-        adSemBadDeprecatedArg,
         adSemMisplacedEffectsOf,
         adSemMissingPragmaArg,
         adSemCannotPushCast,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -784,7 +784,6 @@ type
     rsemBorrowPragmaNonDot
     rsemInvalidExtern
     rsemInvalidPragmaBlock
-    rsemBadDeprecatedArg
     rsemMisplacedEffectsOf
     rsemMissingPragmaArg
     rsemErrGcUnsafe

--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -67,7 +67,6 @@ type
     wSinkInference = "sinkInference", wWarnings = "warnings",
     wHints = "hints", wOptimization = "optimization", wRaises = "raises",
     wWrites = "writes", wReads = "reads", wSize = "size", wEffects = "effects", wTags = "tags",
-    wAssert = "assert",
     wDeadCodeElimUnused = "deadCodeElim",  # deprecated, dead code elim always happens
     wSafecode = "safecode", wPackage = "package",
     wNoRewrite = "norewrite", wNoDestroy = "nodestroy", wPragma = "pragma",

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -933,9 +933,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemInvalidExtern:
       result = "invalid extern name: '" & r.externName & "'. (Forgot to escape '$'?)"
 
-    of rsemBadDeprecatedArg:
-      result = "string literal expected"
-
     of rsemInvalidPragma:
       result = "invalid pragma: " & r.ast.render
 
@@ -1640,7 +1637,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = r.str
 
     of rsemImplicitPragmaError:
-      result = "???"
+      result = "application of implicit pragma failed"
 
     of rsemInvalidModulePath:
       result = "invalid path: " & r.str
@@ -3821,7 +3818,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemLinePragmaExpectsTuple,
       adSemLocksPragmaExpectsList,
       adSemBorrowPragmaNonDot,
-      adSemBadDeprecatedArg,
       adSemMisplacedEffectsOf,
       adSemMissingPragmaArg,
       adSemCannotPushCast,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -461,7 +461,6 @@ func astDiagToLegacyReportKind*(
   of adSemLocksPragmaBadLevelString: rsemLocksPragmaBadLevel
   of adSemBorrowPragmaNonDot: rsemBorrowPragmaNonDot
   of adSemInvalidExtern: rsemInvalidExtern
-  of adSemBadDeprecatedArg: rsemBadDeprecatedArg
   of adSemMisplacedEffectsOf: rsemMisplacedEffectsOf
   of adSemMissingPragmaArg: rsemMissingPragmaArg
   of adSemCannotPushCast: rsemCannotPushCast

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3711,7 +3711,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkUsingStmt: result = semUsing(c, n)
   of nkAsmStmt: result = semAsm(c, n)
   of nkYieldStmt: result = semYield(c, n)
-  of nkPragma: result = pragma(c, c.p.owner, n, stmtPragmas, true)
+  of nkPragma: result = pragmaStmt(c, n, c.p.owner)
   of nkIteratorDef: result = semIterator(c, n)
   of nkProcDef: result = semProc(c, n)
   of nkFuncDef: result = semFunc(c, n)

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -384,7 +384,7 @@ proc generateInstance(c: PContext, fn: PSym, pt: TIdTable,
     addToGenericProcCache(c, fn, entry)
     c.generics.add(makeInstPair(fn, entry))
     if n[pragmasPos].kind != nkEmpty:
-      result.ast[pragmasPos] = pragma(c, result, n[pragmasPos], allRoutinePragmas)
+      result.ast[pragmasPos] = pragmaDecl(c, result, n[pragmasPos], allRoutinePragmas)
       # check if we got any errors and if so report them
       for e in ifErrorWalkErrors(c.config, result.ast[pragmasPos]):
         localReport(c.config, e)

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -1016,18 +1016,14 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   result[namePos] = newSymNode(s)
   result[pragmasPos] = n[pragmasPos]
 
-  discard pragmaCallable(c, s, result, templatePragmas) # just check pragmasPos
+  if n[pragmasPos].kind != nkEmpty:
+    result[pragmasPos] = pragmaDeclNoImplicit(c, s, n[pragmasPos], templatePragmas)
+
+  result[pragmasPos] = implicitPragmas(c, s, result[pragmasPos], templatePragmas)
 
   if result[pragmasPos].kind == nkError:
     hasError = true
-  
-  # this should return the same `s` if there were no errors
-  s = implicitPragmas(c, s, n.info, templatePragmas)
 
-  if s.isError:
-    result[namePos] = s.ast
-    hasError = true
-  
   result[genericParamsPos] = n[genericParamsPos]
   result[miscPos] = n[miscPos]
 

--- a/nimsuggest/tests/ttype_highlight.nim
+++ b/nimsuggest/tests/ttype_highlight.nim
@@ -1,9 +1,9 @@
 type
   TypeA = int
   TypeB* = int
-  TypeC {.unchecked.} = array[1, int]
+  TypeC {.exportc.} = int
   TypeD[T] = T
-  TypeE* {.unchecked.} = array[0, int]#[!]#
+  TypeE* {.exportc.} = int#[!]#
 
 discard """
 $nimsuggest --tester $file
@@ -15,13 +15,11 @@ highlight;;skType;;5;;2;;5
 highlight;;skType;;6;;2;;5
 highlight;;skType;;2;;10;;3
 highlight;;skType;;3;;11;;3
-highlight;;skType;;4;;24;;5
-highlight;;skType;;4;;33;;3
+highlight;;skType;;4;;22;;3
 highlight;;skType;;5;;13;;1
-highlight;;skType;;6;;25;;5
-highlight;;skType;;6;;34;;3
+highlight;;skType;;6;;23;;3
 highlight;;skType;;2;;10;;3
 highlight;;skType;;3;;11;;3
-highlight;;skType;;4;;33;;3
-highlight;;skType;;6;;34;;3
+highlight;;skType;;4;;22;;3
+highlight;;skType;;6;;23;;3
 """

--- a/tests/lang_callable/generics/tparser_generator.nim
+++ b/tests/lang_callable/generics/tparser_generator.nim
@@ -363,7 +363,8 @@ proc `->`*(rule: Rule, production: Rule) =
   doAssert(not isnil(production.parser), "Right hand side of -> is nil - has the rule been defined yet?")
   rule.parser = production.parser
 
-template grammar*[K](Kind, Text, Symbol: typedesc; default: K, code: untyped): typed {.hint[XDeclaredButNotUsed]: off.} =
+template grammar*[K](Kind, Text, Symbol: typedesc; default: K, code: untyped): typed =
+    {.push hint[XDeclaredButNotUsed]: off.}
 
     proc newRule(): Rule[Kind, Text] {.inject.} = newRule[Kind, Text](default)
     proc chartest(testfunc: proc(c: Symbol): bool): Rule[Kind, Text] {.inject.} = chartest[Kind, Text, Symbol](testfunc, default)
@@ -395,8 +396,12 @@ template grammar*[K](Kind, Text, Symbol: typedesc; default: K, code: untyped): t
 
     code
 
-template grammar*[K](Kind: typedesc; default: K, code: untyped): typed {.hint[XDeclaredButNotUsed]: off.} =
+    {.pop.}
+
+template grammar*[K](Kind: typedesc; default: K, code: untyped): typed =
+  {.push hint[XDeclaredButNotUsed]: off.}
   grammar(Kind, string, char, default, code)
+  {.pop.}
 
 block:
   type DummyKind = enum dkDefault

--- a/tests/pragmas/teffects.nim
+++ b/tests/pragmas/teffects.nim
@@ -1,0 +1,21 @@
+discard """
+  description: "Tests for the `.effects.` pragma"
+  action: compile
+  nimout: '''
+Hint: ref IOError
+ [rsemEffectsListingHint]
+Hint: ref IOError
+ref ValueError
+ [rsemEffectsListingHint]'''
+"""
+
+proc p(cond: bool) =
+  if cond:
+    raise IOError.newException("")
+    {.effects.}
+  else:
+    raise ValueError.newException("")
+
+  {.effects.}
+
+p(false)

--- a/tests/pragmas/tno_implicit_pragmas.nim
+++ b/tests/pragmas/tno_implicit_pragmas.nim
@@ -1,0 +1,36 @@
+discard """
+  description: '''
+    Block and statement pragmas don't inherit implicit (i.e. pushed) pragmas
+  '''
+  action: compile
+"""
+
+import std/macros
+
+template custom(x: int) {.pragma.}
+
+macro verify(x: typed) =
+  ## Verifies that the pragma list doesn't contain the ``custom`` pragma
+  expectKind(x, nnkSym)
+  let impl = x.getImpl()
+
+  for it in impl.pragma.items:
+    if it.kind == nnkCall and it[0].kind == nnkSym and
+        it[0] == bindSym"custom":
+      error("the `custom` pragma was found!", it)
+
+proc p() =
+  {.push custom(1).}
+
+  # the content doesn't matter, as long as the pragma list contains at least
+  # one item (in order to prevent them from getting optimized away, now or in
+  # the future)
+  {.cast(noSideEffect).}:
+    discard
+
+  {.hints: off.}
+
+  {.pop.}
+
+# ``p`` must not have the ``custom`` pragma attached!
+verify(p)

--- a/tests/pragmas/tpush_no_cast.nim
+++ b/tests/pragmas/tpush_no_cast.nim
@@ -1,0 +1,5 @@
+discard """
+  errormsg: "a 'cast' pragma cannot be pushed"
+"""
+
+{.push cast(noSideEffect).}

--- a/tests/pragmas/tvar_macro.nim
+++ b/tests/pragmas/tvar_macro.nim
@@ -6,7 +6,7 @@ import macros
 block: # test usage
   macro modify(sec) =
     result = copy sec
-    result[0][0] = ident(repr(result[0][0]) & "Modified")
+    result[0][0][0] = ident(repr(result[0][0][0]) & "Modified")
 
   block:
     let foo {.modify.} = 3
@@ -22,7 +22,7 @@ block: # test usage
 block: # with single argument
   macro appendToName(name: static string, sec) =
     result = sec
-    result[0][0] = ident(repr(result[0][0]) & name)
+    result[0][0][0] = ident(repr(result[0][0][0]) & name)
 
   block:
     let foo {.appendToName: "Bar".} = 3
@@ -37,7 +37,7 @@ block: # with single argument
 
 macro appendToNameAndAdd(name: static string, incr: static int, sec) =
   result = sec
-  result[0][0] = ident(repr(result[0][0]) & name)
+  result[0][0][0] = ident(repr(result[0][0][0]) & name)
   result[0][2] = infix(result[0][2], "+", newLit(incr))
 
 block: # with multiple arguments


### PR DESCRIPTION
## Summary

Processing and application of pragmas during the first semantic
analysis pass was all done by a single routine used for all three
contexts (declarations, statements, blocks), leading to complex
code with lots of conditional logic.


The rework is meant to make future changes to pragmas easier and the
code better to understand, while also adjusting or streamlining the
semantics of some pragmas.

### General changes

- implicit pragmas (i.e. those passed to the `.push` pragma) no longer
  affect pragma statements and pragma blocks
- pragma lists in on identdefs that become empty after macro/template
  pragma application are kept, instead of being replaced with an
  `nkEmpty` node
- allow custom pragmas on iterators (both `.closure` and `.inline`)

### Pragma changes

- the `.linksys` (unused) and `.unchecked` (redundant) pragmas are
  removed
- the `.deprecated` statement's message can now be supplied by a
  constant expression
- `.cast` pragmas cannot be `push`ed anymore
- note-setting pragmas (e.g. `.hint[X]: on`) are now only allowed in
  pragma statements
- `.pure` is now disallowed in pragma statements. It could previously
  be used to mark the enclosing entity (routine or module) as `pure`
- a pushed `.dynlib` now only applies to routines (except templates)
- allow `.stackTrace` and `.lineTrace` on iterators

## Details

For pragmas on declarations and for blocks, analysis and application
are separated into two sequential steps, where first all pragmas are
analysed (`.pragma` pragmas expanded, custom pragmas resolved, early
rejection of unapplicable pragmas) and then all non-erroneous ones
applied.

Since a single pragma in statement can alter note state (which could
affect analysis of the pragmas following it), analysis and application
for statement pragmas happens in an intertwined manner.

Handling of the three special pragmas `.pragma`, `.push`, and `.pop`
no longer relies on a node flag (`nfImplicitPragma`, which is now
removed), but instead happens separately from the other pragmas.

In order to remove the extra arguments previously passed to the
`pragma` procedure, each context where pragmas are applied now uses its
own dedicated procedure.

In general, `nkError` node propagation is improved and the amount of
input AST mutations reduced.

---

## To-do
- [x] apply implicit pragmas to all declarations again
- [x] wrap errors occurring during application of pushed pragmas (i.e. implicit pragmas) in `adSemImplicitPragmaError`s
- [x] use more consistent naming
- [x] write a commit message

## Notes for reviewers
- the goal is to make further changes/improvements to pragma easier and the code easier to navigate