### PR TITLE
sem: refactor `newSymGNode` replaces `newSymG`

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -468,7 +468,7 @@ proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
     else:
       unreachable("only produces `nkSym` or `nkError`")
 
-proc newSymG*(kind: TSymKind, n: PNode, c: PContext): PSym =
+proc newSymG*(kind: TSymKind, n: PNode, c: PContext): PSym {.deprecated: "replace with newSymGNode".} =
   # like newSymS, but considers gensym'ed symbols
   case n.kind
   of nkSym:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -368,9 +368,9 @@ func getDefNameSymOrRecover*(n: PNode): PSym {.inline.} =
   of nkError:
     case n.diag.kind
     of adSemDefNameSym: n.diag.defNameSym
-    else: unreachable("all error cases must be covered")
+    else: unreachable("all error cases must be covered, got: " & $n.diag.kind)
   else:
-    unreachable("no other cases supported")
+    unreachable("no other cases supported, got: " & $n.kind)
 
 proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
   ## like newSymS, but considers gensym'ed symbols, analyses `n` producing a

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3208,14 +3208,14 @@ proc semBlock(c: PContext, n: PNode; flags: TExprFlags): PNode =
         of nkEmpty, nkError:
           givenLabl
         of nkIdent, nkSym, nkAccQuoted:
-          let labl = newSymG(skLabel, givenLabl, c)
-          
+          let
+            lablNode = newSymGNode(skLabel, givenLabl, c)
+            labl = getDefNameSymOrRecover(lablNode)
+
           if sfGenSym notin labl.flags:
             addDecl(c, labl)
           elif labl.owner == nil:
             labl.owner = c.p.owner
-          
-          let lablNode = newSymNode2(labl, givenLabl.info)
 
           suggestSym(c.graph, lablNode.info, labl, c.graph.usageSym)
           styleCheckDef(c.config, labl)
@@ -3227,9 +3227,8 @@ proc semBlock(c: PContext, n: PNode; flags: TExprFlags): PNode =
       bodyRes = semExpr(c, n[1], flags)
 
     result = copyNode(n)
-    result.flags = n.flags # xxx: we should be able to perserve flags, this
-                           #      code didn't used to do a copyNode, it changed
-                           #      `n` directly
+    result.flags = n.flags # xxx: this code used to change `n` directly, do we
+                           #      we need to preserve the flags?
     result.add lablRes
     result.add bodyRes
     result.typ = bodyRes.typ

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1332,9 +1332,8 @@ proc isMagic(sym: PSym): bool =
 proc semProcTypeNode(c: PContext, n, genericParams: PNode,
                      prev: PType, kind: TSymKind; isType=false): PType =
   # TODO: replace with a node return variant that can in band errors
-  # for historical reasons (code grows) this is invoked for parameter
-  # lists too and then 'isType' is false.
-  # xxx: ^^^ this is obviously a bad idea
+  # for historical "reasons" (excuses) this is invoked for parameter lists too
+  # and then 'isType' is false; this is of course all terrible design
   checkMinSonsLen(n, 1, c.config)
   result = newProcType(c, n.info, prev)
   var check = initIntSet()

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -575,8 +575,7 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
       c.config.semReportIllformedAst(
         n, "Expected two nodes for postfix expression, but found " & $n.len)
   else:
-    let identNode = newSymGNode(kind, n, c)
-    result = getDefNameSymOrRecover(identNode)
+    result = getDefNameSymOrRecover(newSymGNode(kind, n, c))
 
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym =


### PR DESCRIPTION
## Summary

Internal refactor replacing `sem.newSymG` with `newSymGNode`, no change
in actual behaviour

## Details

This replaces the `newSymG`, which produced a symbol and effected
errors. `newSymGNode` will return an `nkSym` node on succees and
`nkError` if it failed. The `getDefNameSymOrRecover` proc can be used in
conjunction in order to ensure progress can be made in the presence of
errors.

All call sites updated in such a fashion are now more ready to be
converted to a more `nkError` aware style.