### PR TITLE
frontend: rename default cache folder to nimskull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,8 @@ jobs:
             --git.commit:'${{ github.sha }}' \
             --git.devel:devel
 
-          # Remove leftover nimcache
-          rm -rf doc/html/nimcache
+          # Remove leftover nimskullcache
+          rm -rf doc/html/nimskullcache
 
       - id: package
         name: Create release package
@@ -346,8 +346,8 @@ jobs:
             --git.commit:'${{ github.sha }}' \
             --git.devel:devel
 
-          # Remove leftover nimcache
-          rm -rf doc/html/nimcache
+          # Remove leftover nimskullcache
+          rm -rf doc/html/nimskullcache
 
       - id: package
         name: Create release package

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 !**/
 !*.*
 
-# Cache
+# |Nimskull| Bootstrap Cache
+nimskullcache/
+rnimskullcache/
+dnimskullcache/
+# Old Cache Path
 nimcache/
 rnimcache/
 dnimcache/

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -49,7 +49,8 @@ const
 
 const
   harmlessOptions* = {optForceFullMake, optNoLinking, optRun, optUseColors, optStdout}
-  genSubDir* = RelativeDir"nimcache"
+  genSubDir* = RelativeDir"nimskullcache"
+  # XXX: |Nimskull| extensions and config files
   NimExt* = "nim"
   RodExt* = "rod"
   HtmlExt* = "html"
@@ -1254,7 +1255,7 @@ include compiler/modules/packagehandling
 
 proc getOsCacheDir(): string =
   when defined(posix):
-    result = getEnv("XDG_CACHE_HOME", getHomeDir() / ".cache") / "nim"
+    result = getEnv("XDG_CACHE_HOME", getHomeDir() / ".cache") / "nimskull"
   else:
     result = getHomeDir() / genSubDir.string
 

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1311,7 +1311,7 @@ proc toGeneratedFile*(
     path: AbsoluteFile,
     ext: string
   ): AbsoluteFile =
-  ## converts "/home/a/mymodule.nim", "rod" to "/home/a/nimcache/mymodule.rod"
+  ## converts "/home/a/mymodule.nim", "rod" to "/home/a/nimskullcache/mymodule.rod"
   result = getNimcacheDir(conf) / RelativeFile(
     path.string.splitPath.tail.changeFileExt(ext))
 

--- a/doc/backends.rst
+++ b/doc/backends.rst
@@ -272,7 +272,7 @@ program:
 .. code:: cmd
 
   nim c --noMain --noLinking fib.nim
-  gcc -o m -I$HOME/.cache/nim/fib_d -Ipath/to/nim/lib $HOME/.cache/nim/fib_d/*.c maths.c
+  gcc -o m -I$HOME/.cache/nimskull/fib_d -Ipath/to/nim/lib $HOME/.cache/nimskull/fib_d/*.c maths.c
 
 The first command runs the Nim compiler with three special options to avoid
 generating a `main()`:c: function in the generated files and to avoid linking the

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -252,7 +252,7 @@ as it is the first match.
 
 Generated C code directory
 --------------------------
-The generated files that Nim produces all go into a subdirectory called
+The generated files that |Nimskull| produces all go into a subdirectory called
 ``nimskullcache``. Its full path is
 
 - ``$XDG_CACHE_HOME/nimskull/$projectname(_r|_d)`` or ``~/.cache/nimskull/$projectname(_r|_d)``

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -253,9 +253,9 @@ as it is the first match.
 Generated C code directory
 --------------------------
 The generated files that Nim produces all go into a subdirectory called
-``nimcache``. Its full path is
+``nimskullcache``. Its full path is
 
-- ``$XDG_CACHE_HOME/nim/$projectname(_r|_d)`` or ``~/.cache/nimskull/$projectname(_r|_d)``
+- ``$XDG_CACHE_HOME/nimskull/$projectname(_r|_d)`` or ``~/.cache/nimskull/$projectname(_r|_d)``
   on Posix
 - ``$HOME\nimskullcache\$projectname(_r|_d)`` on Windows.
 
@@ -265,7 +265,7 @@ This makes it easy to delete all generated files.
 
 The `--nimcache`:option:
 `compiler switch <#compiler-usage-commandminusline-switches>`_ can be used to
-to change the ``nimcache`` directory.
+to change the ``nimskullcache`` directory.
 
 However, the generated C code is not platform-independent. C code generated for
 Linux does not compile on Windows, for instance. The comment on top of the

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -255,9 +255,9 @@ Generated C code directory
 The generated files that Nim produces all go into a subdirectory called
 ``nimcache``. Its full path is
 
-- ``$XDG_CACHE_HOME/nim/$projectname(_r|_d)`` or ``~/.cache/nim/$projectname(_r|_d)``
+- ``$XDG_CACHE_HOME/nim/$projectname(_r|_d)`` or ``~/.cache/nimskull/$projectname(_r|_d)``
   on Posix
-- ``$HOME\nimcache\$projectname(_r|_d)`` on Windows.
+- ``$HOME\nimskullcache\$projectname(_r|_d)`` on Windows.
 
 The `_r` suffix is used for release builds, `_d` is for debug builds.
 

--- a/koch.py
+++ b/koch.py
@@ -17,8 +17,8 @@ import sys
 # Nim source directory, which is the directory this script resides in
 NimSource = Path(__file__).resolve(strict=True).parent
 
-# The nimcache folder
-Nimcache = NimSource / "nimcache"
+# The bootstrap nimskullcache folder
+Nimcache = NimSource / "nimskullcache"
 
 
 def exe(p: Path) -> Path:

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -303,7 +303,7 @@ proc boot(args: string) =
   var output = "compiler" / "nim".exe
   var finalDest = "bin" / "nim".exe
   # default to use the 'c' command:
-  let smartNimcache = (if "release" in args or "danger" in args: "nimcache/r_" else: "nimcache/d_") &
+  let smartNimcache = (if "release" in args or "danger" in args: "nimskullcache/r_" else: "nimskullcache/d_") &
                       hostOS & "_" & hostCPU
 
   let nimStart = findStartNim().quoteShell()

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -271,7 +271,7 @@ func ignoreFile(f, explicit: string, allowHtml: bool): bool =
 proc walkDirRecursively(s: var seq[string], root, explicit: string,
                         allowHtml: bool) =
   let tail = splitPath(root).tail
-  if tail == "nimcache" or tail[0] == '.':
+  if tail == "nimcache" or tail == "nimskullcache" or tail[0] == '.':
     return
   let allowHtml = allowHtml or tail == "doc"
   for k, f in walkDir(root):


### PR DESCRIPTION
## Summary
* what changed and how?
`~/.cache/nim` is changed to `~/.cache/nimskull`
`C:/Users/myuser/nimcache` is changed to `C:/Users/myuser/nimskullcache`

* why are we changing it?
Changing cache folder name is also a part of finishing project rebranding.

## Details
* info that couldn't fit into the summary
two hardcoded strings were changed, also there is a comment to easy find `|Nimskull|`