### PR TITLE
improve `getAst` magic processing

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -982,7 +982,7 @@ type
 
   AstDiagVmGenKind* = enum
     ## Kinds for errors produced by `vmgen`
-    adVmGenBadExpandToAstArgRequired      # | TODO: these enum values duplicate
+                                          # | TODO: these enum values duplicate
                                           # |       `VmGenDiagKind` vmgen enum
     adVmGenTooManyRegistersRequired       # |       defined in the `vmdef`
     adVmGenCannotFindBreakTarget          # |       module. There should be a
@@ -1002,8 +1002,7 @@ type
 
   AstDiagVmGenError* = object
     case kind*: AstDiagVmGenKind:
-      of adVmGenBadExpandToAstArgRequired,
-          adVmGenTooManyRegistersRequired,
+      of adVmGenTooManyRegistersRequired,
           adVmGenCannotFindBreakTarget:
         discard
       of adVmGenNotUnused,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -286,7 +286,6 @@ type
     rvmGlobalError ## Error report that was declared as 'global' in the
     ## VM - with current 'globalError-is-a-control-flow-mechanism' approach
     ## this report is largely meaningless, and used only to raise exception.
-    rvmBadExpandToAst
     rvmCannotEvaluateAtComptime
     rvmCannotImportc
     rvmInvalidObjectConstructor

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3370,9 +3370,6 @@ proc reportBody*(conf: ConfigRef, r: VMReport): string =
   of rvmNotAFieldSymbol:
     result = "no field symbol"
 
-  of rvmBadExpandToAst:
-    result = "expandToAst requires 1 argument"
-
   of rvmCannotImportc:
     result = "cannot 'importc' variable/proc at compile time: " & r.symstr
 
@@ -4441,12 +4438,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         location: some location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind)
-    of adVmGenBadExpandToAstArgRequired:
-      vmRep = VMReport(
-        str: "expandToAst requires 1 argument",
-        kind: kind,
-        location: some location,
-        reportInst: diag.instLoc.toReportLineInfo)
     of adVmGenNotUnused,
         adVmGenNotAFieldSymbol,
         adVmGenCannotGenerateCode,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -413,7 +413,6 @@ func astDiagVmGenToLegacyReportKind*(
   of adVmGenCodeGenGenericInNonMacro: rvmCannotGenerateCode
   of adVmGenCodeGenUnexpectedSym: rvmCannotGenerateCode
   of adVmGenCannotCast: rvmCannotCast
-  of adVmGenBadExpandToAstArgRequired: rvmBadExpandToAst
   of adVmGenCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of adVmGenCannotImportc: rvmCannotImportc
   of adVmGenInvalidObjectConstructor: rvmInvalidObjectConstructor

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -582,7 +582,6 @@ type
 
   VmGenDiagKind* = enum
     # has no extra data
-    vmGenDiagBadExpandToAstArgRequired
     vmGenDiagTooManyRegistersRequired
     vmGenDiagCannotFindBreakTarget
     # has ast data
@@ -645,8 +644,7 @@ type
           vmGenDiagCannotEvaluateAtComptime,
           vmGenDiagInvalidObjectConstructor:
         ast*: PNode
-      of vmGenDiagBadExpandToAstArgRequired,
-          vmGenDiagTooManyRegistersRequired,
+      of vmGenDiagTooManyRegistersRequired,
           vmGenDiagCannotFindBreakTarget:
         discard
 

--- a/compiler/vm/vmlegacy.nim
+++ b/compiler/vm/vmlegacy.nim
@@ -30,7 +30,6 @@ func vmGenDiagToLegacyReportKind(diag: VmGenDiagKind): ReportKind {.inline.} =
   of vmGenDiagCodeGenGenericInNonMacro: rvmCannotGenerateCode
   of vmGenDiagCodeGenUnexpectedSym: rvmCannotGenerateCode
   of vmGenDiagCannotCast: rvmCannotCast
-  of vmGenDiagBadExpandToAstArgRequired: rvmBadExpandToAst
   of vmGenDiagCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of vmGenDiagCannotImportc: rvmCannotImportc
   of vmGenDiagInvalidObjectConstructor: rvmInvalidObjectConstructor
@@ -78,12 +77,6 @@ func vmGenDiagToLegacyVmReport*(diag: VmGenDiag): VMReport {.inline.} =
         location: std_options.some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind)
-    of vmGenDiagBadExpandToAstArgRequired:
-      VMReport(
-        str: "expandToAst requires 1 argument",
-        kind: kind,
-        location: std_options.some diag.location,
-        reportInst: diag.instLoc.toReportLineInfo)
     of vmGenDiagNotUnused,
         vmGenDiagNotAFieldSymbol,
         vmGenDiagCannotGenerateCode,

--- a/tests/vm/tvmgen_regressions.nim
+++ b/tests/vm/tvmgen_regressions.nim
@@ -3,7 +3,7 @@ discard """
   targets: vm
 """
 
-import std/parseutils
+import std/[parseutils, macros]
 
 block:
   # the ``parseBiggestFloat`` magic had an evaluation-order issue where the
@@ -17,3 +17,17 @@ block:
 
   doAssert r == 3
   doAssert o == 1.0
+
+block wrong_getast:
+  macro m() = # <- no return type specified
+    result = quote: 1
+
+  macro m2() =
+    # the macro's public signature was used to detect whether it returns
+    # something, which led to incorrect bytecode being generated in situations
+    # where the result of a ``getAst`` call wasn't directly assigned to a
+    # local, as the macro was treated as returning nothing
+    let x = [getAst(m())]
+    doAssert x[0].intVal == 1
+
+  m2()


### PR DESCRIPTION
## Summary

Move part of the processing into `transf` and transform the magic call
into something that matches its semantics better. This fixes a small
issues where the `getAst` magic appeared to return nothing when the
meta-routine to expand is a macro.

## Details

A `getAst` expression like `getAst(templ(a, b, c))` is now transformed
into `getAst(templ, a, b, c)` during `transf`. This is slightly more
correct at the MIR level, as `templ` is not "called" here, but is rather
an argument to the `getAst` magic.

* remove the `mirgen` special handling of `static` parameters for
  templates and macros in a `getAst` context. Attempting to work around
  the issues with `getAst` like this is not a good idea
* adjust `vmgen` to work to the new flat representation of `getAst`
  calls
* remove the `vmGenDiagBadExpandToAstArgRequired` diagnostic (semantic
  analysis already rejects ill-formed `getAst` argument expressions)

The regression was due to `vmgen.genCall` using the type of the
macro call expression (which incorrectly was `nil` when the macro had no
return type specified) for detecting whether it returns something.