### PR TITLE
reports: remove most CLI/cfg related legacy

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -116,7 +116,6 @@ type
     # hints END !! add reports BEFORE the last enum !!
 
     rintStackTrace = "StackTrace" ## Stack trace during internal
-    rintNimconfWrite
     rintListWarnings
     rintListHints
 
@@ -127,51 +126,12 @@ type
     #--------------------------  External reports  ---------------------------#
     # External reports
     # errors begin
-    rextUnknownCCompiler
-
     rextCmdRequiresFile ## fatal error, user failed to provide a file
-
-    # malformed cmdline parameters begin
-    rextInvalidHint
-    rextInvalidWarning
-    rextInvalidCommandLineOption ## Invalid command-line option passed to
-                                 ## the compiler
-    rextOnlyAllOffSupported ## Only `all:off` is supported for mass
-    ## hint/warning modification. Separate diagnostics must be enabled on
-    ## one-by-one basis.
-    rextExpectedOnOrOff ## Command-line option expected 'on' or 'off' value
-    rextExpectedOnOrOffOrList ## Command-line option expected 'on', 'off'
-    ## or 'list' value.
-    rextExpectedCmdArgument ## Command-line option expected argument
-    rextExpectedNoCmdArgument ## Command-line option expected no arguments
-    rextCmdDisallowsAdditionalArguments ## command disallows additional args
-    rextInvalidNumber ## Command-line switch expected a number
-    rextInvalidValue
-    rextUnexpectedValue ## Command-line argument had value, but it did not
-    ## match with any expected.
-
-    rextExpectedCbackendForRun
-    rextExpectedTinyCForRun
-    rextInvalidCommand
-    rextCommandMissing
-    rextExpectedRunOptForArgs
-    rextUnexpectedRunOpt
-    rextInvalidPath ## Invalid path for a command-line argument
-
-    rextInvalidPackageName ## When adding packages from the `--nimbleDir`
-    ## (or it's default value), names are validated. This error is
-    ## generated if package name is not correct.
     # errors END !! add reports BEFORE the last enum !!
 
-    # warnings begin
-    rextDeprecated ## Report about use of the deprecated feature that is
-    ## not in the semantic pass. Things like deprecated flags, compiler
-    ## commands and so on.
-    # warnings end
-
     # hints start
-    rextConf = "Conf" ## Processing user configutation file
-    rextPath = "Path" ## Add nimble path
+    rextConf = "Conf" ## Processed user configutation file; not a "report"
+    rextPath = "Path" ## Add nimble path; xxx: this isn't a "report"
     # hints END !! add reports BEFORE the last enum !!
 
     # external reports END !! add reports BEFORE the last enum !!
@@ -205,11 +165,6 @@ type
     # string
     rlexUnclosedTripleString
     rlexUnclosedSingleString
-
-    # xxx: expected token and invalid direct are not really "lexer" errors, it
-    #      is `nimconf` module abusing error reporting facilities
-    rlexExpectedToken
-    rlexCfgInvalidDirective
 
     # comments
     rlexUnclosedComment
@@ -977,7 +932,7 @@ type
 
   BackendReportKind* = range[rbackCannotWriteScript .. rbackLinking]
 
-  ExternalReportKind* = range[rextUnknownCCompiler .. rextPath]
+  ExternalReportKind* = range[rextCmdRequiresFile .. rextPath]
 
   InternalReportKind* = range[rintUnknown .. rintEchoMessage]
 
@@ -1037,8 +992,7 @@ const
 
   #------------------------------  external  -------------------------------#
   repExternalKinds* = {low(ExternalReportKind) .. high(ExternalReportKind)}
-  rextErrorKinds* = {rextUnknownCCompiler .. rextInvalidPackageName}
-  rextWarningKinds* = {rextDeprecated}
+  rextErrorKinds* = {rextCmdRequiresFile .. rextCmdRequiresFile}
   rextHintKinds* = {rextConf .. rextPath}
 
 
@@ -1060,7 +1014,6 @@ const
       rlexWarningKinds +
       rparWarningKinds +
       rbackWarningKinds +
-      rextWarningKinds +
       rvmWarningKinds +
       rcmdWarningKinds +
       rintWarningKinds

--- a/compiler/ast/reports_external.nim
+++ b/compiler/ast/reports_external.nim
@@ -14,29 +14,9 @@ type
     ## Report about external environment reads, passed configuration
     ## options etc.
     msg*: string
-
-    case kind*: ReportKind
-      of rextInvalidHint .. rextInvalidPath:
-        cmdlineSwitch*: string ## Switch in processing
-        cmdlineProvided*: string ## Value passed to the command-line
-        cmdlineAllowed*: seq[string] ## Allowed command-line values
-        cmdlineError*: string ## Textual description of the cmdline failure
-
-      of rextUnknownCCompiler:
-        knownCompilers*: seq[string]
-        passedCompiler*: string
-
-      of rextInvalidPackageName:
-        packageName*: string
-
-      of rextPath:
-        packagePath*: string
-
-      else:
-        discard
+    kind*: ReportKind
 
 func severity*(report: ExternalReport): ReportSeverity =
   case ExternalReportKind(report.kind):
     of rextErrorKinds: rsevError
-    of rextWarningKinds: rsevWarning
     of rextHintKinds: rsevHint

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2686,8 +2686,6 @@ To create a stacktrace, rerun compilation with './koch temp $1 <file>'
     of rintMsgOrigin, rintErrKind:
       assert false, "is a configuration hint, should not be reported manually"
 
-    of rintNimconfWrite:
-      result = r.msg
 
 proc reportFull*(conf: ConfigRef, r: InternalReport): string =
   assertKind r
@@ -2770,12 +2768,6 @@ proc reportBody*(conf: ConfigRef, r: LexerReport): string =
     of rlexUnclosedSingleString:
       result.add "closing \" expected"
 
-    of rlexExpectedToken:
-      result.add "expected $1" % r.msg
-
-    of rlexCfgInvalidDirective:
-      result.addf("invalid directive: '$1'", r.msg)
-
     of rlexUnclosedComment:
       result.add "end of multiline comment expected"
 
@@ -2807,89 +2799,13 @@ proc reportBody*(conf: ConfigRef, r: ExternalReport): string =
   assertKind r
   case ExternalReportKind(r.kind):
     of rextConf:
-      result.add("used config file '$1'" % r.msg, conf.suffix(r))
+      unreachable("this should never be reported")
 
     of rextCmdRequiresFile:
       result = "command requires a filename"
 
-    of rextCommandMissing:
-      result.add("Command missing")
-
-    of rextInvalidHint:
-      result.add("Invalid hint - ", r.cmdlineProvided)
-
-    of rextInvalidWarning:
-      result.add("Invalid warning - ", r.cmdlineProvided)
-
-    of rextInvalidCommand:
-       result.add("Invalid command - ", r.cmdlineProvided)
-
-    of rextInvalidCommandLineOption:
-      result = "Invalid command line option - $1" % r.cmdlineProvided
-
-    of rextUnknownCCompiler:
-      result = "unknown C compiler: '$1'. Available options are: $2" %
-                [r.passedCompiler, r.knownCompilers.join(", ")]
-
-    of rextOnlyAllOffSupported:
-      result = "only 'all:off' is supported"
-
-    of rextExpectedOnOrOff:
-      result = "'on' or 'off' expected, but '$1' found" % r.cmdlineProvided
-
-    of rextExpectedOnOrOffOrList:
-      result = "'on', 'off' or 'list' expected, but '$1' found" % r.cmdlineProvided
-
-    of rextExpectedCmdArgument:
-      result = "argument for command line option expected: '$1'" % r.cmdlineSwitch
-
-    of rextExpectedNoCmdArgument:
-      result = "invalid argument ('$1') for command line option: '$2'" %
-                  [r.cmdlineProvided, r.cmdlineSwitch]
-
-    of rextCmdDisallowsAdditionalArguments:
-      result = "$1 command does not support additional arguments: '$2'" %
-                  [r.cmdlineSwitch, r.cmdlineProvided]
-
-    of rextInvalidNumber:
-      result = "$1 is not a valid number" % r.cmdlineProvided
-
-    of rextInvalidValue:
-      result = ("Unexpected value for " &
-        "the $1. Expected one of $2, but got '$3'") % [
-          r.cmdlineSwitch,
-          r.cmdlineAllowed.mapIt("'" & it & "'").join(", "),
-          r.cmdlineProvided
-      ]
-
-    of rextUnexpectedValue:
-      result = "Unexpected value for $1. Expected one of $2" % [
-        r.cmdlineSwitch, r.cmdlineAllowed.join(", ")
-      ]
-
-    of rextExpectedTinyCForRun:
-      result = "'run' command not available; rebuild with -d:tinyc"
-
-    of rextExpectedCbackendForRun:
-      result = "'run' requires c backend, got: '$1'" % $conf.backend
-
-    of rextExpectedRunOptForArgs:
-      result = "arguments can only be given if the '--run' option is selected"
-
-    of rextUnexpectedRunOpt:
-      result = "'$1 cannot handle --run" % r.cmdlineProvided
-
-    of rextInvalidPath:
-      result = "invalid path: " & r.cmdlineProvided
-
-    of rextInvalidPackageName:
-      result = "invalid package name: " & r.packageName
-
-    of rextDeprecated:
-      result = r.msg
-
     of rextPath:
-      result = "added path: '$1'" % r.packagePath
+      unreachable("this should never be reported")
 
 proc reportFull*(conf: ConfigRef, r: ExternalReport): string =
   assertKind r

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -68,7 +68,6 @@ from std/osproc import execCmd
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_internal import InternalReport
-from compiler/ast/reports_external import ExternalReport
 from compiler/ast/report_enums import ReportKind,
   repHintKinds,
   repWarningKinds,
@@ -652,8 +651,8 @@ proc mainCommand*(graph: ModuleGraph) =
     setOutFile(graph.config)
     commandJsonScript(graph)
   of cmdUnknown, cmdNone, cmdIdeTools, cmdNimfix:
-    localReport(conf, ExternalReport(
-      msg: conf.command, kind: rextInvalidCommand))
+    conf.logError(CliEvent(kind: cliEvtErrInvalidCommand, cmd: conf.command,
+                           srcCodeOrigin: instLoc()))
 
   if optProfileVM in conf.globalOptions:
     conf.writeln cmdOutUserProf, conf.dump(conf.vmProfileData)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -40,10 +40,6 @@ import
 
 from std/osproc import execCmd
 
-# xxx: reports are a code smell meaning data types are misplaced
-from compiler/ast/reports_external import ExternalReport
-from compiler/ast/report_enums import ReportKind
-
 from std/browsers import openDefaultBrowser
 from compiler/utils/nodejs import findNodeJs
 
@@ -127,15 +123,17 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef): CmdLineHandlingResult =
     of cmdDocLike, cmdRst2html, cmdRst2tex: # bugfix(cmdRst2tex was missing)
       if conf.arguments.len > 0:
         # reserved for future use
-        localReport(conf, ExternalReport(
-          kind: rextCmdDisallowsAdditionalArguments,
-          cmdlineSwitch: $conf.command,
-          cmdlineProvided: conf.arguments))
+        conf.logError:
+          CliEvent(kind: cliEvtErrCmdExpectedNoAdditionalArgs,
+                   cmd: $conf.command,
+                   unexpectedArgs: conf.arguments,
+                   srcCodeOrigin: instLoc())
       openDefaultBrowser($output)
     else:
       # support as needed
-      localReport(conf, ExternalReport(
-        kind: rextUnexpectedRunOpt, cmdlineSwitch: $conf.command))
+      conf.logError(CliEvent(kind: cliEvtErrUnexpectedRunOpt,
+                             cmd: $conf.command,
+                             srcCodeOrigin: instLoc()))
 
 when declared(GC_setMaxPause):
   GC_setMaxPause 2_000


### PR DESCRIPTION
## Summary

With the introduction of `commands.CliEvent` and compiler messages a
number of legacy reports related to thses are no longer required. This
change removes a large majority of these.

## Details

Removes a number of report kind enums, most of these are external
reports relating to command, flags, and arguments. This also removes a
few incorrectly categorized lexer reports, which relate to cfg
processing.

This change is entirely internal, and the messages are still produced as
before.