### PR TITLE
cfg: drop project ".nimcfg" support

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1447,7 +1447,8 @@ proc findModule*(conf: ConfigRef; modulename, currentModule: string): AbsoluteFi
 
 proc findProjectNimFile*(conf: ConfigRef; pkg: string): string =
   ## Find configuration file for a current project
-  const extensions = [".nims", ".cfg", ".nimcfg", ".nimble"]
+  const extensions = [".nims", ".cfg", ".nimble"]
+    # xxx: remove '.nimble' (and nimble files from compiler src)
   var
     candidates: seq[string] = @[]
     dir = pkg


### PR DESCRIPTION
## Summary

It was possible to defined a project config with a `.nimcfg` extension,
this is no longer supported. Now config file discovery is a bit simpler
and this half-baked bug-in-waiting is removed.

## Details

`nimconf` now uses a simple iterator to produce a list of config files
to attempt processing, making its implementation easier to follow.
Removed ".nimcfg" from `options.findProjectNimFile`'s heuristic.