### PR TITLE
remove the `.dynlib` "extension loader" feature

### DIFF
--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -177,8 +177,6 @@ type
     typeNodes*, nimTypes*: int ## used for type info generation
     typeNodesName*, nimTypesName*: Rope ## used for type info generation
     labels*: Natural          ## for generating unique module-scope names
-    extensionLoaders*: array['0'..'9', Rope] ## special procs for the
-                                             ## OpenGL wrapper
     sigConflicts*: CountTable[SigHash]
     g*: BModuleList
     ndi*: NdiFile


### PR DESCRIPTION
## Summary

When using a call like `getProcAddr(x)` as the expression
with the `.dynlib` pragma on a procedure, where `x` is a 1-sized
string literal with the single item being a numeric character,
executing the call and assigning its result to the correct global was
emitted into a procedure named `nimLoadProcsX` (where X is the number
from the string literal) that could then be manually called.

The feature was introduced to improve extension loading for the Nim
OpenGL wrapper, but it was never documented, and its existence now
complicates moving more code generator logic into the unified backend
processing pipeline.

## Details

This reverts commit https://github.com/nim-works/nimskull/commit/cf06131decb2d46304874bd243c29267876e0076.