### PR TITLE
front: rework `--eval`

### DIFF
--- a/compiler/front/scriptconfig.nim
+++ b/compiler/front/scriptconfig.nim
@@ -232,7 +232,6 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
       setResult(a, stdin.readAll())
 
 proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
-                   idgen: IdGenerator;
                    freshDefines=true; conf: ConfigRef, stream: PLLStream) =
 
   conf.localReport DebugReport(
@@ -263,7 +262,7 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
 
   var m = graph.makeModule(scriptName)
   incl(m.flags, sfMainModule)
-  var vm = setupVM(m, cache, scriptName.string, graph, idgen)
+  var vm = setupVM(m, cache, scriptName.string, graph, graph.idgen)
   let disallowDanger =
     defined(nimsuggest) or graph.config.cmd == cmdCheck or
     vmopsDanger notin graph.config.features

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -127,8 +127,11 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags, fr
     onProcessing(graph, fileIdx, moduleStatus, fromModule = fromModule)
     var s: PLLStream
     if sfMainModule in flags:
-      if graph.config.projectIsStdin: s = stdin.llStreamOpen
-      elif graph.config.projectIsCmd: s = llStreamOpen(graph.config.cmdInput)
+      s =
+        case graph.config.inputMode
+        of pimStdin: llStreamOpen(stdin)
+        of pimCmd:   llStreamOpen(graph.config.commandArgs[0])
+        of pimFile:  nil # handled by ``processModule``
     discard processModule(graph, result, idGeneratorFromModule(result), s)
 
   if result == nil:

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -31,9 +31,8 @@ Options:
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
-  --eval:cmd                evaluate nim code directly; e.g.: `nim --eval:"echo 1"`
-                            defaults to `e` (nimscript) but customizable:
-                            `nim r --eval:'for a in stdin.lines: echo a'`
+  --fromCmd                 treat the 'projectfile' argument as the contents of
+                            the project file
   --fullhelp                show all command line switches
   -h, --help                show this help
   -v, --version             show detailed version information

--- a/tests/compilerunits/confread/treport_filtering.nim
+++ b/tests/compilerunits/confread/treport_filtering.nim
@@ -67,7 +67,7 @@ proc cfgPass*(file: string, args: seq[string]): ConfigRef =
 
   var cache = newIdentCache()
   var graph = newModuleGraph(cache, result)
-  loadConfigs(DefaultConfig, cache, result, graph.idgen)
+  loadConfigs(DefaultConfig, cache, result)
 
 proc assertInter[T](inters: set[T], want: set[T] = {}) =
   doAssert inters == want, $want


### PR DESCRIPTION
## Summary

The `--eval` option was previously responsible for two things:
- if no command was specified yet, changing the command to `e`
- overriding the content of the main module with the given argument

Its implementation was scattered and the behaviour not very intuitive, so the option is simplified:
- it no longer accepts an operand, but instead uses the second command- line argument as the main modules content
- it doesn't set the active main command anymore

In addition, the option is renamed to `fromcmd` in order to better match its new behaviour. Example usage: `nim e --fromcmd "echo 1"`

One thing that is now no longer possible is overriding the contents of the main module while still using the provided project path.

## Details

- instead of multiple booleans, the source mode for the main module is now provided via an enum
- remove the now unused state previously required by the `--eval` implementation
- perform project name and path initialization in a single place (`processCmdLineAndProjectPath`)
- adjust the `truner.nim` test, which made use of `--eval`

### NimScript execution

When executing a NimScript file by either using the `e` command or only providing the path of a NimScript file, running the script now happens when during main command processing, instead of during configuration loading.

### Misc

Remove the `IdGenerator` parameter from `runNimScript`. The `IdGenerator` of the `ModuleGraph` used for executing the NimScript is passed to the VM context setup instead, which is a step towards sandboxing/isolating NimScript execution.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* being able to provide the code to compile on the command-line (without using the standard input) seemed like a useful feature, so I opted to keep it.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
