### PR TITLE
stdlib: fix `range` types for `repr_v2`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1183,6 +1183,7 @@ type
     adSemExprHasNoAddress
     adSemExpectedOrdinal
     adSemConstExprExpected
+    adSemExpectedRangeType
     # semobjconstr
     adSemFieldAssignmentInvalidNeedSpace
     adSemFieldAssignmentInvalid
@@ -1313,7 +1314,8 @@ type
         adSemFoldDivByZero,
         adSemInvalidRangeConversion,
         adSemFoldCannotComputeOffset,
-        adSemExpectedIdentifierQuoteLimit:
+        adSemExpectedIdentifierQuoteLimit,
+        adSemExpectedRangeType:
       discard
     of adSemExpectedIdentifierInExpr:
       notIdent*: PNode

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3878,7 +3878,8 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemFoldOverflow,
       adSemFoldDivByZero,
       adSemFoldCannotComputeOffset,
-      adSemExpectedIdentifierQuoteLimit:
+      adSemExpectedIdentifierQuoteLimit,
+      adSemExpectedRangeType:
     semRep = SemReport(
         location: some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -553,6 +553,7 @@ func astDiagToLegacyReportKind*(
   of adSemExprHasNoAddress: rsemExprHasNoAddress
   of adSemExpectedOrdinal: rsemExpectedOrdinal
   of adSemConstExprExpected: rsemConstExprExpected
+  of adSemExpectedRangeType: rsemExpectedRange
   of adSemRecursiveDependencyIterator: rsemRecursiveDependencyIterator
   of adSemCallIndirectTypeMismatch: rsemCallIndirectTypeMismatch
   of adSemSystemNeeds: rsemSystemNeeds

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -227,6 +227,16 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
       arg = arg.base.skipTypes(skippedTypes + {tyGenericInst})
       if not rec: break
     result = getTypeDescNode(c, arg, operand.owner, traitCall.info)
+  of "rangeBase":
+    # return the range's base type
+    let arg = operand.skipTypes({tyGenericInst})
+    if arg.kind == tyRange:
+      result = getTypeDescNode(c, arg.base, operand.owner, traitCall.info)
+    else:
+      result = traitCall
+      result[1] = c.config.newError(traitCall[1],
+                                    PAstDiag(kind: adSemExpectedRangeType))
+      result = c.config.wrapError(result)
   of "isCyclical":
     let r =
       if operand.skipTypes(abstractInst).kind in ConcreteTypes:

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -184,6 +184,19 @@ since (1, 3, 5):
 
     typeof(block: (for ai in a: ai))
 
+proc rangeBase*(t: typedesc): typedesc {.magic: "TypeTrait".} =
+  ## Returns the base type of the ``range`` type `t`. Only a single level is
+  ## skipped, that is, if the range type's base type is also a range type,
+  ## the base type is not skipped.
+  runnableExamples:
+    type
+      Range = range[1..3]
+      Nested = range[Range(1)..Range(3)]
+
+    doAssert rangeBase(Range) is int
+    doAssert rangeBase(Range) isnot range
+    doAssert rangeBase(Nested) is Range
+
 proc isCyclical*(t: typedesc): bool {.magic: "TypeTrait".} =
   ## Returns whether the type `t` is *potentially* able to be part of a
   ## reference cycle when used as the type of a managed heap location.

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -6,6 +6,9 @@ proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
 proc distinctBase(T: typedesc, recursive: static bool = true): typedesc {.magic: "TypeTrait".}
   ## imported from typetraits
 
+proc rangeBase(T: typedesc): typedesc {.magic: "TypeTrait".}
+  ## imported from typetraits
+
 proc repr*(x: NimNode): string {.magic: "Repr", noSideEffect.}
 
 proc repr*(x: int): string =
@@ -92,8 +95,15 @@ proc repr*(p: proc): string =
   ## repr of a proc as its address
   repr(cast[ptr pointer](unsafeAddr p)[])
 
-template repr*(x: distinct): string =
-  repr(distinctBase(typeof(x))(x))
+template repr*[T: distinct|range](x: T): string =
+  # note: distinct and range match equally well, so it's not possible to use
+  # two templates -- doing so would lead to ambiguity errors
+  when T is range:
+    repr(rangeBase(typeof(x))(x))
+  elif T is distinct:
+    repr(distinctBase(typeof(x))(x))
+  else:
+    {.error: "unreachable".}
 
 template repr*(t: typedesc): string = $t
 

--- a/tests/stdlib/algorithm/trepr.nim
+++ b/tests/stdlib/algorithm/trepr.nim
@@ -67,6 +67,20 @@ template main() =
     else:
       doAssert reprOpenarray(arr) == "[1, 2, 3]"
 
+  block repr_with_range:
+    type
+      Range = range[1..2]
+      DistinctRange = distinct range[1..2]
+      Nested = distinct range[DistinctRange(1)..DistinctRange(2)]
+
+    # simple case: only a range
+    doAssert repr(Range(1)) == "1"
+    # more complex: a range wrapped in a ``distinct``
+    doAssert repr(DistinctRange(1)) == "1"
+    # complex case: a distinct range where the base type is also a distinct
+    # type
+    doAssert repr(Nested(DistinctRange(1))) == "1"
+
   block: # bug #17292 repr with `do`
     template foo(a, b, c, d) = discard
     block:

--- a/tests/typerel/trange_with_distinct.nim
+++ b/tests/typerel/trange_with_distinct.nim
@@ -1,0 +1,19 @@
+discard """
+  knownIssue: '''
+    A range type with a distinct base matches equally well against both
+    ``range`` and ``distinct``, which leads to ambiguity errors
+  '''
+"""
+
+type DInt = distinct int
+
+proc p[T: range](x: T): int =
+  result = 1
+
+proc p[T: distinct](x: T): int =
+  result = 2
+
+var x: range[DInt(0)..DInt(1)]
+# the overload using the ``range``-constraint should match better than the one
+# with the ``distinct``
+doAssert p(x) == 1


### PR DESCRIPTION
## Summary

Fix an infinite template expansion error when passing a range type with a `distinct T` base type to `repr` while using `repr_v2`.

In order to support to fix the `repr` the implementation, the new type-trait routine `rangeBase` is introduced. As the name implies, it used for querying a `range` type's base type.

## Details

For an expression of type `range T` where `T` is a `distinct`, the template `repr(x: distinct)` is chosen by overload resolution.

But since `range T` is not a `distinct` type, `distinctBase` returns the same type as is passed in, which causes the type to be left unchanged and the same `repr` overload to be selected again.

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* blocks #630

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
