### PR TITLE
cgen: handle uncaught exceptions at module exit

### DIFF
--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -313,6 +313,12 @@ func vmEventToLegacyVmReport(
           kind: kind,
           str: evt.callName & "()",
           ast: evt.argAst)
+      of vmEvtUnhandledException:
+        VMReport(
+          location: location,
+          reportInst: evt.instLoc.toReportLineInfo,
+          kind: kind,
+          ast: evt.exc)
       else:
         VMReport(
           location: location,

--- a/tests/exception/munhandled_in_non_main.nim
+++ b/tests/exception/munhandled_in_non_main.nim
@@ -1,0 +1,3 @@
+var e* = CatchableError.newException("failure")
+# raise an unhandled exception
+raise e

--- a/tests/exception/tunhandled_in_non_main.nim
+++ b/tests/exception/tunhandled_in_non_main.nim
@@ -1,0 +1,16 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    An unhandled exception not raised inside the main module must also
+    terminate the program
+  '''
+  joinable: false
+  outputsub: "Error: unhandled exception: failure [CatchableError]"
+  exitcode: 1
+"""
+
+import munhandled_in_non_main
+
+# an unhandled exception was raised when initializing the imported module;
+# execution must not reach here
+e.msg = "unreachable"


### PR DESCRIPTION
## Summary

For the C target, uncaught exceptions were only detected and reported (via `nimTestErrorFlag`) when raised from inside the main module, but not when raised from inside others.

When starting to execute the next module, the error mode was still active, which, depending on the contents of the module's module-level code, could lead to a cascade of failures eventually resulting in a crash unrelated to the original exception.

A call to `nimTestErrorFlag` is now inserted at the exit of every module's init procedure.

## Misc

- fix a `FieldDefect` error in `vmrunner` that ocurred when reporting an unhandled exception

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
* the issues surfaced during megatest execution in #630

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
* handle the single commit message requirement at the end of review
