### PR TITLE
sem: report an error for calls to erroneous routines

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1107,6 +1107,7 @@ type
     adSemUndeclaredField
     adSemCannotInstantiate
     adSemWrongNumberOfGenericParams
+    adSemCalleeHasAnError
     # sem
     adSemExpressionHasNoType
     # semtypes
@@ -1377,6 +1378,8 @@ type
     of adSemWrongNumberOfGenericParams:
       countMismatch*: tuple[expected, got: int]
       gnrcCallLineInfo*: TLineInfo
+    of adSemCalleeHasAnError:
+      callee*: PSym
     of adSemIllformedAstExpectedOneOf:
       expectedKinds*: TNodeKinds
     of adSemImplementationExpected:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -484,6 +484,7 @@ type
     rsemIsOperatorTakes2Args
     rsemWrongNumberOfVariables
     rsemWrongNumberOfGenericParams
+    rsemCalleeHasAnError
     rsemNoGenericParamsAllowed
     rsemAmbiguousCall
     rsemCallingConventionMismatch

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1837,6 +1837,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         $r.countMismatch.expected
       )
 
+    of rsemCalleeHasAnError:
+      result = "cannot call '$1'; its definition has an error [defined at '$2']" %
+               [r.symstr, conf.toFileLineCol(r.sym.info)]
+
     of rsemNoGenericParamsAllowed:
       result = "no generic parameters allowed for $1" % r.symstr
 
@@ -4080,6 +4084,13 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       kind: rsemWrongNumberOfGenericParams,
       ast: diag.wrongNode,
       countMismatch: diag.countMismatch)
+  of adSemCalleeHasAnError:
+    semRep = SemReport(
+      location: some diag.location,
+      reportInst: diag.instLoc.toReportLineInfo,
+      kind: rsemCalleeHasAnError,
+      ast: diag.wrongNode,
+      sym: diag.callee)
   of adSemIllformedAstExpectedPragmaOrIdent:
     semRep = SemReport(
       location: some diag.location,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -501,6 +501,7 @@ func astDiagToLegacyReportKind*(
   of adSemUndeclaredField: rsemUndeclaredField
   of adSemCannotInstantiate: rsemCannotInstantiate
   of adSemWrongNumberOfGenericParams: rsemWrongNumberOfGenericParams
+  of adSemCalleeHasAnError: rsemCalleeHasAnError
   of adSemExpressionHasNoType: rsemExpressionHasNoType
   of adSemTypeExpected: rsemTypeExpected
   of adSemIllformedAst: rsemIllformedAst

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -98,7 +98,7 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
     else:
       result.add newNodeI(nkEmpty, templ.info)
   of nkError:
-    c.config.localReport(templ)
+    c.config.internalError(templ.info, "unreported error")
   else:
     let parentIsDeclarative = c.isDeclarative
     if templ.kind in routineDefs + {nkTypeSection, nkVarSection, nkLetSection, nkConstSection}:

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -994,7 +994,9 @@ proc semCustomPragma(c: PContext, n: PNode): PNode =
     return
 
   let r = c.semOverloadedCall(c, callNode, {skTemplate}, {efNoUndeclared})
-  if r.isNil or sfCustomPragma notin r[0].sym.flags:
+  if r.isError:
+    return r
+  elif r.isNil or sfCustomPragma notin r[0].sym.flags:
     result = invalidPragma(c, n)
     return
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -142,6 +142,13 @@ proc isArrayConstr(n: PNode): bool {.inline.} =
   result = n.kind == nkBracket and
     n.typ.skipTypes(abstractInst).kind == tyArray
 
+proc wrapErrorAndUpdate(c: ConfigRef, n: PNode, s: PSym): PNode =
+  ## Wraps the erroneous AST `n` in an error node, sets it as the AST of `s`,
+  ## and returns the wrapped node. Note that `s` itself is not transitioned to
+  ## an ``skError``.
+  result = c.wrapError(n)
+  s.ast = result
+
 proc deltaTrace(stopProc, indent: string, entries: seq[StackTraceEntry])
   {.inline.} =
   # find the actual StackTraceEntry index based on the name

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -532,7 +532,14 @@ proc semOverloadedCall(c: PContext, n: PNode,
           callMismatches: errorsToReport
         ))
 
-    result = semResolvedCall(c, r, n, flags)
+    result =
+      case r.calleeSym.ast.kind
+      of nkError:
+        # the symbol refers to an erroneous entity
+        c.config.newError(r.call):
+          PAstDiag(kind: adSemCalleeHasAnError, callee: r.calleeSym)
+      else:
+        semResolvedCall(c, r, n, flags)
 
   elif r.call.isError:
     result = r.call

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -393,6 +393,13 @@ proc generateInstance(c: PContext, fn: PSym, pt: TIdTable,
       n[bodyPos] = copyTree(getBody(c.graph, fn))
     if c.inGenericContext == 0:
       instantiateBody(c, n, fn.typ.n, result, fn)
+      if result.ast[bodyPos].kind == nkError:
+        # XXX: we also need to report the error here for now. Without the
+        #      ``localReport``, the error would never get reported
+        localReport(c.config, result.ast[bodyPos])
+        # compilation might continue after the report
+        result.ast = c.config.wrapError(result.ast)
+
     sideEffectsCheck(c, result)
     if result.magic notin {mSlice, mTypeOf}:
       # 'toOpenArray' is special and it is allowed to return 'openArray':

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1649,6 +1649,10 @@ proc canCaptureFrom*(captor, target: PSym): bool =
 
 proc trackProc*(c: PContext; s: PSym, body: PNode) =
   addInNimDebugUtils(c.config, "trackProc")
+  if body.kind == nkError:
+    # the body has an error, don't attempt to analyse it further
+    return
+
   let g = c.graph
   var effects = s.typ.n[0]
   if effects.kind != nkEffectList: return

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2721,7 +2721,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   if result[pragmasPos].isError:
     closeScope(c)
     popOwner(c)
-    return wrapError(c.config, result)
+    return wrapErrorAndUpdate(c.config, result, s)
 
   if n[pragmasPos].kind != nkEmpty and sfBorrow notin s.flags:
     setEffectsForProcType(c.graph, s.typ, n[pragmasPos], s)
@@ -2855,7 +2855,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     localReport(c.config, s.info, reportSym(
       rsemUnexpectedClosureOnToplevelProc, s))
   if s.ast[bodyPos].kind == nkError:
-    result = c.config.wrapError(n)
+    result = c.config.wrapErrorAndUpdate(n, s)
 
 proc determineType(c: PContext, s: PSym) =
   if s.typ != nil: return

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -1116,7 +1116,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     c.patterns.add(s)
 
   if hasError:
-    result = c.config.wrapError(result)
+    result = c.config.wrapErrorAndUpdate(result, s)
 
 proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
   ## Analyse `n` a term rewriting pattern body producing an instantiable

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -26,8 +26,7 @@ import
     idents,
     renderer,
     types,
-    lineinfos,
-    errorreporting
+    lineinfos
   ],
   compiler/modules/[
     magicsys,
@@ -907,10 +906,7 @@ proc transform(c: PTransf, n: PNode): PNode =
       c.deferAnchor = n
   case n.kind
   of nkError:
-    # XXX: yet another place to report on nkError
-    result = n
-    c.graph.config.localReport(n)
-    return
+    unreachable("errors can't reach here")
   of nkSym:
     result = transformSym(c, n)
   of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit:
@@ -1122,11 +1118,6 @@ proc transformBody*(g: ModuleGraph; idgen: IdGenerator; prc: PSym; cache: bool):
     result = prc.transformedBody
   elif nfTransf in getBody(g, prc).flags or prc.kind in {skTemplate}:
     result = getBody(g, prc)
-  elif prc.kind == skError:
-      # xxx: wrap this in an nkError for the whole body
-      result = prc.ast
-      assert result != nil and result.kind == nkError,
-        "assume we've populated the nkError here"
   else:
     var c = PTransf(graph: g, module: prc.getModule, idgen: idgen)
     prc.transformedBody = newNode(nkEmpty) # protects from recursion


### PR DESCRIPTION
## Summary

If overload resolution picked the symbol of a routine whose definition (header or body) contains an error, the call expression was passed on, resulting in AST containing `nkError` nodes to possibly `transf` and `mirgen` (in the case of macro evaluation), crashing the compiler.

After overload resolution, `semOverloadedCall` now produces an `nkError` if the callee's definition contains an error (identified by the `TSym.ast` field containing an `nkError` node).

## Details

- update the `TSym.ast` of the produced symbol with the error AST in `semProcAux`, `semTemplateDef`, and `generateInstance`
- short-circuit `trackProc` if the body has an error. This fixes some compiler crashes due to errors reaching logic that they shouldn't, and also fixes errors in routine bodies being reported twice

There still exists logic that doesn't resolve macros and templates through `semOverloadedCall` call. In order to help with finding these, `nkError` nodes reaching `transf` or template expansion are now treated as an internal error.

### Misc

- fix a field-access defect in `semCustomPragma` that happened when `semOverloadedCall` returns an error

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this change unblocks #590
* the short-circuiting in `trackProc` fixes an issue that blocks #594 

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
