### PR TITLE
closureiters: use `case`-based dispatcher

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -233,8 +233,8 @@ type
     nkPattern             ## a special pattern; used for matching
     nkHiddenTryStmt       ## a hidden try statement
     nkClosure             ## (prc, env)-pair (internally used for code gen)
-    nkGotoState           ## used for the state machine (for iterators)
-    nkState               ## give a label to a code section (for iterators)
+    nkGotoState           ## used only temporarily during closure iterator
+                          ## transformation
     nkFuncDef             ## a func
     nkTupleConstr         ## a tuple constructor
     nkError               ## erroneous AST node see `errorhandling`

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -1627,15 +1627,6 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
     initContext c
     putWithSpace g, tkSymbol, "goto"
     gsons(g, n, c)
-  of nkState:
-    var c: TContext
-    initContext c
-    putWithSpace g, tkSymbol, "state"
-    gsub(g, n[0], c)
-    putWithSpace(g, tkColon, ":")
-    indentNL(g)
-    gsons(g, n, c, 1)
-    dedent(g)
   of nkTypeClassTy:
     gTypeClassTy(g, n)
   of nkError:

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2967,9 +2967,6 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
           # by ensuring it's no inner proc (owner is a module).
           # Generate proc even if empty body, bugfix #11651.
           genProc(p.module, prc)
-  of nkState: genState(p, n)
-  of nkGotoState:
-    genGotoState(p, n)
   of nkMixinStmt, nkBindStmt: discard
   else:
     internalError(p.config, n.info, "expr(" & $n.kind & "); unknown node kind")

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -960,9 +960,6 @@ proc allPathsAsgnResult(n: PNode): InitResultEnum =
       if result == InitSkippable: result = Unknown
   of harmless:
     result = Unknown
-  of nkGotoState:
-    # give up for now.
-    result = InitRequired
   of nkSym:
     # some path reads from 'result' before it was written to!
     if n.sym.kind == skResult: result = InitRequired

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2640,10 +2640,6 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
     if {sfExportc, sfCompilerProc} * s.flags == {sfExportc}:
       genSym(p, n[namePos], r)
       r.res = ""
-  of nkGotoState, nkState:
-    globalReport(p.config, n.info, BackendReport(
-      kind: rbackJsUnsupportedClosureIter))
-
   of nkPragmaBlock: gen(p, n.lastSon, r)
   else: internalError(p.config, n.info, "gen: unknown node type: " & $n.kind)
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1988,7 +1988,7 @@ proc gen(c: var TCtx, n: PNode) =
     if hasInteresting:
       c.stmts.add MirNode(kind: mnkPNode, node: n)
 
-  of nkGotoState, nkState, nkAsmStmt:
+  of nkAsmStmt:
     # these don't have a direct MIR counterpart
     c.stmts.add MirNode(kind: mnkPNode, node: n)
   of nkWhenStmt:

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -241,8 +241,8 @@ type
              ## If it appears as a statement, it is expected to not have any
              ## obsersvable effects
              ## XXX: eventually, everything that currently requires
-             ##      ``mnkPNode`` (for example, ``nkGotoState``, ``nkAsmStmt``,
-             ##      emit, etc.) should be expressable directly in the IR
+             ##      ``mnkPNode`` (for example, ``nkAsmStmt``, emit, etc.)
+             ##      should be expressable directly in the IR
 
   EffectKind* = enum
     ekMutate    ## the value in the location is mutated

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3823,12 +3823,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     n[0] = semExpr(c, n[0])
     if not n[0].typ.isEmptyType and not implicitlyDiscardable(n[0]):
       localReport(c.config, n, reportSem rsemExpectedTypelessDeferBody)
-  of nkGotoState, nkState:
-    if n.len != 1 and n.len != 2:
-      semReportIllformedAst(c.config, n, "")
-
-    for i in 0..<n.len:
-      n[i] = semExpr(c, n[i])
   of nkMixinStmt: discard
   of nkBindStmt:
     if c.p != nil:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3272,7 +3272,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
        sfNoReturn in x[0].sym.flags:
       for j in i + 1..<n.len:
         case n[j].kind
-        of nkPragma, nkCommentStmt, nkNilLit, nkEmpty, nkState:
+        of nkPragma, nkCommentStmt, nkNilLit, nkEmpty:
           discard
         else:
           localReport(c.config, n[j].info,

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -22,7 +22,7 @@ import std/private/since
 # If you look for the implementation of the magic symbol
 # ``{.magic: "Foo".}``, search for `mFoo` and `opcFoo`.
 
-template skipEnumValue(define: untyped, predecessor: untyped): untyped =
+template skipEnumValue(define: untyped, predecessor: untyped; gap = 1): untyped =
   ## This template is used to keep the ordinal values of the ``TNodeKind``
   ## enum in sync with the ``NimNodeKind`` enum.
   ##
@@ -36,12 +36,14 @@ template skipEnumValue(define: untyped, predecessor: untyped): untyped =
   ## ``NimNodeKind`` are removed, the successor of the removed enum entry uses
   ## ``skipEnumValue`` to leave a gap in the case that `define`, which is used
   ## to indicate that the enum entry is not present in the compiler, is not
-  ## defined
+  ## defined.
+  ##
+  ## `gap` specifies the amount of enum fields to skip.
   when defined(define):
     ord(predecessor) + 1
   else:
-    # leave a gap where the removed node kind is located
-    ord(predecessor) + 2
+    # leave a gap where the removed node kinds are located
+    ord(predecessor) + gap + 1
 
 type
   NimNodeKind* = enum
@@ -106,8 +108,7 @@ type
     nnkHiddenTryStmt,
     nnkClosure,
     nnkGotoState,
-    nnkState,
-    nnkFuncDef = skipEnumValue(nimHasNkBreakStateNodeRemoved, nnkState)
+    nnkFuncDef = skipEnumValue(nimHasNkBreakStateNodeRemoved, nnkGotoState, 2),
     nnkTupleConstr,
     nnkError,  ## erroneous AST node
     nnkNimNodeLit


### PR DESCRIPTION
## Summary

Use a case statement for the dispatcher generated by the `closureiters` transformation, removing the need for both dedicated code generator support and the `nkState` node kind. This is a significant step towards closure iterator support the JavaScript and VM backend.

While neither officially supported nor documented, it was previously possible to emit `nkGotoState` and `nkState` nodes from a macro, which could be used for unsafe unstructured control-flow. With the removal of the `nkState` node kind and `nkGotoState` being disallowed in AST reaching semantic analysis, the aforementioned is no longer possible.

## Details

The AST generated by the `closureiters` transformation always looked as follows:

```nim
while true:
  block :stateLoop: # the block's body is wrapped in a try-except, if
		    # necessary
    goto env.:state # goto the label corresponding to the run-time value
                    # of `:state`
    # declarations
    body
```

where `body` defines the code blocks associated with each state value, like so:

```nim
state 0:
...
env.:state = 1
break :stateLoop
state 1:
...
state 2:
...
... # more labels (if used) follow
```

The control-flow described by the `goto` (`nkGotoState`) followed by the labels (`nkState`) is equally representable by the use of a case statement, which is what is now done after this commit.

To summarize the change:
- don't support `nkGotoState` nodes in AST reaching sem
- adjust `closureiters` to generate a case statement for the dispatcher and to not depend on `nkState`
- remove C code-generator support for `nkGotoState` and `nkState`
- remove the `nkState` node kind

Nodes with the `nkGotoState` kind now only exists *during* the transformation, but never before or after.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* all code-generators support the closure-iterator transformation now, but `jsgen` and `vmgen` don't implement the `mFinished` magic yet, meaning that `.closure` iterators are still not supported by the respective backends
* I'm going to implement `mFinished` support as a follow-up PR

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
