### PR TITLE
magics: move `compileroption` to `magicsafteroverloadresolution`

### DIFF
--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -36,7 +36,6 @@ import
     vmops
   ],
   compiler/front/[
-    msgs,
     condsyms,
     options,
   ],

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -15,6 +15,9 @@ proc semDiscard(c: PContext, n: PNode): PNode =
   checkSonsLen(n, 1, c.config)
   if n[0].kind != nkEmpty:
     n[0] = semExprWithType(c, n[0])
+    if n[0].kind == nkError:
+      result = c.config.wrapError(n)
+      return
     let sonType = n[0].typ
     let sonKind = n[0].kind
     if isEmptyType(sonType) or sonType.kind in {tyNone, tyTypeDesc} or sonKind == nkTypeOfExpr:

--- a/tests/misc/tsystem_compileoption_err1.nim
+++ b/tests/misc/tsystem_compileoption_err1.nim
@@ -1,0 +1,7 @@
+discard """
+  description: "Regression tests to see if invalid option fails correctly"
+  errormsg: "Invalid compiler option - 'bob'"
+"""
+
+static:
+  discard compileOption("bob")

--- a/tests/misc/tsystem_compileoption_err2.nim
+++ b/tests/misc/tsystem_compileoption_err2.nim
@@ -1,0 +1,7 @@
+discard """
+  description: "Regression tests to see if invalid option fails correctly"
+  errormsg: "Unexpected value for option 'exceptions'. Expected one of native, goto, but got 'bob'"
+"""
+
+static:
+  discard compileOption("exceptions", "bob")


### PR DESCRIPTION
## Summary

Moved `compileOption` and `compileOptionArg` magics handling from the
`semfold` module to `semmagic`, specifically into the procedure
`magicsAfterOverloadResolution`. This avoids yet another place where
`semfold` can generate an `nkError` that would pollute `transf`. This
also fixes a bug where the compiler would crash if an compile option was
tested.

## Details

Beyond the procedure move, the implementation now uses
`sem.evalConstExpr` instead of `semfold.getConstExpr`, this not only
cleans up the call, but more accurately represents what should be
happening. What's happening: semantic analysis replaces at compile time
calls to `system.compileOption` with their value. Meaning that these
calls never reach runtime (only the results), but it "feels" like it.

Also added some tests to ensure the regression of the compiler crash
when providing invalid arguments doesn't happen again. As part of this
testing a small bug was found in `semDiscard` where the operand for a
discard statement wasn't checked for `nkError` (this has also been
fixed) and triggered an assert in `transf`.

Finally some unused imports were opportunistically removed in order to
quiet some build warnings.