### PR TITLE
static `try` void-expression no longer crashes

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -528,7 +528,7 @@ type
       ## instantiation and prior to this it has the potential to
       ## be any type.
 
-    tyVoid ## now different from tyEmpty, hurray!
+    tyVoid ## void type, lack of a value or unit
 
 static:
   # remind us when TTypeKind stops to fit in a single 64-bit word

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -153,9 +153,9 @@ type
     # -------------------------------------------------------------------------
     enforceVoidContext*: PType
       ## for `if cond: stmt else: foo`, `foo` will be evaluated under
-      ## enforceVoidContext != nil; meaning we infered if to contain a a `stmt`
-      ## (void) and so `foo` must result in an expression that can be `void`.
-      ## Which plays into discard checks.
+      ## enforceVoidContext != nil; meaning we infered the `if` to contain a
+      ## `stmt` (void) and so `foo` must result in an expression that can be
+      ## `void`. Which plays into discard checks.
       ##
       ## It's used as a sentinel value, setting a node's typ field to this can
       ## then be compared with later to raise errors or to see if something is

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -918,15 +918,15 @@ proc rawExecute(c: var TCtx, pc: var int): YieldReason =
     case instr.opcode
     of opcEof:
       # XXX: eof shouldn't be used to return a register
-      return YieldReason(kind: yrkDone, reg: some(ra))
+      return YieldReason(kind: yrkDone, reg: none[TRegister]())
     of opcRet:
       let newPc = c.cleanUpOnReturn(c.sframes[tos])
       # Perform any cleanup action before returning
       if newPc < 0:
         pc = c.sframes[tos].comesFrom
         if tos == 0:
-          # opcRet always returns its value in register '0'
-          return YieldReason(kind: yrkDone, reg: some(TRegister 0))
+          # opcRet returns its value as indicated in the first operand
+          return YieldReason(kind: yrkDone, reg: some(instr.regA))
 
         assert c.code[pc].opcode in {opcIndCall, opcIndCallAsgn}
         if c.code[pc].opcode == opcIndCallAsgn:
@@ -2218,7 +2218,7 @@ proc rawExecute(c: var TCtx, pc: var int): YieldReason =
       c.currentExceptionA = raisedRef
       c.activeException = raisedRef
 
-      # gather the stack-tace for the exception:
+      # gather the stack-trace for the exception:
       block:
         var pc = pc
         c.activeExceptionTrace.setLen(c.sframes.len)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3258,20 +3258,14 @@ proc genExpr*(c: var TCtx; n: PNode, requiresValue = true): VmGenResult =
     c.gen(n, d)
 
   if d < 0:
-    c.config.internalAssert(not requiresValue, n.info, "VM problem: dest register is not set")
-
+    c.config.internalAssert(not requiresValue, n.info):
+      "VM problem: dest register is not set"
     d = 0
 
-  c.gABC(n, opcEof, d)
-  # TODO: use `opcRet` for expressions that yield something, instead of
-  #       overloading opcEof with this behaviour
-  #[
   if requiresValue:
-    assert d == 0
-    c.gABC(n, opcRet)
-
-  c.gABC(n, opcEof)
-  ]#
+    c.gABC(n, opcRet, d)
+  else:
+    c.gABC(n, opcEof)
 
   result = VmGenResult.ok:
     (start: start, regCount: c.prc.regInfo.len)

--- a/compiler/vm/vmutils.nim
+++ b/compiler/vm/vmutils.nim
@@ -10,11 +10,15 @@ import
   ],
   compiler/ast/[
     ast,
-    reports
+    lineinfos,
   ],
   compiler/vm/[
     vmdef
   ]
+
+# TODO: remove legacy reports cruft
+import compiler/ast/reports
+import compiler/ast/reports_debug
 
 type
   VmGenCodeListing* = tuple[

--- a/tests/lang_stmts/static_stmt/tstatic_stmt.nim
+++ b/tests/lang_stmts/static_stmt/tstatic_stmt.nim
@@ -1,0 +1,14 @@
+discard """
+description: "Tests static statement blocks"
+"""
+
+block regression_void_try_stmt:
+  # static blocks are currently statements (void expressions), `vmgen` used to
+  # produce code that just happened to work for most void expressions, but
+  # failed when encountering the one below. This is what led to the distinction
+  # of existing with an `opcEof` vs `opcRet`.
+  static:
+    try:
+      discard
+    finally:
+      discard


### PR DESCRIPTION
## Summary

Fix compiler crash for `try` void expressions in `static` blocks;
moreover, this fixes a crash for any AST that produced bytecode but
didn't allocate any registers.

## Details

Static blocks presently are void-expressions (statements), `vmgen` and
the `compilerbridge` were not handling these correctly in all cases.
When `vmgen` generated bytecode that didn't allocate any registers the
`compilerbridge` would crash attempting to access a non-existent local
for a return value. One way to trigger this scenario is with some void-
expressions (see added test).

In particular it uses `opcRet` for expression evaluation, where a return
value is required from VM code execution, and `opcEof` when one is not
required. In the case of the former the present behaviour is largely
maintained except we now return the index of local storage in the main
VM stack-frame; and for the latter we don't return any index signaling
to the consumer that no value as a `TFullRegister` with kind `rkNone` is
to be provided.

In debugging this change, an issue with VM code gen listings was found
and resolved, as well.