### PR TITLE
system: use a `seq` with `WideCStringObj`

### DIFF
--- a/tests/stdlib/strings/twchartoutf8.nim
+++ b/tests/stdlib/strings/twchartoutf8.nim
@@ -66,8 +66,9 @@ else:
 
   #RFC-2781 "UTF-16, an encoding of ISO 10646"
 
-  var wc: WideCString
-  unsafeNew(wc, 1024 * 4 + 2)
+  var
+    wco = newWideCString(2048)
+    wc  = toWideCString(wco)
 
   #U+0000 to U+D7FF
   #skip the U+0000


### PR DESCRIPTION
## Summary

When using the old runtime, the implementation was `ref`-based
(requiring the use of `unsafeNew`), while with the new runtime it was
destructor-based.

Change `WideCStringObj` to store the character buffer as a
`seq[Utf16Char]`, which has the benefit that:
- only a single implementation is required
- the implementation becomes simpler
- the type is usable at compile-time and with the JS and VM target

The downside is that each `WideCStringObj` requires 4 or 8 byte
(depending on the target's integer size) more heap memory because of the
capacity stored by the `seq` as part of the payload. The public API
stays the same.