### PR TITLE
internal: begin moving `newSymG` to `newSymGNode`

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -520,8 +520,9 @@ proc transitionGenericParamToType*(s: PSym) =
 
 proc transitionRoutineSymKind*(s: PSym, kind: range[skProc..skTemplate]) =
   transitionSymKindCommon(kind)
-  s.gcUnsafetyReason = obj.gcUnsafetyReason
-  s.transformedBody = obj.transformedBody
+  if obj.kind in routineKinds:
+    s.gcUnsafetyReason = obj.gcUnsafetyReason
+    s.transformedBody = obj.transformedBody
 
 proc transitionToLet*(s: PSym) =
   transitionSymKindCommon(skLet)

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -111,6 +111,8 @@ const
   nkFloatKinds* = nkFloatLiterals
   nkStrKinds*   = nkStrLiterals
 
+  nkAllNodeKinds* = {low(TNodeKind) .. high(TNodeKind)}
+
   skLocalVars* = {skVar, skLet, skForVar, skParam, skResult}
   skProcKinds* = {skProc, skFunc, skTemplate, skMacro, skIterator,
                   skMethod, skConverter}

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1109,6 +1109,7 @@ type
     adSemCalleeHasAnError
     # sem
     adSemExpressionHasNoType
+    adSemDefNameSym   ## when creating a sym node from `nkIdentKinds`
     # semtypes
     adSemTypeExpected
     # semtempl
@@ -1470,6 +1471,24 @@ type
     of adSemInvalidIntDefine,
         adSemInvalidBoolDefine:
       invalidDef*: string
+    of adSemDefNameSym:
+      defNameSym*: PSym
+      defNameSymData*: AdSemDefNameSym
+
+  AdSemDefNameSymKind* = enum
+    adSemDefNameSymExpectedKindMismatch
+    adSemDefNameSymIdentGenFailed
+    adSemDefNameSymExistingError
+    adSemDefNameSymIllformedAst
+  AdSemDefNameSym* = object
+    case kind*: AdSemDefNameSymKind:
+      of adSemDefNameSymExpectedKindMismatch:
+        expectedKind*: TSymKind # xxx: maybe always capture this?
+      of adSemDefNameSymIdentGenFailed:
+        identGenErr*: PNode
+      of adSemDefNameSymExistingError,
+          adSemDefNameSymIllformedAst:
+        discard
 
   TNode*{.final, acyclic.} = object # on a 32bit machine, this takes 32 bytes
     id*: NodeId

--- a/compiler/ast/errorreporting.nim
+++ b/compiler/ast/errorreporting.nim
@@ -43,13 +43,14 @@ proc errorHandling*(err: PNode): TErrorHandling =
 
 template localReport*(conf: ConfigRef, node: PNode) =
   ## Write out existing sem report that is stored in the nkError node
-  assert node.kind == nkError, $node.kind
+  {.line.}:
+    assert node.kind == nkError, $node.kind
 
-  when defined(nimDebugUnreportedErrors):
-    conf.unreportedErrors.del node.id
+    when defined(nimDebugUnreportedErrors):
+      conf.unreportedErrors.del node.id
+      for err in walkErrors(conf, node):
+        conf.unreportedErrors.del err.id
+
     for err in walkErrors(conf, node):
-      conf.unreportedErrors.del err.id
-
-  for err in walkErrors(conf, node):
-    if true or canReport(conf, err):
-      handleReport(conf, err.diag, instLoc(), node.errorHandling)
+      if true or canReport(conf, err):
+        handleReport(conf, err.diag, instLoc(), node.errorHandling)

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -4367,6 +4367,26 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       kind: kind,
       ast: diag.wrongNode,
       str: diag.invalidDef)
+  of adSemDefNameSym:
+    case diag.defNameSymData.kind
+    of adSemDefNameSymExpectedKindMismatch:
+      semRep = SemReport(
+        location: some diag.location,
+        reportInst: diag.instLoc.toReportLineInfo,
+        kind: rsemSymbolKindMismatch,
+        sym: diag.wrongNode.sym,
+        expectedSymbolKind: {diag.defNameSymData.expectedKind},
+        ast: diag.wrongNode)
+    of adSemDefNameSymIllformedAst:
+      semRep = SemReport(
+        location: some diag.location,
+        reportInst: diag.instLoc.toReportLineInfo,
+        kind: rsemExpectedIdentifier,
+        ast: diag.wrongNode)
+    of adSemDefNameSymIdentGenFailed:
+      return astDiagToLegacyReport(conf, diag.defNameSymData.identGenErr.diag)
+    of adSemDefNameSymExistingError:
+      return astDiagToLegacyReport(conf, diag.wrongNode.diag)
   of adVmError:
     let
       kind = diag.vmErr.kind.astDiagVmToLegacyReportKind()

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -425,6 +425,9 @@ func astDiagToLegacyReportKind*(
   vmGenDiag: Option[AstDiagVmGenKind] = none(AstDiagVmGenKind),
   vmEvent: Option[AstDiagVmKind] = none(AstDiagVmKind)
   ): ReportKind {.inline.} =
+  ## with the introduction of `adSemDefNameSym` style diagnostics, this
+  ## function is no longer all that sensible. `AstDiagKind` will move towards
+  ## very broad categories and they'll no longer map to "reports".
   case diag
   of adWrappedError: rsemWrappedError
   of adSemTypeMismatch: rsemTypeMismatch
@@ -586,6 +589,7 @@ func astDiagToLegacyReportKind*(
   of adSemFoldDivByZero: rsemSemfoldDivByZero
   of adSemInvalidRangeConversion: rsemSemfoldInvalidConversion
   of adSemFoldCannotComputeOffset: rsemCantComputeOffsetof
+  of adSemDefNameSym: rsemExpectedIdentifier
 
 func astDiagToLegacyReportKind*(diag: PAstDiag): ReportKind {.inline.} =
   case diag.kind

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3753,7 +3753,15 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     result = semProcAnnotation(c, n)
     if result == nil:
       result = n
-      result[namePos] = semRoutineName(c, n[namePos], skProc)
+      # heuristic to figure out if the lambda original started as a function,
+      # iterator, or procedure, and in turn set the expected symbol kind.
+      let kind =
+        if n[namePos].kind == nkSym and
+            n[namePos].sym.kind in {skProc, skFunc, skIterator}:
+          n[namePos].sym.kind
+        else:
+          skProc
+      result[namePos] = semRoutineName(c, n[namePos], kind, allowAnon = true)
       result = semProcAux(c, result, lambdaPragmas, flags)
   of nkDerefExpr: result = semDeref(c, n)
   of nkAddr:

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -1039,10 +1039,9 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   result.sons.newSeq(n.len) # make space for the kids
 
   result[namePos] = n[namePos]
+  var hasError = result[namePos].kind == nkError
 
-  var
-    hasError = false
-    s = n[namePos].sym
+  let s = result[namePos].getDefNameSymOrRecover()
 
   assert s.kind == skTemplate
 
@@ -1056,7 +1055,6 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   pushOwner(c, s)
   openScope(c)
 
-  result[namePos] = newSymNode(s)
   result[pragmasPos] = n[pragmasPos]
 
   if n[pragmasPos].kind != nkEmpty:


### PR DESCRIPTION
## Summary

Internal refactoring for how definition position `nkIdentKinds` are
handled in semantic analysis. Added `newSymGNode` as a replacement of
`newSymG` which returns a canonical symbol node or an error and no
longer does any legacy reporting. As part of this change also introduced
an approach that consolidates diagnostic kinds and let us do more error
recovery (for `check`, `suggest`, etc use cases).

## Details

As mentioned added `newSymGNode`, `semRoutine` now uses it instead of
`newSymG`, in follow-up changes we'll be able to drop a number of legacy
reports.

Unlike `newSymG` which produces a `PSym` along with report side-effects,
`newSymGNode` only returns a `PNode`, which might be an error. What's
different about `newSymGNode` is that it only ever returns a single
diagnostic kind `adSemDefNameSym`. This singular kind describes all
possible errors as subvariants, which no longer run into all sorts of
naming colisions or giant `TAstDiag` variant of doom. With this
approach, common fields were easily setup and a singular recovery symbol
field was provided, along callees to trivially continue to make progress
and have easy access to the original input.

As part of error generation, `newSymGNode` will not modify existing
symbols and instead will create a copy of the original to avoid mutating
pre-existing symbols.

With the above change, lambda kinds which previously assumed that all
lambdas are to be treated as `skProc` triggered the error condition,
resulting in a copy being made. Copies have a "desemming" affect where
any previously attached AST is dropped. Instead of copying over the AST
on error, the `nkLambdaKinds` branch in `semexprs` was modified with a
heuristic to determine whether an `skFunc`, `skIterator` or `skProc`
should be asked for when calling `newSymG`.

Additional improvements made while working on this change:
- `semOverride`: replace node param with info
- `semOverride`: move `prevDestructor` & `bindTypeHook` helpers inside
- `semstmts.swapResult`: single use; now inner proc
- `errorreporting.localReport` add `line` pragma for better stacktrace

### Follow-Up Work

In no particular order:
- update all other `newSymG` callsites
- update `considerQuotedIdent` to behave similarly
- similarily update `semIdentVis` and other definition name analyses

### Longer-Term

Consolidated diagnostic kinds should allow for far more error recovery
and better encode the expected ordering of analyses/diagnostics.

### Observations

`checkSpecialOperators` is `adSemDefinitionNameSym` aware. When doing
this I realized there is likely two dimensions along which we want to
organize diagnostic kinds. One is grouping based on AST position, or the
kind of analysis, the other is within that the fidelity, or timing, of
the analysis. A higher fidelity analysis should result in diagnostics
that are aware of the lower fidelidty ones in the same position. So in
this case, `checkSpecialOperators` like `newSymGNode` both operate over
'definition name' positions, so their diagnostic kinds should fall under
the same branch of the hierarchy, but within that branch, the analysis
carried out by, and resulting diagnostics, `checkSpecialOperators` must
be `newSymGNode` or another other lower fidelity analysis/diagnostic.
By having an ordering of diagnostic kinds we easily check and wrap
error nodes, which will let us compose them.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* will refine diagnostic kind consolidation and naming further in future PRs -- need more examples