### PR TITLE
vmgen: fix `set` elements with large offsets

### DIFF
--- a/tests/stdlib/types/sets/tsets.nim
+++ b/tests/stdlib/types/sets/tsets.nim
@@ -1,4 +1,7 @@
-# Test builtin sets
+discard """
+  targets: "c js vm"
+  description: "Test builtin sets"
+"""
 
 # xxx these tests are not very good, this should be revisited.
 
@@ -69,7 +72,15 @@ type Foo = enum
 let x = { Foo1, Foo2 }
 # bug #8425
 
-block:
+template disallowVm(code: untyped) =
+  when not defined(vm):
+    block:
+      code
+
+# knownIssue: the serilization logic (``vm/packed_env``) doesn't offset the
+#             elements for sets, resulting in either crashes or wrong values
+#             if the first element of a set doesn't have the ordinal value '0'
+disallowVm:
   # bug #2880
   type
     FakeMsgKind = enum

--- a/tests/vm/tlarge_set_offsets.nim
+++ b/tests/vm/tlarge_set_offsets.nim
@@ -1,0 +1,41 @@
+discard """
+  targets: vm
+  labels: "set"
+  description: '''
+    Regression test for sets where the first possible element has
+    a large offset from zero
+  '''
+"""
+
+template rangeSet(a, b: static int): typedesc =
+  set[range[a..b]]
+
+template testCase(name: untyped, r: static Slice[int], val: static int) =
+  block name:
+    var s: rangeSet(r.a, r.b) = {}
+    s.incl val
+    {.line.}: doAssert val in s
+
+    s.excl val
+    # test with a run-time value. In order to prevent the optimizer from
+    # replacing it with a constant, it's returned by a procedure
+    proc get(): int {.noinline.} = val
+
+    var tmp = get()
+    s.incl tmp
+    {.line.}: doAssert tmp in s
+
+# test for the case where the offset is representable with 7 bits
+testCase small_offset, 20..30, 25
+
+block abi_edge:
+  # make sure the right encoding is chosen if the offset value is either -128,
+  # -127, 127, or 128 (at the edge of what the ABI encoding supports)
+  testCase _, -128..0, -10
+  testCase _, -127..0, -10
+  testCase _, 127..256, 150
+  testCase _, 128..256, 150
+
+testCase less_than_16bit, 10_000..11_000, 10_500
+testCase greater_than_16bit, 100_000..100_003, 100_002
+testCase greater_than_32bit, int(high(int64)-4)..int(high(int64)), int(high(int64)-2)


### PR DESCRIPTION
## Summary

Using a non-static value as a `set` element operand to procedures like `in`, `incl`, etc. resulted in an internal compiler when the lower bound of the target `set` had an offset outside of the -127..127 range.

This was caused by the code generator incorrectly assuming that the offset would fit into the immediate operand of an instruction using the ABI encoding.

The code generator now selects the appropriate instruction for applying the offset, considering the offset value.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* an issue that I noticed as part of implementing `mFinished` support for the VM
* the issues found by the `tsets.nim` test is pre-existing

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
