### PR TITLE
backtick identifier construction fully recursive

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1040,6 +1040,7 @@ type
     adSemExpectedIdentifier
     adSemExpectedIdentifierInExpr          ## Expr is the wrongNode itself
     adSemExpectedIdentifierWithExprContext ## Expr part is informational
+    adSemExpectedIdentifierQuoteLimit      ## backtick ident construction limit
     adSemModuleAliasMustBeIdentifier
     adSemOnlyDeclaredIdentifierFoundIsError
     # imports
@@ -1311,7 +1312,8 @@ type
         adSemFoldOverflow,
         adSemFoldDivByZero,
         adSemInvalidRangeConversion,
-        adSemFoldCannotComputeOffset:
+        adSemFoldCannotComputeOffset,
+        adSemExpectedIdentifierQuoteLimit:
       discard
     of adSemExpectedIdentifierInExpr:
       notIdent*: PNode

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -641,6 +641,7 @@ type
     # Identifier Lookup
     rsemUndeclaredIdentifier
     rsemExpectedIdentifier
+    rsemExpectedIdentifierQuoteLimit
     rsemExpectedIdentifierInExpr
     rsemExpectedIdentifierWithExprContext
     rsemModuleAliasMustBeIdentifier

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2163,6 +2163,11 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "in expression '$1': identifier expected, but found '$2'" %
                 [r.ast.render(), r.wrongNode.render()]
 
+    of rsemExpectedIdentifierQuoteLimit:
+      result =
+        "identifier expected, found too large identifier construction '$1'" %
+          [r.ast.render()]
+
     of rsemExpectedIdentifierWithExprContext:
       # `ast` the identifier, the expression `wrongNode` (where the error is)
       # clarifies the message.
@@ -3877,7 +3882,8 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemExpectedObjectType,
       adSemFoldOverflow,
       adSemFoldDivByZero,
-      adSemFoldCannotComputeOffset:
+      adSemFoldCannotComputeOffset,
+      adSemExpectedIdentifierQuoteLimit:
     semRep = SemReport(
         location: some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -437,6 +437,7 @@ func astDiagToLegacyReportKind*(
   of adSemExpectedIdentifier: rsemExpectedIdentifier
   of adSemExpectedIdentifierInExpr: rsemExpectedIdentifierInExpr
   of adSemExpectedIdentifierWithExprContext: rsemExpectedIdentifierWithExprContext
+  of adSemExpectedIdentifierQuoteLimit: rsemExpectedIdentifierQuoteLimit
   of adSemOnlyDeclaredIdentifierFoundIsError: rsemOnlyDeclaredIdentifierFoundIsError
   of adSemModuleAliasMustBeIdentifier: rsemModuleAliasMustBeIdentifier
   of adSemCannotImportItself: rsemCannotImportItself

--- a/tests/lang/s02_core/s05_templates/t01_templates.nim
+++ b/tests/lang/s02_core/s05_templates/t01_templates.nim
@@ -89,19 +89,23 @@ block identifier_join:
     doAssert getvar(2'i32) == 50
     doAssert getvar(2'i64) == 50
 
-    when false:
-      # These are gaps in the spec, what sort of error should result?
-      # the spec feels really half-baked at this point... we should probably
-      # create an identifier type and constructor and only accept those
-      getVar(-2)   # produces "varName-2"
-      getVar('\n') # produces "varName10" ... wtf
-      getVar("\n") # produces "varName<newLine>"
+  block works_with_stropping:
+    ## Stropping works with identifier join in templates
+    var `varName??` = 50
+    doAssert getVar(`??`) == 50
 
-  when defined(tryBrokenSpecification):
-    block works_with_stropping:
-      ## Stropping does not work with identifier join in templates
-      var `varName??` = 50
-      doAssert getVar(`??`) == 50
+  block silly_things_like_this_are_probably_going_to_go:
+    ## don't expect this to last, likely to be dropped from the spec
+    var foo = 10
+    doAssert foo == `r"foo"`
+
+  when false:
+    # These are gaps in the spec, what sort of error should result?
+    # the spec feels really half-baked at this point... we should probably
+    # create an identifier type and constructor and only accept those
+    getVar(-2)   # produces "varName-2"
+    getVar('\n') # produces "varName10" ... wtf
+    getVar("\n") # produces "varName<newLine>"
 
   # TODO: these aren't really identifier construction tests, move them out
   block substitution_is_ast_based:


### PR DESCRIPTION
## Summary

Identifier construction using backticks (```) is now fully recrusive.
Allowing constructing identifiers from other `nkAccQuoted` identifier
strings.

## Details

Changed `considerQuotedIdent` to construct an identifier from child
node string values. In addition, a hardcoded limit on the number of
elements in a `nkAccQuoted` evaluation has been set to avoid run away 
computations.

It was always the case, but more so than ever, identifier construction
can be triggered from anywhere and is more capable than ever. See below
for initial thoughts about the discussion that needs to happen.

As a result of the vague nature of what should be, and how pervasively
we should allow identifier construction, which hasn't been detangled
from keyword escaping (much easier to do now), the code is a little
over-engineered.

#### Bigger Discussion/Open Question

`considerQuotedIdent` raises an interesting question around what is a
syntactically valid identifier vs a core language valid identifier.
That is to say what can a human provide as source that'll pass lexing
and parsing, and is generally known as Nimskull vs what our "lisp-y"
core language allows. Further to that, what do we afford
end-programmers via templates vs macros? Presently, `nkAccQuote` we
don't _really_ enforce identifier well-formed-ness in many places and
`nkAccQuoted` identifier construction let's us get away with a lot
more than keyword escaping.


---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* admittedly feels over-engineered
* fun fact, we can do identifier construction pretty much everywhere, because hacks