### PR TITLE
cgen: remove more obsolete code

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -63,7 +63,7 @@ const
   
   PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
                                       nfDotSetter, nfDotField,
-                                      nfIsRef, nfIsPtr, nfPreventCg, nfLL,
+                                      nfIsRef, nfIsPtr, nfLL,
                                       nfFromTemplate, nfDefaultRefsParam}
   
   namePos*          = 0 ## Name of the type/proc-like node

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -647,7 +647,6 @@ type
     nfExplicitCall ## `x.y()` was used instead of x.y
     nfIsRef     ## this node is a 'ref' node; used for the VM
     nfIsPtr     ## this node is a 'ptr' node; used for the VM
-    nfPreventCg ## this node should be ignored by the codegen
     nfBlockArg  ## this a stmtlist appearing in a call (e.g. a do block)
     nfFromTemplate ## a top-level node returned from a template
     nfDefaultParam ## an automatically inserter default parameter
@@ -1611,7 +1610,6 @@ type
     lfFullExternalName, ## only used when 'conf.cmd == cmdNimfix': Indicates
       ## that the symbol has been imported via 'importc: "fullname"' and
       ## no format string.
-    lfNoDeepCopy,             ## no need for a deep copy
     lfNoDecl,                 ## do not declare it in C
     lfDynamicLib,             ## link symbol to dynamic library
     lfExportLib,              ## export symbol for dynamic library generation

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -114,7 +114,7 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
         pl.add(~");$n")
         line(p, cpsStmts, pl)
         exitCall(p, ri[0], canRaise)
-        genAssignment(p, d, tmp, {}) # no need for deep copying
+        genAssignment(p, d, tmp)
     else:
       pl.add(~")")
       if isHarmlessStore(p, canRaise, d):
@@ -123,7 +123,7 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
         var list: TLoc
         initLoc(list, locCall, d.lode, OnUnknown)
         list.r = pl
-        genAssignment(p, d, list, {}) # no need for deep copying
+        genAssignment(p, d, list)
         exitCall(p, ri[0], canRaise)
       else:
         var tmp: TLoc
@@ -131,9 +131,9 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
         var list: TLoc
         initLoc(list, locCall, d.lode, OnUnknown)
         list.r = pl
-        genAssignment(p, tmp, list, {}) # no need for deep copying
+        genAssignment(p, tmp, list)
         exitCall(p, ri[0], canRaise)
-        genAssignment(p, d, tmp, {})
+        genAssignment(p, d, tmp)
   else:
     pl.add(~");$n")
     line(p, cpsStmts, pl)
@@ -253,13 +253,13 @@ proc withTmpIfNeeded(p: BProc, a: TLoc, needsTmp: bool): TLoc =
   if needsTmp and a.lode.typ != nil and p.config.selectedGC in {gcArc, gcOrc} and
       getSize(p.config, a.lode.typ) < 1024:
     getTemp(p, a.lode.typ, result, needsInit=false)
-    genAssignment(p, result, a, {})
+    genAssignment(p, result, a)
   else:
     result = a
 
 proc literalsNeedsTmp(p: BProc, a: TLoc): TLoc =
   getTemp(p, a.lode.typ, result, needsInit=false)
-  genAssignment(p, result, a, {})
+  genAssignment(p, result, a)
 
 proc genArgStringToCString(p: BProc, n: PNode, needsTmp: bool): Rope {.inline.} =
   var a: TLoc
@@ -439,7 +439,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
         pl.add(addrLoc(p.config, tmp))
         genCallPattern()
         exitCall(p, ri[0], canRaise)
-        genAssignment(p, d, tmp, {}) # no need for deep copying
+        genAssignment(p, d, tmp)
     elif isHarmlessStore(p, canRaise, d):
       if d.k == locNone: getTemp(p, typ[0], d)
       assert(d.t != nil)        # generate an assignment to d:
@@ -449,7 +449,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
         list.r = PatIter % [rdLoc(op), pl, pl.addComma, rawProc]
       else:
         list.r = PatProc % [rdLoc(op), pl, pl.addComma, rawProc]
-      genAssignment(p, d, list, {}) # no need for deep copying
+      genAssignment(p, d, list)
       exitCall(p, ri[0], canRaise)
     else:
       var tmp: TLoc
@@ -461,9 +461,9 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
         list.r = PatIter % [rdLoc(op), pl, pl.addComma, rawProc]
       else:
         list.r = PatProc % [rdLoc(op), pl, pl.addComma, rawProc]
-      genAssignment(p, tmp, list, {})
+      genAssignment(p, tmp, list)
       exitCall(p, ri[0], canRaise)
-      genAssignment(p, d, tmp, {})
+      genAssignment(p, d, tmp)
   else:
     genCallPattern()
     exitCall(p, ri[0], canRaise)

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -241,7 +241,6 @@ proc genIf(p: BProc, n: PNode) =
   stmtBlock(p, it[1])
 
 proc genReturnStmt(p: BProc, t: PNode) =
-  if nfPreventCg in t.flags: return
   p.flags.incl beforeRetNeeded
   genLineDir(p, t)
   if (t[0].kind != nkEmpty): genStmts(p, t[0])
@@ -876,9 +875,9 @@ proc asgnFieldDiscriminant(p: BProc, e: PNode) =
   initLocExpr(p, e[0], a)
   getTemp(p, a.t, tmp)
   expr(p, e[1], tmp)
-  genAssignment(p, a, tmp, {})
+  genAssignment(p, a, tmp)
 
-proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
+proc genAsgn(p: BProc, e: PNode) =
   if e[0].kind == nkSym and sfGoto in e[0].sym.flags:
     genLineDir(p, e)
     genGotoVar(p, e[1])
@@ -894,7 +893,6 @@ proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
     a.flags.incl {lfEnforceDeref, lfPrepareForMutation}
     expr(p, le, a)
     a.flags.excl lfPrepareForMutation
-    if fastAsgn: a.flags.incl lfNoDeepCopy
     assert(a.t != nil)
     genLineDir(p, ri)
     loadInto(p, le, ri, a)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -363,14 +363,9 @@ proc rdCharLoc(a: TLoc): Rope =
   if skipTypes(a.t, abstractRange).kind == tyChar:
     result = "((NU8)($1))" % [result]
 
-type
-  TAssignmentFlag = enum
-    needToCopy
-  TAssignmentFlags = set[TAssignmentFlag]
-
 proc genObjConstr(p: BProc, e: PNode, d: var TLoc)
 proc rawConstExpr(p: BProc, n: PNode; d: var TLoc)
-proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags)
+proc genAssignment(p: BProc, dest, src: TLoc)
 
 type
   ObjConstrMode = enum
@@ -422,7 +417,7 @@ proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: TLoc,
             [rdLoc(a), rdLoc(tmp), getTypeDesc(p.module, objType, mapTypeChooser(a))])
       else:
         let tmp = defaultValueExpr(p, t, a.lode.info)
-        genAssignment(p, a, tmp, {})
+        genAssignment(p, a, tmp)
 
 proc isComplexValueType(t: PType): bool {.inline.} =
   let t = t.skipTypes(abstractInst + tyUserTypeClasses)
@@ -514,7 +509,6 @@ proc localVarDecl(p: BProc; n: PNode): Rope =
   let s = n.sym
   if s.loc.k == locNone:
     fillLoc(s.loc, locLocalVar, n, mangleLocalName(p, s), OnStack)
-    if s.kind == skLet: incl(s.loc.flags, lfNoDeepCopy)
   if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
     result.addf("NIM_ALIGN($1) ", [rope(s.alignment)])
   result.add getTypeDesc(p.module, s.typ, skVar)
@@ -837,22 +831,6 @@ proc containsResult(n: PNode): bool =
 const harmless = {nkConstSection, nkTypeSection, nkEmpty, nkCommentStmt, nkTemplateDef,
                   nkMacroDef, nkMixinStmt, nkBindStmt} +
                   declarativeDefs
-
-proc easyResultAsgn(n: PNode): PNode =
-  case n.kind
-  of nkStmtList, nkStmtListExpr:
-    var i = 0
-    while i < n.len and n[i].kind in harmless: inc i
-    if i < n.len: result = easyResultAsgn(n[i])
-  of nkAsgn, nkFastAsgn:
-    if n[0].kind == nkSym and n[0].sym.kind == skResult and not containsResult(n[1]):
-      incl n.flags, nfPreventCg
-      return n[1]
-  of nkReturnStmt:
-    if n.len > 0:
-      result = easyResultAsgn(n[0])
-      if result != nil: incl n.flags, nfPreventCg
-  else: discard
 
 type
   InitResultEnum = enum Unknown, InitSkippable, InitRequired


### PR DESCRIPTION
## Summary

Remove leftover obsolete code from `cgen`:
* the `earlyResultAsgn` procedure
* the `nfPreventCg` node flag
* the `lfNoDeepCopy` loc flag
* the `TAssignmentFlag` enum and usages thereof

Thanks to ARC, there's no difference between `nkAsgn` and `nkFastAsgn`
in the C code generator, so the two branches are collapsed into a single
one.