### PR TITLE
std/parseopt2: new exec argument parsing library

### DIFF
--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -16,16 +16,16 @@
 const bootSwitchEnabled: seq[string] = block:
   var result: seq[string]
   
-  template testSwitch(expr, userString) =
+  template detectBootSwitch(expr, userString) =
     ## Helper to build boot constants
     if expr:
       result.add(userString)
 
   # TODO: show all the -d:xxx used. Currently it's a limited selection
-  testSwitch(defined(release), "-d:release")
-  testSwitch(defined(danger), "-d:danger")
-  testSwitch(defined(useLinenoise), "-d:useLinenoise")
-  testSwitch(defined(tinyc), "-d:tinyc")
+  detectBootSwitch(defined(release), "-d:release")
+  detectBootSwitch(defined(danger), "-d:danger")
+  detectBootSwitch(defined(useLinenoise), "-d:useLinenoise")
+  detectBootSwitch(defined(tinyc), "-d:tinyc")
 
   result
 

--- a/lib/pure/parseopt2.nim
+++ b/lib/pure/parseopt2.nim
@@ -1,0 +1,134 @@
+## argument parser (akin to POSIX getopt)
+## 
+## Can handle:
+## -c c_val
+## -c:c_val
+## -c=c_val
+## -abcc_val
+## -abc c_val
+## -abc:c_val
+## -abc=c_val
+## --long val
+## --long:val
+## --long=val
+## --long=    (empty val)
+## -- -positional1 --positional2
+## 
+## -    is treated as positional
+## --   skipped once; everything after this is treated as positional
+## ---  is treated as long arg "-"
+## 
+## -:   undefined behavior (separator after dash)
+
+import options, strutils
+
+type
+  OptKind* = enum
+    optShort ## -s
+    optLong  ## --long
+    optPos   ## positional
+  Opt* = object
+    case kind*: OptKind
+    of optShort:
+      keyShort*: char
+    of optLong:
+      keyLong*: string
+    of optPos:
+      discard
+    val*: string
+  OptError* = ref object of CatchableError
+  OptExtraneousVal* = ref object of OptError
+    case kind*: OptKind
+    of optShort:
+      keyShort*: char
+    of optLong:
+      keyLong*: string
+    of optPos:
+      discard
+  OptMissingVal* = ref object of OptError
+    case kind*: OptKind
+    of optShort:
+      keyShort*: char
+    of optLong:
+      keyLong*: string
+    of optPos:
+      discard
+
+# xxx: trivial impl. remove this once == for case objects is implemented
+proc`==`*(a, b: Opt): bool =
+  a.kind == b.kind and a.val == b.val and (
+    case a.kind:
+    of optShort:
+      a.keyShort == b.keyShort
+    of optLong:
+      a.keyLong == b.keyLong
+    of optPos:
+      true
+  )
+
+iterator opts*(argv: openArray[string], shortHasVal: openArray[char] = [], longHasVal: openArray[string] = [], sep: set[char] = {'=', ':'}): Opt =
+  var all_positional = false
+  var partial = Opt.none
+  for arg in argv:
+    if partial.isSome: # fill val of partial opt
+      var opt = partial.get
+      opt.val = arg
+      yield opt
+      partial = Opt.none
+    elif all_positional:
+      yield Opt(kind: optPos, val: arg)
+    elif arg == "-":
+      yield Opt(kind: optPos, val: arg)
+    elif arg == "--":
+      all_positional = true
+    elif arg.startsWith "--": # process long
+      # long
+      var key = ""
+      var i = 2 # skip starting --
+      block process_arg:
+        while i < arg.len:
+          let c = arg[i]
+          i.inc
+          if c in sep:
+            if key notin longHasVal:
+              raise OptExtraneousVal(kind: optLong, keyLong: key)
+            yield Opt(kind: optLong, keyLong: key, val: arg[i..^1])
+            break process_arg
+          else:
+            key &= c
+        
+        let opt = Opt(kind: optLong, keyLong: key)
+        if key in longHasVal:
+          partial = some opt # wait for .val to be filled
+        else:
+          yield opt
+    elif arg.startsWith "-": # process short
+      var i = 1
+      while i < arg.len:
+        let c = arg[i]
+        i.inc
+        if c in shortHasVal:
+          if i < arg.len:
+            if arg[i] in sep:
+              # skip = in -a=c if exist
+              i.inc
+            yield Opt(kind: optShort, keyShort: c, val: arg[i..^1])
+            break
+          else:
+            partial = some Opt(kind: optShort, keyShort: c)
+            break
+        else:
+          yield Opt(kind: optShort, keyShort: c)
+    else: # process positional
+      yield Opt(kind: optPos, val: arg)
+
+  # throw on missing val
+  if partial.isSome:
+    let opt = partial.get
+    case opt.kind
+    of optShort:
+      raise OptMissingVal(kind: optShort, keyShort: opt.keyShort)
+    of optLong:
+      raise OptMissingVal(kind: optLong, keyLong: opt.keyLong)
+    else:
+      doAssert false, "unreachable"

--- a/lib/pure/parseopt2.nim
+++ b/lib/pure/parseopt2.nim
@@ -97,28 +97,27 @@ iterator opts*(argv: openArray[string], shortHasVal: openArray[char] = [], longH
           else:
             key &= c
         
-        let opt = Opt(kind: optLong, keyLong: key)
         if key in longHasVal:
-          partial = some opt # wait for .val to be filled
+          # wait for .val to be filled
+          partial = some Opt(kind: optLong, keyLong: key)
         else:
-          yield opt
+          yield Opt(kind: optLong, keyLong: key)
     elif arg.startsWith "-": # process short
-      var i = 1
+      var i = 1 # skip starting -
       while i < arg.len:
         let c = arg[i]
         i.inc
-        if c in shortHasVal:
-          if i < arg.len:
-            if arg[i] in sep:
-              # skip = in -a=c if exist
-              i.inc
-            yield Opt(kind: optShort, keyShort: c, val: arg[i..^1])
-            break
-          else:
-            partial = some Opt(kind: optShort, keyShort: c)
-            break
-        else:
+        if c notin shortHasVal:
           yield Opt(kind: optShort, keyShort: c)
+        elif i < arg.len:
+          if arg[i] in sep:
+            # skip separator (e.g. '=') in "-a=c" if it exist
+            i.inc
+          yield Opt(kind: optShort, keyShort: c, val: arg[i..^1])
+          break
+        else:
+          partial = some Opt(kind: optShort, keyShort: c)
+          break
     else: # process positional
       yield Opt(kind: optPos, val: arg)
 

--- a/lib/pure/parseopt2.nim
+++ b/lib/pure/parseopt2.nim
@@ -20,7 +20,7 @@
 ## 
 ## -:   undefined behavior (separator after dash)
 
-import options, strutils
+import std/[options, strutils]
 
 type
   OptKind* = enum
@@ -66,7 +66,11 @@ proc`==`*(a, b: Opt): bool =
       true
   )
 
-iterator opts*(argv: openArray[string], shortHasVal: openArray[char] = [], longHasVal: openArray[string] = [], sep: set[char] = {'=', ':'}): Opt =
+const defaultSeparators* = {'=', ':'}
+
+iterator opts*(argv: openArray[string], shortHasVal: openArray[char] = [], 
+               longHasVal: openArray[string] = [],
+               sep: set[char] = defaultSeparators): Opt =
   var all_positional = false
   var partial = Opt.none
   for arg in argv:

--- a/tests/stdlib/tparseopt2.nim
+++ b/tests/stdlib/tparseopt2.nim
@@ -13,37 +13,37 @@ func allRequired[T](a: openArray[T]): seq[(T, OptValExpectation)] =
     result &= (x, optValRequired)
 
 checkOpts opts(["-c", "c_val"], shortVal=['c'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+  @[Opt(kind: short, keyShort: 'c', value: "c_val")]
 checkOpts opts(["-c:c_val"], shortVal=['c'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+  @[Opt(kind: short, keyShort: 'c', value: "c_val")]
 checkOpts opts(["-c=c_val"], shortVal=['c'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+  @[Opt(kind: short, keyShort: 'c', value: "c_val")]
 checkOpts opts(["-cc_val", "-j4"], shortVal=['c', 'j'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'c', val: "c_val"), Opt(kind: optShort, keyShort: 'j', val: "4")]
+  @[Opt(kind: short, keyShort: 'c', value: "c_val"), Opt(kind: short, keyShort: 'j', value: "4")]
 checkOpts opts(["-abcc_val"], shortVal=['c'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+  @[Opt(kind: short, keyShort: 'a', value: ""), Opt(kind: short, keyShort: 'b', value: ""), Opt(kind: short, keyShort: 'c', value: "c_val")]
 checkOpts opts(["-abc", "c_val"], shortVal=['c'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+  @[Opt(kind: short, keyShort: 'a', value: ""), Opt(kind: short, keyShort: 'b', value: ""), Opt(kind: short, keyShort: 'c', value: "c_val")]
 checkOpts opts(["-abc:c_val"], shortVal=['c'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+  @[Opt(kind: short, keyShort: 'a', value: ""), Opt(kind: short, keyShort: 'b', value: ""), Opt(kind: short, keyShort: 'c', value: "c_val")]
 checkOpts opts(["-abc=c_val"], shortVal=['c'].allRequired),
-  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+  @[Opt(kind: short, keyShort: 'a', value: ""), Opt(kind: short, keyShort: 'b', value: ""), Opt(kind: short, keyShort: 'c', value: "c_val")]
 checkOpts opts(["--long", "val"], longVal=["long"].allRequired),
-  @[Opt(kind: optLong, keyLong: "long", val: "val")]
+  @[Opt(kind: long, keyLong: "long", value: "val")]
 checkOpts opts(["--long:val"], longVal=["long"].allRequired),
-  @[Opt(kind: optLong, keyLong: "long", val: "val")]
+  @[Opt(kind: long, keyLong: "long", value: "val")]
 checkOpts opts(["--long=val"], longVal=["long"].allRequired),
-  @[Opt(kind: optLong, keyLong: "long", val: "val")]
+  @[Opt(kind: long, keyLong: "long", value: "val")]
 checkOpts opts(["--long="], longVal=["long"].allRequired),
-  @[Opt(kind: optLong, keyLong: "long", val: "")]
+  @[Opt(kind: long, keyLong: "long", value: "")]
 checkOpts opts(["--", "-positional1", "--positional2", "positional3"]),
-  @[Opt(kind: optPos, val: "-positional1"), Opt(kind: optPos, val: "--positional2"), Opt(kind: optPos, val: "positional3")]
+  @[Opt(kind: positional, value: "-positional1"), Opt(kind: positional, value: "--positional2"), Opt(kind: positional, value: "positional3")]
 checkOpts opts(["-"]),
-  @[Opt(kind: optPos, val: "-")]
+  @[Opt(kind: positional, value: "-")]
 let emptySeq: seq[Opt] = @[]
 checkOpts opts(["--"]), emptySeq
 checkOpts opts(["---"]),
-  @[Opt(kind: optLong, keyLong: "-", val: "")]
+  @[Opt(kind: long, keyLong: "-", value: "")]
 
 
 # mixed tests
@@ -51,33 +51,33 @@ checkOpts opts(["---"]),
 import std/strutils
 checkOpts opts("hello world! -abcde --f:g --h=i --j --k l m".split(" "), shortVal=['c'].allRequired, longVal=["f","h","k"].allRequired),
   @[
-    Opt(kind: optPos, val: "hello"),
-    Opt(kind: optPos, val: "world!"),
-    Opt(kind: optShort, keyShort: 'a', val: ""),
-    Opt(kind: optShort, keyShort: 'b', val: ""),
-    Opt(kind: optShort, keyShort: 'c', val: "de"),
-    Opt(kind: optLong, keyLong: "f", val: "g"),
-    Opt(kind: optLong, keyLong: "h", val: "i"),
-    Opt(kind: optLong, keyLong: "j", val: ""),
-    Opt(kind: optLong, keyLong: "k", val: "l"),
-    Opt(kind: optPos, val: "m"),
+    Opt(kind: positional, value: "hello"),
+    Opt(kind: positional, value: "world!"),
+    Opt(kind: short, keyShort: 'a', value: ""),
+    Opt(kind: short, keyShort: 'b', value: ""),
+    Opt(kind: short, keyShort: 'c', value: "de"),
+    Opt(kind: long, keyLong: "f", value: "g"),
+    Opt(kind: long, keyLong: "h", value: "i"),
+    Opt(kind: long, keyLong: "j", value: ""),
+    Opt(kind: long, keyLong: "k", value: "l"),
+    Opt(kind: positional, value: "m"),
   ]
 
 # optional tests
 # the way to make short opt simple flag, but long opt optionally on/off
 
 checkOpts opts(["--foo"]),
-  @[Opt(kind: optLong, keyLong: "foo", val: "")]
+  @[Opt(kind: long, keyLong: "foo", value: "")]
 checkOpts opts(["--foo:bar"]),
-  @[Opt(kind: optLong, keyLong: "foo", val: "bar")]
+  @[Opt(kind: long, keyLong: "foo", value: "bar")]
 checkOpts opts(["--foo=bar"]),
-  @[Opt(kind: optLong, keyLong: "foo", val: "bar")]
+  @[Opt(kind: long, keyLong: "foo", value: "bar")]
 checkOpts opts(["-fbar"]),
   @[
-    Opt(kind: optShort, keyShort: 'f', val: ""),
-    Opt(kind: optShort, keyShort: 'b', val: ""),
-    Opt(kind: optShort, keyShort: 'a', val: ""),
-    Opt(kind: optShort, keyShort: 'r', val: ""),
+    Opt(kind: short, keyShort: 'f', value: ""),
+    Opt(kind: short, keyShort: 'b', value: ""),
+    Opt(kind: short, keyShort: 'a', value: ""),
+    Opt(kind: short, keyShort: 'r', value: ""),
   ]
 
 # todo: test exceptions

--- a/tests/stdlib/tparseopt2.nim
+++ b/tests/stdlib/tparseopt2.nim
@@ -54,3 +54,5 @@ checkOpts opts("hello world! -abcde --f:g --h=i --j --k l m".split(" "), shortHa
   Opt(kind: optLong, keyLong: "k", val: "l"),
   Opt(kind: optPos, val: "m"),
 ]
+
+# todo: test exceptions

--- a/tests/stdlib/tparseopt2.nim
+++ b/tests/stdlib/tparseopt2.nim
@@ -14,6 +14,8 @@ checkOpts opts(["-c:c_val"], shortHasVal="c"),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
 checkOpts opts(["-c=c_val"], shortHasVal="c"),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["-cc_val", "-j4"], shortHasVal=['c', 'j']),
+  @[Opt(kind: optShort, keyShort: 'c', val: "c_val"), Opt(kind: optShort, keyShort: 'j', val: "4")]
 checkOpts opts(["-abcc_val"], shortHasVal="c"),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
 checkOpts opts(["-abc", "c_val"], shortHasVal="c"),

--- a/tests/stdlib/tparseopt2.nim
+++ b/tests/stdlib/tparseopt2.nim
@@ -80,4 +80,12 @@ checkOpts opts(["-fbar"]),
     Opt(kind: short, keyShort: 'r', value: ""),
   ]
 
-# todo: test exceptions
+# errors
+checkOpts opts(["--foo=bar"], longVal={"foo": optValNone}),
+  @[Opt(kind: long, keyLong: "foo", value: "bar", error: OptError.extraneous)]
+checkOpts opts(["--foo"], longVal={"foo": optValRequired}),
+  @[Opt(kind: long, keyLong: "foo", value: "", error: OptError.missing)]
+checkOpts opts(["-f=bar"], shortVal={'f': optValNone}),
+  @[Opt(kind: short, keyShort: 'f', value: "bar", error: OptError.extraneous)]
+checkOpts opts(["-f"], shortVal={'f': optValRequired}),
+  @[Opt(kind: short, keyShort: 'f', value: "", error: OptError.missing)]

--- a/tests/stdlib/tparseopt2.nim
+++ b/tests/stdlib/tparseopt2.nim
@@ -1,0 +1,56 @@
+discard """
+"""
+
+import std/[unittest, parseopt2, sequtils]
+
+template checkopts(args; expected) =
+  check(toSeq(args) == expected)
+
+## test edge cases
+
+checkOpts opts(["-c", "c_val"], shortHasVal="c"),
+  @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["-c:c_val"], shortHasVal="c"),
+  @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["-c=c_val"], shortHasVal="c"),
+  @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["-abcc_val"], shortHasVal="c"),
+  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["-abc", "c_val"], shortHasVal="c"),
+  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["-abc:c_val"], shortHasVal="c"),
+  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["-abc=c_val"], shortHasVal="c"),
+  @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
+checkOpts opts(["--long", "val"], longHasVal=["long"]),
+  @[Opt(kind: optLong, keyLong: "long", val: "val")]
+checkOpts opts(["--long:val"], longHasVal=["long"]),
+  @[Opt(kind: optLong, keyLong: "long", val: "val")]
+checkOpts opts(["--long=val"], longHasVal=["long"]),
+  @[Opt(kind: optLong, keyLong: "long", val: "val")]
+checkOpts opts(["--long="], longHasVal=["long"]),
+  @[Opt(kind: optLong, keyLong: "long", val: "")]
+checkOpts opts(["--", "-positional1", "--positional2", "positional3"]),
+  @[Opt(kind: optPos, val: "-positional1"), Opt(kind: optPos, val: "--positional2"), Opt(kind: optPos, val: "positional3")]
+checkOpts opts(["-"]),
+  @[Opt(kind: optPos, val: "-")]
+let emptySeq: seq[Opt] = @[]
+checkOpts opts(["--"]), emptySeq
+checkOpts opts(["---"]),
+  @[Opt(kind: optLong, keyLong: "-", val: "")]
+
+
+## mixed test
+import std/strutils
+checkOpts opts("hello world! -abcde --f:g --h=i --j --k l m".split(" "), shortHasVal="c", longHasVal=["f","h","k"]), @[
+  Opt(kind: optPos, val: "hello"),
+  Opt(kind: optPos, val: "world!"),
+  Opt(kind: optShort, keyShort: 'a', val: ""),
+  Opt(kind: optShort, keyShort: 'b', val: ""),
+  Opt(kind: optShort, keyShort: 'c', val: "de"),
+  Opt(kind: optLong, keyLong: "f", val: "g"),
+  Opt(kind: optLong, keyLong: "h", val: "i"),
+  Opt(kind: optLong, keyLong: "j", val: ""),
+  Opt(kind: optLong, keyLong: "k", val: "l"),
+  Opt(kind: optPos, val: "m"),
+]

--- a/tests/stdlib/tparseopt2.nim
+++ b/tests/stdlib/tparseopt2.nim
@@ -6,59 +6,78 @@ import std/[unittest, parseopt2, sequtils]
 template checkOpts(args; expected) =
   check(toSeq(args) == expected)
 
-## test edge cases
+# test edge cases
 
 func allRequired[T](a: openArray[T]): seq[(T, OptValExpectation)] =
   for x in a:
     result &= (x, optValRequired)
 
-checkOpts opts(["-c", "c_val"], optValNone, shortVal=['c'].allRequired),
+checkOpts opts(["-c", "c_val"], shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-c:c_val"], optValNone, shortVal=['c'].allRequired),
+checkOpts opts(["-c:c_val"], shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-c=c_val"], optValNone, shortVal=['c'].allRequired),
+checkOpts opts(["-c=c_val"], shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-cc_val", "-j4"], optValNone, shortVal=['c', 'j'].allRequired),
+checkOpts opts(["-cc_val", "-j4"], shortVal=['c', 'j'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val"), Opt(kind: optShort, keyShort: 'j', val: "4")]
-checkOpts opts(["-abcc_val"], optValNone, shortVal=['c'].allRequired),
+checkOpts opts(["-abcc_val"], shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-abc", "c_val"], optValNone, shortVal=['c'].allRequired),
+checkOpts opts(["-abc", "c_val"], shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-abc:c_val"], optValNone, shortVal=['c'].allRequired),
+checkOpts opts(["-abc:c_val"], shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-abc=c_val"], optValNone, shortVal=['c'].allRequired),
+checkOpts opts(["-abc=c_val"], shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["--long", "val"], optValNone, longVal=["long"].allRequired),
+checkOpts opts(["--long", "val"], longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "val")]
-checkOpts opts(["--long:val"], optValNone, longVal=["long"].allRequired),
+checkOpts opts(["--long:val"], longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "val")]
-checkOpts opts(["--long=val"], optValNone, longVal=["long"].allRequired),
+checkOpts opts(["--long=val"], longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "val")]
-checkOpts opts(["--long="], optValNone, longVal=["long"].allRequired),
+checkOpts opts(["--long="], longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "")]
-checkOpts opts(["--", "-positional1", "--positional2", "positional3"], optValNone),
+checkOpts opts(["--", "-positional1", "--positional2", "positional3"]),
   @[Opt(kind: optPos, val: "-positional1"), Opt(kind: optPos, val: "--positional2"), Opt(kind: optPos, val: "positional3")]
-checkOpts opts(["-"], optValNone),
+checkOpts opts(["-"]),
   @[Opt(kind: optPos, val: "-")]
 let emptySeq: seq[Opt] = @[]
-checkOpts opts(["--"], optValNone), emptySeq
-checkOpts opts(["---"], optValNone),
+checkOpts opts(["--"]), emptySeq
+checkOpts opts(["---"]),
   @[Opt(kind: optLong, keyLong: "-", val: "")]
 
 
-## mixed test
+# mixed tests
+
 import std/strutils
-checkOpts opts("hello world! -abcde --f:g --h=i --j --k l m".split(" "), optValNone, shortVal=['c'].allRequired, longVal=["f","h","k"].allRequired), @[
-  Opt(kind: optPos, val: "hello"),
-  Opt(kind: optPos, val: "world!"),
-  Opt(kind: optShort, keyShort: 'a', val: ""),
-  Opt(kind: optShort, keyShort: 'b', val: ""),
-  Opt(kind: optShort, keyShort: 'c', val: "de"),
-  Opt(kind: optLong, keyLong: "f", val: "g"),
-  Opt(kind: optLong, keyLong: "h", val: "i"),
-  Opt(kind: optLong, keyLong: "j", val: ""),
-  Opt(kind: optLong, keyLong: "k", val: "l"),
-  Opt(kind: optPos, val: "m"),
-]
+checkOpts opts("hello world! -abcde --f:g --h=i --j --k l m".split(" "), shortVal=['c'].allRequired, longVal=["f","h","k"].allRequired),
+  @[
+    Opt(kind: optPos, val: "hello"),
+    Opt(kind: optPos, val: "world!"),
+    Opt(kind: optShort, keyShort: 'a', val: ""),
+    Opt(kind: optShort, keyShort: 'b', val: ""),
+    Opt(kind: optShort, keyShort: 'c', val: "de"),
+    Opt(kind: optLong, keyLong: "f", val: "g"),
+    Opt(kind: optLong, keyLong: "h", val: "i"),
+    Opt(kind: optLong, keyLong: "j", val: ""),
+    Opt(kind: optLong, keyLong: "k", val: "l"),
+    Opt(kind: optPos, val: "m"),
+  ]
+
+# optional tests
+# the way to make short opt simple flag, but long opt optionally on/off
+
+checkOpts opts(["--foo"]),
+  @[Opt(kind: optLong, keyLong: "foo", val: "")]
+checkOpts opts(["--foo:bar"]),
+  @[Opt(kind: optLong, keyLong: "foo", val: "bar")]
+checkOpts opts(["--foo=bar"]),
+  @[Opt(kind: optLong, keyLong: "foo", val: "bar")]
+checkOpts opts(["-fbar"]),
+  @[
+    Opt(kind: optShort, keyShort: 'f', val: ""),
+    Opt(kind: optShort, keyShort: 'b', val: ""),
+    Opt(kind: optShort, keyShort: 'a', val: ""),
+    Opt(kind: optShort, keyShort: 'r', val: ""),
+  ]
 
 # todo: test exceptions

--- a/tests/stdlib/tparseopt2.nim
+++ b/tests/stdlib/tparseopt2.nim
@@ -3,48 +3,52 @@ discard """
 
 import std/[unittest, parseopt2, sequtils]
 
-template checkopts(args; expected) =
+template checkOpts(args; expected) =
   check(toSeq(args) == expected)
 
 ## test edge cases
 
-checkOpts opts(["-c", "c_val"], shortHasVal="c"),
+func allRequired[T](a: openArray[T]): seq[(T, OptValExpectation)] =
+  for x in a:
+    result &= (x, optValRequired)
+
+checkOpts opts(["-c", "c_val"], optValNone, shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-c:c_val"], shortHasVal="c"),
+checkOpts opts(["-c:c_val"], optValNone, shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-c=c_val"], shortHasVal="c"),
+checkOpts opts(["-c=c_val"], optValNone, shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-cc_val", "-j4"], shortHasVal=['c', 'j']),
+checkOpts opts(["-cc_val", "-j4"], optValNone, shortVal=['c', 'j'].allRequired),
   @[Opt(kind: optShort, keyShort: 'c', val: "c_val"), Opt(kind: optShort, keyShort: 'j', val: "4")]
-checkOpts opts(["-abcc_val"], shortHasVal="c"),
+checkOpts opts(["-abcc_val"], optValNone, shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-abc", "c_val"], shortHasVal="c"),
+checkOpts opts(["-abc", "c_val"], optValNone, shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-abc:c_val"], shortHasVal="c"),
+checkOpts opts(["-abc:c_val"], optValNone, shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["-abc=c_val"], shortHasVal="c"),
+checkOpts opts(["-abc=c_val"], optValNone, shortVal=['c'].allRequired),
   @[Opt(kind: optShort, keyShort: 'a', val: ""), Opt(kind: optShort, keyShort: 'b', val: ""), Opt(kind: optShort, keyShort: 'c', val: "c_val")]
-checkOpts opts(["--long", "val"], longHasVal=["long"]),
+checkOpts opts(["--long", "val"], optValNone, longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "val")]
-checkOpts opts(["--long:val"], longHasVal=["long"]),
+checkOpts opts(["--long:val"], optValNone, longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "val")]
-checkOpts opts(["--long=val"], longHasVal=["long"]),
+checkOpts opts(["--long=val"], optValNone, longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "val")]
-checkOpts opts(["--long="], longHasVal=["long"]),
+checkOpts opts(["--long="], optValNone, longVal=["long"].allRequired),
   @[Opt(kind: optLong, keyLong: "long", val: "")]
-checkOpts opts(["--", "-positional1", "--positional2", "positional3"]),
+checkOpts opts(["--", "-positional1", "--positional2", "positional3"], optValNone),
   @[Opt(kind: optPos, val: "-positional1"), Opt(kind: optPos, val: "--positional2"), Opt(kind: optPos, val: "positional3")]
-checkOpts opts(["-"]),
+checkOpts opts(["-"], optValNone),
   @[Opt(kind: optPos, val: "-")]
 let emptySeq: seq[Opt] = @[]
-checkOpts opts(["--"]), emptySeq
-checkOpts opts(["---"]),
+checkOpts opts(["--"], optValNone), emptySeq
+checkOpts opts(["---"], optValNone),
   @[Opt(kind: optLong, keyLong: "-", val: "")]
 
 
 ## mixed test
 import std/strutils
-checkOpts opts("hello world! -abcde --f:g --h=i --j --k l m".split(" "), shortHasVal="c", longHasVal=["f","h","k"]), @[
+checkOpts opts("hello world! -abcde --f:g --h=i --j --k l m".split(" "), optValNone, shortVal=['c'].allRequired, longVal=["f","h","k"].allRequired), @[
   Opt(kind: optPos, val: "hello"),
   Opt(kind: optPos, val: "world!"),
   Opt(kind: optShort, keyShort: 'a', val: ""),


### PR DESCRIPTION
## Summary

Brand new and simpler implementation of 'parseopt', the new module does
not replace `parseopt` to allow the compiler code base time to migrate.

## Details

The parsing approach takes after posix getOpt, taking on conventions
such as space separated flag arguments and treating all args after `--`
as positional.

The new API is main the `opts` iterator which parse input and produces
`Opt` for each option, and input errors are inline via a field.

Along with the new module is a comprehensive set of tests.