### PR TITLE
add test to disallow variants in a union

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -218,9 +218,9 @@ proc isCastable(c: PContext; dst, src: PType): bool =
   var dstSize, srcSize: BiggestInt
   dstSize = computeSize(conf, dst)
   srcSize = computeSize(conf, src)
-  if dstSize == -3 or srcSize == -3: # szUnknownSize
+  if dstSize == szUnknownSize or srcSize == szUnknownSize:
     # The Nim compiler can't detect if it's legal or not.
-    # Just assume the programmer knows what he is doing.
+    # Just assume the programmer knows what they're is doing.
     return true
   if dstSize < 0:
     result = false

--- a/compiler/sem/sizealignoffsetimpl.nim
+++ b/compiler/sem/sizealignoffsetimpl.nim
@@ -166,7 +166,7 @@ proc computeObjectOffsetsFoldFunction(conf: ConfigRef; n: PNode, packed: bool, a
     accum.offset = szUnknownSize
 
 proc computeUnionObjectOffsetsFoldFunction(conf: ConfigRef; n: PNode; packed: bool; accum: var OffsetAccum) =
-  ## ``accum.offset`` will the offset from the larget member of the union.
+  ## ``accum.offset`` will be the offset from the largest member of the union.
   case n.kind
   of nkRecCase:
     accum.offset = szUnknownSize

--- a/tests/types/tunion_variant_disallowed.nim
+++ b/tests/types/tunion_variant_disallowed.nim
@@ -1,0 +1,17 @@
+discard """
+description: "Variants are not allowed in unions"
+errormsg: "Illegal use of ``case`` in union type."
+line: 9
+"""
+
+type
+  Disallowed {.union.} = object
+    case foo: bool:
+      of true:
+        a: string
+        b: int
+      of false:
+        c: float
+
+var foo: Disallowed
+doAssert sizeof(Disallow) == 8 # made up number, test should just fail


### PR DESCRIPTION
## Summary

Added a test for `union` objects cannot be variants.

## Details

There was not test for this case, now a basic one exists. This stemmed from an attempt at removing `localReport` from `sizealignoffsetimpl`, a few small stylistic improvements were also made as part of this change.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* the code isn't ready to have reports removed, this is what I could salavage from wrestling with it