### PR TITLE
cli: gcstats flag; dropped hint "gcstats"

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -106,7 +106,6 @@ type
     rintErrKind = "ErrKind" ## Show report kind in error messages
                             # REFACTOR this is a global option not a hint
 
-    rintGCStats = "GCStats" ## Print GC statistics for the compiler run
     rintQuitCalled = "QuitCalled" ## `quit()` called by the macro code
     ## compilation error handling and similar
     rintMissingStackTrace ## Stack trace would've been generated in the

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2732,9 +2732,6 @@ To create a stacktrace, rerun compilation with './koch temp $1 <file>'
     of rintSource:
       assert false, "is a configuration hint, should not be reported manually"
 
-    of rintGCStats:
-      result = r.msg
-
     of rintQuitCalled:
       result = "quit() called"
 

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -48,6 +48,9 @@ import
   compiler/backend/[
     extccomp
   ],
+  experimental/[
+    colortext,    # required for pretty output; TODO: factor out
+  ],
   compiler/utils/[
     nversion,
     pathutils,
@@ -492,6 +495,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "implicitstatic": result = contains(conf.options, optImplicitStatic)
   of "trmacros": result = contains(conf.options, optTrMacros)
   of "excessivestacktrace": result = contains(conf.globalOptions, optExcessiveStackTrace)
+  of "cmdexitgcstats": result = contains(conf.globalOptions, optCmdExitGcStats)
   else: invalidCmdLineOption(conf, passCmd1, switch, info)
 
 proc processPath(conf: ConfigRef; path: string, info: TLineInfo, switch: string,
@@ -1145,6 +1149,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     processOnOffSwitchG(conf, {optEnableDeepCopy}, arg, pass, info, switch)
   of "": # comes from "-" in for example: `nim c -r -` (gets stripped from -)
     conf.inputMode = pimStdin
+  of "cmdexitgcstats":
+    expectNoArg(conf, switch, arg, pass, info)
+    processOnOffSwitchG(conf, {optCmdExitGcStats}, arg, pass, info, switch)
   else:
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)
     else: invalidCmdLineOption(conf, pass, switch, info)
@@ -1164,6 +1171,69 @@ proc processSwitch*(pass: TCmdLinePass; p: OptParser; config: ConfigRef) =
     processSwitch(key, val, pass, gCmdLineInfo, config)
   else:
     processSwitch(p.key, p.val, pass, gCmdLineInfo, config)
+
+# temporary home for formatting output during early cli/config phase; this
+# should move to a better suited module.
+
+const
+  pathFmtStr = "$#($#, $#)" ## filename(line, column)
+
+func stylize*(str: string, color: ForegroundColor, styles: set[Style] = {}): string =
+  if str.len == 0:
+    result = str
+  else:
+    result = "\e[$#m" % $color.int
+    for s in styles:
+      result.addf "\e[$#m", s.int
+    result.add str
+    result.add "\e[0m"
+
+func stylize*(str: string, color: ForegroundColor,
+              style: Style): string {.inline.} =
+  stylize(str, color, {style})
+
+func cliFmtLineInfo*(filename: string, line, col: int, useColor: bool): string =
+  const pathFmtStr = "$#($#, $#)" ## filename(line, column)
+  let pathStr = pathFmtStr % [filename, $line, $col]
+  if useColor:
+    stylize(pathStr, fgDefault, {styleBright})
+  else:
+    pathStr
+
+func cliFmtSrcCodeOrigin*(origin: InstantiationInfo, useColor: bool): string =
+  cliFmtLineInfo(origin.filename, origin.line, origin.column, useColor)
+
+func cliFmt*(conf: ConfigRef, info: TLineInfo, useColor: bool): string =
+  cliFmtLineInfo(conf.toFullPath(info), info.line.int, info.col + 1, useColor)
+
+func cliFmtMsgOrigin*(origin: InstantiationInfo, showSuffix, useColor: bool): string =
+  const suffixText = "[MsgOrigin]"
+  let suffix =
+        if showSuffix:
+          if useColor:
+            stylize(suffixText, fgCyan)
+          else:
+            suffixText
+        else:
+          ""
+  result.addf "\n$# msg instantiated here$#$#",
+                [cliFmtSrcCodeOrigin(origin, useColor),
+                 if showSuffix: " " else: "",           # spacing
+                 suffix]
+
+proc writeLog(conf: ConfigRef, msg: string, srcLoc: InstantiationInfo) =
+  var result = msg
+  if conf.hasHint(rintMsgOrigin):
+    result.addf cliFmtMsgOrigin(srcLoc, showSuffix = conf.hasHint(rintErrKind),
+                                useColor = conf.useColor())
+  conf.msgWrite(result & "\n")
+
+proc logGcStats*(conf: ConfigRef, stats: string, srcLoc = instLoc()) =
+  ## log a 'debug' level message with the GC `stats`
+  # TODO: document log levels, eventual introduction of `channels`,
+  #       suppression, formatting, etc
+  if optCmdExitGcStats in conf.globalOptions:
+    conf.writeLog(stats, srcLoc)
 
 proc processArgument*(pass: TCmdLinePass; p: OptParser;
                       argsCount: var int; config: ConfigRef): bool =

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -62,9 +62,9 @@ type
     optSourcemap
     optProfileVM              ## enable VM profiler
     optEnableDeepCopy         ## ORC specific: enable 'deepcopy' for all types
+    optCmdExitGcStats         ## print gc stats as part of command exit
 
   TGlobalOptions* = set[TGlobalOption]
-
 
   TGCMode* = enum             # the selected GC
     gcUnselected = "unselected"

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -871,7 +871,6 @@ proc computeNotesVerbosity(): tuple[
       rsemHintLibDependency,
       rsemGlobalVar,
 
-      rintGCStats,
       rintMsgOrigin,
 
       rextPath,

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -84,9 +84,8 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
     return
 
   mainCommand(graph)
-  if conf.hasHint(rintGCStats):
-    conf.localReport(InternalReport(
-      kind: rintGCStats, msg: GC_getStatistics()))
+  if optCmdExitGcStats in conf.globalOptions:
+    conf.logGcStats(GC_getStatistics())
 
   if conf.errorCounter != 0: return
   when hasTinyCBackend:

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -154,3 +154,7 @@ Advanced options:
   --sinkInference:on|off    turn sink parameter inference on|off (default: on)
   --panics:on|off           turn panics into process terminations (default: off)
   --deepcopy:on|off         enable 'system.deepCopy' for ``--gc:arc|orc``
+
+Command Debug/Testing Options:
+  --cmdExitGcStats          output GC statistics at the end of compilation and
+                            before any binary is run


### PR DESCRIPTION
## Summary

Removed "gcstats" "hint" and made it a flag, updated docs accordingly.

## Details

This resulted in less legacy reports code (enum and variant) and the
introduction of a new global option `optCmdExitGcStats` for tracking the
flag state.