### PR TITLE
threads: free reference cycles when terminating

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -175,6 +175,11 @@ template threadProcWrapperBody(closure: untyped): untyped =
   # However this is doomed to fail, because we already unmapped every heap
   # page!
 
+  when compileOption("gc", "orc"):
+    # run a full garbage collection pass in order to free all cells
+    # kept alive only through reference cycles
+    GC_fullCollect()
+
   # mark as not running anymore:
   thrd.core = nil
   thrd.dataFn = nil

--- a/tests/threads/tthread_cycles.nim
+++ b/tests/threads/tthread_cycles.nim
@@ -1,0 +1,36 @@
+discard """
+  matrix: "--threads:on --gc:orc"
+  description: '''
+    Reference cycles created by a thread must be freed prior to it
+    terminating
+  '''
+  output: "d\nd\nd\nexit"
+"""
+
+type
+  Ref = ref Obj
+  Obj = object
+    x: Ref
+
+proc `=destroy`(x: var Obj) =
+  echo "d"
+
+proc t() {.thread.} =
+  # create a reference cycle that involves multiple cells
+  var
+    v1 = Ref()
+    v2 = Ref(x: v1)
+    v3 = Ref(x: v2)
+  v1.x = v3
+
+proc main() =
+  # wrap the test in a procedure to prevent the thread from being a
+  # global
+  var thr: Thread[void]
+  createThread(thr, t)
+  joinThread(thr)
+  # the reference cycles created by `thr` must have all been freed
+  # by the time ``joinThread`` returns
+  echo "exit"
+
+main()


### PR DESCRIPTION
## Summary

When using `--gc:orc`, run a full cycle collection pass prior to exiting
the internal thread procedure, freeing all heap cells only kept alive
through reference cycles created by the thread.

Previously, they were simply not freed, with manually freeing them being
impossible once the thread terminated.

## Details

Running the cycle collector (via ``GC_fullCollect``) has to happen
*before* deallocating the ``GcThread`` instance, as the latter step
frees - when using emulated thread-local storage - the thread's
thread-local storage (which the cycle collector still depends on).