### PR TITLE
cgen: fix regression with `.nodecl` consts

### DIFF
--- a/tests/lang/s05_pragmas/s01_interop/t04_imported_constants.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t04_imported_constants.nim
@@ -1,0 +1,23 @@
+discard """
+  targets: "c js"
+  description: '''
+    A |NimSkull| constant can act as an alias for an external, constant
+    entity
+  '''
+"""
+
+type Obj = object # something complex that isn't inlined
+  val: int
+
+const
+  constA {.exportc.} = Obj(val: 2)
+  constB {.importc: "constA", nodecl.} = Obj(val: 1)
+
+static:
+  # in a compile-time context, the constant represents the value as is
+  # specified by the constant's initializer expression
+  doAssert constB == Obj(val: 1)
+
+# in a run-time context, the constant acts as an alias for the imported
+# entity
+doAssert constB == Obj(val: 2)


### PR DESCRIPTION
## Summary

Fix a regression where the C code generator ignored the `.nodecl`
pragma for constants.

## Details

Apart from the fix, the single-use `genConstSetup` is inlined into
`useConst`. Since the loc for constants is setup in `genConstDefinition`
(which is always called before `useConst`), the `fillLoc` call is not
added to `useConst` (this is also a step towards `fillLoc` only being
used in procedures responsible for definitions).

In addition, a test for the current behaviour of imported `.nodecl`