### PR TITLE
system: remove the `shallow` procedure

### DIFF
--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -84,7 +84,6 @@ proc scopeMangledParam(p: BProc; param: PSym) =
   ## generate unique identifiers reliably (consider that ``var a = a`` is
   ## even an idiom in Nim).
   var key = param.name.s.mangle
-  shallow(key)
   p.sigConflicts.inc(key)
 
 const

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1209,15 +1209,13 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
 
   try:
     canon = canonicalizePath(conf, filename)
-    shallow(canon.string)
   except OSError:
     canon = filename
     # The compiler uses "filenames" such as `command line` or `stdin`
     # This flag indicates that we are working with such a path here
     pseudoPath = true
 
-  var canon2: string
-  forceCopy(canon2, canon.string) # because `canon` may be shallow
+  var canon2 = canon.string
   canon2.canonicalCase
 
   if conf.m.filenameToIndexTbl.hasKey(canon2):

--- a/compiler/utils/strutils2.nim
+++ b/compiler/utils/strutils2.nim
@@ -22,25 +22,6 @@ proc dataPointer*[T](a: T): pointer =
     cast[pointer](a)
   else: static: doAssert false, $T
 
-proc setLen*(result: var string, n: int, isInit: bool) =
-  ## when isInit = false, elements are left uninitialized, analog to `{.noinit.}`
-  ## else, there are 0-initialized.
-  # xxx placeholder until system.setLen supports this
-  # to distinguish between algorithms that need 0-initialization vs not; note
-  # that `setLen` for string is inconsistent with `setLen` for seq.
-  # likwise with `newString` vs `newSeq`. This should be fixed in `system`.
-  let n0 = result.len
-  result.setLen(n)
-  if isInit and n > n0:
-    zeroMem(result[n0].addr, n - n0)
-
-proc forceCopy*(result: var string, a: string) =
-  ## also forces a copy if `a` is shallow
-  # the naitve `result = a` would not work if `a` is shallow
-  let n = a.len
-  result.setLen n, isInit = false
-  copyMem(result.dataPointer, a.dataPointer, n)
-
 proc isUpperAscii(c: char): bool {.inline.} =
   # avoids import strutils.isUpperAscii
   c in {'A'..'Z'}

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -830,20 +830,6 @@ For `let` symbols a copy is not always necessary:
 
   let s = varA    # may only copy a pointer if it safe to do so
 
-
-If you know what you're doing, you can also mark single-string (or sequence)
-objects as `shallow`:idx:\:
-
-.. code-block:: Nim
-
-  var s = "abc"
-  shallow(s) # mark 's' as a shallow string
-  var x = s  # now might not copy the string!
-
-Usage of `shallow` is always safe once you know the string won't be modified
-anymore, similar to Ruby's `freeze`:idx:.
-
-
 The compiler optimizes string case statements: A hashing scheme is used for them
 if several different string constants are used. So code like this is reasonably
 efficient:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2749,29 +2749,6 @@ when compileOption("rangechecks"):
 else:
   template rangeCheck*(cond) = discard
 
-proc shallow*[T](s: var seq[T]) {.noSideEffect, inline.} =
-  ## Marks a sequence `s` as `shallow`:idx:. Subsequent assignments will not
-  ## perform deep copies of `s`.
-  ##
-  ## This is only useful for optimization purposes.
-  if s.len == 0: return
-  when not defined(js) and not isNimVmTarget and not defined(nimSeqsV2):
-    var s = cast[PGenericSeq](s)
-    s.reserved = s.reserved or seqShallowFlag
-
-proc shallow*(s: var string) {.noSideEffect, inline.} =
-  ## Marks a string `s` as `shallow`:idx:. Subsequent assignments will not
-  ## perform deep copies of `s`.
-  ##
-  ## This is only useful for optimization purposes.
-  when not defined(js) and not isNimVmTarget and not defined(nimSeqsV2):
-    var s = cast[PGenericSeq](s)
-    if s == nil:
-      s = cast[PGenericSeq](newString(0))
-    # string literals cannot become 'shallow':
-    if (s.reserved and strlitFlag) == 0:
-      s.reserved = s.reserved or seqShallowFlag
-
 type
   NimNodeObj = object
 

--- a/tests/lang_callable/converter/tconverter_subtype_parameters.nim
+++ b/tests/lang_callable/converter/tconverter_subtype_parameters.nim
@@ -26,7 +26,6 @@ proc initBytesRange*(s: var Bytes, ibegin = 0, iend = -1): BytesRange =
           else: iend
   assert ibegin >= 0 and e <= s.len
 
-  shallow(s)
   result.bytes = s
   result.ibegin = ibegin
   result.iend = e

--- a/tests/lang_callable/converter/tconverter_template_non_ref_err.nim
+++ b/tests/lang_callable/converter/tconverter_template_non_ref_err.nim
@@ -24,7 +24,6 @@ proc initBytesRange*(s: var Bytes, ibegin = 0, iend = -1): BytesRange =
           else: iend
   assert ibegin > 0 and e <= s.len
 
-  shallow(s)
   result.bytes = s
   result.ibegin = ibegin
   result.iend = e

--- a/tests/stdlib/strings/tstrutils2.nim
+++ b/tests/stdlib/strings/tstrutils2.nim
@@ -1,26 +1,5 @@
 import "$lib/.." / compiler/utils/strutils2
 
-block: # setLen
-  var a = "abc"
-  a.setLen 0
-  a.setLen 3, isInit = false
-  doAssert a[1] == 'b'
-  a.setLen 0
-  a.setLen 3, isInit = true
-  doAssert a[1] == '\0'
-
-block: # forceCopy
-  var a: string
-  a = "foo"
-  shallow(a)
-  var b: string
-  b = a
-  doAssert b[0].addr == a[0].addr
-  var c: string
-  c.forceCopy a
-  doAssert c == a
-  doAssert c[0].addr != a[0].addr
-
 block: # toLowerAscii
   var a = "fooBAr"
   a.toLowerAscii

--- a/tests/stdlib/types/collections/tseq.nim
+++ b/tests/stdlib/types/collections/tseq.nim
@@ -176,16 +176,6 @@ block tshallowemptyseq:
     var emptySeq: seq[int] = newSeq[int]()
     block:
       var t = @[1,2,3]
-      shallow(nilSeq)
-      t = nilSeq
-      doAssert t == @[]
-    block:
-      var t = @[1,2,3]
-      shallow(emptySeq)
-      t = emptySeq
-      doAssert t == @[]
-    block:
-      var t = @[1,2,3]
       shallowCopy(t, nilSeq)
       doAssert t == @[]
     block:

--- a/tests/system/tnilconcats.nim
+++ b/tests/system/tnilconcats.nim
@@ -23,10 +23,3 @@ when true:
   doAssert s == "fooabc"
 
   echo x
-
-  # casting an empty string as sequence with shallow() should not segfault
-  var s2: string
-  shallow(s2)
-  s2 &= "foo"
-  doAssert s2 == "foo"
-


### PR DESCRIPTION
## Summary

The `shallow` procedure was used to toggle whether a `seq` or `string`
uses a shallow copy when copying it. Given that it only has an effect
for the C target and when using the sequence implementation from the old
runtime, it is removed as a preparation for ORC becoming the default and
the old runtime being eventually removed.

## Details

* remove all usages of `shallow` from the compiler and tests
* remove the compiler-internal and experimental `forceCopy` procedure
  (it no longer has a purpose)
* remove mentions of the `shallow` procedure from documentation

The compiler-internal and experimental `setLen` procedure from the
`strutils2` is also removed, as it is not compatible with the string
implementation from the new runtime.