### PR TITLE
jsgen: fix destructors for globals not being run

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2710,11 +2710,13 @@ proc wholeCode(graph: ModuleGraph; m: BModule): Rope =
   result = globals.typeInfo & globals.constants & globals.code
 
 proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
-  result = myProcess(b, n)
   var m = BModule(b)
   if sfMainModule in m.module.flags:
     for destructorCall in graph.globalDestructors:
       n.add destructorCall
+
+  result = myProcess(b, n)
+
   if sfSystemModule in m.module.flags:
     PGlobals(graph.backend).inSystem = false
   if passes.skipCodegen(m.config, n): return n

--- a/tests/lang_objects/destructor/tglobaldestructor.nim
+++ b/tests/lang_objects/destructor/tglobaldestructor.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: '''nim c --gc:arc $file'''
+  targets: "c js !vm"
   output: '''(v: 42)
 igotdestroyed'''
 """


### PR DESCRIPTION
## Summary

The code for calling the destructors was set up, but never passed to
code generation. It now is, meaning that destructors are now called for
globals when using the JavaScript backend.