### PR TITLE
cgen: unify field defect raising

### DIFF
--- a/lib/system/chcks.nim
+++ b/lib/system/chcks.nim
@@ -29,13 +29,31 @@ proc raiseFieldError(f: string) {.compilerproc, noinline.} =
   ## remove after bootstrap > 1.5.1
   sysFatal(FieldDefect, f)
 
+proc raiseFieldErrorBool(f: string, val: bool) {.compilerproc, noinline.} =
+  sysFatal(FieldError, formatFieldDefect(f, $val))
+
+when false:
+  # XXX: the character value needs to be escaped properly, but the ``reprChar``
+  #      is not defined yet (or at all)
+  proc raiseFieldErrorChar(f: string, val: char) {.compilerproc, noinline.} =
+    sysFatal(FieldError, formatFieldDefect(f, $val))
+
+proc raiseFieldErrorInt(f: string, val: int64) {.compilerproc, noinline.} =
+  sysFatal(FieldError, formatFieldDefect(f, $val))
+
+proc raiseFieldErrorUInt(f: string, val: uint64) {.compilerproc, noinline.} =
+  sysFatal(FieldError, formatFieldDefect(f, $val))
+
+proc raiseFieldErrorStr(f: string, val: string) {.compilerproc, noinline.} =
+  sysFatal(FieldError, formatFieldDefect(f, val))
+
 when defined(nimV2):
   proc raiseFieldError2(f: string, discVal: int) {.compilerproc, noinline.} =
-    ## raised when field is inaccessible given runtime value of discriminant
+    ## Obsolete. Remove after updating the csources compiler
     sysFatal(FieldError, formatFieldDefect(f, $discVal))
 else:
   proc raiseFieldError2(f: string, discVal: string) {.compilerproc, noinline.} =
-    ## raised when field is inaccessible given runtime value of discriminant
+    ## Obsolete. Remove after updating the csources compiler
     sysFatal(FieldError, formatFieldDefect(f, discVal))
 
 proc raiseRangeErrorI(i, a, b: BiggestInt) {.compilerproc, noinline.} =

--- a/tests/misc/tfield_defect_message.nim
+++ b/tests/misc/tfield_defect_message.nim
@@ -1,0 +1,52 @@
+discard """
+  matrix: "--gc:refc; --gc:orc"
+  targets: "c js !vm"
+  description: "Tests for ensuring that ``FieldDefect``'s messages are correct"
+"""
+
+# knownIssue: ``FieldDefect``s are not currently catchable with the VM target,
+#             not even for debugging purposes
+
+type
+  Enum = enum
+    e1
+    e2
+
+  Object = object
+    case boolKind: bool
+    of false: a: int
+    of true:  discard
+
+    case charKind: char
+    of 'a': b: int
+    else:   discard
+
+    case enumKind: Enum
+    of e1: c: int
+    of e2: discard
+
+    case intKind: range[0..1]
+    of 0: d: int
+    of 1: discard
+
+    case uintKind: range[0'u..1'u]
+    of 0: e: int
+    of 1: discard
+
+var obj = Object(boolKind: true, charKind: 'b', enumKind: e2, intKind: 1,
+                 uintKind: 1)
+
+template test(field: untyped, expect: string) =
+  try:
+    # write something to the field in order to make sure it's really accessed
+    obj.field = 1
+  except FieldDefect as e:
+    doAssert e.msg == expect, "got: " & e.msg
+
+test(a, "field 'a' is not accessible for type 'Object' using 'boolKind = true'")
+test(b, "field 'b' is not accessible for type 'Object' using 'charKind = 98'")
+# XXX: the runtime doesn't support rendering characters in field defect
+#      messages yet
+test(c, "field 'c' is not accessible for type 'Object' using 'enumKind = e2'")
+test(d, "field 'd' is not accessible for type 'Object' using 'intKind = 1'")
+test(e, "field 'e' is not accessible for type 'Object' using 'uintKind = 1'")

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -335,7 +335,6 @@ mused3.nim(75, 10) Hint: duplicate import of 'mused3a'; previous import here: mu
     fn("-d:case2 --gc:refc"): """mfield_defect.nim(25, 15) field 'f2' is not accessible for type 'Foo' [discriminant declared in mfield_defect.nim(14, 8)] using 'kind = k3'"""
     fn("-d:case1 -b:js"): """mfield_defect.nim(25, 15) Error: field 'f2' is not accessible for type 'Foo' [discriminant declared in mfield_defect.nim(14, 8)] using 'kind = k3'"""
     fn("-d:case2 -b:js"): """field 'f2' is not accessible for type 'Foo' [discriminant declared in mfield_defect.nim(14, 8)] using 'kind = k3'"""
-    # 3 instead of k3, because of lack of RTTI
-    fn("-d:case2 --gc:arc"): """mfield_defect.nim(25, 15) field 'f2' is not accessible for type 'Foo' [discriminant declared in mfield_defect.nim(14, 8)] using 'kind = 3'"""
+    fn("-d:case2"): """mfield_defect.nim(25, 15) field 'f2' is not accessible for type 'Foo' [discriminant declared in mfield_defect.nim(14, 8)] using 'kind = k3'"""
 else:
   discard # only during debugging, tests added here will run with `-d:nimTestsTrunnerDebugging` enabled


### PR DESCRIPTION
## Summary

Simplify and streamline the logic for emitting the raising of field
defects in `ccgexprs`, which results in the message now properly
rendering enum and boolean discriminator values when using `--gc:orc`.

## Details

* use a common set of `raiseFieldDefectX` runtime procedures, and mark
  the old ones as obsolete
* `reprDiscriminant` is now no longer used for the C target
* when using the runtime, render enum discriminator values with the
  compiler-generated enum-to-string procedure
* remove the backwards-compatibility logic for supporting legacy stdlib
  versions

With the IC backend, using the compiler-generated enum-to-string for
rendering the discriminator value would require `dce` to analyzing
`nkCheckedFieldExpr` nodes in a similar fashion to the `nkChckRange`
analysis, but this is skipped for now. When both the IC backend and
the new runtime are used, enum discriminator values continue to be
rendered as integers.