### PR TITLE
vmgen: work around a VM issue

### DIFF
--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2346,7 +2346,15 @@ proc genSymAsgn(c: var TCtx, le, ri: PNode) =
       # if the location is backed by a register (i.e., is not in stored
       # in a memory cell), we don't use a temporary register + assignment
       # but directly write to the destination register
-      gen(c, ri, local(c.prc, s))
+      # XXX: we can't. If the right-hand side is a call and it raises an
+      #      exception, the way the VM currently implements ``IndCallAsgn``
+      #      would result in the local's register becoming uninitialized. In
+      #      other words, we have to also use a temporary here, at least until
+      #      the VM no longer clears out the destination register
+      #gen(c, ri, local(c.prc, s))
+      let b = c.genx(ri)
+      c.gABC(le, whichAsgnOpc(le), dest, b)
+      c.freeTemp(b)
     else:
       # an assignment is required to the local. Views are always stored as
       # handles in this case, so a register move is used for assigning them

--- a/tests/exception/tassignment.nim
+++ b/tests/exception/tassignment.nim
@@ -24,3 +24,21 @@ block unobservable_rvo_assignment:
     doAssert x[0] == 0, "following statement observed changed value"
 
   test()
+
+block primitive_type_assignment:
+  # assignments to locations of primitive type have no effect when the right-
+  # hand is a call expression raising an exception
+  proc raiseEx(): int =
+    result = 0
+    raise CatchableError.newException("")
+
+  proc test() =
+    var x = 1
+    try:
+      x = raiseEx()
+    except CatchableError:
+      doAssert x == 1
+
+    doAssert x == 1
+
+  test()


### PR DESCRIPTION
## Summary

Adjust the VM code generator to always use an intermediate temporary when assigning the result of a call to a local of primitive type. This fixes wrong values or VM crashes when raising from inside the procedure appearing on the right-hand side of such assignments.

The test suite was affected (`lang_stmts/casestmt/tcasestmt.nim`), so this is another step of making the test suite work with a `release` compiler.

## Details

The call-and-assign `IndCallAsgn` operation is currently implemented by moving the register representing the destination register into the callee's register file (its stack frame). Once the procedure exits, the register is moved back, but only if the procedure didn't exit via an unhandled exception.

While this is not a problem for complex return values (a temporary is currently always used for them), it is for primitive ones (int, float, etc.) stored directly in registers, as no temporary is used for them and thus raising an exception from inside the callee leaves the register empty.

There are other workarounds possible, but adjusting the code generator is the one with the smallest amount of impact.