### PR TITLE
internal: clarify type-bound operator attachment

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -560,12 +560,7 @@ when false:
 func hasDestructor*(t: PType): bool {.inline.} =
   ## Returns whether the underlying concrete type of `t` has attached lifetime
   ## tracking hooks (that is, is resource-like).
-  # skip all wrapper-like types that cannot have type-bound operations attached
-  # themeselves operations attached. Also skip user-type-classes here, as they
-  # should be resolved at this point
-  let t = t.skipTypes({tyGenericInst, tyOrdinal, tyAlias, tyInferred, tySink} +
-                       tyUserTypeClasses)
-  result = tfHasAsgn in t.flags
+  result = tfHasAsgn in t.skipTypes(skipForHooks).flags
 
 template incompleteType*(t: PType): bool =
   t.sym != nil and {sfForward, sfNoForward} * t.sym.flags == {sfForward}

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -565,6 +565,11 @@ const
   typedescPtrs* = abstractPtrs + {tyTypeDesc}
   typedescInst* = abstractInst + {tyTypeDesc, tyUserTypeClass}
 
+  skipForHooks* = {tyGenericInst, tyOrdinal, tyAlias, tySink, tyInferred} +
+                  tyUserTypeClasses
+    ## the types to skip in order to reach the type that instantiated
+    ## type-bound operations are attached to. User type-classes are also
+    ## unconditionally included in this set
 
 type
   TTypeKinds* = set[TTypeKind]

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -368,6 +368,8 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   ## ``n`` the ast like it would be passed to a real macro
   ## ``flags`` Some flags for more contextual information on how the
   ## "macro" is calld.
+  addInNimDebugUtils(c.config, "magicsAfterOverloadResolution", n, result,
+                     flags)
 
   if n.isError:
     result = n
@@ -423,18 +425,11 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = n
     else:
       result = plugin(c, n)
-  of mDestroy:
+  of mDestroy, mTrace:
+    # these are explicit calls to hooks for which overload resolution picked
+    # the generic magic from system. Leave them be; ``sempass2`` will patch
+    # these calls with the correct procedure
     result = n
-    let t = n[1].typ.skipTypes(abstractVar)
-    let op = getAttachedOp(c.graph, t, attachedDestructor)
-    if op != nil:
-      result[0] = newSymNode(op)
-  of mTrace:
-    result = n
-    let t = n[1].typ.skipTypes(abstractVar)
-    let op = getAttachedOp(c.graph, t, attachedTrace)
-    if op != nil:
-      result[0] = newSymNode(op)
 
   of mSetLengthSeq:
     result = n

--- a/tests/lang_callable/generics/tgenerics_issues.nim
+++ b/tests/lang_callable/generics/tgenerics_issues.nim
@@ -28,6 +28,7 @@ H:1:0.1
 (foo: some(@[(a: "world", bar: none(Bar))]), s: "hello,")
 @[(a: "hey", bar: none(Bar))]
 '''
+matrix: "--gc:refc; --gc:orc"
 joinable: false
 """
 


### PR DESCRIPTION
## Summary

Move to only attaching type-bound operators to unwrapped types, by
skipping to the underlying concrete type before calling
`createTypeBoundOps` in `sempass2`. This is small step towards cleaning
up the type-bound operator implementation.

In addition, this also fixes a regression caused by `hasDestructor` now
skipping the wrapper-like types, which caused alias types and generic
instantiations to not be detected as having a destructor attached.

## Details

* move the skip set used in `hasDestructor` to the `skipForHooks`
  constant
* skip types from the `skipForHooks` set before querying or creating the
  type-bound operators for a type in `sempass2`
* skip types from the `skipForHooks` set before querying type-bound
  operators in `injectdestructors`
* don't attempt to rewrite explicit type-bound operators call during
  `sem` -- that's the responsibility of the `sempass2`
* use `getOp` for querying the attached sink operator in
  `injectdestructors` (it should have been used there from the start)

Calls to `createTypeBoundOps` from `liftdestructors` still attach the
operators to the original (read, unskipped) type.

### The fixed problem

Both closure types (`tyProc` with the `ccClosure` calling convention)
and compound types where none of the element/field types has an
overridden type-bound operation at the time when the compound type is
defined don't have the `tfHasAsgn` flag included at definition time.

`createTypeBoundOps` only includes the flag on the type that was passed
to it, not the skipped one, meaning that if `createTypeBoundOps` is
never invoked directly with the skipped type, the skipped type doesn't
get the `tfHasAsgn` flag included, resulting in it being effectively
treated as having no attached type operation.