### PR TITLE
refactor: comptime compile option testing

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1203,6 +1203,10 @@ type
     adSemFoldDivByZero      # xxx: remove 'Fold' from name?
     adSemInvalidRangeConversion
     adSemFoldCannotComputeOffset
+    adSemCompilerOptionInvalid
+    adSemCompilerOptionArgInvalid
+    adSemDeprecatedCompilerOpt      # warning promoted to error
+    adSemDeprecatedCompilerOptArg   # warning promoted to error
 
   PAstDiag* = ref TAstDiag
   TAstDiag* {.acyclic.} = object
@@ -1473,6 +1477,15 @@ type
     of adSemInvalidIntDefine,
         adSemInvalidBoolDefine:
       invalidDef*: string
+    of adSemCompilerOptionInvalid,
+        adSemDeprecatedCompilerOpt:
+      badCompilerOpt*: PNode
+    of adSemDeprecatedCompilerOptArg:
+      compilerOpt*: PNode
+      compilerOptArg*: PNode
+    of adSemCompilerOptionArgInvalid:
+      forCompilerOpt*: PNode
+      badCompilerOptArg*: PNode
     of adSemDefNameSym:
       defNameSym*: PSym
       defNameSymData*: AdSemDefNameSym

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -763,6 +763,9 @@ type
     rsemLinePragmaExpectsTuple
     rsemRaisesPragmaExpectsObject
 
+    rsemCompilerOptionInvalid
+    rsemCompilerOptionArgInvalid
+
     # -- locking
     rsemLocksPragmaExpectsList
     rsemLocksPragmaBadLevel
@@ -786,12 +789,14 @@ type
     # END !! add reports BEFORE the last enum !!
 
     # Semantic warnings begin
-    rsemUserWarning            = "User" ## `{.warning: }`
-    rsemUnknownMagic           = "UnknownMagic"
-    rsemUnusedImport           = "UnusedImport"
-    rsemDeprecated             = "Deprecated"
-    rsemLockLevelMismatch      = "LockLevel"
-    rsemTypelessParam          = "TypelessParam"
+    rsemUserWarning              = "User" ## `{.warning: }`
+    rsemUnknownMagic             = "UnknownMagic"
+    rsemUnusedImport             = "UnusedImport"
+    rsemDeprecated               = "Deprecated"
+    rsemDeprecatedCompilerOpt    = "Deprecated"
+    rsemDeprecatedCompilerOptArg = "Deprecated"
+    rsemLockLevelMismatch        = "LockLevel"
+    rsemTypelessParam            = "TypelessParam"
     rsemOwnedTypeDeprecated
 
     rsemWarnUnlistedRaises = "Effect" ## `sempass2.checkRaisesSpec` had

--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -87,6 +87,13 @@ type
           unsafeRelation: SemGcUnsafetyKind,
         ]
 
+      of rsemDeprecatedCompilerOptArg:
+        compilerOptArg*: string
+
+      of rsemCompilerOptionArgInvalid:
+        badCompilerOptArg*: string
+        allowedOptArgs*: seq[string]
+
       of rsemHasSideEffects:
         sideEffectTrace*: seq[tuple[isUnsafe: PSym,
                                     unsafeVia: PSym,

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -123,15 +123,6 @@ type
 
   TOptions* = set[TOption]
 
-  TBackend* = enum
-    ## Target compilation backend
-    backendInvalid = "" # for parseEnum
-    backendC = "c"
-    backendJs = "js"
-    backendNimVm = "vm"
-    # backendNimscript = "nimscript" # this could actually work
-    # backendLlvm = "llvm" # probably not well supported; was cmdCompileToLLVM
-
   Command* = enum
     ## Compiler execution command
     cmdNone        ## not yet processed command
@@ -171,20 +162,6 @@ type
     foName          ## lastPathPart, e.g.: foo.nim
     foStacktrace    ## if optExcessiveStackTrace: foAbs else: foName
 
-  Feature* = enum  ## experimental features; DO NOT RENAME THESE!
-    implicitDeref,
-    dotOperators,
-    callOperator,
-    destructor,
-    notnil,
-    vmopsDanger,
-    strictFuncs,
-    views,
-    strictNotNil,
-    overloadableEnums,
-    strictEffects,
-    unicodeOperators
-
   TSystemCC* = enum
     ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccBcc, ccVcc,
     ccTcc, ccEnv, ccIcl, ccIcc, ccClangCl
@@ -201,11 +178,42 @@ type
     v2Sf         ## who knows, probably a bad idea
     stressTest   ## likely more bad ideas
 
+type
+  TBackend* = enum
+    ## Target compilation backend
+    backendInvalid = "" # for parseEnum
+    backendC = "c"
+    backendJs = "js"
+    backendNimVm = "vm"
+    # backendNimscript = "nimscript" # this could actually work
+    # backendLlvm = "llvm" # probably not well supported; was cmdCompileToLLVM
+  TValidBackend* = range[backendC .. backendJs]
+
+const validBackends*: set[TValidBackend] = {backendC .. backendJs}
+
+type
   # "reports" strikes again, this bit of silliness is to stop reports from
   # infecting the `commands` module among others.
   MsgFormatKind* = enum
     msgFormatText = "text" ## text legacy reports message formatting
     msgFormatSexp = "sexp" ## sexp legacy reports message formatting
+
+type
+  Feature* = enum  ## experimental features; DO NOT RENAME THESE!
+    implicitDeref,
+    dotOperators,
+    callOperator,
+    destructor,
+    notnil,
+    vmopsDanger,
+    strictFuncs,
+    views,
+    strictNotNil,
+    overloadableEnums,
+    strictEffects,
+    unicodeOperators
+
+const experimentalFeatures*: set[Feature] = {implicitDeref..unicodeOperators}
 
 type
   ConfNoteSet* = enum

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -589,6 +589,10 @@ func astDiagToLegacyReportKind*(
   of adSemInvalidRangeConversion: rsemSemfoldInvalidConversion
   of adSemFoldCannotComputeOffset: rsemCantComputeOffsetof
   of adSemDefNameSym: rsemExpectedIdentifier
+  of adSemCompilerOptionInvalid: rsemCompilerOptionInvalid
+  of adSemDeprecatedCompilerOpt: rsemDeprecatedCompilerOpt
+  of adSemCompilerOptionArgInvalid: rsemCompilerOptionArgInvalid
+  of adSemDeprecatedCompilerOptArg: rsemDeprecatedCompilerOptArg
 
 func astDiagToLegacyReportKind*(diag: PAstDiag): ReportKind {.inline.} =
   case diag.kind

--- a/compiler/modules/nimblecmd.nim
+++ b/compiler/modules/nimblecmd.nim
@@ -20,7 +20,6 @@ import
   ],
   compiler/front/[
     options,
-    msgs,
   ],
   compiler/utils/[
     pathutils


### PR DESCRIPTION
## Summary

Implementation refactor of [rogrammatic testing of compile options via
the magics `compileOption` and `compileOptionArg` was refactored to use
functions and push diagnostics to the edge. `semfold` now generates
diags on errors and legacy reports for warnings/hints. The error messages
are now also a bit more specific.

## Details

Added necessary ast diags and conversion to legacy reports for invalid
options, option arguments, deprecations, etc. To reduce the amount of
naked constant string sequences for option arg value allow lists, added
constnat enum sets for backends and experimental features.

Minor changes
- cleanup of poor formatting in `cli_reporter` 
- removed an unnecessary import in nimblecmd (clearing the warning)