### PR TITLE
cgendata: remove unused fields

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -157,7 +157,7 @@ proc blockLeaveActions(p: BProc, howManyTrys, howManyExcepts: int) =
 
   # Pop exceptions that was handled by the
   # except-blocks we are in
-  if noSafePoints notin p.flags:
+  block:
     for i in countdown(howManyExcepts-1, 0):
       linefmt(p, cpsStmts, "#popCurrentException();$n", [])
 
@@ -320,11 +320,6 @@ proc genReturnStmt(p: BProc, t: PNode) =
   blockLeaveActions(p,
     howManyTrys    = p.nestedTryStmts.len,
     howManyExcepts = p.inExceptBlockLen)
-  if (p.finallySafePoints.len > 0) and noSafePoints notin p.flags:
-    # If we're in a finally block, and we came here by exception
-    # consume it before we return.
-    var safePoint = p.finallySafePoints[^1]
-    linefmt(p, cpsStmts, "if ($1.status != 0) #popCurrentException();$n", [safePoint])
   lineF(p, cpsStmts, "goto BeforeRet_;$n", [])
 
 proc genGotoForCase(p: BProc; caseStmt: PNode) =

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -87,7 +87,6 @@ type
     beforeRetNeeded,
     threadVarAccessed,
     hasCurFramePointer,
-    noSafePoints,
     nimErrorFlagAccessed,
     nimErrorFlagDeclared,
     nimErrorFlagDisabled
@@ -101,8 +100,6 @@ type
                               ## in how many nested try statements we are
                               ## (the vars must be volatile then)
                               ## bool is true when are in the except part of a try block
-    finallySafePoints*: seq[Rope]  ## For correctly cleaning up exceptions when
-                                   ## using return in finally statements
     labels*: Natural          ## for generating unique labels in the C proc
     blocks*: seq[TBlock]      ## nested blocks
     breakIdx*: int            ## the block that will be exited
@@ -142,7 +139,6 @@ type
     typeInfoMarkerV2*: TypeCacheWithOwner
     config*: ConfigRef
     graph*: ModuleGraph
-    strVersion*, seqVersion*: int ## version of the string/seq implementation to use
 
     nimtv*: Rope            ## Nim thread vars; the struct body
     nimtvDeps*: seq[PType]  ## type deps: every module needs whole struct
@@ -211,7 +207,6 @@ proc newProc*(prc: PSym, module: BModule): BProc =
                    else: module.config.options
   newSeq(result.blocks, 1)
   result.nestedTryStmts = @[]
-  result.finallySafePoints = @[]
   result.sigConflicts = initCountTable[string]()
 
 proc newModuleList*(g: ModuleGraph): BModuleList =


### PR DESCRIPTION
## Summary

* remove the `TCProc.finallySafePoints` field
* remove the `TCProcFlag.noSafePoints` enum field
* remove the `strVersion` and `seqVersion` fields from `BModuleList`
* remove stale usages of the removed fields