### PR TITLE
sem: fix a common crash caused by `semSym`

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1602,14 +1602,20 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
     else:
       result = newSymNode(s, n.info)
   of skMacro:
-    if efNoEvaluateGeneric in flags and s.ast[genericParamsPos].len > 0 or
+    if s.ast.kind == nkError:
+      result = c.config.newError(n,
+        PAstDiag(kind: adSemCalleeHasAnError, callee: s))
+    elif efNoEvaluateGeneric in flags and s.ast[genericParamsPos].safeLen > 0 or
        (n.kind notin nkCallKinds and s.requiredParams > 0):
       markUsed(c, n.info, s)
       result = symChoice(c, n, s, scClosed)
     else:
       result = semMacroExpr(c, n, s, flags)
   of skTemplate:
-    if efNoEvaluateGeneric in flags and s.ast[genericParamsPos].len > 0 or
+    if s.ast.kind == nkError:
+      result = c.config.newError(n,
+        PAstDiag(kind: adSemCalleeHasAnError, callee: s))
+    elif efNoEvaluateGeneric in flags and s.ast[genericParamsPos].safeLen > 0 or
        (n.kind notin nkCallKinds and s.requiredParams > 0) or
        sfCustomPragma in sym.flags:
       let info = getCallLineInfo(n)


### PR DESCRIPTION
## Summary

This is a quick-fix for the long-standing issue of `semSym` crashing with a `FieldDefect` when a non-generic macro or template reaches it in a `efNoEvaluateGeneric` context (e.g. the `m` in `m[int]()`).

The logic assumed that a macro/template always has a node with a `sons` field in the generic parameter list slot, which is incorrect. `safeLen` is used instead of `len` now, fixing the defect.

In addition, the macro and template symbol is now checked for errors, with an error being produced if it does.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this issue is present since `nkEmpty` was made a node kind without access to the `TNode.sons` field
* it so far never surfaced in the CI due to the usage of a `-d:danger` compiler there, but I think it might be the cause of the CI failure in #615

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
