### PR TITLE
ccgexprs: fix two copy-on-write string bugs

### DIFF
--- a/tests/stdlib/strings/tdouble_evaluation_bug.nim
+++ b/tests/stdlib/strings/tdouble_evaluation_bug.nim
@@ -1,0 +1,50 @@
+discard """
+  targets: "c !js vm"
+  description: '''
+    Regression test for a double-evaluation bug involving assignment to or
+    creating view of string characters
+  '''
+"""
+
+# knownIssue: double evaluation bug with arguments to ``swap`` when using
+# the JavaScript backend
+
+block:
+  # for a string access used as the argument to a ``swap`` call, the string
+  # expression was evaluated twice. The string access had to be string
+  # subscript expression *directly*; a statement list expression didn't
+  # trigger the code generator bug
+  var i = 0
+  var a = "abc"
+  var b = "def"
+
+  # still test with a statement list expression:
+  swap((inc i; a[0]), (inc i; b[0]))
+  doAssert a == "dbc" and b == "aef"
+  doAssert i == 2, $i
+
+  proc get(x: var string): var string =
+    inc i # <- side effect
+    x
+
+  i = 0
+  # the bug was triggered here:
+  swap(get(a)[0], get(b)[0])
+  doAssert a == "abc" and b == "def"
+  doAssert i == 2
+
+block:
+  # assigning the result of a string subscript expression to a ``var char``
+  # location (i.e., creating a view) also triggered the bug
+  var i = 0
+  proc get(x: var string): var string =
+    inc i
+    x
+
+  proc access(s: var string): var char =
+    result = get(s)[0]
+
+  var s = "abc"
+  access(s) = 'd'
+  doAssert s == "dbc"
+  doAssert i == 1, $i

--- a/tests/stdlib/strings/tindirect_string_mutation.nim
+++ b/tests/stdlib/strings/tindirect_string_mutation.nim
@@ -1,0 +1,43 @@
+discard """
+  targets: "c js vm"
+  description: "Tests for indirectly modifying a string's element"
+"""
+
+# indirect here means: not via a direct assignment where the left-hand side
+# is a string subscript operation
+
+{.experimental: "views".}
+
+block through_view:
+  var
+    s = "abc"
+    v: var char = s[0]
+
+  v = 'd'
+  doAssert s == "dbc"
+
+block through_var_parameter:
+  var s = "abc"
+  proc p(c: var char) =
+    c = 'd'
+
+  p(s[0])
+  doAssert s == "dbc"
+
+block through_swap:
+  var
+    s = "abc"
+    c = 'd'
+
+  swap(s[0], c)
+
+  doAssert c == 'a'
+  doAssert s == "dbc"
+
+block through_var_openarray:
+  var s = "abc"
+  proc p(v: var openArray[char]) =
+    v[0] = 'd'
+
+  p(s)
+  doAssert s == "dbc"


### PR DESCRIPTION
## Summary

Fix two bugs where incorrect C code was generated in situations where
copy-on-write string are involved. These are:
1. the `s` in `result = s[0]` or `yield s[0]`, where the return type is
   `var char`, was evaluated two times
2. the source string was not prepared for mutation when passing a `s[0]`
   expression to a `var char` parameter or using it as the initializer
   expression for a mutable view

Bug 2 resulted in crashes at run-time when the source string hadn't been
prepared for mutation already.

## Details

Instead of the manual `cow` and `cowBracket` calls (which were the
reason for the double evaluation), emitting the
`nimPrepareStrMutationV2` calls is now left to `genSeqElem`, which
detects when to emit the call by checking for the presence of the
`lfPrepareMutation` loc flag on the destination location.

`genAddr` now accepts an additional `mutate` parameter, which decides
whether `genAddr` includes the `lfPrepareMutation` flag on the
intermediate `TLoc` it creates. For `nkHiddenAddr` nodes that produce
an address meant for mutation, `mutate` is set to 'true'; all other
address-of operation pass 'false'.

This makes `cow` and `cowBracket` obsolete, and preparing a string for
mutation work in all cases where a `nkHiddenAddr` is involved (which is
the case for the two situations where the prepare calls were previously
missing).

Since the arguments to `swap` are not wrapped in `nkHiddenAddr` nodes,
`genSwap` has to handle including the loc flag itself.

### Misc

Remove the redundant elif branch in `genAddr`. It does the same thing as
the `else` branch, and since `mapType` will never map a `tyRef` or
`tyPtr` to `ctArray`, both can be merged.