### PR TITLE
refactor(ast): minimize usage of `nfBlockArg` flag

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -840,8 +840,6 @@ proc toPNode*(parsed: ParsedNode): PNode =
   else:
     if parsed.isBlockArg:
       result.flags.incl nfBlockArg
-    doAssert nfBlockArg notin result.flags or result.kind == nkStmtList,
-      "block args only applies to stmtlists, kind: " & $result.kind
 
     for sub in parsed.sons.items:
       result.add toPNode(sub)

--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -840,6 +840,8 @@ proc toPNode*(parsed: ParsedNode): PNode =
   else:
     if parsed.isBlockArg:
       result.flags.incl nfBlockArg
+    doAssert nfBlockArg notin result.flags or result.kind == nkStmtList,
+      "block args only applies to stmtlists, kind: " & $result.kind
 
     for sub in parsed.sons.items:
       result.add toPNode(sub)

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -1411,7 +1411,8 @@ proc postExprBlocks(p: var Parser, x: ParsedNode): ParsedNode =
         nextBlock.add parseStmt(p)
 
       # nextBlock.flags.incl nfBlockArg # XXXX
-      nextBlock.isBlockArg = true
+      if nextBlock.kind in {pnkStmtList, pnkStmtListExpr}:
+        nextBlock.isBlockArg = true
       result.add nextBlock
 
       if nextBlock.kind in {pnkElse, pnkFinally}: break

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3506,9 +3506,8 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
       # assured that the maximum nesting is of depth 1
 
       for j, a in x.pairs:
-        # TODO: guard against last node being an nkStmtList?
         addStmt(a)
-        
+
         if a.kind == nkError:
           hasError = true
     else:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3505,15 +3505,12 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
       # this can be flattened, because of the earlier semExpr call we are
       # assured that the maximum nesting is of depth 1
 
-      if nfBlockArg in x.flags:
-        addStmt(x)
-      else:
-        for j, a in x.pairs:
-          # TODO: guard against last node being an nkStmtList?
-          addStmt(a)
-          
-          if a.kind == nkError:
-            hasError = true
+      for j, a in x.pairs:
+        # TODO: guard against last node being an nkStmtList?
+        addStmt(a)
+        
+        if a.kind == nkError:
+          hasError = true
     else:
       addStmt(x)
   


### PR DESCRIPTION
## Summary

Only statement list nodes are flagged with `nfBlockArg` as a purely
internal refactoring.

## Details

The `nfBlockArg` flag is used to indicate that a statement list
(`nkStmtList` or `nkStmtListExpr`) is a block argument and not to be
unwrapped if containing a single expression. The flagging is done in the
`parser` and was being applied to non-statement list nodes where such
guards are not required.

Also removed a unnecessary unwrapping guard in `semStmtList`.

Guarding against unwrapping is an operand handling matter and should
probably be handled as part of `sigmatch`, in `prepareOperand` and
`semOperand`.