### PR TITLE
sem: refactor and fix `semArrayConstr`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1430,7 +1430,6 @@ type
       nonOrdInput*: PNode
       indexExpr*: PNode
     of adSemIndexOutOfBounds:
-      maxOrdIdx*: int
       outOfBoundsIdx*: int
       ordRange*: PType
     of adSemExpectedOrdinal:

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -838,7 +838,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "unknown trait: " & r.sym.name.s
 
     of rsemExpectedOrdinal:
-      if r.ast != nil and r.ast.kind == nkBracket:
+      if r.ast != nil and r.ast.kind == nkExprColonExpr:
         result.add "expected ordinal value for array index, got '$1'" % r.wrongNode.render
       else:
         result = "ordinal type expected"
@@ -4253,7 +4253,8 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       kind: rsemIndexOutOfBounds,
       ast: diag.wrongNode,
       typ: diag.ordRange,
-      countMismatch: (diag.maxOrdIdx, diag.outOfBoundsIdx))
+      countMismatch: (toInt(lastOrd(conf, diag.ordRange)),
+                      diag.outOfBoundsIdx))
   of adSemExpectedOrdinal:
     semRep = SemReport(
       location: some diag.location,

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -537,6 +537,17 @@ proc semConstExpr(c: PContext, n: PNode): PNode =
     localReport(c.config, result)
     result = e # error correction
 
+proc semRealConstExpr(c: PContext, n: PNode): PNode =
+  ## Semantically analyses the expression `n` and evaluates it. An error is
+  ## returned if the expression either contains an error or is not a constant
+  ## expression.
+  addInNimDebugUtils(c.config, "semRealConstExpr", n, result)
+  assert not n.isError
+
+  result = semExprWithType(c, n)
+  if result.kind != nkError:
+    result = evalConstExpr(c, result)
+
 proc semExprFlagDispatched(c: PContext, n: PNode, flags: TExprFlags): PNode =
   if efNeedStatic in flags:
     if efPreferNilResult in flags:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1073,7 +1073,7 @@ proc semNormalizedConst(c: PContext, n: PNode): PNode =
         defInitPart.typ
       else:
         initExpr.typ
-    haveInit = not initType.isError
+    haveInit = defInitPart.kind != nkEmpty
   
   # expansion of the given type
   let

--- a/tests/lang_types/array/tsink_in_array.nim
+++ b/tests/lang_types/array/tsink_in_array.nim
@@ -1,0 +1,12 @@
+discard """
+  description: '''
+    Test array type inference where the first element is a ``sink`` type
+  '''
+"""
+
+proc p(x: sink int) =
+  var a = [x] # the array must not be of ``array[0..0, sink int]`` type
+  doAssert a is array[0..0, int]
+  doAssert a[0] == 1
+
+p(1)


### PR DESCRIPTION
## Summary

Refactor the `semArrayConstr` procedure, make it propagate `nkError` nodes, and fix a type inference issue: if the first element in an array constructor was a `sink T` parameter, the array's element type was inferred to be `sink T`, which resulted in a `type not allowed` error.

## Details

- move array element analysis to a separate procedure
- wrap the result in `semArrayConstr` in an `nkError`, if necessary
- improve the documentation of `semArrayConstr`
- add `semRealConstExpr`, meant for expressions that *must* be constant
- remove the `TAstDiag.maxOrdIdx` field -- the value is now taken from the provided `ordRange`
- don't treat a `nkConstDef` as having no init part if the init part is erroneous. This fixes a `constant expression expected` error always replacing the actual error

### Known issue

The (pre-existing) logic for rejecting up- or down-conversion of objects in an array constructor doesn't skip `sink`, alias, and generic instance types, which is incorrect. Correctly skipping the types uncovered that a test is depending on the previous behaviour, and called into question whether disallowing object slicing in array constructors is the right semantics.

For the time being, the incorrect logic is kept as-is.

---

## Notes for reviewers
* this unblocks #598

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
