### PR TITLE
drop `legacyRelProj` from `--filenames` CLI switch

### DIFF
--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -1137,24 +1137,19 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "stdout":
     processOnOffSwitchG(conf, {optStdout}, arg, pass, info, switch)
   of "filenames":
+    # xxx: this and `listfullpaths` needs to be reconsidered, this isn't quite
+    #      a global thing that past approaches have attempted.
     case arg.normalize
     of "abs": conf.filenameOption = foAbs
     of "canonical": conf.filenameOption = foCanonical
-    of "legacyrelproj": conf.filenameOption = foLegacyRelProj
-    else:
-      conf.localReport(info, invalidSwitchValue @["abs", "canonical", "legacyRelProj"])
-
+    else: conf.localReport(info, invalidSwitchValue @["abs", "canonical"])
+  of "listfullpaths":
+    conf.filenameOption = if switchOn(arg): foAbs else: foCanonical
   of "msgformat":
-    case arg.normalize:
-      of "text":
-        conf.setReportHook cli_reporter.reportHook
-
-      of "sexp":
-        conf.setReportHook sexp_reporter.reportHook
-
-      else:
-        conf.localReport(info, invalidSwitchValue @["text", "sexp"])
-
+    case arg.normalize
+    of "text": conf.setReportHook cli_reporter.reportHook
+    of "sexp": conf.setReportHook sexp_reporter.reportHook
+    else:      conf.localReport(info, invalidSwitchValue @["text", "sexp"])
   of "processing":
     incl(conf, cnCurrent, rsemProcessing)
     incl(conf, cnMainPackage, rsemProcessing)
@@ -1168,9 +1163,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       conf.localReport(info, invalidSwitchValue @["dots", "filenames", "off"])
   of "unitsep":
     conf.unitSep = if switchOn(arg): "\31" else: ""
-  of "listfullpaths":
-    # xxx in future work, use `warningDeprecated`
-    conf.filenameOption = if switchOn(arg): foAbs else: foCanonical
   of "spellsuggest":
     if arg.len == 0: conf.spellSuggestMax = spellSuggestSecretSauce
     elif arg == "auto": conf.spellSuggestMax = spellSuggestSecretSauce

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -170,7 +170,6 @@ type
     foAbs           ## absolute path, e.g.: /pathto/bar/foo.nim
     foRelProject    ## relative to project path, e.g.: ../foo.nim
     foCanonical     ## canonical module name
-    foLegacyRelProj ## legacy, shortest of (foAbs, foRelProject)
     foName          ## lastPathPart, e.g.: foo.nim
     foStacktrace    ## if optExcessiveStackTrace: foAbs else: foName
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -165,14 +165,6 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
     let absPath = toFullPath(conf, fileIdx)
     result = canonicalImportAux(conf, absPath.AbsoluteFile)
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
-  of foLegacyRelProj:
-    let
-      absPath = toFullPath(conf, fileIdx)
-      relPath = toProjPath(conf, fileIdx)
-    result = if (relPath.len > absPath.len) or (relPath.count("..") > 2):
-               absPath
-             else:
-               relPath
   of foStacktrace:
     if optExcessiveStackTrace in conf.globalOptions:
       result = toFilenameOption(conf, fileIdx, foAbs)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -38,7 +38,7 @@ Advanced options:
   --stdout:on|off           output to stdout
   --colors:on|off           turn compiler messages coloring on|off
   --msgFormat:text|sexp     Select compiler message format - text or S-expressions
-  --filenames:abs|canonical|legacyRelProj
+  --filenames:abs|canonical
                             customize how filenames are rendered in compiler messages,
                             defaults to `abs` (absolute)
   --processing:dots|filenames|off

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -11,7 +11,6 @@ switch("excessiveStackTrace", "off")
 
 when (NimMajor, NimMinor, NimPatch) >= (1,5,1):
   # to make it easier to test against older nim versions, (best effort only)
-  switch("filenames", "legacyRelProj")
   switch("spellSuggest", "0")
 
 # for std/unittest


### PR DESCRIPTION
## Summary

Removes the `legacyRelProj` option from the switch, leaving `"abs"` and `"canonical"`.

## Details

Left a comment to consolidate/revisit `--filenames` and `--listfullpaths` switches.

---

## Notes for Reviewers
* less is more