### PR TITLE
testament: small architectural refactoring

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -9,7 +9,6 @@
 
 import
   std/[
-    sequtils,
     parseutils,
     strutils,
     os,
@@ -18,7 +17,8 @@ import
     tables,
     hashes,
     sets
-  ]
+  ],
+  system/platforms
 
 type TestamentData* = ref object
   # better to group globals under 1 object; could group the other ones here too
@@ -32,6 +32,7 @@ var
   skips*: seq[string]
 
 let testamentData0* = TestamentData()
+# TODO: ^^ move to ``testament.nim``
 
 type
   TTestAction* = enum
@@ -106,8 +107,13 @@ type
     ccodeCheck*: seq[string] ## List of peg patterns that need to be
     ## searched for in the generated code. Used for backend code testing.
     maxCodeSize*: int ## Maximum allowed code size (in bytes) for the test.
-    err*: TResultEnum
-    inCurrentBatch*: bool
+    disabledOs*: set[OsPlatform]
+      ## the OS'es the test is disabled for
+    disabledCpu*: set[CpuPlatform]
+      ## the cpu architectures the test is disabled for
+    disable32bit*: bool
+      ## whether the test is disabled on 32-bit systems
+
     targets*: set[TTarget]
     specifiedTargets*: set[SpecifiedTarget] ## targets as described by the spec
     matrix*: seq[string]
@@ -125,7 +131,6 @@ type
     timeout*: float ## in seconds, fractions possible, but don't rely on
     ## much precision
     inlineErrors*: seq[InlineError] ## line information to error message
-    debugInfo*: string ## debug info to give more context
     knownIssues*: seq[string] ## known issues to be fixed
     labels*: seq[string] ## user-added metadata
 
@@ -138,6 +143,7 @@ type
 
 # Exported global RetryContainer object.
 var retryContainer* = RetryContainer(retry: false)
+# TODO: ^^ move to ``testament.nim``
 
 proc getCmd*(s: TSpec): string =
   ## Get runner command for a given test specification
@@ -317,6 +323,7 @@ proc initSpec*(filename: string): TSpec =
   result.file = filename
 
 proc isCurrentBatch*(testamentData: TestamentData; filename: string): bool =
+  # TODO: move elsewhere
   if testamentData.testamentNumBatch != 0:
     hash(filename) mod testamentData.testamentNumBatch == testamentData.testamentBatch
   else:
@@ -327,14 +334,6 @@ proc parseSpec*(filename: string,
                 nativeTarget: TTarget): TSpec =
   ## Extract and parse specification for a given file path
   result.file = filename
-
-  when defined(windows):
-    let cmpString = result.file.replace(r"\", r"/")
-  else:
-    let cmpString = result.file
-  if retryContainer.retry and not retryContainer.names.anyIt(cmpString == it[0]):
-    result.err = reDisabled
-    return result
 
   let specStr = extractSpec(filename, result)
   var ss = newStringStream(specStr)
@@ -431,33 +430,32 @@ proc parseSpec*(filename: string,
           result.useValgrind = disabled
       of "disabled":
         case e.value.normalize
-        of "y", "yes", "true", "1", "on": result.err = reDisabled
+        of "y", "yes", "true", "1", "on":
+          result.disabledOs = {low(OsPlatform)..high(OsPlatform)}
+          result.disabledCpu = {low(CpuPlatform)..high(CpuPlatform)}
         of "n", "no", "false", "0", "off": discard
         of "win", "windows":
-          when defined(windows): result.err = reDisabled
+          result.disabledOs.incl OsPlatform.windows
         of "linux":
-          when defined(linux): result.err = reDisabled
+          result.disabledOs.incl OsPlatform.linux
         of "bsd":
-          when defined(bsd): result.err = reDisabled
+          result.disabledOs.incl {netbsd, freebsd, openbsd}
         of "osx", "macosx": # xxx remove `macosx` alias?
-          when defined(osx): result.err = reDisabled
-        of "unix":
-          when defined(unix): result.err = reDisabled
-        of "posix":
-          when defined(posix): result.err = reDisabled
+          result.disabledOs.incl OsPlatform.macosx
+        of "unix", "posix":
+          result.disabledOs.incl {linux, netbsd, freebsd, openbsd, macosx}
         of "32bit":
-          if sizeof(int) == 4:
-            result.err = reDisabled
+          result.disable32bit = true
         of "freebsd":
-          when defined(freebsd): result.err = reDisabled
+          result.disabledOs.incl OsPlatform.freebsd
         of "arm64":
-          when defined(arm64): result.err = reDisabled
+          result.disabledCpu.incl CpuPlatform.arm64
         of "i386":
-          when defined(i386): result.err = reDisabled
+          result.disabledCpu.incl CpuPlatform.i386
         of "openbsd":
-          when defined(openbsd): result.err = reDisabled
+          result.disabledOs.incl OsPlatform.openbsd
         of "netbsd":
-          when defined(netbsd): result.err = reDisabled
+          result.disabledOs.incl OsPlatform.netbsd
         else:
           result.parseErrors.addLine "cannot interpret as a bool or platform name: ", e.value
       of "cmd":
@@ -522,7 +520,6 @@ proc parseSpec*(filename: string,
         of "n", "no", "false", "0": discard
         else:
             result.knownIssues.add e.value
-            result.err = reKnownIssue
       of "labels":
          discard """
          Adding only key support for now.
@@ -542,17 +539,8 @@ proc parseSpec*(filename: string,
       break
   close(p)
 
-  if skips.anyIt(it in result.file):
-    result.err = reDisabled
   if nimoutFound and result.nimout.len == 0 and not result.nimoutFull:
     result.parseErrors.addLine "empty `nimout` is vacuously true, use `nimoutFull:true` if intentional"
 
-  if result.parseErrors.len > 0:
-    result.err = reInvalidSpec
-
-  result.inCurrentBatch = isCurrentBatch(testamentData0, filename) or result.unbatchable
-  if not result.inCurrentBatch:
-    result.err = reDisabled
-  
-  if result.targets == {} and result.err != reInvalidSpec:
+  if result.targets == {} and result.parseErrors.len == 0:
     result.targets = catTargets

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -323,7 +323,7 @@ proc initSpec*(filename: string): TSpec =
   result.file = filename
 
 proc isCurrentBatch*(testamentData: TestamentData; filename: string): bool =
-  # TODO: move elsewhere
+  # TODO: not related to spec parsing; move to ``testament.nim``
   if testamentData.testamentNumBatch != 0:
     hash(filename) mod testamentData.testamentNumBatch == testamentData.testamentBatch
   else:

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -70,7 +70,6 @@ type
     testArgs: seq[string]
     startTime: float
     spec: TSpec
-
     inCurrentBatch: bool ## whether the test is part of the current
                          ## batch
 
@@ -84,7 +83,7 @@ type
     debugInfo: string
 
   CompilerOutput = object
-    ## Describes the output of a a compiler invocation.
+    ## Describes the output of a compiler invocation.
     cmd: string    ## the command that was run
     nimout: string ## compiler output
     output: string ## test output


### PR DESCRIPTION
## Summary

Make `TSpec` a pure description of the test specification and don't
reuse it for storing test output. This moves decision-making regarding
whether or not to run a test out of specification parsing, and slightly
improves `testament`s general architecture.

## Details

* remove the `err` property from `TSpec`
* make `inCurrentBatch` a property of `TTest` (instead of `TSpec`)
* introduce the `CompileOutput` type, which captures the output of a
  compiler invocation -- `callNimCompiler` now returns an instance of it
* move early decision-making about what to do with a test (is it
  disabled?, the specification invalid?, etc.) into the new
  `computeEarly` procedure
* adjust `testSpec` and `testSpecWithNimcache` to use `computeEarly`

Due to `compilerOutputTests` re-using `CompileOutput` (previously
`TSpec`) for temporary storage, `CompileOutput` still stores a
`TResultEnum` instead of just a simple boolean.

Multiple types and globals in `spec.nim` can now be moved to
`testament.nim`, but for the sake of a smaller changeset, this is left
to a follow-up commit.