### PR TITLE
sem: `typed` AST normalizes out `include` stmts

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -323,7 +323,6 @@ type
     rsemInvalidModuleName
     rsemCannotImportItself
     rsemRecursiveInclude
-    rsemRecursiveImport
     rsemCannotOpenFile
     rsemExportRequiresToplevel
     rsemExperimentalRequiresToplevel

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1675,9 +1675,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemCannotImportItself:
       result = "module '$1' cannot import itself" % r.symstr
 
-    of rsemRecursiveImport:
-      result = "recursive dependency: '$1'" % r.str
-
     of rsemCannotOpenFile:
       result = "cannot open '$1'" % r.str
 

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1891,10 +1891,8 @@ proc checkCovariantParamsUsages(c: PContext; genericType: PType) =
       if result:
         c.config.localReport(genericType.sym.info, reportTyp(
           rsemExpectedInvariantParam, t))
-
     of tySequence:
       return traverseSubTypes(c, t[0])
-
     of tyGenericInvocation:
       let targetBody = t[0]
       for i in 1..<t.len:
@@ -1905,7 +1903,6 @@ proc checkCovariantParamsUsages(c: PContext; genericType: PType) =
             if tfCovariant notin formalFlags:
               c.config.localReport(genericType.sym.info, reportSym(
                 rsemCovariantUsedAsNonCovariant, param.sym))
-
             elif tfWeakCovariant in formalFlags:
               param.flags.incl tfWeakCovariant
             result = true
@@ -1914,31 +1911,25 @@ proc checkCovariantParamsUsages(c: PContext; genericType: PType) =
             if tfContravariant notin formalParam.typ.flags:
               c.config.localReport(genericType.sym.info, reportSym(
                 rsemContravariantUsedAsNonCovariant, param.sym))
-
             result = true
         else:
           subresult traverseSubTypes(c, param)
     of tyAnd, tyOr, tyNot, tyStatic, tyBuiltInTypeClass, tyCompositeTypeClass:
       c.config.localReport(genericType.sym.info, reportTyp(
         rsemNonInvariantCannotBeUsedWith, t))
-
     of tyUserTypeClass, tyUserTypeClassInst:
       c.config.localReport(genericType.sym.info, reportTyp(
         rsemNonInvariantCnnnotBeUsedInConcepts, t))
-
     of tyTuple:
       for fieldType in t.sons:
         subresult traverseSubTypes(c, fieldType)
     of tyPtr, tyRef, tyVar, tyLent:
       if t.base.kind == tyGenericParam: return true
       return traverseSubTypes(c, t.base)
-
     of tyDistinct, tyAlias, tySink:
       return traverseSubTypes(c, t.lastSon)
-
     of tyGenericInst:
       internalError(c.config, "???")
-
     else:
       discard
   discard traverseSubTypes(c, body)
@@ -2067,7 +2058,6 @@ proc checkForMetaFields(c: PContext; n: PNode) =
       if t.kind == tyBuiltInTypeClass and t.len == 1 and t[0].kind == tyProc:
         localReport(c.config, n.info, reportTyp(
           rsemProcIsNotAConcreteType, t))
-
       else:
         localReport(c.config, n.info, reportTyp(
           rsemTIsNotAConcreteType, t))
@@ -2138,14 +2128,13 @@ proc semAllTypeSections(c: PContext; n: PNode): PNode =
   proc gatherStmts(c: PContext; n: PNode; result: PNode) {.nimcall.} =
     case n.kind
     of nkIncludeStmt:
-      for i in 0 ..< n.len:
-        var f = checkModuleName(c.config, n[i])
+      for p in n.items:
+        let f = checkModuleName(c.config, p)
         if f != InvalidFileIdx:
           if containsOrIncl(c.includedFiles, f.int):
             localReport(c.config, n.info, reportAst(
               rsemRecursiveImport, n,
               str = toMsgFilename(c.config, f)))
-
           else:
             let code = c.graph.includeFileCallback(c.graph, c.module, f)
             gatherStmts c, code, result
@@ -2170,20 +2159,6 @@ proc semAllTypeSections(c: PContext; n: PNode): PNode =
 
   rec typeSectionRightSidePass
   rec typeSectionFinalPass
-  when false:
-    # too beautiful to delete:
-    template rec(name; setbit=false) =
-      proc `name rec`(c: PContext; n: PNode) {.nimcall.} =
-        if n.kind == nkTypeSection:
-          when setbit: incl n.flags, nfSem
-          name(c, n)
-        elif n.kind == nkStmtList:
-          for i in 0..<n.len:
-            `name rec`(c, n[i])
-      `name rec`(c, n)
-    rec typeSectionLeftSidePass, true
-    rec typeSectionRightSidePass
-    rec typeSectionFinalPass
 
 proc semTypeSection(c: PContext, n: PNode): PNode =
   ## Processes a type section. This must be done in separate passes, in order
@@ -2204,7 +2179,6 @@ proc addParams(c: PContext, n: PNode) =
   for i in 1..<n.len:
     if n[i].kind == nkSym:
       addParamOrResult(c, n[i].sym)
-
     else:
       semReportIllformedAst(c.config, n[i], {nkSym})
 
@@ -3187,39 +3161,30 @@ proc semRoutineDef(c: PContext, n: PNode): PNode =
     of skMacro:     semMacroDef(c, result)
     else:           unreachable(kind)
 
-
-proc incMod(c: PContext, n: PNode, it: PNode, includeStmtResult: PNode) =
-  var f = checkModuleName(c.config, it)
-  if f != InvalidFileIdx:
-    addIncludeFileDep(c, f)
-    onProcessing(c.graph, f, "include", c.module)
-    if containsOrIncl(c.includedFiles, f.int):
-      localReport(c.config, n.info, reportStr(
-        rsemRecursiveInclude, toMsgFilename(c.config, f)))
-
-    else:
-      includeStmtResult.add semStmt(
-        c, c.graph.includeFileCallback(c.graph, c.module, f), {})
-
-      excl(c.includedFiles, f.int)
-
 proc evalInclude(c: PContext, n: PNode): PNode =
+  proc incMod(c: PContext, n, it, includeStmtResult: PNode) {.nimcall.} =
+    let f = checkModuleName(c.config, it)
+    if f != InvalidFileIdx:
+      addIncludeFileDep(c, f)
+      onProcessing(c.graph, f, "include", c.module)
+      if containsOrIncl(c.includedFiles, f.int):
+        localReport(c.config, n.info, reportStr(
+          rsemRecursiveInclude, toMsgFilename(c.config, f)))
+      else:
+        includeStmtResult.add:
+          semStmt(c, c.graph.includeFileCallback(c.graph, c.module, f), {})
+        excl(c.includedFiles, f.int)
+
   result = newNodeI(nkStmtList, n.info)
-  result.add n
-  for i in 0..<n.len:
-    var imp: PNode
-    let it = n[i]
+  for it in n.items:
     if it.kind == nkInfix and it.len == 3 and it[0].ident.s != "/":
       localReport(c.config, it.info, reportAst(
         rsemUnexpectedInfixInInclude, it, str = it[0].ident.s))
-
     if it.kind == nkInfix and it.len == 3 and it[2].kind == nkBracket:
-      let sep = it[0]
-      let dir = it[1]
-      imp = newNodeI(nkInfix, it.info)
-      imp.add sep
-      imp.add dir
-      imp.add sep # dummy entry, replaced in the loop
+      let imp = shallowCopy(it)
+        ## normalized include path, reused to process each import
+      imp[0] = it[0] # separator
+      imp[1] = it[1] # path
       for x in it[2]:
         imp[2] = x
         incMod(c, n, imp, result)

--- a/tests/lang_meta/readme.md
+++ b/tests/lang_meta/readme.md
@@ -1,0 +1,4 @@
+Tests for the meta-programming aspects of the language:
+- routines: templates and macros
+- types: `typed` and `untyped`
+- misc: `include` and term-rewriting

--- a/tests/lang_meta/typed/mbar.nim
+++ b/tests/lang_meta/typed/mbar.nim
@@ -1,0 +1,1 @@
+proc thingy() = discard

--- a/tests/lang_meta/typed/tinclude_only_processed_once.nim
+++ b/tests/lang_meta/typed/tinclude_only_processed_once.nim
@@ -1,0 +1,32 @@
+discard """
+  action: compile
+  description: '''include statements are dropped from `typed` so they're only
+                  processed once'''
+"""
+
+import std/macros
+
+# xxx: ideally we don't need to drop them, instead the typing of the parameter
+#      shouldn't pollute the callsite, followed by re-evaluation of the
+#      untrusted macro output being analysed yet again (if the untrusted AST
+#      contains the `include`, it'll be evaluated twice and produce a
+#      redefinition error).
+
+block:
+  macro bob(n: typed) =
+    doAssert n.kind != nnkIncludeStmt
+    n
+
+  bob:
+    include mbar
+
+block:
+  macro bob(n: typed) =
+    doAssert n.kind != nnkIncludeStmt
+    discard
+
+  # typing it twice shouldn't be an issue
+  bob:
+    include mbar
+  bob:
+    include mbar


### PR DESCRIPTION
## Summary

Previously `include` statements, outside of type sections, were re-added
to `typed` AST. This is no longer the case, they're instead wholy
replaced by the included AST, which prevents repeated processing and
is consistent with `include`'s behaviour in type sections.

## Details

`semstmts` evaluates both declarative and type sections includes. Only
declarative includes, handled in `evalInclude` reintroduced the
`nkIncludeStmt` node within its results. It's been modified to no longer
do that.

In addition, `evalInclude` used a one off procedure `incMod` as part of
its processing, this has been made an inner proc.

Also removed deadcode `semAllTypeSections` and the `rsemRecursiveImport`
legacy report.

Lastly, a test was added to ensure we don't regress.