### PR TITLE
compiler: improve macro parameter handling

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -520,7 +520,7 @@ proc transitionGenericParamToType*(s: PSym) =
 
 proc transitionRoutineSymKind*(s: PSym, kind: range[skProc..skTemplate]) =
   transitionSymKindCommon(kind)
-  if obj.kind in routineKinds:
+  if obj.kind in routineKinds - {skMacro} and s.kind != skMacro:
     s.gcUnsafetyReason = obj.gcUnsafetyReason
     s.transformedBody = obj.transformedBody
 

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -981,7 +981,7 @@ type
   AstDiagVmGenKind* = enum
     ## Kinds for errors produced by `vmgen`
     adVmGenBadExpandToAstArgRequired      # | TODO: these enum values duplicate
-    adVmGenBadExpandToAstCallExprRequired # |       `VmGenDiagKind` vmgen enum
+                                          # |       `VmGenDiagKind` vmgen enum
     adVmGenTooManyRegistersRequired       # |       defined in the `vmdef`
     adVmGenCannotFindBreakTarget          # |       module. There should be a
     adVmGenNotUnused                      # |       way to cross-reference data
@@ -1001,7 +1001,6 @@ type
   AstDiagVmGenError* = object
     case kind*: AstDiagVmGenKind:
       of adVmGenBadExpandToAstArgRequired,
-          adVmGenBadExpandToAstCallExprRequired,
           adVmGenTooManyRegistersRequired,
           adVmGenCannotFindBreakTarget:
         discard
@@ -1595,10 +1594,15 @@ type
   TSym* {.acyclic.} = object of TIdObj # Keep in sync with PackedSym
     ## proc and type instantiations are cached in the generic symbol
     case kind*: TSymKind
-    of routineKinds:
+    of routineKinds - {skMacro}:
       #procInstCache*: seq[PInstantiation]
       gcUnsafetyReason*: PSym  ## for better error messages regarding gcsafe
       transformedBody*: PNode  ## cached body after transf pass
+    of skMacro:
+      internal*: PType ## the internal signature that the macro has in a
+                       ## compile-time evaluation context. Can be used to
+                       ## query the symbols the parameters use in the macro's
+                       ## body
     of skLet, skVar, skField, skForVar:
       guard*: PSym
       bitsize*: int

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -4497,12 +4497,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         kind: kind,
         location: some location,
         reportInst: diag.instLoc.toReportLineInfo)
-    of adVmGenBadExpandToAstCallExprRequired:
-      vmRep = VMReport(
-        str: "expandToAst requires a call expression",
-        kind: kind,
-        location: some location,
-        reportInst: diag.instLoc.toReportLineInfo)
     of adVmGenNotUnused,
         adVmGenNotAFieldSymbol,
         adVmGenCannotGenerateCode,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -414,7 +414,6 @@ func astDiagVmGenToLegacyReportKind*(
   of adVmGenCodeGenUnexpectedSym: rvmCannotGenerateCode
   of adVmGenCannotCast: rvmCannotCast
   of adVmGenBadExpandToAstArgRequired: rvmBadExpandToAst
-  of adVmGenBadExpandToAstCallExprRequired: rvmBadExpandToAst
   of adVmGenCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of adVmGenCannotImportc: rvmCannotImportc
   of adVmGenInvalidObjectConstructor: rvmInvalidObjectConstructor

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -124,7 +124,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType
 proc semStmt(c: PContext, n: PNode; flags: TExprFlags): PNode
 proc semOpAux(c: PContext, n: PNode): bool
 proc semParamList(c: PContext, n, genericParams: PNode, kind: TSymKind): PType
-proc addParams(c: PContext, n: PNode, kind: TSymKind)
+proc addParams(c: PContext, n: PNode)
 proc maybeAddResult(c: PContext, s: PSym, n: PNode)
 proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode
 proc activate(c: PContext, n: PNode)

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -89,7 +89,7 @@ proc freshGenSyms(c: PContext; n: PNode, owner, orig: PSym, symMap: var TIdTable
   else:
     for i in 0..<n.safeLen: freshGenSyms(c, n[i], owner, orig, symMap)
 
-proc addParamOrResult(c: PContext, param: PSym, kind: TSymKind)
+proc addParamOrResult(c: PContext, param: PSym)
 
 proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
   if n[bodyPos].kind != nkEmpty:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1096,27 +1096,12 @@ proc findEnforcedStaticType(t: PType): PType =
       let t = findEnforcedStaticType(s)
       if t != nil: return t
 
-proc addParamOrResult(c: PContext, param: PSym, kind: TSymKind) =
-  if kind == skMacro:
-    let staticType = findEnforcedStaticType(param.typ)
-    if staticType != nil:
-      var a = copySym(param, nextSymId c.idgen)
-      a.typ = staticType.base
-      addDecl(c, a)
-      #elif param.typ != nil and param.typ.kind == tyTypeDesc:
-      #  addDecl(c, param)
-    else:
-      # within a macro, every param has the type NimNode!
-      let nn = getSysSym(c.graph, param.info, "NimNode")
-      var a = copySym(param, nextSymId c.idgen)
-      a.typ = nn.typ
-      addDecl(c, a)
-  else:
-    if sfGenSym in param.flags:
-      # bug #XXX, fix the gensym'ed parameters owner:
-      if param.owner == nil:
-        param.owner = getCurrOwner(c)
-    else: addDecl(c, param)
+proc addParamOrResult(c: PContext, param: PSym) =
+  if sfGenSym in param.flags:
+    # bug #XXX, fix the gensym'ed parameters owner:
+    if param.owner == nil:
+      param.owner = getCurrOwner(c)
+  else: addDecl(c, param)
 
 template shouldHaveMeta(t) =
   c.config.internalAssert tfHasMeta in t.flags
@@ -1460,7 +1445,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
 
       result.n.add newSymNode(arg)
       rawAddSon(result, finalType)
-      addParamOrResult(c, arg, kind)
+      addParamOrResult(c, arg)
       styleCheckDef(c.config, a[j].info, arg)
       a[j] = newSymNode(arg)
 

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -540,8 +540,11 @@ proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph; templInstC
   # put the generic arguments into registers
   let gp = sym.ast[genericParamsPos]
   for i in 0..<gp.safeLen:
-    let idx = sym.typ.len + i
-    setupMacroParam(tos.slots[idx], c[], args[idx - 1], gp[i].sym.typ)
+    # skip implicit type parameters -- they're not part of the internal
+    # signature
+    if tfImplicitTypeParam notin gp[i].sym.typ.flags:
+      let idx = sym.typ.len + i
+      setupMacroParam(tos.slots[idx], c[], args[idx - 1], gp[i].sym.typ)
 
   let cb = mkCallback(c, r): r.nimNode
   result = execute(c[], start, tos, cb).unpackResult(c.config, call)

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -572,7 +572,6 @@ type
   VmGenDiagKind* = enum
     # has no extra data
     vmGenDiagBadExpandToAstArgRequired
-    vmGenDiagBadExpandToAstCallExprRequired
     vmGenDiagTooManyRegistersRequired
     vmGenDiagCannotFindBreakTarget
     # has ast data
@@ -636,7 +635,6 @@ type
           vmGenDiagInvalidObjectConstructor:
         ast*: PNode
       of vmGenDiagBadExpandToAstArgRequired,
-          vmGenDiagBadExpandToAstCallExprRequired,
           vmGenDiagTooManyRegistersRequired,
           vmGenDiagCannotFindBreakTarget:
         discard

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -155,8 +155,14 @@ proc genProc(c: var TCtx, s: PSym): VmGenResult =
     c.code.setLen(last)
     c.debug.setLen(last)
 
-  var
-    body = transformBody(c.graph, c.idgen, s, cache = not isCompileTimeProc(s))
+  var body =
+    if s.kind == skMacro:
+      transformBody(c.graph, c.idgen, s, s.ast[bodyPos])
+    else:
+      # what out! While compile-time only procedures don't need to be cached
+      # here, we still need to retrieve their already cached body (if one
+      # exists). Lifted inner procedures would otherwise not work.
+      transformBody(c.graph, c.idgen, s, cache = not isCompileTimeProc(s))
 
   body = canonicalize(c.graph, c.idgen, s, body, selectOptions(c))
 

--- a/compiler/vm/vmlegacy.nim
+++ b/compiler/vm/vmlegacy.nim
@@ -31,7 +31,6 @@ func vmGenDiagToLegacyReportKind(diag: VmGenDiagKind): ReportKind {.inline.} =
   of vmGenDiagCodeGenUnexpectedSym: rvmCannotGenerateCode
   of vmGenDiagCannotCast: rvmCannotCast
   of vmGenDiagBadExpandToAstArgRequired: rvmBadExpandToAst
-  of vmGenDiagBadExpandToAstCallExprRequired: rvmBadExpandToAst
   of vmGenDiagCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of vmGenDiagCannotImportc: rvmCannotImportc
   of vmGenDiagInvalidObjectConstructor: rvmInvalidObjectConstructor
@@ -82,12 +81,6 @@ func vmGenDiagToLegacyVmReport*(diag: VmGenDiag): VMReport {.inline.} =
     of vmGenDiagBadExpandToAstArgRequired:
       VMReport(
         str: "expandToAst requires 1 argument",
-        kind: kind,
-        location: std_options.some diag.location,
-        reportInst: diag.instLoc.toReportLineInfo)
-    of vmGenDiagBadExpandToAstCallExprRequired:
-      VMReport(
-        str: "expandToAst requires a call expression",
         kind: kind,
         location: std_options.some diag.location,
         reportInst: diag.instLoc.toReportLineInfo)

--- a/tests/lang_callable/macros/tgeneric_macros.nim
+++ b/tests/lang_callable/macros/tgeneric_macros.nim
@@ -1,0 +1,14 @@
+discard """
+  description: "Tests for macros with explicit generic parameters"
+  action: compile
+"""
+
+import std/macros
+
+block generic_parameter_access:
+  macro m[T]() =
+    # the `T` is accesible as a ``NimNode`` in the macro
+    doAssert T is NimNode
+    doAssert T.typeKind == ntyInt
+
+  m[int]()

--- a/tests/lang_callable/macros/tmacros_issues.nim
+++ b/tests/lang_callable/macros/tmacros_issues.nim
@@ -519,3 +519,23 @@ block double_sem_for_procs:
     result = 10.0
 
   discard exp(5.0)
+
+block orginal_parameter_types:
+  # inspecting a parameter type in the macro's header yields the
+  # original type, not ``NimNode``
+
+  template assertTypeOfInt(s): typedesc =
+    static:
+      # make sure that the type really is ``int``
+      doAssert typeof(s) is int
+    typeof(s)
+
+  macro m(x: int, y: assertTypeOfInt(x)) =
+    static:
+      doAssert typeof(x) is NimNode
+      doAssert typeof(y) is NimNode
+
+    doAssert x.intVal == 1
+    doAssert y.intVal == 2
+
+  m(1, 2)


### PR DESCRIPTION
## Summary

This commit introduces internal signatures for macros, removing conditional logic from parameter symbol handling and generally moving the details of how macro parameters work out of `vmgen` and more into a single place in `sem`.

As two side-effect of the above:
- inspecting parameter types from a macro's header (via, for example, `typeof`) now yields the types as specified, instead of as `NimNode`
- the types (or values, in case of `static[T]`) passed to a macro's generic parameters can now be inspected by the macro

## Details

The symbols belonging to macro parameters were previously replaced with new ones that used either `NimNode` or, in the case of `static[T]`, the base type as the type, prior to adding them to the symbol table.

Replacing the symbols at some point is necessary in order for semantic analysis inside the macro body to view them as the correct type, but the previous implementation had two issues:
1. the parameters were only visible as `NimNode` to other types or expressions referencing them
2. the symbols were freestanding. They weren't registered anywhere, meaning that it was not possible to, for example, map all parameter symbols via their ID to some other entity

To fix both issues and in order for the implementation to be less scattered, a different approach is now used. Macro parameter handling is moved out of routine header analysis into `semMacroDef` (fixing issue 1). This allows for a more flexible implementation (more contextual information is available) and also reduces the amount of context required by `addParam`, etc.

So that they can be later queried, the created internal symbols are added as parameters to a dedicated `tyProc` type that represents the macro's internal signature, which is then stored as part of the macro's symbol.

### Changes

- remove macro parameter handling from `addParamOrResult` and `addResult`
- add a dedicated branch for `skMacro` to `TSym` and adjust the places depending on the previous layout
- create the internal symbols for macro parameters in `semMacroDef`, where they're also used to populate the internal signature
- add a `transformBody` variant that doesn't query nor updates the symbols `transformBody` field
- change `vmgen` to consider the macros internal signature, making the previously used workarounds obsolete
- rewrite `getAst(macro(a, b, c))` during `mirgen`, slightly simplifying the related logic in `vmgen`
- remove the now unused `adVmGenBadExpandToAstCallExprRequired` diagnostic

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* this removes the last remaining blocker for #548

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
