### PR TITLE
vmbackend: basic support for lifetime hooks

### DIFF
--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -149,7 +149,7 @@ func collectRoutineSyms(ast: PNode, syms: var seq[PSym]) =
 
 proc genStmt(c: var TCtx, n: PNode): auto =
   ## Wrapper around ``vmgen.genStmt`` that canonicalizes the input AST first
-  let n = canonicalizeSingle(c.graph, c.idgen, c.module, n, {goIsNimvm})
+  let n = canonicalizeWithInject(c.graph, c.idgen, c.module, n, {goIsNimvm})
   c.gatherDependencies(n, withGlobals=true)
   vmgen.genStmt(c, n)
 
@@ -185,7 +185,7 @@ proc generateCodeForProc(c: var TCtx, s: PSym,
   ## to `globals`.
   var body = transformBody(c.graph, c.idgen, s, cache = false)
   extractGlobals(body, globals, isNimVm = true)
-  body = canonicalize(c.graph, c.idgen, s, body, {goIsNimvm})
+  body = canonicalizeWithInject(c.graph, c.idgen, s, body, {goIsNimvm})
   c.gatherDependencies(body, withGlobals=true)
   result = genProc(c, s, body)
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1894,7 +1894,7 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
     c.freeTemp(tmp1)
     c.freeTemp(tmp2)
     c.freeTemp(tmp3)
-  of mReset:
+  of mReset, mWasMoved:
     unused(c, n, dest)
     let
       (dest, isDirect) = genNoLoad(c, n[1])

--- a/tests/lang_objects/destructor/tdestructor_before_init_requireinit.nim
+++ b/tests/lang_objects/destructor/tdestructor_before_init_requireinit.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--gc:arc"
+  targets: "c js vm"
   description: '''
   . From https://github.com/nim-lang/Nim/issues/16607
     Constructing a named tuple of a requiresInit type causes destructions

--- a/tests/lang_objects/destructor/tdestructor_manual_invocation.nim
+++ b/tests/lang_objects/destructor/tdestructor_manual_invocation.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--gc:arc"
+  targets: "c js vm"
   description: '''
   . From https://github.com/nim-lang/Nim/issues/5342
     Enable manual destructor invocation for implicitly generated destructors

--- a/tests/lang_objects/destructor/tduplicate_local.nim
+++ b/tests/lang_objects/destructor/tduplicate_local.nim
@@ -1,12 +1,10 @@
 discard """
-  targets: "c js !vm"
+  targets: "c js vm"
   description: '''
     A regression test to make sure that redefined locals don't reach (or at
     least cause issues with) the mid- and back-end
   '''
 """
-
-# knownIssue: the ``injectdestructors`` pass is disabled for the VM target
 
 # bug https://github.com/nim-lang/nim/issues/13622
 

--- a/tests/lang_objects/destructor/teval_order.nim
+++ b/tests/lang_objects/destructor/teval_order.nim
@@ -3,11 +3,9 @@ discard """
     Tests to make sure that the left-to-right evaluation order is respected for
     assignments involving types with destructors
   '''
-  target: "c js !vm"
+  target: "c js vm"
   matrix: "--cursorInference:off"
 """
-
-## knownIssue: no destructor injection is performed for the VM target
 
 import mhelper
 

--- a/tests/lang_objects/destructor/tglobaldestructor.nim
+++ b/tests/lang_objects/destructor/tglobaldestructor.nim
@@ -4,6 +4,9 @@ discard """
 igotdestroyed'''
 """
 
+# knownIssue: destructors for top-level globals are not yet supported by the
+#             VM backend
+
 import objFile
 
 echo test

--- a/tests/lang_objects/destructor/tglobals.nim
+++ b/tests/lang_objects/destructor/tglobals.nim
@@ -1,6 +1,6 @@
 discard """
   description: "Tests for globals that have lifetime hooks attached"
-  targets: "c js !vm"
+  targets: "c js vm"
   matrix: "--cursorInference:off"
 """
 

--- a/tests/lang_objects/destructor/tlate_use.nim
+++ b/tests/lang_objects/destructor/tlate_use.nim
@@ -4,8 +4,8 @@ discard """
     control-flow reaches the call, not when it reaches the argument expression
   '''
   action: reject
-  cmd: "nim $target --filenames=canonical --msgFormat=sexp $options $file"
-  targets: "c js !vm"
+  matrix: "--filenames=canonical --msgFormat=sexp"
+  targets: "c js vm"
   nimoutFormat: sexp
 """
 

--- a/tests/lang_objects/destructor/tself_assign.nim
+++ b/tests/lang_objects/destructor/tself_assign.nim
@@ -1,6 +1,6 @@
 discard """
   description: "Tests for self assignments of types with lifetime hooks"
-  targets: "c js !vm"
+  targets: "c js vm"
   matrix: "--cursorInference:off"
 """
 

--- a/tests/lang_objects/destructor/ttuple_unpacking.nim
+++ b/tests/lang_objects/destructor/ttuple_unpacking.nim
@@ -2,7 +2,7 @@ discard """
   description: '''
     Tests for tuple unpacking in the presence of types with lifetime hooks
   '''
-  targets: "c js !vm"
+  targets: "c js vm"
   matrix: "--cursorInference:off"
 """
 

--- a/tests/lang_objects/destructor/tuse_result_prevents_sinks.nim
+++ b/tests/lang_objects/destructor/tuse_result_prevents_sinks.nim
@@ -1,6 +1,6 @@
 discard """
   output: ""
-  targets: "c"
+  targets: "c js vm"
 """
 
 # bug #9594

--- a/tests/lang_stmts/for_stmt/tforloop_tuple_unpacking.nim
+++ b/tests/lang_stmts/for_stmt/tforloop_tuple_unpacking.nim
@@ -1,11 +1,9 @@
 discard """
   description: "Tests for tuple unpacking done by for-loops"
-  targets: "c !js !vm"
+  targets: "c !js vm"
 """
 
 # knownIssue: fails for the JS back-end with an internal compiler error
-# knownIssue: fails for the VM back-end because `=copy` hooks are not
-#             supported there
 
 type
   Tup = tuple


### PR DESCRIPTION
## Summary

Enable the `injectdestructors` pass for the VM backend, which is the
first step towards full lifetime hook support there. They currently have
the same limitations as they do with the JavaScript backend, with the
additional one that destructors do not work for top-level globals.

In addition, the `wasMoved` magic procedure is now supported for code
running in the VM (which includes code running at compile time).

This change is meant as a preparation for unifying the backend
processing.

## Details

* use `canonicalizeWithInject` (which runs the `injectdestructors` pass)
  instead of just `canonicalize` in `vmbackend`
* add support for the `mWasMoved` magic for `vmgen` by re-using the
  `mReset` implementation
* enable tests from the `lang_objects/destructor` category for the VM
  target where doing so is possible
* enable the `tforloop_tuple_unpacking.nim` test for the VM target

The limitations of lifetime hooks for the VM backend currently are:
* destructors aren't called for refcounted heap cells (i.e., `ref`s)
* destructors aren't called for top-level globals
* the copy and destroy hooks are not called for `seq` elements when the
  `seq` is copied or destroyed
* cursors are ignored and no shallow copies are used when assigning to
  them