### PR TITLE
IC: fix an internal loading bug

### DIFF
--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -1071,32 +1071,24 @@ proc loadProcBody*(config: ConfigRef, cache: IdentCache;
 
 proc loadTypeFromId*(config: ConfigRef, cache: IdentCache;
                      g: var PackedModuleGraph; module: int; id: PackedItemId): PType =
-  if id.item < g[module].types.len:
+  if id.module == LitId(0) and g[module].typesInit:
+    # it's a type from `module`, but it doesn't have to be cached yet
     result = g[module].types[id.item]
-  else:
-    result = nil
+
   if result == nil:
-    var decoder = PackedDecoder(
-      lastModule: int32(-1),
-      lastLit: LitId(0),
-      lastFile: FileIndex(-1),
-      config: config,
-      cache: cache)
+    setupDecoder()
     result = loadType(decoder, g, module, id)
 
 proc loadSymFromId*(config: ConfigRef, cache: IdentCache;
                     g: var PackedModuleGraph; module: int; id: PackedItemId): PSym =
-  if id.item < g[module].syms.len:
+  ## Loads the symbol with `id` from the context of the module `module`. The
+  ## resulting symbol is cached if it wasn't already.
+  if id.module == LitId(0) and g[module].symsInit:
+    # it's a symbol from `module`, but it doesn't have to be cached yet
     result = g[module].syms[id.item]
-  else:
-    result = nil
+
   if result == nil:
-    var decoder = PackedDecoder(
-      lastModule: int32(-1),
-      lastLit: LitId(0),
-      lastFile: FileIndex(-1),
-      config: config,
-      cache: cache)
+    setupDecoder()
     result = loadSym(decoder, g, module, id)
 
 proc translateId*(id: PackedItemId; g: PackedModuleGraph; thisModule: int; config: ConfigRef): ItemId =

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -128,28 +128,24 @@ proc replayGenericCacheInformation*(g: ModuleGraph; module: int) =
 
   for it in mitems(g.packed[module].fromDisk.procInstCache):
     let key = translateId(it.key, g.packed, module, g.config)
-    let sym = translateId(it.sym, g.packed, module, g.config)
     var concreteTypes = newSeq[FullId](it.concreteTypes.len)
     for i in 0..high(it.concreteTypes):
-      let tmp = translateId(it.concreteTypes[i], g.packed, module, g.config)
-      concreteTypes[i] = FullId(module: tmp.module, packed: it.concreteTypes[i])
+      concreteTypes[i] = FullId(module: module, packed: it.concreteTypes[i])
 
     g.procInstCache.mgetOrPut(key, @[]).add LazyInstantiation(
-      module: module, sym: FullId(module: sym.module, packed: it.sym),
+      module: module, sym: FullId(module: module, packed: it.sym),
       concreteTypes: concreteTypes, inst: nil)
 
   for it in mitems(g.packed[module].fromDisk.methodsPerType):
     let key = translateId(it[0], g.packed, module, g.config)
     let col = it[1]
-    let tmp = translateId(it[2], g.packed, module, g.config)
-    let symId = FullId(module: tmp.module, packed: it[2])
+    let symId = FullId(module: module, packed: it[2])
     g.methodsPerType.mgetOrPut(key, @[]).add (col, LazySym(id: symId, sym: nil))
 
   for it in mitems(g.packed[module].fromDisk.enumToStringProcs):
     let key = translateId(it[0], g.packed, module, g.config)
-    let tmp = translateId(it[1], g.packed, module, g.config)
-    let symId = FullId(module: tmp.module, packed: it[1])
-    g.enumToStringProcs[key] = LazySym(id: symId, sym: nil)
+    g.enumToStringProcs[key] =
+      LazySym(id: FullId(module: module, packed: it[1]), sym: nil)
 
   for it in mitems(g.packed[module].fromDisk.methods):
     let sym = loadSymFromId(g.config, g.cache, g.packed, module,

--- a/tests/ic/mdeferred_items_1.nim
+++ b/tests/ic/mdeferred_items_1.nim
@@ -1,0 +1,13 @@
+## This module only defines the type and procedure
+
+type Type*[T] = object
+
+# create an instance of the type to test with in this module. The instance of
+# a generic is used, since those not loaded and cached early like top-level
+# definitions are
+discard $Type[int]
+
+proc test*[T](): int =
+  var counter {.global.} = 0
+  inc counter
+  result = counter

--- a/tests/ic/mdeferred_items_2.nim
+++ b/tests/ic/mdeferred_items_2.nim
@@ -1,0 +1,6 @@
+import mdeferred_items_1
+
+# create an instantiation of the generic procedure with a type from the
+# ``mdeferred_items_1`` module
+proc call*(): int =
+  result = test[Type[int]]()

--- a/tests/ic/tdeferred_items.nim
+++ b/tests/ic/tdeferred_items.nim
@@ -1,0 +1,31 @@
+discard """
+  description: '''
+    Regression test for an internal type and symbol loading bug, where packed
+    item IDs were decoded from context of the wrong module
+  '''
+"""
+
+import mdeferred_items_1, mdeferred_items_2
+
+# first, create an unrelated instance. This forces the entries in the
+# instantiation cache to be resolved, but without ``Type[int]`` being
+# explicitly used prior (<-- this is important)
+doAssert test[int]() == 1
+
+# invoke the instantiation created by ``mdeferred_items_2``
+doAssert call() == 1
+# create the same instantiation as ``mdeferred_items_2`` does. If the generic
+# cache worked and it's really the same, this is the second call to it
+doAssert test[Type[int]]() == 2
+
+#!EDIT!#
+discard """
+"""
+
+import mdeferred_items_1, mdeferred_items_2
+
+# logically the same as above, just without comments in order to force a
+# recompilation
+doAssert test[int]() == 1
+doAssert call() == 1
+doAssert test[Type[int]]() == 2


### PR DESCRIPTION
## Summary

Fix a severe internal bug with type and symbol loading. In the common
case it had no effect, but in many other cases it would either cause an
internal compiler error or, in the worst case, would cause the
wrong symbol or type being silently loaded.

## Details

Apart from the packed item ID, items that support on-demand loading
(symbols and types) also store an additional module ID. This ID
identifies the module as part of which the packed item ID was originally
encoded, and is required to correctly decode the packed ID.

There were two problems. First, the loader logic assumed that the
decoding module is the same as the module to which the to-be-loaded
symbol belongs, and tried to look up the item in the decoding module's
cache. If this resulted in a cache hit, a fully unrelated symbol or
type was returned instead of the requested one, and subsequently
persisted!

The second problem was that the logic for replaying various
`ModuleGraph` state changes (`replayGenericCacheInformation`) treated
foreign types and symbols as being encoded as part of the attached-to
module instead of the one to which the state change was recorded (which
is the module that the IDs were encoded with).

A concrete situation where this led to issues is the following: module
`A` imports module `B`, and both import `C`. `B` records an
procedure instantiation cache entry that uses type `T`, which is
attached to `C`. `A` queries the instantiation cache.

When both `A` and `B` are recompiled, everything works as expected.
When only `A` is recompiled, however, and the compiler resolves (i.e.
loads) the deferred types part of the instantiation cache entry, the ID
of `T` is decoded with the context of module `C`, which is incorrect --
it needs to be `B`, as `B` recorded the instantiation (and encoded the
packed ID).