### PR TITLE
custom numeric literal parsing no longer crashes

### DIFF
--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -265,6 +265,9 @@ const
   pnkParsedKindsWithSons* = {pnkCall..pnkUsingStmt}
   pnkCallKinds* = {pnkCall, pnkInfix, pnkPrefix, pnkPostfix,
                   pnkCommand, pnkCallStrLit}
+  pnkFloatKinds* = {pnkFloatLit..pnkFloat128Lit}
+  pnkIntKinds* = {pnkCharLit..pnkUInt64Lit}
+  pnkStrKinds* = {pnkStrLit..pnkTripleStrLit}
 
 func len*(node: ParsedNode): int =
   ## Number of sons of the parsed node

--- a/tests/lang_syntax/lexer/tcustom_numeric_literals.nim
+++ b/tests/lang_syntax/lexer/tcustom_numeric_literals.nim
@@ -181,5 +181,7 @@ template main =
         doAssert a1 == "{-128}"
         doAssert a2 == "{-128}"
 
-static: main()
 main()
+static: main()  # run the vm version second, because semfold/VM supress errors
+                # or ignore errors and simultaneously modify the AST, meaning
+                # that runtime never sees the issue.


### PR DESCRIPTION
## Summary

Parsing for custom numeric literals led to a compiler crash as the
logic resulted in a field access defect. That's been fixed and the
tests adjusted.

## Details

Updated `toPNode` routine to no longer attempt to access the
`isBlockArg` and `sons` fields for a parsed custom literal as those
fields do not exist on that node type.

Note, testing was finding the issue before, sort of. The reason why it
went unnoticed was because `tcustom_numeric_literals` reported a pass
because we first test it via a `static: ` call. This likely caused the
semfold/VM to not only suppress the errors but potentially modify the
AST such that runtime never executes the code. As a workaround for
this, until the real reason is found I've inverted the execution,
ensuring runtime is first.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* found while adding tests for token construction