### PR TITLE
cgen: fix a severe issue with `finally`

### DIFF
--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -80,7 +80,6 @@ type
     wAsmNoStackFrame = "asmNoStackFrame", wImplicitStatic = "implicitStatic",
     wGlobal = "global", wCodegenDecl = "codegenDecl", wUnchecked = "unchecked",
     wGuard = "guard", wLocks = "locks", wExplain = "explain",
-    wEnforceNoRaises = "enforceNoRaises",
 
     wAuto = "auto", wBool = "bool", wCatch = "catch", wChar = "char",
     wClass = "class", wCompl = "compl", wConst_cast = "const_cast", wDefault = "default",

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -117,7 +117,6 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasHintAll")
   defineSymbol("nimHasTrace")
   defineSymbol("nimHasEffectsOf")
-  defineSymbol("nimHasEnforceNoRaises")
   defineSymbol("nimHasNkComesFromNodeRemoved")
   defineSymbol("nimHasNkParForStmtNodeRemoved")
   defineSymbol("nimHasTyConceptRemoved")

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -75,8 +75,7 @@ const
     wBorrow, wImportCompilerProc, wThread,
     wAsmNoStackFrame, wDiscardable, wNoInit, wCodegenDecl,
     wGensym, wInject, wRaises, wEffectsOf, wTags, wLocks, wDelegator, wGcSafe,
-    wStackTrace, wLineTrace, wNoDestroy,
-    wEnforceNoRaises}
+    wStackTrace, wLineTrace, wNoDestroy}
   converterPragmas* = procPragmas
   methodPragmas* = procPragmas+{wBase}-{wOverride}
   templatePragmas* = {wDeprecated, wError, wGensym, wInject, wDirty,
@@ -1414,9 +1413,6 @@ proc applySymbolPragma(c: PContext, sym: PSym, it: PNode): PNode =
       of wUsed:
         result = noVal(c, it)
         sym.flags.incl sfUsed
-      of wEnforceNoRaises:
-        result = noVal(c, it)
-        sym.flags.incl sfNeverRaises
       of wCast:
         result = c.config.newError(it, PAstDiag(kind: adSemCastRequiresStatement))
       of wInvalid:

--- a/lib/std/private/digitsutils.nim
+++ b/lib/std/private/digitsutils.nim
@@ -78,17 +78,14 @@ func addIntImpl(result: var string, x: uint64) {.inline.} =
     dec next
   addChars(result, tmp, next, tmp.len - next)
 
-when not defined(nimHasEnforceNoRaises):
-  {.pragma: enforceNoRaises.}
-
-func addInt*(result: var string, x: uint64) {.enforceNoRaises.} =
+func addInt*(result: var string, x: uint64) =
   when nimvm: addIntImpl(result, x)
   else:
     when not defined(js): addIntImpl(result, x)
     else:
       addChars(result, numToString(x))
 
-proc addInt*(result: var string; x: int64) {.enforceNoRaises.} =
+proc addInt*(result: var string; x: int64) =
   ## Converts integer to its string representation and appends it to `result`.
   runnableExamples:
     var s = "foo"
@@ -113,5 +110,5 @@ proc addInt*(result: var string; x: int64) {.enforceNoRaises.} =
       addChars(result, numToString(x))
     else: impl()
 
-proc addInt*(result: var string; x: int) {.inline, enforceNoRaises.} =
+proc addInt*(result: var string; x: int) {.inline.} =
   addInt(result, int64(x))

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -93,6 +93,9 @@ proc setFrameState*(state: FrameState) {.compilerRtl, inl.} =
 proc getFrame*(): PFrame {.compilerRtl, inl.} = framePtr
 
 proc popFrame {.compilerRtl, inl.} =
+  # note: this procedure is potentially called while unwinding is happening,
+  # and thus must not, under any circumstances, perfom any action that might
+  # test or alter the error flag
   framePtr = framePtr.prev
 
 when false:

--- a/tests/exception/tfinally5.nim
+++ b/tests/exception/tfinally5.nim
@@ -1,0 +1,36 @@
+discard """
+  matrix: "--exceptions:setjmp; --exceptions:goto --panics:on"
+  targets: c
+"""
+
+block potentially_raising_call_in_finally:
+  # a test to make sure that error mode is disabled for the duration of
+  # a 'finally' clause. This also has to happen when the finally's body doesn't
+  # raise any uncaught exceptions or defects
+  proc p2(x: bool) {.noinline.} =
+    if x:
+      raise CatchableError.newException("")
+
+  proc p() {.raises: [].} = # must have no unhandled exception effects
+    var i = 0
+    try:
+      p2(false) # known to not raise an exception at run-time
+      i = 1
+    except CatchableError:
+      doAssert false
+
+    doAssert i == 1
+
+  var i = 0
+  try:
+    try:
+      # enter the finally with an active exception
+      raise CatchableError.newException("")
+    finally:
+      p() # never raises an exception or defect
+      i = 1
+  except CatchableError:
+    doAssert i == 1
+    i = 2
+
+  doAssert i == 2


### PR DESCRIPTION
## Summary

When using `--exceptions:goto`, `try` blocks inside a `finally` clause now work properly when the `finally` clause doesn't raise an *uncaught* exception or defect. Previously, the first call executed as part of the nested `try` block that can potentially raise an exception would be treated as having raised an exception.

Since it is obsolete now, remove the undocumented `enforceNoRaises` pragma introduced as a workaround for the underlying issues.

## Details

The root cause of the issues is an incorrect optimization performed by the code generator: if a `finally` clause doesn't raise an *uncaught* exception or defect, the error flag (which indicates that unwinding is in progress) was not cleared.

This is wrong. No exceptional control-flow leaving the `finally` clause does not imply that the error flag is not tested within (both directly and indirectly). If it is tested as part of calling a routine that can potentially raise, and the `finally` clause was entered as part of unwinding caused by a raised exception, unwinding would start again, regardless of whether the called routine actually raised an exception.

### The Fix

The error flag is now only left unchanged if neither the `try`'s body nor any `except` branches have exception-related control-flow effects (i.e., they must not raise an uncaught exception for the optimization to be applied).

In the future, the code generator should track for each procedure whether it observes the error flag (both directly and transitively), and use this information to safely apply the partially removed optimization.