### PR TITLE
cli: now properly exits if no mainmodule exists

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -129,6 +129,8 @@ type
     # errors begin
     rextUnknownCCompiler
 
+    rextCmdRequiresFile ## fatal error, user failed to provide a file
+
     # malformed cmdline parameters begin
     rextInvalidHint
     rextInvalidWarning

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -644,6 +644,10 @@ template globalAssert*(
     if arg.len > 0: arg2.add "; " & astToStr(arg) & ": " & arg
     handleReport(conf, info, errGenerated, arg2, doRaise, instLoc())
 
+template fatalReport*(conf: ConfigRef, info: TLineInfo, report: ReportTypes) =
+  # this works around legacy reports stupidity
+  handleReport(conf, wrap(report, instLoc(), info), instLoc(), doAbort)
+
 template globalReport*(
   conf: ConfigRef; info: TLineInfo, report: ReportTypes) =
   ## `local` means compilation keeps going until errorMax is reached (via

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -574,7 +574,8 @@ from compiler/ast/reports_internal import severity
 func isCompilerFatal*(conf: ConfigRef, report: Report): bool =
   ## Check if report stores fatal compilation error
   report.category == repInternal and
-  report.internalReport.severity() == rsevFatal
+  report.internalReport.severity() == rsevFatal or
+  report.kind == rextCmdRequiresFile
 
 func severity*(conf: ConfigRef, report: ReportTypes | Report): ReportSeverity =
   # style checking is a hint by default, but can be globally overriden to

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -193,7 +193,8 @@ proc compileSystemModule*(graph: ModuleGraph) =
 
 proc wantMainModule*(conf: ConfigRef) =
   if conf.projectFull.isEmpty:
-    localReport(conf, gCmdLineInfo, ExternalReport(kind: rextInvalidPath))
+    # user didn't specify a project file, time to pack it in
+    conf.fatalReport(gCmdLineInfo, ExternalReport(kind: rextCmdRequiresFile))
 
   conf.projectMainIdx = fileInfoIdx(conf, addFileExt(conf.projectFull, NimExt))
 

--- a/tests/cli/tcompilercli_compileneedsfilename.nim
+++ b/tests/cli/tcompilercli_compileneedsfilename.nim
@@ -1,0 +1,9 @@
+discard """
+  description: "test compile subcommand outputs an error for no filename arg"
+  cmd: "nim c"
+  target: native
+  joinable: false
+  action: reject
+  errormsg: "command requires a filename"
+  file: ""
+"""

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -198,9 +198,12 @@ sub/mmain.idx""", context
     doAssert exitCode == 0
     let
       dir = getCurrentDir()
-      files = ["tests/misc/config/bar/nim.cfg", "tests/misc/config/bar/mfoo.nim.cfg"]
+      files = ["config/nim.cfg",
+                "tests/nim.cfg",
+                "tests/misc/config/bar/nim.cfg",
+                "tests/misc/config/bar/mfoo.nim.cfg"]
       expected = files.mapIt("Hint: used config file '$1' [Conf]\n" % (dir / it)).join("")
-    doAssert outp.endsWith expected, outp & "\n" & expected
+    doAssert outp.endsWith expected, "\n" & expected & "\n" & outp
 
   block: # scripting allows custom extensions mfoo2.customext
     let filename = testsDir / "misc/config/foo2/mfoo2.customext"


### PR DESCRIPTION
## Summary

This fixes a legacy reports bug, where the migration stopped program
termination even when requiring a main module to exist. This now works
and a more approriate error message is provided instead of a path error.

## Details

`modules.wantMainModule` now generates an `rextCmdRequiresFile` (new
legacy report kind), which is treated as a fatal error by
`options.isCompilerFatal`. In addition a quick tests was added to ensure
this continues to function going forward.