### PR TITLE
backend: simpler error handling

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -29,8 +29,6 @@ import
     pathutils
   ]
 
-from compiler/sem/passes import skipCodegen
-
 proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   ## Entry point for C code-generation. Only the C code is generated -- nothing
   ## is written to disk yet.
@@ -66,8 +64,7 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
 
     # pass all top-level code to the code generator:
     for it in m.stmts.items:
-      if not skipCodegen(bmod.config, it):
-        genTopLevelStmt(bmod, it)
+      genTopLevelStmt(bmod, it)
 
     # wrap up the main part of code generation for the module. Note that this
     # doesn't mean that they're closed for writing; invoking the code generator

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1733,7 +1733,7 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
     if {optGenStaticLib, optGenDynLib, optNoMain} * m.config.globalOptions == {}:
       for i in countdown(high(graph.globalDestructors), 0):
         n.add graph.globalDestructors[i]
-  if passes.skipCodegen(m.config, n): return
+
   if moduleHasChanged(graph, m.module):
     # if the module is cached, we don't regenerate the main proc
     # nor the dispatchers? But if the dispatchers changed?

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -22,7 +22,6 @@ import
   ],
   compiler/sem/[
     collectors,
-    passes,
     sourcemap
   ],
   compiler/utils/[
@@ -61,8 +60,7 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
 
     # invoke ``jsgen`` for all top-level code:
     for n in m.stmts.items:
-      if not skipCodegen(graph.config, n):
-        genTopLevelStmt(globals, bmod, n)
+      genTopLevelStmt(globals, bmod, n)
 
     # close the module:
     finalCodegenActions(graph, globals, bmod)


### PR DESCRIPTION
## Summary

Consistently disable the code generation phase across backends when
there were errors during the semantic phase, and make sure that the
first error reported during code generation terminates the compiler.

This prevents errors destabilizing the code generators when
`errorMax` > 1.

## Details

The goal is to eventually remove all raising of semantic errors from the
code generators, so overriding the user-provided error upper-bound in
the meantime is acceptable.