### PR TITLE
astgen: fix issues with the MIR -> AST step

### DIFF
--- a/tests/lang_objects/destructor/tmisc_destructors.nim
+++ b/tests/lang_objects/destructor/tmisc_destructors.nim
@@ -41,3 +41,33 @@ proc main =
     echo buffer
 
 main()
+
+block move_from_temporary_inner:
+  # regression test: partially moving from a materialized-into-temporary
+  # object returned by a call led to the moved-from location not being reset,
+  # causing a double free. The issue only ocurred when the path expression
+  # doesn't name a fixed location (e.g. an array access with a non-constant
+  # index value), the moved-from location is of numeric type, or both
+  type
+    Inner = distinct int
+    Outer = array[1, Inner]
+
+  var numDestroyed = 0
+
+  proc `=destroy`(x: var Inner) =
+    if ord(x) != 0:
+      inc numDestroyed
+      # don't manually set `x` to 0 here -- the injected ``wasMoved`` needs to
+      # take care of that
+
+  proc produce(): Outer = [Inner(1)]
+
+  proc test(i: int) =
+    # use a parameter for the index in order to prevent the optimizer from
+    # inlining the value
+    var x = produce()[i]
+    doAssert ord(x) == 1
+
+  test(0)
+
+  doAssert numDestroyed == 1


### PR DESCRIPTION
## Summary

Fix two issues in `astgen` where the semantics of the MIR were not
correctly mapped to `PNode` AST. This led to `wasMoved` operations only
being applied to intermediate temporary locations in some situations,
causing double frees.

## Details

The first issue was that an expression like `(a; lvalue).c` was not
detected to be an lvalue expression due to the first operand being a
statement list expression (`nkStmtListExpr`), causing a temporary
instead of an lvalue reference (view) to be created when using the
expression as a to-be-consumed operand to a MIR region.

If the operand was passed on to a `wasMoved` operation, only the
temporary location is reset, but not the expected source location. To
visualize the problem:
```nim
  x = callReturningASeq()[0] # x is something with a destructor
  # gets transformed to MIR code that, after translation back to AST,
  # looked roughly like:
  var tmp: T
  var tmp2: T = (tmp = callReturningASeq(); tmp)[0]
  x = tmp2
  wasMoved(tmp2) # `tmp[0]` is what needs to be reset here
  ...
```

For fixing the issue, the existing unwrapping transformation that is
applied prior to detecting whether an expression is a view is extended
to also "forward" nodes: an expression like `(a; b).c` gets transformed
into `(a; b.c)`. Besides fixing the issue, this also reduces nesting of
the generated AST a bit.

Using the example from above, it now looks like:
```nim
  var tmp: T
  tmp = callReturningASeq()
  var tmp2: var T = tmp[0]
  x = tmp2
  wasMoved(tmp2)
  ...
```
which is correct.

The second issue was with 'consume' arguments of numeric type not being
passed translated to lvalue references (if possible).