### PR TITLE
internal: separate `TLoc` from `TSym` and `TType`

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -510,7 +510,8 @@ template transitionSymKindCommon*(k: TSymKind) =
   s[] = TSym(kind: k, itemId: obj.itemId, magic: obj.magic, typ: obj.typ, name: obj.name,
              info: obj.info, owner: obj.owner, flags: obj.flags, ast: obj.ast,
              options: obj.options, position: obj.position, offset: obj.offset,
-             loc: obj.loc, annex: obj.annex, constraint: obj.constraint)
+             loc: obj.loc, locId: obj.locId,
+             annex: obj.annex, constraint: obj.constraint)
   when defined(nimsuggest):
     s.allUsages = obj.allUsages
 

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1590,19 +1590,13 @@ type
     data*: seq[PSym]
 
   # -------------- backend information -------------------------------
-  TLocKind* = enum
-    locNone,                  ## no location
-    locTemp,                  ## temporary location
-    locLocalVar,              ## location is a local variable
-    locGlobalVar,             ## location is a global variable
-    locParam,                 ## location is a parameter
-    locField,                 ## location is a record field
-    locExpr,                  ## "location" is really an expression
-    locProc,                  ## location is a proc (an address of a procedure)
-    locData,                  ## location is a constant
-    locCall,                  ## location is a call expression
-    locOther                  ## location is something other
   TLocFlag* = enum
+    # XXX: `TLocFlag` conflates two things:
+    #      - flags regarding the external interface (e.g., `lfHeader`; set by
+    #        sem, used by sem and the code generators)
+    #      - location-related flags (e.g., ``lfIndirect``, ``lfSingleUse``,
+    #        etc.; only relevant to the C code generator)
+    #      Split the enum up.
     lfIndirect,               ## backend introduced a pointer
     lfFullExternalName, ## only used when 'conf.cmd == cmdNimfix': Indicates
       ## that the symbol has been imported via 'importc: "fullname"' and
@@ -1617,19 +1611,8 @@ type
                               ## ptr array due to C array limitations.
                               ## See #1181, #6422, #11171
     lfPrepareForMutation      ## string location is about to be mutated (V2)
-  TStorageLoc* = enum
-    OnUnknown,                ## location is unknown (stack, heap or static)
-    OnStatic,                 ## in a static section
-    OnStack,                  ## location is on hardware stack
-    OnHeap                    ## location is on heap or global
-                              ## (reference counting needed)
+
   TLocFlags* = set[TLocFlag]
-  TLoc* = object
-    k*: TLocKind              ## kind of location
-    storage*: TStorageLoc
-    flags*: TLocFlags         ## location's flags
-    lode*: PNode              ## Node where the location came from; can be faked
-    r*: Rope                  ## rope value of location (code generators)
 
   # ---------------- end of backend information ------------------------------
 
@@ -1713,7 +1696,10 @@ type
                               ## to the module's fileIdx
                               ## for variables a slot index for the evaluator
     offset*: int              ## offset of record field
-    loc*: TLoc
+    extname*: string          ## the external name of the type, or empty if a
+                              ## generated name is to be used
+    locFlags*: TLocFlags      ## additional flags that are relevant to code
+                              ## generation
     locId*: uint32            ## associates the symbol with a loc in the C code
                               ## generator. 0 means unset.
     annex*: PLib              ## additional fields (seldom used, so we use a

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1714,6 +1714,8 @@ type
                               ## for variables a slot index for the evaluator
     offset*: int              ## offset of record field
     loc*: TLoc
+    locId*: uint32            ## associates the symbol with a loc in the C code
+                              ## generator. 0 means unset.
     annex*: PLib              ## additional fields (seldom used, so we use a
                               ## reference to another object to save space)
     constraint*: PNode        ## additional constraints like 'lit|result'; also
@@ -1759,7 +1761,6 @@ type
     align*: int16             ## the type's alignment requirements
     paddingAtEnd*: int16      ##
     lockLevel*: TLockLevel    ## lock level as required for deadlock checking
-    loc*: TLoc
     typeInst*: PType          ## for generic instantiations the tyGenericInst that led to this
                               ## type; for tyError the previous type if avaiable
     uniqueId*: ItemId         ## due to a design mistake, we need to keep the real ID here as it

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -486,7 +486,7 @@ func discoverFrom*(data: var DiscoveryData, decl: PNode) =
     of nkProcDef, nkFuncDef, nkConverterDef, nkMethodDef:
       let prc = n[namePos].sym
       if {sfExportc, sfCompilerProc} * prc.flags == {sfExportc} or
-         (sfExportc in prc.flags and lfExportLib in prc.loc.flags):
+         (sfExportc in prc.flags and lfExportLib in prc.locFlags):
         # an exported routine. It must always have code generated for it. Note
         # that compilerprocs, while exported, are still only have code generated
         # for them when used
@@ -524,7 +524,7 @@ func queue(iter: var ProcedureIter, prc: PSym, m: FileIndex) =
   ## If eligible for processing and code generation, adds `prc` to
   ## `iter`'s queue.
   assert prc.kind in routineKinds
-  if lfNoDecl notin prc.loc.flags and
+  if lfNoDecl notin prc.locFlags and
      (sfImportc notin prc.flags or (iter.config.noImported and
                                     prc.ast[bodyPos].kind != nkEmpty)):
     iter.queued.add (prc, m)
@@ -564,7 +564,7 @@ proc preprocessDynlib(graph: ModuleGraph, idgen: IdGenerator,
   #       horrendous, but fortunately, this hack (`preprocessDynlib``) can
   #       be removed once handling of dynlib procedures and globals is fully
   #       implemented in the ``process`` iterator
-  if lfDynamicLib in sym.loc.flags:
+  if lfDynamicLib in sym.locFlags:
     if sym.annex.path.kind in nkStrKinds:
       # it's a string, no need to transform nor scan it
       discard

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -151,7 +151,7 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
   # XXX: dynlib procedure handling is going to move into the unified backend
   #      processing pipeline (i.e., the ``process`` iterator) in the future
   for _, s in peek(discovery.procedures):
-    if lfDynamicLib in s.loc.flags:
+    if lfDynamicLib in s.locFlags:
       let m = g.modules[s.itemId.module.int]
       fillProcLoc(m, newSymNode(s))
       symInDynamicLib(m, s)
@@ -365,8 +365,8 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
 
     # the init and data-init procedures use special names in the
     # generated code:
-    m.init.loc.r = getInitName(bmod)
-    m.dataInit.loc.r = getDatInitName(bmod)
+    m.init.extname = getInitName(bmod)
+    m.dataInit.extname = getDatInitName(bmod)
 
     # mark the init procedure so that the code generator can detect and
     # special-case it:

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -467,7 +467,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
 
 proc notYetAlive(n: PNode): bool {.inline.} =
   let r = getRoot(n)
-  result = r != nil and r.loc.lode == nil
+  result = r != nil and r.locId == 0
 
 proc isInactiveDestructorCall(p: BProc, e: PNode): bool =
   #[ Consider this example.

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2138,7 +2138,7 @@ proc useConst*(m: BModule; sym: PSym) =
     m.s[cfsData].add(headerDecl)
 
 proc genConstDefinition*(q: BModule; sym: PSym) =
-  let name = mangleName(q, sym)
+  let name = mangleName(q.g.graph, sym)
   if lfNoDecl notin sym.locFlags:
     let p = newProc(nil, q)
     q.s[cfsData].addf("N_LIB_PRIVATE NIM_CONST $1 $2 = $3;$n",

--- a/compiler/backend/ccgreset.nim
+++ b/compiler/backend/ccgreset.nim
@@ -30,9 +30,8 @@ proc specializeResetN(p: BProc, accessor: Rope, n: PNode;
   of nkRecCase:
     p.config.internalAssert(n[0].kind == nkSym, n.info, "specializeResetN")
     let disc = n[0].sym
-    if disc.loc.r == "": fillObjectFields(p.module, typ)
-    p.config.internalAssert(disc.loc.t != nil, n.info, "specializeResetN()")
-    lineF(p, cpsStmts, "switch ($1.$2) {$n", [accessor, disc.loc.r])
+    ensureObjectFields(p.module, disc, typ)
+    lineF(p, cpsStmts, "switch ($1.$2) {$n", [accessor, p.fieldLoc(disc).r])
     for i in 1..<n.len:
       let branch = n[i]
       assert branch.kind in {nkOfBranch, nkElse}
@@ -43,13 +42,12 @@ proc specializeResetN(p: BProc, accessor: Rope, n: PNode;
       specializeResetN(p, accessor, lastSon(branch), typ)
       lineF(p, cpsStmts, "break;$n", [])
     lineF(p, cpsStmts, "} $n", [])
-    specializeResetT(p, "$1.$2" % [accessor, disc.loc.r], disc.loc.t)
+    specializeResetT(p, "$1.$2" % [accessor, p.fieldLoc(disc).r], disc.typ)
   of nkSym:
     let field = n.sym
     if field.typ.kind == tyVoid: return
-    if field.loc.r == "": fillObjectFields(p.module, typ)
-    p.config.internalAssert(field.loc.t != nil, n.info, "specializeResetN()")
-    specializeResetT(p, "$1.$2" % [accessor, field.loc.r], field.loc.t)
+    ensureObjectFields(p.module, field, typ)
+    specializeResetT(p, "$1.$2" % [accessor, p.fieldLoc(field).r], field.typ)
   else: internalError(p.config, n.info, "specializeResetN()")
 
 proc specializeResetT(p: BProc, accessor: Rope, typ: PType) =

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -169,7 +169,7 @@ proc genSingleVar(p: BProc, v: PSym; vn, value: PNode) =
 
   if value.kind != nkEmpty:
     genLineDir(p, vn)
-    # we have an parameter aliasing issue here: passing `p.locals[v]`
+    # we have a parameter aliasing issue here: passing `p.locals[v]`
     # as the parameter directly would be an aliasing rule violation.
     # Since the initializer expression cannot reference `v` itself,
     # it's safe to temporarily move the loc out of ``p.locals``

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -169,7 +169,13 @@ proc genSingleVar(p: BProc, v: PSym; vn, value: PNode) =
 
   if value.kind != nkEmpty:
     genLineDir(p, vn)
-    loadInto(p, vn, value, v.loc)
+    # we have an parameter aliasing issue here: passing `p.locals[v]`
+    # as the parameter directly would be an aliasing rule violation.
+    # Since the initializer expression cannot reference `v` itself,
+    # it's safe to temporarily move the loc out of ``p.locals``
+    var loc = move p.locals[v]
+    loadInto(p, vn, value, loc)
+    p.locals.assign(v, loc) # put it back
 
 proc genSingleVar(p: BProc, a: PNode) =
   let v = a[0].sym
@@ -355,7 +361,6 @@ proc genBlock(p: BProc, n: PNode) =
       # named block?
       assert(n[0].kind == nkSym)
       var sym = n[0].sym
-      sym.loc.k = locOther
       sym.position = p.breakIdx+1
     genStmts(p, n[1])
     endBlock(p)
@@ -366,7 +371,7 @@ proc genBreakStmt(p: BProc, t: PNode) =
     # named break?
     assert(t[0].kind == nkSym)
     var sym = t[0].sym
-    doAssert(sym.loc.k == locOther)
+    doAssert(sym.kind == skLabel)
     idx = sym.position-1
   else:
     # an unnamed 'break' can only break a loop after 'transf' pass:
@@ -745,16 +750,9 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): Rope =
       of skField:
         # special support for raw field symbols
         discard getTypeDesc(p.module, skipTypes(sym.typ, abstractPtrs))
-        var r = sym.loc.r
-        if r == "":
-          # problem: a field doesn't know what type it is part of, so we
-          # can neither use ``fillObjectFields`` nor a ``FieldX`` name
-          # (in the case of tuples). To make sure that the mangled name is
-          # at  least correct for object types, we always use field name
-          # mangling
-          r = mangleRecFieldName(p.module, sym)
-          sym.loc.r = r       # but be consequent!
-        res.add(r)
+        p.config.internalAssert(sym.locId != 0, it.info):
+          "field's surrounding type not setup"
+        res.add(p.fieldLoc(sym).r)
       else:
         unreachable(sym.kind)
     of nkType:

--- a/compiler/backend/ccgthreadvars.nim
+++ b/compiler/backend/ccgthreadvars.nim
@@ -29,16 +29,16 @@ proc declareThreadVar*(m: BModule, s: PSym, isExtern: bool) =
     # storage for that somehow, can't use the thread local storage
     # allocator for it :-(
     if not containsOrIncl(m.g.nimtvDeclared, s.id):
-      m.g.nimtvDeps.add(s.loc.t)
-      m.g.nimtv.addf("$1 $2;$n", [getTypeDesc(m, s.loc.t), s.loc.r])
+      m.g.nimtvDeps.add(s.typ)
+      m.g.nimtv.addf("$1 $2;$n", [getTypeDesc(m, s.typ), m.globals[s].r])
   else:
     if isExtern: m.s[cfsVars].add("extern ")
     elif lfExportLib in s.loc.flags: m.s[cfsVars].add("N_LIB_EXPORT_VAR ")
     else: m.s[cfsVars].add("N_LIB_PRIVATE ")
     if optThreads in m.config.globalOptions:
       m.s[cfsVars].add("NIM_THREADVAR ")
-    m.s[cfsVars].add(getTypeDesc(m, s.loc.t))
-    m.s[cfsVars].addf(" $1;$n", [s.loc.r])
+    m.s[cfsVars].add(getTypeDesc(m, s.typ))
+    m.s[cfsVars].addf(" $1;$n", [m.globals[s].r])
 
 proc generateThreadLocalStorage(m: BModule) =
   if m.g.nimtv != "" and (usesThreadVars in m.flags or sfMainModule in m.module.flags):

--- a/compiler/backend/ccgthreadvars.nim
+++ b/compiler/backend/ccgthreadvars.nim
@@ -33,7 +33,7 @@ proc declareThreadVar*(m: BModule, s: PSym, isExtern: bool) =
       m.g.nimtv.addf("$1 $2;$n", [getTypeDesc(m, s.typ), m.globals[s].r])
   else:
     if isExtern: m.s[cfsVars].add("extern ")
-    elif lfExportLib in s.loc.flags: m.s[cfsVars].add("N_LIB_EXPORT_VAR ")
+    elif lfExportLib in s.locFlags: m.s[cfsVars].add("N_LIB_EXPORT_VAR ")
     else: m.s[cfsVars].add("N_LIB_PRIVATE ")
     if optThreads in m.config.globalOptions:
       m.s[cfsVars].add("NIM_THREADVAR ")

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -493,8 +493,8 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
     if field.locId == 0:
       # XXX: the C struct definition for the type is re-generated in every C
       #      file the type is used in, so the field might have an associated
-      #      loc. Eventually, each C type is only generated once, and then the
-      #      guard can be removed
+      #      loc. Eventually, each C type will only be generated once, and then
+      #      the guard can be removed
       m.fields.put(field):
         initLoc(locField, n, unionPrefix & sname, OnUnknown)
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -532,7 +532,7 @@ include ccgthreadvars
 proc varInDynamicLib(m: BModule, sym: PSym)
 
 proc fillGlobalLoc*(m: BModule, s: PSym, n: PNode) =
-  m.globals.put(s, initLoc(locGlobalVar, n, mangleName(m, s), OnHeap))
+  m.globals.put(s, initLoc(locGlobalVar, n, mangleName(m.g.graph, s), OnHeap))
 
 proc defineGlobalVar*(m: BModule, n: PNode) =
   let s = n.sym
@@ -568,7 +568,8 @@ proc fillProcLoc*(m: BModule; n: PNode) =
   let sym = n.sym
   if sym.locId == 0:
     m.procs.put(sym):
-      (initLoc(locProc, n, mangleName(m, sym), OnStack), (seq[TLoc])(@[]))
+      (initLoc(locProc, n, mangleName(m.g.graph, sym), OnStack),
+       (seq[TLoc])(@[]))
 
 proc getLabel(p: BProc): TLabel =
   inc(p.labels)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -116,6 +116,9 @@ proc initLoc(result: var TLoc, k: TLocKind, lode: PNode, s: TStorageLoc) =
   result.r = ""
   result.flags = {}
 
+func initLoc(kind: TLocKind, n: PNode, name: sink string, storage: TStorageLoc): TLoc =
+  TLoc(k: kind, storage: storage, lode: n, r: name, flags: {})
+
 proc fillLoc(a: var TLoc, k: TLocKind, lode: PNode, r: Rope, s: TStorageLoc) =
   ## fills the loc if it is not already initialized
   if a.k == locNone:
@@ -463,7 +466,7 @@ proc initLocalVar(p: BProc, v: PSym, immediateAsgn: bool) =
     # ``var v = X()`` gets transformed into ``X(&v)``.
     # Nowadays the logic in ccgcalls deals with this case however.
     if not immediateAsgn:
-      constructLoc(p, v.loc)
+      constructLoc(p, p.locals[v])
 
 proc getTemp(p: BProc, t: PType, result: var TLoc; needsInit=false) =
   inc(p.labels)
@@ -494,8 +497,7 @@ proc getIntTemp(p: BProc, result: var TLoc) =
 
 proc localVarDecl(p: BProc; n: PNode): Rope =
   let s = n.sym
-  if s.loc.k == locNone:
-    fillLoc(s.loc, locLocalVar, n, mangleLocalName(p, s), OnStack)
+  let loc = initLoc(locLocalVar, n, mangleLocalName(p, s), OnStack)
   if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
     result.addf("NIM_ALIGN($1) ", [rope(s.alignment)])
   result.add getTypeDesc(p.module, s.typ, skVar)
@@ -506,12 +508,21 @@ proc localVarDecl(p: BProc; n: PNode): Rope =
     if sfVolatile in s.flags: result.add(" volatile")
     if sfNoalias in s.flags: result.add(" NIM_NOALIAS")
     result.add(" ")
-    result.add(s.loc.r)
+    result.add(loc.r)
+
+  # XXX: inline procedure are generated multiple times, so the symbol can
+  #      already have a non-zero ``locId``
+  if s notin p.locals:
+    p.locals.forcePut(s, loc)
+  else:
+    # XXX: finally blocks are duplicated by the code generator, so we have to
+    #      be lenient here and allow the local already existing. This is a bad
+    #      idea, however; if finally clauses are implemented via code
+    #      duplication, then that duplication needs to happen prior to code
+    #      generation
+    p.locals.assign(s, loc)
 
 proc assignLocalVar(p: BProc, n: PNode) =
-  #assert(s.loc.k == locNone) # not yet assigned
-  # this need not be fulfilled for inline procs; they are regenerated
-  # for each module that uses them!
   let nl = if optLineDir in p.config.options: "" else: "\L"
   let decl = localVarDecl(p, n) & ";" & nl
   line(p, cpsLocals, decl)
@@ -521,12 +532,11 @@ include ccgthreadvars
 proc varInDynamicLib(m: BModule, sym: PSym)
 
 proc fillGlobalLoc*(m: BModule, s: PSym, n: PNode) =
-  fillLoc(s.loc, locGlobalVar, n, mangleName(m, s), OnHeap)
+  m.globals.put(s, initLoc(locGlobalVar, n, mangleName(m, s), OnHeap))
 
 proc defineGlobalVar*(m: BModule, n: PNode) =
   let s = n.sym
-  if s.loc.k == locNone:
-    fillGlobalLoc(m, s, n)
+  fillGlobalLoc(m, s, n)
 
   assert s.id notin m.declaredThings
   assert findPendingModule(m, s) == m, "not the attached-to module"
@@ -539,7 +549,7 @@ proc defineGlobalVar*(m: BModule, n: PNode) =
     if lfNoDecl notin s.loc.flags:
       incl(m.declaredThings, s.id)
       var decl = ""
-      var td = getTypeDesc(m, s.loc.t, skVar)
+      var td = getTypeDesc(m, m.globals[s].t, skVar)
       if true:
         if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
           decl.addf "NIM_ALIGN($1) ", [rope(s.alignment)]
@@ -550,21 +560,15 @@ proc defineGlobalVar*(m: BModule, n: PNode) =
         if sfRegister in s.flags: decl.add(" register")
         if sfVolatile in s.flags: decl.add(" volatile")
         if sfNoalias in s.flags: decl.add(" NIM_NOALIAS")
-        decl.addf(" $1;$n", [s.loc.r])
+        decl.addf(" $1;$n", [m.globals[s].r])
 
       m.s[cfsVars].add(decl)
 
-proc assignParam(p: BProc, s: PSym, retType: PType) =
-  assert(s.loc.r != "")
-  scopeMangledParam(p, s)
-
-proc fillProcLoc(n: PNode, name: Rope) {.inline.} =
-  fillLoc(n.sym.loc, locProc, n, name, OnStack)
-
 proc fillProcLoc*(m: BModule; n: PNode) =
   let sym = n.sym
-  if sym.loc.k == locNone:
-    fillProcLoc(n, mangleName(m, sym))
+  if sym.locId == 0:
+    m.procs.put(sym):
+      (initLoc(locProc, n, mangleName(m, sym), OnStack), (seq[TLoc])(@[]))
 
 proc getLabel(p: BProc): TLabel =
   inc(p.labels)
@@ -688,8 +692,10 @@ proc symInDynamicLib*(m: BModule, sym: PSym) =
   let isCall = isGetProcAddr(lib)
   var extname = sym.loc.r
   if not isCall: loadDynamicLib(m, lib)
-  var tmp = mangleDynLibProc(sym)
-  sym.loc.r = tmp             # from now on we only need the internal name
+  let tmp = mangleDynLibProc(sym)
+  # XXX: dynlib procedures should be treated as globals here (because that's
+  #      what they are, really)
+  m.procs[sym].loc.r = tmp    # from now on we only need the internal name
   sym.typ.sym = nil           # generate a new name
   inc(m.labels, 2)
   if isCall:
@@ -718,28 +724,28 @@ proc symInDynamicLib*(m: BModule, sym: PSym) =
     appcg(m, m.s[cfsDynLibInit],
         "\t$1 = ($2) #nimGetProcAddr($3, $4);$n",
         [tmp, getTypeDesc(m, sym.typ, skVar), lib.name, makeCString($extname)])
-  m.s[cfsVars].addf("$2 $1;$n", [sym.loc.r, getTypeDesc(m, sym.loc.t, skVar)])
+  m.s[cfsVars].addf("$2 $1;$n", [tmp, getTypeDesc(m, sym.typ, skVar)])
 
 proc varInDynamicLib(m: BModule, sym: PSym) =
   var lib = sym.annex
   var extname = sym.loc.r
   loadDynamicLib(m, lib)
-  incl(sym.loc.flags, lfIndirect)
-  var tmp = mangleDynLibProc(sym)
-  sym.loc.r = tmp             # from now on we only need the internal name
+  let tmp = mangleDynLibProc(sym)
+  incl(m.globals[sym].flags, lfIndirect)
+  m.globals[sym].r = tmp  # from now on we only need the internal name
   inc(m.labels, 2)
   appcg(m, m.s[cfsDynLibInit],
       "$1 = ($2*) #nimGetProcAddr($3, $4);$n",
       [tmp, getTypeDesc(m, sym.typ, skVar), lib.name, makeCString($extname)])
   m.s[cfsVars].addf("$2* $1;$n",
-      [sym.loc.r, getTypeDesc(m, sym.loc.t, skVar)])
+      [tmp, getTypeDesc(m, sym.typ, skVar)])
 
 proc cgsym(m: BModule, name: string): Rope =
   let sym = magicsys.getCompilerProc(m.g.graph, name)
   if sym != nil:
     case sym.kind
     of skProc, skFunc, skMethod, skConverter, skIterator:
-      genProcPrototype(m, sym) # emit a prototype
+      useProc(m, sym)
       m.extra.add(sym) # notify the caller about the dependency
     of skVar, skResult, skLet: genVarPrototype(m, newSymNode sym)
     of skType: discard getTypeDesc(m, sym.typ)
@@ -787,7 +793,7 @@ proc closureSetup(p: BProc, prc: PSym) =
   assignLocalVar(p, ls)
   # generate cast assignment:
   linefmt(p, cpsStmts, "$1 = ($2) ClE_0;$n",
-          [rdLoc(env.loc), getTypeDesc(p.module, env.typ)])
+          [rdLoc(p.locals[env]), getTypeDesc(p.module, env.typ)])
 
 proc containsResult(n: PNode): bool =
   result = false
@@ -914,7 +920,10 @@ proc isNoReturn(m: BModule; s: PSym): bool {.inline.} =
 proc startProc*(m: BModule, prc: PSym; procBody: PNode = nil): BProc =
   var p = newProc(prc, m)
   assert(prc.ast != nil)
-  prepareParameters(m, prc.typ)
+  fillProcLoc(m, prc.ast[namePos]) # ensure that a loc exists
+  if m.procs[prc].params.len == 0:
+    # if a prototype was emitted, the parameter list already exists
+    m.procs[prc].params = prepareParameters(m, prc.typ)
 
   if sfPure notin prc.flags and prc.typ[0] != nil:
     m.config.internalAssert(resultPos < prc.ast.len, prc.info, "proc has no result symbol")
@@ -924,11 +933,10 @@ proc startProc*(m: BModule, prc: PSym; procBody: PNode = nil): BProc =
       if sfNoInit in prc.flags: incl(res.flags, sfNoInit)
       # declare the result symbol:
       assignLocalVar(p, resNode)
-      assert(res.loc.r != "")
       initLocalVar(p, res, immediateAsgn=false)
     else:
-      fillResult(p.config, resNode)
-      assignParam(p, res, prc.typ[0])
+      p.params[0] = initResultParamLoc(p.config, resNode)
+      scopeMangledParam(p, res)
       # We simplify 'unsureAsgn(result, nil); unsureAsgn(result, x)'
       # to 'unsureAsgn(result, x)'
       # Sketch why this is correct: If 'result' points to a stack location
@@ -939,10 +947,10 @@ proc startProc*(m: BModule, prc: PSym; procBody: PNode = nil): BProc =
       elif procBody != nil and
            allPathsAsgnResult(procBody) == InitSkippable: discard
       else:
-        resetLoc(p, res.loc)
+        resetLoc(p, p.params[0])
       if skipTypes(res.typ, abstractInst).kind == tyArray:
         #incl(res.loc.flags, lfIndirect)
-        res.loc.storage = OnUnknown
+        p.params[0].storage = OnUnknown
 
   # for now, we treat all compilerprocs as being able to run in a boot
   # environment where the error flag is not yet accessible. This is not quite
@@ -958,8 +966,8 @@ proc startProc*(m: BModule, prc: PSym; procBody: PNode = nil): BProc =
 
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym
-    if param.loc.k == locNone: continue
-    assignParam(p, param, prc.typ[0])
+    if p.params[i].k == locNone: continue
+    scopeMangledParam(p, param)
   closureSetup(p, prc)
 
   if sfPure notin prc.flags and optStackTrace in prc.options:
@@ -978,12 +986,12 @@ proc finishProc*(p: BProc, prc: PSym): string =
     p.blocks[0].sections[cpsInit].add(ropecg(p.module, "nimErr_ = #nimErrorFlag();$n", []))
 
   var
-    header = genProcHeader(p.module, prc)
+    header = genProcHeader(p.module, prc, p.params)
     returnStmt = ""
 
   if sfPure notin prc.flags and not isInvalidReturnType(p.config, prc.typ[0]):
     returnStmt = ropecg(p.module, "\treturn $1;$n",
-                        [rdLoc(prc.ast[resultPos].sym.loc)])
+                        [rdLoc(p.locals[prc.ast[resultPos].sym])])
 
   var generatedProc: Rope
   generatedProc.genCLineDir prc.info, p.config
@@ -1037,10 +1045,12 @@ proc genProcPrototype(m: BModule, sym: PSym) =
         not containsOrIncl(m.declaredThings, sym.id):
       m.s[cfsVars].add(ropecg(m, "$1 $2 $3;$n",
                         ["extern",
-                        getTypeDesc(m, sym.loc.t), mangleDynLibProc(sym)]))
+                        getTypeDesc(m, m.procs[sym].loc.t), mangleDynLibProc(sym)]))
 
   elif not containsOrIncl(m.declaredProtos, sym.id):
-    var header = genProcHeader(m, sym)
+    if m.procs[sym].params.len == 0:
+      m.procs[sym].params = prepareParameters(m, sym.typ)
+    var header = genProcHeader(m, sym, m.procs[sym].params)
     block:
       if isNoReturn(m, sym) and hasDeclspec in extccomp.CC[m.config.cCompiler].props:
         header = "__declspec(noreturn) " & header
@@ -1068,13 +1078,10 @@ proc genVarPrototype(m: BModule, n: PNode) =
   #assert(sfGlobal in sym.flags)
   let sym = n.sym
   useHeader(m, sym)
-  fillLoc(sym.loc, locGlobalVar, n, mangleName(m, sym), OnHeap)
-
   if (lfNoDecl in sym.loc.flags) or contains(m.declaredThings, sym.id):
     return
   if sym.owner.id != m.module.id:
     # else we already have the symbol generated!
-    assert(sym.loc.r != "")
     if sfThread in sym.flags:
       declareThreadVar(m, sym, true)
     else:
@@ -1082,12 +1089,12 @@ proc genVarPrototype(m: BModule, n: PNode) =
       if sym.kind in {skLet, skVar, skField, skForVar} and sym.alignment > 0:
         m.s[cfsVars].addf "NIM_ALIGN($1) ", [rope(sym.alignment)]
       m.s[cfsVars].add("extern ")
-      m.s[cfsVars].add(getTypeDesc(m, sym.loc.t, skVar))
+      m.s[cfsVars].add(getTypeDesc(m, sym.typ, skVar))
       if lfDynamicLib in sym.loc.flags: m.s[cfsVars].add("*")
       if sfRegister in sym.flags: m.s[cfsVars].add(" register")
       if sfVolatile in sym.flags: m.s[cfsVars].add(" volatile")
       if sfNoalias in sym.flags: m.s[cfsVars].add(" NIM_NOALIAS")
-      m.s[cfsVars].addf(" $1;$n", [sym.loc.r])
+      m.s[cfsVars].addf(" $1;$n", [m.globals[sym].r])
 
 proc addNimDefines(result: var Rope; conf: ConfigRef) {.inline.} =
   result.addf("#define NIM_INTBITS $1\L", [

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -45,6 +45,34 @@ type
     ## ``TSym.locId``.
     store: Store[range[0'u32..high(uint32)-1], T]
 
+  TLocKind* = enum
+    locNone,                  ## no location
+    locTemp,                  ## temporary location
+    locLocalVar,              ## location is a local variable
+    locGlobalVar,             ## location is a global variable
+    locParam,                 ## location is a parameter
+    locField,                 ## location is a record field
+    locExpr,                  ## "location" is really an expression
+    locProc,                  ## location is a proc (an address of a procedure)
+    locData,                  ## location is a constant
+    locCall,                  ## location is a call expression
+    locOther                  ## location is something other
+
+  TStorageLoc* = enum
+    # XXX: ``TStorageLoc`` is obsolete -- remove it
+    OnUnknown,                ## location is unknown (stack, heap or static)
+    OnStatic,                 ## in a static section
+    OnStack,                  ## location is on hardware stack
+    OnHeap                    ## location is on heap or global
+                              ## (reference counting needed)
+
+  TLoc* = object
+    k*: TLocKind              ## kind of location
+    storage*: TStorageLoc
+    flags*: TLocFlags         ## location's flags
+    lode*: PNode              ## Node where the location came from; can be faked
+    r*: Rope                  ## rope value of location (code generators)
+
   TLabel* = Rope              ## for the C generator a label is just a rope
   TCFileSection* = enum       ## the sections a generated C file consists of
     cfsMergeInfo,             ## section containing merge information

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -27,12 +27,24 @@ import
     options
   ],
   compiler/utils/[
+    containers,
     ropes,
     pathutils
   ]
 
 
 type
+  SymbolMap*[T] = object
+    ## Associates extra location-related data with symbols. This is
+    ## temporary scaffolding until each entity (type, local, procedure,
+    ## etc.) is consistently represented as an index-like handle in the
+    ## code generator, at which point a ``Store`` (or ``SeqMap``) can be
+    ## used directly.
+    ##
+    ## Mapping from a symbol to the associated data currently happens via
+    ## ``TSym.locId``.
+    store: Store[range[0'u32..high(uint32)-1], T]
+
   TLabel* = Rope              ## for the C generator a label is just a rope
   TCFileSection* = enum       ## the sections a generated C file consists of
     cfsMergeInfo,             ## section containing merge information
@@ -114,6 +126,8 @@ type
     withinBlockLeaveActions*: int ## complex to explain
     sigConflicts*: CountTable[string]
 
+    locals*: SymbolMap[TLoc]  ## the locs for all locals of the procedure
+
   TTypeSeq* = seq[PType]
   TypeCache* = Table[SigHash, Rope]
   TypeCacheWithOwner* = Table[SigHash, tuple[str: Rope, owner: int32]]
@@ -146,6 +160,16 @@ type
                             ## unconditionally...
                             ## nimtvDeps is VERY hard to cache because it's
                             ## not a list of IDs nor can it be made to be one.
+
+    globals*: SymbolMap[TLoc]
+      ## the locs for all alive globals of the program
+    consts*: SymbolMap[TLoc]
+      ## the locs for all alive constants of the program
+    procs*: SymbolMap[tuple[loc: TLoc, params: seq[TLoc]]]
+      ## the locs for all alive procedure of the program. Also stores the
+      ## locs for the parameters
+    fields*: SymbolMap[TLoc]
+      ## the locs for all fields
 
     hooks*: seq[(BModule, PSym)]
       ## late late-dependencies. Generating code for a procedure might lead
@@ -196,6 +220,20 @@ type
 template config*(m: BModule): ConfigRef = m.g.config
 template config*(p: BProc): ConfigRef = p.module.g.config
 
+template procs*(m: BModule): untyped   = m.g.procs
+template fields*(m: BModule): untyped  = m.g.fields
+template globals*(m: BModule): untyped = m.g.globals
+template consts*(m: BModule): untyped  = m.g.consts
+
+template fieldLoc*(p: BProc, field: PSym): TLoc =
+  ## Returns the loc for the given `field`.
+  p.module.fields[field]
+
+template params*(p: BProc): seq[TLoc] =
+  ## Returns the mutable list with the locs of `p`'s
+  ## parameters.
+  p.module.procs[p.prc].params
+
 proc includeHeader*(this: BModule; header: string) =
   if not this.headerFiles.contains header:
     this.headerFiles.add header
@@ -226,3 +264,33 @@ iterator cgenModules*(g: BModuleList): BModule =
   for m in g.modulesClosed:
     # iterate modules in the order they were closed
     yield m
+
+func put*[T](m: var SymbolMap[T], sym: PSym, it: sink T) {.inline.}  =
+  ## Adds `it` to `m` and registers a mapping between the item and
+  ## `sym`. `sym` must have no mapping registered yet.
+  assert sym.locId == 0, "symbol already registered"
+  sym.locId = uint32(m.store.add(it)) + 1
+
+func forcePut*[T](m: var SymbolMap[T], sym: PSym, it: sink T) {.inline.} =
+  ## Adds `it` to `m` and register a mapping between the item and
+  ## `sym`, overwriting any existing mappings of `sym`.
+  sym.locId = uint32(m.store.add(it)) + 1
+
+func assign*[T](m: var SymbolMap[T], sym: PSym, it: sink T) {.inline.}  =
+  ## Sets the value of the item in `m` with which `sym` is associated. This is
+  ## only meant as a workaround.
+  assert sym.locId > 0
+  m.store[sym.locId - 1] = it
+
+func `[]`*[T](m: SymbolMap[T], sym: PSym): lent T {.inline.} =
+  m.store[sym.locId - 1]
+
+func `[]`*[T](m: var SymbolMap[T], sym: PSym): var T {.inline.} =
+  m.store[sym.locId - 1]
+
+func contains*[T](m: SymbolMap[T], sym: PSym): bool {.inline.} =
+  sym.locId > 0 and m.store.nextId().uint32 > sym.locId - 1
+
+iterator items*[T](m: SymbolMap[T]): lent T =
+  for it in m.store.items:
+    yield it

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -293,13 +293,13 @@ iterator cgenModules*(g: BModuleList): BModule =
     # iterate modules in the order they were closed
     yield m
 
-func put*[T](m: var SymbolMap[T], sym: PSym, it: sink T) {.inline.}  =
+proc put*[T](m: var SymbolMap[T], sym: PSym, it: sink T) {.inline.}  =
   ## Adds `it` to `m` and registers a mapping between the item and
   ## `sym`. `sym` must have no mapping registered yet.
   assert sym.locId == 0, "symbol already registered"
   sym.locId = uint32(m.store.add(it)) + 1
 
-func forcePut*[T](m: var SymbolMap[T], sym: PSym, it: sink T) {.inline.} =
+proc forcePut*[T](m: var SymbolMap[T], sym: PSym, it: sink T) {.inline.} =
   ## Adds `it` to `m` and register a mapping between the item and
   ## `sym`, overwriting any existing mappings of `sym`.
   sym.locId = uint32(m.store.add(it)) + 1

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -148,7 +148,7 @@ proc createDispatcher(s: PSym; g: ModuleGraph; idgen: IdGenerator): PSym =
   if disp.typ.callConv == ccInline: disp.typ.callConv = ccNimCall
   disp.ast = copyTree(s.ast)
   disp.ast[bodyPos] = newNodeI(nkEmpty, s.info)
-  disp.loc.r = ""
+  disp.extname = ""
   if s.typ[0] != nil:
     if disp.ast.len > resultPos:
       disp.ast[resultPos].sym = copySym(s.ast[resultPos].sym, nextSymId(idgen))

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -147,6 +147,7 @@ proc createDispatcher(s: PSym; g: ModuleGraph; idgen: IdGenerator): PSym =
   # we can't inline the dispatcher itself (for now):
   if disp.typ.callConv == ccInline: disp.typ.callConv = ccNimCall
   disp.ast = copyTree(s.ast)
+  disp.ast[namePos] = newSymNode(disp)
   disp.ast[bodyPos] = newNodeI(nkEmpty, s.info)
   disp.extname = ""
   if s.typ[0] != nil:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -277,7 +277,7 @@ func mangleName(m: BModule, s: PSym): Rope =
 
 proc mangledName(p: PProc, s: PSym, info: TLineInfo): string =
   ## Returns the cached JavaScript name for `s`.
-  ## At the time of writing, a borrowed string (``lent string``) from
+  ## At the time of writing, a borrowed string (``lent string``)
   ## can't be returned because of compiler shortcomings.
   template get(tbl: untyped): string =
     p.module.config.internalAssert(s.id in tbl, info):

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -275,9 +275,12 @@ func mangleName(m: BModule, s: PSym): Rope =
       result.add("_")
       result.add(rope(s.id))
 
-proc mangledName(p: PProc, s: PSym, info: TLineInfo): lent string =
-  template get(tbl: untyped): untyped =
-    p.config.internalAssert(s.id in tbl, info):
+proc mangledName(p: PProc, s: PSym, info: TLineInfo): string =
+  ## Returns the cached JavaScript name for `s`.
+  ## At the time of writing, a borrowed string (``lent string``) from
+  ## can't be returned because of compiler shortcomings.
+  template get(tbl: untyped): string =
+    p.module.config.internalAssert(s.id in tbl, info):
       "symbol has no generated name: " & s.name.s
     tbl[s.id]
 
@@ -305,7 +308,7 @@ proc ensureMangledName(p: PProc, s: PSym): lent string =
     # the mangled named hasn't been generated yet
     n[] = mangleName(p.module, s)
 
-  result = n[]
+  result = p.g.names[s.id]
 
 proc escapeJSString(s: string): string =
   result = newStringOfCap(s.len + s.len shr 2)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -113,6 +113,9 @@ type
     typeInfoGenerated: IntSet
     unique: int    # for temp identifier generation
 
+    names: Table[int, string]
+      ## maps a symbol IDs to the symbol's JavaScript name
+
     extra*: seq[PSym]
 
   PProc* = ref TProc
@@ -126,6 +129,11 @@ type
     unique: int    # for temp identifier generation
     blocks: seq[TBlock]
     extraIndent: int
+
+    params: seq[string]
+      ## mangled names of the procedure's parameters
+    localNames: Table[int, string]
+      ## mapes the symbol ID of locals to the JavaScript name
 
 const
   sfModuleInit* = sfMainModule
@@ -233,7 +241,7 @@ func mangleJs(name: string): string =
     else:
       result.add("HEX" & toHex(ord(c), 2))
 
-proc mangleName(m: BModule, s: PSym): Rope =
+func mangleName(m: BModule, s: PSym): Rope =
   proc validJsName(name: string): bool =
     result = true
     const reservedWords = ["abstract", "await", "boolean", "break", "byte",
@@ -267,7 +275,37 @@ proc mangleName(m: BModule, s: PSym): Rope =
       result.add("_")
       result.add(rope(s.id))
 
-    s.loc.r = result
+proc mangledName(p: PProc, s: PSym, info: TLineInfo): lent string =
+  template get(tbl: untyped): untyped =
+    p.config.internalAssert(s.id in tbl, info):
+      "symbol has no generated name: " & s.name.s
+    tbl[s.id]
+
+  case s.kind
+  of skVar, skLet, skTemp, skForVar:
+    if sfGlobal in s.flags:
+      result = get(p.g.names)
+    else:
+      result = get(p.localNames)
+  of skResult:
+    result = get(p.localNames)
+  of skParam:
+    result = p.params[s.position]
+  of routineKinds, skConst:
+    result = get(p.g.names)
+  else:
+    unreachable()
+
+proc ensureMangledName(p: PProc, s: PSym): lent string =
+  ## Looks up and returns the mangled name for the non-local symbol
+  ## `s`, generating and caching the mangled name if it hasn't been
+  ## already.
+  let n = addr p.g.names.mgetOrPut(s.id, "")
+  if n[].len == 0:
+    # the mangled named hasn't been generated yet
+    n[] = mangleName(p.module, s)
+
+  result = n[]
 
 proc escapeJSString(s: string): string =
   result = newStringOfCap(s.len + s.len shr 2)
@@ -751,8 +789,9 @@ proc genTry(p: PProc, n: PNode) =
       # If some branch requires a local alias introduce it here. This is needed
       # since JS cannot do ``catch x as y``.
       if excAlias != nil:
-        excAlias.sym.loc.r = mangleName(p.module, excAlias.sym)
-        lineF(p, "var $1 = lastJSError;$n", excAlias.sym.loc.r)
+        let name = mangleName(p.module, excAlias.sym)
+        lineF(p, "var $1 = lastJSError;$n", name)
+        p.localNames[excAlias.sym.id] = name
       genStmt(p, n[i][^1])
       lineF(p, "}$n", [])
     inc(i)
@@ -839,7 +878,6 @@ proc genBlock(p: PProc, n: PNode) =
     # named block?
     p.config.internalAssert(n[0].kind == nkSym, n.info, "genBlock")
     var sym = n[0].sym
-    sym.loc.k = locOther
     sym.position = idx+1
   let labl = p.unique
   lineF(p, "Label$1: do {$n", [labl.rope])
@@ -856,7 +894,7 @@ proc genBreakStmt(p: PProc, n: PNode) =
     # named break?
     assert(n[0].kind == nkSym)
     let sym = n[0].sym
-    assert(sym.loc.k == locOther)
+    assert(sym.kind == skLabel)
     idx = sym.position-1
   else:
     # an unnamed 'break' can only break a loop after 'transf' pass:
@@ -910,7 +948,7 @@ proc genIf(p: PProc, n: PNode) =
   genStmt(p, it[1])
   lineF(p, "}$n", [])
 
-proc generateHeader(prc: PSym): Rope =
+proc generateHeader(prc: PSym, params: openArray[string]): Rope =
   ## Generates the JavaScript function header for `prc`. The parameters are
   ## assumed to already have their mangled names set.
   result = ""
@@ -922,7 +960,7 @@ proc generateHeader(prc: PSym): Rope =
     var param = typ.n[i].sym
     if isCompileTimeOnly(param.typ): continue
     if result != "": result.add(", ")
-    let name = param.loc.r
+    let name = params[i-1]
     result.add(name)
     if mapType(param.typ) == etyBaseIndex:
       result.add(", ")
@@ -1046,9 +1084,7 @@ proc genFieldAddr(p: PProc, n: PNode, r: var TCompRes) =
     r.res = makeJSString("Field" & $getFieldPosition(p, b[1]))
   else:
     p.config.internalAssert(b[1].kind == nkSym, b[1].info, "genFieldAddr")
-    var f = b[1].sym
-    if f.loc.r == "": f.loc.r = mangleName(p.module, f)
-    r.res = makeJSString($f.loc.r)
+    r.res = makeJSString(ensureMangledName(p, b[1].sym))
   internalAssert p.config, a.typ != etyBaseIndex
   r.address = a.res
   r.kind = resExpr
@@ -1074,9 +1110,7 @@ proc genFieldAccess(p: PProc, n: PNode, r: var TCompRes) =
     mkTemp(0)
   else:
     p.config.internalAssert(n[1].kind == nkSym, n[1].info, "genFieldAccess")
-    var f = n[1].sym
-    if f.loc.r == "": f.loc.r = mangleName(p.module, f)
-    r.res = "$1.$2" % [r.res, f.loc.r]
+    r.res = "$1.$2" % [r.res, ensureMangledName(p, n[1].sym)]
     mkTemp(1)
   r.kind = resExpr
 
@@ -1096,11 +1130,9 @@ proc genCheckedFieldOp(p: PProc, n: PNode, takeAddr: bool, r: var TCompRes) =
   # Field symbol
   var field = accessExpr[1].sym
   internalAssert p.config, field.kind == skField
-  if field.loc.r == "": field.loc.r = mangleName(p.module, field)
   # Discriminant symbol
   let disc = checkExpr[2].sym
   internalAssert p.config, disc.kind == skField
-  if disc.loc.r == "": disc.loc.r = mangleName(p.module, disc)
 
   var setx: TCompRes
   gen(p, checkExpr[1], setx)
@@ -1117,16 +1149,17 @@ proc genCheckedFieldOp(p: PProc, n: PNode, takeAddr: bool, r: var TCompRes) =
   useMagic(p, "reprDiscriminant") # no need to offset by firstOrd unlike for cgen
   let msg = genFieldDefect(p.config, field.name.s, disc)
   lineF(p, "if ($1[$2.$3]$4undefined) { raiseFieldError2(makeNimstrLit($5), reprDiscriminant($2.$3, $6)); }$n",
-    setx.res, tmp, disc.loc.r, if negCheck: ~"!==" else: ~"===",
+    setx.res, tmp, ensureMangledName(p, disc), if negCheck: ~"!==" else: ~"===",
     makeJSString(msg), genTypeInfo(p, disc.typ))
 
+  let name = ensureMangledName(p, field)
   if takeAddr:
     r.typ = etyBaseIndex
-    r.res = makeJSString($field.loc.r)
+    r.res = makeJSString(name)
     r.address = tmp
   else:
     r.typ = etyNone
-    r.res = "$1.$2" % [tmp, field.loc.r]
+    r.res = "$1.$2" % [tmp, name]
   r.kind = resExpr
 
 proc genArrayAddr(p: PProc, n: PNode, r: var TCompRes) =
@@ -1200,21 +1233,21 @@ proc genSymAddr(p: PProc, n: PNode, r: var TCompRes) =
   ## Generates the code for taking the address of the location identified by
   ## symbol node `n`
   let s = n.sym
-  p.config.internalAssert(s.loc.r != "", n.info, "genAddr: 3")
   case s.kind
   of skVar, skLet, skResult, skForVar, skParam:
+    let name = mangledName(p, s, n.info)
     r.kind = resExpr
     r.typ = etyBaseIndex
     r.res = "0"
     if isIndirect(s):
-      r.address = s.loc.r
+      r.address = name
     elif mapType(s.typ) == etyBaseIndex and not isBoxedPointer(s):
       # box the separate base+index into an array first
-      r.address = "[[$1, $1_Idx]]" % s.loc.r
+      r.address = "[[$1, $1_Idx]]" % name
     else:
       # something that doesn't directly support having its address
       # taken (e.g. imported variable, parameter, let, etc.)
-      r.address = "[$1]" % s.loc.r
+      r.address = "[$1]" % name
   else: internalError(p.config, n.info, $("genAddr: 2", s.kind))
 
 proc genAddr(p: PProc, n: PNode, r: var TCompRes) =
@@ -1260,47 +1293,38 @@ proc genAddr(p: PProc, n: PNode, r: var TCompRes) =
   else:
     internalError(p.config, n.info, "genAddr: " & $n.kind)
 
-proc genVarInit(p: PProc, v: PSym, n: PNode)
-
 proc genSym(p: PProc, n: PNode, r: var TCompRes) =
   var s = n.sym
   case s.kind
   of skVar, skLet, skParam, skTemp, skResult, skForVar:
-    p.config.internalAssert(s.loc.r != "", n.info, "symbol has no generated name: " & s.name.s)
+    let name = mangledName(p, s, n.info)
     let k = mapType(s.typ)
     if k == etyBaseIndex:
       r.typ = etyBaseIndex
       if isBoxedPointer(s):
         if isIndirect(s):
-          r.address = "$1[0][0]" % [s.loc.r]
-          r.res = "$1[0][1]" % [s.loc.r]
+          r.address = "$1[0][0]" % [name]
+          r.res = "$1[0][1]" % [name]
         else:
-          r.address = "$1[0]" % [s.loc.r]
-          r.res = "$1[1]" % [s.loc.r]
+          r.address = "$1[0]" % [name]
+          r.res = "$1[1]" % [name]
       else:
-        r.address = s.loc.r
-        r.res = s.loc.r & "_Idx"
+        r.address = name
+        r.res = name & "_Idx"
     elif isIndirect(s):
-      r.res = "$1[0]" % [s.loc.r]
+      r.res = "$1[0]" % [name]
     else:
-      r.res = s.loc.r
+      r.res = name
   of skConst:
-    p.config.internalAssert(s.loc.r != "", n.info, "symbol has no generated name: " & s.name.s)
-    r.res = s.loc.r
+    r.res = mangledName(p, s, n.info)
   of skProc, skFunc, skConverter, skMethod, skIterator:
     if sfCompileTime in s.flags:
       localReport(p.config, n.info, reportSym(
         rsemCannotCodegenCompiletimeProc, s))
 
-    discard mangleName(p.module, s)
-    r.res = s.loc.r
+    r.res = ensureMangledName(p, s)
   else:
-    p.config.internalAssert(s.loc.r != "", n.info, "symbol has no generated name: " & s.name.s)
-    if mapType(s.typ) == etyBaseIndex:
-      r.address = s.loc.r
-      r.res = s.loc.r & "_Idx"
-    else:
-      r.res = s.loc.r
+    unreachable()
   r.kind = resVal
 
 proc genDeref(p: PProc, n: PNode, r: var TCompRes) =
@@ -1441,7 +1465,6 @@ proc genInfixCall(p: PProc, n: PNode, r: var TCompRes) =
   # don't call '$' here for efficiency:
   let f = n[0].sym
   assert sfInfixCall in f.flags
-  if f.loc.r == "": f.loc.r = mangleName(p.module, f)
   if true:
     let pat = f.loc.r
     internalAssert p.config, pat.len > 0
@@ -1610,35 +1633,37 @@ template returnType: untyped = ~""
 
 proc defineGlobal*(globals: PGlobals, m: BModule, v: PSym) =
   ## Emits the definition for the single global `v` into the top-level section,
-  ## with `m` being the module the global belongs to. Also sets up the symbols
-  ## mangled name.
+  ## with `m` being the module the global belongs to. Also sets up the
+  ## symbol's JavaScript name.
   let p = newInitProc(globals, m)
+  let name = mangleName(m, v)
   if lfNoDecl notin v.loc.flags and sfImportc notin v.flags:
-    let name = mangleName(m, v) # mutates `v`
     lineF(p, "var $1 = $2;$n", [name, createVar(p, v.typ, isIndirect(v))])
 
+  globals.names[v.id] = name
   # add to the top-level section:
   globals.code.add(p.body)
 
 proc defineGlobals*(globals: PGlobals, m: BModule, vars: openArray[PSym]) =
   ## Emits definitions for the items in `vars` into the top-level section,
-  ## with `m` being the module the globals belong to. Also updates each
-  ## symbol that requires name mangling with the mangled name.
+  ## with `m` being the module the globals belong to. Also sets up the
+  ## JavaScript name for the globals.
   let p = newInitProc(globals, m)
     ## required for emitting code
   for v in vars.items:
+    let name = mangleName(m, v)
     if lfNoDecl notin v.loc.flags and sfImportc notin v.flags:
-      let name = mangleName(m, v) # mutates `v`
       lineF(p, "var $1 = $2;$n", [name, createVar(p, v.typ, isIndirect(v))])
+
+    globals.names[v.id] = name
 
   # add to the top-level section:
   globals.code.add(p.body)
 
-proc genVarInit(p: PProc, v: PSym, n: PNode) =
+proc genVarInit(p: PProc, v: PSym, varName: string, n: PNode) =
   var
     a: TCompRes
     s: Rope
-    varName = mangleName(p.module, v)
 
   if n.kind == nkEmpty:
     if not isIndirect(v) and
@@ -1662,31 +1687,39 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
         s = "[$1, $2]" % [a.address, a.res]
       else:
         lineF(p, "var $1 = $2, $1_Idx = $3;$n",
-                 [v.loc.r, a.address, a.res])
+                 [varName, a.address, a.res])
         # exit early because we've already emitted the definition
         return
     else:
       s = a.res
     if isIndirect(v):
-      lineF(p, "var $1 = [$2];$n", [v.loc.r, s])
+      lineF(p, "var $1 = [$2];$n", [varName, s])
     else:
-      lineF(p, "var $1 = $2;$n", [v.loc.r, s])
+      lineF(p, "var $1 = $2;$n", [varName, s])
 
 proc genVarStmt(p: PProc, n: PNode) =
   for it in n.items:
     assert it.kind == nkIdentDefs
     assert it[0].kind == nkSym
     let v = it[0].sym
+    let name = mangleName(p.module, v)
     if lfNoDecl notin v.loc.flags and sfImportc notin v.flags:
       genLineDir(p, it)
-      genVarInit(p, v, it[2])
+      genVarInit(p, v, name, it[2])
+
+    # all locals need a name:
+    p.localNames[v.id] = name
 
 proc genConstant*(g: PGlobals, m: BModule, c: PSym) =
+  let name = mangleName(m, c)
   if lfNoDecl notin c.loc.flags:
     var p = newInitProc(g, m)
     #genLineDir(p, c.ast)
-    genVarInit(p, c, c.ast)
+    genVarInit(p, c, name, c.ast)
     g.constants.add(p.body)
+
+  # all constants need a name:
+  g.names[c.id] = name
 
 proc genNew(p: PProc, n: PNode) =
   var a: TCompRes
@@ -2085,17 +2118,17 @@ proc genObjConstr(p: PProc, n: PNode, r: var TCompRes) =
     let val = it[1]
     gen(p, val, a)
     var f = it[0].sym
-    if f.loc.r == "": f.loc.r = mangleName(p.module, f)
+    let name = ensureMangledName(p, f)
     fieldIDs.incl(lookupFieldAgain(n.typ, f).id)
 
     let typ = val.typ.skipTypes(abstractInst)
     if a.typ == etyBaseIndex:
-      initList.addf("$#: [$#, $#]", [f.loc.r, a.address, a.res])
+      initList.addf("$#: [$#, $#]", [name, a.address, a.res])
     else:
       if not needsNoCopy(p, val):
         useMagic(p, "nimCopy")
         a.res = "nimCopy(null, $1, $2)" % [a.rdLoc, genTypeInfo(p, typ)]
-      initList.addf("$#: $#", [f.loc.r, a.res])
+      initList.addf("$#: $#", [name, a.res])
   let t = skipTypes(n.typ, abstractInst + skipPtrs)
   createObjInitList(p, t, fieldIDs, initList)
   r.res = ("{$1}") % [initList]
@@ -2219,25 +2252,29 @@ proc startProc*(g: PGlobals, module: BModule, prc: PSym): PProc =
   let p = newProc(g, module, prc, prc.options)
 
   # make sure the procedure has a mangled name:
-  discard mangleName(p.module, prc)
+  discard ensureMangledName(p, prc)
+
+  p.params.newSeq(prc.typ.len - 1 + ord(prc.typ.callConv == ccClosure))
+  # -1 for the result type
 
   # same for the result symbol and parameters:
   if prc.typ[0] != nil and sfPure notin prc.flags:
-    discard mangleName(p.module, prc.ast[resultPos].sym)
+    let s = prc.ast[resultPos].sym
+    p.localNames[s.id] = mangleName(p.module, s)
 
   # set the mangled name for the parameters:
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym
     if not isCompileTimeOnly(param.typ):
-      discard mangleName(p.module, param)
+      p.params[i-1] = mangleName(p.module, param)
 
   if prc.typ.callConv == ccClosure:
     # generate the name for the hidden environment parameter. When creating a
     # closure object, the environment is bound to the ``this`` argument of the
     # function, hence using ``this`` for the name
-    let hidden = prc.ast[paramsPos].lastSon
-    assert hidden.kind == nkSym, "the hidden parameter is missing"
-    hidden.sym.loc.r = "this"
+    assert prc.ast[paramsPos].lastSon.kind == nkSym,
+           "the hidden parameter is missing"
+    p.params[^1] = "this"
 
   result = p
 
@@ -2251,7 +2288,7 @@ proc finishProc*(p: PProc): string =
 
   if prc.typ[0] != nil and sfPure notin prc.flags:
     let resultSym = prc.ast[resultPos].sym
-    let mname = resultSym.loc.r
+    let mname = p.localNames[resultSym.id]
     let returnAddress = not isIndirect(resultSym) and
       resultSym.typ.kind in {tyVar, tyPtr, tyLent, tyRef} and
         mapType(resultSym.typ) == etyBaseIndex
@@ -2272,8 +2309,8 @@ proc finishProc*(p: PProc): string =
     result = lineDir(p.config, prc.info, toLinenumber(prc.info))
 
   let
-    name   = prc.loc.r
-    header = generateHeader(prc)
+    name   = p.g.names[prc.id]
+    header = generateHeader(prc, p.params)
 
   var def: Rope
   if not prc.constraint.isNil:

--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -63,7 +63,7 @@ proc isExportedToC(c: var AliveContext; g: PackedModuleGraph; symId: int32): boo
         (symPtr.kind == skMethod):
       result = true
       # XXX: This used to be a condition to:
-      #  (sfExportc in prc.flags and lfExportLib in prc.loc.flags) or
+      #  (sfExportc in prc.flags and lfExportLib in prc.locFlags) or
     if sfCompilerProc in flags:
       c.compilerProcs[g[c.thisModule].fromDisk.strings[symPtr.name]] = (c.thisModule, symId)
 

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -418,8 +418,8 @@ proc storeSym*(s: PSym; c: var PackedEncoder; m: var PackedModule): PackedItemId
       p.bitsize = s.bitsize
       p.alignment = s.alignment
 
-    p.externalName = toLitId(s.loc.r, m)
-    p.locFlags = s.loc.flags
+    p.externalName = toLitId(s.extname, m)
+    p.locFlags = s.locFlags
     c.addMissing s.typ
     p.typ = s.typ.storeType(c, m)
     c.addMissing s.owner
@@ -878,8 +878,8 @@ proc symBodyFromPacked(c: var PackedDecoder; g: var PackedModuleGraph;
   result.owner = loadSym(c, g, si, s.owner)
   let externalName = g[si].fromDisk.strings[s.externalName]
   if externalName != "":
-    result.loc.r = rope externalName
-  result.loc.flags = s.locFlags
+    result.extname = rope externalName
+  result.locFlags = s.locFlags
 
 proc loadSym(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int; s: PackedItemId): PSym =
   if s == nilItemId:

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -125,7 +125,7 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap,
               buf.add MirNode(kind: mnkConsume, typ: typ)
             buf.add MirNode(kind: mnkInit)
         elif {sfImportc, sfNoInit} * sym.flags == {} and
-             {lfDynamicLib, lfNoDecl} * sym.loc.flags == {}:
+             {lfDynamicLib, lfNoDecl} * sym.locFlags == {}:
           # XXX: ^^ re-think this condition from first principles. Right now,
           #      it's just meant to make some tests work
           # the location doesn't have an explicit starting value. Initialize

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -205,14 +205,14 @@ proc setExternName(c: PContext; s: PSym, ext: string) =
 
   # special cases to improve performance:
   if ext == "$1":
-    s.loc.r = s.name.s
+    s.extname = s.name.s
   elif '$' notin ext:
-    s.loc.r = ext
+    s.extname = ext
   else:
-    s.loc.r = ext % s.name.s
+    s.extname = ext % s.name.s
   if c.config.cmd == cmdNimfix and '$' notin ext:
     # note that '{.importc.}' is transformed into '{.importc: "$1".}'
-    s.loc.flags.incl(lfFullExternalName)
+    s.locFlags.incl(lfFullExternalName)
 
 proc makeExternImport(c: PContext; s: PSym, ext: string) =
   ## produces (mutates) `s`'s `loc`ation setting the import name, marks it as
@@ -235,7 +235,7 @@ proc processImportCompilerProc(c: PContext; s: PSym, ext: string) =
   setExternName(c, s, ext)
   incl(s.flags, sfImportc)
   excl(s.flags, sfForward)
-  incl(s.loc.flags, lfImportCompilerProc)
+  incl(s.locFlags, lfImportCompilerProc)
 
 proc getStrLitNode(c: PContext, n: PNode): PNode =
   ## returns a PNode that's either an error or a string literal node
@@ -402,9 +402,9 @@ proc processDynLib(c: PContext, n: PNode, sym: PSym): PNode =
         var lib = getLib(c, libDynamic, libNode)
         if not lib.isOverriden:
           addToLib(lib, sym)
-          incl(sym.loc.flags, lfDynamicLib)
+          incl(sym.locFlags, lfDynamicLib)
     else:
-      incl(sym.loc.flags, lfExportLib)
+      incl(sym.locFlags, lfExportLib)
     # since we'll be loading the dynlib symbols dynamically, we must use
     # a calling convention that doesn't introduce custom name mangling
     # cdecl is the default - the user can override this explicitly
@@ -1150,7 +1150,7 @@ proc applySymbolPragma(c: PContext, sym: PSym, it: PNode): PNode =
             c.config.newError(it, PAstDiag(kind: adSemAlignRequiresPowerOfTwo))
       of wNodecl:
         result = noVal(c, it)
-        incl(sym.loc.flags, lfNoDecl)
+        incl(sym.locFlags, lfNoDecl)
       of wPure, wAsmNoStackFrame:
         result = noVal(c, it)
         incl(sym.flags, sfPure)
@@ -1192,9 +1192,9 @@ proc applySymbolPragma(c: PContext, sym: PSym, it: PNode): PNode =
         let lib = getLib(c, libHeader, path)
         addToLib(lib, sym)
         sym.flags.incl sfImportc
-        sym.loc.flags.incl {lfHeader, lfNoDecl}
+        sym.locFlags.incl {lfHeader, lfNoDecl}
         # implies nodecl, because otherwise header would not make sense
-        if sym.loc.r == "": sym.loc.r = sym.name.s
+        if sym.extname == "": sym.extname = sym.name.s
       of wNoSideEffect:
         result = noVal(c, it)
         incl(sym.flags, sfNoSideEffect)
@@ -1853,13 +1853,13 @@ proc inheritDynlib*(c: PContext, sym: PSym) =
   ## imported, but no header nor dynlib are specified.
   let lib = c.optionStack[^1].dynlib
   if lib != nil and sfImportc in sym.flags and
-     {lfDynamicLib, lfHeader} * sym.loc.flags == {}:
-    incl(sym.loc.flags, lfDynamicLib)
+     {lfDynamicLib, lfHeader} * sym.locFlags == {}:
+    incl(sym.locFlags, lfDynamicLib)
     addToLib(lib, sym)
-    if sym.loc.r == "":
+    if sym.extname == "":
       # XXX: this looks like a unnecessary defensive check. If the symbol is
       #      marked as imported, it already has an external name set
-      sym.loc.r = sym.name.s
+      sym.extname = sym.name.s
 
 proc containsError(n: PNode): bool =
   for it in n.items:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -930,8 +930,8 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
       f.options = c.config.options
       if fieldOwner != nil and
          {sfImportc, sfExportc} * fieldOwner.flags != {} and
-         not hasCaseFields and f.loc.r == "":
-        f.loc.r = rope(f.name.s)
+         not hasCaseFields and f.extname == "":
+        f.extname = rope(f.name.s)
         f.flags.incl {sfImportc, sfExportc} * fieldOwner.flags
       inc(pos)
       if containsOrIncl(check, f.name.id):

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -152,9 +152,9 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
     # is actually safe without an infinite recursion check:
     if t.sym != nil:
       if {sfCompilerProc} * t.sym.flags != {}:
-        doAssert t.sym.loc.r != ""
+        doAssert t.sym.extname != ""
         # The user has set a specific name for this type
-        c &= t.sym.loc.r
+        c &= t.sym.extname
       elif CoOwnerSig in flags:
         c.hashTypeSym(t.sym)
       else:

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -107,6 +107,11 @@ iterator pairs*[I, T](x: Store[I, T]): (I, lent T) =
     yield (I(i), x.data[i])
     inc i
 
+func nextId*[I; T](x: Store[I, T]): I {.inline.} =
+  ## Returns the ID that would be assigned to the next added item.
+  rangeCheck x.data.len.BiggestUInt < high(I).BiggestUInt
+  result = I(x.data.len)
+
 func add*[I; T](x: var Store[I, T], it: sink T): I {.inline.} =
   ## Appends a new item to the Store and returns the ID assigned to
   ## it

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -132,7 +132,7 @@ proc genStmt(c: var TCtx, f: var CodeFragment, stmt: PNode) =
 proc declareGlobal(c: var TCtx, sym: PSym) =
   # we silently ignore imported globals here and let ``vmgen`` raise an
   # error when one is accessed
-  if lfNoDecl notin sym.loc.flags and sfImportc notin sym.flags:
+  if lfNoDecl notin sym.locFlags and sfImportc notin sym.flags:
     # make sure the type is generated and register the global in the
     # link table
     discard getOrCreate(c, sym.typ)
@@ -153,7 +153,7 @@ proc prepare(c: var TCtx, data: var DiscoveryData) =
     # don't want any processing to happen for it, which we signal to the
     # event producer via ``lfNoDecl``
     if c.functions[i].kind == ckCallback:
-      it.loc.flags.incl lfNoDecl
+      it.locFlags.incl lfNoDecl
 
   # register the constants with the link table:
   for i, s in visit(data.constants):


### PR DESCRIPTION
## Summary

Remove the `loc` fields from both `TSym` and `TType` and leave it to
the code generators how and if they use `TLoc` -- `TSym` only stores the
external name plus interface flags now. The benefits:
- another point of coupling (through data-types) between semantic
  analysis and code generation is removed
- the size of an `TType` instance shrinks from 120 to 96 bytes (with a
  64-bit target)
- the size of an `TSym` instance shrinks from 168 to 160 bytes

Because of its `lode` field, `TLoc` not being defined in the `ast_types`
module is also an important prerequisite for introducing a code IR for
the code generators.

## Details

The key changes:
- move `TLoc` and the associated types only relevant to the C code
  generator to `cgendata`
- remove the `loc` field from `TSym` and `TType` -- `TSym` stores the
  external name and interface flags via the new `extname` and `locFlags`
  fields
- as an interim solution, add the `locId` field to `TSym`
- fix the name slot in the `ast` of dispatcher storing the wrong symbol
- NDI file generation is now the responsibility of the orchestrator

### `cgen`

For associating a `PSym` with a `TLoc`, multiple `Store`s shared across
all C modules are used. The `TSym.locId` is an index into the
`SymbolMap` (which is a `Store` underneath) for the respective symbol
kind (globals, constants, procedures, fields). While a single
`SymbolMap` could be used (for the non-procedure entities), the plan is
to use dedicated types for the entities in the future, and using
separate stores is a preparation for that.

In order to not re-mangle parameters every time when emitting a
prototype, the locs for parameters are stored with their procedure.

Since locals are known to not outlive their surrounding procedure, the
locs for them are stored in a dedicated `SymbolMap` with the procedure
context -- once a procedure context goes away, the locals' `TLoc`s can
be, and are, freed already.

In general, the C code generator is now more strict with who is
responsible for filling-in loc information: for constants and globals,
it must only happen once during definition. Procedures and fields still
need to support ad-hoc loc setup, and fields need special-casing because
of `.inline` procedures and how `finally` clauses work (i.e., they're
duplicated at a too late time).

A table-based approach where the symbol IDs are mapped to `TLoc`s would
have also worked, but measurements showed that it was ~1.4% slower.

#### NDI files

Instead of directly updating the NDI file with a new entry when
generating a mangled name, as was done previously, adding the entries is
now the responsibility of the orchestrator: entries for whole-program
entities are added after code generation has finished -- entries for
locals once code generation for a procedure has finished.

For NDI file generation to work, the symbol. This was already the case
for all entities except constants, so constants now also store a `nkSym`
node in their `lode` field.

### `jsgen`

Due to it being less complex than the C code generator, a table-based
approach is okay for the JavaScript code generator. Only the JavaScript
name is relevant to the code generator, so it maps the symbol IDs
directly to strings and doesn't use `TLoc`. Separate tables are used
for global entities (globals, constants, procedures, and fields),
locals, and parameters.