### PR TITLE
tester: escape strings in EPC mode

### DIFF
--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -5,7 +5,7 @@
 # When debugging, to run a single test, use for e.g.:
 # `nim r nimsuggest/tester.nim nimsuggest/tests/tsug_accquote.nim`
 
-import std/[os, osproc, strutils, streams, re, net]
+import std/[os, osproc, strutils, streams, re, net, strformat]
 import experimental/sexp
 from sequtils import toSeq
 
@@ -41,7 +41,7 @@ proc parseTest(filename: string; epcMode=false): Test =
     let marker = x.find(cursorMarker)
     if marker >= 0:
       if epcMode:
-        markers.add "(\"" & filename & "\" " & $i & " " & $marker & " \"" & result.dest & "\")"
+        markers.add fmt"({escapeJson(filename)} {i} {marker} {escapeJson(result.dest)})"
       else:
         markers.add "\"" & filename & "\";\"" & result.dest & "\":" & $i & ":" & $marker
       tmp.writeLine x.replace(cursorMarker, "")


### PR DESCRIPTION
## Summary

Escape the path strings part of the S-expression messages generated by
the `nimsuggest` tester. Because of the backslashes used by paths on
Windows, the strings not being escaped properly led to all EPC tests
failing there.

## Details

Since the strings are part of an S-expression, `escapeJson` is used
instead of `escape`.