### PR TITLE
sem: propagate `nkError` in `semCast`

### DIFF
--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2182,6 +2182,23 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
   n.typ = result
   dec c.inTypeContext
 
+proc semTypeNode2(c: PContext, n: PNode, prev: PType): PNode =
+  ## Semantically analyzes the type AST `n`, and returns either the analyzed
+  ## AST or an error.
+  ##
+  ## XXX: this procedure is meant to eventually replace the current
+  ##      ``semTypeNode``, which mutates the input AST and returns a type
+  let typ = semTypeNode(c, n, prev)
+  if typ.isNil:
+    result = newError(c.config, n, PAstDiag(kind: adSemTypeExpected))
+  elif typ.kind == tyError and typ.n.kind == nkError:
+    result = typ.n
+  else:
+    # the type is either valid or an error type that doesn't store a
+    # diagnostic. For the latter, ``localReport`` was already used to report
+    # the error, so no extra error node is created here
+    result = copyTree(n)
+
 proc setMagicType(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
   # source : https://en.wikipedia.org/wiki/Data_structure_alignment#x86
   m.typ.kind = kind

--- a/tests/stdlib/algorithm/tsequtils.nim
+++ b/tests/stdlib/algorithm/tsequtils.nim
@@ -1,15 +1,12 @@
 discard """
   targets: "c js !vm"
+  matrix: "--gc:refc; --gc:orc"
 """
 
 # knownIssue: disable for the VM due to an internal VM crash at run-time. Needs to be investigated further
 
 # xxx move all tests under `main`
-
-import std/vmutils
-
-import std/sequtils
-import strutils
+import std/[sequtils, strutils]
 from algorithm import sorted
 
 {.experimental: "strictEffects".}


### PR DESCRIPTION
## Summary

- make `semCast` propagate error nodes
- introduce `semTypeNode2`, which is similar to `semTypeNode`, but
  returns a node instead of a type
- handle error types in `isCastable`, `productReachable`, and
  `iterOverTypeAux`

### AST types

- extend the `CheckedAst` API with `typ` accessors and more ways to
  initialize
- disallow and prevent `CheckedAst` from storing an error node directly
- add the experimental ``ElaborateAst`` type (name is going to change)

## Details

The idea with `semTypeNode2` is that it should eventually replace
`semTypeNode`, with all of `semtypes` being refactored to return nodes
instead of types. This would allow the type-node usage sites to store
typed AST, would reduce the amount of input AST modifications, and make
error propagation in type node contexts a bit simpler.

A lesson learned from the `tsequtils.nim` test failure is that error
types (`tyError`) are sometimes either dropped or reported too late.
The direction that this commit goes into in order to prevent this, is
to produce an error node for all erroneous type-expressions appearing
in the AST.