### PR TITLE
sempass2: fix illegal capture detection

### DIFF
--- a/tests/lang_callable/closure/tclosure.nim
+++ b/tests/lang_callable/closure/tclosure.nim
@@ -445,3 +445,16 @@ test non_nested_closure, {c, js}:
   var cl = proc (): int {.closure.} = 1
   doAssert cl is "closure"
   doAssert cl() == 1
+
+block close_over_compile_time_loc:
+  proc p() {.compileTime.} =
+    var x = 0
+    proc inner(cmp: int) = # `inner` is explicitly not compile-time-only
+      inc x
+      doAssert x == cmp
+
+    inner(1)
+    inner(2)
+
+  static:
+    p()

--- a/tests/lang_callable/closure/tillegal_comptime_capture.nim
+++ b/tests/lang_callable/closure/tillegal_comptime_capture.nim
@@ -21,10 +21,35 @@ block:
         discard x #[tt.Error
                ^ (SemIllegalCompTimeCapture)]#
 
-block:
+block close_over_runtime_location:
   proc outer() {.compileTime.} =
-    proc innerInner() = # a compile-time procedure that's not explicitly
-                        # marked as such
+    proc inner() =
       var y = 0
-      proc innerInnerInner() {.compileTime.} =
-        discard y # legal; `innerInner` is also a compile-time procedure
+      proc innerInner() {.compileTime.} =
+        discard y #[tt.Error
+               ^ (SemIllegalCompTimeCapture)]#
+
+block capture_across_non_compile_time_proc:
+  proc outer() {.compileTime.} =
+    var x = 0
+    proc inner() =
+      proc innerInner() {.compileTime.} =
+        # closing over `x` would be legal if `inner` is also a compile-time-
+        # only procedure
+        discard x #[tt.Error
+               ^ (SemIllegalCompTimeCapture)]#
+
+block inner_macro:
+  proc outer() =
+    var x = 0
+    macro m() =
+      discard x #[tt.Error
+             ^ (SemIllegalCompTimeCapture)]#
+
+      proc inner() =
+        discard x #[tt.Error
+               ^ (SemIllegalCompTimeCapture)]#
+
+      proc inner2() {.compileTime.} =
+        discard x #[tt.Error
+               ^ (SemIllegalCompTimeCapture)]#


### PR DESCRIPTION
## Summary

The illegal capture detection treated all routines enclosed by a `.compileTime` routine as also being being compile-time-only. This to illegal code (according to the current language rules) not being rejected.

The rules are updated and the detection adjusted to work according to them; see the changes to the related tests for details.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this doesn't block off inferring routines defined inside compile-time-only contexts as `.compileTime` -- it only removes the decision making from `sempass2`

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
