### PR TITLE
cgen: don't emit unnecessary case statements

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1153,7 +1153,7 @@ proc specializeInitObjectN(p: BProc, accessor: Rope, n: PNode, typ: PType) =
 proc specializeInitObject(p: BProc, accessor: Rope, typ: PType,
                           info: TLineInfo) =
   ## Generates type field (if there are any) initialization code for a
-  ## loaction of type `typ`, where `accessor` is the path of the
+  ## location of type `typ`, where `accessor` is the path of the
   ## location.
   if typ == nil:
     return

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1152,9 +1152,9 @@ proc specializeInitObjectN(p: BProc, accessor: Rope, n: PNode, typ: PType) =
 
 proc specializeInitObject(p: BProc, accessor: Rope, typ: PType,
                           info: TLineInfo) =
-  ## Generates type field (if there are any) initialization code for an
-  ## variable of `typ` at `accessor`. Specialiaztion for the run-time
-  ## `objectInit` function (that's also only available for the old runtime)
+  ## Generates type field (if there are any) initialization code for a
+  ## loaction of type `typ`, where `accessor` is the path of the
+  ## location.
   if typ == nil:
     return
 
@@ -1186,7 +1186,8 @@ proc specializeInitObject(p: BProc, accessor: Rope, typ: PType,
                          typ[1], info)
     lineF(p, cpsStmts, "}$n", [])
   of tyObject:
-    proc pred(t: PType): bool = not isObjLackingTypeField(t)
+    proc pred(t: PType): bool =
+      t.kind == tyObject and not isObjLackingTypeField(t)
 
     var
       t = typ
@@ -1295,8 +1296,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
       genAssignment(p, d, tmp, {})
 
   if hasCase:
-    # fill in type type fields. Always use `specializeInitObject`, even when
-    # compiling for the old runtime (`objectInit` could be used there)
+    # initialize the object's type fields, if there are any
 
     # XXX: for some discriminators, the value is known at compile-time, so
     #      their switch-case stmt emitted by `specializeInitObject` could be


### PR DESCRIPTION
## Summary

Fix a logic bug in `cgen`'s object-init specialization that led to
potentially large but empty C case statements being emitted.

While the bug had no effect on program semantics, it did cause more C
code to be emitted, which translated to more work for both the NimSkull
and C compiler.

## Details

The predicate was the inverse of `isObjLackingTypeField`, but that is
incorrect. `isObjLackingTypeField` also returns false for anything
besides `tyObject`, so in effect, all objects that had fields of
non-object types were erroneously treated as having a type field
somewhere.

Also adjust stale documentation related to object-init specialization.