### PR TITLE
testament: support executing "known issue" tests

### DIFF
--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -43,6 +43,8 @@ Options
                           By default turned on.
 --skipFrom:file           Read tests to skip from ``file`` - one test per
                           line, # comments ignored
+--tryFailing              Run tests marked as "known issue" and verify that
+                          they're still failing
 
 
 Running a single test

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -515,7 +515,7 @@ proc runJoinedTest(r: var TResults, targets: set[TTarget], testsDir, options: st
 
 proc processCategory(r: var TResults, cat: Category, targets: set[TTarget],
                      options, testsDir: string,
-                     runJoinableTests: bool) =
+                     runJoinableTests, runKnownIssues: bool) =
   let cat2 = cat.string.split("/")[0].normalize
   case cat2
   of "js":
@@ -554,7 +554,10 @@ proc processCategory(r: var TResults, cat: Category, targets: set[TTarget],
     for i, name in files:
       let test = makeTest(name, options, cat)
       var res = computeEarly(test.spec, test.inCurrentBatch)
-      if runJoinableTests or
+      if res == reKnownIssue and runKnownIssues:
+        # we want to still run the test
+        res = reSuccess
+      elif runJoinableTests or
           not isJoinableSpec(test.spec, targets, res) or
           cat.string in specialCategories:
         discard "run the test"

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -48,6 +48,7 @@ type
     reExeNotFound,
     reInstallFailed    # package installation failed
     reBuildFailed      # package building failed
+    reUnexpectedSuccess# test is expected to fail, but didn't
     reDisabled,        # test is disabled
     reJoined,          # test is disabled because it was joined into the megatest
     reInvalidSpec      # test had problems to parse the spec

--- a/testament/tests/shouldfail/tworking_known_issue.nim
+++ b/testament/tests/shouldfail/tworking_known_issue.nim
@@ -1,0 +1,4 @@
+discard """
+  description: "Test is marked as having known issues, but it succesfully runs"
+  knownIssue: "Well, not really"
+"""

--- a/tests/testament/tshould_not_work.nim
+++ b/tests/testament/tshould_not_work.nim
@@ -36,6 +36,8 @@ FAIL: tests/shouldfail/ttimeout.nim
 Failure: reTimeout
 FAIL: tests/shouldfail/tvalgrind.nim
 Failure: reExitcodesDiffer
+FAIL: tests/shouldfail/tworking_known_issue.nim
+Failure: reUnexpectedSuccess
 """
 
 import std/[os,strformat,osproc]
@@ -45,7 +47,7 @@ proc main =
   const nim = getCurrentCompilerExe()
   # TODO: bin/testament instead? like other tools (eg bin/nim, bin/nimsuggest etc)
   let testamentExe = "testament/testament"
-  let cmd = fmt"{testamentExe} --directory:testament --colors:off --backendLogging:off --nim:{nim} category shouldfail"
+  let cmd = fmt"{testamentExe} --directory:testament --colors:off --tryFailing --backendLogging:off --nim:{nim} category shouldfail"
   let (outp, status) = execCmdEx(cmd)
   doAssert status == 1, $status
 


### PR DESCRIPTION
## Summary

Introduce the `--tryFailing` switch for testament, which enables
execution of tests marked as having known issues (and are thus expected
to fail). A "known issue" test successfully finishing in this mode
counts as a test failure.

The plan is to enable this new switch in the CI, in order to
automatically notify about tests that start working after a change. It
is not yet enabled in the CI yet, however.

## Details

* add the `--tryFailing` CLI switch, which sets the `runKnownIssue`
  execution flag
* add the `reUnexpectedSuccess` test result code
* render expectedly failing or untried "known issue" tests as
  `KNOWNISSUE` instead of `SKIP` or `NOTINBATCH` in the output

Refer to https://github.com/nim-works/nimskull/issues/61 for more information.