### PR TITLE
sem: rework explicit generic calls

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -490,6 +490,20 @@ proc requiredParams*(s: PSym): int =
       return i - 1
   return s.typ.len - 1
 
+proc requiredGenericParams*(s: PSym): int =
+  # Returns the number of required generic parameters (without default
+  # values).
+  let params = s.ast[genericParamsPos]
+  if params.kind == nkEmpty:
+    # doesn't have generic parameters
+    return
+
+  for i in 0..<params.len:
+    if params[i].sym.ast != nil:
+      return i
+
+  result = params.len
+
 proc hasPattern*(s: PSym): bool {.inline.} =
   result = isRoutine(s) and s.ast[patternPos].kind != nkEmpty
 

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -31,6 +31,8 @@ type
   MismatchKind* = enum
     ## Procedure call argument mismatch reason
     kUnknown
+    kGenericTypeMismatch    ## Generic parameter type mismatch
+    kNotGeneric             ## Generic routine expected
     kAlreadyGiven           ## Named argument already given
     kUnknownNamedParam      ## No such named parameter
     kTypeMismatch           ## Parameter type mismatch

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2514,6 +2514,8 @@ proc presentFailedCandidates(
       candidates.add("  first type mismatch at position: " & $err.firstMismatch.pos)
       # candidates.add "\n  reason: " & $err.firstMismatch.kind # for debugging
       case err.firstMismatch.kind:
+        of kNotGeneric:
+          candidates.add("\n  routine is not generic")
         of kUnknownNamedParam:
           if nArg == nil:
             candidates.add("\n  unknown named parameter")
@@ -2532,7 +2534,7 @@ proc presentFailedCandidates(
         of kMissingParam:
           candidates.add("\n  missing parameter: " & nameParam)
 
-        of kTypeMismatch, kVarNeeded:
+        of kTypeMismatch, kVarNeeded, kGenericTypeMismatch:
           doAssert nArg != nil
           doAssert err.firstMismatch.formal != nil
           let wanted = err.firstMismatch.formal.typ

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -34,7 +34,6 @@ proc sameMethodDispatcher(a, b: PSym): bool =
       # instantiated.
 
 proc initCandidateSymbols(c: PContext, headSymbol: PNode,
-                          initialBinding: PNode,
                           filter: TSymKinds,
                           best, alt: var TCandidate,
                           o: var TOverloadIter): seq[tuple[s: PSym, scope: int]] =
@@ -47,16 +46,13 @@ proc initCandidateSymbols(c: PContext, headSymbol: PNode,
       localReport(c.config, symx.ast)
     symx = nextOverloadIter(o, c, headSymbol)
   if result.len > 0:
-    initCandidate(c, best, result[0].s, initialBinding,
-                  result[0].scope)
-    initCandidate(c, alt, result[0].s, initialBinding,
-                  result[0].scope)
+    initCallCandidate(c, best, result[0].s, result[0].scope)
+    initCallCandidate(c, alt, result[0].s, result[0].scope)
     best.state = csNoMatch
 
 proc pickBestCandidate(c: PContext,
                        headSymbol: PNode,
                        n: PNode,
-                       initialBinding: PNode,
                        filter: TSymKinds,
                        best, alt: var TCandidate,
                        errors: var seq[SemCallMismatch]) =
@@ -81,8 +77,8 @@ proc pickBestCandidate(c: PContext,
   while sym != nil:
     if sym.kind in filter:
       # Initialise 'best' and 'alt' with the first available symbol
-      initCandidate(c, best, sym, initialBinding, scope)
-      initCandidate(c, alt, sym, initialBinding, scope)
+      initCallCandidate(c, best, sym, scope)
+      initCallCandidate(c, alt, sym, scope)
       best.state = csNoMatch
       break
     else:
@@ -96,7 +92,7 @@ proc pickBestCandidate(c: PContext,
       continue
     c.config.internalAssert(sym.typ != nil or sym.magic != mNone,
                             "missing type information")
-    initCandidate(c, z, sym, initialBinding, scope)
+    initCallCandidate(c, z, sym, scope)
     if c.currentScope.symbols.counter == counterInitial or syms.len != 0:
       matches(c, n, z)
       if z.state == csMatch:
@@ -118,8 +114,7 @@ proc pickBestCandidate(c: PContext,
     else:
       # Symbol table has been modified. Restart and pre-calculate all syms
       # before any further candidate init and compare. SLOW, but rare case.
-      syms = initCandidateSymbols(c, headSymbol, initialBinding, filter,
-                                  best, alt, o)
+      syms = initCandidateSymbols(c, headSymbol, filter, best, alt, o)
       noSyms = false
     if noSyms:
       sym = nextOverloadIter(o, c, headSymbol)
@@ -283,26 +278,74 @@ proc getMsgDiagnostic(
       # +2`, so command is not always an identifier.
       result.spellingAlts = fixSpelling(c, f.ident)
 
+proc semGenericArgs(c: PContext, n: PNode): PNode =
+  ## Semantically analyses the generic arguments passed to a routine invocation
+  ## (i.e.: the bracket part in ``routine[A, B](a, b, c)``), producing the
+  ## ``nkBracketExpr`` with the typed arguments, or an error.
+  ##
+  ## Since generic argument expressions must evaluate to either a type or a
+  ## static value (both which can be disambiguated between without access to
+  ## formal parameters), we fully analyse them here instead of deferring
+  ## that to sigmatch. This has the benefit that we only need to analyse/
+  ## evaluate each argument once, instead of for each matched against overload.
+  assert n.kind == nkBracketExpr
+  result = shallowCopy(n)
+  result[0] = n[0]
+
+  var hasError = false
+  for i in 1..<n.len:
+    # a generic argument must either evaluate to a type (``tyTypedesc``) or
+    # static value
+    # XXX: ``semOperand`` is the procedure that best matches what we want, but
+    #      it's still not entirely correct. A dedicated ``semTypeExpr`` (that
+    #      also handles ``tyStatic``) is likely needed here
+    let opr = c.semOperand(c, n[i], {})
+    case opr.typ.kind
+    of tyError:
+      hasError = true
+      result[i] = opr
+    of tyTypeDesc:
+      # the operand is a type
+      result[i] = opr
+    else:
+      let evaluated = evalConstExpr(c, opr)
+      case evaluated.kind
+      of nkError:
+        # not a constant expression
+        hasError = true
+        result[i] = evaluated
+      of nkType:
+        result[i] = evaluated
+      else:
+        # sigmatch expects the non-type generic arugments to use ``tyStatic``
+        opr.typ = newTypeS(tyStatic, c)
+        opr.typ.sons = @[evaluated.typ]
+        opr.typ.n = evaluated
+
+        result[i] = opr
+
+  if hasError:
+    result = c.config.wrapError(result)
+
 proc resolveOverloads(c: PContext, n: PNode,
                       filter: TSymKinds, flags: TExprFlags,
                       errors: var seq[SemCallMismatch]): TCandidate =
   addInNimDebugUtils(c.config, "resolveOverloads", n, filter, errors, result)
   var
-    initialBinding: PNode
     alt: TCandidate
     f = n[0]
   
   case f.kind
   of nkBracketExpr:
-    # fill in the bindings:
-    let hasError = semOpAux(c, f)
-    initialBinding = f
-    if hasError:
-      f = c.config.wrapError(f)
+    # the call has explicit generic arguments specified
+    let args = semGenericArgs(c, f)
+    if args.kind == nkError:
+      f = args
     else:
-      f = f[0]
+      n[0] = args
+      f = args[0]
   else:
-    initialBinding = nil
+    discard
 
   if f.isError:
     n[0] = f
@@ -310,8 +353,7 @@ proc resolveOverloads(c: PContext, n: PNode,
     return
 
   template pickBest(headSymbol) =
-    pickBestCandidate(c, headSymbol, n, initialBinding,
-                      filter, result, alt, errors)
+    pickBestCandidate(c, headSymbol, n, filter, result, alt, errors)
   pickBest(f)
 
   let overloadsState = result.state
@@ -429,7 +471,7 @@ proc inferWithMetatype(c: PContext, formal: PType,
       result = copyTree(arg)
       result.typ = formal
 
-proc updateDefaultParams(call: PNode) =
+proc updateDefaultParams(conf: ConfigRef, call: PNode): PNode =
   # In generic procs, the default parameter may be unique for each
   # instantiation (see tlateboundgenericparams).
   # After a call is resolved, we need to re-assign any default value
@@ -437,11 +479,26 @@ proc updateDefaultParams(call: PNode) =
   # the default params with `nfDefaultParam` and `instantiateProcType`
   # computes correctly the default values for each instantiation.
   let calleeParams = call[0].sym.typ.n
+  var hasError = false
   for i in 1..<call.len:
     if nfDefaultParam in call[i].flags:
       let def = calleeParams[i].sym.ast
       if nfDefaultRefsParam in def.flags: call.flags.incl nfDefaultRefsParam
-      call[i] = def
+      call[i] =
+        case def.kind
+        of nkEmpty:
+          # ``instantiateProcType`` uses ``nkEmpty`` to signal an incompatible
+          # default expression
+          hasError = true
+          conf.newError(calleeParams[i],
+                        PAstDiag(kind: adSemIncompatibleDefaultExpr,
+                                 formal: calleeParams[i].sym))
+        else:
+          def
+
+  result =
+    if hasError: conf.wrapError(call)
+    else:        call
 
 proc getCallLineInfo(n: PNode): TLineInfo =
   case n.kind
@@ -498,7 +555,7 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   instGenericConvertersSons(c, result, x)
   result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))
   result.typ = finalCallee.typ[0]
-  updateDefaultParams(result)
+  result = updateDefaultParams(c.config, result)
 
 proc canDeref(n: PNode): bool {.inline.} =
   result = n.len >= 2 and (let t = n[1].typ;
@@ -554,78 +611,77 @@ proc explicitGenericInstError(c: PContext; n: PNode): PNode =
                                 callLineInfo: getCallLineInfo(n)))
 
 proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
-  # binding has to stay 'nil' for this to work!
-  var m = newCandidate(c, s, nil)
+  ## Tries to create an instance of the generic routine `s`. If `s` is not a
+  ## generic routine, or the provided arguments `n` don't fit the parameters,
+  ## ``nil`` is returned. Otherwise, a node with the symbol of the instance is
+  ## returned
+  let params = s.ast[genericParamsPos]
+  if params.kind == nkEmpty:
+    # not a generic routine
+    return nil
 
-  for i in 1..<n.len:
-    let formal = s.ast[genericParamsPos][i-1].typ
-    var arg = n[i].typ
-    # try transforming the argument into a static one before feeding it into
-    # typeRel
-    if formal.kind == tyStatic and arg.kind != tyStatic:
-      let evaluated = c.semTryConstExpr(c, n[i])
-      if evaluated != nil:
-        arg = newTypeS(tyStatic, c)
-        arg.sons = @[evaluated.typ]
-        arg.n = evaluated
-    let tm = typeRel(m, formal, arg)
-    if tm in {isNone, isConvertible}: return nil
+  var m = newCallCandidate(c, s)
+  matchesGenericParams(c, n, m)
+  if m.state != csMatch:
+    return nil
+
+  # a match doesn't mean that the routine can be instantiated. We still need
+  # to check for missing arguments
+
+  for i in (n.len-1)..<params.len:
+    if params[i].sym.ast == nil:
+      # a parameter has no binding -> cannot instantiate
+      return nil
+
+  # generate an instance with the bindings as filled in by
+  # ``matchesGenericParams``
   var newInst = generateInstance(c, s, m.bindings, n.info)
-  newInst.typ.flags.excl tfUnresolved
   let info = getCallLineInfo(n)
   markUsed(c, info, s)
-  result = newSymNode(newInst, info)
+  newInst.typ.flags.excl tfUnresolved
+  newSymNode(newInst, info)
 
-proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
+proc explicitGenericInstantiation(c: PContext, n: PNode): PNode =
   assert n.kind == nkBracketExpr
-  for i in 1..<n.len:
-    let e = semExpr(c, n[i])
-    if e.isError:
-      n[i] = e
-      result = c.config.wrapError(n)
-      return
-    elif e.typ == nil:
-      n[i].typ = errorType(c)
-    else:
-      n[i].typ = e.typ.skipTypes({tyTypeDesc})
-  var s = s
-  var a = n[0]
+  # analyse the operands first
+  let args = semGenericArgs(c, n)
+  if args.kind == nkError:
+    return args
+
+  let a = n[0]
   case a.kind
   of nkSym:
     # common case; check the only candidate has the right
     # number of generic type parameters:
-    result =
-      if s.ast[genericParamsPos].safeLen != n.len-1:
-        let expected = s.ast[genericParamsPos].safeLen
-        c.config.newError(
-          n,
-          PAstDiag(kind: adSemWrongNumberOfGenericParams,
-                    gnrcCallLineInfo: getCallLineInfo(n),
-                    countMismatch: (
-                      expected: expected,
-                      got: n.len - 1)))
-      else:
-        explicitGenericSym(c, n, s)
-    
+    let s = a.sym
+    result = explicitGenericSym(c, args, s)
     if result.isNil:
-      result = explicitGenericInstError(c, n)
+      # TODO: provide the diagnostic taken from the ``TCandidate`` instead
+      result =
+        if n.len-1 < s.requiredGenericParams:
+          # provide a better diagnostic for argument mismatch
+          c.config.newError(
+            args,
+            PAstDiag(kind: adSemWrongNumberOfGenericParams,
+                      gnrcCallLineInfo: getCallLineInfo(n),
+                      countMismatch: (
+                        expected: s.requiredGenericParams,
+                        got: n.len - 1)))
+        else:
+          explicitGenericInstError(c, args)
   of nkClosedSymChoice, nkOpenSymChoice:
-    # choose the generic proc with the proper number of type parameters.
-    # XXX I think this could be improved by reusing sigmatch.paramTypesMatch.
-    # It's good enough for now.
+    # collect all matching generic routines into a symbol choice
     result = newNodeI(a.kind, getCallLineInfo(n))
+    result.typ = newTypeS(tyNone, c)
+
     for i in 0..<a.len:
-      var candidate = a[i].sym
-      
+      let candidate = a[i].sym
       if candidate.kind in {skProc, skMethod, skConverter,
                             skFunc, skIterator}:
-        # it suffices that the candidate has the proper number of generic
-        # type parameters:
-        if candidate.ast[genericParamsPos].safeLen == n.len-1:
-          let x = explicitGenericSym(c, n, candidate)
-          if x != nil:
-            result.add(x)
-    
+        let x = explicitGenericSym(c, args, candidate)
+        if x != nil:
+          result.add(x)
+
     # get rid of nkClosedSymChoice if not ambiguous:
     if result.len == 1 and a.kind == nkClosedSymChoice:
       result = result[0]

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -342,7 +342,7 @@ proc nameFits(c: PContext, s: PSym, n: PNode): bool =
 proc argsFit(c: PContext, candidate: PSym, n: PNode): bool =
   case candidate.kind
   of OverloadableSyms:
-    var m = newCandidate(c, candidate, nil)
+    var m = newCallCandidate(c, candidate)
     sigmatch.partialMatch(c, n, m)
     result = m.state != csNoMatch
   else:

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -303,7 +303,7 @@ else:
       setAffinity(t.sys, csize_t(sizeof(s)), s)
 
 proc createThread*(t: var Thread[void], tp: proc () {.thread, nimcall.}) =
-  createThread[void](t, tp)
+  (createThread[void])(t, tp)
 
 when not defined(gcOrc):
   include threadids

--- a/nimsuggest/tests/tgeneric_highlight.nim
+++ b/nimsuggest/tests/tgeneric_highlight.nim
@@ -1,20 +1,16 @@
 newSeq[int]()
 system.newSeq[int]()#[!]#
 offsetOf[int]()
+# note: the ``offsetOf`` template is not reported by the command because the
+# invocation doesn't get through overload resolution (the arguments are
+# missing)
 
 discard """
 $nimsuggest --tester $file
 >highlight $1
 highlight;;skType;;1;;7;;3
 highlight;;skProc;;1;;0;;6
-highlight;;skProc;;1;;0;;6
-highlight;;skType;;1;;7;;3
-highlight;;skProc;;1;;0;;6
 highlight;;skType;;2;;14;;3
 highlight;;skProc;;2;;7;;6
-highlight;;skProc;;2;;7;;6
-highlight;;skType;;2;;14;;3
-highlight;;skProc;;2;;7;;6
-highlight;;skTemplate;;3;;0;;8
 highlight;;skType;;3;;9;;3
 """

--- a/tests/lang/s05_pragmas/s02_misc/t04_warning.nim
+++ b/tests/lang/s05_pragmas/s02_misc/t04_warning.nim
@@ -5,9 +5,9 @@ description: '''
 
 nimout: '''
 t04_warning.nim(17, 10) Warning: User-provided warning message [User]
-t04_warning.nim(22, 5) template/generic instantiation of `gen1` from here
+t04_warning.nim(22, 10) template/generic instantiation of `gen1` from here
 t04_warning.nim(20, 12) Warning: gen1 name of the argument is int [User]
-t04_warning.nim(23, 5) template/generic instantiation of `gen1` from here
+t04_warning.nim(23, 12) template/generic instantiation of `gen1` from here
 t04_warning.nim(20, 12) Warning: gen1 name of the argument is float [User]
 '''
 

--- a/tests/lang_callable/generics/tearly_instantiation.nim
+++ b/tests/lang_callable/generics/tearly_instantiation.nim
@@ -1,0 +1,52 @@
+discard """
+  description: '''
+    Tests overload resolution where the overload set comes from an explicit
+    instantiation
+  '''
+"""
+
+block single_overload:
+  # only a single routine exists in the overload set
+  proc p[T](): T =
+    result = 1
+
+  doAssert (p[int])() == 1
+
+block two_overloads:
+  # all matching generic routines are instantiated before overload
+  # resolution (hence the description "early instantiation")
+  var
+    inst1 {.compileTime.} = 0
+    inst2 {.compileTime.} = 0
+
+  proc p[T](x: T): T = # 1
+    static: inc inst1
+    result = x
+
+  proc p[T](x: string): T = # 2
+    static: inc inst2
+    result = 2
+
+  proc p[T, U](x: string, y: U): T = # 3
+    {.error: "should not be instantiated".}
+
+  # only the overloads with the single generic parameters match (and are
+  # instantiated)
+  doAssert (p[int])(1) == 1 # resolves to a call of overload #1
+  doAssert (p[int])("") == 2 # resolves to a call of overload #2
+  static:
+    doAssert inst1 == 1
+    doAssert inst2 == 1
+
+# XXX: should work, but doesn't. The second overload is currently treated as
+#      a redifinition of the first (because generic parameter are not
+#      considered)
+when false: #block dont_include_non_matching:
+  proc p[T](x: T): T =
+    static: inc inst3
+    result = x
+
+  proc p[T, U](x: T): T =
+    {.error: "should not be instantiated".}
+
+  doAssert (p[int])(1) == 1

--- a/tests/lang_callable/generics/tgenerics_various.nim
+++ b/tests/lang_callable/generics/tgenerics_various.nim
@@ -253,3 +253,16 @@ block:
 
   var x: Que[int]
   doAssert(x.x == 0)
+
+block tlate_instantiation:
+  # generic routines not matching because of their formal parameters are *not*
+  # instantiated early, even if all generic parameters are explicitly bound a
+  # type
+
+  proc p[T]() =
+    {.error: "must not be instantiated".}
+
+  proc p[T](x: T): T =
+    result = x
+
+  doAssert p[int](1) == 1

--- a/tests/lang_callable/generics/timplicit_and_explicit.nim
+++ b/tests/lang_callable/generics/timplicit_and_explicit.nim
@@ -34,7 +34,7 @@ block: #15622
   proc test1[T](a: T, b: static[string] = "") = discard
   test1[int64](123)
   proc test2[T](a: T, b: static[string] = "") = discard
-  test2[int64, static[string]](123)
+  test2[int64, ""](123)
 
 block: #4688
   proc convertTo[T](v: int or float): T = (T)(v)

--- a/tests/lang_callable/generics/tlate_bound_typedesc.nim
+++ b/tests/lang_callable/generics/tlate_bound_typedesc.nim
@@ -1,0 +1,15 @@
+discard """
+  errormsg: "The default parameter 'arg' has incompatible type with the explicitly requested proc instantiation"
+  line: 12
+"""
+
+# original issue https://github.com/nim-lang/nim/issues/11660
+
+# XXX: this semantics of ``typedesc`` as the parameter type are very likely
+#      going the change in the future. For the time being, the test ensures
+#      that the behaviour doesn't silently change
+
+func typedescDefault(T: typedesc; arg: T = 0) =
+  discard
+
+typedescDefault(int)

--- a/tests/lang_callable/generics/treject_invalid_type_arguments.nim
+++ b/tests/lang_callable/generics/treject_invalid_type_arguments.nim
@@ -1,0 +1,75 @@
+discard """
+  description: '''
+    Invalid type arguments (not a type/static expression, etc.) also need to
+    be detected and reported when using late instantiation
+  '''
+  cmd: "nim check --hints:off $options $file"
+  action: reject
+  nimout: '''
+treject_invalid_type_arguments.nim(57, 7) Error: type mismatch: got <int literal(1)>
+but expected one of:
+proc test[A: int; B: float](x: static int)
+  first type mismatch at position: 2
+  missing parameter: A
+
+expression: test[](1)
+treject_invalid_type_arguments.nim(58, 10) Error: type mismatch: got <int literal(1)>
+but expected one of:
+proc test[A: int; B: float](x: static int)
+  first type mismatch at position: 2
+  missing parameter: B
+
+expression: test[int](1)
+treject_invalid_type_arguments.nim(59, 25) Error: type mismatch: got <int literal(1)>
+but expected one of:
+proc test[A: int; B: float](x: static int)
+  first type mismatch at position: 0
+  extra argument given
+
+expression: test[int, float, 1, int](1)
+treject_invalid_type_arguments.nim(63, 6) Error: cannot evaluate at compile time: x
+treject_invalid_type_arguments.nim(64, 8) Error: invalid expression: A = int
+treject_invalid_type_arguments.nim(67, 22) Error: type mismatch: got <int literal(1)>
+but expected one of:
+proc test[A: int; B: float](x: static int)
+  first type mismatch at position: 0
+  required type for A: A: int
+  but expression '"string"' is of type: static[string]("string")
+
+expression: test["string", float](1)
+treject_invalid_type_arguments.nim(74, 22) Error: type mismatch: got <int literal(1)>
+but expected one of:
+proc test[A: int; B: float](x: static int)
+  first type mismatch at position: 2
+  required type for x:type: static[int]
+  but expression 'int' is of type: typedesc[int]
+
+expression: test[int, float, int](1)'''
+"""
+
+# using an implicit generic parameter forces late instantiation
+proc test[A: int; B: float](x: static int) =
+  discard
+
+test[int, float](1) # works
+
+# arity checks
+test[](1)                   # missing parameter
+test[int](1)                # missing parameter
+test[int, float, 1, int](1) # extra argument
+
+# a valid type expression is required
+var x = 0
+test[x, float](1)       # not a type expression
+test[A = int, float](1) # not supported
+
+# constraint matching
+test["string", float](1)
+
+# knownIssue: the following two should fail (a ``static[T]`` type must not
+#             match a ``T`` constraint), but currently don't
+test[2, float](1)
+test[int, 1.0](1)
+
+test[int, float, int](1) # mismatch: the lifted implicit parameter has to be a
+                         # ``static[int]``

--- a/tests/lang_callable/generics/twrong_explicit_typeargs.nim
+++ b/tests/lang_callable/generics/twrong_explicit_typeargs.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "cannot instantiate: 'newImage[string]'"
+  errormsg: "type mismatch: got <int literal(320), int literal(200)>"
   line: 16
 """
 

--- a/tests/lang_callable/overload/toverload_explicit_generic.nim
+++ b/tests/lang_callable/overload/toverload_explicit_generic.nim
@@ -1,0 +1,45 @@
+discard """
+  description: '''
+    The '[]' syntax is used to request overload resolution to only consider
+    generic routines
+  '''
+"""
+
+block single_param:
+  proc p(x: int): int =
+    result = x + 1
+
+  proc p[T](x: T): T =
+    result = x + 2
+
+  # the non-generic overload would match better, but the empty brackets force
+  # a generic routine to be chosen
+  doAssert p[](1) == 3
+
+block nullary_generic:
+  proc p(x: float64): int =
+    result = 1
+
+  proc p[](x: float32): int =
+    result = 2
+
+  # the call would be ambiguous would a generic overload not be requested
+  doAssert p[](1) == 2
+
+block generic_parameter_with_default:
+  proc p(x: int): int =
+    result = x + 1
+
+  # XXX: use the below instead, once it doesn't cause redefinition errors
+  #      anymore
+  # proc p[T = int](x: int): int =
+  #   doAssert T is int
+  #   result = x + 2
+
+  proc p[T = int; U = int](x: T): T =
+    doAssert T is int
+    doAssert U is int
+    result = x + 2
+
+  # the freestanding `U` type parameter has a default value, so this works
+  doAssert p[](1) == 3

--- a/tests/lang_experimental/views/tprocedural_views.nim
+++ b/tests/lang_experimental/views/tprocedural_views.nim
@@ -1,0 +1,40 @@
+discard """
+  targets: "c js !vm"
+  description: '''
+    Tests for indirect calls where the callee is an expression evaluating to a
+    view
+  '''
+"""
+
+# knownIssue: vmgen generates incorrect code for view dereferences
+
+{.experimental: "views".}
+
+type Proc = proc(x: int): int {.nimcall.}
+
+block direct_view:
+  # the callee is view stored in a global
+  let p = proc (x: int): int = x
+  let view: lent Proc = p
+
+  doAssert view(1) == 1
+
+block complex_view_callee:
+  # the callee expression evaluate to a view is a:
+  # - dot expression
+  # - a bracket expression
+  # - a parenthesized expression
+  type Obj = object
+    x: lent Proc
+    tup: (lent Proc,)
+
+  let
+    p = proc (x: int): int = x
+    o = Obj(x: p, tup: (p,))
+
+  doAssert o.x(2) == 2
+  doAssert (o.x)(3) == 3
+  # XXX: semantic analysis currently generates invalid code tuple or array
+  #      constructors where an element is a view, so the below would crash at
+  #      run-time
+  doAssert compiles(o.tup[0](4) == 4)

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -6,8 +6,8 @@ destroying O1'''
   cmd: '''nim c --gc:arc --expandArc:main --expandArc:main1 --expandArc:main2 --expandArc:main3 --hints:off --assertions:off $file'''
   nimout: '''--expandArc: main
 
-var :tmp
 var data
+var :tmp
 var :tmp_1
 try:
   var :tmp_2 = encode do:
@@ -25,8 +25,8 @@ finally:
 --expandArc: main1
 
 var s
-var :tmp
 var data
+var :tmp
 try:
   s = newString(100)
   var :tmp_1 = encode(toOpenArrayByte(s, 0, `-`(len(s), 1)))
@@ -40,9 +40,9 @@ finally:
 -- end of expandArc ------------------------
 --expandArc: main2
 
-var s
-var :tmp
 var data
+var :tmp
+var s
 try:
   s = newSeq(100)
   var :tmp_1 = encode(s)
@@ -56,8 +56,8 @@ finally:
 -- end of expandArc ------------------------
 --expandArc: main3
 
-var :tmp
 var data
+var :tmp
 var :tmp_1
 try:
   var :tmp_2 = encode do:

--- a/tests/lang_objects/metatype/tunresolved_return_type.nim
+++ b/tests/lang_objects/metatype/tunresolved_return_type.nim
@@ -1,6 +1,6 @@
 discard """
-  errormsg: "cannot instantiate: 'T'"
-  line: 12
+  errormsg: "type mismatch: got <int literal(23)>"
+  line: 20
 """
 
 # bug #2594

--- a/tests/misc/tparamsindefault.nim
+++ b/tests/misc/tparamsindefault.nim
@@ -18,7 +18,6 @@ f3 10 15 25
 true true
 false true
 world
-typedescDefault
 '''
 """
 
@@ -112,9 +111,3 @@ block:
     return s[revStart ..  revEnd-1]
 
   echo pySubstr("Hello world", -5)
-
-
-# bug #11660
-
-func typedescDefault(T: typedesc; arg: T = 0) = debugEcho "typedescDefault"
-typedescDefault(int)

--- a/tests/threads/threadex.nim
+++ b/tests/threads/threadex.nim
@@ -38,8 +38,8 @@ proc produce() {.thread.} =
   chan.send(m)
 
 open(chan)
-createThread[void](consumer, consume)
-createThread[void](producer, produce)
+(createThread[void])(consumer, consume)
+(createThread[void])(producer, produce)
 joinThread(consumer)
 joinThread(producer)
 

--- a/tests/threads/tonthreadcreation.nim
+++ b/tests/threads/tonthreadcreation.nim
@@ -18,7 +18,7 @@ proc foo() {.thread.} =
 
 proc main =
   var t: Thread[void]
-  createThread[void](t, foo)
+  (createThread[void])(t, foo)
   t.joinThread()
 
 main()

--- a/tests/threads/tthreadheapviolation1.nim
+++ b/tests/threads/tthreadheapviolation1.nim
@@ -14,5 +14,5 @@ proc horrible() {.thread.} =
   var mydata = (x, "my string too")
   echo global
 
-createThread[void](t, horrible)
+(createThread[void])(t, horrible)
 joinThread(t)

--- a/tests/typerel/tvoid.nim
+++ b/tests/typerel/tvoid.nim
@@ -28,10 +28,12 @@ proc emptyProc() =
   echo "empty"
 
 callProc[int](intProc, 12)
-callProc[void](emptyProc)
+# for ``void`` parameter erasure to work, the generic needs to be instantiated
+# early, hence the parenthesis
+(callProc[void])(emptyProc)
 
 
-ReturnT[void]()
+(ReturnT[void])()
 echo ReturnT[string]("abc")
 nothing()
 


### PR DESCRIPTION
## Summary

Rework and unify the handling of calls with explicitly provided type bindings (e.g.: `someRoutine[int, float]()`), significantly improving the usability of generic routines and fixing a large amount of related issues/bugs.

The core of the change is, that generic routines are now, except if explicitly requested otherwise, instantiated *after* overload resolution, instead of *before*. Forcing early instantiation is still possible via the `(someRoutine[int, float])()` syntax.

Since `void` parameter erasure only applies when when using early instantiation, code depending on the erasure needs to be adjusted.

Language changes/clarifications
-------------------------------

- default values for generic parameters on routines are now supported
- alias macros/templates are no longer considered for expansion in the callee position of the `someRoutine[A, B](c)` construct, making the behaviour consistent with that of normal call expressions
- the `someRoutine[]()` syntax is now valid. Instead of being treated as a dereference operation, it can now be used to force overload resolution to pick a generic routine (which includes nullary generics)
- using parenthesized callee expressions is now supported when the callee evaluates to a symbol choice
- the `T = x` (`nkExprEqExpr`) syntax is disallowed for type arguments

Fixed issues
------------

- fix passing values to type arguments with the `static[T]` not working when the callee is a template/macro, or the call located inside a template body / generic routine. A `type expected, but got` error was previously reported when attempting to pass the type argument
- all generic routines are now considered during overload resolution, regardless of which routine lookup finds first

## Details

### Previous implementation

Invocation of a routine where explicit generic type arguments where provided was handled by the compiler in two different ways:
1. explicit instantiation + overload resolution using the resulting instantiations (also referred to as early or eager instantiation here)
2. normal overload resolution (also referred to as late instantiation here)

How generic calls were treated was very dependent on the first symbol found by lookup. Early instantiation instantiation happened when:
- the first routine found by qualified lookup is not a template or macro
- the first non-template/macro routine in the candidate set had implicit generic parameters, and none of them were explicitly supplied
- the call expression was located in either the body of a template or generic routine (macros excluded)
while normal overload resolution was chosen in all other cases.

The early instantiation route worked by: gathering a set with all overloads; discarding all templates, macros, and routines with a different number of expected generic parameters (both explicit and implicit) than provided generic arguments; and generating an instantiation
for each remaining routine where the generic arguments matched the formal types.

If the resulting set was empty, a `cannot instantiate` error was produced. Otherwise, the closed set with the instantiated routines was passed on to normal overload resolution.

When taking the late instantiation route, the call expression with the callee being an `nkBracketExpr` node is passed directly to `resolveOverloads`, where the expressions in the bracket are analysed as normal operand expressions and the *types* of the analysed expressions are used as the initial bindings. No arity nor formal vs. argument type checking took place in this case, which allowed for semantically invalid programs to compile and possibly run.

There was another quirk with the late instantiation route: if the first found symbol is a macro or template, or the call expression is coming from a template/generic instantiation macros, each expression in the brackets was required to be a type expression (which prevents most valid `static` expressions), making it effectively impossible to use routines with explicit generic parameters using `static[T]` in these contexts.

### Now

* analyse and resolve all call expressions of the exact form `someRoutine[A, B](c)` through normal overload resolution
* extend `sigmatch` to perform the matching of generic arguments (if present) against the generic parameters -- a mismatch results in the overload to be rejected
* use the same analysis for generic arguments in the context of explicit instantiation (`explicitInstantiation`) and overload resolution (`resolveOverloads`)
* use dedicated processing for the generic call syntax in `semIndirectOp`, which allows for `someRoutine[]()` to work and also prevents alias templates/macros to be expanded in the callee symbols slot

### Other changes

* an implicit dereference is now inserted for `x.field()` where `field` is a view, making the behaviour of `nkDotExpr` consistent with other expressions in the context of indirect calls

### `void` parameter erasure

`sigmatch` could be adjusted to treat `void` parameters as effectively non-existing, though this wouldn't make `proc` types using generic parameters that are bound to `void` work.

### Error messages

When not explicitly requested, no instantiation of generic routines takes place prior to overload resolution, meaning that, for example, a type argument mismatch doesn't produce a `cannot instantiate` error anymore.

The `MismatchInfo` is extended to also include information about generic-parameter-related errors, but rendering of the error is still very basic.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## To-do
- [X] ~match default parameter values against the formal type~
- [X] add regression tests for the fixed issues

## Notes for Reviewers
* improving the error messages makes more sense as separate PR, I think
* the changeset is quite small compared to its impact
* I'm not sure if the language changes / additions should be reflected in the manual yet

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
