### PR TITLE
cli: help and verison flags are CLI only

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -120,11 +120,6 @@ type
     rintListWarnings
     rintListHints
 
-    rintCliHelp # cli report first!
-    rintCliFullHelp
-    rintCliVersion
-    rintCliAdvancedUsage # cli report last!
-
     rintEchoMessage # last !
 
     # internal reports END !! add reports BEFORE the last enum !!
@@ -1055,7 +1050,6 @@ const
   rintWarningKinds* = {rintWarnCannotOpenFile .. rintWarnFileChanged}
   rintHintKinds* = {rintSource .. rintSuccessX}
   rintDataPassKinds* = {rintStackTrace .. rintEchoMessage}
-  rintCliKinds* = {rintCliHelp .. rintCliAdvancedUsage}
 
 
 const

--- a/compiler/ast/reports_internal.nim
+++ b/compiler/ast/reports_internal.nim
@@ -37,16 +37,6 @@ type
       of false:
         discard
 
-  InternalCliData* = object
-    ## Information used to construct messages for CLI reports - `--help`,
-    ## `--fullhelp`
-    version*: string ## Language version
-    sourceHash*: string ## Compiler source code git hash
-    sourceDate*: string ## Compiler source code date
-    boot*: seq[string] ## nim compiler boot flags
-    cpu*: TSystemCPU ## Target CPU
-    os*: TSystemOS ## Target OS
-
   InternalReport* = object of ReportBase
     ## Report generated for the internal compiler workings
     msg*: string
@@ -65,9 +55,6 @@ type
 
       of rintListWarnings, rintListHints:
         enabledOptions*: set[ReportKind]
-
-      of rintCliKinds:
-        cliData*: InternalCliData
 
       else:
         discard

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -46,7 +46,6 @@ import
     reports_external,
   ],
   compiler/utils/[
-    platform,
     nversion,
     astrepr,
     idioms
@@ -2608,30 +2607,6 @@ const
 proc reportBody*(conf: ConfigRef, r: InternalReport): string =
   assertKind r
   case InternalReportKind(r.kind):
-    of rintCliKinds:
-      let d = r.cliData
-      result = HelpMessage % [
-        VersionAsString,
-        platform.OS[d.os].name,
-        CPU[d.cpu].name
-      ]
-
-      if r.kind == rintCliVersion:
-        if d.sourceHash != "":
-          result.add "\n"
-          result.add CommitMessage % [d.sourceHash, d.sourceDate
-          ]
-
-        result.add "\n"
-        result.add "active boot switches:" & d.boot.join(" ")
-
-      else:
-        if r.kind in {rintCliHelp, rintCliFullHelp}:
-          result.add Usage
-
-        if r.kind in {rintCliFullHelp, rintCliAdvancedUsage}:
-          result.add AdvancedUsage
-
     of rintStackTrace:
       result = conf.formatTrace(r.trace)
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -64,7 +64,14 @@ proc getNimRunExe(conf: ConfigRef): string =
     if conf.isDefined("i386"): result = "wine"
     elif conf.isDefined("amd64"): result = "wine64"
 
-proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
+type
+  CmdLineHandlingResult = enum
+    cliFinished             # might still have errors, check `conf.errorCount`
+    cliErrNoParamsProvided
+    cliErrConfigProcessing
+    cliErrCommandProcessing
+
+proc handleCmdLine(cache: IdentCache; conf: ConfigRef): CmdLineHandlingResult =
   ## Main entry point to the compiler - dispatches command-line commands
   ## into different subsystems, sets up configuration options for the
   ## `conf`:arg: and so on.
@@ -74,13 +81,14 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   )
   self.initDefinesProg(conf, "nim_compiler")
   if paramCount() == 0:
-    writeCommandLineUsage(conf)
-    return
+    return cliErrNoParamsProvided
 
   self.processCmdLineAndProjectPath(conf)
-  var graph = newModuleGraph(cache, conf)
+  if conf.errorCounter != 0: return
+  let graph = newModuleGraph(cache, conf)
 
-  if not self.loadConfigsAndProcessCmdLine(cache, conf, graph):
+  if not self.loadConfigsAndProcessCmdLine(cache, conf, graph) or
+      conf.errorCounter != 0:
     return
 
   mainCommand(graph)
@@ -109,7 +117,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       of backendNimVm:
         if cmdPrefix.len == 0:
           cmdPrefix = changeFileExt(getAppDir() / "vmrunner", ExeExt)
-      else: doAssert false, $conf.backend
+      of backendInvalid: doAssert false, $conf.backend
       if cmdPrefix.len > 0: cmdPrefix.add " "
         # without the `cmdPrefix.len > 0` check, on windows you'd get a cryptic:
         # `The parameter is incorrect`
@@ -146,7 +154,15 @@ when not defined(selftest):
     proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
       conf.writeHook(conf, msg & "\n", flags)
 
-  handleCmdLine(newIdentCache(), conf)
+  case handleCmdLine(newIdentCache(), conf)
+  of cliErrNoParamsProvided:
+    inc conf.errorCounter # causes a non-0 exit, will be replaced soon
+    conf.msgWrite("no command-line parameters provided\n", {msgNoUnitSep})
+    conf.showMsg(helpOnErrorMsg(conf))
+  of cliErrConfigProcessing, cliErrCommandProcessing, cliFinished:
+    # TODO: more specific handling here
+    discard "error messages reported internally"
+
   when declared(GC_setMaxPause):
     echo GC_getStatistics()
 

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -16,11 +16,11 @@ static:
     const nim = getCurrentCompilerExe()
     let ret = gorgeEx(nim & " --version")
     doAssert ret.exitCode == 0
-    doAssert ret.output.contains "Nim Compiler"
+    doAssert ret.output.contains "Nimskull Compiler"
     let ret2 = gorgeEx(nim & " --nonxistent")
     doAssert ret2.exitCode != 0
     let output3 = gorge(nim & " --version")
-    doAssert output3.contains "Nim Compiler"
+    doAssert output3.contains "Nimskull Compiler"
 
   block:
     const key = "D20181210T175037"


### PR DESCRIPTION
## Summary

help, version, advanced, fullhelp, and their short forms are now CLI
only, meaning they cannot be set programmatically or via config. This
fixes an interface bug and removes legacy reports from the mix.

## Details

Help, version, etc data is now all generated within `commands`, removing
legacy reports dependencies, no more bouncing around modules to figure
out what these are. The compiler version string now says 'Nimskull'
instead of 'Nim', the tests `tvmops` requried an update.

Dropped a bunch of legacy reports hacks that were put in place to handle
these:
- no more hacks in `writabilityKind`
- no more `ReportKind` enum values and consts