### PR TITLE
compiler: add the `native` GC option

### DIFF
--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -69,6 +69,7 @@ type
   TGCMode* = enum             # the selected GC
     gcUnselected = "unselected"
     gcNone = "none"
+    gcNative = "native" ## use the memory management native to the backend
     gcBoehm = "boehm"
     gcRegions = "regions"
     gcArc = "arc"

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -441,7 +441,7 @@ proc customizeForBackend*(graph: ModuleGraph, conf: ConfigRef,
     of excNone, excNative: conf.exc = excGoto
     of excGoto:            discard
 
-    if conf.selectedGC == gcUnselected:
+    if conf.selectedGC in {gcUnselected, gcNative}:
       # the default gc for the C backend is ORC. We can't just set it to
       # ``gcOrc`` directly, however, as additional defines, etc. are required
       # XXX: the dependency on ``optionsprocessor`` hints that a different
@@ -452,7 +452,7 @@ proc customizeForBackend*(graph: ModuleGraph, conf: ConfigRef,
     # force the exception mode to 'native', and the selected gc to 'refc'.
     # Note that both targets don't really use 'refc'.
     conf.exc = excNative
-    conf.selectedGC = gcRefc
+    conf.selectedGC = gcNative
   of backendInvalid:
     unreachable()
 

--- a/compiler/front/optionsprocessor.nim
+++ b/compiler/front/optionsprocessor.nim
@@ -589,7 +589,7 @@ proc processCompile(conf: ConfigRef; filename: string) =
 # multiple names for the same garbage collector.
 const
   gcNames = @[
-    "boehm", "refc", "markandsweep", "destructors", "arc", "orc",
+    "native", "boehm", "refc", "markandsweep", "destructors", "arc", "orc",
     "hooks", "go", "none", "stack", "regions",]
 
   cmdNames = @[
@@ -644,6 +644,7 @@ func testCompileOptionArg*(conf: ConfigRef; switch, arg: string): CompileOptArgC
   case switch.normalize
   of "gc":
     case arg.normalize
+    of "native": asResult conf.selectedGC == gcNative
     of "boehm": asResult conf.selectedGC == gcBoehm
     of "refc": asResult conf.selectedGC == gcRefc
     of "markandsweep": asResult conf.selectedGC == gcMarkAndSweep
@@ -1153,6 +1154,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass,
     expectArg(switch, arg)
     if pass in {passCmd2, passPP}:
       case arg.normalize
+      of "native":
+        conf.selectedGC = gcNative
       of "boehm":
         conf.selectedGC = gcBoehm
         defineSymbol(conf, "boehmgc")

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -117,8 +117,9 @@ Advanced options:
   --skipUserCfg:on|off      do not read the user's configuration file
   --skipParentCfg:on|off    do not read the parent dirs' configuration files
   --skipProjCfg:on|off      do not read the project's configuration file
-  --gc:refc|arc|orc|markAndSweep|boehm|go|none|regions
-                            select the GC to use; default is 'refc'
+  --gc:native|refc|arc|orc|markAndSweep|boehm|go|none|regions
+                            select the GC to use; default depends on the selected
+                            backend ('orc' for C, 'native' for Javascript and the VM)
   --exceptions:native|goto
                             select the exception handling implementation
   --index:on|off            turn index file generation on|off

--- a/doc/gc.rst
+++ b/doc/gc.rst
@@ -34,6 +34,8 @@ Multi-paradigm Memory Management Strategies
 
 To choose the memory management strategy use the `--gc:` switch.
 
+--gc:native   The native GC for the selected backend. Redirects to `--gc:orc`
+  for the C backend.
 --gc:refc    This is the default GC. It's a
   deferred reference counting based garbage collector
   with a simple Mark&Sweep backup GC in order to collect cycles. Heaps are thread-local.
@@ -65,6 +67,7 @@ ORC                Shared   Cycle Collector   No             `--gc:orc`
 Boehm              Shared   Cycle Collector   Yes            `--gc:boehm`
 Go                 Shared   Cycle Collector   Yes            `--gc:go`
 None               Manual   Manual            Manual         `--gc:none`
+Native             Depends  Depends           Depends        `--gc:native`
 ================== ======== ================= ============== ===================
 
 .. default-role:: code
@@ -72,8 +75,8 @@ None               Manual   Manual            Manual         `--gc:none`
 
 JavaScript's garbage collector is used for the `JavaScript and NodeJS
 <backends.html#backends-the-javascript-target>`_ compilation targets.
-The `NimScript <nims.html>`_ target uses the memory management strategy built into
-the Nim compiler.
+The `NimScript <nims.html>`_ and VM targets use their own custom garbage
+collector, which, as of now, leaks reference cycles.
 
 ARC
 ===


### PR DESCRIPTION
## Summary

Introduce the `native` GC option and make it the default for the
JavaScript and VM targets. `refc` was previously selected there, but
this is not correct, as the JavaScript target uses JavaScript's garbage
collector and the VM uses its own internal one.

Besides allowing for distinguishing between `refc` and "native GC", this
is also a preparation for the removal of `refc`, as without the `native`
option, both targets would be left without a GC option to use internally
until they support ORC.

For the C backend, `--gc:native` redirects to `--gc:orc`.