### PR TITLE
std/parseopt: only parses command arg vectors

### DIFF
--- a/compiler/front/cmdlinehelper.nim
+++ b/compiler/front/cmdlinehelper.nim
@@ -54,6 +54,7 @@ proc prependCurDir*(f: AbsoluteFile): AbsoluteFile =
     result = f
 
 type
+  # xxx: this is only used by compiler(nim) and nimsuggest. remove this if convenient
   NimProg* = ref object
     suggestMode*: bool
     supportsStdinFile*: bool

--- a/compiler/front/cmdlinehelper.nim
+++ b/compiler/front/cmdlinehelper.nim
@@ -57,7 +57,7 @@ type
   NimProg* = ref object
     suggestMode*: bool
     supportsStdinFile*: bool
-    processCmdLine*: proc(pass: TCmdLinePass, cmd: string; config: ConfigRef)
+    processCmdLine*: proc(pass: TCmdLinePass, cmd: openArray[string]; config: ConfigRef)
 
 type
   ConfDiagSeverity = enum
@@ -207,7 +207,7 @@ proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
   # parsing; don't need to care about the rest
   conf.setMsgFormat = legacyReportsMsgFmtSetter
 
-proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef, cmd: string = "") =
+proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef, cmd: openArray[string]) =
   self.processCmdLine(passCmd1, cmd, conf)
   if conf.inputMode == pimFile and self.supportsStdinFile and conf.projectName == "-":
     conf.inputMode = pimStdin
@@ -230,7 +230,7 @@ proc loadConfigs*(
   loadConfigs(cfg, cache, conf, writeConfigEvent, stopOnError)
 
 proc loadConfigsAndProcessCmdLine*(self: NimProg, cache: IdentCache; conf: ConfigRef;
-                                   graph: ModuleGraph): bool =
+                                   graph: ModuleGraph, argv: openArray[string]): bool =
   ## Load all the necessary configuration files and command-line options.
   ## Main entry point for configuration processing.
   if self.suggestMode:
@@ -248,7 +248,7 @@ proc loadConfigsAndProcessCmdLine*(self: NimProg, cache: IdentCache; conf: Confi
     # now process command line arguments again, because some options in the
     # command line can overwrite the config file's settings
     extccomp.initVars(conf)
-    self.processCmdLine(passCmd2, "", conf)
+    self.processCmdLine(passCmd2, argv, conf)
     graph.suggestMode = self.suggestMode
     if conf.cmd == cmdNone:
       conf.logError(CliEvent(kind: cliEvtErrCmdMissing,
@@ -261,7 +261,7 @@ proc loadConfigsAndProcessCmdLine*(self: NimProg, cache: IdentCache; conf: Confi
     result = false
 
 proc loadConfigsAndRunMainCommand*(
-    self: NimProg, cache: IdentCache; conf: ConfigRef; graph: ModuleGraph): bool =
+    self: NimProg, cache: IdentCache; conf: ConfigRef; graph: ModuleGraph, argv: openArray[string]): bool =
 
   ## Alias for loadConfigsAndProcessCmdLine, here for backwards compatibility
-  loadConfigsAndProcessCmdLine(self, cache, conf, graph)
+  loadConfigsAndProcessCmdLine(self, cache, conf, graph, argv)

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -9,7 +9,6 @@
 
 ## This module handles the parsing of command line arguments.
 
-
 # Switches specified when the compiler is built (-d:xxx)
 # 
 # Don't use the constant for anything other than printing.
@@ -17,7 +16,6 @@ const bootSwitchEnabled: seq[string] = block:
   var result: seq[string]
   
   template testSwitch(expr, userString) =
-    ## Helper to build boot constants
     if expr:
       result.add(userString)
 

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -415,7 +415,7 @@ proc writeVersionInfo(conf: ConfigRef) =
     commitMsg &
     "\nactive boot switches:" & bootSwitchesMsg
 
-proc processCmdLine*(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
+proc processCmdLine*(pass: TCmdLinePass, cmd: openArray[string]; config: ConfigRef) =
   ## Process input command-line parameters into `config` settings. Input is
   ## a joined list of command-line arguments with multiple options and/or
   ## configurations.

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -16,6 +16,7 @@ const bootSwitchEnabled: seq[string] = block:
   var result: seq[string]
   
   template testSwitch(expr, userString) =
+    ## Helper to build boot constants
     if expr:
       result.add(userString)
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -74,14 +74,13 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef, argv: openArray[string]):
     processCmdLine: processCmdLine
   )
   self.initDefinesProg(conf, "nim_compiler")
-  if paramCount() == 0:
+  if argv.len == 0:
     return cliErrNoParamsProvided
 
   self.processCmdLineAndProjectPath(conf, argv)
   if conf.errorCounter != 0: return
   
   let graph = newModuleGraph(cache, conf)
-  if conf.errorCounter != 0: return
   
   if not self.loadConfigsAndProcessCmdLine(cache, conf, graph, argv):
     return
@@ -147,9 +146,7 @@ when not defined(selftest):
     proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
       conf.writeHook(conf, msg & "\n", flags)
 
-  var argv = newSeq[string](paramCount())
-  for i in 0..<paramCount():
-    argv[i] = paramStr(i+1)
+  let argv = getAppArguments()
   case handleCmdLine(newIdentCache(), conf, argv)
   of cliErrNoParamsProvided:
     inc conf.errorCounter # causes a non-0 exit, will be replaced soon

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -146,7 +146,7 @@ when not defined(selftest):
     proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
       conf.writeHook(conf, msg & "\n", flags)
 
-  let argv = getAppArguments()
+  let argv = getExecArgs()
   case handleCmdLine(newIdentCache(), conf, argv)
   of cliErrNoParamsProvided:
     inc conf.errorCounter # causes a non-0 exit, will be replaced soon

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3508,5 +3508,8 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
     if cmpIgnoreCase(f.name, invalid) == 0: return false
 
 proc getAppArguments*(): seq[string] =
+  ## Returns argument to the running executable
+  ##
+  ## Does not contain the executable path (argv[0]). This is equivalent to argv[1..^1] in C.
   for i in 1..paramCount():
     result.add(paramStr(i))

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3507,7 +3507,7 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
   for invalid in invalidFilenames:
     if cmpIgnoreCase(f.name, invalid) == 0: return false
 
-proc getAppArguments*(): seq[string] =
+proc getExecArgs*(): seq[string] =
   ## Returns arguments given by the OS to the running process
   ##
   ## Does not contain the executable path (argv[0] in C). This is equivalent to argv[1..^1] in C.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3506,3 +3506,7 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
     find(f.name, invalidFilenameChars) != -1): return false
   for invalid in invalidFilenames:
     if cmpIgnoreCase(f.name, invalid) == 0: return false
+
+proc getAppArguments*(): seq[string] =
+  for i in 1..paramCount():
+    result &= paramStr(i)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3509,4 +3509,4 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
 
 proc getAppArguments*(): seq[string] =
   for i in 1..paramCount():
-    result &= paramStr(i)
+    result.add(paramStr(i))

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3508,8 +3508,8 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
     if cmpIgnoreCase(f.name, invalid) == 0: return false
 
 proc getAppArguments*(): seq[string] =
-  ## Returns argument to the running executable
+  ## Returns arguments given by the OS to the running process
   ##
-  ## Does not contain the executable path (argv[0]). This is equivalent to argv[1..^1] in C.
+  ## Does not contain the executable path (argv[0] in C). This is equivalent to argv[1..^1] in C.
   for i in 1..paramCount():
     result.add(paramStr(i))

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -192,57 +192,16 @@ proc parseWord(s: string, i: int, w: var string,
       add(w, s[result])
       inc(result)
 
-proc initOptParser*(cmdline = "", shortNoVal: set[char] = {},
+proc getArguments*(): seq[string] =
+  for i in 1..paramCount():
+    result &= paramStr(i)
+
+proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
                     longNoVal: seq[string] = @[];
                     allowWhitespaceAfterColon = true): OptParser =
   ## Initializes the command line parser.
   ##
-  ## If `cmdline == ""`, the real command line as provided by the
-  ## `os` module is retrieved instead if it is available. If the
-  ## command line is not available, a `ValueError` will be raised.
-  ##
-  ## `shortNoVal` and `longNoVal` are used to specify which options
-  ## do not take values. See the `documentation about these
-  ## parameters<#shortnoval-and-longnoval>`_ for more information on
-  ## how this affects parsing.
-  ##
-  ## See also:
-  ## * `getopt iterator<#getopt.i,OptParser>`_
-  runnableExamples:
-    var p = initOptParser()
-    p = initOptParser("--left --debug:3 -l -r:2")
-    p = initOptParser("--left --debug:3 -l -r:2",
-                      shortNoVal = {'l'}, longNoVal = @["left"])
-
-  result.pos = 0
-  result.idx = 0
-  result.inShortState = false
-  result.shortNoVal = shortNoVal
-  result.longNoVal = longNoVal
-  result.allowWhitespaceAfterColon = allowWhitespaceAfterColon
-  if cmdline != "":
-    result.cmds = parseCmdLine(cmdline)
-  else:
-    when declared(paramCount):
-      result.cmds = newSeq[string](paramCount())
-      for i in countup(1, paramCount()):
-        result.cmds[i-1] = paramStr(i)
-    else:
-      # we cannot provide this for NimRtl creation on Posix, because we can't
-      # access the command line arguments then!
-      doAssert false, "empty command line given but" &
-        " real command line is not accessible"
-
-  result.kind = cmdEnd
-  result.key = ""
-  result.val = ""
-
-proc initOptParser*(cmdline: openArray[string], shortNoVal: set[char] = {},
-                    longNoVal: seq[string] = @[];
-                    allowWhitespaceAfterColon = true): OptParser =
-  ## Initializes the command line parser.
-  ##
-  ## If `cmdline.len == 0`, the real command line as provided by the
+  ## If `args.len == 0`, the real command line as provided by the
   ## `os` module is retrieved instead if it is available. If the
   ## command line is not available, a `ValueError` will be raised.
   ## Behavior of the other parameters remains the same as in
@@ -252,7 +211,7 @@ proc initOptParser*(cmdline: openArray[string], shortNoVal: set[char] = {},
   ## See also:
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
   runnableExamples:
-    var p = initOptParser()
+    var p = initOptParser(getArguments())
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"])
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"],
                       shortNoVal = {'l'}, longNoVal = @["left"])
@@ -263,20 +222,11 @@ proc initOptParser*(cmdline: openArray[string], shortNoVal: set[char] = {},
   result.shortNoVal = shortNoVal
   result.longNoVal = longNoVal
   result.allowWhitespaceAfterColon = allowWhitespaceAfterColon
-  if cmdline.len != 0:
-    result.cmds = newSeq[string](cmdline.len)
-    for i in 0..<cmdline.len:
-      result.cmds[i] = cmdline[i]
-  else:
-    when declared(paramCount):
-      result.cmds = newSeq[string](paramCount())
-      for i in countup(1, paramCount()):
-        result.cmds[i-1] = paramStr(i)
-    else:
-      # we cannot provide this for NimRtl creation on Posix, because we can't
-      # access the command line arguments then!
-      doAssert false, "empty command line given but" &
-        " real command line is not accessible"
+
+  result.cmds = newSeq[string](args.len)
+  for i in 0..<args.len:
+    result.cmds[i] = args[i]
+
   result.kind = cmdEnd
   result.key = ""
   result.val = ""

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -207,9 +207,9 @@ proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
   ##   arguments
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
   runnableExamples:
-    var p = initOptParser(getExecArgs())
-    p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"])
-    p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"],
+    var p = initOptParser([])
+    p = initOptParser(["--left", "--debug:3", "-l", "-r:2"])
+    p = initOptParser(["--left", "--debug:3", "-l", "-r:2"],
                       shortNoVal = {'l'}, longNoVal = @["left"])
 
   result.pos = 0

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -51,7 +51,7 @@
 ## .. code-block::
 ##   import std/parseopt
 ##
-##   var p = initOptParser("-ab -e:5 --foo --bar=20 file.txt")
+##   var p = initOptParser(["-ab", "-e:5", "--foo", "--bar=20", "file.txt"])
 ##   while true:
 ##     p.next()
 ##     case p.kind
@@ -259,7 +259,7 @@ proc next*(p: var OptParser) {.rtl, extern: "npo$1".} =
   ## `p.kind` describes what kind of token has been parsed. `p.key` and
   ## `p.val` are set accordingly.
   runnableExamples:
-    var p = initOptParser("--left -r:2 file.txt")
+    var p = initOptParser(["--left", "-r:2", "file.txt"])
     p.next()
     doAssert p.kind == cmdLongOption and p.key == "left"
     p.next()
@@ -333,7 +333,7 @@ when declared(quoteShellCommand):
     ## **Examples:**
     ##
     ## .. code-block::
-    ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
+    ##   var p = initOptParser(["--left", "-r:2", "--", "foo.txt", "bar.txt"])
     ##   while true:
     ##     p.next()
     ##     if p.kind == cmdLongOption and p.key == "":  # Look for "--"
@@ -351,7 +351,7 @@ proc remainingArgs*(p: OptParser): seq[string] {.rtl, extern: "npo$1".} =
   ## **Examples:**
   ##
   ## .. code-block::
-  ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
+  ##   var p = initOptParser(["--left", "-r:2", "--", "foo.txt", "bar.txt"])
   ##   while true:
   ##     p.next()
   ##     if p.kind == cmdLongOption and p.key == "":  # Look for "--"
@@ -379,7 +379,7 @@ iterator getopt*(p: var OptParser): tuple[kind: CmdLineKind, key,
   ##   proc writeVersion() = discard
   ##
   ##   var filename: string
-  ##   var p = initOptParser("--left --debug:3 -l -r:2")
+  ##   var p = initOptParser(["--left", "--debug:3", "-l", "-r:2"])
   ##
   ##   for kind, key, val in p.getopt():
   ##     case kind

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -197,11 +197,15 @@ proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
                     allowWhitespaceAfterColon = true): OptParser =
   ## Initializes the command line parser.
   ##
-  ##
+  ## `shortNoVal` and `longNoVal` are used to specify which options
+  ## do not take values. See the `documentation about these
+  ## parameters<#shortnoval-and-longnoval>`_ for more information on
+  ## how this affects parsing.
+  ## 
   ## See also:
-  ## * `os.getAppArguments` for getting command arguments
+  ## * `getAppArguments <os.html#getAppArguments>`_ for getting command-line
+  ##   arguments
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
-  # xxx: fix the link above after having proper links in doc comments
   runnableExamples:
     var p = initOptParser(getAppArguments())
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"])

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -203,7 +203,7 @@ proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
   ## how this affects parsing.
   ## 
   ## See also:
-  ## * `getAppArguments <os.html#getAppArguments>`_ for getting command-line
+  ## * `getExecArgs <os.html#getExecArgs>`_ for getting command-line
   ##   arguments
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
   runnableExamples:

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -197,15 +197,11 @@ proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
                     allowWhitespaceAfterColon = true): OptParser =
   ## Initializes the command line parser.
   ##
-  ## If `args.len == 0`, the real command line as provided by the
-  ## `os` module is retrieved instead if it is available. If the
-  ## command line is not available, a `ValueError` will be raised.
-  ## Behavior of the other parameters remains the same as in
-  ## `initOptParser(string, ...)
-  ## <#initOptParser,string,set[char],seq[string]>`_.
   ##
   ## See also:
+  ## * `os.getAppArguments` for getting command arguments
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
+  # xxx: fix the link above after having proper links in doc comments
   runnableExamples:
     var p = initOptParser(getAppArguments())
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"])

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -237,7 +237,7 @@ proc initOptParser*(cmdline = "", shortNoVal: set[char] = {},
   result.key = ""
   result.val = ""
 
-proc initOptParser*(cmdline: seq[string], shortNoVal: set[char] = {},
+proc initOptParser*(cmdline: openArray[string], shortNoVal: set[char] = {},
                     longNoVal: seq[string] = @[];
                     allowWhitespaceAfterColon = true): OptParser =
   ## Initializes the command line parser.

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -207,7 +207,7 @@ proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
   ##   arguments
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
   runnableExamples:
-    var p = initOptParser(getAppArguments())
+    var p = initOptParser(getExecArgs())
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"])
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"],
                       shortNoVal = {'l'}, longNoVal = @["left"])

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -192,10 +192,6 @@ proc parseWord(s: string, i: int, w: var string,
       add(w, s[result])
       inc(result)
 
-proc getArguments*(): seq[string] =
-  for i in 1..paramCount():
-    result &= paramStr(i)
-
 proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
                     longNoVal: seq[string] = @[];
                     allowWhitespaceAfterColon = true): OptParser =
@@ -211,7 +207,7 @@ proc initOptParser*(args: openArray[string], shortNoVal: set[char] = {},
   ## See also:
   ## * `getopt iterator<#getopt.i,seq[string],set[char],seq[string]>`_
   runnableExamples:
-    var p = initOptParser(getArguments())
+    var p = initOptParser(getAppArguments())
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"])
     p = initOptParser(@["--left", "--debug:3", "-l", "-r:2"],
                       shortNoVal = {'l'}, longNoVal = @["left"])

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -252,6 +252,11 @@ proc handleShortOption(p: var OptParser; cmd: string) =
     p.inShortState = false
     p.pos = 0
     inc p.idx
+    if p.idx < p.cmds.len and
+       card(p.shortNoVal) > 0 and p.key[0] notin p.shortNoVal and
+       p.val == "":
+      p.val = p.cmds[p.idx]
+      inc p.idx
 
 proc next*(p: var OptParser) {.rtl, extern: "npo$1".} =
   ## Parses the next token.

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -737,7 +737,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef, argv: openArray[string]) 
     mainCommand(graph)
 
 when isMainModule:
-  let argv = getAppArguments()
+  let argv = getExecArgs()
   let conf = newConfigRef(cli_reporter.reportHook)
   conf.astDiagToLegacyReport = cli_reporter.legacyReportBridge
   handleCmdLine(newIdentCache(), conf, argv)

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -1234,7 +1234,7 @@ proc main() =
   ## Define CLI Options/Args Parsing loops
   var
     execState = Execution(flags: {outputColour, logBackend})
-    p = initOptParser(getAppArguments())
+    p = initOptParser(getExecArgs())
 
   ## Main procedure
   backend.open()

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -1234,7 +1234,7 @@ proc main() =
   ## Define CLI Options/Args Parsing loops
   var
     execState = Execution(flags: {outputColour, logBackend})
-    p = initOptParser()
+    p = initOptParser(getAppArguments())
 
   ## Main procedure
   backend.open()

--- a/tests/compilerunits/confread/treport_filtering.nim
+++ b/tests/compilerunits/confread/treport_filtering.nim
@@ -53,7 +53,7 @@ proc firstPass*(args: seq[string]): ConfigRef =
   ## Create config ref object and run fist CLI pass of on the configuration
   result = newConfigRef(hook)
   result.astDiagToLegacyReport = cli_reporter.legacyReportBridge
-  processCmdLine(passCmd1, args.join(" "), result)
+  processCmdLine(passCmd1, args, result)
 
 proc assertInter[T](inters: set[T], want: set[T] = {}) =
   doAssert inters == want, $want

--- a/tests/misc/tparseopt.nim
+++ b/tests/misc/tparseopt.nim
@@ -22,11 +22,7 @@ kind: cmdShortOption	key:val  --  r:0
 kind: cmdShortOption	key:val  --  l:
 kind: cmdShortOption	key:val  --  r:4
 kind: cmdLongOption	key:val  --  debug:
-cmdShortOption key: v value: ''
-cmdArgument key: ABC value: ''
 cmdShortOption key: v value: 'ABC'
-cmdShortOption key: v value: ''
-cmdArgument key: ABC value: ''
 cmdShortOption key: v value: ''
 cmdArgument key: ABC value: ''
 cmdShortOption key: j value: '4'
@@ -53,7 +49,7 @@ else:
 
     # pass custom cmdline arguments
     echo "first round"
-    var argv = "--left --debug:3 -l=4 -r:2"
+    var argv = ["--left", "--debug:3", "-l=4", "-r:2"]
     var p = parseopt.initOptParser(argv)
     for kind, key, val in parseopt.getopt(p):
       echo "kind: ", kind, "\tkey:val  --  ", key, ":", val
@@ -72,7 +68,7 @@ else:
   block:
     echo "parseoptNoVal"
     # test NoVal mode with custom cmdline arguments
-    var argv = "--left --debug:3 -l -r:2 --debug 2 --debug=1 -r1 -r=0 -lr4 --debug:"
+    var argv = ["--left", "--debug:3", "-l", "-r:2", "--debug", "2", "--debug=1", "-r1", "-r=0", "-lr4", "--debug:"]
     var p = parseopt.initOptParser(argv,
                                     shortNoVal = {'l'}, longNoVal = @["left"])
     for kind, key, val in parseopt.getopt(p):
@@ -134,23 +130,14 @@ arg 6 ai.len:4 :{a7'b}"""
 
 
   block:
-    let args = @["-v", "ABC"]
-    var p = parseopt.initOptParser(args, shortnoVal = {'n'}, longnoVal = @["novalue"])
-    for kind, key, val in parseopt.getopt(p):
-      echo kind," key: ", key, " value: '", val, "'"
-
-    var r = parseopt.initOptParser(@["-v ABC"], shortnoVal = {'n'}, longnoVal = @["novalue"])
+    var r = parseopt.initOptParser(["-v", "ABC"], shortnoVal = {'n'}, longnoVal = @["novalue"])
     for kind, key, val in parseopt.getopt(r):
       echo kind," key: ", key, " value: '", val, "'"
 
-    var s = parseopt.initOptParser("-v ABC", shortnoVal = {'v'}, longnoVal = @["novalue"])
+    var s = parseopt.initOptParser(["-v", "ABC"], shortnoVal = {'v'}, longnoVal = @["novalue"])
     for kind, key, val in parseopt.getopt(s):
       echo kind," key: ", key, " value: '", val, "'"
 
-    var m = parseopt.initOptParser("-v ABC", shortnoVal = {'n'}, longnoVal = @["novalue"])
-    for kind, key, val in parseopt.getopt(m):
-      echo kind," key: ", key, " value: '", val, "'"
-
-    var n = parseopt.initOptParser("-j4 ok", shortnoVal = {'n'}, longnoVal = @["novalue"])
+    var n = parseopt.initOptParser(["-j4", "ok"], shortnoVal = {'n'}, longnoVal = @["novalue"])
     for kind, key, val in parseopt.getopt(n):
       echo kind," key: ", key, " value: '", val, "'"

--- a/tests/misc/tparseopt.nim
+++ b/tests/misc/tparseopt.nim
@@ -1,16 +1,17 @@
 discard """
   output: '''
-parseopt
-first round
+t 0-0
+t 0-1
 kind: cmdLongOption	key:val  --  left:
-second round
+t 0-2
 kind: cmdLongOption	key:val  --  left:
 kind: cmdLongOption	key:val  --  debug:3
 kind: cmdShortOption	key:val  --  l:4
 kind: cmdShortOption	key:val  --  r:2
+t 0-3
 cmdLongOption foo
 cmdLongOption path
-parseoptNoVal
+t 1-0
 kind: cmdLongOption	key:val  --  left:
 kind: cmdLongOption	key:val  --  debug:3
 kind: cmdShortOption	key:val  --  l:
@@ -22,9 +23,12 @@ kind: cmdShortOption	key:val  --  r:0
 kind: cmdShortOption	key:val  --  l:
 kind: cmdShortOption	key:val  --  r:4
 kind: cmdLongOption	key:val  --  debug:
+t 4-0
 cmdShortOption key: v value: 'ABC'
+t 4-1
 cmdShortOption key: v value: ''
 cmdArgument key: ABC value: ''
+t 4-2
 cmdShortOption key: j value: '4'
 cmdArgument key: ok value: ''
 '''
@@ -42,31 +46,32 @@ when defined(testament_tparseopt):
 else:
   from parseopt import nil
 
-  block:
-    echo "parseopt"
+  block: # general test
+    echo "t 0-0"
     for kind, key, val in parseopt.getopt():
       echo "kind: ", kind, "\tkey:val  --  ", key, ":", val
 
     # pass custom cmdline arguments
-    echo "first round"
+    echo "t 0-1"
     var argv = ["--left", "--debug:3", "-l=4", "-r:2"]
     var p = parseopt.initOptParser(argv)
     for kind, key, val in parseopt.getopt(p):
       echo "kind: ", kind, "\tkey:val  --  ", key, ":", val
       break
     # reset getopt iterator and check arguments are returned correctly.
-    echo "second round"
+    echo "t 0-2"
     for kind, key, val in parseopt.getopt(p):
       echo "kind: ", kind, "\tkey:val  --  ", key, ":", val
 
     # bug #9619
+    echo "t 0-3"
     var x = parseopt.initOptParser(@["--foo:", "--path"],
         allowWhitespaceAfterColon = false)
     for kind, key, val in parseopt.getopt(x):
       echo kind, " ", key
 
-  block:
-    echo "parseoptNoVal"
+  block: # parseOptNoVal
+    echo "t 1-0"
     # test NoVal mode with custom cmdline arguments
     var argv = ["--left", "--debug:3", "-l", "-r:2", "--debug", "2", "--debug=1", "-r1", "-r=0", "-lr4", "--debug:"]
     var p = parseopt.initOptParser(argv,
@@ -79,25 +84,23 @@ else:
   import stdtest/unittest_light
 
   block: # fix #9951
-    template runTest(parseoptCustom) =
-      var p = parseoptCustom.initOptParser(@["echo \"quoted\""])
-      let expected = when defined(windows):
-        """"echo \"quoted\"""""
-      else:
-        """'echo "quoted"'"""
-      assertEquals parseoptCustom.cmdLineRest(p), expected
+    var p = parseopt.initOptParser(@["echo \"quoted\""])
+    let expected = when defined(windows):
+      """"echo \"quoted\"""""
+    else:
+      """'echo "quoted"'"""
+    assertEquals parseopt.cmdLineRest(p), expected
 
-      doAssert "a5'b" == "a5\'b"
+    doAssert "a5'b" == "a5\'b"
 
-      let args = @["a1b", "a2 b", "", "a4\"b", "a5'b", r"a6\b", "a7\'b"]
-      var p2 = parseoptCustom.initOptParser(args)
-      let expected2 = when defined(windows):
-        """a1b "a2 b" "" a4\"b a5'b a6\b a7'b"""
-      else:
-        """a1b 'a2 b' '' 'a4"b' 'a5'"'"'b' 'a6\b' 'a7'"'"'b'"""
-      doAssert "a5'b" == "a5\'b"
-      assertEquals parseoptCustom.cmdLineRest(p2), expected2
-    runTest(parseopt)
+    let args = @["a1b", "a2 b", "", "a4\"b", "a5'b", r"a6\b", "a7\'b"]
+    var p2 = parseopt.initOptParser(args)
+    let expected2 = when defined(windows):
+      """a1b "a2 b" "" a4\"b a5'b a6\b a7'b"""
+    else:
+      """a1b 'a2 b' '' 'a4"b' 'a5'"'"'b' 'a6\b' 'a7'"'"'b'"""
+    doAssert "a5'b" == "a5\'b"
+    assertEquals parseopt.cmdLineRest(p2), expected2
 
   block: # fix #9842
     let exe = buildDir / "D20190112T145450".addFileExt(ExeExt)
@@ -130,14 +133,17 @@ arg 6 ai.len:4 :{a7'b}"""
 
 
   block:
+    echo "t 4-0"
     var r = parseopt.initOptParser(["-v", "ABC"], shortnoVal = {'n'}, longnoVal = @["novalue"])
     for kind, key, val in parseopt.getopt(r):
       echo kind," key: ", key, " value: '", val, "'"
 
+    echo "t 4-1"
     var s = parseopt.initOptParser(["-v", "ABC"], shortnoVal = {'v'}, longnoVal = @["novalue"])
     for kind, key, val in parseopt.getopt(s):
       echo kind," key: ", key, " value: '", val, "'"
 
+    echo "t 4-2"
     var n = parseopt.initOptParser(["-j4", "ok"], shortnoVal = {'n'}, longnoVal = @["novalue"])
     for kind, key, val in parseopt.getopt(n):
       echo kind," key: ", key, " value: '", val, "'"

--- a/tests/system/tparams.nim
+++ b/tests/system/tparams.nim
@@ -14,7 +14,7 @@ if argv == @[]:
   # this won't work with spaces
   doAssert execShellCmd(getAppFilename() & " \"foo bar\" --aa:bar=a --a=c:d --ab -c --a[baz]:doo") == 0
 else:
-  let f = toSeq(getopt())
+  let f = toSeq(getopt(argv))
   doAssert f[0].kind == cmdArgument and f[0].key == "foo bar" and f[0].val == ""
   doAssert f[1].kind == cmdLongOption and f[1].key == "aa" and f[1].val == "bar=a"
   doAssert f[2].kind == cmdLongOption and f[2].key == "a" and f[2].val == "c:d"

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -132,4 +132,4 @@ block:  # cpDir, cpFile, dirExists, fileExists, mkDir, mvDir, mvFile, rmDir, rmF
 
 block:
   # check parseopt can get command line:
-  discard initOptParser()
+  discard initOptParser(getAppArguments())

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -132,4 +132,4 @@ block:  # cpDir, cpFile, dirExists, fileExists, mkDir, mvDir, mvFile, rmDir, rmF
 
 block:
   # check parseopt can get command line:
-  discard initOptParser(getAppArguments())
+  discard initOptParser(getExecArgs())

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -606,7 +606,7 @@ proc branchDone() =
     exec("git pull --rebase")
 
 when isMainModule:
-  var op = initOptParser()
+  var op = initOptParser(getAppArguments())
   var
     latest = false
 

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -606,7 +606,7 @@ proc branchDone() =
     exec("git pull --rebase")
 
 when isMainModule:
-  var op = initOptParser(getAppArguments())
+  var op = initOptParser(getExecArgs())
   var
     latest = false
 

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -175,7 +175,7 @@ Compile_options:
 """
 
 proc parseCmdLine(c: var ConfigData) =
-  var p = initOptParser()
+  var p = initOptParser(getAppArguments())
   while true:
     next(p)
     var kind = p.kind

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -175,7 +175,7 @@ Compile_options:
 """
 
 proc parseCmdLine(c: var ConfigData) =
-  var p = initOptParser(getAppArguments())
+  var p = initOptParser(getExecArgs())
   while true:
     next(p)
     var kind = p.kind

--- a/tools/release_manifest.nim
+++ b/tools/release_manifest.nim
@@ -512,6 +512,7 @@ proc main() =
   ## The CLI entrypoint and parser
   var
     cliParser = initOptParser(
+      getExecArgs(),
       shortNoVal = {'h'},
       longNoVal = @["--help"],
       allowWhitespaceAfterColon = false


### PR DESCRIPTION
## Summary

The `parseopt` module no longer supports parsing arbitrary strings as
command line parameters. Instead a `seq[string]` representing an argv
(argument vector) must be supplied. In addition to removing the API for
this, it no longer automatically fetches command line parameters.

In addition, parsing empty argument lists and short flags with value was
fixed. In particular, input such as `["-s", "foo"]`, where `"-s"`
expects an argument is correctly treated as `-s:foo` or `-s=foo`.

## Details

As part of this change the `string` accepting variant of the
`initOptParser` procedure was removed, along with the similarly misguided
`getOpts` iterator. Lastly, an empty list no longer triggers argument
retrieval via the `os` module, meaning these are handled correctly.

Modified the compiler and various executables to transition to the
revised API, in order to facilitate this introduced the `os.getExecArgs`
procedure.