### PR TITLE
sexp_reporter: fix `sexp` for `PNode`

### DIFF
--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -117,13 +117,14 @@ proc sexp*(node: PNode): SexpNode =
   result = newSList()
   result.add newSSymbol(($node.kind)[2 ..^ 1])
   case node.kind:
+    of nkNone, nkEmpty:           discard
     of nkCharLit..nkUInt64Lit:    result.add sexp(node.intVal)
     of nkFloatLit..nkFloat128Lit: result.add sexp(node.floatVal)
     of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)
     of nkSym:                     result.add newSSymbol(node.sym.name.s)
     of nkIdent:                   result.add newSSymbol(node.ident.s)
     of nkError:                   result.add sexp(node.diag.wrongNode)
-    else:
+    of nkWithSons:
       for node in node.sons:
         result.add sexp(node)
 


### PR DESCRIPTION
## Summary

The procedure treated both `nkEmpty` and `nkNone` treated as nodes with children, which caused a `FieldDefect` when generating the S-expression representation for them.

The case statement is now exhaustive, preventing the same issue from happening again in the future.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* a small issue I found while working on decoupling `semMacroDef` from `semProcAux`

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
