### PR TITLE
lambdalifting: improve generated environment setup code

### DIFF
--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -148,10 +148,10 @@ const
   paramName* = ":envP"
   envName* = ":env"
 
-proc newCall(a: PSym, b: PNode): PNode =
-  result = newNodeI(nkCall, a.info)
-  result.add newSymNode(a)
-  result.add b
+proc newObjConstr(typ: PType, info: TLineInfo): PNode =
+  ## Creates an object constructor node with no arguments for type `typ`, using
+  ## `info` for source line information.
+  newTreeIT(nkObjConstr, info, typ, [newNodeIT(nkType, info, typ)])
 
 proc createClosureIterStateType*(g: ModuleGraph; iter: PSym; idgen: IdGenerator): PType =
   var n = newNodeI(nkRange, iter.info)
@@ -284,8 +284,8 @@ proc liftIterSym*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner: PSym): PN
     let v = newTreeI(nkVarSection, n.info):
       newIdentDefs(env)
     result.add(v)
-  # add 'new' statement:
-  result.add newCall(getSysSym(g, n.info, "internalNew"), env)
+  # add init statement:
+  result.add newAsgnStmt(env, newObjConstr(env.typ, n.info))
   createTypeBoundOpsLL(g, env.typ, n.info, idgen, owner)
   result.add makeClosure(g, idgen, iter, env, n.info)
 
@@ -570,11 +570,8 @@ proc rawClosureCreation(owner: PSym;
     env = setupEnvVar(owner, d, c, info)
     if env.kind == nkSym:
       let v = newTreeI(nkVarSection, env.info):
-        newIdentDefs(env)
+        newIdentDefs(env, newObjConstr(env.typ, env.info))
       result.add(v)
-
-    # add 'new' statement:
-    result.add(newCall(getSysSym(d.graph, env.info, "internalNew"), env))
 
     # add assignment statements for captured parameters:
     for i in 1..<owner.typ.n.len:
@@ -619,7 +616,7 @@ proc closureCreationForIter(iter: PNode;
     let vs = newTreeI(nkVarSection, iter.info):
       newIdentDefs(vnode)
     result.add(vs)
-  result.add(newCall(getSysSym(d.graph, iter.info, "internalNew"), vnode))
+  result.add(newAsgnStmt(vnode, newObjConstr(vnode.typ, iter.info)))
   createTypeBoundOpsLL(d.graph, vnode.typ, iter.info, d.idgen, owner)
 
   let upField = lookupInRecord(v.typ.skipTypes({tyRef, tyPtr}).n, getIdent(d.graph.cache, upName))
@@ -875,11 +872,10 @@ proc liftForLoop*(g: ModuleGraph; body: PNode; idgen: IdGenerator; owner: PSym):
     env.typ = hp.typ
     env.flags = hp.flags
 
-    let v = newTreeI(nkVarSection, body.info):
-      newIdentDefs(newSymNode(env))
+    let v = newTreeI(nkLetSection, body.info):
+      newIdentDefs(newSymNode(env), newObjConstr(env.typ, env.info))
     result.add(v)
-    # add 'new' statement:
-    result.add(newCall(getSysSym(g, env.info, "internalNew"), env.newSymNode))
+
     createTypeBoundOpsLL(g, env.typ, body.info, idgen, owner)
 
   elif op.kind == nkStmtListExpr:

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -149,8 +149,8 @@ const
   envName* = ":env"
 
 proc newObjConstr(typ: PType, info: TLineInfo): PNode =
-  ## Creates an object constructor node with no arguments for type `typ`, using
-  ## `info` for source line information.
+  ## Creates an object construction node with no arguments for type `typ`,
+  ## using `info` for source line information.
   newTreeIT(nkObjConstr, info, typ, [newNodeIT(nkType, info, typ)])
 
 proc createClosureIterStateType*(g: ModuleGraph; iter: PSym; idgen: IdGenerator): PType =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -267,6 +267,7 @@ const ThisIsSystem = true
 
 proc internalNew*[T](a: var ref T) {.magic: "New", noSideEffect.}
   ## Leaked implementation detail. Do not use.
+  # TODO: obsolete; remove after the next csource update
 
 proc wasMoved*[T](obj: var T) {.magic: "WasMoved", noSideEffect.} =
   ## Resets an object `obj` to its initial (binary zero) value to signify

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -265,9 +265,13 @@ proc typeof*(x: untyped; mode = typeOfIter): typedesc {.
 
 const ThisIsSystem = true
 
-proc internalNew*[T](a: var ref T) {.magic: "New", noSideEffect.}
-  ## Leaked implementation detail. Do not use.
-  # TODO: obsolete; remove after the next csource update
+when compileOption("gc", "refc"):
+  # TODO: obsolete magic definition; remove after the next csource update.
+  #       The magic is unrelated to refc, but since only the csource
+  #       compiler still supports and uses refc, we can use its presense as
+  #       a way it to identify the csources compiler
+  proc internalNew*[T](a: var ref T) {.magic: "New", noSideEffect.}
+    ## Leaked implementation detail. Do not use.
 
 proc wasMoved*[T](obj: var T) {.magic: "WasMoved", noSideEffect.} =
   ## Resets an object `obj` to its initial (binary zero) value to signify


### PR DESCRIPTION
## Summary

Use an assignment with an object constructor expression instead of a
call to `internalNew`. This makes the resulting code easier to reason
about for the analysis passes, and the `internalNew` definition in the
`system` module becomes obsolete.

## Details

The csources compiler still needs the `internalNew` symbol, so removing
the definition is only possible after the next csources update.

Because of using an assignment, the environment setup code now looks
like
```nim
:env = Env()
```
instead of
```nim
`=destroy`(:env)
internalNew(:env)
```
after the `injectdestructors` pass has run.