### PR TITLE
adjust the `.compileTime` pragma's semantics

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -373,7 +373,8 @@ type
     sfShadowed        ## a symbol that was shadowed in some inner scope
     sfThread          ## proc will run as a thread
                       ## variable is a thread variable
-    sfCompileTime     ## proc can be evaluated at compile time
+    sfCompileTime     ## proc can only be used in compile time contexts;
+                      ## global is accessible in compile time contexts
     sfDispatcher      ## copied method symbol is the dispatcher
                       ## deprecated and unused, except for the con
     sfBorrow          ## proc is borrowed
@@ -1134,6 +1135,7 @@ type
     adSemCannotInferTypeOfLiteral
     adSemProcHasNoConcreteType
     adSemPragmaDisallowedForTupleUnpacking
+    adSemIllegalCompileTime
     adSemDifferentTypeForReintroducedSymbol
     adSemThreadvarCannotInit
     adSemWrongNumberOfVariables
@@ -1270,6 +1272,7 @@ type
         adSemInvalidExpression,
         adSemExpectedNonemptyPattern,
         adSemPragmaDisallowedForTupleUnpacking,
+        adSemIllegalCompileTime,
         adSemThreadvarCannotInit,
         adSemLetNeedsInit,
         adSemConstExpressionExpected,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -738,6 +738,10 @@ type
       ## underspecified. This is not a matter of reenabling it as a rethinking
       ## the approach from a first principles perspective is required.
 
+    rsemIllegalCompileTime
+      ## when used on variables, the ``.compileTime`` pragma must only be
+      ## applied to locals inside compile-time procedures or to globals
+
     rsemSymbolKindMismatch
     rsemIllformedAst
     rsemInitHereNotAllowed

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -899,6 +899,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         "this is a know design issue; as a work around split pragmas and " &
         "unpacking into two steps."
 
+    of rsemIllegalCompileTime:
+      result = "the '.compileTime' pragma must only be used with locals inside" &
+               " compile-time-only procedures or with globals."
+
     of rsemPragmaOptionExpected:
       result = "option expected"
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -559,6 +559,7 @@ func astDiagToLegacyReportKind*(
   of adSemCannotInferTypeOfLiteral: rsemCannotInferTypeOfLiteral
   of adSemProcHasNoConcreteType: rsemProcHasNoConcreteType
   of adSemPragmaDisallowedForTupleUnpacking: rsemPragmaDisallowedForTupleUnpacking
+  of adSemIllegalCompileTime: rsemIllegalCompileTime
   of adSemDifferentTypeForReintroducedSymbol: rsemDifferentTypeForReintroducedSymbol
   of adSemThreadvarCannotInit: rsemThreadvarCannotInit
   of adSemTypeKindMismatch: rsemTypeKindMismatch
@@ -733,6 +734,7 @@ func astDiagToLegacyReport*(diag: PAstDiag): Report {.inline.} =
       adSemInvalidExpression,
       adSemExpectedNonemptyPattern,
       adSemPragmaDisallowedForTupleUnpacking,
+      adSemIllegalCompileTime,
       adSemThreadvarCannotInit,
       adSemLetNeedsInit,
       adSemConstExpressionExpected,

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1277,11 +1277,7 @@ proc prepareSinglePragma(
         result = processMagic(c, it, sym)
       of wCompileTime:
         result = noVal(c, it)
-        if comesFromPush:
-          if sym.kind in {skProc, skFunc}:
-            incl(sym.flags, sfCompileTime)
-        else:
-          incl(sym.flags, sfCompileTime)
+        incl(sym.flags, sfCompileTime)
       of wGlobal:
         result = noVal(c, it)
         sym.flags.incl {sfGlobal, sfPure}

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -830,6 +830,15 @@ proc semNormalizedLetOrVar(c: PContext, n: PNode, symkind: TSymKind): PNode =
           # xxx: helpful hints like this should call a proc with a better name
           localReport(c.config, defPart.info, reportSem(rsemResultShadowed))
 
+    if not v.isError and sfCompileTime in v.flags:
+      if c.inCompileTimeOnlyContext:
+        # ignore ``.compileTime`` when the definition is already located in
+        # a compile-time-only context
+        excl(v.flags, sfCompileTime)
+      elif sfGlobal notin v.flags:
+        v.transitionToError:
+          c.config.newError(r, PAstDiag(kind: adSemIllegalCompileTime))
+
     if v.isError:
       producedDecl[i] = newSymNode2(v)
       hasError = true

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6385,7 +6385,7 @@ Is the same as:
   proc astHelper(n: NimNode): NimNode {.compileTime.} =
     result = n
 
-`compileTime` variables are available at runtime too. This simplifies certain
+`compileTime` globals are available at runtime too. This simplifies certain
 idioms where variables are filled at compile-time (for example, lookup tables)
 but accessed at runtime:
 
@@ -6410,6 +6410,9 @@ but accessed at runtime:
 
   doAssert nameToProc[2][1]() == "baz"
 
+For locals defined inside compile-time-only routines, the `compileTime`
+pragma is ignored -- for all other locals, using the pragma is a semantic
+error.
 
 noreturn pragma
 ---------------

--- a/tests/pragmas/tpragma_compiletime_var.nim
+++ b/tests/pragmas/tpragma_compiletime_var.nim
@@ -1,0 +1,75 @@
+discard """
+  description: "Tests for the '.compileTime' pragma"
+  targets: "c !js vm"
+"""
+
+# knownIssue: support for accessing a ``.compileTime`` variable at run-time is
+#             not properly implemented in the JS backend
+
+template test(global: int) {.dirty.} =
+  block:
+    # make sure that the global can be accessed in a compile-time context
+    static:
+      doAssert global == 1
+      global = 2
+
+    const c = global
+    static:
+      doAssert c == 2
+
+  block:
+    # make sure that the global can be accessed in a run-time context
+    doAssert global == 1
+    global = 2
+    doAssert global == 2
+
+# top-level global
+var g {.compileTime.} = 1
+test(g)
+
+block static_global:
+  static:
+    var inner {.compileTime.} = 1 # the pragma is a no-op
+    doAssert inner == 1
+    inner = 2
+    doAssert inner == 2
+
+block procedure_global:
+  proc p() =
+    var pg {.compileTime, global.} = 1
+    test(pg)
+
+    when false: # XXX: doesn't work because of an unrelated issue
+      static:
+        # the procedure itself is not compile-time-only, but `inner` is defined in a
+        # compile-time-only context, so the `.compileTime` is valid (and a no-op)
+        var inner {.compileTime.} = 1
+        doAssert inner == 1
+        inner = 2
+        doAssert inner == 2
+
+  static:
+    p() # also has to work when `p` is executed at compile-time
+  p()
+
+block compiletime_proc:
+  proc p() {.compileTime.} =
+    var local {.compileTime.} = 1 # the pragma is treated as a no-op
+    doAssert local == 1
+    local = 2
+    doAssert local == 2
+
+  static:
+    # call the procedure twice to make sure that `local` is really a `local`
+    p()
+    p()
+
+block compiletime_macro:
+  macro m() = # a macro is implicitly a compile-time procedure
+    var local {.compileTime.} = 1 # the pragma is a no-op
+    doAssert local == 1
+    local = 2
+    doAssert local == 2
+
+  m()
+  m()

--- a/tests/pragmas/tpragma_compiletime_var_error.nim
+++ b/tests/pragmas/tpragma_compiletime_var_error.nim
@@ -1,0 +1,13 @@
+discard """
+  description: '''
+    The '.compileTime' pragma is only allowed for globals or with location
+    declarations in compile-time-only contexts
+  '''
+  nimoutformat: "sexp"
+  cmd: "nim check --filenames=canonical --msgFormat=sexp $options $file"
+"""
+
+block non_compiletime_only_procedure:
+  proc p() =
+    var local {.compileTime.} = 1 #[tt.Error
+             ^ (SemIllegalCompileTime)]#


### PR DESCRIPTION
## Summary

Adjust the semantics of the `.compileTime` pragma regarding locals in order to make it compose better and to slightly simplify/clean-up the implementation. The pragma is now:
- disallowed for locals not defined inside a compile-time-only routine
- treated as a no-op when used with locals defined inside a compile- time-only routine

## Details

### General changes

- add a dedicated error diagnostic for reporting illegal usage of the `.compileTime` pragma
- update the "compileTime pragma" section in the manual

### Semantic analysis changes

- apply the `.compileTime` pragma to all symbols (on which it is usable) during pragma application

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this fixes a blocker of #573

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
