### PR TITLE
semexprs: make `semStaticExpr` error-node aware

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -593,7 +593,6 @@ type
     rsemCannotFindPlugin
     rsemExpectedProcReferenceForFinalizer
     rsemCannotIsolate
-    rsemCannotInterpretNode
     rsemRecursiveDependencyIterator
     rsemIllegalNimvmContext
     rsemDisallowedNilDeref

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1467,9 +1467,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemStackEscape:
       result = "address of '$1' may not escape its stack frame" % r.ast.render
 
-    of rsemCannotInterpretNode:
-      result = "cannot evaluate '$1'" % r.ast.render
-
     of rsemRecursiveDependencyIterator:
       result = "recursion is not supported in iterators: '$1'" % r.symstr
 


### PR DESCRIPTION
## Summary

The procedure now prevents errors from reaching `transf`, and propagates errors upwards.

In addition, the logic for implicit static evaluation is adjusted to consider `nkError` nodes, making it work in simple cases again.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* fixes yet another blocker of #598
* the `evalAtCompileTime` adjustment is not directly related to `semStaticExpr`, but given the change's low impact, I opted to included it here

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
