### PR TITLE
remove `extccomp` dep from `nim` and `main`

### DIFF
--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -419,7 +419,7 @@ proc execWithEcho(conf: ConfigRef; cmd: string, execKind: ReportKind): int =
   conf.localReport(CmdReport(kind: execKind, cmd: cmd))
   result = execCmd(cmd)
 
-proc execExternalProgram*(conf: ConfigRef; cmd: string, kind: ReportKind) =
+proc execExternalProgram(conf: ConfigRef; cmd: string, kind: ReportKind) =
   let code = execWithEcho(conf, cmd, kind)
   if code != 0:
     conf.localReport CmdReport(kind: rcmdFailedExecution, cmd: cmd, code: code)

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -1161,6 +1161,20 @@ proc logGcStats*(conf: ConfigRef, stats: string, srcLoc = instLoc()) =
   if optCmdExitGcStats in conf.globalOptions:
     conf.writeLog(stats, srcLoc)
 
+proc logExecStart*(conf: ConfigRef, cmd: string, srcLoc = instLoc()) =
+  ## use when a command invocation begins a shell exec as part of its
+  ## operations; not currently meant for shell execs initiated by input source
+  ## code or scripts.
+  # xxx: maybe allow configurable command action logging
+  if conf.verbosity > compVerbosityDefault:
+    conf.writeLog(cmd, srcLoc)
+
+proc logError*(conf: ConfigRef, msg: string, srcLoc = instLoc()) =
+  ## logs and error message, typically this means writing to console, and bumps
+  ## the error counter in `ConfigRef` to ensure a non-zero exit code.
+  inc conf.errorCounter
+  writeLog(conf, msg, srcLoc)
+
 proc processArgument*(pass: TCmdLinePass; p: OptParser;
                       argsCount: var int; config: ConfigRef): bool =
   if argsCount == 0:
@@ -1240,6 +1254,7 @@ func cliMsgLede(data: CliData): string {.inline.} =
   ]
 
 func helpOnErrorMsg*(conf: ConfigRef): string =
+  # TODO: rename this, it's just the usage.
   cliMsgLede(cliData) & Usage
 
 proc writeHelp(conf: ConfigRef) =


### PR DESCRIPTION
Summary
- `extccomp.execExternalProgram` is no longer exported
- `nim` and `main` modules now simply exec and report themselves

Details
- added `logError` proc to `commands` to msg and bump error counter
- the above ensures proper non-zero exit code on error
- removes some more legacy reports dependencies
- this change also fixes an otherwise unreported typo error `main`