### PR TITLE
compiler: unify the pre-code-gen processing

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -376,13 +376,11 @@ const
 
     nkAsgn, nkFastAsgn,
 
-    nkProcDef, nkMethodDef, nkConverterDef, nkIteratorDef, nkFuncDef,
-
     nkAsmStmt, nkPragma,
 
     nkIfStmt, nkWhileStmt, nkCaseStmt,
 
-    nkVarSection, nkLetSection, nkConstSection,
+    nkVarSection, nkLetSection,
     nkTryStmt,
 
     nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkBlockStmt, nkDiscardStmt,

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -42,11 +42,13 @@ proc generateMain*(graph: ModuleGraph, modules: ModuleList, result: PNode) =
     # the system module is special cased: its fully initialized during the
     # data-init phase
     if sfSystemModule in it.sym.flags:
+      emitOpCall(graph, it.preInit, result)
       emitOpCall(graph, it.init, result)
 
   # then the modules are initialized and their module-level code executed
   for it in closed(modules):
     if sfSystemModule notin it.sym.flags:
+      emitOpCall(graph, it.preInit, result)
       emitOpCall(graph, it.init, result)
 
 proc generateTeardown*(graph: ModuleGraph, modules: ModuleList, result: PNode) =

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -76,7 +76,7 @@ type
     ## Combines a sequence of items with a "read" cursor.
     data: seq[T]
     progress: int
-      ## remembers the the position until which the items have already
+      ## remembers the position until which the items have already
       ## been processed
 
   DiscoveryData* = object
@@ -428,7 +428,7 @@ proc produceFragmentsForGlobals(data: var DiscoveryData, identdefs: seq[PNode],
         if it[2].kind == nkEmpty:
           # no explicit initializer expression means that the default value
           # should be used
-          # XXX: ^^ it'd make to instead let semantic analysis ensure this
+          # XXX: ^^ it'd make sense to instead let semantic analysis ensure this
           #      (i.e. by placing a ``default(T)`` in the initializer slot)
           r.add(it[2]): MirNode(kind: mnkArgBlock)
           r.add(it[2]): MirNode(kind: mnkEnd, start: mnkArgBlock)

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -493,7 +493,15 @@ func discoverFrom*(data: var DiscoveryData, decl: PNode) =
         register(data, procedures, prc)
     of nkIteratorDef:
       discard "ignore; cannot be exported"
-    of nkConstSection, nkTypeSection:
+    of nkConstSection:
+      # scan the section for exported constants:
+      for it in n.items:
+        if it.kind == nkConstDef:
+          let s = it[0].sym
+          if {sfExportc, sfCompilerProc} * s.flags == {sfExportc}:
+            register(data, constants, s)
+
+    of nkTypeSection:
       discard
     else:
       unreachable(n.kind)

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -1,28 +1,197 @@
 ## Shared processing logic used by all backends.
 
 import
+  std/[
+    deques,
+    intsets
+  ],
   compiler/ast/[
     ast,
     idents,
     lineinfos
+  ],
+  compiler/backend/[
+    cgmeth
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/mir/[
+    astgen,
+    mirbridge,
+    mirgen,
+    mirtrees,
+    sourcemaps
   ],
   compiler/modules/[
     modulegraphs,
     magicsys
   ],
   compiler/sem/[
-    modulelowering
+    injectdestructors,
+    modulelowering,
+    transf,
+    varpartitions
   ],
   compiler/utils/[
-    containers
+    containers,
+    idioms
   ]
 
-iterator ritems[T](x: openArray[T]): lent T =
-  ## Iterates and yields the items from the container `x` in reverse.
-  var i = x.high
-  while i >= 0:
-    yield x[i]
-    dec i
+type
+  MirFragment* = object
+    tree*: MirTree
+    source*: SourceMap
+
+  Procedure* = object
+    sym*: PSym
+    case isImported*: bool ## wether it's a .dynlib procedure
+    of false:
+      body*: MirFragment
+        ## the procedure's body
+
+      globals*: seq[PNode]
+        ## the unprocessed identdefs of globals defined as part of the
+        ## procedure's body. Due to how ``transf`` handles inlining, this
+        ## list can contain duplicates
+    of true:
+      discard
+
+  BackendConfig* = object
+    ## Configuration state altering the operation of the ``process``
+    ## iterator.
+    options*: set[GenOption]
+      ## passed on to ``mirgen``. See ``mirgen.generateCode`` for more
+      ## details
+    noImported*: bool
+      ## if ``true``, indicates that a procedure with a body should not be
+      ## treated as imported, even if it's marked as such
+
+  ProcedureIter = object
+    queued: Deque[tuple[prc: PSym, fr: FileIndex]]
+      ## procedures that are queued for code-generation
+    config: BackendConfig
+
+  Queue*[T] = object
+    ## Combines a sequence of items with a "read" cursor.
+    data: seq[T]
+    progress: int
+      ## remembers the the position until which the items have already
+      ## been processed
+
+  DiscoveryData* = object
+    ## Bundles all data needed during the disovery of alive, backend-relevant
+    ## entities.
+    # XXX: this type does too much. It acts as both a symbol table and
+    #      communication interface. Eventually, it should be split up.
+    seen: IntSet
+      ## remembers the symbol ID of all discovered entities
+
+    procedures*: Queue[PSym]
+    constants*: Queue[PSym]
+    globals*: Queue[PSym]
+    threadvars*: Queue[PSym]
+
+    additional: seq[tuple[m: FileIndex, prc: PSym]]
+      # HACK: see documentation of the procedure that appends to this list
+
+  EventContext = object
+    ## The data that guides the post-event-processing actions.
+    start: int
+      ## the procedure progress indicator at the start of the current cycle
+    preIndirect: int
+      ## the procedure progress indicator before indirect dependencies were
+      ## discovered
+    fin: int
+      ## the procedure progress indicator prior to event processing
+
+    indirect: seq[tuple[m: FileIndex, index: int]]
+      ## the list of all indirect procedure dependencies that need to be
+      ## queued (stored as indices into the procedure list)
+
+  BackendEventKind* = enum
+    bekModule    ## the initial set of alive entities for a module was
+                 ## discovered
+    bekPartial   ## a fragment of a procedure that's generated incrementally
+                 ## became available
+    bekProcedure ## a complete procedure was processed and transformed
+
+  BackendEvent* = object
+    ## Progress event returned by the ``process`` iterator.
+    module*: FileIndex
+      ## the module in whose context the processing happens. For actions
+      ## related to .inline procedures, this is not necessarily the module
+      ## the symbol is attached to
+
+    case kind*: BackendEventKind
+    of bekModule:
+      discard
+    of bekPartial, bekProcedure:
+      sym*: PSym
+        ## the symbol of the procedure the event is about
+      body*: MirFragment
+
+template add[T](x: Deque[T], elem: T) =
+  ## Convenience template for appending to a deque.
+  x.addLast elem
+
+func append*(dest: var MirFragment, src: sink MirFragment) =
+  ## Appends the code from `src` to `dest`. No check whether the resulting
+  ## code is semantically valid is performed
+  dest.tree.add src.tree
+  dest.source.append src.source
+
+# ----- private and public API for ``Queue`` -----
+
+iterator visit*[T](q: var Queue[T]): (int, lent T) =
+  ## Returns all unread items from `q` together with their index, and marks
+  ## them the items as read (or processed).
+  while q.progress < q.data.len:
+    yield (q.progress, q.data[q.progress])
+    inc q.progress
+
+iterator peek*[T](q: Queue[T]): (int, lent T) =
+  ## Returns all unread items from `q` together with their index, but doesn't
+  ## mark them as read.
+  for i in q.progress..<q.data.len:
+    yield (i, q.data[i])
+
+iterator all*[T](q: Queue[T]): (int, lent T) =
+  ## Returns *all* items (regardless of whether their read or unread) from
+  ## `q` together with their index.
+  for i in 0..<q.data.len:
+    yield (i, q.data[i])
+
+func len*[T](q: Queue[T]): int =
+  q.data.len
+
+func isProcessed*[T](q: Queue[T]): bool =
+  q.progress == q.data.len
+
+func add[T](q: var Queue[T], item: sink T) =
+  q.data.add item
+
+func addProcessed[T](q: var Queue[T], item: sink T) =
+  assert q.progress == q.data.len
+  q.data.add item
+  inc q.progress
+
+func rewind[T](q: var Queue[T], pos: int): int =
+  assert pos <= q.progress
+  result = q.progress
+  q.progress = pos
+
+func markProcessed[T](q: var Queue[T]): int =
+  q.progress = q.data.len
+  result = q.progress
+
+func moduleId*(o: PIdObj): int32 {.inline.} =
+  ## Returns the ID of the module `o` is *attached* to. Do note that in the
+  ## case of generic instantiations, this is not the necessarily the same
+  ## module as the one indicated via the owner.
+  o.itemId.module
+
+# ---- main procedure generation -----
 
 proc emitOpCall(graph: ModuleGraph, op: PSym, dest: PNode) =
   ## Emits a call to the provided operator `op`, but only if the operator is
@@ -99,3 +268,469 @@ proc generateMainProcedure*(graph: ModuleGraph, idgen: IdGenerator,
   # attach the result symbol:
   result.ast.sons.setLen(resultPos + 1)
   result.ast[resultPos] = newSymNode(resSym)
+
+# ----- general queries about MIR fragments and trees -----
+
+func isEmpty*(tree: MirTree): bool =
+  ## Returns whether `tree` contains either no nodes or only nodes that have
+  ## no meaning by themselves.
+  for n in tree.items:
+    if n.kind notin {mnkScope, mnkStmtList, mnkEnd}:
+      return false
+
+  result = true
+
+func isEmpty*(f: MirFragment): bool {.inline.} =
+  isEmpty(f.tree)
+
+iterator deps*(tree: MirTree; includeMagics: set[TMagic]): PSym =
+  ## Returns all external entities (procedures, globals, etc.) that `tree`
+  ## references *directly*, in an unspecified order.
+  var i = NodePosition(0)
+  while i < NodePosition(tree.len):
+    let n {.cursor.} = tree[i]
+    case n.kind
+    of mnkDef:
+      # make sure to not process the entity inside a 'def'
+      i = sibling(tree, i)
+      continue
+    of mnkProc:
+      # XXX: `includeMagics` is a workaround. Magics should either lowered
+      #      already or encoded as ``mnkMagic`` nodes when reaching here
+      if n.sym.magic == mNone or n.sym.magic in includeMagics:
+        yield n.sym
+    of mnkConst, mnkGlobal:
+      yield n.sym
+    else:
+      discard "nothing to do"
+
+    inc i
+
+# ----- procedure lowering and transformation -----
+
+proc preprocess*(conf: BackendConfig, prc: PSym, graph: ModuleGraph,
+                 idgen: IdGenerator): Procedure =
+  ## Transforms the body of the given procedure and translates it to MIR code.
+  ## No MIR passes are applied yet
+  result = Procedure(sym: prc, isImported: false)
+
+  var body = transformBodyWithCache(graph, idgen, prc)
+
+  # extract the identdefs of lifted globals (which is the first step towards
+  # actually lifting them into proper globals) and store them with the
+  # result. Do note that this step modifies the potentially cached body.
+  extractGlobals(body, result.globals, isNimVm = goIsNimvm in conf.options)
+
+  if optCursorInference in graph.config.options and
+      shouldInjectDestructorCalls(prc):
+    # TODO: turn cursor inference into a MIR pass and remove this part
+    computeCursors(prc, body, graph)
+
+  echoInput(graph.config, prc, body)
+
+  (result.body.tree, result.body.source) =
+    generateCode(graph, prc, conf.options, body)
+
+  echoMir(graph.config, prc, result.body.tree)
+
+proc process*(prc: var Procedure, graph: ModuleGraph, idgen: IdGenerator) =
+  ## Applies all applicable MIR passes to the procedure `prc`.
+  rewriteGlobalDefs(prc.body.tree, prc.body.source, outermost = true)
+
+  if shouldInjectDestructorCalls(prc.sym):
+    injectDestructorCalls(graph, idgen, prc.sym,
+                          prc.body.tree, prc.body.source)
+
+  rewriteGlobalDefs(prc.body.tree, prc.body.source, outermost = false)
+  # XXX: ^^ this is a hack. See the documentation of the routine for more
+  #      details
+
+proc process(body: var MirFragment, ctx: PSym, graph: ModuleGraph,
+             idgen: IdGenerator) =
+  ## Applies all applicable MIR passes to the fragment `body`. `ctx`
+  ## represents the procedure in whose context the processing happens, and
+  ## is used for the purpose of error reporting and debug tracing.
+  injectDestructorCalls(graph, idgen, ctx, body.tree, body.source)
+
+proc generateAST*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
+                  code: sink MirFragment): PNode =
+  ## Translates the MIR code provided by `code` into ``PNode`` AST and,
+  ## if enabled, echoes the result.
+  result = generateAST(graph, idgen, owner, code.tree, code.source)
+  echoOutput(graph.config, owner, result)
+
+# ------- handling of lifted globals ---------
+
+func add(frag: var MirFragment, origin: PNode, node: sink MirNode) =
+  assert frag.tree.len == frag.source.map.len
+  frag.source.map.add(frag.source.source.add(origin))
+  frag.tree.add node
+
+proc updateWithSource(f: var MirFragment, origin: PNode) =
+  ## Sets `origin` as the source node of all MIR nodes that have no source
+  ## information associated yet.
+  # TODO: replace this with using the routines from ``mirgen``, once they're
+  #       sufficiently generalized
+  let
+    id = f.source.source.add(origin)
+    start = f.source.map.len
+  f.source.map.setLen(f.tree.len)
+  for i in start..<f.tree.len:
+    f.source.map[i] = id
+
+proc produceFragmentsForGlobals(data: var DiscoveryData, identdefs: seq[PNode],
+                                graph: ModuleGraph,
+                                options: set[GenOption]): tuple[init, deinit: MirFragment] =
+  ## Given a list of identdefs of lifted globals, produces the MIR code for
+  ## initialzing and deinitializing the globals. `data` is updated with
+  ## not-yet-seen globals, and is at the same time used for discarding
+  ## the identdefs for globals that were already processed.
+
+  func prepare(f: var MirFragment, n: PNode) {.nimcall.} =
+    # the fragments need to be wrapped in scopes; some MIR passes depend
+    # on this
+    if f.tree.len == 0:
+      f.add(n): MirNode(kind: mnkScope)
+
+  func finish(f: var MirFragment, n: PNode) {.nimcall.} =
+    if f.tree.len > 0:
+      f.add(n): MirNode(kind: mnkEnd, start: mnkScope)
+
+  # lifted globals can appear re-appear in the identdefs list for two reasons:
+  # - the definition appears in the body of a for-loop using an inline iterator
+  #   with multiple yields
+  # - the definition appears in the body of an inline iterator
+  #
+  # in both cases, all encountered definitions of a global are equal, but we
+  # only want to generate code for the first definition we encounter
+  for it in identdefs.items:
+    let s = it[0].sym
+    if not containsOrIncl(data.seen, s.id): # have we seen it yet?
+      if sfThread in s.flags:
+        data.threadvars.add(s)
+      else:
+        data.globals.add(s)
+
+      if sfThread in s.flags:
+        # threadvars don't support initialization nor destruction, so skip the
+        # logic ahead
+        continue
+
+      # generate the MIR code for an initializing assignment:
+      block:
+        template r: MirFragment = result.init
+
+        prepare(r, graph.emptyNode)
+        r.add(it): MirNode(kind: mnkArgBlock)
+        r.add(it[0]): MirNode(kind: mnkGlobal, sym: s, typ: s.typ)
+        r.add(it[0]): MirNode(kind: mnkTag, typ: s.typ)
+        r.add(it[0]): MirNode(kind: mnkName, typ: s.typ)
+        if it[2].kind == nkEmpty:
+          # no explicit initializer expression means that the default value
+          # should be used
+          # XXX: ^^ it'd make to instead let semantic analysis ensure this
+          #      (i.e. by placing a ``default(T)`` in the initializer slot)
+          r.add(it[2]): MirNode(kind: mnkArgBlock)
+          r.add(it[2]): MirNode(kind: mnkEnd, start: mnkArgBlock)
+          r.add(it[2]): MirNode(kind: mnkMagic, magic: mDefault, typ: s.typ)
+        else:
+          generateCode(graph, options, it[2], r.tree, r.source)
+
+        r.add(it[2]): MirNode(kind: mnkConsume, typ: s.typ)
+        r.add(it): MirNode(kind: mnkEnd, start: mnkArgBlock)
+        r.add(it): MirNode(kind: mnkInit)
+
+      # if the global requires one, emit a destructor call into the deinit
+      # fragment:
+      if hasDestructor(s.typ):
+        prepare(result.deinit, graph.emptyNode)
+        genDestroy(result.deinit.tree, graph, s.typ):
+          MirNode(kind: mnkGlobal, sym: s, typ: s.typ)
+        updateWithSource(result.deinit, it[0])
+
+  finish(result.init, graph.emptyNode)
+  finish(result.deinit, graph.emptyNode)
+
+# ----- discovery and queueing logic -----
+
+func includeIfUnseen(q: var Queue[PSym], marker: var IntSet, sym: PSym) =
+  if not marker.containsOrIncl(sym.id):
+    q.data.add(sym)
+
+template register(data: var DiscoveryData, queue: untyped, s: PSym) =
+  data.queue.includeIfUnseen(data.seen, s)
+
+func discoverFrom*(data: var DiscoveryData, noMagics: set[TMagic], body: MirTree) =
+  ## Updates `data` with all not-yet-seen entities (except for globals) that
+  ## `body` references.
+  for dep in deps(body, noMagics):
+    case dep.kind
+    of routineKinds:
+      register(data, procedures, dep)
+    of skConst:
+      register(data, constants, dep)
+    of skVar, skLet, skForVar:
+      discard "a global; ignore"
+    else:
+      unreachable()
+
+func discoverFrom*(data: var DiscoveryData, decl: PNode) =
+  ## Updates `data` with all not-yet-seen entities from the declarative
+  ## statement list `decl`.
+  if decl.kind == nkEmpty:
+    return # nothing to do
+
+  assert decl.kind == nkStmtList
+  for n in decl.items:
+    case n.kind
+    of nkProcDef, nkFuncDef, nkConverterDef, nkMethodDef:
+      let prc = n[namePos].sym
+      if {sfExportc, sfCompilerProc} * prc.flags == {sfExportc} or
+         (sfExportc in prc.flags and lfExportLib in prc.loc.flags):
+        # an exported routine. It must always have code generated for it. Note
+        # that compilerprocs, while exported, are still only have code generated
+        # for them when used
+        register(data, procedures, prc)
+    of nkIteratorDef:
+      discard "ignore; cannot be exported"
+    of nkConstSection, nkTypeSection:
+      discard
+    else:
+      unreachable(n.kind)
+
+func queue(iter: var ProcedureIter, prc: PSym, m: FileIndex) =
+  ## If eligible for processing and code generation, adds `prc` to
+  ## `iter`'s queue.
+  assert prc.kind in routineKinds
+  if lfNoDecl notin prc.loc.flags and
+     (sfImportc notin prc.flags or (iter.config.noImported and
+                                    prc.ast[bodyPos].kind != nkEmpty)):
+    iter.queued.add (prc, m)
+
+func queueAll(iter: var ProcedureIter, data: var DiscoveryData,
+              origin: FileIndex) =
+  ## Queues all newly discovered procedures and marks the now queued ones as
+  ## processed/read.
+  for _, it in visit(data.procedures):
+    queue(iter, it, origin)
+
+func discoveryFromValue(data: var DiscoveryData, ast: PNode) =
+  ## Discover new routines from `ast`, which is an AST representing a value
+  ## construction expression.
+  case ast.kind
+  of nkSym:
+    let s = ast.sym
+    if s.kind in routineKinds:
+      register(data, procedures, s)
+  of nkWithSons:
+    for n in ast.items:
+      discoveryFromValue(data, n)
+  of nkWithoutSons - {nkSym}:
+    discard "nothing to do"
+
+# ----- ``process`` iterator implementation -----
+
+proc isTrivialProc(graph: ModuleGraph, prc: PSym): bool {.inline.} =
+  getBody(graph, prc).kind == nkEmpty
+
+proc next(iter: var ProcedureIter, graph: ModuleGraph,
+          modules: ModuleList): tuple[origin: FileIndex, prc: Procedure] =
+  ## Retrieves and transforms the procedure that is next in the queue.
+  let
+    (sym, origin) = iter.queued.popFirst()
+    idgen         = modules[moduleId(sym).FileIndex].idgen
+
+  result.prc = preprocess(iter.config, sym, graph, idgen)
+  result.origin = origin
+
+  if not result.prc.isImported:
+    # apply all MIR passes:
+    process(result.prc, graph, idgen)
+
+func processConstants(data: var DiscoveryData): seq[(FileIndex, int)] =
+  ## Registers with `data` the procedures used by all un-processed constants
+  ## and marks the constants as processed.
+  assert data.procedures.isProcessed
+  for _, s in peek(data.constants):
+    discoveryFromValue(data, astdef(s))
+    # the procedure needs to be queued from the context of the module `s` is
+    # attached to:
+    let m = moduleId(s).FileIndex
+    for i, _ in visit(data.procedures):
+      result.add (m, i)
+
+func processAdditional(iter: var ProcedureIter, data: var DiscoveryData) =
+  ## Queues all extra dependencies registered with `data`.
+  for m, s in data.additional.items:
+    if not data.seen.containsOrIncl(s.id):
+      data.procedures.addProcessed(s)
+      queue(iter, s, m)
+
+  data.additional.setLen(0) # we've processed everything; reset
+
+func preActions(discovery: var DiscoveryData): EventContext =
+  ## Performs the actions required before emitting a ``BackendEvent``. New
+  ## entities need to be discovered, but they must not be queued for
+  ## processing yet -- the caller might still want to intercept / pre-process.
+  result.start = discovery.procedures.progress
+  result.preIndirect = discovery.procedures.markProcessed()
+  # discover the procedures referenced by the new constants:
+  result.indirect = processConstants(discovery)
+
+  # rewind the progress indicator so that all procedures marked as
+  # processed as part of this cycle appear as unprocessed again:
+  result.fin = discovery.procedures.rewind(result.start)
+
+func postActions(iter: var ProcedureIter, discovery: var DiscoveryData,
+                 m: FileIndex, ctx: sink EventContext) =
+  ## Queues for processing all procedures that were discovered (by both
+  ## ``progress`` and its caller) during the current event cycle.
+
+  # make sure that all new constants discovered as part of this cycle are
+  # marked as processed:
+  discard markProcessed(discovery.constants)
+
+  # now comes the complex part: all new procedures discovered as part of this
+  # cycle need to be queued for processing
+
+  # first come the direct procedure dependencies. They're associated with the
+  # provided module:
+  for i in ctx.start..<ctx.preIndirect:
+    queue(iter, discovery.procedures.data[i], m)
+
+  # then come the indirect procedure dependencies:
+  for moduleId, i in ctx.indirect.items:
+    queue(iter, discovery.procedures.data[i], moduleId)
+
+  # set the progress indicator to where it was prior to event processing:
+  discovery.procedures.progress = ctx.fin
+
+  # finally, queue all late dependencies raised by the event processor:
+  queueAll(iter, discovery, m)
+  processAdditional(iter, discovery)
+
+iterator process*(graph: ModuleGraph, modules: var ModuleList,
+                  discovery: var DiscoveryData, noMagics: set[TMagic],
+                  conf: BackendConfig): BackendEvent =
+  ## Implements discovery of alive entities (procedures, globals, constants,
+  ## etc.) and applying the various transformations and MIR passes to
+  ## the alive procedures. Progress is reported by returning an event (refer
+  ## to `BackendEventKind <#BackendEventKind>`_ for more informations about the
+  ## events).
+  ##
+  ## `noMagics` is the set of magics that need to be treated as normal
+  ## procedure during discovery of alive procedures, and `conf` is additional
+  ## configuration that modifies some aspects of the processing.
+  ##
+  ## The iterator is complex and contains multiple yield statements, so it's
+  ## advised to implement ``BackendEvent`` processing with a dedicated
+  ## procedure.
+  ##
+  ## When control is passed to the caller, the `discovery.procedures` and
+  ## `discovery.constants` queues contain all new procedures and constants
+  ## that were discovered directly or indirectly for the entity that the
+  ## returned event is about. The `globals` and `threadvars` queues, while
+  ## possibly filled with new content, are not "drained" yet, and have the
+  ## same "read" position that the caller left them with.
+  var
+    iter = ProcedureIter(config: conf)
+
+  # future direction: both the registered-from tracking and the support
+  # for late dependencies are fundamentally workarounds. They can and
+  # should be removed once:
+  # 1. procedure inlining is managed at the |NimSkull| side
+  # 2. the code generators do not raise new dependencies
+
+  # first, generate the method dispatchers, so that we can treat the
+  # dispatchers as normal procedures:
+  generateMethodDispatchers(graph)
+
+  # queue the init procedures:
+  for id, m in modules.modules.pairs:
+    discoverFrom(discovery, m.decls)
+
+    if not isTrivialProc(graph, m.init):
+      register(discovery, procedures, m.init)
+
+    if not isTrivialProc(graph, m.destructor):
+      register(discovery, procedures, m.destructor)
+
+    # register the globals and threadvars:
+    for s in m.structs.globals.items:
+      register(discovery, globals, s)
+
+    for s in m.structs.nestedGlobals.items:
+      register(discovery, globals, s)
+
+    for s in m.structs.threadvars.items:
+      register(discovery, threadvars, s)
+
+    let ctx = preActions(discovery)
+    # inform the caller that the initial set of alive entities became
+    # available:
+    yield BackendEvent(module: id, kind: bekModule)
+    postActions(iter, discovery, id, ctx)
+
+  template reportBody(prc: PSym, m: FileIndex, evt: BackendEventKind,
+                      frag: MirFragment) =
+    ## Reports (i.e., yields an event) a procedure-related event.
+    discoverFrom(discovery, noMagics, frag.tree)
+
+    let work = preActions(discovery)
+    yield BackendEvent(module: m, kind: evt, sym: prc, body: frag)
+    postActions(iter, discovery, m, work)
+
+  # process queued procedures until there are none left:
+  while iter.queued.len > 0:
+    let
+      (origin, prc) = next(iter, graph, modules)
+      module = moduleId(prc.sym).FileIndex
+        ## the module the procedure is *attached* to
+
+    case prc.isImported
+    of false:
+      block:
+        # produce the init/de-init code for the lifted globals:
+        var (init, deinit) =
+          produceFragmentsForGlobals(discovery, prc.globals, graph,
+                                     conf.options)
+
+        template reportProgress(prc: PSym, frag: MirFragment) =
+          ## Applies the relevant passes, and notifies the caller about the
+          ## fragments.
+          if not isEmpty(frag):
+            process(frag, prc, graph, modules[module].idgen)
+            reportBody(prc, module, bekPartial, frag)
+
+            # mark the procedure as non-empty:
+            if prc.ast[bodyPos].kind == nkEmpty:
+              prc.ast[bodyPos] = newNode(nkStmtList)
+
+        reportProgress(modules[module].preInit, init)
+        reportProgress(modules[module].postDestructor, deinit)
+
+      # for inline procedures, use the context of the module the procedure
+      # was first seen in
+      let id =
+        if prc.sym.typ.callConv == ccInline: origin
+        else:                                module
+
+      reportBody(prc.sym, id, bekProcedure, prc.body)
+    of true:
+      # a procedure imported at run-time (i.e. a .dynlib procedure)
+      discard "still managed by the code generator"
+
+# ----- API for interacting with ``DiscoveryData`` -----
+
+func register*(data: var DiscoveryData, prc: PSym) =
+  ## If not already know to `data`, adds the procedure `prc` to the list
+  ## of known procedures.
+  register(data, procedures, prc)
+
+func registerLate*(discovery: var DiscoveryData, prc: PSym, module: FileIndex) =
+  ## Registers a late late-dependency with `data`. These are dependencies
+  ## that were raised while processing some code fragment, but that are not
+  ## directly related to said fragment. They should be kept to a minimum, and
+  ## `register <#register,DiscoveryData,PSym>`_ should be preferred whenever
+  ## possible.
+  discovery.additional.add (module, prc)

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -311,6 +311,10 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
     m.init.loc.r = getInitName(bmod)
     m.dataInit.loc.r = getDatInitName(bmod)
 
+    # mark the init procedure so that the code generator can detect and
+    # special-case it:
+    m.init.flags.incl sfTopLevel
+
   # ----- main event processing -----
   let
     config = BackendConfig()

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -1,25 +1,58 @@
-## The code-generation orchestrator for the C backend. It generates the C code
-## for the semantically analysed AST of the whole progam by invoking ``cgen``.
+## The code-generation orchestrator for the C backend. It takes the
+## semantically analysed AST of the whole program as input and is responsible
+## for assembling the final C code.
 ##
-## The general direction is to move more logic out of the code generator (such
-## as figuring out the set of alive procedures) and into the orchestrator,
-## leaving only the core of code generation to ``cgen``.
+## Generating the actual code is implemented by `cgen`, with the orchestrator
+## directing the code generator, managing emission of ``.inline`` procedures,
+## and assembling the C code fragments produced into complete files (currently
+## by dispatching to `cgen`).
+##
+## Inlining
+## --------
+##
+## Inlining of procedures marked as ``.inline`` is currently not implemented
+## at the |NimSkull| side, but is left to the optimizer of the used C
+## compiler. For the C inliner to inline functions (when link-time
+## optimizations are not employed, which by default, they aren't), the full
+## C definition of an inline procedure must be present in all C translation
+## units where the procedure is used.
+##
+## When the orchestrator encounters an alive inline procedure, it fully
+## transforms and lowers its body (which is then cached), generates the code
+## for it with the context of the module the procedure is first seen in, and
+## then records all the direct dependencies it has on other inline procedures.
+## In addition, an inline procedure is registered with each module it is
+## directly used in.
+##
+## Once the code for all alive procedure has been generated (i.e., the main
+## part of code generation done), the generated code of each inline procedure
+## (along with its recorded transitive ``.inline`` dependencies) is emitted
+## into the modules they were previously registered with.
 
 import
+  std/[
+    hashes,
+    intsets,
+    tables
+  ],
   compiler/ast/[
-    ast
+    ast,
+    lineinfos
   ],
   compiler/backend/[
     backends,
     cgen,
     cgendata,
-    cgmeth,
     extccomp
   ],
   compiler/front/[
     options
   ],
+  compiler/mir/[
+    mirtrees
+  ],
   compiler/modules/[
+    magicsys,
     modulegraphs
   ],
   compiler/sem/[
@@ -27,16 +60,180 @@ import
   ],
   compiler/utils/[
     containers,
-    pathutils
+    pathutils,
+    ropes
   ]
 
-proc configureInitProcedure(prc: PSym, name: string) =
-  ## Generating and emitting the C code for a modules' init procedures is
-  ## currently still the responsibility of the code generator. In order to
-  ## support this in a clean way, the init procedures are treated as
-  ## imported.
-  prc.flags.incl sfImportc
-  prc.loc.r = name # set the mangled name
+import std/options as std_options
+
+type
+  InlineProc = object
+    ## Information about an inline procedure.
+    sym: PSym
+    body: PNode
+      ## the fully processed body of the procedure
+
+    deps: PackedSet[uint32]
+      ## other inline procedures this procedure directly references
+      ## (i.e., depends on)
+
+  ModuleId = FileIndex
+
+  InliningData = object
+    ## Management data for the inlining logic.
+    inlineProcs: Store[uint32, InlineProc]
+      ## stores the additional information plus the generated code for each
+      ## alive inline procedure
+    inlineMap: Table[int, uint32]
+      ## maps a symbol ID to the associated ``InlineProc`` ID
+
+    inlined: OrdinalSeq[ModuleId, PackedSet[uint32]]
+      ## for each module, the starting set of inline procedures that need
+      ## to be duplicated into the module's corresponding C file
+
+func hash(x: PSym): int = hash(x.id)
+
+func registerInline(g: var InliningData, prc: PSym): uint32 =
+  ## If not already registered, registers the inline procedure `prc` with
+  ## `g`. This only sets up an ``InlineProc`` stub -- the entry is
+  ## not populated yet.
+  if prc.id in g.inlineMap:
+    # XXX: double lookup
+    result = g.inlineMap[prc.id]
+  else:
+    result = g.inlineProcs.add(InlineProc(sym: prc))
+    g.inlineMap[prc.id] = result
+
+proc dependOnCompilerProc(g: var InliningData, d: var DiscoveryData, m: ModuleId,
+                          graph: ModuleGraph, name: string) =
+  let sym = getCompilerProc(graph, name)
+  assert sym != nil, "compilerproc missing"
+  register(d, sym)
+  # a compilerproc can also be an inline procedure:
+  if sym.typ.callConv == ccInline:
+    g.inlined[m].incl registerInline(g, sym)
+
+func dependOnInline(g: var InliningData, m: ModuleId, id: Option[uint32], dep: PSym) =
+  ## Raise a dependency on an inline procedure `dep`, with `m` being the
+  ## current module and `id` the ID of the inline procedure the in whose
+  ## context the dependency is raised.
+  let other = registerInline(g, dep)
+  g.inlined[m].incl other
+
+  if id.isSome:
+    # remember the dependency:
+    g.inlineProcs[id.unsafeGet].deps.incl other
+
+proc prepare(g: BModuleList, d: var DiscoveryData) =
+  ## Emits the definitions for constants, globals, and threadvars discovered
+  ## as part of producing the current event.
+
+  # emit definitions for constants:
+  for _, s in visit(d.constants):
+    genConstDefinition(g.modules[moduleId(s)], s)
+
+  # emit definitions for the lifted globals we've discovered:
+  for _, s in visit(d.globals):
+    defineGlobalVar(g.modules[moduleId(s)], newSymNode(s))
+
+  for _, s in visit(d.threadvars):
+    let bmod = g.modules[moduleId(s)]
+    fillGlobalLoc(bmod, s, newSymNode(s))
+    declareThreadVar(bmod, s, sfImportc in s.flags)
+
+proc processEvent(g: BModuleList, inl: var InliningData, discovery: var DiscoveryData, partial: var Table[PSym, BProc], evt: sink BackendEvent) =
+  ## The orchestrator's event processor.
+  let bmod = g.modules[evt.module.int]
+
+  prepare(g, discovery)
+
+  # prepare the newly discovered dynlib procedures:
+  for _, s in peek(discovery.procedures):
+    if lfDynamicLib in s.loc.flags:
+      let bmod = g.modules[s.itemId.module.int]
+      fillProcLoc(bmod, newSymNode(s))
+      symInDynamicLib(bmod, s)
+
+  proc handleInline(inl: var InliningData, m: ModuleId, prc: PSym,
+                    body: MirTree): Option[uint32] {.nimcall.} =
+    ## Registers the dependency on inline procedure that `body` has
+    ## with module `m` and, if an inline procedure, also `prc`. Returns
+    ## the inline ID of the `prc`, or 'none', if `prc` is not an inline
+    ## procedure.
+    result =
+      if prc.typ.callConv == ccInline:
+        some(registerInline(inl, prc))
+      else:
+        none(uint32)
+
+    # remember usages of inline procedures for the purpose of emitting
+    # them later:
+    for dep in deps(body, NonMagics):
+      if dep.kind in routineKinds and dep.typ.callConv == ccInline:
+        dependOnInline(inl, m, result, dep)
+
+  proc processLate(bmod: BModule, data: var DiscoveryData, inl: var InliningData,
+                   m: ModuleId, inlineId: Option[uint32]) {.nimcall.} =
+    ## Registers late-dependencies raised by the code generator with `data`.
+    ##
+    ## The code generator currently emits calls to ``.compilerprocs``, which
+    ## the alive set needs to know about.
+    for it in bmod.extra.items:
+      register(data, it)
+      if it.typ.callConv == ccInline:
+        dependOnInline(inl, m, inlineId, it)
+
+    # we processed/consumed all elements
+    bmod.extra.setLen(0)
+
+    # we also need to update the alive entities with the used hooks:
+    for bmod, s in bmod.g.hooks.items:
+      # queue the hook from the module it was used from:
+      registerLate(data, s, bmod.module.position.ModuleId)
+
+    bmod.g.hooks.setLen(0)
+
+  case evt.kind
+  of bekModule:
+    # the code generator emits a call for setting up the TLS, which is a
+    # procedure dependency that needs to be communicated
+    if sfSystemModule in bmod.module.flags and
+       emulatedThreadVars(g.config):
+      dependOnCompilerProc(inl, discovery, evt.module, g.graph,
+                           "initThreadVarsEmulation")
+
+  of bekPartial:
+    # register inline dependencies:
+    let inlineId = handleInline(inl, evt.module, evt.sym, evt.body.tree)
+
+    var p = getOrDefault(partial, evt.sym)
+    if p == nil:
+      p = startProc(g.modules[evt.module.int], evt.sym)
+      partial[evt.sym] = p
+
+    let body = generateAST(g.graph, bmod.idgen, evt.sym, evt.body)
+    # emit into the procedure:
+    genStmts(p, body)
+
+    processLate(bmod, discovery, inl, evt.module, inlineId)
+  of bekProcedure:
+    let inlineId = handleInline(inl, evt.module, evt.sym, evt.body.tree)
+
+    # mark the procedure as declared, first. This gets around an unnecessary
+    # emit of the prototype in the case of self-recursion
+    bmod.declaredThings.incl(evt.sym.id)
+    let
+      body = generateAST(g.graph, bmod.idgen, evt.sym, evt.body)
+      r    = genProc(bmod, evt.sym, body)
+
+    if inlineId.isSome:
+      # remember the generated body:
+      inl.inlineProcs[inlineId.unsafeGet].body = body
+
+    # add the C function to the C file's procedure section:
+    bmod.s[cfsProcs].add(r)
+
+    processLate(bmod, discovery, inl, evt.module, inlineId)
 
 proc generateCodeForMain(m: BModule, modules: ModuleList) =
   ## Generates and emits the C code for the program's or library's entry
@@ -56,7 +253,7 @@ proc generateCodeForMain(m: BModule, modules: ModuleList) =
     generateTeardown(m.g.graph, modules, body)
 
   # now generate the C code for the body:
-  genProcBody(p, body)
+  genStmts(p, body)
   var code: string
   code.add(p.s(cpsLocals))
   code.add(p.s(cpsInit))
@@ -105,64 +302,73 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
   ## Implements the main part of the C code-generation orchestrator. Expects an
   ## already populated ``BModuleList``.
 
-  generateMethodDispatchers(graph)
-
-  # generate the definitions for all globals first, so that the symbols all
-  # have mangled names already; the order in which this happens doesn't matter
+  # pre-process the init procedures:
   for key, m in mlist.modules.pairs:
     let bmod = g.modules[key.int]
-    for s in m.structs.globals.items:
-      defineGlobalVar(bmod, newSymNode(s))
 
-    for s in m.structs.nestedGlobals.items:
-      defineGlobalVar(bmod, newSymNode(s))
+    # the init and data-init procedures use special names in the
+    # generated code:
+    m.init.loc.r = getInitName(bmod)
+    m.dataInit.loc.r = getDatInitName(bmod)
 
-    for s in m.structs.threadvars.items:
-      fillGlobalLoc(bmod, s, newSymNode(s))
-      declareThreadVar(bmod, s, sfImportc in s.flags)
+  # ----- main event processing -----
+  let
+    config = BackendConfig()
 
-  # the main part: invoke the code generator for all declarative code and the
-  # init procedures
+  var
+    inl:       InliningData
+    discovery: DiscoveryData
+    partial:   Table[PSym, BProc]
+
+  inl.inlined.newSeq(g.modules.len)
+
+  # discover and generate code for all alive procedures:
+  for ac in process(graph, mlist, discovery, NonMagics, config):
+    processEvent(g, inl, discovery, partial, ac)
+
+  # finish the partial procedures:
+  for s, p in partial.pairs:
+    p.module.s[cfsProcs].add(finishProc(p, s))
+
+  # -------------------------
+  # all alive entities must have been discovered when reaching here; it is
+  # not allowed to raise new ones beyond this point
+
+  # now emit a duplicate of each inline procedure into the C files where the
+  # procedure is used. Due to how ``cgen`` currently works, this means
+  # generating C code for the procedure again
+  for i, m in mlist.modules.pairs:
+    proc emit(m: BModule, inl: InliningData, prc: InlineProc, r: var Rope) =
+      # guard against recurisve inline procedures and the procedure having
+      # been emitted already
+      if m.declaredThings.containsOrIncl(prc.sym.id):
+        return
+
+      # emit the dependencies first:
+      for dep in prc.deps.items:
+        emit(m, inl, inl.inlineProcs[dep], r)
+
+      assert prc.body != nil, "missing body"
+      # conservatively emit a prototype for all procedures to make sure that
+      # recursive procedures work:
+      genProcPrototype(m, prc.sym)
+      r.add(genProc(m, prc.sym, prc.body))
+
+    let bmod = g.modules[i.int]
+
+    var r: Rope
+    for it in inl.inlined[i].items:
+      emit(bmod, inl, inl.inlineProcs[it], r)
+
+    # append the generated procedures to the module:
+    bmod.s[cfsProcs].add(r)
+
+  # finalize code generation for the modules and generate and emit the code
+  # for the 'main' procedure:
   for m in closed(mlist):
-    let bmod = g.modules[m.sym.position]
-
-    # process the declarative statements first:
-    genTopLevelStmt(bmod, m.decls)
-    # generate code for the init procedure:
-    genInitProc(bmod, m.init)
-    # XXX: ^^ this is wrong. The init procedure should be treated
-    #      like any other procedure, but ``cgen`` still depends on appending
-    #      to it from all over the place. Untangling this will require
-    #      multiple intermediate refactorings.
-
-    # wrap up the main part of code generation for the module. Note that this
-    # doesn't mean that they're closed for writing; invoking the code generator
-    # for other modules' code can still add new code to this module's sections
-    finalCodegenActions(graph, bmod, newNode(nkStmtList))
-
-  # all alive globals are discovered now, so we can finish the modules'
-  # deinitialization procedures. Note that we have to already pass the
-  # procedures to code generation here
-  finishDeinit(graph, mlist)
-  for pos, m in mlist.modules.pairs:
-    genProc(g.modules[pos.int], m.destructor)
-
-  # the main part of code generation is wrapped up. Generate and emit the entry
-  # point, and then we're done. Note that no more dependencies (new globals,
-  # procedure, constants, etc.) must be raised beyond this point
-  for m in closed(mlist):
-    let bmod = g.modules[m.sym.position]
-
     let
-      hasInit = genInitCode(bmod)
+      bmod = g.modules[m.sym.position]
       hasDatInit = genDatInitCode(bmod)
-
-    if not hasInit:
-      # communicate to the dead-code elimination later performed by
-      # ``backends.generateMain`` that the init procedure has no content
-      m.init.ast[bodyPos] = graph.emptyNode
-    else:
-      configureInitProcedure(m.init, getInitName(bmod))
 
     if hasDatInit:
       # the data-init procedure is currently empty by default. We signal that
@@ -171,7 +377,10 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
       # XXX: this is only a temporary solution until populating the procedure
       #      is the responsibility of the orchestrator (or an earlier step)
       m.dataInit.ast[bodyPos] = newNode(nkStmtList)
-      configureInitProcedure(m.dataInit, getDatInitName(bmod))
+
+    # XXX: ``cgenWriteModules`` still expects a populated ``modulesClosed``
+    #      list
+    g.modulesClosed.add bmod
 
     finalizeModule(bmod)
     if sfMainModule in m.sym.flags:

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -74,8 +74,6 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   let
     config = graph.config
 
-  generateMethodDispatchers(graph)
-
   var g = newModuleList(graph)
 
   # first create a module list entry for each input module. This has to happen
@@ -106,6 +104,8 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
 proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
   ## Implements the main part of the C code-generation orchestrator. Expects an
   ## already populated ``BModuleList``.
+
+  generateMethodDispatchers(graph)
 
   # generate the definitions for all globals first, so that the symbols all
   # have mangled names already; the order in which this happens doesn't matter

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -157,9 +157,10 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
       symInDynamicLib(m, s)
 
       if m != bmod:
-        # record the foreign dependencies as late late-dependencies
+        # move the foreign dependencies into the global late-dependencies list,
+        # so that they will be registered as late late-dependencies
         for it in m.extra.items:
-          registerLate(discovery, s, m.module.position.FileIndex)
+          g.hooks.add (m, it)
 
         m.extra.setLen(0)
 

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2313,10 +2313,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
     assert p.config.exc == excGoto
     genTryGoto(p, n)
   of nkRaiseStmt: genRaiseStmt(p, n)
-  of nkIteratorDef: discard
   of nkPragma: genPragma(p, n)
-  of nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef, nkConstSection:
-    discard
   of nkType, nkNimNodeLit:
     unreachable()
   of nkWithSons + nkWithoutSons - codegenExprNodeKinds:

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2154,8 +2154,6 @@ proc useConst*(m: BModule; sym: PSym) =
     let headerDecl = "extern NIM_CONST $1 $2;$n" %
         [getTypeDesc(m, sym.loc.t, skVar), sym.loc.r]
     m.s[cfsData].add(headerDecl)
-    if sfExportc in sym.flags and m.g.generatedHeader != nil:
-      m.g.generatedHeader.s[cfsData].add(headerDecl)
 
 proc genConstDefinition*(q: BModule; sym: PSym) =
   let p = newProc(nil, q)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -655,6 +655,8 @@ proc genFieldCheck(p: BProc, e: PNode, obj: Rope, field: PSym) =
       else:
         # use the compiler-generated enum-to-string procedure
         let prc = p.module.g.graph.getToStringProc(disc.typ)
+        p.module.extra.add prc # late dependency
+
         var tmp: TLoc
         expr(p, newSymNode(prc), tmp)
         toStr = "$1($2)" % [rdLoc(tmp), rdLoc(v)]

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -646,21 +646,14 @@ proc genFieldCheck(p: BProc, e: PNode, obj: Rope, field: PSym) =
     # generate and emit the code for the failure case:
     case base.kind
     of tyEnum:
-      if useAliveDataFromDce in p.module.flags:
-        # DCE doesn't scan the ``nkCheckedFieldExpr`` nodes yet, meaning that
-        # the compiler-generated enum-to-string procedures aren't reliably
-        # available. Fallback to rendering the enum as it's integer value
-        toStr = "(NI)" & rdLoc(v)
-        raiseProc = "raiseFieldErrorInt"
-      else:
-        # use the compiler-generated enum-to-string procedure
-        let prc = p.module.g.graph.getToStringProc(disc.typ)
-        p.module.extra.add prc # late dependency
+      # use the compiler-generated enum-to-string procedure
+      let prc = p.module.g.graph.getToStringProc(disc.typ)
+      p.module.extra.add prc # late dependency
 
-        var tmp: TLoc
-        expr(p, newSymNode(prc), tmp)
-        toStr = "$1($2)" % [rdLoc(tmp), rdLoc(v)]
-        raiseProc = "raiseFieldErrorStr"
+      var tmp: TLoc
+      expr(p, newSymNode(prc), tmp)
+      toStr = "$1($2)" % [rdLoc(tmp), rdLoc(v)]
+      raiseProc = "raiseFieldErrorStr"
 
     of tyChar:
       # XXX: rendering as a character is supported by the runtime

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2187,11 +2187,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
     var sym = n.sym
     case sym.kind
     of skMethod:
-      if useAliveDataFromDce in p.module.flags or {sfForward} * sym.flags != {}:
-        fillProcLoc(p.module, n)
-        genProcPrototype(p.module, sym)
-      else:
-        genProc(p.module, sym)
+      genProc(p.module, sym)
       putLocIntoDest(p, d, sym.loc)
     of skProc, skConverter, skIterator, skFunc:
       #if sym.kind == skIterator:

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -777,7 +777,7 @@ proc genAsmStmt(p: BProc, t: PNode) =
   # see bug #2362, "top level asm statements" seem to be a mis-feature
   # but even if we don't do this, the example in #2362 cannot possibly
   # work:
-  if p.prc == nil:
+  if sfTopLevel in p.prc.flags:
     # top level asm statement?
     p.module.s[cfsProcHeaders].add runtimeFormat(CC[p.config.cCompiler].asmStmtFrmt, [s])
   else:
@@ -793,7 +793,7 @@ proc determineSection(n: PNode): TCFileSection =
 
 proc genEmit(p: BProc, t: PNode) =
   var s = genAsmOrEmitStmt(p, t[1])
-  if p.prc == nil:
+  if sfTopLevel in p.prc.flags:
     # top level emit pragma?
     let section = determineSection(t[1])
     genCLineDir(p.module.s[section], t.info, p.config)

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -161,45 +161,15 @@ proc genSingleVar(p: BProc, v: PSym; vn, value: PNode) =
     # translate 'var state {.goto.} = X' into 'goto LX':
     genGotoVar(p, value)
     return
-  var targetProc = p
-  if sfGlobal in v.flags:
-    assert {sfPure, sfThread} * v.flags != {}, "normal globals don't reach here"
-    if v.flags * {sfImportc, sfExportc} == {sfImportc} and
-        value.kind == nkEmpty and
-        v.loc.flags * {lfHeader, lfNoDecl} != {}:
-      return
-    if sfPure in v.flags:
-      # v.owner.kind != skModule:
-      targetProc = p.module.preInitProc
-    defineGlobalVar(targetProc.module, vn)
-    # XXX: be careful here.
-    # Global variables should not be zeromem-ed within loops
-    # (see bug #20).
-    # That's why we are doing the construction inside the preInitProc.
-    # genObjectInit relies on the C runtime's guarantees that
-    # global variables will be initialized to zero.
-    if true:
-      var loc = v.loc
 
-      # When the native TLS is unavailable, a global thread-local variable needs
-      # one more layer of indirection in order to access the TLS block.
-      # Only do this for complex types that may contain type fields
-      if sfThread in v.flags and emulatedThreadVars(p.config) and
-        isComplexValueType(v.typ):
-        initLocExprSingleUse(p.module.preInitProc, vn, loc)
-      genObjectInit(p.module.preInitProc, cpsInit, v.typ, loc, constructObj)
-    # Alternative construction using default constructor (which may zeromem):
-    # if sfImportc notin v.flags: constructLoc(p.module.preInitProc, v.loc)
-    if sfExportc in v.flags and p.module.g.generatedHeader != nil:
-      genVarPrototype(p.module.g.generatedHeader, vn)
-  else:
-    let imm = isAssignedImmediately(p.config, value)
-    assignLocalVar(p, vn)
-    initLocalVar(p, v, imm)
+  assert {sfGlobal, sfThread} * v.flags == {}
+  let imm = isAssignedImmediately(p.config, value)
+  assignLocalVar(p, vn)
+  initLocalVar(p, v, imm)
 
   if value.kind != nkEmpty:
-    genLineDir(targetProc, vn)
-    loadInto(targetProc, vn, value, v.loc)
+    genLineDir(p, vn)
+    loadInto(p, vn, value, v.loc)
 
 proc genSingleVar(p: BProc, a: PNode) =
   let v = a[0].sym

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -1034,7 +1034,8 @@ proc fakeClosureType(m: BModule; owner: PSym): PType =
   result.rawAddSon(r)
 
 proc genDeepCopyProc(m: BModule; s: PSym; result: Rope) =
-  genProc(m, s)
+  useProc(m, s)
+  m.g.hooks.add (m, s)
   m.s[cfsTypeInit3].addf("$1.deepcopy =(void* (N_RAW_NIMCALL*)(void*))$2;$n",
      [result, s.loc.r])
 
@@ -1076,7 +1077,9 @@ proc genHook(m: BModule; t: PType; info: TLineInfo; op: TTypeAttachedOp): Rope =
       localReport(m.config, info, reportSym(
         rsemExpectedNimcallProc, theProc))
 
-    genProc(m, theProc)
+    useProc(m, theProc)
+    m.g.hooks.add (m, theProc)
+
     result = theProc.loc.r
 
     when false:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -579,7 +579,7 @@ proc getLabel(p: BProc): TLabel =
 proc fixLabel(p: BProc, labl: TLabel) =
   lineF(p, cpsStmts, "$1: ;$n", [labl])
 
-proc genVarPrototype(m: BModule, n: PNode)
+proc genVarPrototype*(m: BModule, n: PNode)
 proc genProcPrototype*(m: BModule, sym: PSym)
 proc genStmts*(p: BProc, t: PNode)
 proc expr(p: BProc, n: PNode, d: var TLoc)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1343,6 +1343,10 @@ proc genDatInitCode*(m: BModule): bool =
   # directive from a function written by the user spills after itself
   genCLineDir(prc, "generated_not_to_break_here", 999999, m.config)
 
+  if m.typeNodes > 0:
+    # emit a definition for the node storage, if used
+    appcg(m, m.s[cfsTypeInit1], "static #TNimNode $1[$2];$n",
+          [m.typeNodesName, m.typeNodes])
 
   for i in cfsTypeInit1..cfsDynLibInit:
     if m.s[i].len != 0:
@@ -1375,13 +1379,6 @@ proc genInitCode*(m: BModule): bool =
   # we don't want to break into such init code - could happen if a line
   # directive from a function written by the user spills after itself
   genCLineDir(prc, "generated_not_to_break_here", 999999, m.config)
-  if m.typeNodes > 0:
-    appcg(m, m.s[cfsTypeInit1], "static #TNimNode $1[$2];$n",
-          [m.typeNodesName, m.typeNodes])
-
-  if m.nimTypes > 0:
-    appcg(m, m.s[cfsTypeInit1], "static #TNimType $1[$2];$n",
-          [m.nimTypesName, m.nimTypes])
 
   template writeSection(thing: untyped, section: TCProcSection) =
     if m.thing.s(section).len > 0:
@@ -1509,7 +1506,6 @@ proc rawNewModule*(g: BModuleList; module: PSym, filename: AbsoluteFile): BModul
   initNodeTable(result.dataCache)
   result.typeStack = @[]
   result.typeNodesName = getTempName(result)
-  result.nimTypesName = getTempName(result)
   # no line tracing for the init sections of the system module so that we
   # don't generate a TFrame which can confuse the stack bottom initialization:
   if sfSystemModule in module.flags:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1121,8 +1121,8 @@ proc genProcNoForward(m: BModule, prc: PSym) =
     genProcPrototype(m, prc)
 
 proc requestConstImpl(p: BProc, sym: PSym) =
-  if genConstSetup(p, sym):
-    let m = p.module
+  let m = p.module
+  if genConstSetup(m, sym):
     # declare implementation:
     var q = findPendingModule(m, sym)
     if q != nil and not containsOrIncl(q.declaredThings, sym.id):
@@ -1130,7 +1130,7 @@ proc requestConstImpl(p: BProc, sym: PSym) =
       genConstDefinition(q, p, sym)
     # declare header:
     if q != m and not containsOrIncl(m.declaredThings, sym.id):
-      genConstHeader(m, q, p, sym)
+      genConstHeader(m, q, sym)
 
 proc isActivated(prc: PSym): bool = prc.typ != nil
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -100,6 +100,11 @@ const NonMagics* = {mNewString, mNewStringOfCap, mNewSeq, mSetLengthSeq,
   ## magics that are treated like normal procedures by the code generator.
   ## This set only applies when using the new runtime.
 
+const
+  sfTopLevel* = sfMainModule
+    ## the procedure contains top-level code, which currently affects how
+    ## emit, asm, and error handling works
+
 proc findPendingModule(m: BModule, s: PSym): BModule =
   let ms = s.itemId.module  #getModule(s)
   result = m.g.modules[ms]
@@ -1022,6 +1027,10 @@ proc finishProc*(p: BProc, prc: PSym): string =
     generatedProc.add(p.s(cpsInit))
     generatedProc.add(p.s(cpsStmts))
     if beforeRetNeeded in p.flags: generatedProc.add(~"\t}BeforeRet_: ;$n")
+
+    if sfTopLevel in prc.flags:
+      generatedProc.add ropecg(p.module, "\t#nimTestErrorFlag();$n", [])
+
     if optStackTrace in prc.options: generatedProc.add(deinitFrame(p))
     generatedProc.add(returnStmt)
     generatedProc.add(~"}$N")

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1316,9 +1316,6 @@ proc rawNewModule*(g: BModuleList; module: PSym, filename: AbsoluteFile): BModul
   result.sigConflicts = initCountTable[SigHash]()
   result.initProc = newProc(nil, result)
   result.initProc.options = initProcOptions(result)
-  result.preInitProc = newProc(nil, result)
-  result.preInitProc.flags.incl nimErrorFlagDisabled
-  result.preInitProc.labels = 100_000 # little hack so that unique temporaries are generated
   initNodeTable(result.dataCache)
   result.typeStack = @[]
   result.typeNodesName = getTempName(result)
@@ -1326,7 +1323,6 @@ proc rawNewModule*(g: BModuleList; module: PSym, filename: AbsoluteFile): BModul
   # don't generate a TFrame which can confuse the stack bottom initialization:
   if sfSystemModule in module.flags:
     incl result.flags, preventStackTrace
-    excl(result.preInitProc.options, optStackTrace)
   let ndiName = if optCDebug in g.config.globalOptions: changeFileExt(completeCfilePath(g.config, filename), "ndi")
                 else: AbsoluteFile""
   open(result.ndi, ndiName, g.config)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -60,7 +60,6 @@ import
   compiler/backend/[
     extccomp,
     ccgutils,
-    cgmeth,
     cgendata
   ],
   compiler/plugins/[
@@ -1636,12 +1635,6 @@ proc finalCodegenActions*(graph: ModuleGraph; m: BModule; n: PNode) =
       m.initProc.options = initProcOptions(m)
       genProcBody(m.initProc, n)
 
-    if sfMainModule in m.module.flags and useAliveDataFromDce in m.flags:
-        # methods need to be special-cased for IC, as whether a dispatcher is
-        # alive is only know after ``transf`` (phase-ordering problem)
-        generateMethodDispatchers(graph)
-        for disp in dispatchers(graph):
-          genProcAux(m, disp)
 
   # for compatibility, the code generator still manages its own "closed order"
   # list, but this should be phased out eventually

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -180,7 +180,6 @@ type
     headerFiles*: seq[string] ## needed headers to include
     typeInfoMarker*: TypeCache ## needed for generating type information
     typeInfoMarkerV2*: TypeCache
-    initProc*: BProc          ## code for init procedure
     typeStack*: TTypeSeq      ## used for type generation
     dataCache*: TNodeTable
     typeNodes*: int ## used for type info generation

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -125,8 +125,6 @@ type
                         ## a frame var twice in an init proc
     isHeaderFile,       ## C source file is the header file
     includesStringh,    ## C source file already includes ``<string.h>``
-    useAliveDataFromDce ## use the `alive: IntSet` field instead of
-                        ## computing alive data on our own.
 
   BModuleList* = ref object of RootObj
     mapping*: Rope             ## the generated mapping file (if requested)
@@ -176,7 +174,6 @@ type
     forwTypeCache*: TypeCache ## cache for forward declarations of types
     declaredThings*: IntSet   ## things we have declared in this .c file
     declaredProtos*: IntSet   ## prototypes we have declared in this .c file
-    alive*: IntSet            ## symbol IDs of alive data as computed by `dce.nim`
     headerFiles*: seq[string] ## needed headers to include
     typeInfoMarker*: TypeCache ## needed for generating type information
     typeInfoMarkerV2*: TypeCache

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -149,6 +149,16 @@ type
                             ## nimtvDeps is VERY hard to cache because it's
                             ## not a list of IDs nor can it be made to be one.
 
+    hooks*: seq[(BModule, PSym)]
+      ## late late-dependencies. Generating code for a procedure might lead
+      ## to the RTTI setup code for some type from a foreign module (i.e., one
+      ## different from the module that acts as the current context) to be
+      ## emitted, and this setup code might reference additional procedures.
+      ## Written: by the code generator; reset by the orchestrator
+      ## Read:    by the orchestrator
+      # XXX: move emission of RTTI setup into the orchestrator and remove this
+      #      facility
+
   TCGen = object ## represents a C source file
     idgen*: IdGenerator
     s*: TCFileSections        ## sections of the C file
@@ -182,6 +192,12 @@ type
     sigConflicts*: CountTable[SigHash]
     g*: BModuleList
     ndi*: NdiFile
+
+    extra*: seq[PSym]
+      ## communicates dependencies introduced by the code-generator
+      ## back to the caller. The caller is responsible for clearing the list
+      ## after it's done with processing it. The code-generator only ever
+      ## appends to it
 
 template config*(m: BModule): ConfigRef = m.g.config
 template config*(p: BProc): ConfigRef = p.module.g.config

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -152,7 +152,8 @@ type
       ## to the RTTI setup code for some type from a foreign module (i.e., one
       ## different from the module that acts as the current context) to be
       ## emitted, and this setup code might reference additional procedures.
-      ## Written: by the code generator; reset by the orchestrator
+      ## Written: by the code generator and orchestrator; reset by the
+      ##          orchestrator
       ## Read:    by the orchestrator
       # XXX: move emission of RTTI setup into the orchestrator and remove this
       #      facility

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -181,7 +181,6 @@ type
     typeInfoMarker*: TypeCache ## needed for generating type information
     typeInfoMarkerV2*: TypeCache
     initProc*: BProc          ## code for init procedure
-    preInitProc*: BProc       ## code executed before the init proc
     typeStack*: TTypeSeq      ## used for type generation
     dataCache*: TNodeTable
     typeNodes*: int ## used for type info generation

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -174,8 +174,8 @@ type
     preInitProc*: BProc       ## code executed before the init proc
     typeStack*: TTypeSeq      ## used for type generation
     dataCache*: TNodeTable
-    typeNodes*, nimTypes*: int ## used for type info generation
-    typeNodesName*, nimTypesName*: Rope ## used for type info generation
+    typeNodes*: int ## used for type info generation
+    typeNodesName*: Rope ## used for type info generation
     labels*: Natural          ## for generating unique module-scope names
     extensionLoaders*: array['0'..'9', Rope] ## special procs for the
                                              ## OpenGL wrapper

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -128,6 +128,13 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   for m in closed(mlist):
     let bmod = newModule(graph, m.sym)
     bmod.idgen = m.idgen
+
+    if m.init.ast[bodyPos].kind != nkEmpty: # dead-code elimination
+      # HACK: we mark the procedure with the ``sfModuleInit`` flag in order to
+      #       signal to ``jsgen`` that a special stack-trace entry needs to
+      #       be created for the procedure
+      m.init.flags.incl sfModuleInit
+
     modules[m.sym.position.FileIndex] = bmod
 
   for evt in process(graph, mlist, discovery, {}, BackendConfig()):

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -137,7 +137,7 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
 
     modules[m.sym.position.FileIndex] = bmod
 
-  for evt in process(graph, mlist, discovery, {}, BackendConfig()):
+  for evt in process(graph, mlist, discovery, NonMagics, BackendConfig()):
     processEvent(globals, graph, modules, discovery, partial, evt)
 
   # finish the partial procedures:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2497,7 +2497,6 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkIfStmt: genIf(p, n)
   of nkWhileStmt: genWhileStmt(p, n)
   of nkVarSection, nkLetSection: genVarStmt(p, n)
-  of nkConstSection: discard
   of nkCaseStmt: genCaseJS(p, n)
   of nkReturnStmt: genReturnStmt(p, n)
   of nkBreakStmt: genBreakStmt(p, n)
@@ -2511,13 +2510,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkAsmStmt: genAsmOrEmitStmt(p, n)
   of nkTryStmt: genTry(p, n)
   of nkRaiseStmt: genRaiseStmt(p, n)
-  of nkIteratorDef: discard
   of nkPragma: genPragma(p, n)
-  of nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef:
-    var s = n[namePos].sym
-    if {sfExportc, sfCompilerProc} * s.flags == {sfExportc}:
-      genSym(p, n[namePos], r)
-      r.res = ""
   of nkFloat128Lit, nkNimNodeLit:
     unreachable()
   of nkWithSons + nkWithoutSons - codegenExprNodeKinds:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1648,8 +1648,7 @@ proc defineGlobals*(globals: PGlobals, m: BModule, vars: openArray[PSym]) =
   let p = newInitProc(globals, m)
     ## required for emitting code
   for v in vars.items:
-    if lfNoDecl notin v.loc.flags and sfImportc notin v.flags and
-       sfPure notin v.flags: # XXX: temporary workaround
+    if lfNoDecl notin v.loc.flags and sfImportc notin v.flags:
       let name = mangleName(m, v) # mutates `v`
       lineF(p, "var $1 = $2;$n", [name, createVar(p, v.typ, isIndirect(v))])
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -174,16 +174,16 @@ proc rdLoc(a: TCompRes): Rope {.inline.} =
   else:
     result = "$1[$2]" % [a.address, a.res]
 
-proc newProc(globals: PGlobals, module: BModule, procDef: PNode,
+proc newProc(globals: PGlobals, module: BModule, prc: PSym,
              options: TOptions): PProc =
   result = PProc(
     blocks: @[],
     options: options,
     module: module,
-    procDef: procDef,
+    prc: prc,
+    procDef: (if prc != nil: prc.ast else: nil),
     g: globals,
-    extraIndent: int(procDef != nil))
-  if procDef != nil: result.prc = procDef[namePos].sym
+    extraIndent: int(prc != nil))
 
 proc newInitProc(globals: PGlobals, module: BModule): PProc =
   result = newProc(globals, module, nil, {})
@@ -2237,7 +2237,7 @@ proc optionalLine(p: Rope): Rope =
     return p & "\L"
 
 proc startProc*(g: PGlobals, module: BModule, prc: PSym): PProc =
-  let p = newProc(g, module, prc.ast, prc.options)
+  let p = newProc(g, module, prc, prc.options)
 
   # make sure the procedure has a mangled name:
   discard mangleName(p.module, prc)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -141,6 +141,10 @@ const
   sfModuleInit* = sfMainModule
     ## the procedure is the 'init' procedure of a module
 
+  NonMagics* = { mDotDot }
+    ## magics that are treated like normal procedures by the code
+    ## generator
+
 template config*(p: PProc): ConfigRef = p.module.config
 
 proc indentLine(p: PProc, r: Rope): Rope =

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -118,7 +118,6 @@ type
 
   PGlobals* = ref object
     typeInfo, constants*, code*: Rope
-    generatedSyms: IntSet
     typeInfoGenerated: IntSet
     unique: int    # for temp identifier generation
 
@@ -165,7 +164,6 @@ template nested(p, body) =
 
 proc newGlobals*(): PGlobals =
   new(result)
-  result.generatedSyms = initIntSet()
   result.typeInfoGenerated = initIntSet()
 
 proc rdLoc(a: TCompRes): Rope {.inline.} =

--- a/compiler/ic/cbackend.nim
+++ b/compiler/ic/cbackend.nim
@@ -10,11 +10,6 @@
 ## Entry point into the C code generator when rodfiles are used. Instead of
 ## invoking the code generator directly, it simply invokes the normal code
 ## generation orchestrator for the C backend.
-##
-## However, instead of leaving dead-code elimination (=DCE) to the
-## orchestrator, we compute the set of alive symbols here, through a prepass
-## over the entire packed module graph. The code generator currently picks
-## this up via the ``useAliveDataFromDce`` flag.
 
 import
   std/[
@@ -60,10 +55,6 @@ proc unpackTree(g: ModuleGraph; thisModule: int;
 proc setupBackendModule(g: BModuleList; m: var LoadedModule, alive: AliveSyms) =
   var bmod = cgen.newModule(g, m.module, g.config)
   bmod.idgen = idgenFromLoadedModule(m)
-
-  bmod.flags.incl useAliveDataFromDce
-  # XXX: we need to copy for now :(
-  bmod.alive = alive[m.module.position]
 
 proc addFileToLink(config: ConfigRef; m: PSym) {.used.} =
   # XXX: currently unused, but kept in case it is needed again

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -100,18 +100,12 @@ proc rewriteGlobalDefs(body: var MirTree, sourceMap: var SourceMap,
     case n.kind
     of DefNodes:
       let def = i + 1
-      if body[def].kind == mnkGlobal and
-        body[def].sym.owner.kind == skModule and
-        (not outermost or depth == 1):
+      if body[def].kind == mnkGlobal and (not outermost or depth == 1):
         let
           sym = body[def].sym
           typ = sym.typ
         changes.seek(i)
-        if sfPure in sym.flags:
-          # HACK: yet another hack for the JS backend not using
-          #       ``transf.extractGlobals``...
-          discard "do nothing"
-        elif hasInput(body, Operation i):
+        if hasInput(body, Operation i):
           # the global has a starting value
           changes.replaceMulti(buf):
             let tmp = changes.getTemp()

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -1,10 +1,5 @@
 ## A temporary module that implements convenience routines for the ``PNode``
 ## AST <-> ``MirTree`` translation.
-##
-## With the current implementation, the code-generators are responsible for
-## running both translation steps (plus any MIR passes), but this is the wrong
-## approach -- the code reaching the code-generators should have already been
-## processed (i.e. MIR translation and passes done).
 
 import
   compiler/ast/[
@@ -26,10 +21,6 @@ import
   ],
   compiler/modules/[
     modulegraphs
-  ],
-  compiler/sem/[
-    injectdestructors,
-    varpartitions
   ],
   compiler/utils/[
     astrepr
@@ -61,28 +52,28 @@ let reprConfig = block:
 # and outputs in the context of compiler debugging until a more
 # structured/integrated solution is implemented
 
-proc echoInput(config: ConfigRef, owner: PSym, body: PNode) =
+proc echoInput*(config: ConfigRef, owner: PSym, body: PNode) =
   ## If requested via the define, renders the input AST `body` and writes the
   ## result out through ``config.writeLine``.
   if config.getStrDefine("nimShowMirInput") == owner.name.s:
     writeBody(config, "-- input AST: " & owner.name.s):
       config.writeln(treeRepr(config, body, reprConfig))
 
-proc echoMir(config: ConfigRef, owner: PSym, tree: MirTree) =
+proc echoMir*(config: ConfigRef, owner: PSym, tree: MirTree) =
   ## If requested via the define, renders the `tree` and writes the result out
   ## through ``config.writeln``.
   if config.getStrDefine("nimShowMir") == owner.name.s:
     writeBody(config, "-- MIR: " & owner.name.s):
       config.writeln(print(tree))
 
-proc echoOutput(config: ConfigRef, owner: PSym, body: PNode) =
+proc echoOutput*(config: ConfigRef, owner: PSym, body: PNode) =
   ## If requested via the define, renders the output AST `body` and writes the
   ## result out through ``config.writeLine``.
   if config.getStrDefine("nimShowMirOutput") == owner.name.s:
     writeBody(config, "-- output AST: " & owner.name.s):
       config.writeln(treeRepr(config, body, reprConfig))
 
-proc rewriteGlobalDefs(body: var MirTree, sourceMap: var SourceMap,
+proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap,
                        outermost: bool) =
   ## Removes definitions of non-pure globals from `body`, replacing them with
   ## as assignment if necessary.
@@ -157,12 +148,8 @@ proc rewriteGlobalDefs(body: var MirTree, sourceMap: var SourceMap,
 
 proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
                    body: PNode, options: set[GenOption]): PNode =
-  ## No MIR passes exist yet, so the to-and-from translation is treated as a
-  ## canonicalization step. To be able to step-by-step rewrite
-  ## transformations done in ``transf`` and in the back-ends as MIR passes, it
-  ## is important that ``canonicalize`` is applied to *all* code reaching
-  ## the code-generators, so that they can depend on the shape of the
-  ## resulting AST
+  ## Legacy routine. Translates the body `body` of the procedure `owner` to
+  ## MIR code, and the MIR code back to ``PNode`` AST.
   echoInput(graph.config, owner, body)
   # step 1: generate a ``MirTree`` from the input AST
   let (tree, sourceMap) = generateCode(graph, owner, options, body)
@@ -171,47 +158,6 @@ proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
   # step 2: translate it back
   result = generateAST(graph, idgen, owner, tree, sourceMap)
   echoOutput(graph.config, owner, result)
-
-proc canonicalizeWithInject*(graph: ModuleGraph, idgen: IdGenerator,
-                             owner: PSym, body: PNode,
-                             options: set[GenOption]): PNode =
-  ## Transforms `body` through the following steps:
-  ## 1. cursor inference
-  ## 2. translation to MIR code
-  ## 3. removal of non-pure global definitions from the outermost scope
-  ## 4. application of the ``injectdestructors`` pass
-  ## 5. (temporarily) removal of remaining non-pure global definitions
-  ## 6. translation back to AST
-  ##
-  ## Cursor inference and destructor injection are only performed if `owner`
-  ## is eligible according to ``injectdestructors.shouldInjectDestructorCalls``
-  let config = graph.config
-
-  # cursor inference is not a MIR pass yet, so it has to be applied before
-  # the MIR translation/processing
-  let inject = shouldInjectDestructorCalls(owner)
-  if inject and optCursorInference in config.options:
-    computeCursors(owner, body, graph)
-
-  echoInput(config, owner, body)
-
-  # step 1: generate a ``MirTree`` from the input AST
-  var (tree, sourceMap) = generateCode(graph, owner, options, body)
-  echoMir(config, owner, tree)
-
-  rewriteGlobalDefs(tree, sourceMap, outermost = true)
-
-  # step 2: run the ``injectdestructors`` pass
-  if inject:
-    injectDestructorCalls(graph, idgen, owner, tree, sourceMap)
-
-  # XXX: this is a hack. See the documentation of the routine for more
-  #      details
-  rewriteGlobalDefs(tree, sourceMap, outermost = false)
-
-  # step 3: translate the MIR code back to an AST
-  result = generateAST(graph, idgen, owner, tree, sourceMap)
-  echoOutput(config, owner, result)
 
 proc canonicalizeSingle*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
                          n: PNode, options: set[GenOption]): PNode =

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -169,24 +169,14 @@ proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
   ## is important that ``canonicalize`` is applied to *all* code reaching
   ## the code-generators, so that they can depend on the shape of the
   ## resulting AST
-  let config = graph.config
-  if config.getStrDefine("nimShowMirInput") == owner.name.s:
-    writeBody(config, "-- input AST: " & owner.name.s):
-      config.writeln(treeRepr(config, body, reprConfig))
-
+  echoInput(graph.config, owner, body)
   # step 1: generate a ``MirTree`` from the input AST
   let (tree, sourceMap) = generateCode(graph, owner, options, body)
-
-  if graph.config.getStrDefine("nimShowMir") == owner.name.s:
-    writeBody(config, "-- MIR: " & owner.name.s):
-      config.writeln(print(tree))
+  echoMir(graph.config, owner, tree)
 
   # step 2: translate it back
   result = generateAST(graph, idgen, owner, tree, sourceMap)
-
-  if config.getStrDefine("nimShowMirOutput") == owner.name.s:
-    writeBody(config, "-- output AST: " & owner.name.s):
-      config.writeln(treeRepr(config, result, reprConfig))
+  echoOutput(graph.config, owner, result)
 
 proc canonicalizeWithInject*(graph: ModuleGraph, idgen: IdGenerator,
                              owner: PSym, body: PNode,

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -139,6 +139,8 @@ type
   GenOption* = enum
     goIsNimvm     ## choose the ``nimvm`` branch for ``when nimvm`` statements
     goGenTypeExpr ## don't omit type expressions
+    goIsCompileTime ## whether the code is meant to be run at compile-time.
+                    ## Affects handling of ``.compileTime`` globals
 
   TCtx = object
     # output:
@@ -1302,12 +1304,9 @@ proc genLocInit(c: var TCtx, symNode: PNode, initExpr: PNode) =
 
   assert sym.kind in {skVar, skLet, skTemp, skForVar}
 
-  if sfCompileTime in sym.flags and goIsNimvm notin c.options:
+  if sfCompileTime in sym.flags and goIsCompileTime notin c.options:
     # compile-time-only locations don't exist outside of compile-time
     # contexts, so omit their definitions
-    # FIXME: the check above is wrong. ``goIsNimvm`` is also set when using
-    #        the VM backend, but that's not a compile-time context. A
-    #        dedicated option is needed
     return
 
   # if there's an initial value and the destination is non-owning, we pass the

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1913,11 +1913,6 @@ proc gen(c: var TCtx, n: PNode) =
   of nkProcDef, nkFuncDef, nkIteratorDef, nkMethodDef, nkConverterDef:
     c.stmts.subTree MirNode(kind: mnkDef):
       c.stmts.add procNode(n[namePos].sym)
-      # XXX: this is a temporary solution. The current code-generators
-      #      require procdef nodes in some cases, and instead of
-      #      recreating them during ``astgen``, we carry the original nodes
-      #      over
-      c.stmts.add MirNode(kind: mnkPNode, node: n)
 
   of nkDiscardStmt:
     if n[0].kind != nkEmpty:
@@ -1928,14 +1923,10 @@ proc gen(c: var TCtx, n: PNode) =
     # as a ``discard``
     assert n.typ.isEmptyType()
   of nkCommentStmt, nkTemplateDef, nkMacroDef, nkImportStmt,
-     nkImportExceptStmt, nkFromStmt,
-     nkIncludeStmt, nkStaticStmt, nkExportStmt, nkExportExceptStmt,
-     nkTypeSection, nkMixinStmt, nkBindStmt, nkEmpty:
+     nkImportExceptStmt, nkFromStmt, nkIncludeStmt, nkStaticStmt,
+     nkExportStmt, nkExportExceptStmt, nkTypeSection, nkMixinStmt,
+     nkBindStmt, nkConstSection, nkEmpty:
     discard "ignore"
-  of nkConstSection:
-    # const sections are not relevant for the MIR, but the IC implementation
-    # needs them to be present
-    c.stmts.add MirNode(kind: mnkPNode, node: n)
   of nkPragma:
     # if the pragma statement contains an ``.emit`` or ``.computeGoto``, it is
     # stored in the MIR as an ``mnkPNode`` -- otherwise it's discarded

--- a/compiler/mir/sourcemaps.nim
+++ b/compiler/mir/sourcemaps.nim
@@ -10,6 +10,9 @@
 ## data structures.
 
 import
+  std/[
+    options
+  ],
   compiler/ast/[
     ast_types
   ],
@@ -48,3 +51,13 @@ func `[]`*(m: SourceMap, i: NodeInstance): SourceId {.inline.} =
 
 func sourceFor*(m: SourceMap, i: NodeInstance): PNode {.inline.} =
   m.source[m.map[ord(i)]]
+
+func append*(dst: var SourceMap, src: sink SourceMap) =
+  ## Appends all source mappings from `src` to `dst`.
+  if src.map.len == 0:
+    return # nothing to do
+
+  let first = unsafeGet(merge(dst.source, src.source))
+
+  for i, it in src.map.pairs:
+    dst.map.add SourceId(ord(first) + ord(it))

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -132,7 +132,6 @@ type
     cacheCounters*: Table[string, BiggestInt] # IC: implemented
     cacheTables*: Table[string, BTree[string, PNode]] # IC: implemented
     passes*: seq[TPass]
-    globalDestructors*: seq[tuple[module: int32, call: PNode]]
     strongSemCheck*: proc (graph: ModuleGraph; owner: PSym; body: PNode) {.nimcall.}
     compatibleProps*: proc (graph: ModuleGraph; formal, actual: PType): bool {.nimcall.}
     idgen*: IdGenerator

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -200,8 +200,6 @@ import
 from compiler/ast/reports_sem import SemReport
 from compiler/ast/report_enums import ReportKind
 
-from compiler/sem/semdata import makeVarType
-
 type
   AnalyseCtx = object
     cfg: ControlFlowGraph
@@ -299,7 +297,7 @@ func paramType(p: PSym, i: Natural): PType =
 proc getVoidType(g: ModuleGraph): PType {.inline.} =
   g.getSysType(unknownLineInfo, tyVoid)
 
-proc getOp(g: ModuleGraph, t: PType, kind: TTypeAttachedOp): PSym =
+proc getOp*(g: ModuleGraph, t: PType, kind: TTypeAttachedOp): PSym =
   let t = t.skipTypes(skipForHooks)
   result = getAttachedOp(g, t, kind)
   if result == nil or result.ast.isGenericRoutine:
@@ -1286,20 +1284,6 @@ proc lowerBranchSwitch(buf: var MirNodeSeq, body: MirTree, graph: ModuleGraph,
   buf.add MirNode(kind: mnkFastAsgn)
 
   buf.add endNode(mnkRegion)
-
-proc genOp(idgen: IdGenerator, owner, op: PSym, dest: PNode): PNode =
-  let
-    typ = makeVarType(owner, dest.typ, idgen, tyVar)
-    addrExp = newTreeIT(nkHiddenAddr, dest.info, typ): dest
-
-  result = newTreeI(nkCall, dest.info, newSymNode(op), addrExp)
-
-proc genDestroy*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym, dest: PNode): PNode =
-  let
-    t = dest.typ.skipTypes(skipAliases)
-    op = getOp(graph, t, attachedDestructor)
-
-  result = genOp(idgen, owner, op, dest)
 
 proc deferGlobalDestructors(tree: MirTree, g: ModuleGraph, idgen: IdGenerator,
                             owner: PSym) =

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -1331,14 +1331,6 @@ func shouldInjectDestructorCalls*(owner: PSym): bool =
      {sfInjectDestructors, sfGeneratedOp} * owner.flags == {sfInjectDestructors} and
      (owner.kind != skIterator or not isInlineIterator(owner.typ))
 
-proc deferGlobalDestructor*(g: ModuleGraph, idgen: IdGenerator, owner: PSym,
-                            global: PNode) =
-  ## If the global has a destructor, emits a call to it at the end of the
-  ## section of global destructors.
-  if sfThread notin global.sym.flags and hasDestructor(global.typ):
-    g.globalDestructors.add (global.sym.itemId.module,
-                             genDestroy(g, idgen, owner, global))
-
 proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
                             tree: var MirTree, sourceMap: var SourceMap) =
   ## The ``injectdestructors`` pass entry point. The pass is made up of

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -656,8 +656,8 @@ template genWasMoved(buf: var MirNodeSeq, graph: ModuleGraph, body: untyped) =
                   magic: mWasMoved)
   buf.add MirNode(kind: mnkVoid)
 
-proc genDestroy(buf: var MirNodeSeq, graph: ModuleGraph, t: PType,
-                target: sink MirNode) =
+proc genDestroy*(buf: var MirNodeSeq, graph: ModuleGraph, t: PType,
+                 target: sink MirNode) =
   let destr = getOp(graph, t, attachedDestructor)
 
   argBlock(buf):

--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -385,7 +385,7 @@ proc setupModule*(graph: ModuleGraph, idgen: IdGenerator, m: PSym,
 
   # now that we have the code that makes up the user-defined module
   # initialization, we wrap it into a procedure:
-  result.init = createModuleOp(graph, idgen, "Init", m, imperative, options)
+  result.init = createModuleOp(graph, idgen, "", m, imperative, options)
   result.init.flags = m.flags * {sfInjectDestructors} # inherit the flag
   # we also need to make sure that the owner of all entities defined inside
   # the body is adjusted:

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1368,13 +1368,16 @@ proc transformExpr*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode):
     incl(result.flags, nfTransf)
 
 proc extractGlobals*(body: PNode, output: var seq[PNode], isNimVm: bool) =
-  ## Searches for all ``nkIdentDefs`` defining a global that's not owned by a
-  ## module, appends them to `output` in the order they appear in the input
-  ## AST, and removes the nodes from `body`. `isNimVm` signals which branch
-  ## to select for ``when nimvm`` statements/expressions.
+  ## Searches for all ``nkIdentDefs`` defining a global that's either:
+  ## - not owned by a module
+  ## - explicitly marked with the ``.global`` pragma (indicated by the
+  ##   ``sfPure`` flag)
+  ## appends them to `output` in the order they appear in the input AST, and
+  ## removes the nodes from `body`. `isNimVm` signals which branch to select
+  ## for ``when nimvm`` statements/expressions.
   ##
   ## XXX: this can't happen as part of ``transformBody``, as ``transformBody``
-  ##      is reentrant because of ``lambdalifting`` and it's thus not easily
+  ##      is reentrant because of iterator inlining and it's thus not easily
   ##      possible to collect something from the body of a single procedure
   ##      only. There's also the problem that extracting the globals is not
   ##      wanted when transformation happens for a procedure that's invoked
@@ -1411,8 +1414,8 @@ proc extractGlobals*(body: PNode, output: var seq[PNode], isNimVm: bool) =
       if it.kind == nkIdentDefs and
          it[0].kind == nkSym and
          sfGlobal in it[0].sym.flags and
-         it[0].sym.owner.kind in routineKinds:
-        # found one; append it to the output:
+         (sfPure in it[0].sym.flags or it[0].sym.owner.kind in routineKinds):
+        # found a relevant one; append it to the output:
         output.add(it)
         # there's no need to process the initializer expression of the global,
         # as we know that further globals defined inside them are not visible

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1368,16 +1368,13 @@ proc transformExpr*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode):
     incl(result.flags, nfTransf)
 
 proc extractGlobals*(body: PNode, output: var seq[PNode], isNimVm: bool) =
-  ## Searches for all ``nkIdentDefs`` defining a global that's either:
-  ## - not owned by a module
-  ## - explicitly marked with the ``.global`` pragma (indicated by the
-  ##   ``sfPure`` flag)
-  ## appends them to `output` in the order they appear in the input AST, and
-  ## removes the nodes from `body`. `isNimVm` signals which branch to select
-  ## for ``when nimvm`` statements/expressions.
+  ## Searches for all ``nkIdentDefs`` defining a global that's not owned by a
+  ## module, appends them to `output` in the order they appear in the input
+  ## AST, and removes the nodes from `body`. `isNimVm` signals which branch
+  ## to select for ``when nimvm`` statements/expressions.
   ##
   ## XXX: this can't happen as part of ``transformBody``, as ``transformBody``
-  ##      is reentrant because of iterator inlining and it's thus not easily
+  ##      is reentrant because of ``lambdalifting`` and it's thus not easily
   ##      possible to collect something from the body of a single procedure
   ##      only. There's also the problem that extracting the globals is not
   ##      wanted when transformation happens for a procedure that's invoked
@@ -1414,8 +1411,8 @@ proc extractGlobals*(body: PNode, output: var seq[PNode], isNimVm: bool) =
       if it.kind == nkIdentDefs and
          it[0].kind == nkSym and
          sfGlobal in it[0].sym.flags and
-         (sfPure in it[0].sym.flags or it[0].sym.owner.kind in routineKinds):
-        # found a relevant one; append it to the output:
+         it[0].sym.owner.kind in routineKinds:
+        # found one; append it to the output:
         output.add(it)
         # there's no need to process the initializer expression of the global,
         # as we know that further globals defined inside them are not visible

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1334,8 +1334,8 @@ proc transformBody*(g: ModuleGraph; idgen: IdGenerator; prc: PSym; cache: bool):
     # XXX Rodfile support for transformedBody!
 
 proc transformBodyWithCache*(g: ModuleGraph, idgen: IdGenerator, prc: PSym): PNode =
-  ## Transforms the body of `prc` and returns, but doesn't cache, the resulting
-  ## AST. If the transformed body was already cached earlier,
+  ## Fetches the cached transformed body of `prc`, transforming it if not
+  ## available, new transforms are not cached
   assert prc.kind in routineKinds - {skTemplate, skMacro}
   if prc.transformedBody != nil:
     result = prc.transformedBody

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1320,6 +1320,19 @@ proc transformBody*(g: ModuleGraph; idgen: IdGenerator; prc: PSym; cache: bool):
       prc.transformedBody = nil
     # XXX Rodfile support for transformedBody!
 
+proc transformBodyWithCache*(g: ModuleGraph, idgen: IdGenerator, prc: PSym): PNode =
+  ## Transforms the body of `prc` and returns, but doesn't cache, the resulting
+  ## AST. If the transformed body was already cached earlier,
+  assert prc.kind in routineKinds - {skTemplate, skMacro}
+  if prc.transformedBody != nil:
+    result = prc.transformedBody
+  elif nfTransf in getBody(g, prc).flags:
+    # the AST was already transformed:
+    result = getBody(g, prc)
+  else:
+    # no recursion is possible here, so no guard is needed
+    result = transformBody(g, idgen, prc, getBody(g, prc))
+
 proc transformStmt*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode): PNode =
   if nfTransf in n.flags:
     result = n

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1314,9 +1314,7 @@ proc transformBody*(g: ModuleGraph; idgen: IdGenerator; prc: PSym; cache: bool):
     prc.transformedBody = newNode(nkEmpty) # protects from recursion
     result = transformBody(g, idgen, prc, getBody(g, prc))
 
-    if cache or prc.typ.callConv == ccInline:
-      # genProc for inline procs will be called multiple times from different modules,
-      # it is important to transform exactly once to get sym ids and locations right
+    if cache:
       prc.transformedBody = result
     else:
       prc.transformedBody = nil

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -65,6 +65,17 @@ iterator pairs*[K, V](m: SeqMap[K, V]): (K, lent V) =
       yield (K(i), m.data[i])
     inc i
 
+iterator mpairs*[K, V](m: var SeqMap[K, V]): (K, var V) =
+  ## Returns, in an unspecified order, the key and value for each entry in the
+  ## map `m`.
+  mixin isFilled
+  var i = 0
+  let L = m.data.len
+  while i < L:
+    if isFilled(m.data[i]):
+      yield (K(i), m.data[i])
+    inc i
+
 # ---------- Store API ------------
 
 template `[]`*[I; T](x: Store[I, T], i: I): untyped =
@@ -75,6 +86,26 @@ template `[]=`*[I; T](x: var Store[I, T], i: I, it: T): untyped =
   ## Overwrites the item corresponding to `i` with `it`
   # TODO: convert to ``distinctBase`` instead
   x.data[int(i)] = it
+
+iterator items*[I, T](x: Store[I, T]): lent T =
+  ## Iterates over and returns all items in `x`
+  var i = 0
+  let L = x.data.len
+  while i < L:
+    yield x.data[i]
+    inc i
+
+iterator pairs*[I, T](x: Store[I, T]): (I, lent T) =
+  ## Iterates over and returns all items in `x` together with their
+  ## corresponding IDs
+  var i = 0
+  let L = x.data.len
+  while i < L:
+    # there's no need to perform a range check here: ``add`` already errors
+    # when trying to add items for which the index can't be represented with
+    # ``I``
+    yield (I(i), x.data[i])
+    inc i
 
 func add*[I; T](x: var Store[I, T], it: sink T): I {.inline.} =
   ## Appends a new item to the Store and returns the ID assigned to

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -66,8 +66,8 @@ iterator pairs*[K, V](m: SeqMap[K, V]): (K, lent V) =
     inc i
 
 iterator mpairs*[K, V](m: var SeqMap[K, V]): (K, var V) =
-  ## Returns, in an unspecified order, the key and value for each entry in the
-  ## map `m`.
+  ## Returns, in an unspecified order, the key and mutable value for each entry
+  ## in the map `m`.
   mixin isFilled
   var i = 0
   let L = m.data.len
@@ -115,6 +115,7 @@ func add*[I; T](x: var Store[I, T], it: sink T): I {.inline.} =
   result = I(x.data.high)
 
 iterator mitems*[I; T](x: var Store[I, T]): var T =
+  ## Yields a mutable item for each entry in `x`.
   var i = 0
   let L = x.data.len
   while i < L:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3109,8 +3109,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
   of nkLetSection, nkVarSection:
     unused(c, n, dest)
     genVarSection(c, n)
-  of declarativeDefs:
-    unused(c, n, dest)
   of nkChckRangeF, nkChckRange64, nkChckRange:
     let tmp0 = c.genx(n[0])
     # XXX: range checks currently always happen, even if disabled by the user.
@@ -3154,7 +3152,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
       genCastIntFloat(c, n, dest)
   of nkType:
     genTypeLit(c, n.typ, dest)
-  of nkConstSection, nkPragma, nkAsmStmt:
+  of nkPragma, nkAsmStmt:
     unused(c, n, dest)
   of nkWithSons + nkWithoutSons - codegenExprNodeKinds:
     fail(n.info, vmGenDiagCannotGenerateCode, n)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -96,8 +96,8 @@ const
     ## the set of types that are not relevant to the VM. ``tyTypeDesc``, while
     ## not relevant right now, is likely going to be in the future.
 
-  MagicsToKeep = {mNone, mIsolate, mNHint, mNWarning, mNError, mMinI, mMaxI,
-                  mAbsI, mDotDot}
+  MagicsToKeep* = {mNone, mIsolate, mNHint, mNWarning, mNError, mMinI, mMaxI,
+                   mAbsI, mDotDot}
     ## the set of magics that are kept as normal procedure calls and thus need
     ## an entry in the function table. For convenience, the ``mNone`` magic is
     ## also included

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -56,6 +56,9 @@ func selectOptions(c: TCtx): set[GenOption] =
   if cgfAllowMeta in c.flags:
     result.incl goGenTypeExpr
 
+  if c.mode in {emConst, emOptimize, emStaticExpr, emStaticStmt}:
+    result.incl goIsCompileTime
+
 func setupLinkState(c: var TCtx) =
   c.linkState.newProcs.setLen(0)
   c.linkState.newGlobals.setLen(0)

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -30,11 +30,15 @@ copying
 123
 42
 closed
-destroying variable: 20
 destroying variable: 10
+destroying variable: 20
 '''
   cmd: "nim c --gc:arc --deepcopy:on -d:nimAllocPagesViaMalloc $file"
 """
+
+# XXX: the test currently depends on the order in which `{.globals.}` are
+#      destroyed, but this order is unspecified, and the compiler is free
+#      to destroy them in any order
 
 proc takeSink(x: sink string): bool = true
 

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -235,6 +235,10 @@ proc main =
   echo five.left.value
   echo five.right.value
 
+# make sure that the expandArc output has the expected order by directly
+# referencing ``delete`` here
+let _ = topt_no_cursor.delete
+
 main()
 
 type
@@ -252,6 +256,8 @@ proc p1(): Maybe =
 proc tissue15130 =
   doAssert p1().value == @[123]
 
+let _ = topt_no_cursor.p1
+
 tissue15130()
 
 type
@@ -268,6 +274,8 @@ proc encodedQuery =
 
   for elem in query:
     elem.tt()
+
+let _ = topt_no_cursor.tt
 
 encodedQuery()
 

--- a/tests/global/tglobal.nim
+++ b/tests/global/tglobal.nim
@@ -2,13 +2,9 @@ discard """
   description: '''
     Tests for globals defined inside procedures via the `.global.` pragma
   '''
-  targets: "c !js vm"
+  targets: "c js vm"
   output: "in globalaux2: 10\ntotal globals: 2\nint value: 100\nstring value: second"
 """
-
-## knownIssue: when using the JS backend, globals defined inside procedures are
-##             initialized when executing their owning procedures, instead of
-##             during the module's pre-init phase
 
 import globalaux, globalaux2
 

--- a/tests/global/tglobal2.nim
+++ b/tests/global/tglobal2.nim
@@ -1,3 +1,8 @@
+discard """
+  targets: "c js vm"
+  description: "Additional tests for lifted globals"
+"""
+
 block global:
   proc getState(): int =
     var state0 {.global.}: int

--- a/tests/global/tlifted_global_in_inline_iterator.nim
+++ b/tests/global/tlifted_global_in_inline_iterator.nim
@@ -1,7 +1,7 @@
 discard """
   targets: "c js vm"
   description: '''
-    Tests to make sure that lifted globals defined inside inline iterators work
+    Ensure lifted globals defined inside inline iterators work
   '''
 """
 
@@ -25,5 +25,5 @@ let (val, address) = test1()
 doAssert val == 2
 
 # invoking the iterator again must not reset the global to its initial
-# value
+# value, nor move the global (same address)
 doAssert test2() == (3, address)

--- a/tests/global/tlifted_global_in_inline_iterator.nim
+++ b/tests/global/tlifted_global_in_inline_iterator.nim
@@ -1,0 +1,29 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Tests to make sure that lifted globals defined inside inline iterators work
+  '''
+"""
+
+iterator iter(): (int, ptr int) =
+  var global {.global.} = 1
+  inc global
+  yield (global, addr global)
+
+# use the iterator in two separate procedures and check that the accessed
+# global is the same in both
+
+proc test1(): (int, ptr int) =
+  for r in iter():
+    return r
+
+proc test2(): (int, ptr int) =
+  for r in iter():
+    return r
+
+let (val, address) = test1()
+doAssert val == 2
+
+# invoking the iterator again must not reset the global to its initial
+# value
+doAssert test2() == (3, address)

--- a/tests/global/tlifted_global_in_loop_body.nim
+++ b/tests/global/tlifted_global_in_loop_body.nim
@@ -1,0 +1,49 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Tests for globals defined inside for-loop bodies via the `.global` pragma
+  '''
+"""
+
+block single_yield:
+  # test with an inline iterator containing a single yield statement (so no
+  # duplication of the body takes place)
+
+  iterator iter(): int {.inline.} =
+    yield 1
+
+  proc test(): int =
+    for _ in iter():
+      var g {.global.} = 1
+      inc g
+      result = g
+
+  doAssert test() == 2
+  # verify that the global's value persists across calls:
+  doAssert test() == 3
+
+block multi_yield:
+  # test with an inline iteratong that has multiple yield statements
+
+  iterator iter(): int {.inline.} =
+    yield 1
+    yield 2
+    yield 3
+
+  proc test() =
+    var a: ptr int = nil
+
+    for i in iter():
+      var g {.global.} = 1
+      inc g
+
+      # verfiy that the value persists:
+      doAssert g == 1 + i, $g
+
+      if a == nil:
+        a = addr g # remember the address
+      else:
+        # verify that it really is the same location:
+        doAssert a == addr g
+
+  test()

--- a/tests/global/tlifted_global_in_loop_body.nim
+++ b/tests/global/tlifted_global_in_loop_body.nim
@@ -23,7 +23,7 @@ block single_yield:
   doAssert test() == 3
 
 block multi_yield:
-  # test with an inline iteratong that has multiple yield statements
+  # test with an inline iterator that has multiple yield statements
 
   iterator iter(): int {.inline.} =
     yield 1

--- a/tests/lang/s05_pragmas/s01_interop/t03_exported_constants.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t03_exported_constants.nim
@@ -1,0 +1,10 @@
+discard """
+  targets: "c"
+  description: '''
+    Constants marked with the `exportc` pragma are always emitted, even if
+    not used anywhere in the |NimSkull| code
+  '''
+  ccodecheck: "theConst"
+"""
+
+const theConst {.exportc.} = 1

--- a/tests/lang_callable/generics/tvarseq_caching.nim
+++ b/tests/lang_callable/generics/tvarseq_caching.nim
@@ -1,5 +1,4 @@
 discard """
-  target: "!vm"
   output: '''@[1, 2, 3]
 @[4.0, 5.0, 6.0]
 @[1, 2, 3]
@@ -7,8 +6,6 @@ discard """
 @[1, 2, 3]
 @[4, 5, 6]'''
 """
-
-# disabled on VM: SIGSEGVs; needs a deeper dive (knownIssue)
 
 # bug #3476
 

--- a/tests/lang_objects/destructor/tdestructor_in_initializer.nim
+++ b/tests/lang_objects/destructor/tdestructor_in_initializer.nim
@@ -3,17 +3,16 @@ discard """
     Regression test to make sure that locals inside the initializer of a global
     defined inside a procedure's body are properly destroyed
   '''
-  targets: "c"
-  knownIssue: "the `injectdestructors` pass is not invoked for the initializer"
+  targets: "c js vm"
 """
 
-var wasDestroyed: bool
-# don't initialize the global; doing so might override the value assgined
+var wasDestroyed {.noInit.}: bool
+# don't initialize the global; doing so would override the value assgined
 # during pre-initialization
 
-# initialization of ``.global.``s currently happens *before* the code part
-# of the module is executed, so if the destructor was called, ``wasDestroyed``
-# has to be true here
+# initialization of ``.global.``s happens *before* the module's top-level
+# code is run, so if the destructor was called, ``wasDestroyed`` has to be
+# 'true' here
 doAssert wasDestroyed
 
 type Resource = object
@@ -25,5 +24,6 @@ proc prc() =
   var v {.global.} = block:
     var r = Resource() # `r` needs to be destroyed at the end of the block
     1
+  doAssert v == 1
 
 prc() # use the procedure so that the global is part of the alive code


### PR DESCRIPTION
## Summary

Introduce a unified backend processing pipeline (the `process` iterator)
based on the implementation of the `vmbackend` module, and integrate it
into all three code generation orchestrators.

Discovery of alive entities (which automatically includes dead-code
elimination), applying transformations, and various other backend-
agnostic processing are now all implemented via a single, shared
implementation, making them much easier to maintain and adjust.

As a side-effect of the reworked lifted global (globals defined in
procedure via the `.global` pragma) handling, multiple issues and bugs
with them are fixed:
- initialization and destruction order for them is the same across all
  backends
- JavaScript backend: lifted global use the pre-init mechanism for
  lifted globals now, meaning that they are initialized during the
  attached-to module's pre-init phase, instead of when control-flow
  first reaches the `var|let` statement
- names of both normal and lifted globals defined inside a for-loop
  always refer to the same location now, regardless of whether the used
  inline iterator contains multiple `yield` statement
- the name of a lifted global defined inside an `.inline` iterator
  always refers to the exact same location across all usages of the
  iterator (each inlined occurrence got its own copy, previously)
- locals defined in the initializer expression of lifted globals are now
  considered by the move analyser and destructor injection. For example,
  the `s` in `var g {.global.} = (block: (var s = @[...]; 1)) ` is
  now destroyed

In addition:
- constants marked with `exportc` are now always included in the
  generated code, even when not explicitly used
- a regression with `--header` not including the prototypes of
  exportc'ed globals is fixed
- the VM backend doesn't generate code for `.compileTime` globals
  anymore
- custom `.dynlib` procedure loading logic is run during the data-init
  phase of a module, instead of as part of the module-init procedure

## Details

The key changes are:
- the code generators don't implement discovery of alive entities
  anymore
- discovery of alive procedures now uses an *iterative* approach instead
  of a *recursive* one for the C and JS backends (the VM backend already
  did)
- the code generators are passed the fully transformed AST as input
- emitting the definition code for globals is now fully the
  responsibility of the orchestrators
- the module destructor produced by `modulelowering` is no longer
  modified in the backend
- destruction of lifted globals happens in the new "post-destructor"
  module-bound operator
- calls to the pre-init and post-destructor operators are now directly
  emitted into the main procedure
- the orchestrators no longer directly call `generateMethodDispatcher`
- locations marked with `.global` are consistently treated as lifted
  globals (even top-level locations) across the backends

In addition, the module-init procedure is now named the same as the
module it belongs to and longer has an "Init" postfix. This gets around
having to introduce a special case for the init procedure in the C code
generator, now that it treats the module-init procedure like a normal
procedure.

### The `process` iterator

At the center of the additions is the `process` inline iterator (which
represents the unified processing pipeline). It implements the discovery
of alive entities, preparing the procedures for code generation (by
invoking `transf` and applying the MIR passes), generating method
dispatchers, and lifting the pre-init and post-destructor operators.

Whenever interaction with the caller is required, the iterator produces
(yields) an event that contains the information necessary for the caller
to act on it. The caller (the orchestrators) then, if necessary, pre-
processes the newly discovered entities and, if the event is about code
becoming available, invokes the code generator. Newly discovered
entities are communicated through the `DiscoverData` structure that both
the iterator and caller have access to.

The iterator's implementation and design is complicated by two things:
late dependencies and (to a lesser degree) first-seen-in-module
tracking.

#### Late Dependencies

A late dependency of a procedure (or code fragment in general) is a
reference to some procedure that is not visible by scanning the MIR
representation. They occur when a code generator emits a call to a
`.compilerproc`. The general goal is to remove raising late dependencies
from `cgen` and `jsgen`, but until then, the `process` iterator has to
support the case where the caller registers new procedures with
`DiscoverData`.

#### First-seen-in-module Tracking

For the inline procedure handling of the C backend to work, it needs to
know about at least one module an inline procedure is used in. The
first-seen-in-module is used for this, but the unified processing
pipeline has to track it.

### `cgen` and `cbackend`

The key changes / important things to note are:
- emitting procedures into the correct C file section is now done by the
  orchestrator
- inline procedures are now only transformed a single time (if used),
  instead of once for each module they're used in
- header file generation (when using the `--header` option) is fully
  managed by the orchestrator
- pre-init procedure generation and everything related to lifted
  globals is removed from the code generator
- `.dynlib` procedure handling is still mostly handled by the code
  generator
- all dedicated module-init procedure is removed; they are, for the
  largest part, treated as normal procedures now
- all dedicated top-level statement processing is removed from the code
  generator

Other changes and internal restructurings:
- introduce the internal `sfTopLevel` flag and use it to: emit a
  `nimTestErrorFlag` call at the exit of a flagged procedure,
  special casing of `emit` and `asm` statements
- split `genProcAux` into `startProc` and `finishProc`
- move code generation logic for the temporary `TNimNode` storage into
  `genDatInitCode` and remove `genInitCode`
- remove support for alive information provided by `dce.nim`, as the
  code generator is not responsible anymore for deciding which
  procedures need to be processed

Making sure that a duplicate of an inline procedure is emitted into each
C file the procedure is used in doesn't happen automatically anymore and
thus requires special support by the orchestrator.

### `jsgen` and `jsbackend`

- split `genProc` into `startProc` and `finishProc`
- integrate and adjust to the `process` iterator
- remove the DCE related bits from `jsgen`

### `vmbackend`

- integrate and adjust to the `process` iterator
- remove the now-obsolete types and procedures

Constants now use the sequence provided by `DiscoverData`, removing a
usage of the `vmdef.LinkState` type from `vmbackend`.

### `transf` and MIR processing

- introduce a dedicated `goIsCompileTime` option for `mirgen`, so that
  definitions of `.compileTime` globals can be properly ignored when
  using the VM backend 
- remove the workarounds related to lifted globals from the `mirbridge`
  and `injectdestructors` modules
- the transformed body of `.inline` procedures is no longer
  unconditionally cached

With the last bits of the new-style DCE (the one implemented by the
`dce` module) support removed from `cgen`, two MIR simplification are
possible:
- `nkConstSection` are discarded by `mirgen`
- the `def` for a procedure doesn't carry the procdef anymore

#### Duplicated Globals

There was a problem regarding globals in `transf`. When introducing
fresh symbols in the context of iterator inlining, globals were also
copied. While that did work previously, it no longer can, as the whole
backend processing now expects all module-level globals to be known
prior to `transf`.

Keeping the original symbol is possible for to-be-lifted globals
(duplicate definitions of those are filtered out by
`produceFragmentsForGlobals`), but not for module-level globals, as the
`injectdestructors` pass requires the latter to have only a single
definition. Therefore, module-level globals are still copied, but
they're now associated with the original symbol, and the
`rewriteGlobalDefs` procedure uses this information to restore the
original symbols after the `injectdestructors` has run.

This also fixes the pre-existing bug where the name of a global defined
inside a for-loop body referred to different locations when the for-
loop body was duplicated (due to inline iterators with multiple
`yield` statements).

### Other

- don't place module-level globals in a module's struct, and reparent
  them to the module's init procedure -- this makes them appear as
  lifted globals to `transf.extractGlobals` (what to do with them was
  previously up to the used code generator) 
- remove the `ModuleGraph.globalDestructors` list and usages thereof;
  the unified backend processing renders it obsolete

### Misc

- implement the `merge` operation for the `Store` container type
- implement the `append` operation for `SourceMap`
- add new iterators for the `SeqMap` and `Store` types