### PR TITLE
testament: end run sexp compare if it would crash

### DIFF
--- a/testament/backend.nim
+++ b/testament/backend.nim
@@ -30,6 +30,7 @@ type
   TOutCompare* = ref object
     ## Result of comparing two data outputs for a given spec
     match*: bool
+    failed*: bool   ## if true then generating the report failed
     expectedReports*: seq[TOutReport]
     givenReports*: seq[TOutReport]
     sortedMapping*: seq[tuple[pair: (int, int), cost: int]]


### PR DESCRIPTION
## Summary

Sexp comparison is not able to handle malformed output, making it
unsuitable in the face of compiler crashes and other unexpected output.
Testament now detects unexpected output and circumvents sexp
comparison in those circumstances.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* quick change to unblock https://github.com/nim-works/nimskull/pull/590