### PR TITLE
cfg: remove legacy reports tracing

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -901,10 +901,6 @@ type
     rdbgVmExecTraceMinimal
     rdbgVmCodeListing
 
-    rdbgStartingConfRead
-    rdbgFinishedConfRead
-    rdbgCfgTrace
-
     rdbgOptionsPush
     rdbgOptionsPop
 

--- a/compiler/ast/reports_debug.nim
+++ b/compiler/ast/reports_debug.nim
@@ -59,12 +59,6 @@ type
           entries: seq[DebugVmCodeEntry]
         ]
 
-      of rdbgStartingConfRead, rdbgFinishedConfRead:
-        filename*: string
-
-      of rdbgCfgTrace:
-        str*: string
-
       else:
         discard
 

--- a/compiler/ast/reports_internal.nim
+++ b/compiler/ast/reports_internal.nim
@@ -13,11 +13,7 @@ import
   compiler/ast/[
     report_enums,
     reports_base,
-  ],
-  compiler/utils/[
-    platform,
   ]
-
 
 type
   UsedBuildParams* = object

--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -268,9 +268,6 @@ type
       of rdbgTraceLine, rdbgTraceStart:
         ctraceData*: tuple[level: int, entries: seq[StackTraceEntry]]
 
-      of rdbgStartingConfRead, rdbgFinishedConfRead:
-        filename*: string
-
       else:
         discard
 

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3124,15 +3124,6 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
       tern(exec.rc == rkNone, "", $exec.rc)
     )
 
-  of rdbgFinishedConfRead:
-    result = "finished configuration file read $1" % r.filename
-
-  of rdbgStartingConfRead:
-    result = "starting configuration file read $1" % r.filename
-
-  of rdbgCfgTrace:
-    result = "cfg trace '" & r.str & "'"
-
   of rdbgVmCodeListing:
     result.add "Code listing"
     let l = r.vmgenListing
@@ -3186,18 +3177,12 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
 
 proc reportFull*(conf: ConfigRef, r: DebugReport): string =
   assertKind r
-  case r.kind
-  of rdbgCfgTrace:
-    result.add(prefix(conf, r), reportBody(conf, r), suffix(conf, r))
-  else:
-    result = reportBody(conf, r)
+  result = reportBody(conf, r)
 
 proc reportShort*(conf: ConfigRef, r: DebugReport): string =
   # mostly created for nimsuggest
   assertKind r
   result = reportBody(conf, r)
-  if r.kind == rdbgCfgTrace:
-    result.add suffixShort(conf, r)
 
 proc reportBody*(conf: ConfigRef, r: BackendReport): string  =
   assertKind r

--- a/compiler/front/cmdlinehelper.nim
+++ b/compiler/front/cmdlinehelper.nim
@@ -42,7 +42,6 @@ from compiler/ast/reports_lexer import LexerReport
 from compiler/ast/reports_parser import ParserReport
 from compiler/ast/reports_internal import InternalReport
 from compiler/ast/reports_external import ExternalReport
-from compiler/ast/reports_debug import DebugReport
 from compiler/ast/report_enums import ReportKind
 from compiler/ast/reports import Report,
   ReportCategory,
@@ -81,16 +80,10 @@ proc handleConfigEvent(
       rlexCfgInvalidDirective
     of cekWriteConfig:
       rintNimconfWrite
-    of cekDebugTrace:
-      rdbgCfgTrace
     of cekInternalError:
       rintIce
     of cekLexerErrorDiag, cekLexerWarningDiag, cekLexerHintDiag:
       evt.lexerDiag.kind.lexDiagToLegacyReportKind
-    of cekDebugReadStart:
-      rdbgStartingConfRead
-    of cekDebugReadStop:
-      rdbgFinishedConfRead
     of cekProgressConfStart:
       rextConf
 
@@ -138,21 +131,6 @@ proc handleConfigEvent(
             reportInst: evt.instLoc.toReportLineInfo,
             msg: evt.msg,
             kind: kind))
-      of rdbgCfgTrace:
-        Report(
-          category: repDebug,
-          debugReport: DebugReport(
-            location: std_options.some evt.location,
-            reportInst: evt.instLoc.toReportLineInfo,
-            kind: kind,
-            str: evt.msg))
-      of rdbgStartingConfRead, rdbgFinishedConfRead:
-        Report(
-          category: repDebug,
-          debugReport: DebugReport(
-            reportInst: evt.instLoc.toReportLineInfo,
-            kind: kind,
-            filename: evt.msg))
       of rextConf:
         Report(
           category: repExternal,

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -9,13 +9,14 @@
 
 import
   std/[os, strutils, strtabs, sets, tables, packedsets],
-  compiler/utils/[prefixmatches, pathutils, platform, strutils2],
+  compiler/utils/[prefixmatches, pathutils, platform],
   compiler/ast/[lineinfos],
   compiler/modules/nimpaths
 
 import compiler/front/in_options
 export in_options
 
+from compiler/utils/strutils2 import toLowerAscii
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
 from std/private/globs import nativeToUnixPath

--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -46,10 +46,6 @@ import
 
 from compiler/vm/vmlegacy import legacyReportsVmTracer
 
-# xxx: reports are a code smell meaning data types are misplaced
-from compiler/ast/reports_debug import DebugReport
-from compiler/ast/report_enums import ReportKind
-
 # we support 'cmpIgnoreStyle' natively for efficiency:
 from std/strutils import cmpIgnoreStyle, contains
 
@@ -65,10 +61,10 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
 
   proc listDirs(a: VmArgs, filter: set[PathComponent]) =
     let dir = getString(a, 0)
-    var result: seq[string] = @[]
+    var res: seq[string] = @[]
     for kind, path in walkDir(dir):
-      if kind in filter: result.add path
-    writeTo(result, a.getResultHandle(), a.mem[])
+      if kind in filter: res.add path
+    writeTo(res, a.getResultHandle(), a.mem[])
 
   # captured vars:
   var
@@ -189,10 +185,6 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
 
 proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
                    freshDefines=true; conf: ConfigRef, stream: PLLStream) =
-  conf.localReport DebugReport(
-    kind: rdbgStartingConfRead,
-    filename: scriptName.string)
-
   conf.symbolFiles = disabledSf
 
   let graph = newModuleGraph(cache, conf)
@@ -229,7 +221,3 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   discard graph.processModule(m, vm.idgen, stream)
 
   undefSymbol(conf, "nimscript")
-
-  conf.localReport DebugReport(
-    kind: rdbgFinishedConfRead,
-    filename: scriptName.string)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -41,7 +41,6 @@ import
   ]
 
 # xxx: reports are a code smell meaning data types are misplaced
-from compiler/ast/reports_internal import InternalReport
 from compiler/ast/reports_external import ExternalReport
 from compiler/ast/report_enums import ReportKind
 


### PR DESCRIPTION
## Summary

Removed cfg file "debug" facilities from legacy reports, this merely
complicated the code to little benefit; this includes the `@trace`
directive.

## Details

These were introduced as part of structuring compiler "reports" and are
not required for anything in particular, removed:
- start/stop conf read trace "reports" that are basically events
- `@trace` directive from cfg, `@write` already exists
- removed unnecessary test in `treport_filtering`

Also:
- removed leftover start/stop read trace in `scripting` module
- took the opportunity to cleanup some warnings in related code