### PR TITLE
semexprs: make `semReturn` error node aware

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1180,6 +1180,8 @@ type
     adSemDisallowedTypedescForTupleField
     adSemNamedExprNotAllowed
     adSemCannotMixTypesAndValuesInTuple
+    adSemNoReturnTypeDeclared
+    adSemReturnNotAllowed
     # semmagics
     adSemExprHasNoAddress
     adSemExpectedOrdinal
@@ -1292,6 +1294,8 @@ type
         adSemNamedExprExpected,
         adSemDisallowedTypedescForTupleField,
         adSemNamedExprNotAllowed,
+        adSemNoReturnTypeDeclared,
+        adSemReturnNotAllowed,
         adSemFieldAssignmentInvalidNeedSpace,
         adSemFieldAssignmentInvalid,
         adSemObjectConstructorIncorrect,

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3869,6 +3869,8 @@ func astDiagToLegacyReport(diag: PAstDiag): Report {.inline.} =
       adSemNamedExprExpected,
       adSemDisallowedTypedescForTupleField,
       adSemNamedExprNotAllowed,
+      adSemNoReturnTypeDeclared,
+      adSemReturnNotAllowed,
       adSemFieldAssignmentInvalidNeedSpace,
       adSemFieldAssignmentInvalid,
       adSemObjectConstructorIncorrect,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -576,6 +576,8 @@ func astDiagToLegacyReportKind*(
   of adSemDisallowedTypedescForTupleField: rsemDisallowedTypedescForTupleField
   of adSemNamedExprNotAllowed: rsemNamedExprNotAllowed
   of adSemCannotMixTypesAndValuesInTuple: rsemCannotMixTypesAndValuesInTuple
+  of adSemNoReturnTypeDeclared: rsemNoReturnTypeDeclared
+  of adSemReturnNotAllowed: rsemReturnNotAllowed
   of adSemFieldAssignmentInvalidNeedSpace: rsemFieldAssignmentInvalidNeedSpace
   of adSemFieldAssignmentInvalid: rsemFieldAssignmentInvalid
   of adSemFieldNotAccessible: rsemFieldNotAccessible


### PR DESCRIPTION
## Summary

- refactor the `semReturn` procedure to not use `return` and to not modify the input AST
- propagate `nkError` in `semReturn`
- replace `localReport`s with `nkError` node usage

In addition, a `(ReturnStmt (Asgn (...) (...)))` where the assignment is not that of the `result` variable now results in an `invalid expression` error, instead of an `expression has no type` error.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this is requirement for #594
* the code is a bit longer now, though I think it reads better without the return

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
