### PR TITLE
chore: remove compiler build warning

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -16,7 +16,8 @@ import
 import compiler/front/in_options
 export in_options
 
-from compiler/utils/strutils2 import toLowerAscii
+when not FileSystemCaseSensitive:
+  from compiler/utils/strutils2 import toLowerAscii
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
 from std/private/globs import nativeToUnixPath
@@ -1200,7 +1201,7 @@ proc canonicalCase(path: var string) =
   ## the idea is to only use this for checking whether a path is already in
   ## the table but otherwise keep the original case
   when FileSystemCaseSensitive: discard
-  else: toLowerAscii(path)
+  else: path = toLowerAscii(path)
 
 proc fileInfoKnown*(conf: ConfigRef; filename: AbsoluteFile): bool =
   var

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1201,7 +1201,7 @@ proc canonicalCase(path: var string) =
   ## the idea is to only use this for checking whether a path is already in
   ## the table but otherwise keep the original case
   when FileSystemCaseSensitive: discard
-  else: path = toLowerAscii(path)
+  else: toLowerAscii(path)
 
 proc fileInfoKnown*(conf: ConfigRef; filename: AbsoluteFile): bool =
   var


### PR DESCRIPTION
## Summary

Remove trivial compiler build warning, longer term fix would be to
remove the overwrought path handling.

## Details

Guard the `strutils2` (a collection of bad ideas) import behind a
conditional as it's only used for case insensitive file systems for path
handling.