### PR TITLE
internal: drop `nfBlockArg` usage

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -838,8 +838,5 @@ proc toPNode*(parsed: ParsedNode): PNode =
     unreachable("IMPLEMENT ME")
 
   else:
-    if parsed.isBlockArg:
-      result.flags.incl nfBlockArg
-
     for sub in parsed.sons.items:
       result.add toPNode(sub)

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -251,8 +251,6 @@ type
         idents*: seq[tuple[ident: PIdent, line: uint16, col: int16]]
       of pnkCall..pnkUsingStmt:
         token*: ParsedToken
-        isBlockArg*: bool       # TODO: rework ast to eliminate this flag,
-                                #       maybe with a `pnkStmtListArg` kind.
         sons*: seq[ParsedNode]  # TODO: replace `ref` object graph with
                                 #       begin/end ranges for tracking the tree
                                 #       hierarchy in a linear data structure.
@@ -304,7 +302,6 @@ proc transitionSonsKind*(n: ParsedNode, kind: ParsedNodeKind) =
   {.cast(uncheckedAssign).}:
     n[] = ParsedNodeData(kind: kind,
                          token: obj.token,
-                         isBlockArg: obj.isBlockArg,
                          sons: obj.sons,
                          comment: obj.comment,
                          fileIndex: obj.fileIndex)

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -647,7 +647,6 @@ type
     nfExplicitCall ## `x.y()` was used instead of x.y
     nfIsRef     ## this node is a 'ref' node; used for the VM
     nfIsPtr     ## this node is a 'ptr' node; used for the VM
-    nfBlockArg  ## this a stmtlist appearing in a call (e.g. a do block)
     nfFromTemplate ## a top-level node returned from a template
     nfDefaultParam ## an automatically inserter default parameter
     nfDefaultRefsParam ## a default param value references another parameter

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -1360,8 +1360,6 @@ proc postExprBlocks(p: var Parser, x: ParsedNode): ParsedNode =
       # to keep backwards compatibility (see tests/vm/tstringnil)
       if stmtList[0].kind == pnkStmtList: stmtList = stmtList[0]
 
-      stmtList.isBlockArg = true
-      # stmtList.flags.incl nfBlockArg # XXXX
       result.add if openingParams.kind == pnkEmpty and
                     openingPragmas.kind == pnkEmpty:
                    stmtList
@@ -1410,9 +1408,6 @@ proc postExprBlocks(p: var Parser, x: ParsedNode): ParsedNode =
         p.eat(tkColon)
         nextBlock.add parseStmt(p)
 
-      # nextBlock.flags.incl nfBlockArg # XXXX
-      if nextBlock.kind in {pnkStmtList, pnkStmtListExpr}:
-        nextBlock.isBlockArg = true
       result.add nextBlock
 
       if nextBlock.kind in {pnkElse, pnkFinally}: break

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3792,7 +3792,14 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkStaticExpr: result = semStaticExpr(c, n[0])
   of nkAsgn: result = semAsgn(c, n)
   of nkBlockStmt, nkBlockExpr: result = semBlock(c, n, flags)
-  of nkStmtList, nkStmtListExpr: result = semStmtList(c, n, flags)
+  of nkStmtList, nkStmtListExpr:
+    result = semStmtList(c, n, flags,
+                         collapse =
+                            # preserve concept bodies as a stmt list:
+                            c.matchedConcept.isNil and
+                            # also, don't make life complicated for macros.
+                            # they will always expect a proper stmtlist:
+                            nfBlockArg notin n.flags)
   of nkRaiseStmt: result = semRaise(c, n)
   of nkVarSection: result = semConstLetOrVar(c, n, skVar)
   of nkLetSection: result = semConstLetOrVar(c, n, skLet)

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -48,7 +48,7 @@ proc semOperand(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     else:
       semExpr(c, n, exprFlags)
 
-  result.flags.incl nfSem # `semStmtList` doesn't add them
+  result.flags.incl nfSem # `semStmtList` doesn't add it
 
   if result.typ != nil:
     # XXX tyGenericInst here?

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3807,12 +3807,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     result = semStmtList(c, n, flags,
                          # preserve concept bodies as a stmt list:
                          collapse = c.matchedConcept.isNil)
-                        #  collapse =
-                        #     # preserve concept bodies as a stmt list:
-                        #     c.matchedConcept.isNil and
-                        #     # also, don't make life complicated for macros.
-                        #     # they will always expect a proper stmtlist:
-                        #     nfBlockArg notin n.flags)
   of nkRaiseStmt: result = semRaise(c, n)
   of nkVarSection: result = semConstLetOrVar(c, n, skVar)
   of nkLetSection: result = semConstLetOrVar(c, n, skLet)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3403,11 +3403,12 @@ proc inferConceptStaticParam(c: PContext, inferred, n: PNode) =
 
   typ.n = res
 
-proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
+proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, collapse: bool): PNode =
   ## analyses `n`, a statement list or list expression, producing a statement
   ## list or expression with appropriate type and flattening all immediate
   ## children statment list or expressions where possible. on failure an
-  ## nkError is produced instead.
+  ## nkError is produced instead. `collapse` controls whether single child
+  ## statement lists should be unwrapped, yielding the child directly.
   addInNimDebugUtils(c.config, "semStmtList", n, result, flags)
 
   assert n != nil
@@ -3525,11 +3526,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
                       SemReport(kind: rsemUnreachableCode))
 
   if result.kind != nkError and result.len == 1 and
-     # concept bodies should be preserved as a stmt list:
-     c.matchedConcept == nil and
-     # also, don't make life complicated for macros.
-     # they will always expect a proper stmtlist:
-     nfBlockArg notin n.flags and
+     collapse and
      result[0].kind != nkDefer:
     result = result[0]
 

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3421,11 +3421,11 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, collapse: bool): PNod
   result = copyNode(n)
   result.flags = n.flags # preserve flags as copyNode is selective
   result.transitionSonsKind(nkStmtList)
-  
+
   var
     voidContext = false
     hasError = false
-  
+
   let lastInputChildIndex = n.len - 1
 
   # by not allowing for nkCommentStmt etc. we ensure nkStmtListExpr actually
@@ -3440,10 +3440,10 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, collapse: bool): PNod
     let 
       x = semExpr(c, n[i], flags)
       last = lastInputChildIndex == i
-    
+
     if c.matchedConcept != nil and x.typ != nil and
         (nfFromTemplate notin n.flags or not last):
-      
+
       if x.isError:
         result.add:
           newError(c.config, n[i], PAstDiag(kind: adSemConceptPredicateFailed))
@@ -3468,7 +3468,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, collapse: bool): PNod
             x.lastSon
           else:
             x
-        
+
         if verdict == nil or verdict.kind != nkIntLit or verdict.intVal == 0:
           result.add:
             newError(c.config, n[i],
@@ -3494,7 +3494,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, collapse: bool): PNod
           discardCheck(c, kid, flags)
         else:
           kid
-      
+
       if result[^1].isError:
         hasError = true
 
@@ -3513,7 +3513,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, collapse: bool): PNod
           hasError = true
     else:
       addStmt(x)
-  
+
     if x.kind in nkLastBlockStmts or
        x.kind in nkCallKinds and x[0].kind == nkSym and
        sfNoReturn in x[0].sym.flags:
@@ -3526,8 +3526,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags, collapse: bool): PNod
                       SemReport(kind: rsemUnreachableCode))
 
   if result.kind != nkError and result.len == 1 and
-     collapse and
-     result[0].kind != nkDefer:
+     collapse and result[0].kind != nkDefer:
     result = result[0]
 
   when defined(nimfix):

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2581,11 +2581,10 @@ template isVarargsUntyped(x): untyped =
   x.kind == tyVarargs and x[0].kind == tyUntyped
 
 proc findFirstArgBlock(m: var TCandidate, n: PNode): int =
+  # xxx: this "feature" isn't a great idea and the implementation is awful
   # see https://github.com/nim-lang/RFCs/issues/405
   result = int.high
   for a2 in countdown(n.len - 1, 0):
-    # checking `nfBlockArg in n[a2].flags` wouldn't work inside templates
-    # xxx: ^^ why???
     case n[a2].kind
     of nkStmtList:
       let formalLast = m.callee.n[m.callee.n.len - (n.len - a2)]

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2519,24 +2519,6 @@ proc prepareOperand(c: PContext; formal: PType; a: PNode): PNode =
   if formal.kind == tyUntyped:
     assert formal.len != 1
     result = a
-  # elif formal.kind == tyTyped and a.typ.isNil:
-  #   var hasError = false
-  #   case a.kind
-  #   of nkStmtList, nkStmtListExpr:
-  #     result = shallowCopy(a)
-  #     for i, k in a.pairs:
-  #       doAssert k.kind != nkEmpty
-  #       result[i] = c.semOperand(c, k, {efAllowStmt})
-  #       hasError = hasError or result[i].kind == nkError
-  #     # skip the expr/stmt node kind conversion and discard check, because it's
-  #     # a fragment, and might get inserted into a position where that's handled.
-  #     let lastTyp = result.lastSon.typ
-  #     if lastTyp != nil and lastTyp.kind notin {tyError}:
-  #       result.typ = lastTyp
-  #     if hasError:
-  #       result = c.config.wrapError(result)
-  #   else:
-  #     result = c.semOperand(c, a, {efAllowStmt})
   elif a.typ.isNil:
     # XXX This is unsound! 'formal' can differ from overloaded routine to
     # overloaded routine!

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -718,7 +718,7 @@ proc matchUserTypeClass*(m: var TCandidate; ff, a: PType): PType =
 
   # xxx: this is where we end up with collapsed bodies and drives the need for
   #      the check in `semexprs.semExpr`'s `nkStmtList/Expr` branch, a
-  #      `semTryStmt` that doesn't collapse should remove the awkward logic and
+  #      `semTryExpr` that doesn't collapse should remove the awkward logic and
   #      action at a distance.
   var checkedBody = c.semTryExpr(c, body.copyTree, {efExplain})
 

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2514,8 +2514,7 @@ proc setSon(father: PNode, at: int, son: PNode) =
 # we are allowed to modify the calling node in the 'prepare*' procs:
 proc prepareOperand(c: PContext; formal: PType; a: PNode): PNode =
   when defined(nimCompilerStacktraceHints):
-    {.line.}:
-      frameMsg(c.config, a)
+    frameMsg(c.config, a)
   if formal.kind == tyUntyped:
     assert formal.len != 1
     result = a

--- a/tests/lang_callable/macros/tgettypeinst.nim
+++ b/tests/lang_callable/macros/tgettypeinst.nim
@@ -27,6 +27,8 @@ macro testX(x,inst0: typed; recurse: static[bool]; implX: typed) =
   let inst = x.getTypeInst
   let instr = inst.symToIdent.treeRepr
   let inst0r = inst0.symToIdent.treeRepr
+  let implX = if implX.kind in {nnkStmtList, nnkStmtListExpr}: implX[0]
+              else:                                            implX
   if instr != inst0r:
     echo "instr:\n", instr
     echo "inst0r:\n", inst0r


### PR DESCRIPTION
## Summary

`nfBlockArg`, an internal flag used to track whether a block argument,
encoded by the `parser` as a `nkStmtList` is no longer used. This is
largely transparent, except for macros receiving a `typed` argument
block will always be wrapped in a statement list, even if there is only
a single statement.

## Details

Internally the compiler tracked block arguments as statement lists with
an internal flag `nfBlockArg` on the node. This prevented various
normalization within semantic analysis from removing this node. This
flag is no longer used and results in only minor changes to parameter
behaviour within `macros`.

Now, any call to a macro where the block style argument syntax is used,
a statement list node is always passed. Whereas before, singleton
statement list nodes were unwrapped, this is no longer the case. This
is considered acceptable as any non-singleton statement would result in
the macro receiving a statement list, and so this behaviour must be
guarded for regardless.

Within the `parser` `isBlockArg` is no longer tracked and in turn
`nfBlockArg` is not applied to `PNode`s during conversion from the
parsed tree to legacy AST. The flag and field in the `ParsedNodeData`
have been removed.

`semStmtList` now exposes a `collapsed` parameter, which `semExprs` uses
to inform statement list unwrapping, this case only when within a
`concept` matching check. `semOperand` has been updated to check if its
input is a statement list, and if it is, it mimics `semExprs` without
statement unwrapping, such as applying `nfSem` to the semanticized
output.

A described earlier, this change means that `typed` arg blocks will not
be unwrapped, and the `tgettypeinst` was adjusted for this.