### PR TITLE
cli: msgformat is for debug/test only

### DIFF
--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -201,6 +201,12 @@ type
     v2Sf         ## who knows, probably a bad idea
     stressTest   ## likely more bad ideas
 
+  # "reports" strikes again, this bit of silliness is to stop reports from
+  # infecting the `commands` module among others.
+  MsgFormatKind* = enum
+    msgFormatText = "text" ## text legacy reports message formatting
+    msgFormatSexp = "sexp" ## sexp legacy reports message formatting
+
 type
   ConfNoteSet* = enum
     cnCurrent ## notes after resolving all logic(defaults,

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -291,9 +291,10 @@ type
     structuredReportHook*: ReportHook
     astDiagToLegacyReport*: proc(conf: ConfigRef, d: PAstDiag): Report
     vmProfileData*: ProfileData
-
+    setMsgFormat*: proc(config: ConfigRef, fmt: MsgFormatKind) {.closure.}
+      ## callback that sets the message format for legacy reporting, needs to
+      ## set before CLI handling, because reports are just that awful
     hack*: HackController ## Configuration values for debug printing
-
     when defined(nimDebugUtils):
       debugUtilsStack*: seq[string] ## which proc name to stop trace output
       ## len is also used for output indent level

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -34,7 +34,6 @@ Advanced options:
                             to after all options have been processed
   --stdout:on|off           output to stdout
   --colors:on|off           turn compiler messages coloring on|off
-  --msgFormat:text|sexp     Select compiler message format - text or S-expressions
   --filenames:abs|canonical|legacyRelProj
                             customize how filenames are rendered in compiler messages,
                             defaults to `abs` (absolute)
@@ -158,3 +157,5 @@ Advanced options:
 Command Debug/Testing Options:
   --cmdExitGcStats          output GC statistics at the end of compilation and
                             before any binary is run
+  --msgFormat:text|sexp     set compiler message format text or s-expressions,
+                            meant for testing only

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -186,7 +186,9 @@ legacy method.
 Reports
 -------
 
-All output generates during compiler runtime is handled using `Report`
+..note:: Reports are legacy and will be entirely removed/reworked
+
+All output generated during compiler runtime is handled using `Report`
 type, defined in `reports.nim` module. Every single compilation warning,
 hint, error, and lots of other reports are wrapped into several categories
 (lexer, parser, sem, internal, external, debug and backend) and passed

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -92,7 +92,7 @@ Each hint can be activated individually with `--hint:NAME:on|off`:option: or in 
 Name                             Description
 ==========================       ============================================
 CC                               Shows when the C compiler is called.
-SourceCodeFilterOutput           Shows the output of an source code filters
+SourceCodeFilterOutput           Shows the output of a source code filters
 CodeEnd
 CondTrue
 Conf                             A config file was loaded.
@@ -102,7 +102,6 @@ Dependency
 Exec                             Program is executed.
 ExprAlwaysX
 ExtendedContext
-GCStats                          Dumps statistics about the Garbage Collector.
 GlobalVar                        Shows global variables declarations.
 LineTooLong                      Line exceeds the maximum length.
 Link                             Linking phase.
@@ -140,20 +139,6 @@ Level  Description
 3      In addition to the previous levels dumps a debug stack trace
        for compiler developers.
 =====  ============================================
-
-Compiler message formats
-------------------------
-
-The compiler can output messages in both unstructured (plaintext) and
-structured (S-expressions) forms. S-expressions were chosen mostly for
-integration with testament, in the future json support will be added as
-well.
-
-You can select message format using `--msgFormat=text|sexp`:option: switch
-in the compiler. Unstructured compiler reports are formatted for higher
-readability and used by default. Structured reports are formatted as
-S-expressions, one per line. Every single compiler report is wrapped in
-structured data, including ``echo`` messages at compile-time.
 
 
 Compile-time symbols


### PR DESCRIPTION
## Summary

The `--msgformat` legacy reports 'feature' causes too many issues, 
downgrading it to a dev/debug/test only "feature". This is now only
available for the `nim` compiler executable; it should be restricted
further.

## Details

It can now only be set as a cli flag, not via config; docs reflect this.
In addition, since legacy reports conflates, formatting, recovery, and
everything else, this format setting was moved to `cmdlinehelper`, which
uses a callback on `ConfigRef` to update the structured report hook...
for formatting.

This dropped `commands` dependency on cli/sexp reporters, and introduced
an enum, `MsgFormatKind` to encapsulate the choices. Great care hasn't
been taken with this as it's legacy reports cruft.