### PR TITLE
sem: fix the compile-time-only detection

### DIFF
--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -289,7 +289,7 @@ proc semBindSym(c: PContext, n: PNode): PNode =
     return createUndeclaredIdentifierError(c, n[1], sl.strVal)
 
   let sc = symChoice(c, id, s, TSymChoiceRule(rule.intVal))
-  if not (c.inStaticContext > 0 or getCurrOwner(c).isCompileTimeProc):
+  if not inCompileTimeOnlyContext(c):
     # outside of static evaluation and macros, ``bindSym`` resolves to the
     # sym-choice nodes
     result = sc


### PR DESCRIPTION
## Summary

The `inStaticContext` state that is, among other things, used to track whether the currently analysed code is only available at compile-time was part of the shared context (`PContext`), which is incorrect, as it means that the bodies of generic procedures instantiated in, for example, a `static` block are treated as being inside a compile-time-only context (which they are not).

Instead, the `inStaticContext` state is now part of `TProcCon`, and thus local to the analysis of a routine.

## Details

- always mark macros as being available compile-time only. This makes checking for compile-time-only routines easier, as macros no longer need to be tested for separately

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* I found the issue during the `.compileTime` pragma related work
* except for macros, this change doesn't affect which symbols are marked with `sfCompileTime` 

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
