### PR TITLE
codegen: better support for `openArray`

### DIFF
--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -216,10 +216,7 @@ proc openArrayLoc(p: BProc, formalType: PType, n: PNode): Rope =
     case skipTypes(a.t, abstractVar+{tyStatic}).kind
     of tyOpenArray, tyVarargs:
       if reifiedOpenArray(n):
-        if a.t.kind in {tyVar, tyLent}:
-          result = "$1->Field0, $1->Field1" % [rdLoc(a)]
-        else:
-          result = "$1.Field0, $1.Field1" % [rdLoc(a)]
+        result = "$1.Field0, $1.Field1" % [rdLoc(a)]
       else:
         result = "$1, $1Len_0" % [rdLoc(a)]
     of tyString, tySequence:

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -135,7 +135,7 @@ proc mapType(conf: ConfigRef; typ: PType; kind: TSymKind): TCTypeKind =
   of tySet: result = mapSetType(conf, typ)
   of tyOpenArray, tyVarargs:
     if kind == skParam: result = ctArray
-    else: result = ctStruct
+    else: result = ctNimOpenArray
   of tyArray, tyUncheckedArray: result = ctArray
   of tyObject, tyTuple: result = ctStruct
   of tyUserTypeClasses:
@@ -161,7 +161,7 @@ proc mapType(conf: ConfigRef; typ: PType; kind: TSymKind): TCTypeKind =
     of tyArray, tyUncheckedArray: result = ctPtrToArray
     of tyOpenArray, tyVarargs:
       if kind == skParam: result = ctPtrToArray
-      else:               result = ctStruct
+      else:               result = ctNimOpenArray
     of tySet:
       if mapSetType(conf, base) == ctArray: result = ctPtrToArray
       else: result = ctPtr

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -64,6 +64,7 @@ type
     ctFloat, ctFloat32, ctFloat64, ctFloat128,
     ctUInt, ctUInt8, ctUInt16, ctUInt32, ctUInt64,
     ctArray, ctPtrToArray, ctStruct, ctPtr, ctNimStr, ctNimSeq, ctProc,
+    ctNimOpenArray,
     ctCString
   TCFileSections* = array[TCFileSection, Rope] ## represents a generated C file
   TCProcSection* = enum       ## the sections a generated C proc consists of

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1656,7 +1656,7 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
       result = putToSeq("null", indirect)
   of tySequence, tyString:
     result = putToSeq("[]", indirect)
-  of tyCstring, tyProc:
+  of tyCstring, tyProc, tyOpenArray:
     result = putToSeq("null", indirect)
   of tyStatic:
     p.config.internalAssert(t.n != nil, "createVar: " & $t.kind)
@@ -1697,7 +1697,7 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
     gen(p, n, a)
     case mapType(p, v.typ)
     of etyObject, etySeq:
-      if needsNoCopy(p, n):
+      if needsNoCopy(p, n) or classifyBackendView(v.typ) == bvcSequence:
         s = a.res
       else:
         useMagic(p, "nimCopy")

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -973,7 +973,7 @@ proc needsNoCopy(p: PProc; y: PNode): bool =
   return y.kind in nodeKindsNeedNoCopy or
         ((mapType(y.typ) != etyBaseIndex) and
           (skipTypes(y.typ, abstractInst).kind in
-            {tyRef, tyPtr, tyLent, tyVar, tyCstring, tyProc} + IntegralTypes))
+            {tyRef, tyPtr, tyLent, tyVar, tyCstring, tyProc, tyOpenArray} + IntegralTypes))
 
 proc genAsgnAux(p: PProc, x, y: PNode, noCopyNeeded: bool) =
   var a, b: TCompRes

--- a/compiler/backend/jstypes.nim
+++ b/compiler/backend/jstypes.nim
@@ -134,7 +134,7 @@ proc genTypeInfo(p: PProc, typ: PType): Rope =
       "var $1 = {size: 0,kind: $2,base: null,node: null,finalizer: null};$n" %
       [result, rope(ord(t.kind))]
     prepend(p.g.typeInfo, s)
-  of tyVar, tyLent, tyRef, tyPtr, tySequence, tyRange, tySet:
+  of tyVar, tyLent, tyRef, tyPtr, tySequence, tyRange, tySet, tyOpenArray:
     var s =
       "var $1 = {size: 0, kind: $2, base: null, node: null, finalizer: null};$n" %
               [result, rope(ord(t.kind))]

--- a/compiler/mir/astgen.nim
+++ b/compiler/mir/astgen.nim
@@ -52,7 +52,6 @@ import
   ]
 
 from compiler/sem/semdata import makeVarType
-from compiler/sem/typeallowed import directViewType, noView
 
 # TODO: move the procedure somewhere common
 from compiler/vm/vmaux import findRecCase
@@ -534,7 +533,7 @@ proc canUseView(n: PNode): bool =
     of nkCallKinds:
       # if the call yields a view, use an lvalue reference (view) -- otherwise,
       # do not
-      return directViewType(n.typ) != noView
+      return classifyBackendView(n.typ) != bvcNone
     else:
       return false
 

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -766,7 +766,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   case t.kind
   of tyNone, tyEmpty, tyVoid: discard
   of tyPointer, tySet, tyBool, tyChar, tyEnum, tyInt..tyUInt64, tyCstring,
-      tyPtr, tyUncheckedArray, tyVar, tyLent:
+      tyPtr, tyUncheckedArray, tyVar, tyLent, tyVarargs, tyOpenArray:
     defaultOp(c, t, body, x, y)
   of tyRef:
     if c.g.config.selectedGC in {gcArc, gcOrc}:
@@ -817,12 +817,6 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
       fillBody(c, t[0], body, x, y)
   of tyTuple:
     fillBodyTup(c, t, body, x, y)
-  of tyVarargs, tyOpenArray:
-    if c.kind == attachedDestructor and (tfHasAsgn in t.flags or useNoGc(c, t)):
-      forallElements(c, t, body, x, y)
-    else:
-      discard "cannot copy openArray"
-
   of tyFromExpr, tyProxy, tyBuiltInTypeClass, tyUserTypeClass,
      tyUserTypeClassInst, tyCompositeTypeClass, tyAnd, tyOr, tyNot, tyAnything,
      tyGenericParam, tyGenericBody, tyNil, tyUntyped, tyTyped,

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -556,17 +556,13 @@ func prepare(c: var TCtx, dest: var TDest, typ: PType) =
   if dest.isUnset:
     dest = c.getTemp(typ)
 
-func isVarLent(t: PType): bool {.inline.} =
-  ## Returns whether `t` is a ``var`` or ``lent`` type (i.e. a direct
-  ## single-location view type). ``openArray`` types are currently not
-  ## considered.
-  t.skipTypes(abstractInst).kind in {tyVar, tyLent}
+func isLocView(t: PType): bool {.inline.} =
+  ## Returns whether `t` is a a direct single-location view-type.
+  classifyBackendView(t) == bvcSingle
 
 func isDirectView(t: PType): bool {.inline.} =
-  ## Returns whether `t` is a direct view type
-  isVarLent(t)
-  # TODO: use the below once ``openArray``s are properly supported
-  #directViewType(t) != noView
+  ## Returns whether `t` is a direct view-type.
+  classifyBackendView(t) != bvcNone
 
 proc prepare(c: var TCtx, dest: var TDest, n: PNode, typ: PType) =
   ## If `dest` is not already set or refers to an argument slot, allocates a
@@ -2237,7 +2233,7 @@ proc genAsgnSource(c: var TCtx, n: PNode, wantsPtr: bool): TRegister =
   ## handling is required when the source operand is a view. ``wantsPtr``
   ## indicates which one the consumer expects.
   result = c.genx(n)
-  if isVarLent(n.typ):
+  if isLocView(n.typ):
     let isPtr = isPtrView(n)
     # if necessary, convert the view to the representation the destination
     # expects:
@@ -2287,7 +2283,7 @@ proc genSymAsgn(c: var TCtx, le, ri: PNode) =
       # an assignment is required to the local. Views are always stored as
       # handles in this case, so a register move is used for assigning them
       let
-        opc = (if isVarLent(s.typ): opcFastAsgnComplex else: opcWrLoc)
+        opc = (if isDirectView(s.typ): opcFastAsgnComplex else: opcWrLoc)
         b = c.genx(ri)
       c.gABC(le, opc, dest, b)
       c.freeTemp(b)
@@ -2458,7 +2454,7 @@ proc genSym(c: var TCtx; n: PNode; dest: var TDest; load = true) =
     if dest.isUnset:
       dest = c.getTemp(s.typ)
 
-    if load and (isVarLent(s.typ) or fitsRegister(s.typ)):
+    if load and (isLocView(s.typ) or fitsRegister(s.typ)):
       let cc = c.getTemp(n.typ)
       c.gABx(n, opcLdGlobal, cc, pos)
       c.genRegLoad(n, dest, cc)
@@ -2686,7 +2682,7 @@ proc genAddr(c: var TCtx, src, n: PNode, dest: var TDest) =
   of nkHiddenDeref:
     # taking the address of a view's or ``var`` parameter's underlying
     # location
-    assert isVarLent(n[0].typ)
+    assert isLocView(n[0].typ)
     if isPtrView(n[0]):
       # the view is stored as an address; treat the deref as a no-op
       genLvalue(c, n[0], dest)
@@ -2757,7 +2753,7 @@ proc genLvalue(c: var TCtx, n: PNode, dest: var TDest) =
     # type
     gen(c, n, dest)
   of nkHiddenDeref:
-    assert isVarLent(n[0].typ)
+    assert isLocView(n[0].typ)
     if isPtrView(n[0]):
       # we want a handle (``rkHandle``), but the input view uses a pointer
       # (``rkAddress``) internally. Turn it into a handle by dereferencing it
@@ -2774,7 +2770,7 @@ proc genLvalue(c: var TCtx, n: PNode, dest: var TDest) =
     # we only reach this case for ``HiddenAddr (HiddenDeref (Call ...))``.
     # Generate the call returning a view as is
     # XXX: ``astgen`` should not emit these instead
-    assert isVarLent(n.typ)
+    assert isLocView(n.typ)
     gen(c, n, dest)
   of nkStmtListExpr:
     for i in 0..<n.len-1:
@@ -2825,7 +2821,8 @@ proc genVarSection(c: var TCtx; n: PNode) =
 
             c.gABx(a, opc, reg, c.genType(s.typ))
           else:
-            if not usesRegister(c.prc, s) and not isVarLent(s.typ):
+            # XXX: checking for views here is wrong but necessary
+            if not usesRegister(c.prc, s) and not isDirectView(s.typ):
               # only setup a memory location if the local uses one
               c.gABx(a, opcLdNull, reg, c.genType(s.typ))
 
@@ -3042,11 +3039,11 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
   of nkDerefExpr: genDeref(c, n, dest)
   of nkAddr: genAddr(c, n, n[0], dest)
   of nkHiddenDeref:
-    assert isVarLent(n[0].typ)
+    assert isLocView(n[0].typ)
     # a view indirection
     genDerefView(c, n[0], dest)
   of nkHiddenAddr:
-    assert isVarLent(n.typ)
+    assert isLocView(n.typ)
     # load the source operand as a handle
     genLvalue(c, n[0], dest)
   of nkIfStmt:

--- a/tests/lang_types/openarray/topenarray_assign.nim
+++ b/tests/lang_types/openarray/topenarray_assign.nim
@@ -1,0 +1,109 @@
+discard """
+  targets: "c js vm"
+  matrix: "--experimental:views"
+  description: "Tests for assigning first-class openArrays to locals"
+"""
+
+# Note the tests here are only intended to capture the current semantics and
+# make sure they work; they're not intended to describe how things should be.
+# Once the semantics of view-types are more fleshed out, the tests need to be
+# adjusted
+
+proc check(x: openArray[int]) =
+  doAssert x[0] == 1
+  doAssert x.len == 2
+
+proc fromLocal() =
+  # test: assign to ``openArray`` with implicit conversion from a sequence
+  let s = @[1, 2]
+
+  block:
+    let x: openArray[int] = s
+    check(x)
+
+  # XXX: either crashes the compiler or generates invalid code --
+  #      ``lent openArray`` doesn't make much sense in general.
+  when false:
+    let x: lent openArray[int] = s
+    check(x)
+
+  # XXX: currently required for the "outlives" analysis to not report
+  #      an error
+  discard s
+
+fromLocal()
+
+proc copyOpenarray() =
+  # test: copying an ``openArray``
+  let s = @[1, 2]
+  let a: openArray[int] = s
+  check(a)
+
+  let b = a # copy the view
+  doAssert b is openArray[int] # is the type correct?
+  check(b)
+
+  discard a
+  discard s # XXX: work around "outlives" analysis issue
+
+copyOpenarray()
+
+proc copyMutableOpenarray() =
+  # test: copying a ``var openArray``
+  var s = @[1, 2]
+  var a: var openArray[int] = s
+  check(a)
+  # modify `s` through the view
+  a[1] += 1
+
+  static:
+    echo typeof(a)
+
+  var b = a # copy the view
+  doAssert b is openArray[int] # is the type correct?
+  check(b)
+  doAssert b[1] == 3 # is the modification visible through the view?
+  b[1] += 2
+
+  discard a
+  # are the modifications visible at the source location?
+  doAssert s[1] == 5
+
+copyMutableOpenarray()
+
+proc fromParam(oa: openArray[int]) =
+  # test: assign an ``openArray`` parameter to a local
+  let x = oa
+  check(x)
+
+fromParam([1, 2]) # test with array
+fromParam(@[1, 2]) # test with seq
+
+proc fromCall() =
+  # test: assign the ``openArray`` result of a call to a local
+  proc call(x: openArray[int]): openArray[int] =
+    check(x)
+    result = x # pass through
+
+  let
+    s = @[1, 2]
+    v = call(s)
+  check(v)
+
+  discard s # XXX: work around "outlives"-analysis issue
+
+fromCall()
+
+proc mutable() =
+  # test: create mutable view from a seq
+  var s = @[1, 2]
+
+  block:
+    var x: var openArray[int] = s
+    check(x)
+    # verify that mutations are possible:
+    x[0] = 3
+
+  doAssert s[0] == 3
+
+mutable()


### PR DESCRIPTION
## Summary

Fix multiple issues related to the `openArray` type across all three
code generators. The intention is to make using the type stable
enough for the inlining logic in `transf` to use it as the type for
locals and object fields.

The unstable `sink openArray` feature stops working with the changes
here: its viewed elements are no longer destroyed when exiting the
routine accepting a `sink openArray` as a parameter.

## Details

A big part of the changes is to treat `var|lent openArray` types the
same an unqualified `openArray` during the mid- and back-end phase of
compilation. In the future, the types should be lowered into `openArray`
prior to reaching the code generators.

The following list of changes is ordered by compilation phase, with the
earlier steps coming first.

### Operator Lifting

`openArray` types are treated as primitive types, with a normal
assignment being used for copying and sinking, and destruction being a
no-op. This is necessary in order for copying the view to work.

This breaks `sink openArray`, which relied on a non-trivial destroy hook
that destroyed all element being generated for `openArray`.

### MIR generation

Semantic analysis insert s`nkHiddenAddr` and `nkHiddenDeref` nodes for
`var openArray`s. This is both unnecessary and confuses the code
generators, as no indirection is used and thus no taking the address /
dereferencing is needed.

While this ultimately needs to be fixed in sem, it is for now worked
around in `mirgen`: if the operand to `nkHiddenAddr` or `nkHiddenDeref`
is an `openArray`, the operator is ignored.

To make working with view types easier in the compiler's mid- and back-
end part, the `classifyBackendView` procedure is introduced, which for
the provided type computes whether it's a single-location view
(`var|lent` with non-`openArray` element), view of a sequence
(`openArray`), or no view.

### Code generation

#### `cgen`

* introduce the `ctNimOpenArray` enum field
* map `var|lent openArray` to the same C type as an unqualified
  `openArray`
* base `genAssignment` and `constructLoc` on the *C type*, instead of
  the NimSkull type, fixing assignment and initialization of
  `var|lent openArray`s
* fix the C type-name caching logic to not cache `var|lent openArray`
  types

#### `jsgen`

* implement default initialization and type info creation for
  `openArray`. This is required for `openArray`s to be part of compound
  types (arrays, tuples, objects)
* include `tyOpenArray` in the list of "no copy" types
* prevent a call to `nimCopy` during initialization when the destination
  is an `openArray`

#### `vmgen`

Refactor:
* rename `isVarLent` to `isLocView` and use `classifyBackendView`
* use `classifyBackendView` for `isDirectView`

Change:
* `isLocView` only returns 'true' for single-location views
* consider all direct views in `isDirectView` (`openArray` was missing)
* consider all direct views (not only single-location ones) for
  assignments (`genSymAsgn`) and initialization (`genVarStmt`)