### PR TITLE
cli: dump output moved out of legacy reports

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -125,7 +125,6 @@ type
     rintCliVersion
     rintCliAdvancedUsage # cli report last!
 
-    rintDumpState
     rintEchoMessage # last !
 
     # internal reports END !! add reports BEFORE the last enum !!

--- a/compiler/ast/reports_internal.nim
+++ b/compiler/ast/reports_internal.nim
@@ -34,24 +34,8 @@ type
         buildMode*: string
         optimize*: string
         gc*: string
-
       of false:
         discard
-
-  InternalStateDump* = ref object
-    version*: string
-    nimExe*: string
-    prefixdir*: string
-    libpath*: string
-    projectPath*: string
-    definedSymbols*: seq[string]
-    libPaths*: seq[string]
-    lazyPaths*: seq[string]
-    nimbleDir*: string
-    outdir*: string
-    `out`*: string
-    nimcache*: string
-    hints*, warnings*: seq[tuple[name: string, enabled: bool]]
 
   InternalCliData* = object
     ## Information used to construct messages for CLI reports - `--help`,
@@ -69,9 +53,6 @@ type
     case kind*: ReportKind
       of rintStackTrace:
         trace*: seq[StackTraceEntry] ## Generated stack trace entries
-
-      of rintDumpState:
-        stateDump*: InternalStateDump
 
       of rintAssert:
         expression*: string

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2744,56 +2744,6 @@ To create a stacktrace, rerun compilation with './koch temp $1 <file>'
     of rintNimconfWrite:
       result = r.msg
 
-    of rintDumpState:
-      if getConfigVar(conf, "dump.format") == "json":
-        let s = r.stateDump
-        var definedSymbols = newJArray()
-        for s in s.definedSymbols:
-          definedSymbols.elems.add(%s)
-
-        var libpaths = newJArray()
-        var lazyPaths = newJArray()
-        for dir in conf.searchPaths:
-          libpaths.elems.add(%dir.string)
-
-        for dir in conf.lazyPaths:
-          lazyPaths.elems.add(%dir.string)
-
-        var hints = newJObject()
-        for (a, state) in s.hints:
-          hints[$a] = %(state)
-
-        var warnings = newJObject()
-        for (a, state) in s.warnings:
-          warnings[$a] = %(state)
-
-        result = $(%[
-          (key: "version",         val: %s.version),
-          (key: "nimExe",          val: %s.nimExe),
-          (key: "prefixdir",       val: %s.prefixdir),
-          (key: "libpath",         val: %s.libpath),
-          (key: "project_path",    val: %s.projectPath),
-          (key: "defined_symbols", val: definedSymbols),
-          (key: "lib_paths",       val: libpaths),
-          (key: "lazyPaths",       val: lazyPaths),
-          (key: "outdir",          val: %s.outdir),
-          (key: "out",             val: %s.out),
-          (key: "nimcache",        val: %s.nimcache),
-          (key: "hints",           val: hints),
-          (key: "warnings",        val: warnings),
-        ])
-
-      else:
-        result.add "-- list of currently defined symbols --\n"
-        let s = r.stateDump
-        for s in s.definedSymbols:
-          result.add(s, "\n")
-
-        result.add "-- end of list --\n"
-
-        for it in s.libPaths:
-          result.add it, "\n"
-
 proc reportFull*(conf: ConfigRef, r: InternalReport): string =
   assertKind r
   case r.kind:

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -28,11 +28,9 @@ import
   std/[
     os,
     strutils,
-    parseutils,
     parseopt,
     sequtils,
     strtabs,
-    pathnorm
   ],
   compiler/modules/[
     nimblecmd,
@@ -80,6 +78,27 @@ type
     passCmd2,                 # second pass over the command line
     passPP                    # preprocessor called processCommand()
 
+# TODO: temporary, move into `msgs` or `commands`
+type
+  CmdOutputKind* = enum
+    cmdOutUser        ## a command's primary output, e.g. dump's data dump
+    cmdOutStatus      ## command's status, e.g. build success message
+    cmdOutUserProf    ## user requested profiling output
+    cmdOutInternalDbg ## explicitly secondary output for compiler tracing
+
+proc write*(conf: ConfigRef, dest: static[CmdOutputKind], msg: string) =
+  let flags =
+    case dest
+    of cmdOutUser:
+      {msgNoUnitSep, msgStdout}
+    of cmdOutInternalDbg:
+      {msgNoUnitSep, msgStdout}
+    of cmdOutUserProf, cmdOutStatus:
+      {msgNoUnitSep} # xxx: force stderr?
+  conf.msgWrite(msg, flags)
+
+proc writeln*(conf: ConfigRef, dest: static[CmdOutputKind], msg: string) =
+  write(conf, dest, msg & "\n")
 
 proc getNimSourceData(): tuple[hash, date: string] {.compileTime.} =
   ## Retrieve metadata about the compiler source code.


### PR DESCRIPTION
## Summary
The `dump` sub-commands' output generation is back in `main`.

## Details
This moved the `InternalStateDump` data structure out of legacy reports
and adding some output helpers to `commands` (temporary home). This is
part of a long term migration away from legacy reports.