### PR TITLE
sem: don't create improper type instantiations

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -319,6 +319,8 @@ proc semConv(c: PContext, n: PNode): PNode =
   var op = semExprWithType(c, n[1])
   if targetType.kind != tyGenericParam and targetType.isMetaType:
     let final = inferWithMetatype(c, targetType, op, true)
+    # XXX: this makes little sense -- the source and target type of the
+    #      resulting conversion are the same
     result.add final
     result.typ = final.typ
     return handleError(c, result, hasError)

--- a/tests/lang/s02_core/s02_procedures/t03_overload_core_conversion/t01_generic_converter.nim
+++ b/tests/lang/s02_core/s02_procedures/t03_overload_core_conversion/t01_generic_converter.nim
@@ -3,6 +3,7 @@ description: '''
 Converters can be used with generic types without specifying explicit
 parameters
 '''
+matrix: "--gc:refc; --gc:orc"
 joinable: false
 """
 


### PR DESCRIPTION
## Summary

Fix conversions to composite type-classes (e.g. `GenericType(x)`) leading to the creation of improper type instantiations. These would lead to invalid C code being generated and thus, in some cases, C compiler errors.

## Details

An improper type instantiations is a `tyGenericInst` type that wasn't created as the result of resolving/evaluating a `tyGenericInvocation`. Their carried concrete object type (if they carry one, that is) doesn't have the `typeInst` field set, and the concrete type is also possibly missing a `=deepcopy` type-bound operator.

They were the result of a non-concrete `tyGenericInst` (that is, one containing meta types) being subjected to type-var replacing, where all referenced meta types had bindings to concrete type.

Since signature hashing takes an object type's `typeInst` field into account, this lead to the C code generator treating improper instantiations as standalone types, emitting and using a separate C type for them, and thus generating illegal C code.

The logic in `inferWithMetatype` is adjusted to not pass a `tyGenericInst` that contains meta types to `generateTypeInstance`, but to instead create a generic invocation and evaluate that.

### Type-var replacing

As an experiment, `tyGenericInst` types are no longer modified nor copied by `replaceTypeVarsT`, and the workarounds introduced by the the commits f915b3aa86929d87e162b6ddd7589e6337a30397 and 3f3e0fa303a2729d0d6a9ffe54936c1c830e2d7e removed.

For concrete `tyGenericInst` types, this is always correct, as they don't contain any type variables. Copying and processing them is thus unnecessary.

`tyGenericInst` instances that contain meta types *should* only reach through when generic invocations are passed to `prepareMetatypeForSigmatch`, in which case copying and modifying them is wrong.