### PR TITLE
internal: clean up `jsgen`

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1645,7 +1645,7 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
       lineF(p, "var $1 = null;$n", [varName])
       lineF(p, "var $1_Idx = 0;$n", [varName])
     else:
-      lineF(p, "var $2 = $3;$n", [returnType, varName, createVar(p, v.typ, isIndirect(v))])
+      lineF(p, "var $1 = $2;$n", [varName, createVar(p, v.typ, isIndirect(v))])
   else:
     gen(p, n, a)
     case mapType(v.typ)
@@ -1660,16 +1660,16 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
       if isBoxedPointer(v):
         s = "[$1, $2]" % [a.address, a.res]
       else:
-        lineF(p, "var $2 = $3, $2_Idx = $4;$n",
-                 [returnType, v.loc.r, a.address, a.res])
+        lineF(p, "var $1 = $2, $1_Idx = $3;$n",
+                 [v.loc.r, a.address, a.res])
         # exit early because we've already emitted the definition
         return
     else:
       s = a.res
     if isIndirect(v):
-      lineF(p, "var $2 = [$3];$n", [returnType, v.loc.r, s])
+      lineF(p, "var $1 = [$2];$n", [v.loc.r, s])
     else:
-      lineF(p, "var $2 = $3;$n", [returnType, v.loc.r, s])
+      lineF(p, "var $1 = $2;$n", [v.loc.r, s])
 
 proc genVarStmt(p: PProc, n: PNode) =
   for it in n.items:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -10,7 +10,7 @@
 ## This is the JavaScript code generator.
 
 discard """
-The JS code generator contains only 2 tricks:
+The JS code generator contains only 1 trick:
 
 Trick 1
 -------
@@ -18,13 +18,6 @@ Some locations (for example 'var int') require "fat pointers" (`etyBaseIndex`)
 which are pairs (array, index). The derefence operation is then 'array[index]'.
 Check `mapType` for the details.
 
-Trick 2
--------
-It is preferable to generate '||' and '&&' if possible since that is more
-idiomatic and hence should be friendlier for the JS JIT implementation. However
-code like `foo and (let bar = baz())` cannot be translated this way. Instead
-the expressions need to be transformed into statements. `isSimpleExpr`
-implements the required case distinction.
 """
 
 import
@@ -318,16 +311,6 @@ proc useMagic(p: PProc, name: string) =
 
     else:
       localReport(p.config, reportStr(rsemSystemNeeds, name))
-
-proc isSimpleExpr(p: PProc; n: PNode): bool =
-  # calls all the way down --> can stay expression based
-  if n.kind in nkCallKinds+{nkBracketExpr, nkDotExpr, nkPar, nkTupleConstr} or
-      (n.kind in {nkObjConstr, nkBracket, nkCurly}):
-    for c in n:
-      if not p.isSimpleExpr(c): return false
-    result = true
-  elif n.isAtom:
-    result = true
 
 proc getTemp(p: PProc, defineInLocals: bool = true): Rope =
   inc(p.unique)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1440,9 +1440,10 @@ proc genPatternCall(p: PProc; n: PNode; pat: string; typ: PType;
 proc genInfixCall(p: PProc, n: PNode, r: var TCompRes) =
   # don't call '$' here for efficiency:
   let f = n[0].sym
+  assert sfInfixCall in f.flags
   if f.loc.r == "": f.loc.r = mangleName(p.module, f)
-  if sfInfixCall in f.flags:
-    let pat = n[0].sym.loc.r
+  if true:
+    let pat = f.loc.r
     internalAssert p.config, pat.len > 0
     if pat.contains({'#', '(', '@'}):
       var typ = skipTypes(n[0].typ, abstractInst)


### PR DESCRIPTION
## Summary

Remove various outdated or obsolete routines, fields, and logic
from the `jsgen` module.

## Details

* remove the `sigConflict`, `procDef`, and `globals`, `declaredGlobals`
  fields; they were either not written to or read from
* remove the unused `isSimpleExpr` procedure and the associated module
  documentation
* remove the unnecessary `PProc` parameter from `needsTemp`
* remove the `mapType` overload accepting a `PProc`, and adjust the
  usage sites
* remove the extraneous format argument in `genVarInit`
* remove the redundant `sfInfixCall` check in `genInfixCall`