### PR TITLE
don't omit the goto-handler for `system` routines

### DIFF
--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -11,11 +11,13 @@
 ## included from cgen.nim
 
 proc canRaiseDisp(p: BProc; n: PNode): bool =
-  # we assume things like sysFatal cannot raise themselves
+  ## 'true' if calling the callee expression `n` can exit via exceptional
+  ## control-flow, otherwise 'false'. If panics are disabled, this also
+  ## includes all routines that are not certain magics, compiler procs, or
+  ## imported.
   if n.kind == nkSym and {sfNeverRaises, sfImportc, sfCompilerProc} * n.sym.flags != {}:
     result = false
-  elif optPanics in p.config.globalOptions or
-      (n.kind == nkSym and sfSystemModule in getModule(n.sym).flags):
+  elif optPanics in p.config.globalOptions:
     # we know we can be strict:
     result = canRaise(n)
   else:

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -420,7 +420,12 @@ when gotoBasedExceptions:
     ## This proc must be called before `currException` is destroyed.
     ## It also must be called at the end of every thread to ensure no
     ## error is swallowed.
-    if nimInErrorMode and currException != nil:
+    # clear the error flag before doing anything else. Otherwise the first
+    # non-magic call would cause this procedure to exit
+    var wasInErrorMode = false
+    swap(nimInErrorMode, wasInErrorMode)
+
+    if wasInErrorMode and currException != nil:
       reportUnhandledError(currException)
       currException = nil
       quit(1)

--- a/tests/lang_types/float/tfloat1.nim
+++ b/tests/lang_types/float/tfloat1.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--exceptions:setjmp;--exceptions:goto"
   outputsub: "Error: unhandled exception: FPU operation caused an overflow [FloatOverflowDefect]"
   exitcode: "1"
 """


### PR DESCRIPTION
## Summary

Routines defined in the `system` module were effectively treated as being to unable to raise defects. This is incorrect (most notably for `sysFatal`) and would lead to incorrect control-flow in some situations.

Only code built with using `goto` exceptions (implied by `--gc:arc|orc`) and panics disabled (the default) was affected.

## Details

- remove the exception regarding defects for routines defined in `system`
- adjust `nimTestErrorFlag` to clear out the exceptions flag
- test the `tfloat1.nim` with `--exceptions:goto`, as it was affected by the issue

Since a goto-handler is now also emitted when calling non-magic routines from the `system` module, this has small negative impact on execution speed of the generated C code.