### PR TITLE
vmgen: fix accessing `var`/`lent` views in objects

### DIFF
--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1377,10 +1377,9 @@ func fitsRegisterConsiderView(t: PType): bool =
   # XXX: introduce a ``mapType`` (similar to the one used by the other code
   #      generators) and base the "fits register" queries on that
   let t = t.skipTypes(IrrelevantTypes)
-  result = fitsRegister(t)
-  if not result:
-    # is it a direct single-location view?
-    result = t.kind in {tyVar, tyLent} and t.base.kind != tyOpenArray
+  fitsRegister(t) or
+    # is it a direct single-location view?:
+    t.kind in {tyVar, tyLent} and t.base.kind != tyOpenArray
 
 template needsRegLoad(): untyped =
   mixin load

--- a/tests/lang_experimental/views/tprocedural_views.nim
+++ b/tests/lang_experimental/views/tprocedural_views.nim
@@ -6,7 +6,8 @@ discard """
   '''
 """
 
-# knownIssue: vmgen generates incorrect code for view dereferences
+# knownIssue: semantic analysis produces incorrect AST for tuple initialization,
+#             causing VM access violation errors at run-time
 
 {.experimental: "views".}
 

--- a/tests/lang_experimental/views/tviews_in_object.nim
+++ b/tests/lang_experimental/views/tviews_in_object.nim
@@ -1,0 +1,71 @@
+discard """
+  targets: "c !js vm"
+  matrix: "--experimental:views"
+  description: '''
+    Tests for direct single-location views used as the type of
+    object fields. Only read access is tested here.
+  '''
+"""
+
+# knownIssue: multiple problems with the JavaScript code generator
+
+# note: all the tests here are run in the context of procedures; tests for
+# views in the context of top-level code should go elsewhere
+
+template testCase(typ: typed, initial, codeA: untyped) {.dirty.} =
+  block:
+    type
+      ObjImmutable = object
+        field: lent typ
+      ObjMutable = object
+        field: var typ
+
+    proc testA() =
+      let
+        local: typ = initial
+        o = ObjImmutable(field: local)
+      codeA
+
+    testA()
+
+    proc testB() =
+      var
+        local: typ = initial
+        o = ObjMutable(field: local)
+      codeA
+
+    testB()
+
+# test: single primitive location
+testCase(int, 1):
+  doAssert o.field == 1
+
+# test: single array location
+testCase(array[1, int], [1]):
+  doAssert o.field[0] == 1 # subscript access works
+  doAssert o.field == [1]
+
+# test: single string location
+testCase(string, "abc"):
+  doAssert o.field[1] == 'b' # subscript access works
+  doAssert o.field == "abc"
+
+# test: single seq location
+testCase(seq[int], @[1]):
+  doAssert o.field[0] == 1 # subscript access works
+  doAssert o.field == [1]
+
+# XXX: internal compiler error in ``astgen``
+when false:
+  # test: single tuple location
+  testCase(tuple[x: int], (1,)):
+    doAssert o.field[0] == 1 # subscript access works
+    doAssert o.field.x == 1  # dot access works
+    doAssert o.field == (1,)
+
+# test: single object location
+type Object = object
+  value: int
+testCase(Object, Object(value: 1)):
+  doAssert o.field.value == 1
+  doAssert o.field == Object(value: 1)


### PR DESCRIPTION
## Summary

Make `vmgen` emit the bytecode for loading pointer views into a register
prior to the dereference, making access of `var`/`lent` views stored in
objects work for code being compiled for the VM target (refer to the
added tests for examples; most of them previously crashed the VM).

## Details

The VM can only dereference pointers - which direct single-location
views part of compound types map to for the VM target - if they're
stored in registers. Due to the `vmgen` logic for generating the code
for `nkDotExpr` (field access) and `nkBracketExpr` (array and seq
access) expressions not considering views when testing whether a load-
into-register is required, a handle-to-pointer operand was passed to
`LdDeref`.

`needsRegLoad` now checks whether a load-into-register is required via
the new `fitsRegisterConsiderView`, which treats direct single-location
views as fitting into registers.

### Future Direction

The code generator needs to map types to a register / internal type and
then base the various type queries it performs (`isDirectView`,
`fitsRegister`, etc.) on the mapped type.