### PR TITLE
vm: improve and fix numeric conversion support

### DIFF
--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -85,7 +85,7 @@ type
     opcMulSet, opcPlusSet, opcMinusSet, opcConcatStr,
     opcContainsSet, opcRepr, opcSetLenStr, opcSetLenSeq,
     opcIsNil, opcOf,
-    opcParseFloat, opcConv, opcObjConv, opcCast
+    opcParseFloat, opcConv, opcNumConv, opcObjConv, opcCast
     opcQuit, opcInvalidField,
     opcNarrowS, opcNarrowU,
     opcSignExtend,

--- a/compiler/vm/vmutils.nim
+++ b/compiler/vm/vmutils.nim
@@ -80,9 +80,10 @@ func codeListing*(c: TCtx; start = 0; last = -1): seq[DebugVmCodeEntry] =
 
     case opc:
     of opcConv, opcCast:
-      code.types = (c.rtti[c.code[i + 1].regBx-wordExcess].nimType,
-                    c.rtti[c.code[i + 2].regBx-wordExcess].nimType)
-      inc i, 2
+      code.rb = c.code[i + 1].regA
+      code.types = (c.rtti[c.code[i + 0].regBx-wordExcess].nimType,
+                    c.rtti[c.code[i + 1].regBx-wordExcess].nimType)
+      inc i, 1
     of opcLdConst, opcAsgnConst:
       let cnst = c.constants[code.idx]
       code.ast =

--- a/tests/misc/tnumeric_conversions.nim
+++ b/tests/misc/tnumeric_conversions.nim
@@ -1,0 +1,98 @@
+discard """
+  targets: "c !js vm"
+  description: "Tests for conversion between the primitive numeric types"
+"""
+
+# knownIssue: the JavaScript target doesn't yet support full-range integers
+
+block negative_float64_to_uint:
+  # has the same result as converting to a signed int of the same width first,
+  # and then to the unsigned one
+  var f = -1.5
+  doAssert uint64(f) == uint64(int64(f))
+  doAssert uint32(f) == uint32(int32(f))
+  doAssert uint16(f) == uint16(int16(f))
+  doAssert uint8(f) == uint8(int8(f))
+
+block negative_float32_to_uint:
+  # has the same result as converting to a signed int of the same width first,
+  # and then to the unsigned one
+  var f = -1.5'f32
+  doAssert uint64(f) == uint64(int64(f))
+  doAssert uint32(f) == uint32(int32(f))
+  doAssert uint16(f) == uint16(int16(f))
+  doAssert uint8(f) == uint8(int8(f))
+
+block bool_to_float:
+  var b = true
+  doAssert float(b) == 1.0
+  b = false
+  doAssert float(b) == 0.0
+
+block unsigned_to_float:
+  var u = 0xFFFF'u16
+  doAssert float32(u) == 65535
+
+  # edge case: all 64 bits set
+  var
+    full = high(uint64)
+    f32 = float32(full)
+    f64 = float64(full)
+  doAssert f32 == 1.8446744073709552e+19
+  doAssert f64 == 1.8446744073709552e+19
+
+block to_bool:
+  # test the integer/float-to-bool conversion. Only zero maps to `false` --
+  # everything non-zero maps to `true`
+  var f = 0.0
+  doAssert bool(f) == false
+  f = 0.01
+  doAssert bool(f) == true
+  f = -1
+  doAssert bool(f) == true
+
+  var u = high(uint64)
+  doAssert bool(u) == true
+
+  # test that the bool really is stored as `1`, and is not kept as the
+  # ``uint64`` value internally
+  var b = bool(u)
+  doAssert ord(b) == 1
+
+  u = 0
+  doAssert bool(u) == false
+
+  var i = low(int) + 1
+  doAssert bool(i) == true
+
+block truncate:
+  # unsigned integer conversion to a smaller width type truncate
+  var a = 0x8070605040302010'u64 # a value that can't be represented with 32 bits
+  var b = uint32(a)
+  doAssert b == 0x40302010'u32
+  var c = uint16(a)
+  doAssert c == 0x2010'u16
+  var d = uint8(a)
+  doAssert d == 0x10'u8
+
+block signed_to_unsigned:
+  # signed-to-unsigned conversion to also truncate, but otherwise keep the bit
+  # representation intact
+  var x = 0xFFFFFFFF'i32
+  doAssert uint32(x) == 0xFFFFFFFF'u32
+  doAssert uint16(x) == 0xFFFF'u16
+
+  x = 0x0000FFFF'i32
+  doAssert uint32(x) == 0x0000FFFF'u32
+  doAssert uint16(x) == 0xFFFF'u16
+
+block signed_to_larger_unsigned:
+  # bit pattern reinterpretation + truncation (in that order)
+  # XXX: it's unclear whether this is the correct / wanted behaviour
+  var x = 0xFFFF'i16 # -1
+  doAssert uint16(x) == high(uint16)
+  doAssert uint32(x) == high(uint32)
+  doAssert uint64(x) == high(uint64)
+
+  x = 0xFF00'i16
+  doAssert uint32(x) == 0xFFFFFF00'u32


### PR DESCRIPTION
## Summary

Rework the handling of conversion between two numeric values (integers, floats, enums, etc.) in the VM and `vmgen`, fixing two severe issues:
- unsigned integers greater than 2^63 being treated as signed values during unsigned-to-float conversions
- range checks being erroneously inserted for X-to-unsigned conversions

Numeric conversions now work the same for the VM target as they do with the C target. In addition, they no longer use the high-quality RTTI, thus making them more efficient.

## Details

One problem with the previous `Conv` operation was, that the semantics regarding the destination register were dependent on the target type. For to-`string` and to-`openArray` conversions, the destination register was expected to store a handle, while for the numeric conversions it was an "out" register (meaning that its content is overwritten).

Because the operation unconditionally validated the handle stored in destination (even it was only meant as an "out" register), this would lead to spurious access violation errors if the destination register stores a stale handle.

In addition, numeric conversions didn't properly clean up the destination register, which was a cause of memory leaks -- these are fixed now.

- introduce the new `NumConv` operation, which is used for conversion involving floats, and for the to-bool conversion
- adjust numerical conversion handling in `vmgen` to emit `NumConv` where applicable
- remove the numeric-conversion-related logic from `opConv`
- change the `Conv` and `Cast` operation to use two instruction words instead of three
- only emit `RangeCheck` instructions for `nkChckRange` expression if the destination is not an unsigned integer, mirroring the C code- generator's logic
- treat `range`-to-base-type conversions as a no-op in `vmgen`
- split the `cast` generation logic into a separate procedure
- unsupported `cast`s are now reported during code generation instead of at run-time

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* blocks #548, as the changes there trigger the "Conv destination register is stale handle" case 
* this change makes further progress towards the eventual removal of `opcConv`
* changing the encoding of `opcConv` and `opcCast` instructions was also possible prior to separating the numeric conversion

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
