### PR TITLE
vmgen: separate dependency collection

### DIFF
--- a/compiler/front/scriptconfig.nim
+++ b/compiler/front/scriptconfig.nim
@@ -71,7 +71,7 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
   result = newCtx(module, cache, graph, idgen, legacyReportsVmTracer)
   # for backwards compatibility, allow meta expressions in nimscript (this
   # matches the previous behaviour)
-  result.codegenInOut.flags = {cgfAllowMeta}
+  result.flags = {cgfAllowMeta}
   result.mode = emRepl
   registerBasicOps(result[])
   let conf = graph.config

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -166,7 +166,7 @@ proc createInterpreter*(
   incl(m.flags, sfMainModule)
   var idgen = idGeneratorFromModule(m)
   var vm = newCtx(m, cache, graph, idgen, legacyReportsVmTracer)
-  vm.codegenInOut.flags = {cgfAllowMeta}
+  vm.flags = {cgfAllowMeta}
   vm.mode = emRepl
   vm.features = flags
   if registerOps:

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -150,3 +150,9 @@ proc registerProc*(c: var TCtx, prc: PSym): FunctionIndex =
   if result == next.FunctionIndex:
     # a new entry:
     c.functions.add(initProcEntry(c, prc))
+
+proc lookupProc*(c: var TCtx, prc: PSym): FunctionIndex {.inline.} =
+  ## Returns the function-table index corresponding to the provided `prc`
+  ## symbol. Behaviour is undefined if `prc` has no corresponding function-
+  ## table entry.
+  c.symToIndexTbl[prc.id].FunctionIndex

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -520,7 +520,7 @@ proc serialize*(c: var TCtx, n: PNode, dest: LocHandle, t: PType = nil) =
       of nkNilLit: discard "nothing to do"
       of nkClosure:
         assert n[0].kind == nkSym
-        let fnc = toFuncPtr(c.registerProc(n[0].sym))
+        let fnc = toFuncPtr(c.lookupProc(n[0].sym))
 
         let env =
           if n[1].kind == nkNilLit:
@@ -542,7 +542,7 @@ proc serialize*(c: var TCtx, n: PNode, dest: LocHandle, t: PType = nil) =
     else:
       assert n.kind == nkSym
       assert dest.typ.kind == akCallable
-      deref(dest).callableVal = toFuncPtr(c.registerProc(n.sym))
+      deref(dest).callableVal = toFuncPtr(c.lookupProc(n.sym))
   of tyObject:
     assert n.kind == nkObjConstr
     assert dest.typ.kind == akObject

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -549,9 +549,8 @@ type
     ## into `TCtx.globals`; index into `TCtx.complexConsts`
 
   # XXX: design of `CodeGenInOut` is not yet final
-  CodeGenInOut* = object
-    ## Mutable global state for the code-generator (`vmgen`) that is not
-    ## directly related to the code being generated.
+  LinkState* = object
+    ## Temporary state used when gathering new dependencies.
     ##
     ## The `newX` seqs accumulate the symbols added to `symToIndexTbl` during
     ## code-gen, with a seq for each link-item kind. They're never reset by
@@ -567,8 +566,6 @@ type
     nextProc*: LinkIndex
     nextGlobal*: LinkIndex
     nextConst*: LinkIndex
-
-    flags*: set[CodeGenFlag] ## input
 
   VmGenDiagKind* = enum
     # has no extra data
@@ -761,9 +758,15 @@ type
       ## dependencies. Expanded during code-generation and used for looking
       ## up the link-index (e.g. `FunctionIndex`) of a symbol
 
-    codegenInOut*: CodeGenInOut ## Input and outputs to vmgen
-    # TODO: `codegenInOut` shouldn't be part of `TCtx` but rather a `var`
-    #       parameter for the various codegen functions
+    linkState*: LinkState ## temporary state used by dependency collection.
+      ## Stored as part of ``TCtx`` for convenience, and to allow for memory
+      ## reuse
+    # XXX: `linkState` is eventually going to be removed
+
+    flags*: set[CodeGenFlag] ## flags that alter the behaviour of the code
+      ## generator. Initialized by the VM's callsite and queried by the JIT.
+    # XXX: `flags` is code generator / JIT state, and needs to be moved out of
+    #      ``TCtx``
 
     # exception state:
     # XXX: this is thread-local state and should thus not be part of the


### PR DESCRIPTION
## Summary

Move the gathering of dependencies and registering them in the link table out of code generation into a separate step. While less efficient, this greatly reduces the amount of state that code generation and serialization (`vmcompilerserdes`) need access to.

## Details

This change is a preparation for splitting up `TCtx` and for the introduction of the unified backend processing. Most of the code adjusted here will change again as part of implementing the aforementioned tasks.

### Access changes

- the code generator routines no longer mutate `TCtx.symToIndexTbl` and `TCtx.codegenInOut` (the latter is also not accessed anymore)
- `vmcompilerserdes.serialize` no longer queries nor mutates `TCtx.codegenInOut` and `TCtx.typeInfoCache`

### Changes

- add `gatherDependencies` and call it prior to all `vmgen` invocations
- manually register referenced routines in `putIntoReg`
- simplify the procedure processing in `vmbackend` -- collecting routines referenced from constants now happens as part of `gatherDependencies`, removing the need for the loop
- move `flags` from `CodegenInOut` into `TCtx`
- rename `CodegenInOut` to `LinkState`

### Misc

- remove dead code in `vmgen.genVarSection`

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* as mentioned above, this is a preparation for #550
* the change is also going to make splitting up `TCtx` easier
* flat `seq`s are eventually going to replace the usage of `Table` for the linker, which will likely offset the small slowdown incurred here

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
