### PR TITLE
semcall: isolate overload resolution more

### DIFF
--- a/tests/lang_callable/overload/toverload_issues.nim
+++ b/tests/lang_callable/overload/toverload_issues.nim
@@ -195,3 +195,18 @@ doAssert foo(@[1,2,3]) == "foo: seq[int]"
 doAssert foo(@["WER"]) == "foo: seq[T]"
 doAssert foo(MySeq[int]()) == "foo: MySeq[int]"
 doAssert foo(MySeq[string]()) == "foo: MySeq[T]"
+
+block dont_consider_symbols_from_operands:
+  # overloads introduced by sem-checking the operand(s) must not be
+  # considered during overload resolution of the original call
+  proc test(x: float64): int =
+    result = 1
+
+  template define() {.dirty.} =
+    proc test(x: float32): int =
+      result = 2
+
+  # previously, overload resolution also considered the ``test`` overload
+  # introduced by the template expansion. Since `1` matches ``float32`` and
+  # ``float64`` equally well, this lead to an "ambiguous call" error
+  doAssert test((define(); 1)) == 1


### PR DESCRIPTION
## Summary

Prevent symbols introduced by sem-checking the operands from affecting overload resolution. In addition, only commit these symbols to the symbol table if a match is found, which reduces the amount of side-effects `resolveOverloads` has in case of an error.

## Details

- add an `initOverloadIter` overload that allows specifying the scope to start traversal in
- wrap the call(s) to `pickBestCandidate` in a shadow scope that is only merged if a match was found
- set the `currentScope` when initializing an overload iterator with a symbol choice, which prevents changes to the `PContext`'s `currentScope` from affecting the iterator
- remove the logic for detecting symbol table changes from `pickBestCandidate`

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* a small simplification / fix I noticed as part of the explicit generic call rework
* none of my other tasks depend on this PR, so there's no urgency to merging it

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
