### PR TITLE
vmgen: fix double evaluation of `swap` arguments

### DIFF
--- a/compiler/sem/lowerings.nim
+++ b/compiler/sem/lowerings.nim
@@ -128,20 +128,6 @@ proc lowerTupleUnpackingForAsgn*(g: ModuleGraph; n: PNode; idgen: IdGenerator; o
   for i in 0..<lhs.len:
     result.add newAsgnStmt(lhs[i], newTupleAccessRaw(tempAsNode, i))
 
-proc lowerSwap*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner: PSym): PNode =
-  # note: cannot use 'skTemp' here cause we really need the copy for the VM :-(
-  var temp = newSym(skVar, getIdent(g.cache, genPrefix), nextSymId(idgen), owner, n.info, owner.options)
-  temp.typ = n[1].typ
-  temp.flags.incl {sfFromGeneric, sfGenSym}
-
-  let tempAsNode = newSymNode(temp)
-
-  let v = newTreeI(nkVarSection, n.info):
-    newIdentDefs(tempAsNode, n[1])
-
-  result = newTreeI(nkStmtList, n.info):
-    [v, newFastAsgnStmt(n[1], n[2]), newFastAsgnStmt(n[2], tempAsNode)]
-
 proc createObj*(g: ModuleGraph; idgen: IdGenerator; owner: PSym, info: TLineInfo; final=true): PType =
   result = newType(tyObject, nextTypeId(idgen), owner)
   if final:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -51,9 +51,6 @@ import
     msgs,
     options
   ],
-  compiler/sem/[
-    lowerings
-  ],
   compiler/utils/[
     idioms
   ],
@@ -1810,7 +1807,37 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
     c.freeTemp(d)
   of mSwap:
     unused(c, n, dest)
-    c.gen(lowerSwap(c.graph, n, c.idgen, if c.prc == nil or c.prc.sym == nil: c.module else: c.prc.sym))
+    let tmp = getTemp(c, n.typ)
+    # XXX: swap doesn't need to be implemented here; lower it into assignment
+    #      with a MIR pass
+    # there's no ``nkHiddenAddr`` on the operands, so we don't need to skip
+    # var types
+    if fitsRegister(n[1].typ):
+      # we need to account for the fact that either operand could be
+      # stored in a register alreay (because it's a local variable)
+      let
+        a = c.genLoc(n[1])
+        b = c.genLoc(n[2])
+      # register copies are enough, here
+      c.gABC(n, opcFastAsgnComplex, tmp, a.val)
+      c.gABC(n, opcFastAsgnComplex, a.val, b.val)
+      c.gABC(n, opcFastAsgnComplex, b.val, tmp)
+      # write back (if necessary):
+      finish(c, n, b)
+      finish(c, n, a)
+    else:
+      let
+        a = c.genLvalue(n[1])
+        b = c.genLvalue(n[2])
+      # XXX: this currently creates a full copy; the VM is still missing the
+      #      ability to create shallow copies
+      c.gABC(n, opcAsgnComplex, tmp, a)
+      c.gABC(n, opcWrLoc, a, b)
+      c.gABC(n, opcWrLoc, b, tmp)
+      c.freeTemp(b)
+      c.freeTemp(a)
+
+    c.freeTemp(tmp)
   of mIsNil: genUnaryABC(c, n, dest, opcIsNil)
   of mParseBiggestFloat:
     if dest.isUnset: dest = c.getTemp(n.typ)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1814,7 +1814,7 @@ proc genMagic(c: var TCtx; n: PNode; dest: var TDest; m: TMagic) =
     # var types
     if fitsRegister(n[1].typ):
       # we need to account for the fact that either operand could be
-      # stored in a register alreay (because it's a local variable)
+      # stored in a register already (because it's a local variable)
       let
         a = c.genLoc(n[1])
         b = c.genLoc(n[2])

--- a/tests/vm/tswap.nim
+++ b/tests/vm/tswap.nim
@@ -1,34 +1,26 @@
 discard """
-nimout: '''
-x.data = @[10]
-y = @[11]
-x.data = @[11]
-y = @[10]
-@[3, 2, 1]
-'''
+  targets: "vm"
 """
 
-# bug #2946
+# https://github.com/nim-lang/nim/issues/2946
 
-proc testSwap(): int {.compiletime.} =
+proc testSwap(): int =
   type T = object
     data: seq[int]
   var x: T
   x.data = @[10]
   var y = @[11]
-  echo "x.data = ", x.data
-  echo "y = ", y
   swap(y, x.data)
-  echo "x.data = ", x.data
-  echo "y = ", y
+  doAssert x.data == @[11]
+  doAssert y == @[10]
   result = 99
 
-const something = testSwap()
+discard testSwap()
 
-# bug #15463
+# https://github.com/nim-lang/nim/issues/15463
 block:
   static:
     var s = @[1, 2, 3]
     swap(s[0], s[2])
 
-    echo s
+    doAssert s == [3, 2, 1]

--- a/tests/vm/tswap.nim
+++ b/tests/vm/tswap.nim
@@ -24,3 +24,43 @@ block:
     swap(s[0], s[2])
 
     doAssert s == [3, 2, 1]
+
+block arguments_with_side_effect:
+  # both argument expressions must only be evaluated once
+  var
+    a = 1
+    b = 2
+    counter = 0
+
+  swap((inc counter; a), (inc counter; b))
+  doAssert a == 2
+  doAssert b == 1
+  doAssert counter == 2
+
+block primitive_type:
+  # make sure that ``swap`` works for operands of primitive type
+  proc swapLocals() =
+    # both operands are locals
+    var
+      a = 1
+      b = 2
+    swap(a, b)
+    doAssert a == 2
+    doAssert b == 1
+
+  swapLocals()
+
+  proc swapFieldAndLocal() =
+    # one operand is a local, the other one a field
+    type Obj = object
+      field: int
+
+    var
+      a = 1
+      b = Obj(field: 2)
+    swap(a, b.field)
+
+    doAssert a == 2
+    doAssert b.field == 1
+
+  swapFieldAndLocal()


### PR DESCRIPTION
## Summary

Fix a bug the VM code generator had where the expression used
as the first argument was always evaluated twice -- it is now
only evaluated once.

## Details

The `lowerSwap` procedure that was used for lowering the `swap`
call into assignments duplicated the first argument expression,
resulting in it being evaluated two times.

Usage of `lowerSwap` is replaced with manually emitting the
bytecode for the assignments, which in addition to fixing the
bug and making the generated code slightly more efficient (the
introduced temporary is freed immediately after the swap now),
also has the benefit of removing both the import dependency on
`lowering` and `vmgen` needing access to an `IdGenerator`.

`lowerSwap` has no further usage sites, and is thus removed.