### PR TITLE
refactor the `collectors` module

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -12,7 +12,6 @@ import
   compiler/backend/[
     cgen,
     cgendata,
-    collectors,
     extccomp
   ],
   compiler/front/[
@@ -20,6 +19,9 @@ import
   ],
   compiler/modules/[
     modulegraphs
+  ],
+  compiler/sem/[
+    collectors
   ],
   compiler/utils/[
     containers,

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -11,7 +11,6 @@ import
     json
   ],
   compiler/backend/[
-    collectors,
     jsgen
   ],
   compiler/front/[
@@ -21,6 +20,7 @@ import
     modulegraphs
   ],
   compiler/sem/[
+    collectors,
     passes,
     sourcemap
   ],

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -32,6 +32,7 @@ import
     commands
   ],
   compiler/sem/[
+    collectors,
     sem,         # Implementation of the semantic pass
     passes,      # Main procs for compilation pass setups
     passaux
@@ -42,7 +43,6 @@ import
     modulegraphs # Project module graph
   ],
   compiler/backend/[
-    collectors,
     extccomp,    # Calling C compiler
     cgen,        # C code generation
   ],


### PR DESCRIPTION
## Summary

Simplify and clean up the implementation, and move the module to the
`sem` directory. The latter is preparation for the pass taking on
responsibilities that are more part of semantic analysis than they are
of backend-related processing.

## Details

* rename the `Module` type in `vmbackend` to `BModule`, making the name
  adhere to the naming scheme used by the other backends
* rename the `FullModule` type to `Module`
* restructure the passes's implementation so that a `Module` instance is
  produced when a module is *closed*
* don't require `ModuleList` to inherit from `RootObj`