### PR TITLE
cgen: fix `var seq` globals defined in loops

### DIFF
--- a/tests/lang_experimental/views/tglobal_view_in_loop.nim
+++ b/tests/lang_experimental/views/tglobal_view_in_loop.nim
@@ -1,0 +1,16 @@
+discard """
+  targets: "c js vm"
+  matrix: "--experimental:views"
+  description: "Regression test for a C code-generator bug"
+"""
+
+var s = @[1, 2]
+for i in 0..1:
+  # the C code-generator previously default initialized the global by
+  # zero intializing the pointed-to seq. This is incorrect (the pointer
+  # itself needs to be zero-ed, not what it points to) and caused an
+  # access violation error at runtime
+  var v: var seq[int] = s
+  v[i] = i
+
+doAssert s == [0, 1]


### PR DESCRIPTION
## Summary

Fix a C code-generator bug where incorrect code was generated for a
global of `(var|lent) seq` type that was defined inside a loop. The
resulting code crashed at run-time.

## Details

The C code-generators maps `(var|lent) seq` to the `NimSeq*` C type.
When resetting a location through `cgen.resetLoc` (which happens for
globals defined inside loops), the following code was generated:

```c
global->len = 0; global->p = NIM_NIL;
```

That is not correct, as the location itself (the pointer) and not what
the pointer points to needs to be cleared. Due to globals being zero-
initialized, executing the generated code resulted in an access
violation.

Basing the logic in `resetLoc` on the C type fixes the bug (removing
the problematic `if` statement would too), but since the procedure's
code would be almost identical to `constructLoc` then, `resetLoc` now
only dispatches to `constructLoc`.