### PR TITLE
lambdalifting: ignore AST literals for var capture

### DIFF
--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -35,6 +35,7 @@ import
     transf,
     lowerings
   ]
+  , compiler/utils/astrepr
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_sem import SemReport,
@@ -494,6 +495,8 @@ proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
       detectCapturedVars(n[namePos], owner, c)
   of nkReturnStmt:
     detectCapturedVars(n[0], owner, c)
+  of nkNimNodeLit:
+    discard "skip node literals as they're data not code"
   else:
     for i in 0..<n.len:
       detectCapturedVars(n[i], owner, c)

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -35,7 +35,6 @@ import
     transf,
     lowerings
   ]
-  , compiler/utils/astrepr
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_sem import SemReport,

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1602,6 +1602,8 @@ proc detectCapture(owner, top: PSym, n: PNode, marker: var IntSet): PNode =
     result = detectCapture(owner, top, n[1], marker)
   of nkLambdaKinds:
     result = detectCapture(owner, top, n[namePos], marker)
+  of nkNimNodeLit:
+    discard "ignore node literals as they're data not code"
   else:
     for it in n.items:
       result = detectCapture(owner, top, it, marker)

--- a/tests/lang_callable/macros/tnodeliteral.nim
+++ b/tests/lang_callable/macros/tnodeliteral.nim
@@ -1,0 +1,29 @@
+discard """
+  description: "Tests for passing node literals (AST) around"
+"""
+
+import std/macros
+
+block node_literals_are_opaque_in_static_analysis:
+  block regression_ignore_node_literals_in_lambdalifting:
+    proc sym() =
+      discard
+
+    proc outer() {.compileTime.} =
+      var x = 0
+
+      proc sym() {.compileTime.} =
+        # close over an outer local in order to make `sym` a closure procedure:
+        x = 0
+
+      proc inner() {.compileTime.} =
+        let x = bindSym"sym" # create a symbol choice that includes the closure
+                            # procedure
+
+      # `inner` doesn't close over a local and also doesn't access a closure
+      # procedure, so it must not be a closure procedure
+      doAssert inner isnot "closure"
+
+    static:
+      # call the procedure to make sure it passes the lambda-lifting pass
+      outer()


### PR DESCRIPTION
## Summary

`nkNimNodeLit` are no longer scanned during var capture detection,
ensuring that literals do not alter capture analysis of a routine
holding typed literal AST with symbols from the outer routine.

## Details

Capture detection is done in two modules `lambdalifting` and `sempass2`
in the `detectCapturedVars` and `detectCapture` procedures,
respectively. With this change both procedures do not traverse into
`nkNimNodeLit` (treating them as more opaque literal data) for literal
analysis. A regression tests has been added a test for this (thanks to
Zerbina).