### PR TITLE
testament: fix `--tryfailing` not working with `all`

### DIFF
--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -1391,6 +1391,8 @@ proc main() =
         myself &= " " & quoteShell("--failing")
       if retryContainer.retry:
         myself &= " " & quoteShell("--retry")
+      if runKnownIssues:
+        myself &= " " & quoteShell("--tryfailing")
       if targetsStr.len > 0:
         myself &= " " & quoteShell("--targets:" & targetsStr)
       myself &= " " & quoteShell("--nim:" & compilerPrefix)


### PR DESCRIPTION
## Summary

The `--tryfailing` option wasn't passed on to the `testament` processes
spawned when using `all`, meaning that the option had no effect there.