### PR TITLE
codegen: clean up unused code paths

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2346,10 +2346,8 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkBlockExpr, nkBlockStmt: genBlock(p, n, d)
   of nkStmtListExpr: genStmtListExpr(p, n, d)
   of nkStmtList: genStmtList(p, n)
-  of nkIfExpr, nkIfStmt: genIf(p, n, d)
+  of nkIfStmt: genIf(p, n)
   of nkWhen:
-    # This should be a "when nimvm" node.
-    expr(p, n[1][0], d)
   of nkObjDownConv: downConv(p, n, d)
   of nkObjUpConv: upConv(p, n, d)
   of nkChckRangeF, nkChckRange64, nkChckRange: genRangeChck(p, n, d)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2343,7 +2343,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkDerefExpr, nkHiddenDeref: genDeref(p, n, d)
   of nkDotExpr: genRecordField(p, n, d)
   of nkCheckedFieldExpr: genCheckedRecordField(p, n, d)
-  of nkBlockExpr, nkBlockStmt: genBlock(p, n, d)
+  of nkBlockStmt: genBlock(p, n)
   of nkStmtListExpr: genStmtListExpr(p, n, d)
   of nkStmtList: genStmtList(p, n)
   of nkIfStmt: genIf(p, n)
@@ -2362,7 +2362,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
       genConstStmt(p, n)
     # else: consts generated lazily on use
   of nkForStmt: internalError(p.config, n.info, "for statement not eliminated")
-  of nkCaseStmt: genCase(p, n, d)
+  of nkCaseStmt: genCase(p, n)
   of nkReturnStmt: genReturnStmt(p, n)
   of nkBreakStmt: genBreakStmt(p, n)
   of nkAsgn:
@@ -2383,9 +2383,9 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
       initLocExprSingleUse(p, ex, a)
       line(p, cpsStmts, "(void)(" & a.r & ");\L")
   of nkAsmStmt: genAsmStmt(p, n)
-  of nkTryStmt, nkHiddenTryStmt:
+  of nkTryStmt:
     assert p.config.exc == excGoto
-    genTryGoto(p, n, d)
+    genTryGoto(p, n)
   of nkRaiseStmt: genRaiseStmt(p, n)
   of nkTypeSection:
     # we have to emit the type information for object types here to support

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2288,8 +2288,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkIntLit..nkUInt64Lit,
      nkFloatLit..nkFloat128Lit, nkCharLit:
     putIntoDest(p, d, n, genLiteral(p, n))
-  of nkCall, nkHiddenCallConv, nkInfix, nkPrefix, nkPostfix, nkCommand,
-     nkCallStrLit:
+  of nkCall:
     genLineDir(p, n) # may be redundant, it is generated in fixupCall as well
     let op = n[0]
     if n.typ.isNil:

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2242,11 +2242,6 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
         putLocIntoDest(p, d, sym.loc)
       else:
         genComplexConst(p, sym, d)
-    of skEnumField:
-      # we never reach this case - as of the time of this comment,
-      # skEnumField is folded to an int in semfold.nim, but this code
-      # remains for robustness
-      putIntoDest(p, d, n, rope(sym.position))
     of skVar, skForVar, skResult, skLet:
       if {sfGlobal, sfThread} * sym.flags != {}:
         genVarPrototype(p.module, n)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2347,18 +2347,11 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkStmtListExpr: genStmtListExpr(p, n, d)
   of nkStmtList: genStmtList(p, n)
   of nkIfStmt: genIf(p, n)
-  of nkWhen:
   of nkObjDownConv: downConv(p, n, d)
   of nkObjUpConv: upConv(p, n, d)
   of nkChckRangeF, nkChckRange64, nkChckRange: genRangeChck(p, n, d)
   of nkStringToCString: convStrToCStr(p, n, d)
   of nkCStringToString: convCStrToStr(p, n, d)
-  of nkLambdaKinds:
-    var sym = n[namePos].sym
-    genProc(p.module, sym)
-    if sym.loc.r == "" or sym.loc.lode == nil:
-      internalError(p.config, n.info, "expr: proc not init " & sym.name.s)
-    putLocIntoDest(p, d, sym.loc)
   of nkClosure: genClosure(p, n, d)
 
   of nkEmpty: discard
@@ -2403,7 +2396,6 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
      nkFromStmt, nkTemplateDef, nkMacroDef, nkStaticStmt:
     discard
   of nkPragma: genPragma(p, n)
-  of nkPragmaBlock: expr(p, n.lastSon, d)
   of nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef:
     if n[genericParamsPos].kind == nkEmpty:
       var prc = n[namePos].sym

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -441,8 +441,6 @@ proc genComputedGoto(p: BProc; n: PNode) =
 proc genWhileStmt(p: BProc, t: PNode) =
   # we don't generate labels here as for example GCC would produce
   # significantly worse code
-  var
-    a: TLoc
   assert(t.len == 2)
   inc(p.withinLoop)
   genLineDir(p, t)
@@ -458,10 +456,6 @@ proc genWhileStmt(p: BProc, t: PNode) =
     else:
       p.breakIdx = startBlock(p, "while (1) {$n")
       p.blocks[p.breakIdx].isLoop = true
-      initLocExpr(p, t[0], a)
-      if (t[0].kind != nkIntLit) or (t[0].intVal == 0):
-        let label = assignLabel(p.blocks[p.breakIdx])
-        lineF(p, cpsStmts, "if (!$1) goto $2;$n", [rdLoc(a), label])
       genStmts(p, loopBody)
 
       if optProfiler in p.options:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -728,7 +728,6 @@ proc genLineDir(p: PProc, n: PNode) =
     lineF(p, "F.line = $1;$n", [rope(line)])
 
 proc genWhileStmt(p: PProc, n: PNode) =
-  var cond: TCompRes
   internalAssert p.config, isEmptyType(n.typ)
   genLineDir(p, n)
   inc(p.unique)
@@ -737,9 +736,6 @@ proc genWhileStmt(p: PProc, n: PNode) =
   p.blocks[^1].isLoop = true
   let labl = p.unique.rope
   lineF(p, "Label$1: while (true) {$n", [labl])
-  p.nested: gen(p, n[0], cond)
-  lineF(p, "if (!$1) break Label$2;$n",
-       [cond.res, labl])
   p.nested: genStmt(p, n[1])
   lineF(p, "}$n", [labl])
   setLen(p.blocks, p.blocks.len - 1)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -966,8 +966,7 @@ const
   nodeKindsNeedNoCopy = {nkCharLit..nkInt64Lit, nkStrLit..nkTripleStrLit,
     nkFloatLit..nkFloat64Lit, nkPar, nkStringToCString,
     nkObjConstr, nkTupleConstr, nkBracket,
-    nkCStringToString, nkCall, nkPrefix, nkPostfix, nkInfix,
-    nkCommand, nkHiddenCallConv, nkCallStrLit}
+    nkCStringToString, nkCall}
 
 proc needsNoCopy(p: PProc; y: PNode): bool =
   return y.kind in nodeKindsNeedNoCopy or

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2531,9 +2531,6 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       gen(p, lastSon(n), r)
   of nkBlockStmt, nkBlockExpr: genBlock(p, n, r)
   of nkIfStmt: genIf(p, n)
-  of nkWhen:
-    # This is "when nimvm" node
-    gen(p, n[1][0], r)
   of nkWhileStmt: genWhileStmt(p, n)
   of nkVarSection, nkLetSection: genVarStmt(p, n)
   of nkConstSection: discard
@@ -2562,7 +2559,6 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
     if {sfExportc, sfCompilerProc} * s.flags == {sfExportc}:
       genSym(p, n[namePos], r)
       r.res = ""
-  of nkPragmaBlock: gen(p, n.lastSon, r)
   else: internalError(p.config, n.info, "gen: unknown node type: " & $n.kind)
 
 proc newModule*(g: ModuleGraph; module: PSym): BModule =

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -60,7 +60,6 @@ import
     ropes
   ],
   compiler/sem/[
-    lowerings,
     rodutils,
     transf,
   ],
@@ -1760,19 +1759,13 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
     lineF(p, "}$n")
 
 proc genVarStmt(p: PProc, n: PNode) =
-  for i in 0..<n.len:
-    var a = n[i]
-    if a.kind != nkCommentStmt:
-      if a.kind == nkVarTuple:
-        let unpacked = lowerTupleUnpacking(p.module.graph, a, p.module.idgen, p.prc)
-        genStmt(p, unpacked)
-      else:
-        assert(a.kind == nkIdentDefs)
-        assert(a[0].kind == nkSym)
-        var v = a[0].sym
-        if lfNoDecl notin v.loc.flags and sfImportc notin v.flags:
-          genLineDir(p, a)
-          genVarInit(p, v, a[2])
+  for it in n.items:
+    assert it.kind == nkIdentDefs
+    assert it[0].kind == nkSym
+    let v = it[0].sym
+    if lfNoDecl notin v.loc.flags and sfImportc notin v.flags:
+      genLineDir(p, it)
+      genVarInit(p, v, it[2])
 
 proc genConstant(p: PProc, c: PSym) =
   if lfNoDecl notin c.loc.flags and not p.g.generatedSyms.containsOrIncl(c.id):

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -644,30 +644,14 @@ proc isTrue(n: PNode): bool =
 
 proc genWhile(c: var TCtx; n: PNode) =
   # lab1:
-  #   cond, tmp
-  #   fjmp tmp, lab2
   #   body
   #   jmp lab1
   # lab2:
   let lab1 = c.genLabel
   withBlock(nil):
-    if isTrue(n[0]):
-      c.gen(n[1])
-      c.jmpBack(n, lab1)
-    elif isNotOpr(n[0]):
-      var tmp = c.genx(n[0][1])
-      let lab2 = c.xjmp(n, opcTJmp, tmp)
-      c.freeTemp(tmp)
-      c.gen(n[1])
-      c.jmpBack(n, lab1)
-      c.patch(lab2)
-    else:
-      var tmp = c.genx(n[0])
-      let lab2 = c.xjmp(n, opcFJmp, tmp)
-      c.freeTemp(tmp)
-      c.gen(n[1])
-      c.jmpBack(n, lab1)
-      c.patch(lab2)
+    assert isTrue(n[0])
+    c.gen(n[1])
+    c.jmpBack(n, lab1)
 
 proc genBlock(c: var TCtx; n: PNode; dest: var TDest) =
   let oldRegisterCount = c.prc.regInfo.len

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2985,16 +2985,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
         let idx = c.lookupConst(s)
         discard c.getOrCreate(s.typ)
         c.gABx(n, opcLdCmplxConst, dest, idx)
-    of skEnumField:
-      # we never reach this case - as of the time of this comment,
-      # skEnumField is folded to an int in semfold.nim, but this code
-      # remains for robustness
-      if dest.isUnset: dest = c.getTemp(n.typ)
-      if s.position >= low(int16) and s.position <= high(int16):
-        c.gABx(n, opcLdImmInt, dest, s.position)
-      else:
-        var lit = genLiteral(c, newIntNode(nkIntLit, s.position))
-        c.gABx(n, opcLdConst, dest, lit)
     of skGenericParam:
         # note: this can't be replaced with an assert. ``tryConstExpr`` is
         # sometimes used to check whether an expression can be evaluated

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2810,7 +2810,7 @@ proc genVarSection(c: var TCtx; n: PNode) =
   for a in n:
     case a.kind
     of nkIdentDefs:
-      if a[0].kind == nkSym:
+        assert a[0].kind == nkSym
         let s = a[0].sym
         checkCanEval(c, a[0])
         if s.isGlobal:
@@ -2855,13 +2855,6 @@ proc genVarSection(c: var TCtx; n: PNode) =
             # initialization logic here -- the assignment takes care of that
             genSymAsgn(c, a[0], a[2])
 
-      elif a[2].kind == nkEmpty:
-        # The closure's captured value is automatically zero-initialized when
-        # creating the closure environment object; nothing left to do here
-        discard
-      else:
-        # assign to a[0]; happens for closures
-        genAsgn(c, a[0], a[2], true)
     else:
       unreachable(a.kind)
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3077,8 +3077,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
     unused(c, n, dest)
     genTry(c, n)
   of nkStmtList:
-    #unused(c, n, dest)
-    # XXX Fix this bug properly, lexim triggers it
+    unused(c, n, dest)
     for x in n: gen(c, x)
   of nkStmtListExpr:
     for i in 0..<n.len-1: gen(c, n[i])

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3084,9 +3084,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
   of nkIfStmt, nkIfExpr:
     unused(c, n, dest)
     genIf(c, n)
-  of nkWhenStmt:
-    # This is "when nimvm" node. Chose the first branch.
-    gen(c, n[0][1], dest)
   of nkCaseStmt: genCase(c, n, dest)
   of nkWhileStmt:
     unused(c, n, dest)
@@ -3106,8 +3103,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
   of nkStmtListExpr:
     for i in 0..<n.len-1: gen(c, n[i])
     gen(c, n[^1], dest)
-  of nkPragmaBlock:
-    gen(c, n.lastSon, dest)
   of nkDiscardStmt:
     unused(c, n, dest)
     gen(c, n[0])
@@ -3120,11 +3115,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
     genVarSection(c, n)
   of declarativeDefs, nkMacroDef:
     unused(c, n, dest)
-  of nkLambdaKinds:
-    #let s = n[namePos].sym
-    #discard genProc(c, s)
-    let s = n[namePos].sym
-    genProcLit(c, n, s, dest)
   of nkChckRangeF, nkChckRange64, nkChckRange:
     let tmp0 = c.genx(n[0])
     # XXX: range checks currently always happen, even if disabled by the user.

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -30,11 +30,6 @@
 # solves the opcLdConst vs opcAsgnConst issue. Of course whether we need
 # this copy depends on the involved types.
 
-# XXX: a significant amount of AST shapes that ``vmgen`` has logic for are no
-#      longer possible (because of the prior MIR transformation). Some parts
-#      already operate under the assumption that the MIR transformation took
-#      place while others don't
-
 import
   std/[
     intsets,
@@ -1089,7 +1084,6 @@ proc genRegLoad(c: var TCtx, n: PNode, dest, src: TRegister) =
     c.gABC(n, opcNarrowU, dest, TRegister(t.size * 8))
 
 proc genCheckedObjAccessAux(c: var TCtx; n: PNode): TRegister
-proc genSymAddr(c: var TCtx, n: PNode): TRegister
 proc genSym(c: var TCtx, n: PNode, dest: var TDest, load = true)
 
 func usesRegister(p: PProc, s: PSym): bool =
@@ -2088,11 +2082,6 @@ func setSlot(c: var TCtx; v: PSym): TRegister {.discardable.} =
 func cannotEval(c: TCtx; n: PNode) {.noinline, noreturn.} =
   raiseVmGenError(vmGenDiagCannotEvaluateAtComptime, n)
 
-
-func getOwner(c: TCtx): PSym =
-  result = c.prc.sym
-  if result.isNil: result = c.module
-
 proc importcCondVar*(s: PSym): bool {.inline.} =
   # see also importcCond
   if sfImportc in s.flags:
@@ -2497,11 +2486,6 @@ proc genSymAddr(c: var TCtx, n: PNode, dest: var TDest) =
   else:
     let local = local(c, n)
     c.gABC(n, opcAddr, dest, local)
-
-proc genSymAddr(c: var TCtx, n: PNode): TRegister =
-  var dest = TDest(-1)
-  genSymAddr(c, n, dest)
-  result = dest
 
 proc genArrAccessOpcode(c: var TCtx; n: PNode; dest: var TDest; opc: TOpcode; load = true) =
   let


### PR DESCRIPTION
## Summary

Remove unused code paths in `cgen`, `jsgen`, and `vmgen`.

Besides the general benefits that removing unused code paths has, this
also helps with preventing regressions caused by lowerings not being
properly applied, at least until the the code generators are rewritten.

## Details

The AST shapes for which the code paths are removed are:
- `when nimvm` statements
- `if`, `case`, `block`, and `try` *expressions*
- multi-branch `if` statements
- `while x` statements where `x` is something else than a `true` boolean
  literal
- pragma blocks and lambda-expressions
- enum field symbols
- `and`/`or` expressions
- deconstruction in `var`/`let` statements (i.e. `nkVarTuple`) and
  initialization of lifted locals (e.g., `var env.x = 0`)

Except for `skEnumField` symbols (which are lowered away during
`transf`), all of the above are lowered during the MIR phase
already, and never reach code generation.

There are two small changes to the output of the code generators:
`jsgen` no longer emits a redundant `if (!true) break label;` statement
for `while` loops, and `cgen` doesn't lower `if` into gotos anymore. An
example of the latter:
```c
// `if cond: then` now produces: 
if (cond)
{
  then;
}
// instead of:
if (!cond) goto label;
then;
label:
```