### PR TITLE
`semStaticStmt` now produces `nkError`

### DIFF
--- a/compiler/ast/reports_vm.nim
+++ b/compiler/ast/reports_vm.nim
@@ -18,6 +18,8 @@ type
     typ*: PType
     str*: string
     sym*: PSym
+    trace*: ref VMReport  ## for storing an `rvmStackTrace`, not ideal but
+                          ## reports are legacy and to be removed
     case kind*: ReportKind
       of rvmStackTrace:
         currentExceptionA*, currentExceptionB*: PNode

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -609,6 +609,9 @@ proc handleReport*(
   if rep.category in { repSem, repVM } and rep.location.isSome():
     rep.context = conf.getContext(rep.location.get())
 
+  if rep.category == repVM and rep.vmReport.trace != nil:
+    handleReport(conf, wrap(rep.vmReport.trace[]), reportFrom)
+
   let
     userAction = conf.report(rep)
     (action, trace) =

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -464,10 +464,8 @@ proc evalConstExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode):
 proc evalStaticExpr*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym): PNode {.inline.} =
   result = evalConstExprAux(module, idgen, g, prc, e, emStaticExpr)
 
-proc evalStaticStmt*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym) {.inline.} =
-  let r = evalConstExprAux(module, idgen, g, prc, e, emStaticStmt)
-  # TODO: the node needs to be returned to the caller instead
-  reportIfError(g.config, r)
+proc evalStaticStmt*(module: PSym; idgen: IdGenerator; g: ModuleGraph; e: PNode, prc: PSym): PNode {.inline.} =
+  result = evalConstExprAux(module, idgen, g, prc, e, emStaticStmt)
 
 proc setupCompileTimeVar*(module: PSym; idgen: IdGenerator; g: ModuleGraph; n: PNode) {.inline.} =
   let r = evalConstExprAux(module, idgen, g, nil, n, emStaticStmt)


### PR DESCRIPTION
## Summary

Semantic analysis for static statement blocks now produce `nkError` upon
failure instead of relying on legacy reporting.

## Details

As part of this change the VM `compilerbridge` now returns the resultant
`PNode` with possible errors when calling `evalStaticStmt` instead of
directly reportting; further reducing dependence on legacy reports.

Last but not least, `semStaticStmt` previously always attempted static
evaluation of the input AST, even when initial semantic analysis of the
input produced errors. This is no longer the case and instead it returns
the produced error early. This should both further prevent `transf` from
receiving `nkError` nodes, but also speed up that code path.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* kept it as small as possible