### PR TITLE
transf: fix inlining iterators into `closure` iterators

### DIFF
--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -290,15 +290,15 @@ proc liftIterSym*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner: PSym): PN
   result.add makeClosure(g, idgen, iter, env, n.info)
 
 proc freshVarForClosureIter*(g: ModuleGraph; s: PSym; idgen: IdGenerator; owner: PSym): PNode =
-  let envParam = getHiddenParam(g, owner)
-  let obj = envParam.typ.skipTypes({tyRef, tyPtr})
-  addField(obj, s, g.cache, idgen)
-
-  var access = newSymNode(envParam)
+  ## Adds a unique field to `owner`'s environment type, using the name, type,
+  ## and ``.cursor`` information from the local `s`.
+  let
+    envParam = getHiddenParam(g, owner)
+    obj = envParam.typ.base
   assert obj.kind == tyObject
-  let field = getFieldFromObj(obj, s)
-  g.config.internalAssert(field != nil, s.info, "internal error: cannot generate fresh variable")
-  result = rawIndirectAccess(access, field, s.info)
+
+  let field = addUnmappedField(obj, s, g.cache, idgen)
+  result = rawIndirectAccess(newSymNode(envParam), field, s.info)
 
 # ------------------ new stuff -------------------------------------------
 

--- a/compiler/sem/lowerings.nim
+++ b/compiler/sem/lowerings.nim
@@ -204,20 +204,27 @@ proc lookupInRecord(n: PNode, id: ItemId): PSym =
     if n.sym.itemId.module == id.module and n.sym.itemId.item == -abs(id.item): result = n.sym
   else: discard
 
-proc addField*(obj: PType; s: PSym; cache: IdentCache; idgen: IdGenerator) =
+proc addUnmappedField*(obj: PType, s: PSym, cache: IdentCache, idgen: IdGenerator): PSym =
+  ## Adds a new field to `obj` and returns the new field's symbol. The field's
+  ## type and whether it's a cursor are provided by `s`; it's name is based
+  ## on that of `s`, but guaranteed to be unique.
   # because of 'gensym' support, we have to mangle the name with its ID.
   # This is hacky but the clean solution is much more complex than it looks.
   var field = newSym(skField, getIdent(cache, s.name.s & $obj.n.len),
                      nextSymId(idgen), s.owner, s.info, s.options)
-  field.itemId = ItemId(module: s.itemId.module, item: -s.itemId.item)
   let t = skipIntLit(s.typ, idgen)
   field.typ = t
   assert t.kind != tyTyped
-  propagateToOwner(obj, t)
-  field.position = obj.n.len
   field.flags = s.flags * {sfCursor}
-  obj.n.add newSymNode(field)
-  fieldCheck()
+  rawAddField(obj, field)
+
+  result = field
+
+proc addField*(obj: PType; s: PSym; cache: IdentCache; idgen: IdGenerator) =
+  ## Similar to ``addUnmappedField``, but makes sure that the field can later
+  ## be looked up via the ``ItemId`` of `s`.
+  let field = addUnmappedField(obj, s, cache, idgen)
+  field.itemId = ItemId(module: s.itemId.module, item: -s.itemId.item)
 
 proc addUniqueField*(obj: PType; s: PSym; cache: IdentCache; idgen: IdGenerator): PSym {.discardable.} =
   result = lookupInRecord(obj.n, s.itemId)

--- a/tests/lang_callable/iter/tmultiple_inlined_in_closure_iter.nim
+++ b/tests/lang_callable/iter/tmultiple_inlined_in_closure_iter.nim
@@ -1,0 +1,31 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Using the same inline iterator multiple times in the context of a
+    *top-level* closure iterator must be possible and produce the
+    correct code
+  '''
+"""
+
+iterator simple(): int =
+  var i = 0 # each inlining must produce a new instance of the local
+  while i < 2:
+    yield i
+    inc i
+
+iterator iter(): (int, int) {.closure.} =
+  # test that the inline iterator's locals are not shared by nesting
+  # their usage. If the locals are shared, then the outer loop would only
+  # run once, since `i` would be 2 after the inner loop finished iterating
+  for a in simple():
+    for b in simple():
+      yield (a, b)
+
+let it = iter
+# test that all possible pairs are returned in the correct order
+doAssert it() == (0, 0)
+doAssert it() == (0, 1)
+doAssert it() == (1, 0)
+doAssert it() == (1, 1)
+discard it()
+doAssert finished(it)


### PR DESCRIPTION
## Summary

Don't associate the source symbol with the generated environment field
when creating creating fresh variables for the locals of inlined
iterators.

Previously, using the same `.inline` iterator multiple times inside a
`.closure` iterator led to each inlined iterator body effectively
sharing the state of its locals with that of the others. This is now
fixed.

## Details

Only *top-level* closure iterators were affected. The reason being
that for *top-level* closure iterators, the `transf` pass (which is
responsible for inlining `.inline` iterators) is run *after* the
`lambdalifting` pass (which is responsible for lifting locals).

When inlining the `var`/`let` section, `freshVarForClosureIter` is
called, and while that *does* always create a new field, the subsequent
lookup-by-itemId returns the field first associated with the passed-in
symbol.

`freshVarForClosureIter` now creates a field that has no association
with the symbol of a local, fixing the erroneous sharing.