### PR TITLE
sem: fix default parameter handling for macros

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -224,8 +224,6 @@ type
     unitSep*: string ## Unit separator between compiler messages
     evalTemplateCounter*: int ## Template instantiation depth used to guard
     ## against infinite expansion recursion
-    evalMacroCounter*: int ## Macro instantiation depth, used to guard
-    ## against infinite macro expansion recursion
     exitcode*: int8
 
     hintProcessingDots*: bool ## true for dots, false for filenames

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -111,13 +111,19 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
       result.add res
     c.isDeclarative = parentIsDeclarative
 
-proc evalTemplateArgs(n: PNode, s: PSym; conf: ConfigRef; fromHlo: bool): PNode =
+proc evalTemplateArgs*(n: PNode, s: PSym; conf: ConfigRef; fromHlo: bool): PNode =
+  ## Produces an ``nkArgList`` node storing all arguments taken from the
+  ## call-like expression `n`. Immediate templates/macros are also considered,
+  ## by making sure enough parameters are provided and by inserting the default
+  ## for parameters where no argument is provided.
+  ##
+  ## Despite the name, the procedure also applies to macro arguments.
   # if the template has zero arguments, it can be called without ``()``
   # `n` is then a nkSym or something similar
   let
     totalParams = if n.kind in nkCallKinds: n.len-1
                   else: 0
-    # XXX: Since immediate templates are not subject to the
+    # XXX: Since immediate templates/macros are not subject to the
     # standard sigmatching algorithm, they will have a number
     # of deficiencies when it comes to generic params:
     # Type dependencies between the parameters won't be honoured

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1382,6 +1382,8 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
             def.typ = makeTypeFromExpr(c, def.copyTree)
             break determineType
 
+        # FIXME: don't analyse the `def` expression if the type was
+        #        explicitly specified to be ``untyped``
         def = semExprWithType(c, def)
         if def.referencesAnotherParam(getCurrOwner(c)):
           def.flags.incl nfDefaultRefsParam

--- a/tests/lang_callable/macros/tdefault_parameters.nim
+++ b/tests/lang_callable/macros/tdefault_parameters.nim
@@ -1,0 +1,68 @@
+discard """
+  description: "Tests for macros with default parameters"
+  action: compile
+"""
+
+import std/macros
+
+block mixed_explicit_call:
+  # the macro is invoked via call/command syntax and has parameters with and
+  # without defaults
+  macro m(a: int; b: untyped = 2) =
+    doAssert b.intVal == 2
+
+  m(1)
+
+block no_call_syntax:
+  # invoking the macro without call syntax works too
+  macro m(a: untyped = 1; b: untyped = 2) =
+    doAssert a.intVal == 1
+    doAssert b.intVal == 2
+
+  m
+
+block generic_no_call_syntax:
+  # invoking the macro without call syntax also works for generic
+  # macros
+  macro m[T](a: untyped = 1) =
+    # XXX: the ``T`` is not (yet) accesible as a ``NimNode`` in the body
+    #doAssert T.typeKind == ntyInt
+    doAssert a.intVal == 1
+
+  m[int]
+
+# XXX: this doesn't work, but it could. If analysis of the default value would
+#      be deferred until instantiation time (because that's when it's known
+#      whether or not the parameter type is ``untyped``), if the parameter type
+#      depends on a generic parameter.
+#      For related discussion about whether this should be an error instead,
+#      see: https://github.com/nim-works/nimskull/pull/615#discussion_r1155224154
+when false: #block dependent_defaults:
+  macro m[T](a: T = 1): untyped =
+    if a.getType.isNil:
+      result = ident"false" # the input is untyped
+    else:
+      result = ident"true"
+
+  static:
+    doAssert m[untyped]() == false
+    doAssert m[int]() == true
+
+block mixed_explicit_call_in_generic:
+  # immediate macros with default parameters are also evaluated during early
+  # analysis of generic routines
+  var i {.compileTime.} = 0
+
+  macro m(a: untyped; b: untyped = 2) =
+    doAssert a.intVal == 1
+    doAssert b.intVal == 2
+    inc i
+
+  proc p[T]() =
+    m(1)
+
+  # the macro is an immediate macro, so its evaluated during early generic
+  # routine body analysis -- no instance of ``p`` has to be created
+
+  static:
+    doAssert i == 1 # make sure the macro was really evaluated


### PR DESCRIPTION
## Summary

Default parameters did not work for macros that are invoked without overload resolution happening prior, resulting in `wrong number of arguments` errors. This is fixed now, meaning that invoking macros for which all parameters have default values now works even when not using the call or command syntax.

## Details

`semMacroExpr` now uses the `evalTemplateArgs` procedure for pre-processing and validating the arguments.

With the usage of `evalTemplateArgs`, the previous argument validation logic in `semMacroExpr` and `evalMacroCall` becomes redundant and is removed, reducing the amount of code duplication a bit.

In addition, the recursion check in `evalMacroCall` is removed. The procedure is not re-entrant, which made the guard unnecessary. Infinite nesting (i.e.: a macro evaluating to a call to itself) is already detected by `semAfterMacroCall`.

### Issues discovered

Default parameters are *always* analysed during routine header analysis, even for ``untyped`` parameters. In practice, this means that AST passed to ``untyped`` parameters with default values can not be relied on to really be untyped.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* a small preparation for macros storing and using their internal signatures

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
