### PR TITLE
astgen: fix illegal C code being generated

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1388,7 +1388,8 @@ proc isDefectException*(t: PType): bool =
   return false
 
 proc isSinkTypeForParam*(t: PType): bool =
-  ## Returns whether the using `t` as the type of a parameter makes it a sink-like
+  ## Returns whether `t` is considered to be a sink-like type when used in a
+  ## parameter context.
   result = t.skipTypes({tyGenericInst, tyAlias}).kind == tySink
   when false:
     if isSinkType(t):

--- a/compiler/mir/astgen.nim
+++ b/compiler/mir/astgen.nim
@@ -598,7 +598,8 @@ proc handleSpecialConv(c: ConfigRef, n: PNode, info: TLineInfo,
     assert source.kind == dest.kind
 
     if source.base.kind == tyObject:
-      if n.kind in {nkObjUpConv, nkObjDownConv} and sameType(dest, n[0].typ):
+      if n.kind in {nkObjUpConv, nkObjDownConv} and
+         sameType(dest, n[0].typ.skipTypes(abstractInst)):
         # this one and the previous conversion cancel each other out. Both
         # ``nkObjUpConv`` and ``nkObjDownConv`` are not treated as lvalue
         # conversions when the source/dest operands are pointer/reference-like,

--- a/tests/lang_types/sink/tmove_from_lvalue_conversion.nim
+++ b/tests/lang_types/sink/tmove_from_lvalue_conversion.nim
@@ -1,0 +1,44 @@
+discard """
+  targets: "c !js !vm"
+  matrix: "--gc:orc"
+  description: '''
+    Destrutively moving from an up- or down converted `ref` value passed as a
+    `sink` parameter must work
+  '''
+"""
+
+# knownIssue: destructor-using refs (read, arc/orc support) are not yet
+#             implemented for the JS/VM target
+
+type
+  A = object of RootObj
+    val: int
+  B = object of A
+  C = object of B
+
+var instance = (ref C)(val: 1)
+
+template test(target: typedesc, explicit: static[bool]) =
+  block:
+    proc conv(x: sink(ref B)) =
+      when explicit:
+        let y = move(target(x))
+      else:
+        let y = target(x)
+
+      # force a destructive move by reassigning `x`
+      x = new(B)
+
+      # test the value after moving the ref to make sure the move really
+      # worked at run-time
+      doAssert y.val == 1
+
+    conv(instance)
+
+# down conversion
+test(ref A, true)
+test(ref A, false)
+
+# up conversion
+test(ref C, true)
+test(ref C, false)


### PR DESCRIPTION
## Summary

Fix the redundant-conversion elision not triggering due to `tySink`
not being skipped. The optimization is currently necessary in order to
work around a C code-generator issue where illegal C code is generated.