### PR TITLE
system: declare `prepareMutation` for all targets

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -100,13 +100,6 @@ proc newEIO(msg: string): owned(ref IOError) =
   new(result)
   result.msg = msg
 
-template prepareStrMutation(x: var string) =
-  ## A compatibility template that is meant to be used until the
-  ## old runtime is removed.
-  when defined(nimV2):
-    # support copy-on-write strings:
-    prepareMutation(x)
-
 type
   Stream* = ref StreamObj
     ## All procedures of this module use this type.
@@ -247,7 +240,7 @@ proc readDataStr*(s: Stream, buffer: var string, slice: Slice[int]): int =
     result = s.readDataStrImpl(s, buffer, slice)
   else:
     # fallback
-    prepareStrMutation(buffer)
+    prepareMutation(buffer)
     result = s.readData(addr buffer[slice.a], slice.b + 1 - slice.a)
 
 template jsOrVmBlock(caseJsOrVm, caseElse: untyped): untyped =
@@ -932,7 +925,7 @@ proc readStrPrivate(s: Stream, length: int, str: var string) =
   when defined(js):
     let L = readData(s, addr(str), length)
   else:
-    prepareStrMutation(str)
+    prepareMutation(str)
     let L = readData(s, cstring(str), length)
   if L != len(str): setLen(str, L)
 
@@ -959,7 +952,7 @@ proc peekStrPrivate(s: Stream, length: int, str: var string) =
   when defined(js):
     let L = peekData(s, addr(str), length)
   else:
-    prepareStrMutation(str)
+    prepareMutation(str)
     let L = peekData(s, cstring(str), length)
   if L != len(str): setLen(str, L)
 
@@ -1206,7 +1199,7 @@ else: # after 1.3 or JS not defined
       jsOrVmBlock:
         buffer[slice.a..<slice.a+result] = s.data[s.pos..<s.pos+result]
       do:
-        prepareStrMutation(buffer)
+        prepareMutation(buffer)
         copyMem(unsafeAddr buffer[slice.a], addr s.data[s.pos], result)
       inc(s.pos, result)
     else:
@@ -1256,7 +1249,7 @@ else: # after 1.3 or JS not defined
         raise newException(Defect, "could not write to string stream, " &
           "did you use a non-string buffer pointer?", getCurrentException())
     elif not defined(nimscript):
-      prepareStrMutation(s.data)
+      prepareMutation(s.data)
       copyMem(addr(s.data[s.pos]), buffer, bufLen)
     inc(s.pos, bufLen)
 

--- a/lib/std/strbasics.nim
+++ b/lib/std/strbasics.nim
@@ -80,8 +80,7 @@ func setSlice*(s: var string, slice: Slice[int]) =
       when not declared(moveMem):
         impl()
       else:
-        when defined(nimSeqsV2):
-          prepareMutation(s)
+        prepareMutation(s)
         moveMem(addr s[0], addr s[first], last - first + 1)
   s.setLen(last - first + 1)
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3056,7 +3056,7 @@ export widestrs
 import system/io
 export io
 
-when notJSnotNims and not defined(nimSeqsV2):
+when not defined(nimSeqsV2):
   proc prepareMutation*(s: var string) {.inline.} =
     ## String literals (e.g. "abc", etc) in the ARC/ORC mode are "copy on write",
     ## therefore you should call `prepareMutation` before modifying the strings

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -41,8 +41,7 @@ doAssert objDeref.x == 42
 
 # String tests
 obj.s = "lorem ipsum dolor sit amet"
-when defined(nimV2):
-  prepareMutation(obj.s)
+prepareMutation(obj.s)
 var indexAddr = addr(obj.s[2])
 
 doAssert indexAddr[] == 'r'
@@ -249,7 +248,7 @@ block: # bug #15939
 
 proc test15939() = # bug #15939 (v2)
   template fn(a) =
-    when defined(nimV2) and typeof(a) is string:
+    when typeof(a) is string:
       prepareMutation(a)
 
     let pa = a[0].addr
@@ -271,8 +270,7 @@ proc test15939() = # bug #15939 (v2)
   # mycstring[ind].addr
   template cstringTest =
     var a2 = "abc"
-    when defined(nimV2):
-      prepareMutation(a2)
+    prepareMutation(a2)
     var b2 = a2.cstring
     fn(b2)
   when nimvm: cstringTest()

--- a/tests/vm/taddrof.nim
+++ b/tests/vm/taddrof.nim
@@ -91,8 +91,7 @@ proc test() =
   doAssert sc.arr[1].b == 321
 
   var str = "---"
-  when defined(nimV2):
-    prepareMutation(str)
+  prepareMutation(str)
 
   changeChar(str[1])
   assertStrEq str, "-A-"


### PR DESCRIPTION
## Summary

The system procedure for preparing a string for mutation
(`prepareMutation`) was previously only available when targeting C,
requiring one to guard usages of it with `when` statements.

Make it available for all targets, with the ones not using copy-on-write
string literals treating it as a no-op. This makes it easier to write
code that works without change across all backend.

## Details

* declare `prepareMutation` for the JavaScript and VM target
* remove `when` guards around `prepareMutation` call in the standard
  library and tests