### PR TITLE
internal: remove `efDetermineType` sem flag

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1761,22 +1761,22 @@ type
   TExprFlag* = enum
     efLValue, efWantIterator, efInTypeof,
     efNeedStatic,
-      # Use this in contexts where a static value is mandatory
+      ## Use this in contexts where a static value is mandatory
     efPreferStatic,
-      # Use this in contexts where a static value could bring more
-      # information, but it's not strictly mandatory. This may become
-      # the default with implicit statics in the future.
+      ## Use this in contexts where a static value could bring more
+      ## information, but it's not strictly mandatory. This may become
+      ## the default with implicit statics in the future.
     efPreferNilResult,
-      # Use this if you want a certain result (e.g. static value),
-      # but you don't want to trigger a hard error. For example,
-      # you may be in position to supply a better error message
-      # to the user.
-    efWantStmt, efAllowStmt, efDetermineType, efExplain,
+      ## Use this if you want a certain result (e.g. static value),
+      ## but you don't want to trigger a hard error. For example,
+      ## you may be in position to supply a better error message
+      ## to the user.
+    efWantStmt, efAllowStmt, efExplain,
     efWantValue, efOperand, efNoSemCheck,
     efNoEvaluateGeneric, efInCall, efFromHlo, efNoSem2Check,
     efNoUndeclared
-      # Use this if undeclared identifiers should not raise an error during
-      # overload resolution.
+      ## Use this if undeclared identifiers should not raise an error during
+      ## overload resolution.
 
   TExprFlags* = set[TExprFlag]
 

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -303,7 +303,7 @@ proc semShallowCopy(c: PContext, n: PNode, flags: TExprFlags): PNode
 proc semOf(c: PContext, n: PNode): PNode =
   if n.len == 3:
     n[1] = semExprWithType(c, n[1])
-    n[2] = semExprWithType(c, n[2], {efDetermineType})
+    n[2] = semExprWithType(c, n[2])
     #restoreOldStyleType(n[1])
     #restoreOldStyleType(n[2])
     let a = skipTypes(n[1].typ, abstractPtrs)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -251,8 +251,8 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
     localReport(c.config, n, reportSem rsemRangeIsEmpty)
 
   var range: array[2, PNode]
-  range[0] = semExprWithType(c, n[1], {efDetermineType})
-  range[1] = semExprWithType(c, n[2], {efDetermineType})
+  range[0] = semExprWithType(c, n[1])
+  range[1] = semExprWithType(c, n[2])
 
   var rangeT: array[2, PType]
   for i in 0..1:
@@ -326,7 +326,7 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
   if isRange(n):
     result = semRangeAux(c, n, nil)
   else:
-    let e = semExprWithType(c, n, {efDetermineType})
+    let e = semExprWithType(c, n)
     if e.typ.kind == tyFromExpr:
       result = makeRangeWithStaticExpr(c, e.typ.n)
     elif e.kind in {nkIntLit..nkUInt64Lit}:
@@ -1382,7 +1382,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
             def.typ = makeTypeFromExpr(c, def.copyTree)
             break determineType
 
-        def = semExprWithType(c, def, {efDetermineType})
+        def = semExprWithType(c, def)
         if def.referencesAnotherParam(getCurrOwner(c)):
           def.flags.incl nfDefaultRefsParam
 
@@ -1671,7 +1671,7 @@ proc fixupTypeOf(c: PContext, prev: PType, typExpr: PNode) =
     assignType(prev, result)
 
 proc semTypeExpr(c: PContext, n: PNode; prev: PType): PType =
-  var n = semExprWithType(c, n, {efDetermineType})
+  var n = semExprWithType(c, n)
   if n.typ.kind == tyTypeDesc:
     result = n.typ.base
     # fix types constructed by macros/template:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2475,14 +2475,7 @@ proc prepareOperand(c: PContext; formal: PType; a: PNode): PNode =
   elif a.typ.isNil:
     # XXX This is unsound! 'formal' can differ from overloaded routine to
     # overloaded routine!
-    let
-      flags = {efDetermineType, efAllowStmt}
-                #if formal.kind == tyIterable: {efDetermineType, efWantIterator}
-                #else: {efDetermineType, efAllowStmt}
-                #elif formal.kind == tyTyped: {efDetermineType, efWantStmt}
-                #else: {efDetermineType}
-
-    result = c.semOperand(c, a, flags)
+    result = c.semOperand(c, a, {efAllowStmt})
   else:
     result = a
     considerGenSyms(c, result)
@@ -2494,7 +2487,7 @@ proc prepareOperand(c: PContext; formal: PType; a: PNode): PNode =
 
 proc prepareOperand(c: PContext; a: PNode): PNode =
   if a.typ.isNil:
-    result = c.semOperand(c, a, {efDetermineType})
+    result = c.semOperand(c, a)
   else:
     result = a
     considerGenSyms(c, result)


### PR DESCRIPTION
## Summary

`efDetermineType` is a legacy internal flag used to direct semantic
analysis, it like most `TExprFlag` are code smells. The flag is passed
in many places but read in none -- AKA deadcode. This has no impact on
any functionality.

## Details

Deleted definition and all callsites passing the flag in, there were no reads.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* not much to see here