### PR TITLE
internal: make `PEvalContext` a standalone type

### DIFF
--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -49,14 +49,14 @@ from compiler/vm/vmlegacy import legacyReportsVmTracer
 from std/strutils import cmpIgnoreStyle, contains
 
 proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
-              graph: ModuleGraph; idgen: IdGenerator): PEvalContext =
+              graph: ModuleGraph; idgen: IdGenerator): TCtx =
   # For Nimble we need to export 'setupVM'.
-  result = newCtx(module, cache, graph, idgen, legacyReportsVmTracer)
+  result = initCtx(module, cache, graph, idgen, legacyReportsVmTracer)
   # for backwards compatibility, allow meta expressions in nimscript (this
   # matches the previous behaviour)
   result.flags = {cgfAllowMeta}
   result.mode = emRepl
-  registerBasicOps(result[])
+  registerBasicOps(result)
 
   proc listDirs(a: VmArgs, filter: set[PathComponent]) =
     let dir = getString(a, 0)
@@ -213,10 +213,10 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   # - the ``vmopsDanger`` option has no effect on callbacks registered
   #  during `setupVM`
   # - NimScript has access to the macro/compile-time APIs
-  registerAdditionalOps(vm[], disallowDanger)
-  graph.vm = vm
+  registerAdditionalOps(vm, disallowDanger)
+  graph.vm = PEvalContext(vm: vm)
 
   graph.compileSystemModule()
-  discard graph.processModule(m, vm.idgen, stream)
+  discard graph.processModule(m, graph.idgen, stream)
 
   undefSymbol(conf, "nimscript")

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -974,6 +974,14 @@ proc appendInstancedGenericRuntimeRoutines(c: PContext, n: PNode) =
         unreachable()
   c.lastGenericIdx = c.generics.len
 
+proc sealRodFile(c: PContext) =
+  if c.config.symbolFiles != disabledSf:
+    if c.graph.vm != nil:
+      for (m, n) in PEvalContext(c.graph.vm).vm.vmstateDiff:
+        if m == c.module:
+          addPragmaComputation(c, n)
+    c.idgen.sealed = true # no further additions are allowed
+
 proc myClose(graph: ModuleGraph; context: PPassContext, n: PNode): PNode =
   var c = PContext(context)
   if c.config.cmd == cmdIdeTools and not c.suggestionsMade:

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -34,9 +34,6 @@ import
     magicsys,
     modulegraphs,
   ],
-  compiler/vm/[
-    vmdef,
-  ],
   compiler/ic/[
     ic
   ],
@@ -1085,14 +1082,6 @@ proc addToGenericCache*(c: PContext; s: PSym; inst: PType) =
   c.graph.typeInstCache.mgetOrPut(s.itemId, @[]).add LazyType(typ: inst)
   if c.config.symbolFiles != disabledSf:
     storeTypeInst(c.encoder, c.packedRepr, s, inst)
-
-proc sealRodFile*(c: PContext) =
-  if c.config.symbolFiles != disabledSf:
-    if c.graph.vm != nil:
-      for (m, n) in PCtx(c.graph.vm).vmstateDiff:
-        if m == c.module:
-          addPragmaComputation(c, n)
-    c.idgen.sealed = true # no further additions are allowed
 
 proc rememberExpansion*(c: PContext; info: TLineInfo; expandedSym: PSym) =
   ## Templates and macros are very special in Nim; these have

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -1,7 +1,7 @@
 ## This module implements the interface between the VM and the rest of the
 ## compiler. The VM is only interacted with through this interface. Do note
 ## that right now, the compiler still indirectly interacts with the VM through
-## the ``vmdef.PCtx`` object.
+## the ``vmdef.TCtx`` object.
 ##
 ## The interface includes:
 ## - the procedure that sets up a VM instance for use during compilation

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -736,7 +736,7 @@ type
   VmRawStackTrace* = seq[tuple[sym: PSym, pc: PrgCtr]]
 
   PCtx* = ref TCtx
-  TCtx* = object of TPassContext
+  TCtx* = object
     # XXX: TCtx stores three different things:
     #  - VM execution state
     #  - VM environment (code, constants, type data, etc.)
@@ -800,7 +800,7 @@ type
     cache*: IdentCache
     config*: ConfigRef
     graph*: ModuleGraph
-    oldErrorCount*: int
+    idgen*: IdGenerator
     profiler*: Profiler
     templInstCounter*: ref int # gives every template instantiation a unique ID, needed here for getAst
     vmstateDiff*: seq[(PSym, PNode)] # we remember the "diff" to global state here (feature for IC)
@@ -827,8 +827,6 @@ type
     sframe*: StackFrameIndex   ## The current stack frame
 
   TPosition* = distinct int
-
-  PEvalContext* = PCtx
 
 func `<`*(a, b: FieldIndex): bool {.borrow.}
 func `<=`*(a, b: FieldIndex): bool {.borrow.}
@@ -947,9 +945,9 @@ func `==`*(a, b: RoutineSigId): bool {.borrow.}
 proc defaultTracer(c: TCtx, t: VmExecTrace) =
   echo "default echo tracer" & $t
 
-proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
-             idgen: IdGenerator, tracer: TraceHandler = defaultTracer): PCtx =
-  result = PCtx(
+proc initCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
+             idgen: IdGenerator, tracer: TraceHandler = defaultTracer): TCtx =
+  result = TCtx(
     code: @[],
     debug: @[],
     globals: @[],

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -983,12 +983,6 @@ proc registerCallback*(c: var TCtx; name: string; callback: VmCallback): int {.d
   # XXX: for backwards compatibility, `name` is still a `string`
   c.callbackKeys.add(IdentPattern(name))
 
-template registerCallback*(c: PCtx; name: string; callback: VmCallback): int {.deprecated.} =
-  ## A transition helper. Use the `registerCallback` proc that takes
-  ## `var TCtx` instead
-  registerCallback(c[], name, callback)
-
-
 const pseudoAtomKinds* = {akObject, akArray}
 const realAtomKinds* = {low(AtomKind)..high(AtomKind)} - pseudoAtomKinds
 

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -373,7 +373,7 @@ type
     cnstSliceListStr
 
   ConstantId* = int ## The ID of a `VmConstant`. Currently just an index into
-                    ## `PCtx.constants`
+                    ## `TCtx.constants`
 
   VmConstant* = object
     ## `VmConstant`s are used for passing constant data from `vmgen` to the
@@ -735,7 +735,6 @@ type
 
   VmRawStackTrace* = seq[tuple[sym: PSym, pc: PrgCtr]]
 
-  PCtx* = ref TCtx
   TCtx* = object
     # XXX: TCtx stores three different things:
     #  - VM execution state

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -875,7 +875,7 @@ proc genType(c: var TCtx; typ: PType): int =
   internalAssert(c.config, result <= regBxMax, "")
 
 proc genTypeInfo(c: var TCtx, typ: PType): int =
-  ## Returns the stable index into `PCtx.rtti` where `typ`'s corresponding
+  ## Returns the stable index into `TCtx.rtti` where `typ`'s corresponding
   ## `VmTypeInfo` is located. If it doesn't exist yet, it is created first
   for i, t in c.rtti.pairs:
     if sameType(t.nimType, typ): return i


### PR DESCRIPTION
## Summary

As the first step towards splitting up `vmdef.TCtx` into multiple types,
re-purpose the `PEvalContext` type to represent all state and data
required for running code at compile-time (which is what `TCtx`
previously represented).

## Details

* move `PEvalContext` to the `compilerbridge` module and make it an
  object type
* the `ModuleGraph.vm` now stores an instance of `PEvalContext` instead
  of `PCtx`
* since it's not necessary anymore, don't use inheritance with
  `TCtx`
* remove the `PCtx` type and all usages thereof (this includes the
  deprecated `registerCallback` overload)
* adjust all usage sites of `ModuleGraph.vm`

The `sealRodFile` procedure, which accesses the `PEvalContext`, cannot
be part of the `semdata` module anymore, as that would introduce a
cyclic import dependency. It is moved to `sem`, where its only usage
site is.

`TCtx` no longer representing the "compile-time execution context" makes
it possible to split the type up.