### PR TITLE
codegen: make the main case statements exhaustive

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -350,7 +350,7 @@ const
     nkUsingStmt,
   }
 
-  codegenNodeKinds* = {
+  codegenExprNodeKinds* = {
     nkEmpty,
     nkSym,
     nkType,

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -350,6 +350,50 @@ const
     nkUsingStmt,
   }
 
+  codegenNodeKinds* = {
+    nkEmpty,
+    nkSym,
+    nkType,
+
+    nkCharLit,
+    nkIntLit, nkInt8Lit, nkInt16Lit, nkInt32Lit, nkInt64Lit,
+    nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit,
+    nkFloatLit, nkFloat32Lit, nkFloat64Lit, nkFloat128Lit,
+    nkStrLit, nkRStrLit, nkTripleStrLit,
+    nkNilLit,
+
+    nkCall,
+
+    nkObjConstr, nkCurly, nkBracket,
+
+    nkBracketExpr, nkDotExpr, nkCheckedFieldExpr, nkDerefExpr,
+
+    nkHiddenStdConv, nkConv, nkCast, nkAddr, nkHiddenAddr,
+    nkHiddenDeref, nkObjDownConv, nkObjUpConv,
+
+    nkChckRangeF, nkChckRange64, nkChckRange, nkStringToCString,
+    nkCStringToString,
+
+    nkAsgn, nkFastAsgn,
+
+    nkProcDef, nkMethodDef, nkConverterDef, nkIteratorDef, nkFuncDef,
+
+    nkAsmStmt, nkPragma,
+
+    nkIfStmt, nkWhileStmt, nkCaseStmt,
+
+    nkVarSection, nkLetSection, nkConstSection,
+    nkTryStmt,
+
+    nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkBlockStmt, nkDiscardStmt,
+
+    nkStmtList, nkStmtListExpr,
+
+    nkClosure,
+    nkTupleConstr,
+    nkNimNodeLit,
+  }
+
 type
   TSymFlag* = enum    # 48 flags!
     sfUsed            ## read access of sym (for warnings) or simply used

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2398,7 +2398,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
           genProc(p.module, prc)
   of nkType, nkNimNodeLit:
     unreachable()
-  of nkWithSons + nkWithoutSons - codegenNodeKinds:
+  of nkWithSons + nkWithoutSons - codegenExprNodeKinds:
     internalError(p.config, n.info, "expr(" & $n.kind & "); unknown node kind")
 
 proc getDefaultValue(p: BProc; typ: PType; info: TLineInfo): Rope =

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -1273,8 +1273,5 @@ proc genTypeInfoV1(m: BModule, t: PType; info: TLineInfo): Rope =
 
   result = prefixTI.rope & result & ")".rope
 
-proc genTypeSection(m: BModule, n: PNode) =
-  discard
-
 proc genTypeInfo*(config: ConfigRef, m: BModule, t: PType; info: TLineInfo): Rope =
   result = genTypeInfoV2(m, t, info)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2537,7 +2537,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       r.res = ""
   of nkFloat128Lit, nkNimNodeLit:
     unreachable()
-  of nkWithSons + nkWithoutSons - codegenNodeKinds:
+  of nkWithSons + nkWithoutSons - codegenExprNodeKinds:
     internalError(p.config, n.info, "gen: unknown node type: " & $n.kind)
 
 proc newModule*(g: ModuleGraph; module: PSym): BModule =

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3123,7 +3123,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
     genTypeLit(c, n.typ, dest)
   of nkConstSection, nkPragma, nkAsmStmt:
     unused(c, n, dest)
-  of nkWithSons + nkWithoutSons - codegenNodeKinds:
+  of nkWithSons + nkWithoutSons - codegenExprNodeKinds:
     fail(n.info, vmGenDiagCannotGenerateCode, n)
 
 proc genStmt*(c: var TCtx; n: PNode): Result[void, VmGenDiag] =

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2980,7 +2980,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
         vmGenDiagCodeGenUnexpectedSym,
         sym = s
       )
-  of nkCallKinds:
+  of nkCall:
     if n[0].kind == nkSym:
       let s = n[0].sym
       if s.magic != mNone:
@@ -3039,7 +3039,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
     assert isVarLent(n.typ)
     # load the source operand as a handle
     genLvalue(c, n[0], dest)
-  of nkIfStmt, nkIfExpr:
+  of nkIfStmt:
     unused(c, n, dest)
     genIf(c, n)
   of nkCaseStmt:
@@ -3069,14 +3069,14 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
   of nkDiscardStmt:
     unused(c, n, dest)
     gen(c, n[0])
-  of nkHiddenStdConv, nkHiddenSubConv, nkConv:
+  of nkHiddenStdConv, nkConv:
     genConv(c, n, n[1], dest)
   of nkObjDownConv, nkObjUpConv:
     genObjConv(c, n, dest)
   of nkLetSection, nkVarSection:
     unused(c, n, dest)
     genVarSection(c, n)
-  of declarativeDefs, nkMacroDef:
+  of declarativeDefs:
     unused(c, n, dest)
   of nkChckRangeF, nkChckRange64, nkChckRange:
     let tmp0 = c.genx(n[0])
@@ -3105,16 +3105,14 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
         c.freeTemp(tmp0)
       else:
         dest = tmp0
-  of nkEmpty, nkCommentStmt, nkTypeSection, nkConstSection, nkPragma,
-     nkTemplateDef, nkIncludeStmt, nkImportStmt, nkFromStmt, nkExportStmt,
-     nkMixinStmt, nkBindStmt:
+  of nkEmpty:
     unused(c, n, dest)
   of nkStringToCString, nkCStringToString:
     gen(c, n[0], dest)
   of nkBracket: genArrayConstr(c, n, dest)
   of nkCurly: genSetConstr(c, n, dest)
   of nkObjConstr: genObjConstr(c, n, dest)
-  of nkPar, nkTupleConstr: genTupleConstr(c, n, dest)
+  of nkTupleConstr: genTupleConstr(c, n, dest)
   of nkClosure: genClosureConstr(c, n, dest)
   of nkCast:
     if allowCast in c.features:
@@ -3123,11 +3121,9 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
       genCastIntFloat(c, n, dest)
   of nkType:
     genTypeLit(c, n.typ, dest)
-  of nkError:
-    c.config.internalError(n.info, $n.kind)
-    assert false
-  else:
-    echo "fail: ", n.kind
+  of nkConstSection, nkPragma, nkAsmStmt:
+    unused(c, n, dest)
+  of nkWithSons + nkWithoutSons - codegenNodeKinds:
     fail(n.info, vmGenDiagCannotGenerateCode, n)
 
 proc genStmt*(c: var TCtx; n: PNode): Result[void, VmGenDiag] =


### PR DESCRIPTION
## Summary

Introduce a set (`codegenExprNodeKinds`) with all node kinds that can appear
in *general* expression and statement contexts during the code
generation phase. The set is then used to make the `case` statement in
the main AST traversal procedures exhaustive (no more catch-all `else`
branch).

## Details

The set doesn't include node kinds (such as `nkExprColonExpr` or
`nkElse`) that can only appear in nested contexts.