### PR TITLE
drop `ExternalReport` dep in `extccomp` module

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2884,10 +2884,8 @@ proc reportBody*(conf: ConfigRef, r: ExternalReport): string =
       result.add("Invalid command line option - ", r.cmdlineProvided)
 
     of rextUnknownCCompiler:
-      result = "unknown C compiler: '$1'. Available options are: $2" % [
-        r.passedCompiler,
-        r.knownCompilers.join(", ")
-      ]
+      result = "unknown C compiler: '$1'. Available options are: $2" %
+                [r.passedCompiler, r.knownCompilers.join(", ")]
 
     of rextOnlyAllOffSupported:
       result = "only 'all:off' is supported"

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -1031,7 +1031,15 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     os.putEnv(key, val)
   of "cc":
     expectArg(conf, switch, arg, pass, info)
-    setCC(conf, arg, info)
+    case setCC(conf, arg)
+    of ccNone:
+      # xxx: temporarily using legacy reports
+      conf.localReport(ExternalReport(
+                        kind: rextUnknownCCompiler,
+                        knownCompilers: listCCnames(),
+                        passedCompiler: arg))
+    else:
+      discard "valid compiler set"
   of "stdout":
     processOnOffSwitchG(conf, {optStdout}, arg, pass, info, switch)
   of "filenames":

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -376,7 +376,8 @@ proc mainCommand*(graph: ModuleGraph) =
   of cmdBackends: compileToBackend()
   of cmdTcc:
     when hasTinyCBackend:
-      extccomp.setCC(conf, "tcc", unknownLineInfo)
+      let cc = extccomp.setCC(conf, "tcc")
+      doAssert cc == ccTcc, "what happened to tcc?"
       if conf.backend != backendC:
         globalReport(conf, ExternalReport(
           kind: rextExpectedCbackednForRun, usedCompiler: $conf.backend))


### PR DESCRIPTION
## Summary

This removes `ExternalReport`, legacy report cruft, from the `extccomp`
module.

## Details

Made `extccomp.setCC` proc no longer report an error, instead return the
compiler that it set. Callers now deal with the result as required, in
this case `commands` and `main` both need to emit errors. These errors
have to temporarily use legacy report but that's temporary. As part of
this change `listCCnames` was exported in order to allow querying of
compiler definitions, which seems like an oversight all along.