### PR TITLE
partially refactor `semtypes`

### DIFF
--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -217,6 +217,7 @@ type
     stepSymNodeToNode
     stepNodeFlagsToNode
     stepNodeTypeToNode
+    stepNodeToNodeType
     stepTypeTypeToType
     stepResolveOverload
     stepNodeSigMatch
@@ -245,7 +246,7 @@ type
       of stepIdentToSym:
         ident*: PIdent
 
-      of stepNodeTypeToNode, stepTypeTypeToType:
+      of stepNodeTypeToNode, stepTypeTypeToType, stepNodeToNodeType:
         typ*: PType
         typ1*: PType
 

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3096,7 +3096,15 @@ proc reportBody*(conf: ConfigRef, r: TraceSemReport): string =
           else:
             field("to node")
             result.add render(s.node)
-
+        of stepNodeToNodeType:
+          if enter:
+            field("from node")
+            result.add render(s.node)
+          else:
+            field("to node")
+            result.add render(s.node)
+            field("to type")
+            result.add render(s.typ)
         of stepNodeFlagsToNode:
           if enter:
             field("from flags",  " " & conf.wrap($s.flags + fgCyan))

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -121,7 +121,9 @@ proc semProcBody(c: PContext, n: PNode): PNode
 proc fitNode(c: PContext, formal: PType, arg: PNode; info: TLineInfo): PNode
 proc changeType(c: PContext; n: PNode, newType: PType, check: bool): PNode
 
+proc semTypeNodeAux(c: PContext, n: PNode, prev: PType): PNode
 proc semTypeNode(c: PContext, n: PNode, prev: PType): PType
+proc semTypeNode2(c: PContext, n: PNode, prev: PType): PNode
 proc semStmt(c: PContext, n: PNode; flags: TExprFlags): PNode
 proc semOpAux(c: PContext, n: PNode): bool
 proc semParamList(c: PContext, n, genericParams: PNode, kind: TSymKind): PType
@@ -134,7 +136,7 @@ proc finishMethod(c: PContext, s: PSym)
 proc evalAtCompileTime(c: PContext, n: PNode): PNode
 proc indexTypesMatch(c: PContext, f, a: PType, arg: PNode): PNode
 proc semStaticExpr(c: PContext, n: PNode): PNode
-proc semStaticType(c: PContext, childNode: PNode, prev: PType): PType
+proc semStaticType(c: PContext, childNode: PNode, prev: PType): PNode
 proc semTypeOf(c: PContext; n: PNode): PNode
 proc computeRequiresInit(c: PContext, t: PType): bool
 proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1930,6 +1930,7 @@ proc semDeref(c: PContext, n: PNode): PNode =
 
     case derefTarget.kind
     of nkError:
+      result[0] = derefTarget
       result = c.config.wrapError(result)
     else:
       result[0] = semmedTarget

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -291,6 +291,27 @@ template addInNimDebugUtils*(c: ConfigRef; action: string; n, r: PNode) =
 
     addInNimDebugUtilsAux(c, action, enterMsg, leaveMsg)
 
+template addInNimDebugUtils*(c: ConfigRef; action: string; n: PNode, r: PNode, output: PType) =
+  ## add tracing to procs that are primarily `PNode -> PNode`, where the result
+  ## also carries a type
+  when defined(nimCompilerStacktraceHints):
+    {.line.}:
+      frameMsg(c, n)
+  when defined(nimDebugUtils):
+    const loc = instLoc(locOffset)
+    template enterMsg(indentLevel: int) =
+      traceEnterIt(
+        loc, stepParams(c, stepNodeToNode, indentLevel, action)):
+        it.node = n
+
+    template leaveMsg(indentLevel: int) =
+      traceLeaveIt(
+        loc, stepParams(c, stepNodeToNodeType, indentLevel, action)):
+        it.node = r
+        it.typ = output
+
+    addInNimDebugUtilsAux(c, action, enterMsg, leaveMsg)
+
 template addInNimDebugUtilsError*(c: ConfigRef; n, e: PNode) =
   ## add tracing error generation `PNode -> PNode`
   when defined(nimCompilerStacktraceHints):


### PR DESCRIPTION
## Summary

The idea/goal is to produce nodes instead of types for `semTypeNode` and most of the routines in `semtypes`. In short, this means that analysis of type AST stays at the AST level, instead of switching back and forth between types and AST.