### PR TITLE
`lang_callable` tests enabled for all backends

### DIFF
--- a/tests/arc/tclosureiter.nim
+++ b/tests/arc/tclosureiter.nim
@@ -1,7 +1,11 @@
 discard """
-  cmd: '''nim c -d:nimAllocStats --gc:arc $file'''
+  target: "!js !vm"
+  matrix: '''-d:nimAllocStats --gc:arc'''
   output: '''(allocCount: 102, deallocCount: 102)'''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
+# Also, GC stats is a C target thing mostly
 
 type
   FutureBase = ref object

--- a/tests/lang_callable/closure/tboehmdeepcopy.nim
+++ b/tests/lang_callable/closure/tboehmdeepcopy.nim
@@ -1,7 +1,8 @@
 discard """
-  cmd: "nim c --gc:boehm $options $file"
-  output: '''meep'''
+  target: c
+  matrix: "--gc:boehm"
   disabled: "windows"
+  output: '''meep'''
 """
 
 proc callit(it: proc ()) =

--- a/tests/lang_callable/closure/tinfer_closure_for_nestedproc.nim
+++ b/tests/lang_callable/closure/tinfer_closure_for_nestedproc.nim
@@ -1,9 +1,12 @@
 discard """
   action: compile
+  target: "!vm"
 """
 
+# disabled on VM because it crashes (knownIssue)
+
 # bug #9441
-import strtabs
+import std/strtabs
 
 type
   Request = object

--- a/tests/lang_callable/generics/tarc_misc.nim
+++ b/tests/lang_callable/generics/tarc_misc.nim
@@ -1,9 +1,10 @@
 discard """
+  matrix: "--gc:arc"
   output: ''''''
-  cmd: "nim c --gc:arc $file"
 """
 
 # bug #13519
+# Not necessarily just arc, we can just more strict about proc type conversions
 
 var unrelated: seq[proc() {.closure, gcsafe.}]
 

--- a/tests/lang_callable/generics/texplicitgeneric1.nim
+++ b/tests/lang_callable/generics/texplicitgeneric1.nim
@@ -1,5 +1,5 @@
 discard """
-  output: "Key: 12 value: 12Key: 13 value: 13 Key: A value: 12 Key: B value: 13"
+  output: ""
 """
 # test explicit type instantiation
 
@@ -21,6 +21,12 @@ iterator items*[Tkey, TValue](d: PDict[TKey, TValue]): tuple[k: TKey,
                v: TValue] =
   for k, v in items(d.data): yield (k, v)
 
+var stdout = ""
+
+proc write(fakeStdout: var string, stuff: varargs[string]) =
+  for s in stuff:
+    fakeStdout.add s
+
 var d = newDict[int, string]()
 d.add(12, "12")
 d.add(13, "13")
@@ -34,3 +40,5 @@ for k, v in items(c):
   stdout.write(" Key: ", $k, " value: ", v)
 
 stdout.write "\n"
+
+doAssert stdout == "Key: 12 value: 12Key: 13 value: 13 Key: A value: 12 Key: B value: 13\n"

--- a/tests/lang_callable/generics/texplicitgeneric2.nim
+++ b/tests/lang_callable/generics/texplicitgeneric2.nim
@@ -1,5 +1,5 @@
 discard """
-  output: "Key: 12 value: 12Key: 13 value: 13 Key: A value: 12 Key: B value: 13"
+  output: ""
 """
 
 # test explicit type instantiation
@@ -20,6 +20,12 @@ proc add*(d: PDict, k: d.TKey, v: d.TValue) =
 iterator items*(d: PDict): tuple[k: d.TKey, v: d.TValue] =
   for k, v in items(d.data): yield (k, v)
 
+var stdout = ""
+
+proc write(fakeStdout: var string, stuff: varargs[string]) =
+  for s in stuff:
+    fakeStdout.add s
+
 var d = newDict[int, string]()
 d.add(12, "12")
 d.add(13, "13")
@@ -33,3 +39,5 @@ for k, v in items(c):
   stdout.write(" Key: ", $k, " value: ", v)
 
 stdout.write "\n"
+
+doAssert stdout == "Key: 12 value: 12Key: 13 value: 13 Key: A value: 12 Key: B value: 13\n"

--- a/tests/lang_callable/generics/tgeneric0.nim
+++ b/tests/lang_callable/generics/tgeneric0.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!vm"
   output: '''
 100
 0
@@ -8,8 +9,9 @@ float32
 '''
 """
 
+# disabled on VM: it seems to get stuck; needs a deeper dive (knownIssue)
 
-import tables
+import std/tables
 
 
 block tgeneric0:
@@ -76,7 +78,7 @@ block tgeneric1:
 
   proc print[T](heap: PBinHeap[T]) =
     for i in countup(0, heap.last):
-      stdout.write($heap.heap[i].data, "\n")
+      echo $heap.heap[i].data
 
   var heap: PBinHeap[int]
 

--- a/tests/lang_callable/generics/tgeneric3.nim
+++ b/tests/lang_callable/generics/tgeneric3.nim
@@ -1,4 +1,5 @@
 discard """
+target: "!vm"
 output: '''
 312
 1000000
@@ -8,7 +9,9 @@ output: '''
 '''
 """
 
-import strutils
+# disabled on VM: it seems to get stuck; needs a deeper dive (knownIssue)
+
+import std/strutils
 
 type
   PNode[T,D] = ref TNode[T,D]
@@ -180,7 +183,15 @@ proc internalFind[T,D] (n: PNode[T,D], key: T): ref TItem[T,D] {.inline.} =
       return wn.slots[x - 1]
   return nil
 
+proc write(fakeStdout: var string, stuff: varargs[string]) =
+  for s in stuff:
+    fakeStdout.add s
+proc writeLine(fakeStdout: var string, stuff: varargs[string]) =
+  write(fakeStdout, stuff)
+  write(fakeStdout, "\n")
+
 proc traceTree[T,D](root: PNode[T,D]) =
+  var stdout = "" 
   proc traceX(x: int) =
     write stdout, "("
     write stdout, x
@@ -232,6 +243,7 @@ proc traceTree[T,D](root: PNode[T,D]) =
     writeLine stdout,""
 
   doTrace(root, 0)
+  echo stdout
 
 proc InsertItem[T,D](APath: RPath[T,D], ANode:PNode[T,D], Akey: T, Avalue: D) =
   var x = - APath.Xi

--- a/tests/lang_callable/generics/tgenericprocvar.nim
+++ b/tests/lang_callable/generics/tgenericprocvar.nim
@@ -1,8 +1,12 @@
 discard """
-  output: "0false12"
+  output: ""
 """
 
 # Test multiple generic instantiation of generic proc vars:
+var stdout = ""
+proc write(fakeStdout: var string, stuff: varargs[string, `$`]) =
+  for s in stuff:
+    fakeStdout.add s
 
 proc threadProcWrapper[TMsg]() =
   var x: TMsg
@@ -35,3 +39,5 @@ for x in items(test(@[1,2,3], 2)):
   stdout.write(x)
 
 stdout.write "\n"
+
+doAssert stdout == "0false12\n"

--- a/tests/lang_callable/generics/tgenerics_issues.nim
+++ b/tests/lang_callable/generics/tgenerics_issues.nim
@@ -380,27 +380,28 @@ block t2304:
 
 
 block t2752:
-  proc myFilter[T](it: (iterator(): T), f: (proc(anything: T):bool)): (iterator(): T) =
-    iterator aNameWhichWillConflict(): T {.closure.}=
-      for x in it():
-        if f(x):
+  when defined(jsVmClosureIteratorSupported):
+    proc myFilter[T](it: (iterator(): T), f: (proc(anything: T):bool)): (iterator(): T) =
+      iterator aNameWhichWillConflict(): T {.closure.}=
+        for x in it():
+          if f(x):
+            yield x
+      result = aNameWhichWillConflict
+
+    iterator testIt():int {.closure.}=
+      yield -1
+      yield 2
+
+    #let unusedVariable = myFilter(testIt, (x: int) => x > 0)
+
+    proc onlyPos(it: (iterator(): int)): (iterator(): int)=
+      iterator aNameWhichWillConflict(): int {.closure.}=
+        var filtered = onlyPos(myFilter(it, (x:int) => x > 0))
+        for x in filtered():
           yield x
-    result = aNameWhichWillConflict
+      result = aNameWhichWillConflict
 
-  iterator testIt():int {.closure.}=
-    yield -1
-    yield 2
-
-  #let unusedVariable = myFilter(testIt, (x: int) => x > 0)
-
-  proc onlyPos(it: (iterator(): int)): (iterator(): int)=
-    iterator aNameWhichWillConflict(): int {.closure.}=
-      var filtered = onlyPos(myFilter(it, (x:int) => x > 0))
-      for x in filtered():
-        yield x
-    result = aNameWhichWillConflict
-
-  let x = onlyPos(testIt)
+    let x = onlyPos(testIt)
 
 
 

--- a/tests/lang_callable/generics/tobjecttyperel.nim
+++ b/tests/lang_callable/generics/tobjecttyperel.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!vm"
   output: '''(peel: 0, color: 15)
 (color: 15)
 17
@@ -7,6 +8,8 @@ discard """
 cool
 test'''
 """
+
+# disabled on VM until it supports methods (knownIssue)
 
 # bug #5241
 type

--- a/tests/lang_callable/generics/tparser_generator.nim
+++ b/tests/lang_callable/generics/tparser_generator.nim
@@ -1,16 +1,19 @@
 discard """
+  target: "!js !vm"
+  joinable: false
   output: '''Match failed: spam
 Match failed: ham'''
-joinable: false
 """
 
 # bug #6220
 
-import nre
-import options
-import strutils except isAlpha, isLower, isUpper, isSpace
-from unicode import isAlpha, isLower, isUpper, isTitle, isWhiteSpace
-import os
+# fix `std/nre` to work across platforms to enable for js and vm
+
+import std/nre
+import std/options
+import std/strutils except isAlpha, isLower, isUpper, isSpace
+from std/unicode import isAlpha, isLower, isUpper, isTitle, isWhiteSpace
+import std/os
 
 const debugLex = false
 

--- a/tests/lang_callable/generics/treentranttypes.nim
+++ b/tests/lang_callable/generics/treentranttypes.nim
@@ -1,4 +1,5 @@
 discard """
+target: "!vm"
 output: '''
 (10, ("test", 1.2))
 3x3 Matrix [[0.0, 2.0, 3.0], [2.0, 0.0, 5.0], [2.0, 0.0, 5.0]]
@@ -15,6 +16,8 @@ output: '''
 @[1, 2]@[3, 4]
 '''
 """
+
+# disabled on VM: "same" output but float formatting is off (knownIssue)
 
 # https://github.com/nim-lang/Nim/issues/5962
 

--- a/tests/lang_callable/generics/tthread_generic.nim
+++ b/tests/lang_callable/generics/tthread_generic.nim
@@ -1,5 +1,6 @@
 discard """
-  cmd: "nim $target --hints:on --threads:on $options $file"
+  target: "!vm !js"
+  matrix: "--threads:on"
   action: compile
 """
 
@@ -26,14 +27,13 @@ proc `@||->`*[T](fn: proc(): T {.thread.},
 proc `||->`*[T](fn: proc(): T{.thread.}, callback: proc(val: T){.thread.}) =
   discard fn @||-> callback
 
-when true:
-  import os
-  proc testFunc(): int {.thread.} =
-    return 1
-  proc callbackFunc(val: int) {.thread.} =
-    echo($(val))
+import os
+proc testFunc(): int {.thread.} =
+  return 1
+proc callbackFunc(val: int) {.thread.} =
+  echo($(val))
 
-  var thr = (testFunc @||-> callbackFunc)
-  echo("test")
-  joinThread(thr)
-  os.sleep(3000)
+var thr = (testFunc @||-> callbackFunc)
+echo("test")
+joinThread(thr)
+os.sleep(3000)

--- a/tests/lang_callable/generics/tvarseq_caching.nim
+++ b/tests/lang_callable/generics/tvarseq_caching.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!vm"
   output: '''@[1, 2, 3]
 @[4.0, 5.0, 6.0]
 @[1, 2, 3]
@@ -6,6 +7,8 @@ discard """
 @[1, 2, 3]
 @[4, 5, 6]'''
 """
+
+# disabled on VM: SIGSEGVs; needs a deeper dive (knownIssue)
 
 # bug #3476
 

--- a/tests/lang_callable/iter/t2771.nim
+++ b/tests/lang_callable/iter/t2771.nim
@@ -1,3 +1,9 @@
+discard """
+  target: "!js !vm"
+"""
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
+
 template t1(i: int): int=
   i+1
 template t2(i: int): int=

--- a/tests/lang_callable/iter/tanoniter1.nim
+++ b/tests/lang_callable/iter/tanoniter1.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   output: '''1
 2
 3
@@ -6,6 +7,8 @@ discard """
 1
 2'''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 proc factory(a, b: int): iterator (): int =
   iterator foo(): int {.closure.} =

--- a/tests/lang_callable/iter/tclosureiters.nim
+++ b/tests/lang_callable/iter/tclosureiters.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   output: '''0
 1
 2
@@ -23,6 +24,8 @@ discard """
 0
 '''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 when true:
   proc main() =

--- a/tests/lang_callable/iter/tcountup.nim
+++ b/tests/lang_callable/iter/tcountup.nim
@@ -6,11 +6,12 @@ discard """
 """
 
 # Test new countup
+var output = ""
 
 for i in 0 ..< 10'i64:
-  stdout.write(i)
+  output.add($i)
 
-echo()
+echo output
 
 # 11099
 

--- a/tests/lang_callable/iter/titer.nim
+++ b/tests/lang_callable/iter/titer.nim
@@ -1,6 +1,7 @@
 discard """
 output: '''
-testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest2!test3?hi
+testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest2!test3?
+hi
 what's
 your
 name
@@ -38,6 +39,11 @@ iterator interval[T](a, b: T): T =
 #    if shouldClose: close(f)
 #
 
+var stdout = ""
+proc write(fakeStdout: var string, stuff: varargs[string]) =
+  for s in stuff:
+    fakeStdout.add s
+
 for i in xrange(0, 5):
   for k in xrange(1, 7):
     write(stdout, "test")
@@ -45,6 +51,8 @@ for i in xrange(0, 5):
 for j in interval(45, 45):
   write(stdout, "test2!")
   write(stdout, "test3?")
+
+echo stdout
 
 for x in items(["hi", "what's", "your", "name"]):
   echo(x)

--- a/tests/lang_callable/iter/titer11.nim
+++ b/tests/lang_callable/iter/titer11.nim
@@ -1,4 +1,5 @@
 discard """
+target: "!js !vm"
 output: '''
 [
 1
@@ -7,6 +8,8 @@ output: '''
 ]
 '''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 proc represent(i: int): iterator(): string =
   result = iterator(): string =

--- a/tests/lang_callable/iter/titer12.nim
+++ b/tests/lang_callable/iter/titer12.nim
@@ -1,5 +1,12 @@
+discard """
+  target: "!js !vm"
+"""
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
+
 # bug #5522
-import macros, sugar, sequtils
+
+import std/[macros, sugar, sequtils]
 
 proc tryS(f: () -> void): void =
   (try: f() except: discard)

--- a/tests/lang_callable/iter/titer13.nim
+++ b/tests/lang_callable/iter/titer13.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   output: '''b yields
 c yields
 a returns
@@ -13,6 +14,8 @@ c yields
 4
 '''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 block:
   template tloop(iter: untyped) =

--- a/tests/lang_callable/iter/titer3.nim
+++ b/tests/lang_callable/iter/titer3.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   output: '''1231
 4
 6
@@ -10,21 +11,25 @@ discard """
 '''
 """
 
+# JS and VM targets disabled until they support closure iterators (knownIssue)
+
 iterator count1_3: int =
   yield 1
   yield 2
   yield 3
 
+var output = ""
 for x in count1_3():
-  write(stdout, $x)
+  output.add $x
 
 # yield inside an iterator, but not in a loop:
 iterator iter1(a: openArray[int]): int =
   yield a[0]
 
 var x = [[1, 2, 3], [4, 5, 6]]
-for y in iter1(x[0]): write(stdout, $y)
-writeLine(stdout, "")
+for y in iter1(x[0]): output.add $y
+
+echo output
 
 # ensure closure and inline iterators have the same behaviour regarding
 # parameter passing

--- a/tests/lang_callable/iter/titer5.nim
+++ b/tests/lang_callable/iter/titer5.nim
@@ -1,13 +1,16 @@
 discard """
-  output: "abcxyz"
+  output: ""
 """
 # Test method call syntax for iterators:
 import strutils
 
 const lines = """abc  xyz"""
 
+var output = ""
 for x in lines.split():
-  stdout.write(x)
+  output.add(x)
 
 #OUT abcxyz
-stdout.write "\n"
+output.add "\n"
+
+doAssert output == "abcxyz\n"

--- a/tests/lang_callable/iter/titer6.nim
+++ b/tests/lang_callable/iter/titer6.nim
@@ -1,9 +1,9 @@
 discard """
-  output: "000"
+  output: ""
 """
 # Test iterator with more than 1 yield statement
 
-import strutils
+import std/strutils
 
 iterator tokenize2(s: string, seps: set[char] = Whitespace): tuple[
   token: string, isSep: bool] =
@@ -20,9 +20,10 @@ iterator tokenize2(s: string, seps: set[char] = Whitespace): tuple[
         yield (substr(s, i, j-1), false)
     i = j
 
+var output = ""
 for word, isSep in tokenize2("ta da", WhiteSpace):
   var titer2TestVar = 0
-  stdout.write(titer2TestVar)
+  output.add($titer2TestVar)
 
 proc wordWrap2(s: string, maxLineWidth = 80,
                splitLongWords = true,
@@ -32,4 +33,6 @@ proc wordWrap2(s: string, maxLineWidth = 80,
   for word, isSep in tokenize2(s, seps):
     var w = 0
 
-stdout.write "\n"
+output.add "\n"
+
+doAssert output == "000\n"

--- a/tests/lang_callable/iter/titer8.nim
+++ b/tests/lang_callable/iter/titer8.nim
@@ -1,9 +1,11 @@
 discard """
+  target: "!js !vm"
   output: '''tada
 1
 2
 3
-ta da1 1
+ta da
+1 1
 1 2
 1 3
 2 1
@@ -25,7 +27,9 @@ a1: D'''
 """
 # Test first class iterator:
 
-import strutils
+# JS and VM targets disabled until they support closure iterators (knownIssue)
+
+import std/strutils
 
 iterator tokenize2(s: string, seps: set[char] = Whitespace): tuple[
   token: string, isSep: bool] {.closure.} =
@@ -47,17 +51,20 @@ iterator count3(): int {.closure.} =
   yield 2
   yield 3
 
+var output = ""
 for word, isSep in tokenize2("ta da", WhiteSpace):
   if not isSep:
-    stdout.write(word)
-echo ""
+    output.add(word)
+echo output
 
 proc inProc() =
   for c in count3():
     echo c
 
+  var output = ""
   for word, isSep in tokenize2("ta da", WhiteSpace):
-    stdout.write(word)
+    output.add(word)
+  echo output
 
   for c in count3():
     for d in count3():

--- a/tests/lang_callable/iter/titer9.nim
+++ b/tests/lang_callable/iter/titer9.nim
@@ -1,8 +1,11 @@
 discard """
+  target: "!js !vm"
   output: '''5
 14
 0'''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 iterator count[T](x: T, skip: bool): int {.closure.} =
   if skip: return x+10

--- a/tests/lang_callable/iter/titer_issues.nim
+++ b/tests/lang_callable/iter/titer_issues.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   output: '''
 0
 1
@@ -32,8 +33,10 @@ end
 '''
 """
 
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
-import sequtils, strutils
+
+import std/[sequtils, strutils]
 
 
 block t338:

--- a/tests/lang_callable/iter/titer_nested_generic.nim
+++ b/tests/lang_callable/iter/titer_nested_generic.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   description: '''
   . From https://github.com/nim-lang/Nim/issues/1550
     Passing a generic iterator to another iterator doesn't seem to work
@@ -7,6 +8,8 @@ discard """
     works since Nim v1.2.6
   '''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 type
   A[T] = iterator(x: T): T {.gcsafe, closure.}
 

--- a/tests/lang_callable/iter/titerautoerr1.nim
+++ b/tests/lang_callable/iter/titerautoerr1.nim
@@ -1,7 +1,10 @@
 discard """
+  target: "!js !vm"
   errormsg: "type mismatch: got <int literal(1)> but expected 'string'"
-  line: 8
+  line: 11
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 iterator a(): auto {.closure.} =
   if true: return "str"

--- a/tests/lang_callable/iter/titerautoerr2.nim
+++ b/tests/lang_callable/iter/titerautoerr2.nim
@@ -1,7 +1,10 @@
 discard """
+  target: "!js !vm"
   errormsg: "type mismatch: got <string> but expected 'int literal(1)'"
-  line: 8
+  line: 11
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 iterator b(): auto {.closure.} =
   yield 1

--- a/tests/lang_callable/iter/titerconcat.nim
+++ b/tests/lang_callable/iter/titerconcat.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   output: '''1
 2
 3
@@ -8,6 +9,8 @@ discard """
 22
 23'''
 """
+
+# JS and VM targets disabled until they support closure iterators (knownIssue)
 
 proc toIter*[T](s: Slice[T]): iterator: T =
   iterator it: T {.closure.} =

--- a/tests/lang_callable/iter/titervaropenarray.nim
+++ b/tests/lang_callable/iter/titervaropenarray.nim
@@ -1,6 +1,5 @@
 discard """
-  output: "123"
-  targets: "c"
+  output: ""
 """
 # Try to break the transformation pass:
 iterator iterAndZero(a: var openArray[int]): int =
@@ -8,8 +7,8 @@ iterator iterAndZero(a: var openArray[int]): int =
     yield a[i]
     a[i] = 0
 
+var output = ""
 var x = [[1, 2, 3], [4, 5, 6]]
-for y in iterAndZero(x[0]): write(stdout, $y)
-#OUT 123
+for y in iterAndZero(x[0]): output.add $y
 
-write stdout, "\n"
+doAssert output == "123"

--- a/tests/lang_callable/iter/tmoditer.nim
+++ b/tests/lang_callable/iter/tmoditer.nim
@@ -16,16 +16,17 @@ var
 for a in modItems(arr):
   a = "X"
 
+var output = ""
 for a in items(arr):
-  stdout.write(a)
+  output.add(a)
 
 for i, a in modPairs(arr):
   a = $i
 
 for a in items(arr):
-  stdout.write(a)
+  output.add(a)
 
-echo ""
+echo output
 
 #--------------------------------------------------------------------
 # Lent iterators

--- a/tests/lang_callable/iter/tshallowcopy_closures.nim
+++ b/tests/lang_callable/iter/tshallowcopy_closures.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   ccodecheck: "!@('{' \\s* 'NI HEX3Astate;' \\s* '}')"
   output: '''
 a1 10
@@ -6,7 +7,10 @@ a1 9
 '''
 """
 
+# disabled on js and vm until closure iterator support lands (knownIssue)
+
 # bug #1803
+
 type TaskFn = iterator (): float
 
 iterator a1(): float {.closure.} =

--- a/tests/lang_callable/iter/twrap_walkdir.nim
+++ b/tests/lang_callable/iter/twrap_walkdir.nim
@@ -1,8 +1,12 @@
 discard """
 action: compile
+target: c
 """
 
-import os
+# this tests needs to stop depending upon `walkDirRec` and be generalized to
+# work across platforms
+
+import std/os
 
 # bug #3636
 

--- a/tests/lang_callable/macros/tcode_gen_duplicate_definition.nim
+++ b/tests/lang_callable/macros/tcode_gen_duplicate_definition.nim
@@ -1,5 +1,6 @@
 discard """
   action: "compile"
+  target: "!vm"
   description: '''
   . Originally from https://github.com/nim-lang/Nim/issues/6986 as a duplicate
     cpp codegen issue, but this is more testing the invariant for all backends
@@ -7,7 +8,9 @@ discard """
   '''
 """
 
-import sequtils, strutils
+# broken on VM, requires deeper dive (knownIssue)
+
+import std/[sequtils, strutils]
 
 
 let rules = toSeq(lines("input"))

--- a/tests/lang_callable/macros/tgettype.nim
+++ b/tests/lang_callable/macros/tgettype.nim
@@ -1,3 +1,9 @@
+discard """
+target: "!vm"
+"""
+
+# disabled on VM, compiler crash needs a deeper dive (knownIssue)
+
 import std/macros
 import stdtest/testutils
 

--- a/tests/lang_callable/macros/tmacro5.nim
+++ b/tests/lang_callable/macros/tmacro5.nim
@@ -1,4 +1,10 @@
-import macros,json
+discard """
+target: "!vm"
+"""
+
+# disabled on VM, compiler crash needs a deeper dive (knownIssue)
+
+import std/[macros,json]
 
 var decls{.compileTime.}: seq[NimNode] = @[]
 var impls{.compileTime.}: seq[NimNode] = @[]

--- a/tests/lang_callable/macros/tmacro8.nim
+++ b/tests/lang_callable/macros/tmacro8.nim
@@ -1,15 +1,22 @@
 # issue #8573
 
-import
+import std/[
   macros,
-  strutils,
-  terminal
+  strutils]
 
-type LogSeverity* = enum
-  sevError = "Error"
-  sevWarn  = "Warn"
-  sevInfo  = "Info"
-  sevDebug = "Debug"
+type
+  LogSeverity = enum
+    sevError = "Error"
+    sevWarn  = "Warn"
+    sevInfo  = "Info"
+    sevDebug = "Debug"
+  Colours = enum
+    fgRed
+    fgYellow
+    fgWhite
+    fgBlack
+
+proc setForegroundColour(fg: Colours) = discard
 
 macro log*(severity: static[LogSeverity], group: static[string], m: varargs[typed]): untyped =
   let sevStr   = align("[" & toUpperAscii($severity) & "] ", 8)
@@ -22,14 +29,4 @@ macro log*(severity: static[LogSeverity], group: static[string], m: varargs[type
   let groupStr = "[" & $group & "] "
 
   result = quote do:
-    setStyle({ styleBright })
-    setForegroundColor(sevColor) # <==
-    write(stdout, sevStr)
-
-    setStyle({ styleDim })
-    setForegroundColor(fgWhite)
-    write(stdout, groupStr)
-
-  let wl = newCall(bindSym"styledWriteLine", bindSym"stdout")
-  for arg in m: wl.add(arg)
-  result.add(wl)
+    setForegroundColour(sevColor) # <==

--- a/tests/lang_callable/macros/tmacros_various.nim
+++ b/tests/lang_callable/macros/tmacros_various.nim
@@ -109,9 +109,7 @@ block tdebugstmt:
   macro debug(n: varargs[untyped]): untyped =
     result = newNimNode(nnkStmtList, n)
     for i in 0..n.len-1:
-      add(result, newCall("write", newIdentNode("stdout"), toStrLit(n[i])))
-      add(result, newCall("write", newIdentNode("stdout"), newStrLitNode(": ")))
-      add(result, newCall("writeLine", newIdentNode("stdout"), n[i]))
+      add(result, newCall("echo", toStrLit(n[i]), newStrLitNode(": "), n[i]))
 
   var
     a: array[0..10, int]

--- a/tests/lang_callable/macros/tmemit.nim
+++ b/tests/lang_callable/macros/tmemit.nim
@@ -1,4 +1,5 @@
 discard """
+  target: c
   output: '''
 c_func
 12

--- a/tests/lang_callable/macros/tstringinterp.nim
+++ b/tests/lang_callable/macros/tstringinterp.nim
@@ -2,7 +2,7 @@ discard """
   output: "Hello Alice, 64 | Hello Bob, 10$"
 """
 
-import macros, parseutils, strutils
+import std/[macros, parseutils, strutils]
 
 proc concat(strings: varargs[string]): string =
   result = newString(0)
@@ -69,5 +69,4 @@ var
   s1 = concatStyleInterpolation"Hello ${alice}, ${sum(a, b, c)}"
   s2 = formatStyleInterpolation"Hello ${bob}, ${sum(alice.len, bob.len, 2)}$$"
 
-write(stdout, s1 & " | " & s2)
-write(stdout, "\n")
+echo s1 & " | " & s2

--- a/tests/lang_callable/macros/tstructuredlogging.nim
+++ b/tests/lang_callable/macros/tstructuredlogging.nim
@@ -5,7 +5,7 @@ exiting: a=12, b=overriden-b, c=100, msg=bye bye, x=16
 '''
 """
 
-import macros, tables
+import std/[macros, tables]
 
 template scopeHolder =
   0 # scope revision number
@@ -76,6 +76,13 @@ type
     line: string
 
   StdoutLogRecord = object
+    str*: string
+
+proc write(r: var StdoutLogRecord, stuff: string) =
+  r.str.add stuff
+
+proc flushFile(r: var StdoutLogRecord) =
+  echo r.str
 
 template setProperty(r: var TextLogRecord, key: string, val: string, isFirst: bool) =
   if not first: r.line.add ", "
@@ -84,17 +91,16 @@ template setProperty(r: var TextLogRecord, key: string, val: string, isFirst: bo
   r.line.add val
 
 template setEventName(r: var StdoutLogRecord, name: string) =
-  stdout.write(name & ": ")
+  r.write(name & ": ")
 
 template setProperty(r: var StdoutLogRecord, key: string, val: auto, isFirst: bool) =
-  when not isFirst: stdout.write ", "
-  stdout.write key
-  stdout.write "="
-  stdout.write $val
+  when not isFirst: r.write ", "
+  r.write key
+  r.write "="
+  r.write $val
 
 template flushRecord(r: var StdoutLogRecord) =
-  stdout.write "\n"
-  stdout.flushFile
+  r.flushFile
 
 macro logImpl(scopeHolders: typed,
               logStmtProps: varargs[untyped]): untyped =

--- a/tests/lang_callable/macros/ttryparseexpr.nim
+++ b/tests/lang_callable/macros/ttryparseexpr.nim
@@ -1,9 +1,12 @@
 discard """
+  target: "!vm"
   outputsub: '''Error: expression expected, but found '[EOF]' 45'''
 """
 
+# disabled for VM until we support `getCurrentExceptionMsg` (knownIssue)
+
 # feature request #1473
-import macros
+import std/macros
 
 macro test(text: string): untyped =
   try:

--- a/tests/lang_callable/macros/tvtable.nim
+++ b/tests/lang_callable/macros/tvtable.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   output: '''
 OBJ 1 foo
 10

--- a/tests/lang_callable/macros/typesafeprintf.nim
+++ b/tests/lang_callable/macros/typesafeprintf.nim
@@ -1,4 +1,5 @@
 discard """
+  target: c
   output: '''test 10'''
 """
 

--- a/tests/lang_callable/method/tgeneric_methods.nim
+++ b/tests/lang_callable/method/tgeneric_methods.nim
@@ -1,8 +1,12 @@
 discard """
+  target: !vm
   output: '''wow2
 X 1
 X 3'''
 """
+
+# disabled on VM until we support methods (knownIssue)
+
 type
   First[T] = ref object of RootObj
     value: T

--- a/tests/lang_callable/method/tmethod_issues.nim
+++ b/tests/lang_callable/method/tmethod_issues.nim
@@ -1,11 +1,12 @@
 discard """
+  target: "!vm"
   output: '''
 wof!
 wof!
-type A
-type B
 '''
 """
+
+# disabled on VM until we support methods (knownIssue)
 
 
 # bug #1659
@@ -29,15 +30,16 @@ ech a
 
 
 # bug #2401
-type MyClass = ref object of RootObj
+when not defined(js): # knownIssue with JS codegen
+  type MyClass = ref object of RootObj
 
-method HelloWorld*(obj: MyClass) {.base.} =
-  when defined(myPragma):
-    echo("Hello World")
-  # discard # with this line enabled it works
+  method HelloWorld*(obj: MyClass) {.base.} =
+    when defined(myPragma):
+      echo("Hello World")
+    # discard # with this line enabled it works
 
-var obj = MyClass()
-obj.HelloWorld()
+  var obj = MyClass()
+  obj.HelloWorld()
 
 
 
@@ -139,12 +141,12 @@ type
 
   B = ref object of A
 
-method foo(v: sink A, lst: var seq[A]) {.base,locks:0.} =
-  echo "type A"
+method foo(v: sink A, lst: var seq[A]): string {.base,locks:0.} =
+  result = "type A"
   lst.add v
 
-method foo(v: sink B, lst: var seq[A]) =
-  echo "type B"
+method foo(v: sink B, lst: var seq[A]): string =
+  result = "type B"
   lst.add v
 
 proc main() =
@@ -154,8 +156,9 @@ proc main() =
 
   var lst: seq[A]
 
-  foo(a, lst)
-  foo(b, lst)
+  doAssert foo(a, lst) == "type A"
+  doAssert foo(b, lst) == "type B"
 
-main()
+when not defined(js): # knownIssue for JS, causes exception, needs deep dive
+  main()
 

--- a/tests/lang_callable/method/tmethod_various.nim
+++ b/tests/lang_callable/method/tmethod_various.nim
@@ -1,9 +1,12 @@
 discard """
+  target: "!vm"
   output: '''
 do nothing
 HELLO WORLD!
 '''
 """
+
+# disabled on VM until we support methods (knownIssue)
 
 
 # tmethods1

--- a/tests/lang_callable/method/tmultim.nim
+++ b/tests/lang_callable/method/tmultim.nim
@@ -1,4 +1,6 @@
 discard """
+  target: "!vm"
+  joinable: false
   output: '''
 collide: unit, thing
 collide: unit, thing
@@ -9,9 +11,9 @@ collide: unit, thing |
 collide: thing, unit |
 do nothing
 '''
-  joinable: false
-
 """
+
+# disabled on VM until we support methods (knownIssue)
 
 
 # tmultim2

--- a/tests/lang_callable/method/tmultimjs.nim
+++ b/tests/lang_callable/method/tmultimjs.nim
@@ -1,12 +1,14 @@
 discard """
+  target: "js"
   output: '''
 7
 Hi derived!
 hello
 '''
-
 """
 
+# JS specific, but can likely be collapsed into general method coverage when we
+# get to doing that.
 
 # tmultim1
 type

--- a/tests/lang_callable/method/tnildispatcher.nim
+++ b/tests/lang_callable/method/tnildispatcher.nim
@@ -1,7 +1,13 @@
 discard """
+  target: "!vm !js"
   outputsub: '''Error: unhandled exception: cannot dispatch; dispatcher is nil [NilAccessDefect]'''
   exitcode: 1
 """
+
+# disabled on VM until we support methods (knownIssue)
+
+# disabled on JS because sem/codegen lets it through and we get a runtime NPE
+
 # bug #5599
 type
     Base = ref object of RootObj

--- a/tests/lang_callable/method/treturn_var_t.nim
+++ b/tests/lang_callable/method/treturn_var_t.nim
@@ -1,7 +1,10 @@
 discard """
+  target: "!vm"
   output: '''Inh
 45'''
 """
+
+# disabled on VM until we support methods (knownIssue)
 
 type
   Base = ref object of RootObj

--- a/tests/lang_callable/method/tsingle_methods.nim
+++ b/tests/lang_callable/method/tsingle_methods.nim
@@ -1,5 +1,6 @@
 discard """
-  cmd: "nim c --multimethods:off $file"
+  matrix: "--multimethods:off"
+  target: "!vm"
   output: '''base
 base
 base
@@ -8,6 +9,8 @@ base
 base
 '''
 """
+
+# disabled on VM until we support methods (knownIssue)
 
 # bug #10912
 

--- a/tests/lang_callable/overload/toverload_bracket_accessor_template.nim
+++ b/tests/lang_callable/overload/toverload_bracket_accessor_template.nim
@@ -1,4 +1,5 @@
 discard """
+  target: "!js !vm"
   description: '''
    . From https://github.com/nim-lang/Nim/issues/8829
      template that overloads [] accessor does not compile

--- a/tests/lang_callable/overload/toverload_various.nim
+++ b/tests/lang_callable/overload/toverload_various.nim
@@ -1,11 +1,10 @@
 discard """
   output: '''
-true012innertrue
 m1
 tup1
 another number: 123
 yay
-helloa 1 b 2 x @[3, 4, 5] y 6 z 7
+a 1 b 2 x @[3, 4, 5] y 6 z 7
 yay
 12
 ref ref T ptr S
@@ -37,6 +36,11 @@ block overl2:
 
   var
     pp: proc (x: bool): string {.nimcall.} = toverl2
+    stdout = ""
+
+  proc write(fakeStdout: var string, stuff: varargs[string, `$`]) =
+    for s in stuff:
+      fakeStdout.add s
 
   stdout.write(pp(true))
 
@@ -48,8 +52,7 @@ block overl2:
     stdout.write(toverl2(5))
     stdout.write(true)
 
-  stdout.write("\n")
-  #OUT true012innertrue
+  doAssert stdout == "true012innertrue"
 
 
 
@@ -92,8 +95,9 @@ block toverprc:
     result = x("123")
 
   if false:
+    let someInputLine = "69\nnice\nlol"
     echo "Give a list of numbers (separated by spaces): "
-    var x = stdin.readline.split.map(parseInt).max
+    var x = someInputLine.split.map(parseInt).max
     echo x, " is the maximum!"
   echo "another number: ", takeParseInt(parseInt)
 
@@ -112,10 +116,9 @@ block toverprc:
 
 block toverwr:
   # Test the overloading resolution in connection with a qualifier
-  proc write(t: File, s: string) =
-    discard # a nop
-  system.write(stdout, "hello")
-  #OUT hello
+  func len(s: string): int =
+    0
+  doAssert system.len("hello") == 5
 
 
 

--- a/tests/lang_callable/overload/tstatic_with_converter.nim
+++ b/tests/lang_callable/overload/tstatic_with_converter.nim
@@ -1,4 +1,5 @@
 discard """
+target: c
 output: '''
 9.0
 

--- a/tests/lang_callable/overload/tsystemcmp.nim
+++ b/tests/lang_callable/overload/tsystemcmp.nim
@@ -1,9 +1,9 @@
 discard """
-  cmd: r"nim c --hints:on $options --threads:on $file"
+  matrix: "--threads:on"
   output: '''@["", "a", "ha", "hi", "ho", "huu"]'''
 """
 
-import algorithm
+import std/algorithm
 
 # bug #1657
 var modules = @["hi", "ho", "", "a", "ha", "huu"]

--- a/tests/lang_callable/procvar/tprocvar.nim
+++ b/tests/lang_callable/procvar/tprocvar.nim
@@ -1,7 +1,5 @@
 discard """
-  output: '''
-papbpcpdpe7
-'''
+  output: ''''''
 """
 
 block genericprocvar:
@@ -11,24 +9,26 @@ block genericprocvar:
 
 
 block tprocvar2:
-  proc pa() {.cdecl.} = write(stdout, "pa")
-  proc pb() {.cdecl.} = write(stdout, "pb")
-  proc pc() {.cdecl.} = write(stdout, "pc")
-  proc pd() {.cdecl.} = write(stdout, "pd")
-  proc pe() {.cdecl.} = write(stdout, "pe")
+  var output = ""
+  proc pa() {.cdecl.} = output.add "pa"
+  proc pb() {.cdecl.} = output.add "pb"
+  proc pc() {.cdecl.} = output.add "pc"
+  proc pd() {.cdecl.} = output.add "pd"
+  proc pe() {.cdecl.} = output.add "pe"
 
   const algos = [pa, pb, pc, pd, pe]
   var x: proc (a, b: int): int {.cdecl.}
 
   proc ha(c, d: int): int {.cdecl.} =
-    echo(c + d)
     result = c + d
 
   for a in items(algos):
     a()
 
   x = ha
-  discard x(3, 4)
+  output.add $x(3, 4)
+
+  doAssert output == "papbpcpdpe7"
 
 
 block tprocvars:

--- a/tests/lang_callable/template/tgensymregression.nim
+++ b/tests/lang_callable/template/tgensymregression.nim
@@ -1,9 +1,12 @@
 discard """
+  target: "!vm"
   output: '''[0.0, 0.0, 0.0]
 [0.0, 0.0, 0.0, 0.0]
 5050
 123'''
 """
+
+# disabled on VM: "same" output but formatting is off (knownIssue)
 
 template mathPerComponent(op: untyped): untyped =
   proc op*[N,T](v,u: array[N,T]): array[N,T] {.inline.} =

--- a/tests/lang_callable/template/tstempl.nim
+++ b/tests/lang_callable/template/tstempl.nim
@@ -4,7 +4,7 @@ levB'''
 """
 
 # tstempl.nim
-import strutils
+import std/strutils
 
 type
   TLev = enum
@@ -15,10 +15,10 @@ var abclev = levB
 
 template tstLev(abclev: TLev) =
   bind tstempl.abclev, `%`
-  writeLine(stdout, "global = $1, arg = $2, test = $3" % [
-    $tstempl.abclev, $abclev, $(tstempl.abclev == abclev)])
+  echo "global = $1, arg = $2, test = $3" % [
+    $tstempl.abclev, $abclev, $(tstempl.abclev == abclev)]
   # evaluates to true, but must be false
 
 
 tstLev(levA)
-writeLine(stdout, $abclev)
+echo $abclev

--- a/tests/lang_callable/template/ttempl3.nim
+++ b/tests/lang_callable/template/ttempl3.nim
@@ -2,23 +2,30 @@ discard """
 action: compile
 """
 
+type
+  FakeFile = object
+    discard
+
+proc fakeOpen(ff: FakeFile, filename: string, mode: FileMode): bool = true
+proc fakeWriteLine(ff: FakeFile, filename: string) = discard
+proc fakeClose(ff: FakeFile) = discard
 
 template withOpenFile(f: untyped, filename: string, mode: FileMode,
                       actions: untyped): untyped =
   block:
     # test that 'f' is implicitly 'injecting':
-    var f: File
-    if open(f, filename, mode):
+    var f: FakeFile
+    if fakeOpen(f, filename, mode):
       try:
         actions
       finally:
-        close(f)
+        fakeClose(f)
     else:
       quit("cannot open for writing: " & filename)
 
 withOpenFile(txt, "ttempl3.txt", fmWrite):
-  writeLine(txt, "line 1")
-  txt.writeLine("line 2")
+  fakeWriteLine(txt, "line 1")
+  txt.fakeWriteLine("line 2")
 
 var
   myVar: array[0..1, int]


### PR DESCRIPTION
## Summary

Enabled all tests in the `lang_callable` test category for all backends
by default. Some tests might be a platform specific here and there, but
they generally run across the board. This work is to increase test
coverage when enabling closure iterators across all targets.

## Details

This resulted in a number of test modifications, such as dropping usage
of `system.stdout` for output. This was replaced with appending to
strings and/or `echo` as necessary. For disabling specific tests or
subsections comments were recorded with the keyword "knownIssue".

Replacing all `echo`ed output with `doAssert`s wasn't attempted, as the
scope of change would be too large.

Follow-Ups:
- false negatives due to VM floating point to string format differences
- certain imports json/stream/os seem cause VM target failures

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* focused primarily on getting the category running cleanly
* rest of the work can be incrementally approached