### PR TITLE
sempass2: disallow built-ins as procvars in tuples

### DIFF
--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1315,6 +1315,7 @@ proc track(tracked: PEffects, n: PNode) =
   of nkTupleConstr:
     for i in 0..<n.len:
       track(tracked, n[i])
+      notNilCheck(tracked, n[i].skipColon, n[i].typ)
       if tracked.owner.kind != skMacro:
         if n[i].kind == nkExprColonExpr:
           createTypeBoundOps(tracked, n[i][0].typ, n.info)

--- a/tests/errmsgs/tcannot_capture_builtin_2.nim
+++ b/tests/errmsgs/tcannot_capture_builtin_2.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "'chr' cannot be passed to a procvar"
+  line: 6
+"""
+
+let v = (chr, )

--- a/tests/magics/tmagics.nim
+++ b/tests/magics/tmagics.nim
@@ -50,10 +50,6 @@ block t9442:
   GC_ref(v1)
   GC_unref(v1)
 
-block: # bug #6499
-  let x = (chr, 0)
-  doAssert x[1] == 0
-
 block: # bug #12229
   proc foo(T: typedesc) = discard
   foo(ref)


### PR DESCRIPTION
## Summary

Disallow using built-in as procvars in the context of literal tuple
constructor expressions, fixing an inconsistency (using built-ins as
procvars is already disallowed everywhere else) that lead to unexpected
behaviour at run-time.

Previously, the code compiled, but, depending on the built-in, the
procvar stored a procedure that did nothing.

## Details

The `nkTupleConstr` processing in `sempass2.track` was missing a call to
`notNilCheck` (which calls `procVarCheck`).

A regression test is added, and a test that made sure the erroneous
expression compiled adjusted.