### PR TITLE
semexprs: make `semAsgn` error node aware

### DIFF
--- a/tests/errmsgs/ttypeAllowed.nim
+++ b/tests/errmsgs/ttypeAllowed.nim
@@ -1,11 +1,11 @@
 discard """
-cmd: "nim check $file"
+cmd: "nim check --hints:off $file"
 errormsg: ""
 nimout: '''
 ttypeAllowed.nim(13, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for let
 ttypeAllowed.nim(17, 12) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for const
 ttypeAllowed.nim(21, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for var
-ttypeAllowed.nim(26, 10) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for result
+ttypeAllowed.nim(26, 12) Error: invalid type: 'iterator (a: int, b: int, step: Positive): int{.inline, noSideEffect, gcsafe, locks: 0.}' for result
 '''
 """
 


### PR DESCRIPTION
## Summary

- make `asgnToResultVar` `nkError` aware
- remove input AST mutations from  `semAsgn`
- replace `localReport`s with `nkError` usage in `semAsgn`
- make `semAsgn` propagate `nkError`s

In addition, the `semIterator`, `semMethod`, and `semMacroDef` now return early when `semProcAux` returns an error, in which they would previously have crashed.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
