### PR TITLE
vm: fix multiple `raise` and `finally` issues

### DIFF
--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -34,7 +34,7 @@ proc leaveImpl(prof: var Profiler, c: TCtx) {.noinline.} =
       data[li].time += tLeave - prof.tEnter
       if frameIdx == prof.sframe:
         inc data[li].count
-    frameIdx = frame.next
+    dec frameIdx
 
 proc leave*(prof: var Profiler, c: TCtx) {.inline.} =
   if optProfileVM in c.config.globalOptions:

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -47,6 +47,8 @@ from compiler/ast/reports_internal import InternalReport
 from compiler/ast/reports_vm import VMReport
 from compiler/ast/reports import ReportKind, toReportLineInfo
 
+from compiler/vm/vmlegacy import legacyReportsVmTracer
+
 proc loadDiscrConst(s: PackedEnv, constIdx: int, dst: LocHandle,
                     objTyp: PVmType, fieldPos: FieldPosition): int =
   let
@@ -353,7 +355,8 @@ proc main*(args: seq[string]): int =
       conf.writeHook(conf, msg & "\n", flags)
 
   # setup the execution context
-  var c = TCtx(config: config, mode: emStandalone)
+  var c = TCtx(config: config, mode: emStandalone,
+               vmtraceHandler: legacyReportsVmTracer)
   c.features.incl(allowInfiniteLoops)
   c.heap.slots.newSeq(1) # setup the heap
 
@@ -376,7 +379,7 @@ proc main*(args: seq[string]): int =
       newIntNode(nkIntLit, r.intVal)
 
   # setup the starting frame:
-  var frame = TStackFrame(prc: entryPoint.sym, next: -1)
+  var frame = TStackFrame(prc: entryPoint.sym)
   frame.slots.newSeq(entryPoint.regCount)
 
   # the execution part. Set up a thread and run it until it either exits


### PR DESCRIPTION
## Summary

Fix multiple issues with `raise`-related stack unwinding and resuming after `finally` clauses. In addition, prepare for further `finally` fixes.

## Details

When leaving a `finally` section, resuming the stack unwinding started by a `raise` is now handled directly instead of via the indirect back- and-forth mechanism used previously.

As a consequence, cactus-like stack shapes are now no longer possible, which simplifies all logic related to traversing the stack and also makes future VM changes that expect a "real" stack possible. The top-of- stack also no longer has to be tracked, but is now known to always be the last element int the stack-frame sequence.

In addition, the saved program counter (which is now only used during frame cleanup) is stored separately for each stack-frame. This is necessary for the saved counter to be preserved across calls to `rawExecute`, and is also a small step towards `finally` clauses working as expected in the VM: raising and handling an exception or entering a `finally` clause no longer abort clean-up in the frame above.

With both changes together, VM yields no longer interrupt unwinding or frame cleanup.

### Misc

- support traces with the `vmrunner` again

<!--
Pull Request(PR) Help

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
