### PR TITLE
consider destructors of concrete types bound to concepts

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -557,7 +557,15 @@ when false:
       if n[i].containsNil: return true
 
 
-template hasDestructor*(t: PType): bool = tfHasAsgn in t.flags
+func hasDestructor*(t: PType): bool {.inline.} =
+  ## Returns whether the underlying concrete type of `t` has attached lifetime
+  ## tracking hooks (that is, is resource-like).
+  # skip all wrapper-like types that cannot have type-bound operations attached
+  # themeselves operations attached. Also skip user-type-classes here, as they
+  # should be resolved at this point
+  let t = t.skipTypes({tyGenericInst, tyOrdinal, tyAlias, tyInferred, tySink} +
+                       tyUserTypeClasses)
+  result = tfHasAsgn in t.flags
 
 template incompleteType*(t: PType): bool =
   t.sym != nil and {sfForward, sfNoForward} * t.sym.flags == {sfForward}

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1756,6 +1756,9 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
   of tyStatic:
     p.config.internalAssert(t.n != nil, "createVar: " & $t.kind)
     result = createVar(p, lastSon t, indirect)
+  of tyUserTypeClasses:
+    p.config.internalAssert(t.isResolvedUserTypeClass)
+    result = createVar(p, lastSon t, indirect)
   else:
     internalError(p.config, "createVar: " & $t.kind)
     result = ""

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -1187,7 +1187,7 @@ proc injectTemporaries(tree: MirTree, c: var Changeset) =
     let isMangedRValue =
       case n.kind
       of mnkCall, mnkMagic:
-        hasDestructor(n.typ.skipTypes(skipAliases))
+        hasDestructor(n.typ)
       of mnkObjConstr:
         # there's no need to skip ``tyDistinct`` here - a ``distinct ref``
         # can't be constructed. We also don't need to consider non-ref

--- a/tests/lang_experimental/concepts/tconstructor_with_concept_type.nim
+++ b/tests/lang_experimental/concepts/tconstructor_with_concept_type.nim
@@ -1,0 +1,19 @@
+discard """
+  targets: "c js vm"
+  knownIssue: '''
+    A constructor node with a resolved type-class as the type either
+    crashes the compiler or results in an internal compiler error
+  '''
+"""
+
+type
+  MyType = object
+    val: int
+  Concept = concept x
+    x is MyType
+
+# semantic analysis changes the type of the ``nkObjConstr`` node to a resolved
+# ``tyUserTypeClass``, which is something not considered by ``astgen`` and the
+# code generators
+var x: Concept = MyType(val: 1)
+doAssert x.val == 1

--- a/tests/lang_experimental/concepts/tno_type_attached_ops_bug.nim
+++ b/tests/lang_experimental/concepts/tno_type_attached_ops_bug.nim
@@ -1,0 +1,40 @@
+discard """
+  targets: "c js !vm"
+  matrix: "--cursorInference:off"
+  description: '''
+    Regression test to make sure that locations using a resolved concept type
+    are being considered by the ``injectdestructors`` pass
+  '''
+"""
+
+# cursor inference is disable as it interferes with the test
+
+type
+  Type = object
+    val: int
+  TypeConcept = concept x
+    x is Type
+
+var
+  copied = false
+  destroyed = false
+
+proc `=copy`(a: var Type, b: Type) =
+  a.val = b.val
+  copied = true
+
+proc `=destroy`(x: var Type) =
+  destroyed = true
+
+proc test() =
+  var x = Type(val: 1)
+  var y: TypeConcept = x
+
+  # use `x` again to force the earlier assignment being turned into a copy
+  # instead of a sink
+  doAssert x.val == 1
+  doAssert y.val == 1
+
+test()
+doAssert copied
+doAssert destroyed


### PR DESCRIPTION
## Summary

Turn the `hasDestructor` template into a procedure and skip wrapper-like
types (including `tyUserTypeClasses`) before testing for the
`tfHasAsgn`. This fixes:

* resolved concept types not being considered by cursor inference,
  destructor injection, or the move analyser
* `supportsCopyMem` reporting 'false' for concept types where the bound
  concrete type has a destructor

In addition, the JS backend failing with an internal compiler error for
variables using a resolve type-class as the type is also fixed.

## Details

Since the `tyUserTypeClasses` set is not included in `abstractInst`, the
logic part of the mid- and back-end needs to skip them manually, which
it more often than not does not. A `knownIssue` test is added for one
case where this leads to an issue.