### PR TITLE
parser: remove unused `pnkImportAs` node kind

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -732,7 +732,6 @@ func toTNodeKind*(kind: ParsedNodeKind): TNodeKind {.inline.} =
   of pnkStmtListExpr: nkStmtListExpr
   of pnkImportStmt: nkImportStmt
   of pnkImportExceptStmt: nkImportExceptStmt
-  of pnkImportAs: nkImportAs
   of pnkFromStmt: nkFromStmt
   of pnkIncludeStmt: nkIncludeStmt
   of pnkExportStmt: nkExportStmt

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -170,7 +170,6 @@ type
     pnkStmtListExpr
     pnkImportStmt
     pnkImportExceptStmt
-    pnkImportAs
     pnkFromStmt
     pnkIncludeStmt
     pnkExportStmt

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -311,7 +311,7 @@ const
 
     nkStmtList, nkStmtListExpr,
 
-    nkImportStmt, nkImportExceptStmt, nkImportAs, nkFromStmt,
+    nkImportStmt, nkImportExceptStmt, nkFromStmt,
 
     nkIncludeStmt,
 

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -46,7 +46,8 @@ import
   ],
   compiler/utils/[
     pathutils,
-    astrepr
+    astrepr,
+    idioms,
   ]
 
 type
@@ -1461,7 +1462,12 @@ proc parseImport(p: var Parser, kind: ParsedNodeKind): ParsedNode =
   result.add parseExpr(p)
   if p.tok.tokType in {tkComma, tkExcept}:
     if p.tok.tokType == tkExcept:
-      result.transitionSonsKind(succ(kind))
+      let exceptKind =
+        case kind
+        of pnkImportStmt: pnkImportExceptStmt
+        of pnkExportStmt: pnkExportExceptStmt
+        else: unreachable()
+      result.transitionSonsKind(exceptKind)
     p.getTok
     p.optInd(result)
     while true:


### PR DESCRIPTION
## Summary

This node kind is not produced by the parser and is handled entirely in
sem, as such it was removed. No functional change.

## Details

Removed the kind and appropriately updated conversion parsed to ast node
conversion routines to account for this.

This error was potentially introduced because not all parser node kinds
are explicitly mentioned in the `parser` module. The import and export
kinds in particular used `succ` to compute the except conditions. This 
requires the human to "play computer" and result in mistakes such as
these. The code now explicitly maps types without relying on implicit
ordering.