### PR TITLE
internal refactor: slim `sem` module

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -11,7 +11,8 @@ import
     ast_types  # Main ast type definitions
   ],
   compiler/utils/[
-    int128 # Values for integer nodes
+    int128,    # Values for integer nodes
+    idioms,    # `unreachable`
   ]
 
 const
@@ -144,6 +145,23 @@ proc getPIdent*(a: PNode): PIdent {.inline.} =
   of nkSym: a.sym.name
   of nkIdent: a.ident
   else: nil
+
+proc getIdentLineInfo*(n: PNode): TLineInfo =
+  ## Returns the line information of the identifier-like node in the
+  ## (semantically valid) AST `n` appearing in a name slot.
+  var n {.cursor.} = n
+  # unpack the node until we reach the identifier or symbol
+  if n.kind == nkPragmaExpr:
+    n = n[0]
+  if n.kind == nkPostfix:
+    n = n[1]
+  if n.kind == nkAccQuoted:
+    n = n[0]
+
+  result =
+    case n.kind
+    of nkIdent, nkSym: n.info
+    else:              unreachable(n.kind)
 
 proc getnimblePkg*(a: PSym): PSym =
   result = a

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -489,8 +489,6 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym
 
-proc getIdentLineInfo(n: PNode): TLineInfo
-
 proc typeAllowedCheck(c: PContext; info: TLineInfo; typ: PType; kind: TSymKind;
                       flags: TTypeAllowedFlags = {}) =
   let t = typeAllowed(typ, kind, c, flags)

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -204,7 +204,6 @@ proc fitNode(c: PContext, formal: PType, arg: PNode; info: TLineInfo): PNode =
 
   if arg.typ.isNil:
     c.config.localReport(arg.info, reportAst(rsemExpressionHasNoType, arg))
-
     # error correction:
     result = copyTree(arg)
     result.typ = formal

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -518,16 +518,6 @@ proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
 proc semMacroExpr(c: PContext, n: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode
 
-proc symFromType(c: PContext; t: PType, info: TLineInfo): PSym =
-  if t.sym != nil: return t.sym
-  result = newSym(skType, getIdent(c.cache, "AnonType"), nextSymId c.idgen, t.owner, info)
-  result.flags.incl sfAnon
-  result.typ = t
-
-proc symNodeFromType(c: PContext, t: PType, info: TLineInfo): PNode =
-  result = newSymNode(symFromType(c, t, info), info)
-  result.typ = makeTypeDesc(c, t)
-
 proc hasCycle(n: PNode): bool =
   # xxx: this isn't used, we should consider reinstating this?
   incl n.flags, nfNone

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -650,16 +650,6 @@ when not defined(nimHasSinkInference):
 
 include hlo, seminst, semcall
 
-proc resetSemFlag(n: PNode) =
-  if n != nil:
-    excl n.flags, nfSem
-    case n.kind
-    of nkError:
-      discard
-    else:
-      for i in 0..<n.safeLen:
-        resetSemFlag(n[i])
-
 proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
                        s: PSym, flags: TExprFlags): PNode =
   ## Semantically check the output of a macro.
@@ -668,6 +658,17 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
   ## reassigned, and binding the unbound identifiers that the macro output
   ## contains.
   c.config.addInNimDebugUtils("semAfterMacroCall", s, macroResult, result)
+
+  proc resetSemFlag(n: PNode) =
+    if n != nil:
+      excl n.flags, nfSem
+      case n.kind
+      of nkError:
+        discard
+      else:
+        for i in 0..<n.safeLen:
+          resetSemFlag(n[i])
+
   inc(c.config.evalTemplateCounter)
   if c.config.evalTemplateCounter > evalTemplateLimit:
     globalReport(c.config, s.info, SemReport(kind: rsemTemplateInstantiationTooNested))

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -188,7 +188,7 @@ proc fitNodePostMatch(c: PContext, formal: PType, arg: PNode): PNode =
   if (x.kind == nkCurly and formal.kind == tySet and formal.base.kind != tyGenericParam) or
     (x.kind in {nkPar, nkTupleConstr}) and formal.kind notin {tyUntyped, tyBuiltInTypeClass}:
     x = changeType(c, x, formal, check=true)
-    
+
     if x.isError:
       result = c.config.wrapError(a)
       return

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -529,6 +529,7 @@ proc symNodeFromType(c: PContext, t: PType, info: TLineInfo): PNode =
   result.typ = makeTypeDesc(c, t)
 
 proc hasCycle(n: PNode): bool =
+  # xxx: this isn't used, we should consider reinstating this?
   incl n.flags, nfNone
   for i in 0..<n.safeLen:
     if nfNone in n[i].flags or hasCycle(n[i]):

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -635,7 +635,7 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
   ## contains.
   c.config.addInNimDebugUtils("semAfterMacroCall", s, macroResult, result)
 
-  proc resetSemFlag(n: PNode) =
+  proc resetSemFlag(n: PNode) {.nimcall.} =
     if n != nil:
       excl n.flags, nfSem
       case n.kind

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -778,7 +778,7 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
           return true
     else: discard
 
-  proc isEmptyTree(n: PNode): bool =
+  proc isEmptyTree(n: PNode): bool {.nimcall.} =
     ## true if `n` is empty that shouldn't count as a top level statement
     case n.kind
     of nkStmtList:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -537,28 +537,6 @@ proc hasCycle(n: PNode): bool =
       break
   excl n.flags, nfNone
 
-proc fixupTypeAfterEval(c: PContext, evaluated, eOrig: PNode): PNode =
-  # recompute the types as 'eval' isn't guaranteed to construct types nor
-  # that the types are sound:
-  # XXX: `fixupTypeAfterEval` is not really needed anymore
-  when true:
-    if eOrig.typ.kind in {tyUntyped, tyTyped, tyTypeDesc}:
-      # XXX: is this case still used now?
-      result = semExprWithType(c, evaluated)
-    else:
-      result = evaluated
-  else:
-    result = semExprWithType(c, evaluated)
-    #result = fitNode(c, e.typ, result) inlined with special case:
-    let arg = result
-    result = indexTypesMatch(c, eOrig.typ, arg.typ, arg)
-    if result == nil:
-      result = arg
-      # for 'tcnstseq' we support [] to become 'seq'
-      if eOrig.typ.skipTypes(abstractInst).kind == tySequence and
-         isArrayConstr(arg):
-        arg.typ = eOrig.typ
-
 proc tryConstExpr(c: PContext, n: PNode): PNode =
   addInNimDebugUtils(c.config, "tryConstExpr", n, result)
   let e = semExprWithType(c, n)

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -139,9 +139,6 @@ proc semTypeOf(c: PContext; n: PNode): PNode
 proc computeRequiresInit(c: PContext, t: PType): bool
 proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode
 proc hasUnresolvedArgs(c: PContext, n: PNode): bool
-proc isArrayConstr(n: PNode): bool {.inline.} =
-  result = n.kind == nkBracket and
-    n.typ.skipTypes(abstractInst).kind == tyArray
 
 proc wrapErrorAndUpdate(c: ConfigRef, n: PNode, s: PSym): PNode =
   ## Wraps the erroneous AST `n` in an error node, sets it as the AST of `s`,

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -621,20 +621,6 @@ proc semRealConstExpr(c: PContext, n: PNode): PNode =
   if result.kind != nkError:
     result = evalConstExpr(c, result)
 
-proc semExprFlagDispatched(c: PContext, n: PNode, flags: TExprFlags): PNode =
-  if efNeedStatic in flags:
-    if efPreferNilResult in flags:
-      return tryConstExpr(c, n)
-    else:
-      return semConstExpr(c, n)
-  else:
-    result = semExprWithType(c, n, flags)
-    if efPreferStatic in flags:
-      var evaluated = getConstExpr(c.module, result, c.idgen, c.graph)
-      if evaluated != nil: return evaluated
-      evaluated = evalAtCompileTime(c, result)
-      if evaluated != nil: return evaluated
-
 when not defined(nimHasSinkInference):
   {.pragma: nosinks.}
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -488,14 +488,16 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym
 
-proc typeAllowedCheck(c: PContext; info: TLineInfo; typ: PType; kind: TSymKind;
-                      flags: TTypeAllowedFlags = {}) =
-  let t = typeAllowed(typ, kind, c, flags)
+proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
+  let
+    kind = skProc
+    t = typeAllowed(typ, kind, c)
+    info = typ.n.info
   if t != nil:
     # var err: string
     # if t == typ:
     #   err = "invalid type: '$1' for $2" % [typeToString(typ), toHumanStr(kind)]
-    #   if kind in {skVar, skLet, skConst} and taIsTemplateOrMacro in flags:
+    #   if kind in {skVar, skLet, skConst}:
     #     err &= ". Did you mean to call the $1 with '()'?" % [toHumanStr(typ.owner.kind)]
     # else:
     #   err = "invalid type: '$1' in this context: '$2' for $3" % [typeToString(t),
@@ -507,10 +509,7 @@ proc typeAllowedCheck(c: PContext; info: TLineInfo; typ: PType; kind: TSymKind;
         allowed: t,
         actual: typ,
         kind: kind,
-        allowedFlags: flags)))
-
-proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
-  typeAllowedCheck(c, typ.n.info, typ, skProc)
+        allowedFlags: {})))
 
 proc semDirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode
 proc semWhen(c: PContext, n: PNode, semCheck: bool = true): PNode

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -761,7 +761,7 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   ## program compilation.
   addInNimDebugUtils(c.config, "semStmtAndGenerateGenerics", n, result)
 
-  proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool =
+  proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool {.nimcall.} =
     ## true if `n` is an import statement referring to the system module
     if g.systemModule == nil: return false
     case n.kind

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2089,7 +2089,9 @@ proc semSubscript(c: PContext, n: PNode, flags: TExprFlags): PNode =
           of skTemplate: result = semTemplateExpr(c, n, s, flags)
           else: discard
       of skType:
-        result = symNodeFromType(c, semTypeNode(c, n, nil), n.info)
+        let t = semTypeNode(c, n, nil)
+        result = newSymNode(symFromType(c, t, n.info), n.info)
+        result.typ = makeTypeDesc(c, t)
       else:
         discard
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -838,7 +838,7 @@ proc isArrayConstr(n: PNode): bool {.inline.} =
 
 proc fixAbstractType(c: PContext, n: PNode): PNode =
   assert n != nil
-  
+
   var hasError = false
 
   result = n

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -833,6 +833,9 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
     if hasError:
       result = c.config.wrapError(result)
 
+proc isArrayConstr(n: PNode): bool {.inline.} =
+  n.kind == nkBracket and n.typ.skipTypes(abstractInst).kind == tyArray
+
 proc fixAbstractType(c: PContext, n: PNode): PNode =
   assert n != nil
   

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -329,23 +329,6 @@ proc identWithin(n: PNode, s: PIdent): bool =
     if identWithin(n[i], s): return true
   result = n.kind == nkSym and n.sym.name.id == s.id
 
-proc getIdentLineInfo(n: PNode): TLineInfo =
-  ## Returns the line information of the identifier-like node in the
-  ## (semantically valid) AST `n` appearing in a name slot.
-  var n {.cursor.} = n
-  # unpack the node until we reach the identifier or symbol
-  if n.kind == nkPragmaExpr:
-    n = n[0]
-  if n.kind == nkPostfix:
-    n = n[1]
-  if n.kind == nkAccQuoted:
-    n = n[0]
-
-  result =
-    case n.kind
-    of nkIdent, nkSym: n.info
-    else:              unreachable(n.kind)
-
 proc semIdentDef(c: PContext, n: PNode, kind: TSymKind): PSym =
   addInNimDebugUtils(c.config, "semIdentDef", n, result)
   if isTopLevel(c):

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1856,6 +1856,12 @@ proc semProcTypeWithScope(c: PContext, n: PNode,
     when useEffectSystem: setEffectsForProcType(c.graph, result, n[1])
   closeScope(c)
 
+proc symFromType(c: PContext; t: PType, info: TLineInfo): PSym =
+  if t.sym != nil: return t.sym
+  result = newSym(skType, getIdent(c.cache, "AnonType"), nextSymId c.idgen, t.owner, info)
+  result.flags.incl sfAnon
+  result.typ = t
+
 proc symFromExpectedTypeNode(c: PContext, n: PNode): PSym =
   if n.kind == nkType:
     result = symFromType(c, n.typ, n.info)


### PR DESCRIPTION
## Summary

Clean-up the `sem` module, dropping deadcode, moving single use exported
procedures to the use sites, and making one off procedures inner procs.
This is a small step, of many, to reduce dependencies between modules
and public surface area.

## Details

Changes:
- moved `getIdentLineInfo` into `ast_query`
- `isArrayConstr` was only used in `semexprs`, moved there
- `semExprFlagDispatched` move into `semobjconstr`, only user
- move `symFromTyp` to `semtypes`
- dropped `semNodeFromType` as inline in single usage in `semexprs`
- collapsed `typeAllowedCheck` into `paramsTypeCheck

Made inner procs, as they're one offs:
- `resetSemFlag` into `semAfterMacroCall`
- `isImportSystemStmt` & `isEmptyTree` into `semStmtAndGenerateGenerics`