### PR TITLE
parser: fix a use-after-free bug

### DIFF
--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -970,7 +970,8 @@ proc identWithPragma(p: var Parser; allowDot=false): ParsedNode =
   #| identWithPragmaDot = identVisDot pragma?
   let a = p.identVis(allowDot)
   if p.tok.tokType == tkCurlyDotLe:
-    p.newNode(pnkPragmaExpr, p.tok, @[a, parsePragma(p)])
+    let tok = p.tok
+    p.newNode(pnkPragmaExpr, tok, @[a, parsePragma(p)])
   else:
     a
 


### PR DESCRIPTION
## Summary

Create a copy of the token before calling `parsePragma` in
`identWithPragma`, which fixes a subtle issue where the `Token.literal`
string pointed to already-freed heap memory.

## Details

For a call such as `p(a, p2(a))` where `proc p(x: ObjType)` and
`proc p2(x: var ObjType)`, the *C code-generator* introduces a shallow
temporary that captures the state of `a` prior to the evaluating
`p2(a)`, with the temporary then being passed to `p` in the place of `a`.

This is done in order to uphold the left-to-right evaluation guarantees.
However, if the `ObjType` stores indirections such as `seq` or `string`,
updates of their contents are still observable through the shallow
temporary, and should `p2` resize the `seq` or `string`, the pointer in
the shallow temporary becomes dangling.