### PR TITLE
internal: add the `asm` and `emit` MIR operators

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -774,7 +774,7 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): Rope =
           r = mangleName(p.module, sym)
           sym.loc.r = r       # but be consequent!
         res.add($r)
-    of nkTypeOfExpr:
+    of nkType:
       res.add($getTypeDesc(p.module, it.typ))
     else:
       discard getTypeDesc(p.module, skipTypes(it.typ, abstractPtrs))

--- a/compiler/mir/astgen.nim
+++ b/compiler/mir/astgen.nim
@@ -773,23 +773,6 @@ proc tbSingleStmt(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
     result = newTreeI(nkBreakStmt, info, [label])
   of mnkReturn:
     result = newTreeI(nkReturnStmt, info, [newNode(nkEmpty)])
-  of mnkAsm, mnkEmit:
-    var r = newNodeI(nkAsmStmt, info)
-    # there cannot be any sub-trees, so we know that the first 'end' node we
-    # find belongs to the statement
-    while tree[cr].kind != mnkEnd:
-      r.add tbSingle(get(tree, cr), cl, cr.info)
-
-    if n.kind == mnkEmit:
-      # turn the ``asm`` statement into an emit directive:
-      transitionSonsKind(r, nkBracket)
-      let ex = newTreeI(nkExprColonExpr, info):
-        [newIdentNode(cl.cache.getIdent("emit"), info), r]
-      result = newTreeI(nkPragma, info, ex)
-    else:
-      result = r
-
-    leave(tree, cr)
   of mnkPNode:
     result = n.node
   of AllNodeKinds - StmtNodes:
@@ -870,6 +853,17 @@ proc tbOut(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
     newTreeI(nkRaiseStmt, cr.info, [prev.single])
   of mnkCase:
     tbCaseStmt(tree, cl, n, prev, cr)
+  of mnkAsm:
+    var r = newNodeI(nkAsmStmt, cr.info)
+    r.sons = move prev.list
+    r
+  of mnkEmit:
+    var r = newNodeI(nkBracket, cr.info)
+    r.sons = move prev.list
+
+    newTreeI(nkPragma, cr.info, [
+      newTreeI(nkExprColonExpr, cr.info, [
+        newIdentNode(cl.cache.getIdent("emit"), cr.info), r])])
   of AllNodeKinds - OutputNodes:
     unreachable(n.kind)
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1634,6 +1634,13 @@ proc genAsmOrEmitStmt(c: var TCtx, kind: range[mnkAsm..mnkEmit], n: PNode) =
       # (including type expressions) ...
       if it.typ != nil and it.typ.kind == tyTypeDesc:
         chain: genTypeExpr(c, it) => arg(c)
+      elif it.kind == nkSym and it.sym.kind == skField:
+        # emit and asm support using raw symbols. So that we don't
+        # have to allow ``skField``s in general, we special case them
+        # here (by pushing them through the MIR phase boxed as
+        # ``mnkLiteral``s)
+        c.stmts.add MirNode(kind: mnkLiteral, lit: it, typ: it.sym.typ)
+        chain: EValue(typ: it.sym.typ) => arg(c)
       else:
         # XXX: we treat the operands as using pass-by-value. This is not
         #      really correct, but it makes the logic here simpler, and

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -234,6 +234,11 @@ type
 
     mnkBranch ## defines a branch of an ``mnkExcept`` or ``mnkCase``
 
+    mnkAsm    ## corresponds to the high-level ``asm`` statement. The body is a
+              ## sequence of string literals and entity references
+    mnkEmit   ## corresponds to the ``emit`` directive. Has the same structure
+              ## as ``mnkAsm``
+
     mnkEnd    ## marks the physical end of a sub-tree. Has no semantic
               ## meaning -- it's only required to know where a sub-tree ends
 
@@ -330,7 +335,7 @@ const
     ## introduces a named entity)
 
   SubTreeNodes* = {mnkObjConstr, mnkArgBlock, mnkRegion, mnkStmtList, mnkScope,
-                   mnkIf..mnkBlock, mnkBranch } + DefNodes
+                   mnkIf..mnkBlock, mnkBranch, mnkAsm, mnkEmit } + DefNodes
     ## Nodes that mark the start of a sub-tree. They're always matched with a
     ## corrsponding ``mnkEnd`` node
 
@@ -362,7 +367,7 @@ const
     ## Operators and statements that must not have argument-blocks as input
 
   StmtNodes* = {mnkScope, mnkRepeat, mnkTry, mnkBlock, mnkBreak, mnkReturn,
-                mnkPNode} + DefNodes
+                mnkPNode, mnkAsm, mnkEmit} + DefNodes
     ## Nodes that act as statements syntax-wise
 
   SymbolLike* = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal}

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -234,10 +234,11 @@ type
 
     mnkBranch ## defines a branch of an ``mnkExcept`` or ``mnkCase``
 
-    mnkAsm    ## corresponds to the high-level ``asm`` statement. The body is a
-              ## sequence of string literals and entity references
-    mnkEmit   ## corresponds to the ``emit`` directive. Has the same structure
-              ## as ``mnkAsm``
+    mnkAsm    ## corresponds to the high-level ``asm`` statement. Takes an
+              ## argument block as input, but has itself no meaning at the MIR
+              ## level
+    mnkEmit   ## corresponds to the ``emit`` directive. In the context of the
+              ## MIR, has the same behaviour as ``mnkAsm``
 
     mnkEnd    ## marks the physical end of a sub-tree. Has no semantic
               ## meaning -- it's only required to know where a sub-tree ends
@@ -335,7 +336,7 @@ const
     ## introduces a named entity)
 
   SubTreeNodes* = {mnkObjConstr, mnkArgBlock, mnkRegion, mnkStmtList, mnkScope,
-                   mnkIf..mnkBlock, mnkBranch, mnkAsm, mnkEmit } + DefNodes
+                   mnkIf..mnkBlock, mnkBranch } + DefNodes
     ## Nodes that mark the start of a sub-tree. They're always matched with a
     ## corrsponding ``mnkEnd`` node
 
@@ -353,7 +354,7 @@ const
     ## Nodes than can appear in the position of inputs/operands
 
   OutputNodes* = {mnkRaise, mnkFastAsgn..mnkInit, mnkSwitch, mnkVoid, mnkIf,
-                  mnkCase, mnkRegion} + DefNodes
+                  mnkCase, mnkRegion, mnkAsm, mnkEmit} + DefNodes
     ## Node kinds that are allowed in every output context
     # TODO: maybe rename to SinkNodes
 
@@ -367,7 +368,7 @@ const
     ## Operators and statements that must not have argument-blocks as input
 
   StmtNodes* = {mnkScope, mnkRepeat, mnkTry, mnkBlock, mnkBreak, mnkReturn,
-                mnkPNode, mnkAsm, mnkEmit} + DefNodes
+                mnkPNode} + DefNodes
     ## Nodes that act as statements syntax-wise
 
   SymbolLike* = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal}

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -136,9 +136,6 @@ in memory:
   finally  = "finally", stmt, "end"
   try-stmt = "try", stmt, [except], [finally], "end"
 
-  asm = "asm", name, {name}, "end"
-  emit = "emit", name, {name}, "end"
-
   scope = "scope", {stmt-list-item}, "end"
 
   single-stmt = "break" | "return" | "pnode" | def | while-stmt | try-stmt |
@@ -152,7 +149,7 @@ in memory:
 
   in-op     = "none" | name | arg-block | "opParam" {* may only appear inside a region *}
   out-op    = "void" | "raise" | "init" | "fastAsgn" | "asgn" | "switch" |
-              def | if-stmt | case-stmt | region
+              "asm" | "emit" | def | if-stmt | case-stmt | region
   in-out-op = "magic" | "call" | "pathNamed" | "pathPos" | "pathArray" |
               "pathVariant" | "constr" | obj-constr | "cast" | "deref" |
               "addr" | "stdConv" | "conv" | "view" | "derefView"

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -136,6 +136,9 @@ in memory:
   finally  = "finally", stmt, "end"
   try-stmt = "try", stmt, [except], [finally], "end"
 
+  asm = "asm", name, {name}, "end"
+  emit = "emit", name, {name}, "end"
+
   scope = "scope", {stmt-list-item}, "end"
 
   single-stmt = "break" | "return" | "pnode" | def | while-stmt | try-stmt |


### PR DESCRIPTION
Summary
=======

Introduce the dedicated `asm` and `emit` operators to the MIR,
replacing the opaque handling via `mnkPNode`. This:
- fixes expressions used in `asm` and `emit` statements not being
  subject to the MIR transformation
- makes MIR-based dependency scanning possible, without
  requiring special traversal logic for `mnkPNode`

Details
=======

Both the `emit` directive and the `asm` statement can include
arbitrary expression, but these (including the entities referenced by
them) were previously hidden at the MIR level. Dependency scanning by
way of iterating over all MIR nodes in a fragment was thus not
guaranteed to work when they were present.

The new MIR nodes act as output operators without any behaviour of
their own, with the string literals and input expression being passed
via an argument block. Phrased differently, `emit` and `asm` act and
look like calls of effect-free procedures at the MIR level.

The arguments are all communicated as being passed-by-value with the
call not modifying them. While this is not correct (the emitted code
could potentially modify the operands), it's easier to implement it
this way. Given the low-level nature of `asm` and `emit`, this
behaviour is deemed okay for now.

To make generation of the `emit` statement work, `nkPragma` processing
in `mirgen` is changed slightly: instead of persisting the whole
`nkPragma` node that contains an interesting directive, only the
interesting directives are persisted (by first moving them into
standalone `nkPragma` nodes).