### PR TITLE
remove legacy condsyms

### DIFF
--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -20,56 +20,6 @@ proc initDefines*(symbols: StringTableRef) =
   # for bootstrapping purposes and old code:
   template defineSymbol(s) =
     symbols[s] = "true"
-  defineSymbol("nimhygiene") # deadcode
-  defineSymbol("niminheritable") # deadcode
-  defineSymbol("nimmixin") # deadcode
-  defineSymbol("nimeffects") # deadcode
-  defineSymbol("nimbabel") # deadcode
-  defineSymbol("nimcomputedgoto") # deadcode
-  defineSymbol("nimunion") # deadcode
-  defineSymbol("nimnewshared") # deadcode
-  defineSymbol("nimNewTypedesc") # deadcode
-  defineSymbol("nimrequiresnimframe") # deadcode
-  defineSymbol("nimparsebiggestfloatmagic") # deadcode
-  defineSymbol("nimalias") # deadcode
-  defineSymbol("nimlocks") # deadcode
-  defineSymbol("nimnode") # deadcode pending `nimnode` reference in opengl package
-    # refs https://github.com/nim-lang/opengl/pull/79
-  defineSymbol("nimvarargstyped") # deadcode
-  defineSymbol("nimtypedescfixed") # deadcode
-  defineSymbol("nimKnowsNimvm") # deadcode
-  defineSymbol("nimArrIdx") # deadcode
-  defineSymbol("nimHasalignOf") # deadcode
-  defineSymbol("nimDistros") # deadcode
-  defineSymbol("nimHasCppDefine") # deadcode
-  defineSymbol("nimGenericInOutFlags") # deadcode
-  when false: defineSymbol("nimHasOpt") # deadcode
-  defineSymbol("nimNoArrayToCstringConversion") # deadcode
-  defineSymbol("nimHasRunnableExamples") # deadcode
-  defineSymbol("nimNewDot") # deadcode
-  defineSymbol("nimHasNilChecks") # deadcode
-  defineSymbol("nimSymKind") # deadcode
-  defineSymbol("nimVmEqIdent") # deadcode
-  defineSymbol("nimNoNil") # deadcode
-  defineSymbol("nimNoZeroTerminator") # deadcode
-  defineSymbol("nimNotNil") # deadcode
-  defineSymbol("nimVmExportFixed") # deadcode
-  defineSymbol("nimHasSymOwnerInMacro") # deadcode
-  defineSymbol("nimNewRuntime") # deadcode
-  defineSymbol("nimIncrSeqV3") # xxx: turn this into deadcode
-  defineSymbol("nimAshr") # deadcode
-  defineSymbol("nimNoNilSeqs") # deadcode
-  defineSymbol("nimNoNilSeqs2") # deadcode
-  defineSymbol("nimHasUserErrors") # deadcode
-  defineSymbol("nimUncheckedArrayTyp") # deadcode
-  defineSymbol("nimHasTypeof") # deadcode
-  defineSymbol("nimErrorProcCanHaveBody") # deadcode
-  defineSymbol("nimHasInstantiationOfInMacro") # deadcode
-  defineSymbol("nimHasHotCodeReloading") # deadcode
-  defineSymbol("nimHasNilSeqs") # deadcode
-  defineSymbol("nimHasSignatureHashInMacro") # deadcode
-  defineSymbol("nimHasDefault") # deadcode
-  defineSymbol("nimMacrosSizealignof") # deadcode
 
   # > 0.20.0
   defineSymbol("nimNoZeroExtendMagic")
@@ -112,7 +62,6 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasSpellSuggest")
   defineSymbol("nimHasCustomLiterals")
   defineSymbol("nimHasUnifiedTuple")
-  defineSymbol("nimHasTypeofVoid")
   defineSymbol("nimHasDragonBox")
   defineSymbol("nimHasHintAll")
   defineSymbol("nimHasTrace")

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -256,10 +256,6 @@ proc reportException(c: TCtx; trace: VmRawStackTrace, raised: LocHandle) =
                     newStrNode(nkStrLit, msg))
   raiseVmError(VmEvent(kind: vmEvtUnhandledException, exc: ast, trace: trace))
 
-when not defined(nimComputedGoto):
-  {.pragma: computedGoto.}
-
-
 func cleanUpReg(r: var TFullReg, mm: var VmMemoryManager) =
   ## Cleans up and frees a location register's location. If `r` is not a
   ## location register, nothing is done.

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -547,35 +547,8 @@ proc growObj(old: pointer, newsize: int, gch: var GcHeap): pointer =
   gcTrace(res, csAllocated)
   track("growObj old", ol, 0)
   track("growObj new", res, newsize)
-  when defined(nimIncrSeqV3):
-    # since we steal the old seq's contents, we set the old length to 0.
-    cast[PGenericSeq](old).len = 0
-  elif reallyDealloc:
-    sysAssert(allocInv(gch.region), "growObj before dealloc")
-    if ol.refcount shr rcShift <=% 1:
-      # free immediately to save space:
-      if (ol.refcount and ZctFlag) != 0:
-        var j = gch.zct.len-1
-        var d = gch.zct.d
-        while j >= 0:
-          if d[j] == ol:
-            d[j] = res
-            break
-          dec(j)
-      beforeDealloc(gch, ol, "growObj stack trash")
-      decTypeSize(ol, ol.typ)
-      rawDealloc(gch.region, ol)
-    else:
-      # we split the old refcount in 2 parts. XXX This is still not entirely
-      # correct if the pointer that receives growObj's result is on the stack.
-      # A better fix would be to emit the location specific write barrier for
-      # 'growObj', but this is lots of more work and who knows what new problems
-      # this would create.
-      res.refcount = rcIncrement
-      decRef(ol)
-  else:
-    sysAssert(ol.typ != nil, "growObj: 5")
-    zeroMem(ol, sizeof(Cell))
+  # since we steal the old seq's contents, we set the old length to 0.
+  cast[PGenericSeq](old).len = 0
   when useCellIds:
     inc gch.idGenerator
     res.id = gch.idGenerator * 1000_000 + gch.gcThreadId

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -16,8 +16,6 @@
 #    -> defined(useNimRtl) or appType == "lib" and not defined(createNimRtl)
 # 3) Exported into nimrtl.
 #    -> appType == "lib" and defined(createNimRtl)
-when not defined(nimNewShared):
-  {.pragma: gcsafe.}
 
 when defined(createNimRtl):
   when defined(useNimRtl):

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -154,13 +154,9 @@ proc addChar(s: NimString, c: char): NimString =
     result = s
     if result.len >= result.space:
       let r = resize(result.space)
-      when defined(nimIncrSeqV3):
-        result = rawNewStringNoInit(r)
-        result.len = s.len
-        copyMem(addr result.data[0], unsafeAddr(s.data[0]), s.len+1)
-      else:
-        result = cast[NimString](growObj(result,
-          sizeof(TGenericSeq) + r + 1))
+      result = rawNewStringNoInit(r)
+      result.len = s.len
+      copyMem(addr result.data[0], unsafeAddr(s.data[0]), s.len+1)
       result.reserved = r
   result.data[result.len] = c
   result.data[result.len+1] = '\0'
@@ -204,12 +200,9 @@ proc resizeString(dest: NimString, addlen: int): NimString {.compilerRtl.} =
     result = dest
   else: # slow path:
     let sp = max(resize(dest.space), dest.len + addlen)
-    when defined(nimIncrSeqV3):
-      result = rawNewStringNoInit(sp)
-      result.len = dest.len
-      copyMem(addr result.data[0], unsafeAddr(dest.data[0]), dest.len+1)
-    else:
-      result = cast[NimString](growObj(dest, sizeof(TGenericSeq) + sp + 1))
+    result = rawNewStringNoInit(sp)
+    result.len = dest.len
+    copyMem(addr result.data[0], unsafeAddr(dest.data[0]), dest.len+1)
     result.reserved = sp
     #result = rawNewString(sp)
     #copyMem(result, dest, dest.len + sizeof(TGenericSeq))
@@ -233,14 +226,11 @@ proc setLengthStr(s: NimString, newLen: int): NimString {.compilerRtl.} =
     result = s
   else:
     let sp = max(resize(s.space), newLen)
-    when defined(nimIncrSeqV3):
-      result = rawNewStringNoInit(sp)
-      result.len = s.len
-      copyMem(addr result.data[0], unsafeAddr(s.data[0]), s.len+1)
-      zeroMem(addr result.data[s.len], newLen - s.len)
-      result.reserved = sp
-    else:
-      result = resizeString(s, n)
+    result = rawNewStringNoInit(sp)
+    result.len = s.len
+    copyMem(addr result.data[0], unsafeAddr(s.data[0]), s.len+1)
+    zeroMem(addr result.data[s.len], newLen - s.len)
+    result.reserved = sp
   result.len = n
   result.data[n] = '\0'
 
@@ -276,15 +266,11 @@ proc incrSeqV3(s: PGenericSeq, typ: PNimType): PGenericSeq {.compilerproc.} =
     result = s
     if result.len >= result.space:
       let r = resize(result.space)
-      when defined(nimIncrSeqV3):
-        result = cast[PGenericSeq](newSeq(typ, r))
-        result.len = s.len
-        copyMem(dataPointer(result, typ.base.align), dataPointer(s, typ.base.align), s.len * typ.base.size)
-        # since we steal the content from 's', it's crucial to set s's len to 0.
-        s.len = 0
-      else:
-        result = cast[PGenericSeq](growObj(result, align(GenericSeqSize, typ.base.align) + typ.base.size * r))
-        result.reserved = r
+      result = cast[PGenericSeq](newSeq(typ, r))
+      result.len = s.len
+      copyMem(dataPointer(result, typ.base.align), dataPointer(s, typ.base.align), s.len * typ.base.size)
+      # since we steal the content from 's', it's crucial to set s's len to 0.
+      s.len = 0
 
 proc setLengthSeq(seq: PGenericSeq, elemSize, elemAlign, newLen: int): PGenericSeq {.
     compilerRtl, inl.} =
@@ -325,39 +311,36 @@ proc setLengthSeq(seq: PGenericSeq, elemSize, elemAlign, newLen: int): PGenericS
 proc setLengthSeqV2(s: PGenericSeq, typ: PNimType, newLen: int): PGenericSeq {.
     compilerRtl.} =
   sysAssert typ.kind == tySequence, "setLengthSeqV2: type is not a seq"
-  if s == nil:
+  if s.isNil:
     result = cast[PGenericSeq](newSeq(typ, newLen))
   else:
-    when defined(nimIncrSeqV3):
-      let elemSize = typ.base.size
-      let elemAlign = typ.base.align
-      if s.space < newLen:
-        let r = max(resize(s.space), newLen)
-        result = cast[PGenericSeq](newSeq(typ, r))
-        copyMem(dataPointer(result, elemAlign), dataPointer(s, elemAlign), s.len * elemSize)
-        # since we steal the content from 's', it's crucial to set s's len to 0.
-        s.len = 0
-      elif newLen < s.len:
-        result = s
-        # we need to decref here, otherwise the GC leaks!
-        when not defined(boehmGC) and not defined(nogc) and
-            not defined(gcMarkAndSweep) and not defined(gogc) and
-            not defined(gcRegions):
-          if ntfNoRefs notin typ.base.flags:
-            for i in newLen..result.len-1:
-              forAllChildrenAux(dataPointer(result, elemAlign, elemSize, i),
-                                extGetCellType(result).base, waZctDecRef)
+    let elemSize = typ.base.size
+    let elemAlign = typ.base.align
+    if s.space < newLen:
+      let r = max(resize(s.space), newLen)
+      result = cast[PGenericSeq](newSeq(typ, r))
+      copyMem(dataPointer(result, elemAlign), dataPointer(s, elemAlign), s.len * elemSize)
+      # since we steal the content from 's', it's crucial to set s's len to 0.
+      s.len = 0
+    elif newLen < s.len:
+      result = s
+      # we need to decref here, otherwise the GC leaks!
+      when not defined(boehmGC) and not defined(nogc) and
+          not defined(gcMarkAndSweep) and not defined(gogc) and
+          not defined(gcRegions):
+        if ntfNoRefs notin typ.base.flags:
+          for i in newLen..result.len-1:
+            forAllChildrenAux(dataPointer(result, elemAlign, elemSize, i),
+                              extGetCellType(result).base, waZctDecRef)
 
-        # XXX: zeroing out the memory can still result in crashes if a wiped-out
-        # cell is aliased by another pointer (ie proc parameter or a let variable).
-        # This is a tough problem, because even if we don't zeroMem here, in the
-        # presence of user defined destructors, the user will expect the cell to be
-        # "destroyed" thus creating the same problem. We can destroy the cell in the
-        # finalizer of the sequence, but this makes destruction non-deterministic.
-        zeroMem(dataPointer(result, elemAlign, elemSize, newLen), (result.len-%newLen) *% elemSize)
-      else:
-        result = s
-        zeroMem(dataPointer(result, elemAlign, elemSize, result.len), (newLen-%result.len) *% elemSize)
-      result.len = newLen
+      # XXX: zeroing out the memory can still result in crashes if a wiped-out
+      # cell is aliased by another pointer (ie proc parameter or a let variable).
+      # This is a tough problem, because even if we don't zeroMem here, in the
+      # presence of user defined destructors, the user will expect the cell to be
+      # "destroyed" thus creating the same problem. We can destroy the cell in the
+      # finalizer of the sequence, but this makes destruction non-deterministic.
+      zeroMem(dataPointer(result, elemAlign, elemSize, newLen), (result.len-%newLen) *% elemSize)
     else:
-      result = setLengthSeq(s, typ.base.size, newLen)
+      result = s
+      zeroMem(dataPointer(result, elemAlign, elemSize, result.len), (newLen-%result.len) *% elemSize)
+    result.len = newLen


### PR DESCRIPTION
## Summary

This change removes a number of the old defines that were used for
compiler and/or standard library change detection.

## Details

There were a number of haphazardly named defines for a half-baked system
to detect if certain changes were made to the compiler or standard
library. The approach wasn't good, the design leads to lots of action at
a distance, and just more stuff to otherwise puzzle over.

This removes the very "early" conditional syms, there are still newer
ones to get rid of.