### PR TITLE
nimblecmd: remove legacy reports

### DIFF
--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -560,15 +560,26 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectArg(conf, switch, arg, pass, info)
     for path in nimbleSubs(conf, arg):
       addPath(conf, if pass == passPP: processCfgPath(conf, path, info, switch)
-                    else: processPath(conf, path, info, switch), info)
+                    else: processPath(conf, path, info, switch))
   of "nimblepath":
     if pass in {passCmd2, passPP} and optNoNimblePath notin conf.globalOptions:
       expectArg(conf, switch, arg, pass, info)
       var path = processPath(conf, arg, info, switch, notRelativeToProj=true)
+      # TODO: move up nimble stuff, then set path once
       let nimbleDir = AbsoluteDir getEnv("NIMBLE_DIR")
       if not nimbleDir.isEmpty and pass == passPP:
         path = nimbleDir / RelativeDir"pkgs"
-      nimblePath(conf, path, info)
+      let res = nimblePath(conf, path)
+      for it in res.pkgs.items:
+        case it.status
+        of nimblePkgInvalid:
+          conf.localReport(info, ExternalReport(kind: rextInvalidPackageName,
+                                                packageName: it.path))
+        else:
+          discard
+      for p in res.addedPaths.items:
+        conf.localReport(info, ExternalReport(kind: rextPath,
+                                              packagePath: p.string))
   of "nonimblepath":
     expectNoArg(conf, switch, arg, pass, info)
     disableNimblePath(conf)

--- a/tests/compiler/tnimblecmd.nim
+++ b/tests/compiler/tnimblecmd.nim
@@ -1,4 +1,35 @@
-include compiler/modules/[nimblecmd], std/sets
+{.define(tnimblecmd).}
+
+import
+  std/[
+    sets,
+    sequtils,
+  ],
+  compiler/ast/lineinfos,
+  compiler/modules/nimblecmd
+
+from std/strutils import `%`
+
+func `$`(k: NimblePkgAddResult): string =
+  case k
+  of nimblePkgAdded:   "added"
+  of nimblePkgUpdated: "updated"
+  of nimblePkgOlder:   "older"
+  of nimblePkgInvalid: "invalid"
+
+template assertPkgOp(i: var PackageInfo, p: string, k: NimblePkgAddResult) =
+  let r = addPackage(i, p)
+  doAssert r == k, "'$#': expected: $#, got: $#" % [p, $k, $r]
+
+template assertPkgAdd(i: var PackageInfo, p: string) =
+  {.line.}:
+    assertPkgOp(i, p, nimblePkgAdded)
+template assertPkgUpd(i: var PackageInfo, p: string) =
+  {.line.}:
+    assertPkgOp(i, p, nimblePkgUpdated)
+template assertPkgOld(i: var PackageInfo, p: string) =
+  {.line.}:
+    assertPkgOp(i, p, nimblePkgOlder)
 
 proc v(s: string): Version = s.newVersion
 
@@ -16,52 +47,41 @@ proc testAddPackageWithoutChecksum =
   ## sha1 checksum at the end of the name of the Nimble cache directory.
   ## This way a new compiler will be able to work with an older Nimble.
 
-  let conf = newConfigRef(nil)
   var rr: PackageInfo
 
-  addPackage conf, rr, "irc-#a111", unknownLineInfo
-  addPackage conf, rr, "irc-#head", unknownLineInfo
-  addPackage conf, rr, "irc-0.1.0", unknownLineInfo
+  assertPkgAdd(rr, "irc-#a111")
+  assertPkgUpd(rr, "irc-#head")
+  assertPkgOld(rr, "irc-0.1.0")
 
-  addPackage conf, rr, "another-0.1", unknownLineInfo
+  assertPkgAdd(rr, "another-0.1")
 
-  addPackage conf, rr, "ab-0.1.3", unknownLineInfo
-  addPackage conf, rr, "ab-0.1", unknownLineInfo
-  addPackage conf, rr, "justone-1.0", unknownLineInfo
+  assertPkgAdd(rr, "ab-0.1.3")
+  assertPkgOld(rr, "ab-0.1")
+  assertPkgAdd(rr, "justone-1.0")
 
   doAssert toSeq(rr.chosen).toHashSet ==
     ["irc-#head", "another-0.1", "ab-0.1.3", "justone-1.0"].toHashSet
 
 proc testAddPackageWithChecksum =
-  let conf = newConfigRef(nil)
   var rr: PackageInfo
 
   # in the case of packages with the same version, but different checksums for
   # now the first one will be chosen
 
-  addPackage conf, rr, "irc-#a111-DBC1F902CB79946E990E38AF51F0BAD36ACFABD9",
-             unknownLineInfo
-  addPackage conf, rr, "irc-#head-042D4BE2B90ED0672E717D71850ABDB0A2D19CD1",
-             unknownLineInfo
-  addPackage conf, rr, "irc-#head-042D4BE2B90ED0672E717D71850ABDB0A2D19CD2",
-             unknownLineInfo
-  addPackage conf, rr, "irc-0.1.0-6EE6DE936B32E82C7DBE526DA3463574F6568FAF",
-             unknownLineInfo
+  assertPkgAdd(rr, "irc-#a111-DBC1F902CB79946E990E38AF51F0BAD36ACFABD9")
+  assertPkgUpd(rr, "irc-#head-042D4BE2B90ED0672E717D71850ABDB0A2D19CD1")
+  assertPkgOld(rr, "irc-#head-042D4BE2B90ED0672E717D71850ABDB0A2D19CD2")
+  assertPkgOld(rr, "irc-0.1.0-6EE6DE936B32E82C7DBE526DA3463574F6568FAF")
 
-  addPackage conf, rr, "another-0.1", unknownLineInfo
-  addPackage conf, rr, "another-0.1-F07EE6040579F0590608A8FD34F5F2D91D859340",
-             unknownLineInfo
+  assertPkgAdd(rr, "another-0.1")
+  assertPkgOld(rr, "another-0.1-F07EE6040579F0590608A8FD34F5F2D91D859340")
 
-  addPackage conf, rr, "ab-0.1.3-34BC3B72CE46CF5A496D1121CFEA7369385E9EA2",
-             unknownLineInfo
-  addPackage conf, rr, "ab-0.1.3-24BC3B72CE46CF5A496D1121CFEA7369385E9EA2",
-             unknownLineInfo
-  addPackage conf, rr, "ab-0.1-A3CFFABDC4759F7779D541F5E031AED17169390A",
-             unknownLineInfo
+  assertPkgAdd(rr, "ab-0.1.3-34BC3B72CE46CF5A496D1121CFEA7369385E9EA2")
+  assertPkgOld(rr, "ab-0.1.3-24BC3B72CE46CF5A496D1121CFEA7369385E9EA2")
+  assertPkgOld(rr, "ab-0.1-A3CFFABDC4759F7779D541F5E031AED17169390A")
 
   # lower case hex digits is also a valid sha1 checksum
-  addPackage conf, rr, "justone-1.0-f07ee6040579f0590608a8fd34f5f2d91d859340",
-             unknownLineInfo
+  assertPkgAdd(rr, "justone-1.0-f07ee6040579f0590608a8fd34f5f2d91d859340")
 
   doAssert toSeq(rr.chosen).toHashSet == [
     "irc-#head-042D4BE2B90ED0672E717D71850ABDB0A2D19CD1",


### PR DESCRIPTION
## Summary

Although nimble itself is likely to be removed, simplifying the code to
enable throwing out reports from CLI/command modules.

## Details

`nimblecmd` module now returns a data type of what it did, then 
`commands` processes this and determins what to output if at all.

In addition, the `tnimblecmd` test had to be updated as the API no
longer accepts `TLineInfo`, which was only required for "reports".
Additionally, this fixed a minor bug where messages generated lacked
line info, a regression introduced with legacy reports.