### PR TITLE
injectdestructors: keep the relative order of definitions

### DIFF
--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -62,8 +62,8 @@ result.value = move(lvalue)
 var
   :tmp
   :tmp_1
-var :tmp_2
 var a
+var :tmp_2
 try:
   var it_cursor = x
   a = (

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -40,9 +40,9 @@ finally:
 -- end of expandArc ------------------------
 --expandArc: main2
 
+var s
 var data
 var :tmp
-var s
 try:
   s = newSeq(100)
   var :tmp_1 = encode(s)


### PR DESCRIPTION
## Summary

Sort the list of all entities requiring destruction *before* moving
their definitions. This ensures that relative order of the *moved*
definitions is kept intact.

The relative order changing had no effect on program semantics at this
time, but might cause issues in the future. It was also observable via
`--expandArc`, which led to spurious test failures when the IDs assigned
to symbols changed as part of an otherwise unrelated change.

## Details

The order of the items in the list of all entities requiring destruction
is dependent on the order in which the `Table.pairs` iterator yields the
pairs, meaning that changes to the hash function or symbol IDs (which
are used as the key) led to changes in the order that definition
statement for locals had after the `injectdestructors` pass.

Sorting the list prior to iterating over it for the purpose of moving
definitions ensures that the moved definitions' relative order is kept
intact.