### PR TITLE
fix(CI): remove self-executing tests from megatest

### DIFF
--- a/tests/exception/texception_message_null_byte.nim
+++ b/tests/exception/texception_message_null_byte.nim
@@ -5,7 +5,11 @@ description: '''
   . Error output produced by raise newException is inconsistent with other
     IO such as echo or stdout.write.
 '''
+joinable: false
 """
+
+# marked as not joinable because this test self-executes
+
 const msg = "This char is `" & '\0' & "` and works fine!"
 
 when defined nim_t13115:

--- a/tests/lang_exprs/compiles/tstaticlib.nim
+++ b/tests/lang_exprs/compiles/tstaticlib.nim
@@ -1,3 +1,9 @@
+discard """
+  joinable: false
+"""
+
+# marked as not joinable as this test executes other tests
+
 import std/[os, osproc, strformat]
 
 

--- a/tests/stdlib/os/osproc/tclose.nim
+++ b/tests/stdlib/os/osproc/tclose.nim
@@ -1,5 +1,6 @@
 discard """
   exitcode: 0
+  disable: osx
 """
 
 when defined(linux):

--- a/tests/stdlib/os/osproc/tclose.nim
+++ b/tests/stdlib/os/osproc/tclose.nim
@@ -1,6 +1,6 @@
 discard """
   exitcode: 0
-  disable: osx
+  disabled: osx
 """
 
 when defined(linux):

--- a/tests/stdlib/os/osproc/texitsignal.nim
+++ b/tests/stdlib/os/osproc/texitsignal.nim
@@ -2,6 +2,7 @@ discard """
   output: '''true
 true'''
   targets: "c"
+  joinable: false
 """
 
 import os, osproc

--- a/tests/stdlib/os/osproc/treadlines.nim
+++ b/tests/stdlib/os/osproc/treadlines.nim
@@ -1,10 +1,13 @@
 discard """
+  joinable: false
   output: '''
 Error: cannot open 'a.nim'
 Error: cannot open 'b.nim'
 '''
   targets: "c"
 """
+
+# marked as not joinable as this test executes compiler processes (error prone)
 
 import osproc
 from std/os import getCurrentCompilerExe

--- a/tests/stdlib/os/tstackframes.nim
+++ b/tests/stdlib/os/tstackframes.nim
@@ -1,3 +1,9 @@
+discard """
+  joinable: false
+"""
+
+# marked as not joinable as this test self-executes
+
 import std/[strformat,os,osproc]
 import stdtest/unittest_light
 

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -1,14 +1,15 @@
 discard """
+  description: "Tests for VM Operations (`vmops.nim`)"
   matrix: "--experimental:vmopsDanger"
   targets: "c js"
+  joinable: false
 """
 
-#[
-test for vmops.nim
-]#
-import os
-import math
-import strutils
+# marked as not joinable as this test executes the compiler (error prone)
+
+import std/os
+import std/math
+import std/strutils
 
 static:
   # TODO: add more tests


### PR DESCRIPTION
## Summary

Marked `texitsignal` as not joinable to exclude it from the `megatest`
category; this should hopefully limit intermitent CI failures.

## Details

`texitsignal` attempts to execute itself with different parameters and
uses that to branch logic of what to check. This doesn't fit with the
rest of the megatest category.

Also, marked these tests as not `joinable` as they either self-execute
or kickoff compiler processes:

- `texception_message_null_byte`
- `tstaticlib`
- `tstackframes`
- `treadlines`
- `tvmops`

Lastly, disabled `tclose` for macOS testing within the same category, as
it's linux only already to save some CI cycles.