### PR TITLE
ast strictly define nodes with and without sons

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -475,10 +475,9 @@ template copyNodeImpl(dst, src, processSonsStmt) =
   of nkSym: dst.sym = src.sym
   of nkIdent: dst.ident = src.ident
   of nkStrLit..nkTripleStrLit: dst.strVal = src.strVal
-  of nkEmpty, nkNone: discard # no children, nothing to do
-  of nkError:
-    dst.diag = src.diag       # do cheap copies
-  else: processSonsStmt
+  of nkEmpty, nkNone, nkNilLit, nkType: discard "no children"
+  of nkError: dst.diag = src.diag # do cheap copies
+  of nkWithSons: processSonsStmt
 
 proc copyNode*(src: PNode): PNode =
   # does not copy its sons!

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -195,8 +195,9 @@ proc isCallExpr*(n: PNode): bool =
 
 proc safeLen*(n: PNode): int {.inline.} =
   ## works even for leaves.
-  if n.kind in {nkNone..nkNilLit}: result = 0
-  else: result = n.len
+  case n.kind
+  of nkWithoutSons: 0
+  of nkWithSons:    n.len
 
 proc getDeclPragma*(n: PNode): PNode =
   ## return the `nkPragma` node for declaration `n`, or `nil` if no pragma was found.

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -249,6 +249,18 @@ type
   TNodeKinds* = set[TNodeKind]
 
 const
+  nkWithoutSons* =
+    {nkEmpty, nkNone} +
+    {nkIdent, nkSym} +
+    {nkType} +
+    {nkCharLit..nkUInt64Lit} +
+    {nkFloatLit..nkFloat128Lit} +
+    {nkStrLit..nkTripleStrLit} +
+    {nkNilLit} +
+    {nkError}
+
+  nkWithSons* = {low(TNodeKind) .. high(TNodeKind)} - nkWithoutSons
+
   nodeKindsProducedByParse* = {
     nkError, nkEmpty,
     nkIdent,
@@ -1526,11 +1538,11 @@ type
       sym*: PSym
     of nkIdent:
       ident*: PIdent
-    of nkEmpty, nkNone:
+    of nkEmpty, nkNone, nkType, nkNilLit:
       discard
     of nkError:
       diag*: PAstDiag
-    else:
+    of nkWithSons:
       sons*: TNodeSeq
 
   TStrTable* = object         ## a table[PIdent] of PSym
@@ -1755,18 +1767,6 @@ type
 
   TImplication* = enum
     impUnknown, impNo, impYes
-
-const
-  nkWithoutSons* =
-    {nkCharLit..nkUInt64Lit} +
-    {nkFloatLit..nkFloat128Lit} +
-    {nkStrLit..nkTripleStrLit} +
-    {nkSym} +
-    {nkIdent} +
-    {nkError} +
-    {nkEmpty, nkNone}
-
-  nkWithSons* = {low(TNodeKind) .. high(TNodeKind)} - nkWithoutSons
 
 type
   EffectsCompat* = enum

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -3034,7 +3034,7 @@ proc getNullValueAux(p: BProc; t: PType; obj, constOrNil: PNode,
     var branch = Zero
     if constOrNil != nil:
       ## find kind value, default is zero if not specified
-      for i in 1..<constOrNil.len:
+      for i in 1..<constOrNil.safeLen:
         if constOrNil[i].kind == nkExprColonExpr:
           if constOrNil[i][0].sym.name.id == obj[0].sym.name.id:
             branch = getOrdValue(constOrNil[i][1])
@@ -3057,13 +3057,12 @@ proc getNullValueAux(p: BProc; t: PType; obj, constOrNil: PNode,
       result.add "." & mangleRecFieldName(p.module, b.sym) & " = "
       getNullValueAux(p, t,  b, constOrNil, result, countB, isConst, info)
     result.add "}"
-
   of nkSym:
     if count > 0: result.add ", "
     inc count
     let field = obj.sym
     if constOrNil != nil:
-      for i in 1..<constOrNil.len:
+      for i in 1..<constOrNil.safeLen:
         if constOrNil[i].kind == nkExprColonExpr:
           if constOrNil[i][0].sym.name.id == field.name.id:
             result.add genBracedInit(p, constOrNil[i][1], isConst, field.typ)

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -103,7 +103,6 @@ proc sexp*(e: StackTraceEntry): SexpNode =
   result.add newSKeyword(
     "filename", writeConf.formatPath($e.filename).sexp())
 
-
 proc sexp*(typ: PType): SexpNode =
   if typ.isNil: return newSNil()
   result = newSList()
@@ -116,17 +115,18 @@ proc sexp*(node: PNode): SexpNode =
 
   result = newSList()
   result.add newSSymbol(($node.kind)[2 ..^ 1])
-  case node.kind:
-    of nkNone, nkEmpty:           discard
-    of nkCharLit..nkUInt64Lit:    result.add sexp(node.intVal)
-    of nkFloatLit..nkFloat128Lit: result.add sexp(node.floatVal)
-    of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)
-    of nkSym:                     result.add newSSymbol(node.sym.name.s)
-    of nkIdent:                   result.add newSSymbol(node.ident.s)
-    of nkError:                   result.add sexp(node.diag.wrongNode)
-    of nkWithSons:
-      for node in node.sons:
-        result.add sexp(node)
+  case node.kind
+  of nkNone, nkEmpty, nkType:   discard
+  of nkCharLit..nkUInt64Lit:    result.add sexp(node.intVal)
+  of nkFloatLit..nkFloat128Lit: result.add sexp(node.floatVal)
+  of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)
+  of nkSym:                     result.add newSSymbol(node.sym.name.s)
+  of nkIdent:                   result.add newSSymbol(node.ident.s)
+  of nkError:                   result.add sexp(node.diag.wrongNode)
+  of nkNilLit:                  result.add newSNil()
+  of nkWithSons:
+    for node in node.sons:
+      result.add sexp(node)
 
 proc sexp*(t: PSym): SexpNode =
   convertSexp([

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -235,7 +235,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     let a = n.sym
     let b = getGenSym(c, a)
     if b != a: n.sym = b
-  of nkEmpty, succ(nkSym)..nkNilLit:
+  of nkEmpty, succ(nkSym)..nkNilLit, nkCommentStmt:
     # see tests/compile/tgensymgeneric.nim:
     # We need to open the gensym'ed symbol again so that the instantiation
     # creates a fresh copy; but this is wrong the very first reason for gensym

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1595,7 +1595,7 @@ proc detectCapture(owner, top: PSym, n: PNode, marker: var IntSet): PNode =
           result = detect(s)
     else:
       discard "not relevant"
-  of nkWithoutSons - {nkSym}:
+  of nkWithoutSons - {nkSym, nkCommentStmt}:
     discard "not relevant"
   of nkConv, nkHiddenStdConv, nkHiddenSubConv:
     # only analyse the imperative part:
@@ -1605,6 +1605,7 @@ proc detectCapture(owner, top: PSym, n: PNode, marker: var IntSet): PNode =
   of nkNimNodeLit:
     discard "ignore node literals as they're data not code"
   else:
+    # TODO: make exhaustive
     for it in n.items:
       result = detectCapture(owner, top, it, marker)
       if result != nil:

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1284,7 +1284,7 @@ proc extractGlobals*(body: PNode, output: var seq[PNode], isNimVm: bool) =
      nkStaticStmt, nkMixinStmt, nkBindStmt, nkLambdaKinds, routineDefs,
      nkNimNodeLit:
     discard "ignore declarative contexts"
-  of nkWithoutSons:
+  of nkWithoutSons - nkCommentStmt:
     discard "not relevant"
   of nkConv, nkHiddenStdConv, nkHiddenSubConv:
     # only analyse the imperative part:

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -599,7 +599,7 @@ func storeNode(enc: var TypeInfoEncoder, ps: var PackedEnv, n: PNode): NodeId =
   var hasSons = false
   let item =
     case n.kind
-    of nkEmpty: 0'i32 # zero children
+    of nkEmpty, nkType, nkNilLit: 0'i32 # zero children
     of nkIdent: ps.getLitId(n.ident.s).int32
     of nkSym:   enc.storeSymLater(ps, n.sym).int32
     of nkIntKinds:   ps.getLitId(n.intVal).int32
@@ -672,7 +672,7 @@ proc loadNode(dec: var TypeInfoDecoder, ps: PackedEnv, id: NodeId): (PNode, int3
                 typ: loadType(dec, ps, n.typeId))
 
   case n.kind
-  of nkEmpty:
+  of nkEmpty, nkType, nkNilLit:
     discard "do nothing"
   of nkCharLit..nkUInt64Lit:
     r.intVal = ps.numbers[n.operand.LitId]

--- a/lib/system/setops.nim
+++ b/lib/system/setops.nim
@@ -64,6 +64,21 @@ func `-`*[T](x, y: set[T]): set[T] {.magic: "MinusSet".} =
   runnableExamples:
     assert {1, 2, 3} - {2, 3, 4} == {1}
 
+func `+`*[T](x: set[T], y: T): set[T] {.inline.} =
+  ## This operator computes the union of two sets, where the second set operand
+  ## is derived by promoting a single element to a set containing that element.
+  runnableExamples:
+    assert {1, 2, 3} + 4 == {1, 2, 3, 4}
+  x + {y}
+
+func `-`*[T](x: set[T], y: T): set[T] {.inline.} =
+  ## This operator computes the difference of two sets, where the second set
+  ## operand is derived by promoting a single element to a set containing that
+  ## element.
+  runnableExamples:
+    assert {1, 2} - 2 == {1}
+  x - {y}
+
 func contains*[T](x: set[T], y: T): bool {.magic: "InSet".} =
   ## One should overload this proc if one wants to overload the `in` operator.
   ##


### PR DESCRIPTION
## Summary

Strictly define which AST node kinds have `sons` and which don't, then
update the compiler as required.

## Details

Update the definition of `nkWithSons` and `nkWithoutSons`, use
`nkWithSons` in the `TNode` variant to ensure this is strictly followed.
Update various compiler code as necessary.

The added benefit of this is that a number `case`s are now now
exhaustive and will surface bugs more quickly. This should also make it
easier to introduce more variants down the line.