### PR TITLE
cli: removed deprecated flags

### DIFF
--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -63,7 +63,7 @@ type
     wFloatChecks = "floatChecks", wNanChecks = "nanChecks", wInfChecks = "infChecks",
     wStyleChecks = "styleChecks", wStaticBoundchecks = "staticBoundChecks"
 
-    wAssertions = "assertions", wPatterns = "patterns", wTrMacros = "trmacros",
+    wAssertions = "assertions", wTrMacros = "trmacros",
     wSinkInference = "sinkInference", wWarnings = "warnings",
     wHints = "hints", wOptimization = "optimization", wRaises = "raises",
     wWrites = "writes", wReads = "reads", wSize = "size", wEffects = "effects", wTags = "tags",

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -99,7 +99,7 @@ const
     wDeadCodeElimUnused,  # deprecated, always on
     wDeprecated,
     wFloatChecks, wInfChecks, wNanChecks, wPragma, wEmit,
-    wLinearScanEnd, wPatterns, wTrMacros, wEffects, wComputedGoto,
+    wLinearScanEnd, wTrMacros, wEffects, wComputedGoto,
     wExperimental, wUsed, wAssert}
   lambdaPragmas* = {FirstCallConv..LastCallConv,
     wNoSideEffect, wSideEffect, wNoreturn, wNosinks, wDynlib, wHeader,
@@ -477,7 +477,7 @@ proc pragmaToOptions(w: TSpecialWord): TOptions {.inline.} =
   of wMemTracker: {optMemTracker}
   of wByRef: {optByRef}
   of wImplicitStatic: {optImplicitStatic}
-  of wPatterns, wTrMacros: {optTrMacros}
+  of wTrMacros: {optTrMacros}
   of wSinkInference: {optSinkInference}
   else: {}
 
@@ -1514,7 +1514,7 @@ proc prepareSinglePragma(
          wOverflowChecks, wNilChecks, wAssertions, wWarnings, wHints,
          wLineDir, wOptimization, wStaticBoundchecks, wStyleChecks,
          wCallconv, wDebugger, wProfiler,
-         wFloatChecks, wNanChecks, wInfChecks, wPatterns, wTrMacros:
+         wFloatChecks, wNanChecks, wInfChecks, wTrMacros:
         var tmp = c.config.options
         result = processOption(c, it, tmp)
         c.config.options = tmp

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6660,7 +6660,7 @@ hints            on|off           Turns the hint messages of the compiler
                                   on or off.
 optimization     none|speed|size  Optimize the code for speed or size, or
                                   disable optimization.
-patterns         on|off           Turns the term rewriting templates/macros
+trmacros         on|off           Turns the term rewriting templates/macros
                                   on or off.
 callconv         cdecl|...        Specifies the default calling convention for
                                   all procedures (and procedure types) that

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -1266,8 +1266,8 @@ constant folding, so the following does not work:
 
 The reason is that the compiler already transformed the 1 into "1" for
 the `echo` statement. However, a term rewriting macro should not change the
-semantics anyway. In fact, they can be deactivated with the `--patterns:off`:option:
-command line option or temporarily with the `patterns` pragma.
+semantics anyway. In fact, they can be deactivated with the `--trmacros:off`:option:
+command line option or temporarily with the `trmacros` pragma.
 
 
 The `{}` operator

--- a/testament/caasdriver.nim
+++ b/testament/caasdriver.nim
@@ -100,7 +100,7 @@ proc doCommand(session: var NimSession, command: string) =
     # For symbol runs we prepend the necessary parameters to avoid clobbering
     # the normal nimcache.
     if session.mode == SymbolProcRun:
-      command = "--symbolFiles:on --nimcache:" & session.nimcache &
+      command = "--incremental:on --nimcache:" & session.nimcache &
                 " " & command
     session.lastOutput = doProcCommand(session,
                                        command & " " & session.filename)

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -601,7 +601,7 @@ proc srcdist(c: var ConfigData) =
     # Remove the cache if it exist so we get fresh files and avoid any bugs in
     # the caching system
     removeDir(cacheDir)
-    var cmd = ("$# compile -f --symbolfiles:off --compileonly " &
+    var cmd = ("$# compile -f --incremental:off --compileonly " &
                "--gen_mapping --cc:gcc --skipUserCfg" &
                # Silence the compiler to the best of our abilities, or it would
                # be a mess since we are running in parallel


### PR DESCRIPTION
Removed the following deprecated switches:
- `patterns`, as well as the pragma
- `symbolfiles`
- `babelpath` and `nobabelpath`
- `gendeps`

Updated docs and tests where needed.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* less is more