### PR TITLE
system: more correct `SysThread` bindings

### DIFF
--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -88,14 +88,14 @@ else:
                     header: "<sys/types.h>".} = distinct cuint
   elif defined(openbsd) and defined(amd64):
     type
-      SysThread* {.importc: "pthread_t", header: "<pthread.h>".} = object
+      SysThread* {.importc: "pthread_t", header: "<pthread.h>".} = distinct pointer
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<pthread.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",
                      header: "<pthread.h>".} = cint
   else:
     type
-      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = object
+      SysThread* {.importc: "pthread_t", header: "<sys/types.h>".} = distinct pointer
       Pthread_attr {.importc: "pthread_attr_t",
                        header: "<sys/types.h>".} = object
       ThreadVarSlot {.importc: "pthread_key_t",

--- a/tests/lang_callable/generics/tthread_generic.nim
+++ b/tests/lang_callable/generics/tthread_generic.nim
@@ -1,6 +1,6 @@
 discard """
   target: "!vm !js"
-  matrix: "--threads:on"
+  matrix: "--threads:on --gc:refc; --threads:on --gc:orc"
   action: compile
 """
 


### PR DESCRIPTION
## Summary

Change the `pthread_t` type binding (`SysThread`) to be treated as a
`distinct pointer` instead of an `object` for all targets besides 64-bit
Linux at the NimSkull side. The Posix standard doesn't require
`pthread_t` to be implemented as a pointer, but many implementations do
implement it as an opaque pointer.

## Details

Treating the type as an `object` led to the C code generator using
bracket initialization for initializing it in certain contexts, which is
incorrect if `pthread_t` is not implemented as a C struct and thus lead
to C compiler errors (MacOS was affected when using `--gc:orc`).