### PR TITLE
jsgen: fix multiple bugs with `addr` and `lent`

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2472,12 +2472,11 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkObjConstr: genObjConstr(p, n, r)
   of nkHiddenStdConv, nkConv: genConv(p, n, r)
   of nkAddr, nkHiddenAddr:
-    if mapType(n.typ) != etyBaseIndex:
+    if n.typ.kind == tyLent or mapType(n.typ) != etyBaseIndex:
       # the operation doesn't produce an address-like value (e.g. because the
-      # operand is a JS object and those already have reference semantics)
-      # FIXME: this won't work for ``lent`` views (outside of return values),
-      #        as ``lent`` is skipped by ``mapType``, meaning that a
-      #        ``lent int`` is an ``etyInt``
+      # operand is a JS object and those already have reference semantics).
+      # ``lent T`` types are currently treated as normal, non-owning
+      # locations, so the hidden address operation is skipped
       gen(p, n[0], r)
     else:
       genAddr(p, n[0], r)


### PR DESCRIPTION
## Summary

Fix incorrect JavaScript code being generated for `addr` operations
involving parameters, `let` locations, or imported/exported variables,
and for `lent T` types where `T` is a pointer-like type. In addition,
slightly clean up the address-handling in `jsgen`.

## Details

A "fat pointer" (array storing a base and index) needs to be constructed
when taking the address of locations not using indirection (such as
`let` locations), but this was missing, and the variable that represents
the location instead returned directly.

* consider locations not boxed in an array (e.g. `let` locations,
  parameters) in `genSymAddr`
* remove the scattered special handling for taking the address of
  parameters
* introduce the `isBoxedPointer` procedure and use it to replace the
  manual checks
* simplify the address assignment logic in `genVarInit` (made possible
  by `genSymAddr` now working properly)
* enable and unrelated test case in `taddr.nim` that already succeeded
  previously

The above fixes uncovered two additional JS code generator bugs that
were previously hidden:

* `mapType` didn't consider resolved concept types when testing whether
  a type maps to a representation that has reference semantics
* the hidden address-of operation for `lent T` types where `T` is
  something that maps to a "fat pointer" wasn't skipped

Both resulted in incorrect code being generated in the respective
circumstances, but they are now also fixed.