### PR TITLE
makefile.nimf: macos arm64 m1 and m2 CPU support

### DIFF
--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -157,6 +157,9 @@ endif
 ifeq ($(ucpu),aarch64)
   mycpu = arm64
 endif
+ifeq ($(ucpu),arm64)
+  mycpu = arm64
+endif
 ifeq ($(ucpu),riscv64)
   mycpu = riscv64
 endif


### PR DESCRIPTION
Added detection of arm64 CPU, this should allow building on M1/2 macs.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* csources will still have to be updated