### PR TITLE
boot: update the csources version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,31 +185,6 @@ jobs:
         if: failure()
         run: bin/nim r tools/ci_testresults
 
-  orc:
-    needs: [pre_run, binaries]
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        target: ${{ fromJson(needs.pre_run.outputs.target_matrix) }}
-
-    name: Test build compiler with ORC (${{ matrix.target.name }})
-    runs-on: ${{ matrix.target.runner }}
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/download-compiler
-
-      - name: Enable annotations
-        run: echo "::add-matcher::.github/nim-problem-matcher.json"
-
-      - name: Test ORC bootstrap
-        run: ./koch.py --nim:bin/nim boot -d:release --gc:orc
-
   tooling:
     needs: [pre_run, binaries]
 
@@ -503,7 +478,6 @@ jobs:
       - source_binaries
       - package
       - test_package
-      - orc
     if: always()
     runs-on: ubuntu-latest
 

--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -1,5 +1,5 @@
 nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v1
-nim_csourcesUrl=https://github.com/saem/csources_v1.git
-nim_csourcesBranch=saem-unblock-backend-unification-work
-nim_csourcesHash=b0922aaa9f7965ce3587abf0de99db1cdd9b0e54
+nim_csourcesUrl=https://github.com/nim-works/csources_v1.git
+nim_csourcesBranch=master
+nim_csourcesHash=bdb307f6aaeb4ef8f8a6769d4e250d7f98d1f6f4

--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -1,5 +1,5 @@
 nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v1
-nim_csourcesUrl=https://github.com/nim-works/csources_v1.git
-nim_csourcesBranch=master
-nim_csourcesHash=c181c28ae63be7c40cd316eb6744a01561617b6a
+nim_csourcesUrl=https://github.com/saem/csources_v1.git
+nim_csourcesBranch=saem-unblock-backend-unification-work
+nim_csourcesHash=b0922aaa9f7965ce3587abf0de99db1cdd9b0e54

--- a/koch.py
+++ b/koch.py
@@ -258,10 +258,6 @@ def main() -> None:
         # Silence "UnknownMagic" warnings that are common place due to the
         # bootstrapping compiler being older than the stdlib.
         "--warning:UnknownMagic:off",
-        # the csources compiler still uses `setjmp`-exceptions by default, but
-        # since everything related to `setjmp`-exceptions is removed from
-        # system, goto-exceptions need to be explicitly enabled
-        "--exceptions:goto",
         # Prevent users configuration and/or configuration placed in a parent
         # directory from interfering, as they might specify flags that are not
         # in the bootstrap compiler.

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -328,21 +328,6 @@ proc boot(args: string) =
 
       let ret = execCmdEx(nimStart & " --version")
       doAssert ret.exitCode == 0
-      let version = ret.output.splitLines[0]
-      if version.startsWith "Nim Compiler Version 0.20.0":
-        extraOption.add " --lib:lib" # see https://github.com/nim-lang/Nim/pull/14291
-
-      if not version.startsWith("Nimskull Compiler"):
-        # the current csource compiler (which can be identified by it still
-        # calling itself "Nim Compiler") is not able to build the compiler with
-        # ORC enabled, so refc is explicitly used
-        extraOption.add " --gc:refc"
-      # the csource compiler still uses setjmp-exceptions by default, but the
-      # runtime library doesn't support them anymore
-      extraOption.add " --exceptions:goto"
-    else:
-      # use ORC for all further iterations
-      extraOption.add " --gc:orc"
 
     # in order to use less memory, we split the build into two steps:
     # --compileOnly produces a $project.json file and does not run GCC/Clang.


### PR DESCRIPTION
## Summary

Require the latest csources version. In addition, remove support
for using NimSkull compilers without proper `--gc:orc` support
during the first bootstrap iteration.

## Details

The `orc` CI job is now redundant (all bootstrap iterations are
built with ORC enabled), and thus removed.