### PR TITLE
ci: update actions dependencies

### DIFF
--- a/.github/actions/download-compiler/action.yml
+++ b/.github/actions/download-compiler/action.yml
@@ -4,17 +4,17 @@ inputs:
   workspace:
     description: Where to extract the compiler
     required: false
-    default: '.'
+    default: "."
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - uses: actions/download-artifact@v3.0.0
+    - uses: actions/download-artifact@v3.0.2
       with:
         name: compiler ${{ runner.os }}
-        path: '${{ runner.temp }}'
+        path: "${{ runner.temp }}"
 
     - name: Unpack the workspace
-      run: tar xf '${{ runner.temp }}/compiler.tar'
+      run: tar xf "$RUNNER_TEMP/compiler.tar"
       shell: bash
-      working-directory: '${{ inputs.workspace }}'
+      working-directory: "${{ inputs.workspace }}"

--- a/.github/actions/upload-compiler/action.yml
+++ b/.github/actions/upload-compiler/action.yml
@@ -4,10 +4,10 @@ inputs:
   workspace:
     description: What to upload
     required: false
-    default: '.'
+    default: "."
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Package workspace
       run: |
@@ -16,14 +16,15 @@ runs:
         while IFS= read -r -d '' file; do
           diff+=("$file")
         done < <(git ls-files -zmo)
-        tar cf '${{ runner.temp }}/compiler.tar' "${diff[@]}"
+        tar cf "$RUNNER_TEMP/compiler.tar" "${diff[@]}"
       shell: bash
-      working-directory: '${{ inputs.source }}'
+      working-directory: "${{ inputs.source }}"
 
-    - uses: actions/upload-artifact@v3.0.0
+    - uses: actions/upload-artifact@v3.1.2
       with:
         name: compiler ${{ runner.os }}
-        path: '${{ runner.temp }}/compiler.tar'
+        path: "${{ runner.temp }}/compiler.tar"
         # This action is only used to share data between jobs, there is no need
         # to keep this artifact for long.
         retention-days: 1
+        if-no-files-found: error


### PR DESCRIPTION
## Summary
The download-compiler and upload-compiler actions is not tracked by dependabot, so update has to be done manually.

With this the remaining warnings for set-output should be gone.