### PR TITLE
mirgen: ignore `.compileTime` variables

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -74,7 +74,6 @@ proc genVarTuple(p: BProc, n: PNode) =
   for i in 0..<n.len-2:
     let vn = n[i]
     let v = vn.sym
-    if sfCompileTime in v.flags: continue
     var traverseProc: Rope
     if sfGlobal in v.flags:
       assignGlobalVar(p, vn, "")
@@ -275,13 +274,6 @@ proc genSingleVar(p: BProc, v: PSym; vn, value: PNode) =
 
 proc genSingleVar(p: BProc, a: PNode) =
   let v = a[0].sym
-  if sfCompileTime in v.flags:
-    # fix issue #12640
-    # {.global, compileTime.} pragma in proc
-    if sfGlobal in v.flags and p.prc != nil and p.prc.kind == skProc:
-      discard
-    else:
-      return
   genSingleVar(p, v, a[0], a[2])
 
 proc genClosureVar(p: BProc, a: PNode) =

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1411,9 +1411,9 @@ proc genSym(p: PProc, n: PNode, r: var TCompRes) =
   var s = n.sym
   case s.kind
   of skVar, skLet, skParam, skTemp, skResult, skForVar:
-    p.config.internalAssert(s.loc.r != "", n.info, "symbol has no generated name: " & s.name.s)
     if sfCompileTime in s.flags:
       genVarInit(p, s, if s.ast != nil: s.ast else: newNodeI(nkEmpty, s.info))
+    p.config.internalAssert(s.loc.r != "", n.info, "symbol has no generated name: " & s.name.s)
     let k = mapType(p, s.typ)
     if k == etyBaseIndex:
       r.typ = etyBaseIndex
@@ -1844,11 +1844,7 @@ proc genVarStmt(p: PProc, n: PNode) =
         var v = a[0].sym
         if lfNoDecl notin v.loc.flags and sfImportc notin v.flags:
           genLineDir(p, a)
-          if sfCompileTime notin v.flags:
-            genVarInit(p, v, a[2])
-          else:
-            # lazy emit, done when it's actually used.
-            if v.ast == nil: v.ast = a[2]
+          genVarInit(p, v, a[2])
 
 proc genConstant(p: PProc, c: PSym) =
   if lfNoDecl notin c.loc.flags and not p.g.generatedSyms.containsOrIncl(c.id):

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1309,6 +1309,14 @@ proc genLocInit(c: var TCtx, symNode: PNode, initExpr: PNode) =
 
   assert sym.kind in {skVar, skLet, skTemp, skForVar}
 
+  if sfCompileTime in sym.flags and goIsNimvm notin c.options:
+    # XXX: ``.compileTime`` variables are currently lazily generated/emitted
+    #      (that is, only when they're actually used in alive code). This
+    #      approach has issues and needs to eventually be revisited, but for
+    #      now, we omit their definitions in non-compile-time contexts in order
+    #      to make the lazy-generation approach work
+    return
+
   # if there's an initial value and the destination is non-owning, we pass the
   # value directly to the def
   if hasInitExpr and not wantsOwnership:

--- a/tests/lang_callable/generics/tunique_type.nim
+++ b/tests/lang_callable/generics/tunique_type.nim
@@ -1,6 +1,7 @@
 # Bug #2022
 
 discard """
+  matrix: "--gc:refc; --gc:orc"
   output: '''@[97, 45]
 @[true, false]
 @[false, false]'''


### PR DESCRIPTION
## Summary

Don't emit a 'def' for `.compileTime` globals in `mirgen`. Until the
implementation of `.compileTime` variables gets an overhaul, this
restores their lazy-generation behaviour when destructors are used, but
also means that they're for now not destroyed anymore when going out of
scope.

## Details

Lazy-generation not working when destructors are used led to issues when
the `.compileTime` variable in question has an initializer expression
that makes use of compile-time-only procedures.

* ignore definitions of `.compileTime` variables outside of non-compile-
  time contexts in `mirgen`
* remove now obsolete `.compileTime` variable handling from `cgen` and
  `jsgen`
* run the `tunique_type.nim` test with `--gc:orc`

Registering destructors for `.compileTime` variables that require them
is possible, but skipped here because it would only introduce more
obsolete-on-arrival code.