### PR TITLE
cgen: fix `reset` and `default` for resolved concepts

### DIFF
--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -432,7 +432,7 @@ proc isComplexValueType(t: PType): bool {.inline.} =
 include ccgreset
 
 proc resetLoc(p: BProc, loc: var TLoc; doInitObj = true) =
-  let typ = skipTypes(loc.t, abstractVarRange)
+  let typ = skipTypes(loc.t, abstractVarRange + tyUserTypeClasses)
   if typ.kind in {tyString, tySequence}:
     assert rdLoc(loc) != ""
 

--- a/tests/lang_experimental/concepts/tusertypeclasses.nim
+++ b/tests/lang_experimental/concepts/tusertypeclasses.nim
@@ -126,3 +126,10 @@ let
   stud2 = stud.setkey("id")
 
 echo stud2
+
+block reset_and_default:
+  var x: stringTest = "a"  # instantiate the concept
+  doAssert x is stringTest # is the meta-type information kept?
+
+  reset(x)               # ``reset`` must work
+  x = default(typeof(x)) # ``default`` too


### PR DESCRIPTION
## Summary

Skip user type-classes when generating code for `reset` and `default`,
fixing semantically invalid C code being generated when the operand is
a resolved user-type-class.

## Details

When not skipped, the branch that assigned `0` was chosen for strings
and seqs. While skipping `tyUserTypeClasses` fixes the bug, it's
fundamentally a workaround; resolved user-type-classes should not reach
the code generators in the first place.