### PR TITLE
linter: remove `usages` option

### DIFF
--- a/compiler/ast/linter.nim
+++ b/compiler/ast/linter.nim
@@ -207,8 +207,7 @@ proc checkDefImpl(conf: ConfigRef; info: TLineInfo; s: PSym; k: TSymKind) =
       linterFail: (wanted, s.name.s)))
 
 template styleCheckDef*(conf: ConfigRef; info: TLineInfo; s: PSym; k: TSymKind) =
-  if {optStyleHint, optStyleError} * conf.globalOptions != {} and
-      optStyleUsages notin conf.globalOptions:
+  if {optStyleHint, optStyleError} * conf.globalOptions != {}:
     checkDefImpl(conf, info, s, k)
 
 template styleCheckDef*(conf: ConfigRef; info: TLineInfo; s: PSym) =

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -25,8 +25,6 @@ type
     optUseNimcache            ## save artifacts (including binary) in $nimcache
     optStyleHint              ## check that the names adhere to the style guide
     optStyleError             ## enforce that the names adhere to the style guide
-    optStyleUsages            ## only enforce consistent **usages** of the
-                              ## symbol
     optSkipSystemConfigFile   ## skip the system's cfg/nims config file
     optSkipProjConfigFile     ## skip the project's cfg/nims config file
     optSkipUserConfigFile     ## skip the users's cfg/nims config file

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -675,12 +675,9 @@ func isEnabled*(conf: ConfigRef, report: ReportKind): bool =
     strictNotNil in conf.features
   of rdbgVmExecTraceMinimal:
     conf.active.isVmTrace
-  of rlexLinterReport, rsemLinterReport:
+  of rlexLinterReport, rsemLinterReport, rsemLinterReportUse:
     # Regular linter report is enabled if style check is either hint or
     # error, AND not `usages`
-    {optStyleHint, optStyleError} * conf.globalOptions != {} and
-    optStyleUsages notin conf.globalOptions
-  of rsemLinterReportUse:
     {optStyleHint, optStyleError} * conf.globalOptions != {}
   else:
     case report

--- a/compiler/front/optionsprocessor.nim
+++ b/compiler/front/optionsprocessor.nim
@@ -622,7 +622,7 @@ func allowedCompileOptionsArgs*(switch: CmdSwitchKind): seq[string] =
   of cmdSwitchProcessing  : @["dots", "filenames", "off"]
   of cmdSwitchExperimental: experimentalFeatures.toSeq.mapIt($it)
   of cmdSwitchExceptions  : @["native", "goto"]
-  of cmdSwitchStylecheck  : @["off", "hint", "error", "usages"]
+  of cmdSwitchStylecheck  : @["off", "hint", "error"]
   else: unreachable("this is a compiler bug")
 
 func allowedCompileOptionArgs*(switch: string): seq[string] =
@@ -1214,7 +1214,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass,
     of "on", "native", "gdb":
       conf.incl optCDebug
       conf.incl optLineDir
-      #defineSymbol(conf.symbols, "nimTypeNames") # type names are used in gdb pretty printing
     of "off":
       conf.excl optCDebug
     else:
@@ -1584,11 +1583,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass,
       conf.globalOptions = conf.globalOptions + {optStyleHint} - {optStyleError}
     of "error":
       conf.globalOptions = conf.globalOptions + {optStyleError}
-    of "usages":
-      # xxx: this option doesn't make any sense, what should happen:
-      #      - check style for project code not dependencies
-      #      - that's about it
-      conf.incl optStyleUsages
     else:
       invalidArgValue(arg, switch)
   of "showallmismatches":

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -58,8 +58,6 @@ Advanced options:
   --styleCheck:off|hint|error
                             produce hints or errors for identifiers that do not
                             adhere to the style guide
-  --styleCheck:usages       only enforce consistent spellings of identifiers,
-                            do not enforce the style on declarations
   --showAllMismatches:on|off
                             show all mismatching candidates in overloading
                             resolution

--- a/tests/stylecheck/tusages.nim
+++ b/tests/stylecheck/tusages.nim
@@ -1,7 +1,7 @@
 discard """
   action: reject
   nimout: '''tusages.nim(22, 5) Error: 'BAD_STYLE' should be: 'BADSTYLE' [proc declared in tusages.nim(11, 6)] [Name]'''
-  matrix: "--styleCheck:error --styleCheck:usages"
+  matrix: "--styleCheck:error"
 """
 
 


### PR DESCRIPTION
This is a misfeature, it should be based on whether the code is or isn't
under ones control (project).

Removed the `usages` arg from the `stylecheck` option and associated
implementation.