### PR TITLE
enable lambda-lifting for the JavaScript target

### DIFF
--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -472,7 +472,6 @@ proc generateThunk(c: PTransf; prc: PNode, dest: PType): PNode =
 
   # we cannot generate a proper thunk here for GC-safety reasons
   # (see internal documentation):
-  if c.graph.config.backend == backendJs: return prc
   c.graph.config.internalAssert(prc.kind != nkClosure, prc.info, "closure to closure created")
 
   let conv = newTreeIT(nkHiddenSubConv, prc.info, dest):

--- a/tests/lang_callable/closure/tclosure.nim
+++ b/tests/lang_callable/closure/tclosure.nim
@@ -36,10 +36,7 @@ block tclosure:
   doAssert output == [1, 3, 6, 11, 20]
 
 
-# knownIssue: lambda-lifting related transformation are disabled when using
-#             the JS target, violating the expectation of ``vmgen`` and thus
-#             crashing the VM
-test array_of_procs, {c, vm}:
+block array_of_procs:
   # bug https://github.com/nim-lang/nim/issues/5015
 
   type Mutator = proc(matched: string): string {.noSideEffect, gcsafe, locks: 0.}

--- a/tests/lang_callable/closure/tclosure_issues.nim
+++ b/tests/lang_callable/closure/tclosure_issues.nim
@@ -62,8 +62,8 @@ proc foo(): proc =
 
 doAssert foo()() == (999, 0)
 
-# knownIssue: the JS code generator emits doesn't detect the inner procedures
-#             created by the lambda expressions as such
+# knownIssue: `i` is treated as a global defined at the procedure level, which
+#             are not properly supported by the JS backend yet
 test tissue7104, {c, vm}:
   var output: seq[int]
 


### PR DESCRIPTION
## Summary

Previously, inner closure procedures were not lifted into free-standing procedures during `transf`, but rather kept as-is and mapped to nested JavaScript functions by `jsgen`. Besides requiring the JavaScript target to be special-cased in `transf` and `lambdalifting`, this also caused observable semantic issues: the destructors for captured variables were called when leaving the scope in which they were defined, not when the closure got destroyed.

In order to bring the closure semantics in line with the other targets and as a prerequisite for full ORC support, lambda-lifting is now also enabled when using the JS target -- the code generator is adjusted to support the lifted procedures. The code generator changes are also a
preparation for full closure iterator support.

As a side-effect, closures now also work as expected when using the JS target and executing non-compile-time-only procedures that have inner closure procedures at compile-time.

## Details

- remove the dispatching based on the selected backend from `transf` and `lambdalifting`
- remove all code related to the previous closure support from `jsgen`
- implement support for lifted procedures in `jsgen`

The hidden environment parameter of routines using the `.closure` calling convention is mapped to the `this` parameter at the JavaScript level.

When a NimSkull closure object is created, a new function instance is created via `bind` and the provided environment bound to the `this` parameter. In addition, the both the function and environment are also assigned to the respective `prc` and `env` properties on the function object -- this allows for later retrieval.

Compared to using an object, this approach has the benefit that closures can still be passed to an imported procedure that expects a JavaScript function object, without requiring any changes to the user code.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* besides being a prerequisite for full ORC support, this change also simplifies #550

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
