### PR TITLE
support `method`s with the VM backend

### DIFF
--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -22,7 +22,8 @@ import
     lineinfos
   ],
   compiler/backend/[
-    backends
+    backends,
+    cgmeth
   ],
   compiler/front/[
     msgs,
@@ -357,13 +358,11 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
     for s in m.structs.threadvars.items:
       declareGlobal(s)
 
+  generateMethodDispatchers(g)
+
   # generate code for all alive routines
   generateAliveProcs(c, mlist)
   reset(c.linkState.newProcs) # free the occupied memory already
-
-  # XXX: generation of method dispatchers would go here. Note that `method`
-  #      support will require adjustments to DCE handling
-  #generateMethods(c)
 
   # create procs from the global initializer code fragments
   for m in mlist.modules.mitems:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -186,7 +186,7 @@ proc genRegLoad(c: var TCtx, n: PNode, dest, src: TRegister)
 template isUnset(x: TDest): bool = x < 0
 
 
-proc realType(s: PSym): PType {.inline.} =
+proc routineSignature(s: PSym): PType {.inline.} =
   ## Returns the signature type of the routine `s`
   if s.kind == skMacro: s.internal
   else:                 s.typ
@@ -947,7 +947,7 @@ proc writeBackResult(c: var TCtx, info: PNode) =
   ## If the result value fits into a register but is not stored in one
   ## (because it has its address taken, etc.), emits the code for storing it
   ## back into a register. `info` is only used to provide line information.
-  if not isEmptyType(c.prc.sym.realType[0]):
+  if not isEmptyType(c.prc.sym.routineSignature[0]):
     let
       res = c.prc.sym.ast[resultPos]
       typ = res.typ
@@ -3190,11 +3190,11 @@ proc genExpr*(c: var TCtx; n: PNode): Result[TRegister, VmGenDiag] =
 
 proc genParams(prc: PProc; s: PSym) =
   let
-    params = s.realType.n
+    params = s.routineSignature.n
 
   setLen(prc.regInfo, max(params.len, 1))
 
-  if not isEmptyType(s.realType[0]):
+  if not isEmptyType(s.routineSignature[0]):
     prc.locals[s.ast[resultPos].sym.id] = 0
     prc.regInfo[0] = RegInfo(refCount: 1, kind: slotFixedVar)
 
@@ -3274,7 +3274,7 @@ proc prepareParameters(c: var TCtx, info: PNode) =
   ## Prepares immutable parameters backed by registers for having their address
   ## taken. If an immutable parameter has its address taken, it is transitioned
   ## to a VM memory location at the start of the procedure.
-  let typ = c.prc.sym.realType # the procedure's type
+  let typ = c.prc.sym.routineSignature # the procedure's type
 
   template setupParam(c: var TCtx, s: PSym) =
     if fitsRegister(s.typ) and s.id in c.prc.addressTaken:
@@ -3312,7 +3312,7 @@ proc genProcBody(c: var TCtx; s: PSym, body: PNode): int =
     # iterate over the parameters and allocate space for them:
     genParams(c.prc, s)
 
-    if s.realType.callConv == ccClosure:
+    if s.routineSignature.callConv == ccClosure:
       # reserve a slot for the hidden environment parameter and register the
       # mapping
       c.prc.regInfo.add RegInfo(refCount: 1, kind: slotFixedLet)
@@ -3322,7 +3322,7 @@ proc genProcBody(c: var TCtx; s: PSym, body: PNode): int =
     # result register is setup at the start of macro evaluation
     # XXX: initializing the ``result`` of a macro should be handled through
     #      inserting the necessary code either in ``sem` or here
-    let rt = s.realType[0]
+    let rt = s.routineSignature[0]
     if not isEmptyType(rt) and fitsRegister(rt):
       # initialize the register holding the result
       let r = s.ast[resultPos].sym

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2242,6 +2242,9 @@ when not defined(js):
   # Error: system module needs: nimGCvisit
   {.pop.} # stackTrace: off, profiler: off
 
+proc chckNilDisp(p: pointer) {.compilerproc.} =
+  if p.isNil:
+    sysFatal(NilAccessDefect, "cannot dispatch; dispatcher is nil")
 
 
 when notJSnotNims:

--- a/lib/system/chcks.nim
+++ b/lib/system/chcks.nim
@@ -115,10 +115,6 @@ proc chckNil(p: pointer) =
   if p == nil:
     sysFatal(NilAccessDefect, "attempt to write to a nil address")
 
-proc chckNilDisp(p: pointer) {.compilerproc.} =
-  if p == nil:
-    sysFatal(NilAccessDefect, "cannot dispatch; dispatcher is nil")
-
 when defined(nimV2):
   proc raiseObjectCaseTransition() {.compilerproc.} =
     sysFatal(FieldDefect, "assignment to discriminant changes object branch")

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -528,10 +528,6 @@ when not defined(nimNoZeroExtendMagic):
 proc nimMin(a, b: int): int {.compilerproc.} = return if a <= b: a else: b
 proc nimMax(a, b: int): int {.compilerproc.} = return if a >= b: a else: b
 
-proc chckNilDisp(p: pointer) {.compilerproc.} =
-  if p == nil:
-    sysFatal(NilAccessDefect, "cannot dispatch; dispatcher is nil")
-
 include "system/hti"
 
 proc isFatPointer(ti: PNimType): bool =

--- a/tests/lang_callable/generics/tobjecttyperel.nim
+++ b/tests/lang_callable/generics/tobjecttyperel.nim
@@ -9,7 +9,9 @@ cool
 test'''
 """
 
-# disabled on VM until it supports methods (knownIssue)
+# knownIssue: fails for the VM target because ``astgen`` emits the
+#             incorrect conversion operator for ``ref`` types involving
+#             generics
 
 # bug #5241
 type

--- a/tests/lang_callable/method/tgeneric_methods.nim
+++ b/tests/lang_callable/method/tgeneric_methods.nim
@@ -1,11 +1,8 @@
 discard """
-  target: !vm
   output: '''wow2
 X 1
 X 3'''
 """
-
-# disabled on VM until we support methods (knownIssue)
 
 type
   First[T] = ref object of RootObj

--- a/tests/lang_callable/method/tmethod_issues.nim
+++ b/tests/lang_callable/method/tmethod_issues.nim
@@ -1,12 +1,10 @@
 discard """
-  target: "!vm"
   output: '''
 wof!
 wof!
 '''
 """
 
-# disabled on VM until we support methods (knownIssue)
 
 
 # bug #1659

--- a/tests/lang_callable/method/tmethod_various.nim
+++ b/tests/lang_callable/method/tmethod_various.nim
@@ -1,12 +1,9 @@
 discard """
-  target: "!vm"
   output: '''
 do nothing
 HELLO WORLD!
 '''
 """
-
-# disabled on VM until we support methods (knownIssue)
 
 
 # tmethods1

--- a/tests/lang_callable/method/tmultim.nim
+++ b/tests/lang_callable/method/tmultim.nim
@@ -13,8 +13,8 @@ do nothing
 '''
 """
 
-# disabled on VM until we support methods (knownIssue)
-
+# knownIssue: the ``of`` operator only considers the static type when using
+#             the VM backend
 
 # tmultim2
 type

--- a/tests/lang_callable/method/tnildispatcher.nim
+++ b/tests/lang_callable/method/tnildispatcher.nim
@@ -1,10 +1,8 @@
 discard """
-  target: "!vm !js"
+  target: "!js"
   outputsub: '''Error: unhandled exception: cannot dispatch; dispatcher is nil [NilAccessDefect]'''
   exitcode: 1
 """
-
-# disabled on VM until we support methods (knownIssue)
 
 # disabled on JS because sem/codegen lets it through and we get a runtime NPE
 

--- a/tests/lang_callable/method/treturn_var_t.nim
+++ b/tests/lang_callable/method/treturn_var_t.nim
@@ -1,10 +1,7 @@
 discard """
-  target: "!vm"
   output: '''Inh
 45'''
 """
-
-# disabled on VM until we support methods (knownIssue)
 
 type
   Base = ref object of RootObj

--- a/tests/lang_callable/method/tsingle_methods.nim
+++ b/tests/lang_callable/method/tsingle_methods.nim
@@ -1,6 +1,5 @@
 discard """
   matrix: "--multimethods:off"
-  target: "!vm"
   output: '''base
 base
 base
@@ -9,8 +8,6 @@ base
 base
 '''
 """
-
-# disabled on VM until we support methods (knownIssue)
 
 # bug #10912
 


### PR DESCRIPTION
## Summary

Enable dispatcher generation for the VM backend, which makes `method`
(including multi-methods) available for the standalone VM target. Note
that this doesn't apply to compile-time execution, where using `method`s
is still unsupported.

## Details

* move the `chckNilDisp` compilerproc into the `system` module and
  replace the `== nil` with `isNil` (more on that later)
* only report errors on method usage from `vmgne` when not in the
  `standalone` mode
* rename the `realType` procedure to `routineSignature`
* generate the method dispatcher prior to generating code in
  `vmbackend`
* where possible, enable the `method` tests for the VM target

The VM code generator (`vmgen`) previously checked for whether a
procedure returns something by testing for the presence of a procedure's
`result` AST slot. For methods - where the AST always has a `result`
slot, regardless of whether they have a return value - this test is
no longer enough, and is replaced with inspecting the return type.

Regarding the `== nil` -> `isNil` change: the VM comparison operator for
pointer-like types (which `==` maps to) requires both operands to be of
same dynamic type, but in `chckNilDisp`, this is not necessarily the
case (for example, when the dispatched-through type is a `ref` type).
The proper solution would be for `cgmeth.genDispatcher` to wrap the
argument in a `cast[pointer]`, but the VM doesn't yet support casting
references to pointers.