### PR TITLE
IC: support type-bound operators and `--gc:orc`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2945,7 +2945,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
     if n[genericParamsPos].kind == nkEmpty:
       var prc = n[namePos].sym
       if useAliveDataFromDce in p.module.flags:
-        if p.module.alive.contains(prc.itemId.item) and prc.magic in {mNone, mIsolate}:
+        if p.module.alive.contains(prc.itemId.item) and prc.magic in NonMagics:
           genProc(p.module, prc)
       elif prc.skipGenericOwner.kind == skModule and sfCompileTime notin prc.flags:
         if ({sfExportc, sfCompilerProc} * prc.flags == {sfExportc}) or

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -103,6 +103,10 @@ when not declared(dynlib.libCandidates):
 when options.hasTinyCBackend:
   import backend/tccgen
 
+const NonMagics* = {mNone, mIsolate, mNewSeq, mSetLengthSeq, mAppendSeqElem}
+  ## magics that are treated like normal procedures by the code generator.
+  ## This set only applies when using the new runtime.
+
 proc addForwardedProc(m: BModule, prc: PSym) =
   m.g.forwardedProcs.add(prc)
 

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -827,7 +827,7 @@ proc loadProcBody(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: in
       result = loadNodes(c, g, thisModule, tree, n0)
     inc i
 
-proc moduleIndex*(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;
+proc moduleIndex*(c: var PackedDecoder; g: PackedModuleGraph; thisModule: int;
                   s: PackedItemId): int32 {.inline.} =
   result = if s.module == LitId(0): thisModule.int32
            else: toFileIndexCached(c, g, thisModule, s.module).int32

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -554,6 +554,10 @@ proc storeInstantiation*(c: var PackedEncoder; m: var PackedModule; s: PSym; i: 
 proc storeExpansion*(c: var PackedEncoder; m: var PackedModule; info: TLineInfo; s: PSym) =
   toPackedNode(newSymNode(s, info), m.bodies, c, m)
 
+proc storeAttachedOp*(c: var PackedEncoder; m: var PackedModule, kind: TTypeAttachedOp, t: PType, s: PSym) =
+  ## Records a type-bound operator attachment action to module `m`.
+  m.attachedOps.add((kind, storeTypeLater(t, c, m), storeSymLater(s, c, m)))
+
 proc loadError(err: RodFileError; filename: AbsoluteFile; config: ConfigRef;) =
   case err
   of cannotOpen:

--- a/compiler/ic/integrity.nim
+++ b/compiler/ic/integrity.nim
@@ -121,6 +121,12 @@ proc checkModule(c: var CheckedContext; m: PackedModule) =
   checkLocalSymIds c, m, m.methods
   checkLocalSymIds c, m, m.trmacros
   checkLocalSymIds c, m, m.pureEnums
+
+  # check the type-attached operators:
+  for (kind, typ, sym) in m.attachedOps.items:
+    checkType(c, typ)
+    checkForeignSym(c, sym)
+
   #[
     To do: Check all these fields:
 

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -304,6 +304,12 @@ proc ithSon*(tree: PackedTree; n: NodePos; i: int): NodePos =
       inc count
   assert false, "node has no i-th child"
 
+proc lastSon*(tree: PackedTree, n: NodePos): NodePos =
+  assert(not isAtom(tree, n.int))
+  let len = tree.nodes[n.int].operand
+  assert len > 0, "node has no children"
+  result = NodePos(n.int + len)
+
 when false:
   proc `@`*(tree: PackedTree; lit: LitId): lent string {.inline.} =
     tree.sh.strings[lit]

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -254,6 +254,10 @@ template isIterator*(owner: PSym): bool =
 
 proc createTypeBoundOpsLL(g: ModuleGraph; refType: PType; info: TLineInfo; idgen: IdGenerator; owner: PSym) =
   if owner.kind != skMacro:
+    # XXX: this breaks the IC implementation. Lambda-lifting happens as part
+    #      of the backend processing, at which point the packed modules are
+    #      effectively sealed and no more content must be written to them (which
+    #      is what happens here).
     createTypeBoundOps(g, nil, refType.lastSon, info, idgen)
     createTypeBoundOps(g, nil, refType, info, idgen)
     if tfHasAsgn in refType.flags or optSeqDestructors in g.config.globalOptions:

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -990,9 +990,6 @@ proc inst(g: ModuleGraph; c: PContext; t: PType; kind: TTypeAttachedOp; idgen: I
     else:
       localReport(g.config, info, reportSem(rsemUnresolvedGenericParameter))
 
-proc isTrival(s: PSym): bool {.inline.} =
-  s == nil or (s.ast != nil and s.ast[bodyPos].len == 0)
-
 proc createTypeBoundOps(g: ModuleGraph; c: PContext; orig: PType; info: TLineInfo;
                         idgen: IdGenerator) =
   ## In the semantic pass this is called in strategic places
@@ -1041,7 +1038,8 @@ proc createTypeBoundOps(g: ModuleGraph; c: PContext; orig: PType; info: TLineInf
     if canon != orig:
       setAttachedOp(g, idgen.module, orig, k, getAttachedOp(g, canon, k))
 
-  if not isTrival(getAttachedOp(g, orig, attachedDestructor)):
+  let op = getAttachedOp(g, orig, attachedDestructor)
+  if op != nil and getBody(g, op).len != 0:
     #or not isTrival(orig.assignment) or
     # not isTrival(orig.sink):
     orig.flags.incl tfHasAsgn

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -565,10 +565,7 @@ proc processCategory(r: var TResults, cat: Category, targets: set[TTarget],
   of "lib":
     testStdlib(r, "lib/pure/", options, cat)
   of "ic":
-    # XXX: using ``--gc:refc`` for the IC tests only shifts the problem
-    #      around. Eventually, the tests or the implementation need to be
-    #      removed, or IC made to work with ORC
-    icTests(r, testsDir / cat2, cat, options & " --gc:refc")
+    icTests(r, testsDir / cat2, cat, options)
   of "untestable":
     # These require special treatment e.g. because they depend on a third party
     # dependency; see `trunner_special` which runs some of those.


### PR DESCRIPTION
## Summary

Finish the implementation for recording type-bound operator into packed
modules, and adjust the IC backend and its DCE implementation to support
both lifetime hooks and parts of the new runtime.

This allows for simple programs to be compiled with `--incremental:on`
and `--gc:orc`, and is another step towards removing the old runtime.

## Details

Getting type-bound operators and `--gc:orc` supported consists of four
parts.

### Packed Modules

Attaching either a user-defined or generated type-bound operator to a
type is a change to the `ModuleGraph`, and thus has to be recorded in
order to allow for later replay of the state changes. The basic
facilities already existed, but storing and replaying the `attachedOps`
changes was missing.

* implement recording the attachment changes
* implement replaying the attachment changes
* split out replay of state relevant to the backend into a separate
  procedure
* fix the "trivial attached operator" check not taking on-demand
  loading of procedure bodies into account

### Backend setup

Restore backend-relevant `ModuleGraph` state discarded by
`resetForBackend` before running alive analysis -- no information
about attached operator would be present otherwise.

### Dead-code elimination

Compared to the other backends, the IC implementation uses a dedicated
alive analysis pass over the whole packed module-graph in order to
figure out the set of alive routines. Only routines present in this set
have C code generated for them -- the others are ignored.

The `injectdestructors` pass, which is responsible for injecting copy,
sink, and destroy hooks, is only run for all alive code reaching the
code generators, but at that point, the previous alive analysis would
have marked all not explicitly used hooks as dead code.

In order to get around this phase-ordering problem, the alive analysis
now conservatively marks all lifetime hooks for types used by alive:
* locals
* globals
* constants
* parameters

as being in the alive set. The same goes for lifetime hooks attached to
types used as the return type of alive routines.

The downside of this conservative approach is, that hooks ending up
not being actually used are still emitted and compiled, leading to
larger binaries.

### Code generator

Include the magics used by the seqsv2 implementation in the set of
magics to consider for code generation. Said magics are implemented
as normal (generic) procedures, and thus their bodies also need to
be compiled.