### PR TITLE
sem: decouple `semMacroDef` from `semProcAux`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1137,6 +1137,9 @@ type
     adSemSelectorMustBeOfCertainTypes
     adSemInvalidPragmaBlock
     adSemConceptPredicateFailed
+    adSemDotOperatorsNotEnabled
+    adSemCallOperatorsNotEnabled
+    adSemUnexpectedPattern
     # types
     adSemTypeKindMismatch
     # semexprs
@@ -1283,6 +1286,9 @@ type
         adSemSelectorMustBeOfCertainTypes,
         adSemInvalidPragmaBlock,
         adSemConceptPredicateFailed,
+        adSemDotOperatorsNotEnabled,
+        adSemCallOperatorsNotEnabled,
+        adSemUnexpectedPattern,
         adSemIsOperatorTakes2Args,
         adSemNoTupleTypeForConstructor,
         adSemInvalidOrderInArrayConstructor,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -452,6 +452,7 @@ type
     rsemEnableNotNilExperimental
     rsemEnableDotOperatorsExperimental
     rsemEnableCallOperatorExperimental
+    rsemUnexpectedPattern
     rsemExpectedObjectType
     rsemExpectedImportedType
     rsemUnexpectedExportcInAlias

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1803,6 +1803,9 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "the overloaded " & r.symstr &
         " operator has to be enabled with {.experimental: \"callOperator\".}"
 
+    of rsemUnexpectedPattern:
+      result = "patterns can only be specified on macros and templates"
+
     of rsemExpectedImportedType:
       result = "the '$1' modifier can be used only with imported types" % r.ast.render
 
@@ -3850,6 +3853,9 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemSelectorMustBeOfCertainTypes,
       adSemInvalidPragmaBlock,
       adSemConceptPredicateFailed,
+      adSemDotOperatorsNotEnabled,
+      adSemCallOperatorsNotEnabled,
+      adSemUnexpectedPattern,
       adSemIsOperatorTakes2Args,
       adSemNoTupleTypeForConstructor,
       adSemInvalidOrderInArrayConstructor, # xxx: used to capture, but not report, count mismatch

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -527,6 +527,9 @@ func astDiagToLegacyReportKind*(
   of adSemSelectorMustBeOfCertainTypes: rsemSelectorMustBeOfCertainTypes
   of adSemInvalidPragmaBlock: rsemInvalidPragmaBlock
   of adSemConceptPredicateFailed: rsemConceptPredicateFailed
+  of adSemDotOperatorsNotEnabled: rsemEnableDotOperatorsExperimental
+  of adSemCallOperatorsNotEnabled: rsemEnableCallOperatorExperimental
+  of adSemUnexpectedPattern: rsemUnexpectedPattern
   of adSemConstantOfTypeHasNoValue: rsemConstantOfTypeHasNoValue
   of adSemTypeConversionArgumentMismatch: rsemTypeConversionArgumentMismatch
   of adSemUnexpectedEqInObjectConstructor: rsemUnexpectedEqInObjectConstructor

--- a/compiler/sem/hlo.nim
+++ b/compiler/sem/hlo.nim
@@ -29,19 +29,12 @@ proc evalPattern(c: PContext, n: PNode): PNode =
     original = n
 
   let s = n[0].sym
-  case s.kind
-  of skMacro:
-    result = semMacroExpr(c, n, s)
+  result =
+    case s.kind
+    of skMacro:    semMacroExpr(c, n, s)
+    of skTemplate: semTemplateExpr(c, n, s, {efFromHlo})
+    else:          unreachable("not a macro/template: " & $s.kind)
 
-  of skTemplate:
-    result = semTemplateExpr(c, n, s, {efFromHlo})
-
-  else:
-    if s.isError:
-      result = s.ast
-    else:
-      result = semDirectOp(c, n, {})
-    
   if c.config.hasHint(rsemPattern):
     c.config.localReport(n.info, SemReport(
       kind: rsemPattern,

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -388,6 +388,8 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym
 
+proc getIdentLineInfo(n: PNode): TLineInfo
+
 proc typeAllowedCheck(c: PContext; info: TLineInfo; typ: PType; kind: TSymKind;
                       flags: TTypeAllowedFlags = {}) =
   let t = typeAllowed(typ, kind, c, flags)
@@ -692,28 +694,7 @@ proc semConstBoolExpr(c: PContext, n: PNode): PNode =
 proc semGenericStmt(c: PContext, n: PNode): PNode
 proc semConceptBody(c: PContext, n: PNode): PNode
 
-include semtypes
-
-proc setGenericParamsMisc(c: PContext; n: PNode) =
-  ## used by call defs (procs, templates, macros, ...) to analyse their generic
-  ## params, and store the originals in miscPos for better error reporting.
-  let orig = n[genericParamsPos]
-
-  doAssert orig.kind in {nkEmpty, nkGenericParams}
-
-  if n[genericParamsPos].kind == nkEmpty:
-    n[genericParamsPos] = newNodeI(nkGenericParams, n.info)
-  else:
-    # we keep the original params around for better error messages, see
-    # issue https://github.com/nim-lang/Nim/issues/1713
-    n[genericParamsPos] = semGenericParamList(c, orig)
-
-  if n[miscPos].kind == nkEmpty:
-    n[miscPos] = newTree(nkBracket, c.graph.emptyNode, orig)
-  else:
-    n[miscPos][1] = orig
-
-include semtempl, semgnrc, semstmts, semexprs
+include semtypes, semtempl, semgnrc, semstmts, semexprs
 
 proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool =
   ## true if `n` is an import statement referring to the system module

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -33,8 +33,6 @@ proc sameMethodDispatcher(a, b: PSym): bool =
       # be disambiguated by the programmer; this way the right generic is
       # instantiated.
 
-proc determineType(c: PContext, s: PSym)
-
 proc initCandidateSymbols(c: PContext, headSymbol: PNode,
                           initialBinding: PNode,
                           filter: TSymKinds,
@@ -96,7 +94,8 @@ proc pickBestCandidate(c: PContext,
       sym = nextOverloadIter(o, c, headSymbol)
       scope = o.lastOverloadScope
       continue
-    determineType(c, sym)
+    c.config.internalAssert(sym.typ != nil or sym.magic != mNone,
+                            "missing type information")
     initCandidate(c, z, sym, initialBinding, scope)
     if c.currentScope.symbols.counter == counterInitial or syms.len != 0:
       matches(c, n, z)

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -552,8 +552,6 @@ type
       ## written:
       ##  - semdata: init and updated via addPattern, which isn't used by hlo??
       ##  - hlo: `applyPatterns` add patterns for optimizations
-      ##  - semstmts: semProcAux adds term rewriting definitions
-      ##  - semtempl: semTemplateDef adds term rewriting definitions
       ## read:
       ##  - hlo: check len to see if there are patterns to apply
     

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3726,7 +3726,12 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkCurly: result = semSetConstr(c, n)
   of nkBracket: result = semArrayConstr(c, n, flags)
   of nkObjConstr: result = semObjConstr(c, n, flags)
-  of nkLambdaKinds: result = semProcAux(c, n, skProc, lambdaPragmas, flags)
+  of nkLambdaKinds:
+    result = semProcAnnotation(c, n)
+    if result == nil:
+      result = n
+      result[namePos] = semRoutineName(c, n[namePos], skProc)
+      result = semProcAux(c, result, lambdaPragmas, flags)
   of nkDerefExpr: result = semDeref(c, n)
   of nkAddr:
     result = n
@@ -3776,13 +3781,9 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkAsmStmt: result = semAsm(c, n)
   of nkYieldStmt: result = semYield(c, n)
   of nkPragma: result = pragmaStmt(c, n, c.p.owner)
-  of nkIteratorDef: result = semIterator(c, n)
-  of nkProcDef: result = semProc(c, n)
-  of nkFuncDef: result = semFunc(c, n)
-  of nkMethodDef: result = semMethod(c, n)
-  of nkConverterDef: result = semConverterDef(c, n)
-  of nkMacroDef: result = semMacroDef(c, n)
-  of nkTemplateDef: result = semTemplateDef(c, n)
+  of nkProcDef, nkFuncDef, nkIteratorDef, nkConverterDef, nkMethodDef,
+     nkMacroDef, nkTemplateDef:
+    result = semRoutineDef(c, n)
   of nkImportStmt:
     # this particular way allows 'import' in a 'compiles' context so that
     # template canImport(x): bool =

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -899,10 +899,7 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
                      else: rectype.sym
     for i in 0..<n.len-2:
       var f = semIdentWithPragma(c, skField, n[i], {sfExported})
-      let info = if n[i].kind == nkPostfix:
-                   n[i][1].info
-                 else:
-                   n[i].info
+      let info = getIdentLineInfo(n[i])
       suggestSym(c.graph, info, f, c.graph.usageSym)
       f.typ = typ
       f.position = pos

--- a/nimsuggest/tests/tsug_template.nim
+++ b/nimsuggest/tests/tsug_template.nim
@@ -6,7 +6,7 @@ tmp#[!]#
 discard """
 $nimsuggest --tester $file
 >sug $1
+sug;;skTemplate;;tsug_template.tmpa;;template ();;$file;;1;;9;;"";;100;;Prefix
 sug;;skMacro;;tsug_template.tmpb;;macro (){.noSideEffect, gcsafe, locks: 0.};;$file;;2;;6;;"";;100;;Prefix
 sug;;skConverter;;tsug_template.tmpc;;converter ();;$file;;3;;10;;"";;100;;Prefix
-sug;;skTemplate;;tsug_template.tmpa;;template ();;$file;;1;;9;;"";;100;;Prefix
 """

--- a/tests/lang_callable/macros/tdisallow_anonymous.nim
+++ b/tests/lang_callable/macros/tdisallow_anonymous.nim
@@ -1,0 +1,35 @@
+discard """
+  description: '''
+    Routines that require a name but have none provided are rejected
+  '''
+  cmd: "nim check --hints:off $options $file"
+  action: reject
+  nimout: '''
+tdisallow_anonymous.nim(32, 10) Error: identifier expected, but found:
+tdisallow_anonymous.nim(33, 10) Error: identifier expected, but found:
+tdisallow_anonymous.nim(34, 10) Error: identifier expected, but found:
+tdisallow_anonymous.nim(35, 10) Error: identifier expected, but found:
+'''
+"""
+
+import std/macros
+
+macro makeAnon(kind: static NimNodeKind) =
+  let p = newProc(name = newEmptyNode(), procType = kind)
+  if kind in {nnkProcDef, nnkFuncDef, nnkIteratorDef}:
+    # the procedural value needs to be consumed
+    result = newVarStmt(genSym(nskVar, "tmp"), p)
+  else:
+    result = p
+
+# the following routine kinds can be anonymous (which turns them into lambda
+# expressions)
+makeAnon(nnkProcDef)
+makeAnon(nnkFuncDef)
+makeAnon(nnkIteratorDef)
+
+# these can't
+makeAnon(nnkConverterDef)
+makeAnon(nnkMethodDef)
+makeAnon(nnkTemplateDef)
+makeAnon(nnkMacroDef)

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -1,0 +1,59 @@
+discard """
+  description: "Generated symbols not matching the definition must be rejected"
+  action: reject
+  cmd: "nim check --msgFormat:sexp --filenames:canonical $options $file"
+  nimoutFormat: sexp
+"""
+
+import std/macros
+
+macro replaceName(kind: static[NimSymKind], def: untyped): untyped =
+  ## Replaces the identifier in the name slot of `def` with a generated symbol
+  ## of the given `kind`.
+  let def = if def.kind == nnkStmtList: def[0] else: def
+
+  def.expectKind(RoutineNodes)
+
+  proc genSym(kind: NimSymKind, ident: NimNode): NimNode =
+    result = genSym(kind, ident.strVal)
+    copyLineInfo(result, ident)
+
+  def.name = genSym(kind, def.name)
+  result = def
+
+# test each routine definition
+
+replaceName(nskConst):
+  proc p() = #[tt.Error
+      ^ (SemSymbolKindMismatch)]#
+    discard
+
+replaceName(nskProc):
+  func f() = #[tt.Error
+      ^ (SemSymbolKindMismatch)]#
+    discard
+
+replaceName(nskVar):
+  iterator iter() = #[tt.Error
+          ^ (SemSymbolKindMismatch)]#
+    discard
+
+replaceName(nskForVar):
+  converter conv() = #[tt.Error
+           ^ (SemSymbolKindMismatch)]#
+    discard
+
+replaceName(nskForVar):
+  method meth() = #[tt.Error
+        ^ (SemSymbolKindMismatch)]#
+    discard
+
+replaceName(nskTemplate):
+  macro m() = #[tt.Error
+       ^ (SemSymbolKindMismatch)]#
+    discard
+
+replaceName(nskMacro):
+  template t() = #[tt.Error
+          ^ (SemSymbolKindMismatch)]#
+    discard

--- a/tests/lang_experimental/trmacros/tdisallow_non_macros.nim
+++ b/tests/lang_experimental/trmacros/tdisallow_non_macros.nim
@@ -1,0 +1,22 @@
+discard """
+  description: "Only macros and templates can be used for term-rewriting"
+  cmd: "nim check --hints:off $options $file"
+  action: reject
+  nimout: '''
+tdisallow_non_macros.nim(14, 8) Error: patterns can only be specified on macros and templates
+tdisallow_non_macros.nim(16, 8) Error: patterns can only be specified on macros and templates
+tdisallow_non_macros.nim(18, 15) Error: patterns can only be specified on macros and templates
+tdisallow_non_macros.nim(20, 16) Error: patterns can only be specified on macros and templates
+tdisallow_non_macros.nim(22, 10) Error: patterns can only be specified on macros and templates
+'''
+"""
+
+proc p{f(1, 1)}() = discard
+
+func f{f(1, 1)}() = discard
+
+iterator iter{f(1, 1)}() = discard
+
+converter conv{f(1, 1)}() = discard
+
+method m{f(1, 1)}() = discard

--- a/tests/lang_experimental/trmacros/tno_self_apply.nim
+++ b/tests/lang_experimental/trmacros/tno_self_apply.nim
@@ -1,0 +1,21 @@
+discard """
+  description: "Term-rewriting macros don't apply to their own bodies"
+"""
+
+proc add(x, y: int): int = x + y
+proc sub(x, y: int): int = x - y
+
+# term-rewriting macros don't apply to their own body
+macro m{add(x, 1)}(x: untyped): untyped =
+  doAssert add(1, 1) == 2 # must not be rewritten
+  result = x
+
+doAssert add(1, 1) == 1
+
+macro m2{sub(x, 1)}(x: untyped): untyped =
+  # but term-rewriting macro bodies can still be rewritten by others
+  let v = add(3, 1)
+  doAssert v == 3
+  result = x
+
+doAssert sub(2, 1) == 2


### PR DESCRIPTION
## Summary

The `semMacroDef` procedure (semantic analysis of a macro definition) no longer uses `semProcAux`, which allows for removing conditional logic from `semProcAux`, makes it easier to extend macro definition analysis, and is meant to help with the planned `semProcAux` refactoring.

As part of the refactoring, multiple issues were found and fixed. The changes:

#### General fixes

- `nkPragmaExpr` nodes are now disallowed in routine name slots (previously possible via macros)
- template with gensym'ed names have the correct owner now
- it's now enforced that symbols have the expected kind (e.g. that a symbol in an `nkProcDef` name slot is a `skProc`)
- anonymous macros, templates, converters, and methods are disallowed (previously possible via macros)
- dot operators can no longer be enabled with `{.experimental: "destructor".}`
- template symbol suggestions now have the correct relative order to other routine suggestions

#### Term-rewriting macros

- patterns are only registered *once* now (previously each one was redundantly registered twice), improving performance
- term-rewriting macros and templates no longer apply to their own bodies
- patterns are now disallowed on routines outside of macros and templates
- term-rewriting *macros* are now only registered when the definition doesn't have errors

## Details

In general, the commit unifies multiple parts of routine definition analysis by merging the ones that are the same for all of them into dedicated procedures.

All definitions of callables except labmdas are now passed to `semRoutineDef` first. The procedure dispatches to the respective `semXDef` procedure after applying operations common to the all routines, such as applying macro pragmas and producing the name.

### Routine-def analysis

- remove the unused `validPragmas` parameter from `semProcAnnotation`
- add `semRoutineParams`, which replaces `setGenericParamsMisc` and reduces the code duplication between `semProcAux`, `semTemplateDef`, and (the new) `semMacroDef`
- move the check for dot and call operator names into a separate procedure and use AST diagnostics for the errors
- refactor `semProcAux` slightly in order for it to not mutate the input AST as much; this is necessary for `semRoutineParams` to be used
- remove all macro and template related conditional logic from `semProcAux`
- remove the redundant gensym-related check from `semIteratorDef`
- more `nkError` propagation

### Patterns

- remove pattern registration from `semPattern` (separation of concerns)
- use `addPattern` in `semTemplateDef` and `semMacroDef` when registering a pattern

### Other

- unify the lookup of line information for identifiers in name slots (`getIdentLineInfo`)
- replace `determineType` with an assertion; a non-magic routine symbol without type information reaching overload resolution is a logic error

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

### To-do
- [x] add regression tests for the fixed issues
- [x] resolve the remaining inline-questions

## Notes for Reviewers
* apart from the small to-dos above, I consider the PR done

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
