### PR TITLE
sem: disallow `lent|sink T` in non-type contexts

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -281,20 +281,7 @@ proc semConv(c: PContext, n: PNode): PNode =
 
   var hasError = false
 
-  template handleLentOrSunkType(c: PContext, op: PNode, info: TLineInfo, targetType: PType): PNode =
-    let
-      baseType = semTypeNode(c, op, nil).skipTypes({tyTypeDesc})
-      t = newTypeS(targetType.kind, c)
-      res = newNodeI(nkType, info)
-    
-    t.rawAddSonNoPropagationOfTypeFlags baseType
-    
-    res.typ = makeTypeDesc(c, t)
-    res
-
-  if targetType.kind in {tySink, tyLent}:
-    return handleLentOrSunkType(c, n[1], n.info, targetType)
-  else:
+  block:
     let s = qualifiedLookUp(c, n[0], {})
     if s.isError:
       result.add s.ast

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2010,6 +2010,12 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         # skip 'owned' in type expressions and produce a warning
         localReport(c.config, n, reportSem rsemOwnedTypeDeprecated)
         result = semTypeExpr(c, n[1], prev)
+      elif (op.s == "sink" or op.s == "lent") and n.len == 2:
+        # it's a 'sink T' or 'lent T' expression
+        # XXX: consider introducing special words for both (i.e., ``wLent``,
+        #      ``wSink``)
+        result = newOrPrevType((if op.s == "sink": tySink else: tyLent), nil, c)
+        result.rawAddSonNoPropagationOfTypeFlags semTypeNode(c, n[1], nil)
       else:
         if c.inGenericContext > 0 and n.kind == nkCall:
           result = makeTypeFromExpr(c, n.copyTree)

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -1,7 +1,7 @@
 when defined(nimHasLentIterators) and not defined(nimNoLentIterators):
-  template lent2(T): untyped = lent T
+  template lent2(T): typedesc = lent T
 else:
-  template lent2(T): untyped = T
+  template lent2(T): typedesc = T
 
 iterator items*[T: not char](a: openArray[T]): lent2 T {.inline.} =
   ## Iterates over each item of `a`.


### PR DESCRIPTION
## Summary

A `lent|sink T` expression is represented as a `Prefix (Ident ...) (...)` in untyped AST, and was analyzed in `semConv`. Besides this being unintuitive, inefficient, and also inconsistent with other modifiers like `var`, it also allowed `lent|sink T` type expressions in non-type contexts.

Instead, `lent T` and `sink T` type expression are now analyzed as part of `semTypeNode`, which makes their handling more consistent with that of `var T`.

## Details

The `lent2` helper template in the `iterators_1.nim` module is adjusted to use `typedesc` templates. This is now required because `lent T` can no longer be used in a non-type context (which currently includes `untyped` templates being expanded in type positions).