### PR TITLE
`considerQuotedIdent` is no longer call recursive

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -566,7 +566,9 @@ proc mainThread(graph: ModuleGraph) =
       cachedMsgs.setLen 0
       conf.structuredReportHook =
           proc (conf: ConfigRef, report: Report): TErrorHandling =
-            cachedMsgs.add(report)
+            if report.kind notin {rsemProcessing, rsemProcessingStmt}:
+              # pre-filter to save memory
+              cachedMsgs.add(report)
 
       conf.suggestionResultHook = proc (s: Suggest) = discard
       recompileFullProject(graph)

--- a/tests/lang/s02_core/s05_templates/t01_templates.nim
+++ b/tests/lang/s02_core/s05_templates/t01_templates.nim
@@ -48,41 +48,86 @@ block identifier_join:
 
   template getVar(idx: untyped): untyped = `varName idx`
 
-  var
-    varNameQq = 30
-    varNameZzz = 50
+  block using_an_identifier:
+    var varNameQq = 30
+    doAssert getVar(Qq) == 30
 
-    varName1 = 12
-    varName2 = 20
+  block is_style_insensitive:
+    ## Identifier joining is also style-insensitive - variable `varNameZzz`
+    ## can be accessed by passing `zzz`.
+    var varNameZzz = 50
+    doAssert getVar(zzz) == 50
 
+  block works_with_string_literals:
+    var varNameFoo = 12
+    doAssert getVar("foo") == 12
+    doAssert getVar("""foo""") == 12
+    doAssert getVar(r"foo") == 12
+
+  block works_with_character_literals:
+    var varNameB = 20
+    doAssert getVar("b") == 20
+
+  block works_with_bool_literals:
+    ## bool literals can be used as well
+    var varNameFalse = 30
+    doAssert getVar(false) == 30
+
+  block works_with_unsigned_integer_literals:
+    var varName1 = 40
+    doAssert getVar(1'u)   == 40
+    doAssert getVar(1'u8)  == 40
+    doAssert getVar(1'u16) == 40
+    doAssert getVar(1'u32) == 40
+    doAssert getVar(1'u64) == 40
+
+  block works_with_integer_literals:
+    var varName2 = 50
+    doAssert getVar(2)     == 50
+    doAssert getvar(2'i8)  == 50
+    doAssert getvar(2'i16) == 50
+    doAssert getvar(2'i32) == 50
+    doAssert getvar(2'i64) == 50
+
+    when false:
+      # These are gaps in the spec, what sort of error should result?
+      # the spec feels really half-baked at this point... we should probably
+      # create an identifier type and constructor and only accept those
+      getVar(-2)   # produces "varName-2"
+      getVar('\n') # produces "varName10" ... wtf
+      getVar("\n") # produces "varName<newLine>"
 
   when defined(tryBrokenSpecification):
-    ## Stropping does not work with identifier join in templates
-    var `varName??` = 40
-    doAssert getVar(`??`) == 40
+    block works_with_stropping:
+      ## Stropping does not work with identifier join in templates
+      var `varName??` = 50
+      doAssert getVar(`??`) == 50
 
-  doAssert getVar(Qq) == 30
+  # TODO: these aren't really identifier construction tests, move them out
+  block substitution_is_ast_based:
+    ## Note that template arguments are substituted as a code, not by value.
+    ## That's why calling `getVar(idx)` with `idx` being a variable, will
+    ## result in the `varNameIdx` variable being accessed.
+    block subsitute_ast_as_is:
+      var varNameIdx = 900
+      let idx {.used.} = 1
+      doAssert getVar(idx) == 900
 
-  ## Identifier joining is also style-insensetive - variable `varNameZzz`
-  ## can be accessed by passing `zzz`.
-  doAssert getVar(zzz) == 50
+    block same_with_const_known_at_compile_time:
+      var varNameIdx = 910
+      const idx {.used.} = 1
+      doAssert getVar(idx) == 910
 
-  ## Integer literals can be used as well
-  doAssert getVar(1) == 12
-  doAssert getvar(2) == 20
+    block typed_will_take_the_value_of_a_const_as_we_eval_it_first:
+      template getVarTyped(idx: typed): untyped = `varName idx`
+      var varName90 = 1
+      const foo = 90
+      doAssert getVarTyped(foo) == 1
 
-
-  ## Note that template arguments are substituted as a code, not by value.
-  ## That's why calling `getVar(idx)` with `idx` being a variable or even a
-  ## constant (which are known at compile-time), will result in the
-  ## `varNameIdx` variable being accessed.
-
-  var varNameIdx = 900
-
-  block:
-    let idx = 1
-    doAssert getVar(idx) == 900
-
-  block:
-    const idx = 1
-    doAssert getVar(idx) == 900
+    when defined(tryBrokenSpecification):
+      # for some reason the value "bar" isn't being passed unlike the int above
+      block typed_will_take_the_value_of_a_const_as_we_eval_it_first:
+        template getVarTyped(idx: typed): untyped = `varName idx`
+        var varNameBar = 1
+        const foo = "bar"
+        doAssert getVarTyped(foo) == 1


### PR DESCRIPTION
## Summary

Rewrite `lookups.considerQuotedIdent` in preparation for further structuring AST diagnostics. The new version eliminates call recursion.

## Details

A minor improvement to `nimsuggest` was shipped as part of this to slightly reduce memory allocation spikes from reports.

To Revisit in the Future:
Macros can create grammatically invalid structures, including for identifiers, where should we check for identifier well formed-ness? The previous proc was slightly more forgiving but not by much.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* tiny step, next is to further specialize and structure diagnostics it produces, see below


Future Next Steps:

The next step is to have a single primary diagnostic for "considering
an AST node as an identifier". Further "sub-diagnostics" (read: further
nested variant data) will go into detail as required. This will allow
for a sort of hierarchy without inheritance, and more importantly make
recovery from errors, specialization of errors, and querying of error
AST, far smoother.

```nim
type
  # assume a `adSemIdentifierNode` value in `AstDiagKind`
  ADSemIdentifierNodeKind = enum
    adSemIdentifierNodeExpected
    adSemIdentifierNodeAccQuotedEmpty
    adSemIdentifierNodeAccQuotedMalformed
    adSemIdentifierNodeSymChoiceEmpty
    adSemIdentifierNodeSymChoiceMalformed

  ADSemIdentifierNodeData = object
    # `TAstDiag`'s branch for `adSemIdentifierNode` will store this
    case kind*: ADSemIdentifierNodeKind:
      # variant fields
```

The above sketch will be tested as part of creating a variant of
the `newSymG` proc called `newSymGNode`, the difference being that it
will return a `PNode` guaranteed to be a symbolic node or error. In a
prior attempt this ran into roadblocks as `considerQuotedIdent`'s output
is not easy to recover from or disambiguate various identifier errors.
It's easy enough to add more kinds, but then there is a loose
collection of kinds and lots of name collisions for the same data when
storing it and fragmented names for the reader to unify.
