### PR TITLE
jsonutils: no unmarshal support for `cstring` tables

### DIFF
--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -344,7 +344,7 @@ proc toJson*[T](a: T, opt = initToJsonOptions()): JsonNode =
   elif T is cstring: (if a == nil: result = newJNull() else: result = % $a)
   else: result = %a
 
-proc fromJsonHook*[K: string|cstring, V](t: var (Table[K, V] | OrderedTable[K, V]),
+proc fromJsonHook*[K: string, V](t: var (Table[K, V] | OrderedTable[K, V]),
                          jsonNode: JsonNode) =
   ## Enables `fromJson` for `Table` and `OrderedTable` types.
   ##

--- a/tests/stdlib/formats/tjsonutils.nim
+++ b/tests/stdlib/formats/tjsonutils.nim
@@ -66,7 +66,6 @@ template fn() =
   block: # OrderedTable
     testRoundtrip({"z": "Z", "y": "Y"}.toOrderedTable): """{"z":"Z","y":"Y"}"""
     doAssert toJson({"z": 10, "": 11}.newTable).`$`.contains """"":11""" # allows hash to change
-    testRoundtrip({"z".cstring: 1, "".cstring: 2}.toOrderedTable): """{"z":1,"":2}"""
     testRoundtrip({"z": (f1: 'f'), }.toTable): """{"z":{"f1":102}}"""
 
   block: # StringTable


### PR DESCRIPTION
## Summary

Unmarshaling a `Table` or `OrderedTable` where the key is a `cstring`
via `fromJsonHook` cannot be implemented to work in a safe way, at
least when using the C backend. For this reason, the overload is
removed.

## Details

The reason that it cannot work for the C target, is that `cstring`s
are unsafe views into strings there, so the keys of the table can,
in theory, only be valid for as long as the source `JsonNode` is
alive (and unchanged).

In practice, due to the iterators used by `fromJsonHook` not using
`lent` and thus introducing temporary copies, the `cstring` keys were
only valid for the loop iteration in which they were added to the
table.

The test case that existed for `OrderedTable[cstring, int]` only worked
by accident. Changing the allocation behaviour, building with
`-d:useMalloc`, or enabling memory sanitizers would all result in
test failures.