### PR TITLE
fix compiler debug tracing

### DIFF
--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -48,6 +48,7 @@ import
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_sem import SemReport,
+  TraceSemReport,
   reportAst,
   reportSem,
   reportStr,
@@ -635,7 +636,7 @@ proc processDefine(c: PContext, n: PNode): PNode =
     if defined(nimDebugUtils) and
        cmpIgnoreStyle(str, "nimCompilerDebug") == 0:
       c.config.localReport(
-        n.info, DebugReport(kind: rdbgTraceDefined))
+        n.info, TraceSemReport(kind: rdbgTraceDefined))
 
     defineSymbol(c.config, str)
     n
@@ -651,7 +652,7 @@ proc processUndef(c: PContext, n: PNode): PNode =
     if defined(nimDebugUtils) and
        cmpIgnoreStyle(str, "nimCompilerDebug") == 0:
       c.config.localReport(
-        n.info, DebugReport(kind: rdbgTraceUndefined))
+        n.info, TraceSemReport(kind: rdbgTraceUndefined))
 
     undefSymbol(c.config, str)
     n

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2151,6 +2151,7 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
 
 
 proc semAllTypeSections(c: PContext; n: PNode): PNode =
+  addInNimDebugUtils(c.config, "semAllTypeSections", n, result)
   proc gatherStmts(c: PContext; n: PNode; result: PNode) {.nimcall.} =
     case n.kind
     of nkIncludeStmt:


### PR DESCRIPTION
Compiler debug tracing wasn't working because, a `DebugReport` instead
of a `SemTraceReport` was being submitted, meaning the compiler would
fail on an assert. This is yet another design flaw of legacy reports,
the API does not catch this type of error at compile time.

Added instrumentation to `semAllTypeSections`.