### PR TITLE
sem: process `mEnumToStr` earlier

### DIFF
--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -47,6 +47,9 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
   n[bodyPos] = body
   n[resultPos] = newSymNode(res)
   result.ast = n
+  # treat the symbol as a magic so that further processing can easily detect
+  # auto-generated enum-to-string procedures
+  result.magic = mEnumToStr
   result.flags.incl {sfFromGeneric, sfNeverRaises}
 
 proc searchObjCaseImpl(obj: PNode; field: PSym): PNode =

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2348,14 +2348,6 @@ proc genSlice(p: BProc; e: PNode; d: var TLoc) =
     localReport(p.config, e.info, "invalid context for 'toOpenArray'; " &
       "'toOpenArray' is only valid within a call expression")
 
-proc genEnumToStr(p: BProc, e: PNode, d: var TLoc) =
-  let t = e[1].typ.skipTypes(abstractInst+{tyRange})
-  let toStrProc = getToStringProc(p.module.g.graph, t)
-  # XXX need to modify this logic for IC.
-  var n = copyTree(e)
-  n[0] = newSymNode(toStrProc)
-  expr(p, n, d)
-
 proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   case op
   of mOr, mAnd: genAndOr(p, e, d, op)
@@ -2427,7 +2419,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   of mFinished: genBreakState(p, e, d)
   of mEnumToStr:
     if optTinyRtti in p.config.globalOptions:
-      genEnumToStr(p, e, d)
+      genCall(p, e, d)
     else:
       genRepr(p, e, d)
   of mOf: genOf(p, e, d)

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -401,6 +401,14 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = semAsgnOpr(c, n)
     else:
       result = semShallowCopy(c, n, flags)
+  of mEnumToStr:
+    # overload resolution picked the generic enum-to-string magic.
+    # Replace the symbol with that of the auto-generated procedure.
+    let
+      info = n[0].info
+      prc = getToStringProc(c.graph, n[1].typ.skipTypes(abstractRange))
+    result = n
+    result[0] = newSymNode(prc, info)
   of mIsPartOf: result = semIsPartOf(c, n, flags)
   of mTypeTrait: result = semTypeTraits(c, n)
   of mAstToStr:


### PR DESCRIPTION
## Summary

Mark compiler-generated enum-to-string procedures as being `mEnumToStr`
instances, and replace the generic `mEnumToStr` magic symbols with the
compiler-generated ones during semantic analysis already.

This makes it easier for code generators to opt-in to using the
compiler-generated procedure instead of implementing it via custom
logic. As an intentional side-effect of this change, the default
`$` operator for enums can now be used when both the IC backend and
new runtime are enabled.