### PR TITLE
sem: integer literal to holey enum error detection

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -174,6 +174,10 @@ proc checkConvertible(c: PContext, targetTyp: PType, src: PNode): TConvStatus =
       elif src.kind in nkCharLit..nkUInt64Lit and
           not floatRangeCheck(src.intVal.float, targetTyp):
         result = convNotInRange
+    elif targetBaseTyp.enumHasHoles:
+      if src.kind in nkIntLiterals and
+          toInt64(src.getInt).int notin getIntSetOfType(c, targetBaseTyp):
+          result = convNotInRange
   else:
     # we use d, s here to speed up that operation a bit:
     case cmpTypes(c, d, s)

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -163,8 +163,6 @@ template symbolRank*[T: enum](a: T): int =
     assert c2.symbolRank == 2
     assert c2.ord == 12
     assert a2.ord == 11
-    var invalid = 7.A
-    doAssertRaises(IndexDefect): discard invalid.symbolRank
   when T is Ordinal: ord(a) - T.low.ord.static
   else: symbolRankImpl(a)
 

--- a/tests/lang_defs/enum/tenumconvdetectlitoutofrange.nim
+++ b/tests/lang_defs/enum/tenumconvdetectlitoutofrange.nim
@@ -1,0 +1,27 @@
+discard """
+description: "Test out of range int literal conversion for enums"
+cmd: "nim check --filenames:canonical --backend:$target $options $file"
+action: reject
+"""
+
+block out_of_range:
+  type
+    Foo = enum
+      thingy
+  echo 1.Foo #[tt.Error
+        ^ 1 can't be converted to Foo]#
+
+block out_of_range_singleton_holey_enum:
+  type
+    Foo = enum
+      thingy = 2
+  echo 1.Foo #[tt.Error
+        ^ 1 can't be converted to Foo]#
+
+block out_of_range_within_holey_enum:
+  type
+    Foo = enum
+      thingy
+      thangy = 10
+  echo 1.Foo #[tt.Error
+        ^ 1 can't be converted to Foo]#


### PR DESCRIPTION
## Summary
Previously range error detection for integer literal to holey enums were in `semfold`, this is now done in `semConv`.

## Details

This simplifies `semfold` and moves this logic to the earliest point when we have enough information to make the correct judgement. Added some tests to avoid regressions.

### Misc

Aside, noticed `lang_def` vs `lang_types` and that doesn't make sense, will fix in a separate PR.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* one of many issues found while working on `semfold`/`semCase`
