### PR TITLE
generate method dispatchers prior to code-gen

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -12,6 +12,7 @@ import
   compiler/backend/[
     cgen,
     cgendata,
+    cgmeth,
     extccomp
   ],
   compiler/front/[
@@ -35,6 +36,8 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   ## is written to disk yet.
   let
     config = graph.config
+
+  generateMethodDispatchers(graph)
 
   var g = newModuleList(graph)
 

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2268,8 +2268,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
     var sym = n.sym
     case sym.kind
     of skMethod:
-      if useAliveDataFromDce in p.module.flags or {sfDispatcher, sfForward} * sym.flags != {}:
-        # we cannot produce code for the dispatcher yet:
+      if useAliveDataFromDce in p.module.flags or {sfForward} * sym.flags != {}:
         fillProcLoc(p.module, n)
         genProcPrototype(p.module, sym)
       else:
@@ -2471,8 +2470,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
           genProc(p.module, prc)
       elif prc.skipGenericOwner.kind == skModule and sfCompileTime notin prc.flags:
         if ({sfExportc, sfCompilerProc} * prc.flags == {sfExportc}) or
-            (sfExportc in prc.flags and lfExportLib in prc.loc.flags) or
-            (prc.kind == skMethod):
+            (sfExportc in prc.flags and lfExportLib in prc.loc.flags):
           # due to a bug/limitation in the lambda lifting, unused inner procs
           # are not transformed correctly. We work around this issue (#411) here
           # by ensuring it's no inner proc (owner is a module).

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -124,7 +124,6 @@ type
                         ## a frame var twice in an init proc
     isHeaderFile,       ## C source file is the header file
     includesStringh,    ## C source file already includes ``<string.h>``
-    objHasKidsValid     ## whether we can rely on tfObjHasKids
     useAliveDataFromDce ## use the `alive: IntSet` field instead of
                         ## computing alive data on our own.
 

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -258,9 +258,10 @@ proc sortBucket(a: var seq[PSym], relevantCols: IntSet) =
       a[j] = v
     if h == 1: break
 
-proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet): PSym =
+proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet) =
   var base = methods[0].ast[dispatcherPos].sym
-  result = base
+  # XXX: `base` is not the method marked with ``.base``, but rather the
+  #      *dispatcher*
   var paramLen = base.typ.len
   var nilchecks = newNodeI(nkStmtList, base.info)
   var disp = newNodeI(nkIfStmt, base.info)
@@ -315,10 +316,12 @@ proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet): PS
       disp = ret
   nilchecks.add disp
   nilchecks.flags.incl nfTransf # should not be further transformed
-  result.ast[bodyPos] = nilchecks
+  base.ast[bodyPos] = nilchecks
 
-proc generateMethodDispatchers*(g: ModuleGraph): PNode =
-  result = newNode(nkStmtList)
+proc generateMethodDispatchers*(g: ModuleGraph) =
+  ## For each method dispatcher, generates the body and updates the definition.
+  ## This procedure must only be called once, and only *after* all methods were
+  ## registered.
   for bucket in 0..<g.methods.len:
     var relevantCols = initIntSet()
     for col in 1..<g.methods[bucket].methods[0].typ.len:
@@ -327,4 +330,8 @@ proc generateMethodDispatchers*(g: ModuleGraph): PNode =
         # if multi-methods are not enabled, we are interested only in the first field
         break
     sortBucket(g.methods[bucket].methods, relevantCols)
-    result.add newSymNode(genDispatcher(g, g.methods[bucket].methods, relevantCols))
+    genDispatcher(g, g.methods[bucket].methods, relevantCols)
+
+iterator dispatchers*(g: ModuleGraph): PSym =
+  for bucket in g.methods.items:
+    yield bucket.dispatcher

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -11,6 +11,7 @@ import
     json
   ],
   compiler/backend/[
+    cgmeth,
     jsgen
   ],
   compiler/front/[
@@ -47,6 +48,8 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   ## writes it to the output file.
   let
     globals = newGlobals()
+
+  generateMethodDispatchers(graph)
 
   # generate the code for all modules:
   for index in mlist.modulesClosed.items:


### PR DESCRIPTION
## Summary

Move the method dispatcher generation out of the code generators (`cgen`
and `jsgen`) and into the orchestrators. This is another step towards
unifying the backend processing.

Methods are now also subject to dead-code elimination, meaning that if
none of the methods attached to an object hierarchy are called, no code
will be generated for them.

## Details

The dispatchers do not appear in calls prior to `transf`, so the DCE
implementation used by IC backend cannot analyze them. For this reason,
`cgen` continues to special-case methods.

In addition, remove the unused `objHasKidsValid` enum value.

### Future Direction

Given that all backends need to generate method dispatchers, this step
(lowering methods into procedures) should happen through some common
facility in the future.