### PR TITLE
consistent canonical import and package sym naming

### DIFF
--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -153,9 +153,7 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
   of foAbs: result = toFullPath(conf, fileIdx)
   of foRelProject: result = toProjPath(conf, fileIdx)
   of foCanonical:
-    let
-      absPath = toFullPath(conf, fileIdx)
-      (_, _, ext) = absPath.splitFile
+    let absPath = toFullPath(conf, fileIdx)
     result = canonicalImportAux(conf, absPath.AbsoluteFile)
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
   of foLegacyRelProj:

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -153,7 +153,9 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
   of foAbs: result = toFullPath(conf, fileIdx)
   of foRelProject: result = toProjPath(conf, fileIdx)
   of foCanonical:
-    let absPath = toFullPath(conf, fileIdx)
+    let
+      absPath = toFullPath(conf, fileIdx)
+      (_, _, ext) = absPath.splitFile
     result = canonicalImportAux(conf, absPath.AbsoluteFile)
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
   of foLegacyRelProj:

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -250,7 +250,7 @@ type
     errorMax*: int ## Maximum number of errors before compilation will be terminated
     maxLoopIterationsVM*: int ## VM: max iterations of all loops
 
-    packageCache*: StringTableRef
+    packageCache*: StringTableRef      ## absolute path -> absolute path
 
     jsonBuildFile*: AbsoluteFile
     nimStdlibVersion*: NimVer

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1485,7 +1485,8 @@ proc canonicalImportAux*(conf: ConfigRef, file: AbsoluteFile): string =
   let
     desc = getPkgDesc(conf, file.string)
     (_, moduleName, ext) = file.splitFile
-  if desc.pkgKnown:
+  if desc.pkgKnown and
+     AbsoluteFile(getNimbleFile(conf, conf.projectFull.string)) != desc.pkgFile:
     result = desc.pkgRootName
     if desc.pkgSubpath != "":
       result = result / desc.pkgSubpath

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -952,8 +952,6 @@ proc newPackage(config: ConfigRef; cache: IdentCache; fileIdx: FileIndex): PSym 
   let
     filename = AbsoluteFile toFullPath(config, fileIdx)
     info = newLineInfo(fileIdx, 1, 1)
-    # pck = getPackageName(config, filename.string)
-    # pck2 = if pck.len > 0: pck else: "unknown"
   let desc = getPkgDesc(config, filename.string)
   result = newSym(skPackage, getIdent(cache, desc.pkgName),
     ItemId(module: PackageModuleId, item: int32(fileIdx)), nil, info)

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -952,9 +952,10 @@ proc newPackage(config: ConfigRef; cache: IdentCache; fileIdx: FileIndex): PSym 
   let
     filename = AbsoluteFile toFullPath(config, fileIdx)
     info = newLineInfo(fileIdx, 1, 1)
-    pck = getPackageName(config, filename.string)
-    pck2 = if pck.len > 0: pck else: "unknown"
-  result = newSym(skPackage, getIdent(cache, pck2),
+    # pck = getPackageName(config, filename.string)
+    # pck2 = if pck.len > 0: pck else: "unknown"
+  let desc = getPkgDesc(config, filename.string)
+  result = newSym(skPackage, getIdent(cache, desc.pkgName),
     ItemId(module: PackageModuleId, item: int32(fileIdx)), nil, info)
 
 proc setupLookupTables(g: var PackedModuleGraph; conf: ConfigRef; cache: IdentCache;

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -100,7 +100,6 @@ type
 
     startupPackedConfig*: PackedConfig
     packageSyms*: TStrTable
-    modulesPerPackage*: Table[ItemId, TStrTable]
     deps*: IntSet # the dependency graph or potentially its transitive closure.
     suggestMode*: bool # whether we are in nimsuggest mode or not.
     invalidTransitiveClosure: bool

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -84,40 +84,6 @@ proc getPackage2(graph: ModuleGraph, fileIdx: FileIndex): PSym =
       else:
         existingSubPkgSym
 
-proc getPackage(graph: ModuleGraph; fileIdx: FileIndex): PSym =
-  ## returns package symbol (skPackage) for yet to be defined module for fileIdx
-  let
-    filename = AbsoluteFile toFullPath(graph.config, fileIdx)
-    name = getModuleIdent(graph, filename)
-    info = newLineInfo(fileIdx, 1, 1)
-    pck = getPackageName(graph.config, filename.string)
-    pck2 = if pck.len > 0: pck else: "unknown"
-    pack = getIdent(graph.cache, pck2)
-  
-  result = graph.packageSyms.strTableGet(pack)
-  
-  if result == nil:
-    result = newSym(skPackage, getIdent(graph.cache, pck2), packageId(), nil, info)
-    #initStrTable(packSym.tab)
-    graph.packageSyms.strTableAdd(result)
-  else:
-    let modules = graph.modulesPerPackage.getOrDefault(result.itemId)
-    let existing = if modules.data.len > 0: strTableGet(modules, name) else: nil
-    if existing != nil and existing.info.fileIndex != info.fileIndex:
-      when false:
-        # we used to produce an error:
-        localReport(graph.config, info,
-          "module names need to be unique per Nimble package; module clashes with " &
-            toFullPath(graph.config, existing.info.fileIndex))
-      else:
-        # but starting with version 0.20 we now produce a fake Nimble package instead
-        # to resolve the conflicts:
-        let pck3 = fakePackageName(graph.config, filename)
-        # this makes the new `result`'s owner be the original `result`
-        result = newSym(skPackage, getIdent(graph.cache, pck3), packageId(), result, info)
-        #initStrTable(packSym.tab)
-        graph.packageSyms.strTableAdd(result)
-
 proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; filename: AbsoluteFile) =
   let packSym =
     when true:

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -53,7 +53,7 @@ template getModuleIdent(graph: ModuleGraph, filename: AbsoluteFile): PIdent =
 
 template packageId(): untyped {.dirty.} = ItemId(module: PackageModuleId, item: int32(fileIdx))
 
-proc getPackage2(graph: ModuleGraph, fileIdx: FileIndex): PSym =
+proc getPackage(graph: ModuleGraph, fileIdx: FileIndex): PSym =
   ## returns the package symbol (skPackage) for yet to be defined module for
   ## `fileIdx`
   let
@@ -85,11 +85,7 @@ proc getPackage2(graph: ModuleGraph, fileIdx: FileIndex): PSym =
         existingSubPkgSym
 
 proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; filename: AbsoluteFile) =
-  let packSym =
-    when true:
-      getPackage2(graph, fileIdx)
-    else:
-      getPackage(graph, fileIdx)
+  let packSym = getPackage(graph, fileIdx)
   result.owner = packSym
   result.position = int fileIdx
 
@@ -209,11 +205,7 @@ proc compileProject*(graph: ModuleGraph; projectFileIdx = InvalidFileIdx) =
   let projectFile = if projectFileIdx == InvalidFileIdx: conf.projectMainIdx else: projectFileIdx
   conf.projectMainIdx2 = projectFile
 
-  let packSym =
-    when true:
-      getPackage2(graph, projectFile)
-    else:
-      getPackage(graph, projectFile)
+  let packSym = getPackage(graph, projectFile)
   graph.config.mainPackageId = packSym.getnimblePkgId
   graph.importStack.add projectFile
 

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -96,10 +96,6 @@ proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; fil
     #   c.moduleScope.addSym(module) # a module knows itself
     # in sem.nim, around line 527
 
-  if graph.modulesPerPackage.getOrDefault(packSym.itemId).data.len == 0:
-    graph.modulesPerPackage[packSym.itemId] = newStrTable()
-  graph.modulesPerPackage[packSym.itemId].strTableAdd(result)
-
 proc newModule(graph: ModuleGraph; fileIdx: FileIndex): PSym =
   let filename = AbsoluteFile toFullPath(graph.config, fileIdx)
   # We cannot call ``newSym`` here, because we have to circumvent the ID

--- a/compiler/modules/packagehandling.nim
+++ b/compiler/modules/packagehandling.nim
@@ -35,27 +35,26 @@ proc getNimbleFile(conf: ConfigRef; path: string): string =
     dec parents
     if parents <= 0: break
 
-proc getPackageName(conf: ConfigRef; path: string): string =
-  ## legacy stuff
-  ## returns nimble package name, e.g.: `cligen`
-  let path = getNimbleFile(conf, path)
-  result = path.splitFile.name
-
-proc fakePackageName(conf: ConfigRef; path: AbsoluteFile): string =
-  ## legacy stuff for backends
-  ## Convert `path` so that 2 modules with same name
-  ## in different directory get different name and they can be
-  ## placed in a directory.
-  ## foo-#head/../bar becomes @foo-@hhead@s..@sbar
-  result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
-    {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
-
 proc demanglePackageName*(path: string): string =
   # legacy stuff for backends
   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
 
 proc withPackageName*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
   # legacy stuff for backends
+
+  proc getPackageName(conf: ConfigRef; path: string): string =
+    ## returns nimble package name, e.g.: `cligen`
+    let path = getNimbleFile(conf, path)
+    result = path.splitFile.name
+
+  proc fakePackageName(conf: ConfigRef; path: AbsoluteFile): string =
+    ## Convert `path` so that 2 modules with same name
+    ## in different directory get different name and they can be
+    ## placed in a directory.
+    ## foo-#head/../bar becomes @foo-@hhead@s..@sbar
+    result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
+      {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
+
   let x = getPackageName(conf, path.string)
   let (p, file, ext) = path.splitFile
   if x == "stdlib":

--- a/compiler/modules/packagehandling.nim
+++ b/compiler/modules/packagehandling.nim
@@ -15,7 +15,7 @@ iterator myParentDirs(p: string): string =
     if current.len == 0: break
     yield current
 
-proc getNimbleFile*(conf: ConfigRef; path: string): string =
+proc getNimbleFile(conf: ConfigRef; path: string): string =
   ## returns absolute path to nimble file, e.g.: /pathto/cligen.nimble
   # xxx: make this private
   var parents = 0
@@ -68,7 +68,7 @@ type
   PkgDesc* = object
     ## describes the package, and optional sub-package, used in conjunction
     ## with a module to determine its relationship to a package.
-    # todo: support project/default vs unknown vs with file
+    # todo: support project/default vs unknown vs explicit package
     case pkgKnown*: bool:
       of true:
         pkgFile*: AbsoluteFile ## if applicable, package file

--- a/compiler/modules/packagehandling.nim
+++ b/compiler/modules/packagehandling.nim
@@ -17,6 +17,7 @@ iterator myParentDirs(p: string): string =
 
 proc getNimbleFile*(conf: ConfigRef; path: string): string =
   ## returns absolute path to nimble file, e.g.: /pathto/cligen.nimble
+  # xxx: make this private
   var parents = 0
   block packageSearch:
     for d in myParentDirs(path):
@@ -35,22 +36,26 @@ proc getNimbleFile*(conf: ConfigRef; path: string): string =
     if parents <= 0: break
 
 proc getPackageName*(conf: ConfigRef; path: string): string =
+  ## legacy stuff
   ## returns nimble package name, e.g.: `cligen`
   let path = getNimbleFile(conf, path)
   result = path.splitFile.name
 
 proc fakePackageName*(conf: ConfigRef; path: AbsoluteFile): string =
-  # Convert `path` so that 2 modules with same name
-  # in different directory get different name and they can be
-  # placed in a directory.
-  # foo-#head/../bar becomes @foo-@hhead@s..@sbar
+  ## legacy stuff for backends
+  ## Convert `path` so that 2 modules with same name
+  ## in different directory get different name and they can be
+  ## placed in a directory.
+  ## foo-#head/../bar becomes @foo-@hhead@s..@sbar
   result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
     {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
 
 proc demanglePackageName*(path: string): string =
+  # legacy stuff for backends
   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
 
 proc withPackageName*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
+  # legacy stuff for backends
   let x = getPackageName(conf, path.string)
   let (p, file, ext) = path.splitFile
   if x == "stdlib":
@@ -58,3 +63,50 @@ proc withPackageName*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
     result = p / RelativeFile((x & '_' & file) & ext)
   else:
     result = p / RelativeFile(fakePackageName(conf, path))
+
+type
+  PkgDesc* = object
+    ## describes the package, and optional sub-package, used in conjunction
+    ## with a module to determine its relationship to a package.
+    # todo: support project/default vs unknown vs with file
+    case pkgKnown*: bool:
+      of true:
+        pkgFile*: AbsoluteFile ## if applicable, package file
+      of false:
+        discard
+    pkgRootName*: string  ## name of the package root
+    pkgRoot*: AbsoluteDir ## path to the root or project path if unknown pkg
+    pkgSubpath*: string   ## if not empty, sub-package it's a part of
+    pkgName*: string      ## fully escaped package name with any subpaths, same
+                          ## as `pkgRootName` if no subpaths present
+
+proc getPkgDesc*(conf: ConfigRef, modulePath: string): PkgDesc =
+  ## get a description of a package for a given module path
+  # TODO: reserve 'unknown' as a package root name or change it
+  template mangle(s: string): string =
+    ## convert a path to a package name part
+    s.multiReplace({$os.DirSep: "@s",
+                    $os.AltSep: "@s",
+                    "#": "@h",
+                    "@": "@@",
+                    ":": "@c"})
+  let
+    pkgFile = getNimbleFile(conf, modulePath)
+    (pkgFileRoot, pkgFileName, _) = pkgFile.splitFile
+    pkgKnown = pkgFileName != ""
+    pkgRootName = if pkgKnown: pkgFileName else: "unknown"
+    pkgRoot = if pkgKnown: pkgFileRoot else: conf.projectPath.string
+    relativePath = relativePath(modulePath.parentDir, pkgRoot)
+    pkgSubpath = if relativePath == ".": "" else: relativePath
+    pkgName =
+      if pkgKnown and pkgSubpath == "": pkgRootName
+      else: pkgRootName & "@p" & mangle(pkgSubpath)
+  result =
+    if pkgKnown:
+      PkgDesc(pkgKnown: true, pkgFile: AbsoluteFile pkgFile)
+    else:
+      PkgDesc(pkgKnown: false)
+  result.pkgRootName = pkgRootName
+  result.pkgRoot = AbsoluteDir pkgRoot
+  result.pkgSubpath = pkgSubpath
+  result.pkgName = pkgName

--- a/compiler/modules/packagehandling.nim
+++ b/compiler/modules/packagehandling.nim
@@ -35,13 +35,13 @@ proc getNimbleFile*(conf: ConfigRef; path: string): string =
     dec parents
     if parents <= 0: break
 
-proc getPackageName*(conf: ConfigRef; path: string): string =
+proc getPackageName(conf: ConfigRef; path: string): string =
   ## legacy stuff
   ## returns nimble package name, e.g.: `cligen`
   let path = getNimbleFile(conf, path)
   result = path.splitFile.name
 
-proc fakePackageName*(conf: ConfigRef; path: AbsoluteFile): string =
+proc fakePackageName(conf: ConfigRef; path: AbsoluteFile): string =
   ## legacy stuff for backends
   ## Convert `path` so that 2 modules with same name
   ## in different directory get different name and they can be
@@ -99,7 +99,7 @@ proc getPkgDesc*(conf: ConfigRef, modulePath: string): PkgDesc =
     relativePath = relativePath(modulePath.parentDir, pkgRoot)
     pkgSubpath = if relativePath == ".": "" else: relativePath
     pkgName =
-      if pkgKnown and pkgSubpath == "": pkgRootName
+      if pkgKnown or pkgSubpath == "": pkgRootName
       else: pkgRootName & "@p" & mangle(pkgSubpath)
   result =
     if pkgKnown:

--- a/compiler/modules/packagehandling.nim
+++ b/compiler/modules/packagehandling.nim
@@ -98,7 +98,7 @@ proc getPkgDesc*(conf: ConfigRef, modulePath: string): PkgDesc =
     relativePath = relativePath(modulePath.parentDir, pkgRoot)
     pkgSubpath = if relativePath == ".": "" else: relativePath
     pkgName =
-      if pkgKnown or pkgSubpath == "": pkgRootName
+      if pkgKnown and pkgSubpath == "": pkgRootName
       else: pkgRootName & "@p" & mangle(pkgSubpath)
   result =
     if pkgKnown:

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -1495,10 +1495,11 @@ proc writeOutput*(d: PDoc, useWarning = false, groupedToc = false) =
 proc writeOutputJson*(d: PDoc, useWarning = false) =
   runAllExamples(d)
   var modDesc: string
+  let pkgDesc = getPkgDesc(d.conf, d.filename)
   for desc in d.modDescFinal:
     modDesc &= desc
   let content = %*{"orig": d.filename,
-    "nimble": getPackageName(d.conf, d.filename),
+    "nimble": if pkgDesc.pkgKnown: pkgDesc.pkgRootName else: "",
     "moduleDescription": modDesc,
     "entries": d.jEntriesFinal}
   if optStdout in d.conf.globalOptions:

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -194,7 +194,7 @@ proc presentationPath*(conf: ConfigRef, file: AbsoluteFile): RelativeFile =
   template bail() =
     result = relativeTo(file, conf.projectPath)
   proc nimbleDir(): AbsoluteDir =
-    getNimbleFile(conf, file2).parentDir.AbsoluteDir
+    getPkgDesc(conf, file2).pkgRoot
   case conf.docRoot:
   of docRootDefault:
     result = getRelativePathFromConfigPath(conf, file)


### PR DESCRIPTION
## Summary

Package symbols for modules are now generated in a consistent fashion:

- at the root of a package: `pkgroot/module`
- nested within a package: `pkgroot/pkgpath/module`
- modules within the project package omit `pkgroot/`

This leads to more consistent messages and a variety of improvements for
internals (eg: more stable signature hashes) and a better foundation to
build upon.

## Details

Previously, package symbols were created and modules added to them in a
flat manner, until there was a name collision (two modules in different
directories with the same name). In the case of collisions a mangled
package name was created based on the module that caused the collision
and that was used instead. Although the package symbol information isn't
used in too many parts of the compiler this led to yet more broken data
and subtle issues for anything that relied upon it:

- signature hashing owners and procedures
- c, rod, and various file name generation
- error messages: canonical imports
- and more

Getting package info is now done via `packagehandling.getPkgDesc`, which
retrieves various key details, including dealing with the lack of
package definition. Package detection still remains coupled to nimble
files, for now.