### PR TITLE
vmjit: small refactoring

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -466,8 +466,13 @@ proc evalConstExprAux(module: PSym; idgen: IdGenerator;
   defer:
     c.mode = oldMode
 
-  let requiresValue = mode!=emStaticStmt
-  let (start, regCount) = genExpr(c[], n, requiresValue).returnOnErr(c.config, n)
+  let
+    requiresValue = mode != emStaticStmt
+    r =
+      if requiresValue: genExpr(c[], n)
+      else:             genStmt(c[], n)
+
+  let (start, regCount) = r.returnOnErr(c.config, n)
 
   if c.code[start].opcode == opcEof: return newNodeI(nkEmpty, n.info)
   assert c.code[start].opcode != opcEof


### PR DESCRIPTION
## Summary

Make the logic for dispatching to `vmgen` more uniform across the
procedures and remove the `requiresValue` parameter. This is a pure
refactoring, there's no change in behaviour.

## Details

* remove the `requiresValue` parameter from `genExpr` --
  `evalConstExprAux` now dispatches to `genExpr` or `genStmt` itself
* move the result handling (emitting a `Eof` or `Ret` instruction) from
  `vmgen.genExpr` into `vmjit.genExpr`, making the shape of `genExpr`
  consistent with that of `genStmt`
* remove the obsolete `Eof` instruction moving from `genProc`
* move the code in `vmjit.genProc` around so that its shape is more
  consistent with that of `genExpr` and `genStmt`

Together, the changes makes it visible that the `vmjit` procedures
all share roughly the same shape:
1. prepare for appending to the instruction list (`removeLastEof`)
2. setup the link state
3. transform the input AST
4. gather the input code's dependencies
5. invoke `vmgen`
6. emit the instruction marking the end
7. update the VM environment