### PR TITLE
sem: simplify generic parameter symbol handling

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1577,3 +1577,9 @@ proc isCyclePossible*(typ: PType, g: ModuleGraph): bool =
   var marker = initIntSet() # keeps track of which object types we've already
                             # analysed
   result = check(marker, g, typ, typ, isInd=false)
+
+proc isMetaReturnTypeForMacro*(t: PType): bool =
+  ## Returns whether `t` is considered a meta-type when used as the return
+  ## type of macro/template
+  # note: make sure this matches the logic in ``semAfterMacroCall``
+  t != nil and t.kind notin {tyUntyped, tyTyped, tyTypeDesc} and t.isMetaType

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -147,6 +147,8 @@ proc instGenericContainer(c: PContext, info: TLineInfo, header: PType,
     header.kind == tyGenericInvocation,
     "Expected generic invocation for header kind, but found " & $header.kind)
 
+  # TODO: clean up and consider using ``generateTypeInstance`` instead
+
   var
     cl: TReplTypeVars
 
@@ -159,34 +161,34 @@ proc instGenericContainer(c: PContext, info: TLineInfo, header: PType,
   cl.c = c
   cl.allowMetaTypes = allowMetaTypes
 
-  # We must add all generic params in scope, because the generic body
-  # may include tyFromExpr nodes depending on these generic params.
-  # XXX: This looks quite similar to the code in matchUserTypeClass,
-  # perhaps the code can be extracted in a shared function.
-  openScope(c)
-  let genericTyp = header.base
-  for i in 0..<genericTyp.len - 1:
-    let genParam = genericTyp[i]
-    var param: PSym
+  # # We must add all generic params in scope, because the generic body
+  # # may include tyFromExpr nodes depending on these generic params.
+  # # XXX: This looks quite similar to the code in matchUserTypeClass,
+  # # perhaps the code can be extracted in a shared function.
+  # openScope(c)
+  # let genericTyp = header.base
+  # for i in 0..<genericTyp.len - 1:
+  #   let genParam = genericTyp[i]
+  #   var param: PSym
 
-    template paramSym(kind): untyped =
-      newSym(kind, genParam.sym.name, nextSymId c.idgen, genericTyp.sym, genParam.sym.info)
+  #   template paramSym(kind): untyped =
+  #     newSym(kind, genParam.sym.name, nextSymId c.idgen, genericTyp.sym, genParam.sym.info)
 
-    if genParam.kind == tyStatic:
-      param = paramSym skConst
-      param.ast = header[i+1].n
-      param.typ = header[i+1]
-    else:
-      param = paramSym skType
-      param.typ = makeTypeDesc(c, header[i+1])
+  #   if genParam.kind == tyStatic:
+  #     param = paramSym skConst
+  #     param.ast = header[i+1].n
+  #     param.typ = header[i+1]
+  #   else:
+  #     param = paramSym skType
+  #     param.typ = makeTypeDesc(c, header[i+1])
 
-    # this scope was not created by the user,
-    # unused params shouldn't be reported.
-    param.flags.incl sfUsed
-    addDecl(c, param)
+  #   # this scope was not created by the user,
+  #   # unused params shouldn't be reported.
+  #   param.flags.incl sfUsed
+  #   addDecl(c, param)
 
   result = replaceTypeVarsT(cl, header)
-  closeScope(c)
+  # closeScope(c)
 
 proc referencesAnotherParam(n: PNode, p: PSym): bool =
   case n.kind

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -297,6 +297,8 @@ type
 type sink*[T]{.magic: "BuiltinType".}
 type lent*[T]{.magic: "BuiltinType".}
 
+include "system/arithmetics"
+
 proc high*[T: Ordinal|enum|range](x: T): T {.magic: "High", noSideEffect,
   deprecated: "Deprecated since v1.4; there should not be `high(value)`. Use `high(type)`.".}
   ## Returns the highest possible value of an ordinal value `x`.
@@ -517,7 +519,6 @@ let nimvm* {.magic: "Nimvm", compileTime.}: bool = false
   ## It is true in Nim VM context and false otherwise.
 {.pop.}
 
-include "system/arithmetics"
 include "system/comparisons"
 
 const


### PR DESCRIPTION
## Summary

Simplify type instantiation and logic related to generic parameters in general, by treating complex type expressions in generic contexts as generic expressions, with the symbols of generic parameters and parameters being bound during first-phase lookup already.

On the user-facing side of things, this fixes multiple long-standing issues with `undeclared identifier` errors for implicitly instantiated types. For example, the following previously failed:
```nim
type
  Type[B] = object
    a: typeof(B) # using 'A' here would make it compile!

proc p[A](): TypeOf[A] = discard

discard p[int]()
```

The `is` operator now also works properly in `when` expression of generic objects. An `is` expression that was not the top-level one (this includes `not x is y` and `x isnot y`) only checked for type equality and *always* evaluated to true when the right-hand side was a `concept` type.

Another important thing to note is that type expressions used in the header of generic routines are, except for those used in range type constructors, now generic expressions, meaning that non-immediate templates/macros and `static` statements are only evaluated once the type is instantiated.

On the compiler side of things, interactions with generic parameter symbols simplify, with a lot of conditional logic becoming obsolete. Instantiating types no longer requires opening a scope and adding all the bound types and static values as `skType` and `skConst` symbols.

One effect of the change is that generic parameter symbols are now always bound in type expression contexts, but never bound in generic procedure bodies.

Together, this should streamline generic parameter handling, making it more amendable to further changes / improvements in the future.