### PR TITLE
cfg: report parse errors without crashing

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2876,7 +2876,7 @@ proc reportBody*(conf: ConfigRef, r: LexerReport): string =
       result.add "closing \" expected"
 
     of rlexExpectedToken:
-      assert false
+      result.add "expected $1" % r.msg
 
     of rlexCfgInvalidDirective:
       result.addf("invalid directive: '$1'", r.msg)

--- a/compiler/front/cmdlinehelper.nim
+++ b/compiler/front/cmdlinehelper.nim
@@ -35,7 +35,7 @@ import
     extccomp
   ]
 
-from std/strutils import endsWith
+from std/strutils import endsWith, `%`
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_lexer import LexerReport
@@ -101,6 +101,19 @@ proc handleConfigEvent(
       evt.lexerDiag.lexerDiagToLegacyReport
     else:
       case kind
+      of rlexExpectedToken:
+        let msgTempl =
+          case evt.kind
+          of cekParseExpectedCloseX: "closing '$1'"
+          of cekParseExpectedX:      "'$1'"
+          else: unreachable()
+        Report(
+          category: repLexer,
+          lexReport: LexerReport(
+            location: std_options.some evt.location,
+            reportInst: evt.instLoc.toReportLineInfo,
+            msg: msgTempl % evt.msg,
+            kind: kind))
       of rlexCfgInvalidDirective:
         Report(
           category: repLexer,

--- a/tests/misc/config/cfg_syntax/tcfg_closingtokenerr.nim
+++ b/tests/misc/config/cfg_syntax/tcfg_closingtokenerr.nim
@@ -1,0 +1,5 @@
+discard """
+  description: "tests config parsing error, see corresponding '.nim.cfg' file"
+  errormsg: "expected closing ']'"
+  file: "tcfg_closingtokenerr.nim.cfg"
+"""

--- a/tests/misc/config/cfg_syntax/tcfg_closingtokenerr.nim.cfg
+++ b/tests/misc/config/cfg_syntax/tcfg_closingtokenerr.nim.cfg
@@ -1,0 +1,1 @@
+--lol[wut # no closing ']' for u!

--- a/tests/misc/config/cfg_syntax/tcfg_endiferr.nim
+++ b/tests/misc/config/cfg_syntax/tcfg_endiferr.nim
@@ -1,0 +1,5 @@
+discard """
+  description: "tests config parsing error, see corresponding '.nim.cfg' file"
+  errormsg: "expected '@end'"
+  file: "tcfg_endiferr.nim.cfg"
+"""

--- a/tests/misc/config/cfg_syntax/tcfg_endiferr.nim.cfg
+++ b/tests/misc/config/cfg_syntax/tcfg_endiferr.nim.cfg
@@ -1,0 +1,2 @@
+@if whatever:
+  # lol, no @end for you


### PR DESCRIPTION
## Summary

Missing closing tokens such as `]` and `@end` are now reported as
errors.

## Details

This was a bug in legacy reports where these would simply `assert false`
either crashing the compiler or resulting in a no-op. Config parsing in
`nimconf` has been updated along with the addition of a few tests.