### PR TITLE
internal: split up `TLocFlag`

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -325,7 +325,7 @@ proc assignType*(dest, src: PType) =
     if dest.sym != nil:
       dest.sym.flags.incl src.sym.flags-{sfExported}
       if dest.sym.annex == nil: dest.sym.annex = src.sym.annex
-      dest.sym.locFlags.incl src.sym.locFlags
+      dest.sym.extFlags.incl src.sym.extFlags
       if dest.sym.extname.len == 0:
         dest.sym.extname = src.sym.extname
     else:
@@ -350,7 +350,7 @@ proc copySym*(s: PSym; id: ItemId): PSym =
   result.options = s.options
   result.position = s.position
   result.extname = s.extname
-  result.locFlags = s.locFlags
+  result.extFlags = s.extFlags
   result.annex = s.annex      # BUGFIX
   result.constraint = s.constraint
   if result.kind in {skVar, skLet, skField}:
@@ -368,7 +368,7 @@ proc createModuleAlias*(s: PSym, id: ItemId, newIdent: PIdent, info: TLineInfo;
   result.options = s.options
   result.position = s.position
   result.extname = s.extname
-  result.locFlags = s.locFlags
+  result.extFlags = s.extFlags
   result.annex = s.annex
 
 proc initStrTable*(x: var TStrTable) =
@@ -506,7 +506,7 @@ template transitionSymKindCommon*(k: TSymKind) =
   s[] = TSym(kind: k, itemId: obj.itemId, magic: obj.magic, typ: obj.typ, name: obj.name,
              info: obj.info, owner: obj.owner, flags: obj.flags, ast: obj.ast,
              options: obj.options, position: obj.position, offset: obj.offset,
-             extname: obj.extname, locFlags: obj.locFlags, locId: obj.locId,
+             extname: obj.extname, extFlags: obj.extFlags, locId: obj.locId,
              annex: obj.annex, constraint: obj.constraint)
   when defined(nimsuggest):
     s.allUsages = obj.allUsages

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1589,30 +1589,18 @@ type
     counter*: int
     data*: seq[PSym]
 
-  # -------------- backend information -------------------------------
-  TLocFlag* = enum
-    # XXX: `TLocFlag` conflates two things:
-    #      - flags regarding the external interface (e.g., `lfHeader`; set by
-    #        sem, used by sem and the code generators)
-    #      - location-related flags (e.g., ``lfIndirect``, ``lfSingleUse``,
-    #        etc.; only relevant to the C code generator)
-    #      Split the enum up.
-    lfIndirect,               ## backend introduced a pointer
-    lfFullExternalName, ## only used when 'conf.cmd == cmdNimfix': Indicates
+  ExternalFlag* = enum
+    ## Flags that describe a symbol's external interface.
+    exfFullExternalName  ## only used when 'conf.cmd == cmdNimfix': Indicates
       ## that the symbol has been imported via 'importc: "fullname"' and
       ## no format string.
-    lfNoDecl,                 ## do not declare it in C
-    lfDynamicLib,             ## link symbol to dynamic library
-    lfExportLib,              ## export symbol for dynamic library generation
-    lfHeader,                 ## include header file for symbol
-    lfImportCompilerProc,     ## ``importc`` of a compilerproc
-    lfSingleUse               ## no location yet and will only be used once
-    lfEnforceDeref            ## a copyMem is required to dereference if this a
-                              ## ptr array due to C array limitations.
-                              ## See #1181, #6422, #11171
-    lfPrepareForMutation      ## string location is about to be mutated (V2)
+    exfNoDecl                 ## do not declare it in C
+    exfDynamicLib             ## link symbol to dynamic library
+    exfExportLib              ## export symbol for dynamic library generation
+    exfHeader                 ## include header file for symbol
+    exfImportCompilerProc     ## ``importc`` of a compilerproc
 
-  TLocFlags* = set[TLocFlag]
+  ExternalFlags* = set[ExternalFlag]
 
   # ---------------- end of backend information ------------------------------
 
@@ -1698,7 +1686,7 @@ type
     offset*: int              ## offset of record field
     extname*: string          ## the external name of the type, or empty if a
                               ## generated name is to be used
-    locFlags*: TLocFlags      ## additional flags that are relevant to code
+    extFlags*: ExternalFlags  ## additional flags that are relevant to code
                               ## generation
     locId*: uint32            ## associates the symbol with a loc in the C code
                               ## generator. 0 means unset.

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -486,7 +486,7 @@ func discoverFrom*(data: var DiscoveryData, decl: PNode) =
     of nkProcDef, nkFuncDef, nkConverterDef, nkMethodDef:
       let prc = n[namePos].sym
       if {sfExportc, sfCompilerProc} * prc.flags == {sfExportc} or
-         (sfExportc in prc.flags and lfExportLib in prc.locFlags):
+         (sfExportc in prc.flags and exfExportLib in prc.extFlags):
         # an exported routine. It must always have code generated for it. Note
         # that compilerprocs, while exported, are still only have code generated
         # for them when used
@@ -524,7 +524,7 @@ func queue(iter: var ProcedureIter, prc: PSym, m: FileIndex) =
   ## If eligible for processing and code generation, adds `prc` to
   ## `iter`'s queue.
   assert prc.kind in routineKinds
-  if lfNoDecl notin prc.locFlags and
+  if exfNoDecl notin prc.extFlags and
      (sfImportc notin prc.flags or (iter.config.noImported and
                                     prc.ast[bodyPos].kind != nkEmpty)):
     iter.queued.add (prc, m)
@@ -564,7 +564,7 @@ proc preprocessDynlib(graph: ModuleGraph, idgen: IdGenerator,
   #       horrendous, but fortunately, this hack (`preprocessDynlib``) can
   #       be removed once handling of dynlib procedures and globals is fully
   #       implemented in the ``process`` iterator
-  if lfDynamicLib in sym.locFlags:
+  if exfDynamicLib in sym.extFlags:
     if sym.annex.path.kind in nkStrKinds:
       # it's a string, no need to transform nor scan it
       discard

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -160,7 +160,7 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
   # XXX: dynlib procedure handling is going to move into the unified backend
   #      processing pipeline (i.e., the ``process`` iterator) in the future
   for _, s in peek(discovery.procedures):
-    if lfDynamicLib in s.locFlags:
+    if exfDynamicLib in s.extFlags:
       let m = g.modules[s.itemId.module.int]
       fillProcLoc(m, newSymNode(s))
       symInDynamicLib(m, s)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1901,7 +1901,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
     # Why would anyone want to set nodecl to one of these hardcoded magics?
     # - not sure, and it wouldn't work if the symbol behind the magic isn't
     #   somehow forward-declared from some other usage, but it is *possible*
-    if lfNoDecl notin opr.locFlags:
+    if exfNoDecl notin opr.extFlags:
       let prc = magicsys.getCompilerProc(p.module.g.graph, opr.extname)
       assert prc != nil, opr.extname
       # Make the function behind the magic get actually generated
@@ -2126,7 +2126,7 @@ proc exprComplexConst(p: BProc, n: PNode, d: var TLoc) =
 
 proc useConst*(m: BModule; sym: PSym) =
   useHeader(m, sym)
-  if lfNoDecl in sym.locFlags:
+  if exfNoDecl in sym.extFlags:
     return
 
   let q = findPendingModule(m, sym)
@@ -2139,7 +2139,7 @@ proc useConst*(m: BModule; sym: PSym) =
 
 proc genConstDefinition*(q: BModule; sym: PSym) =
   let name = mangleName(q.g.graph, sym)
-  if lfNoDecl notin sym.locFlags:
+  if exfNoDecl notin sym.extFlags:
     let p = newProc(nil, q)
     q.s[cfsData].addf("N_LIB_PRIVATE NIM_CONST $1 $2 = $3;$n",
         [getTypeDesc(q, sym.typ), name,

--- a/compiler/backend/ccgthreadvars.nim
+++ b/compiler/backend/ccgthreadvars.nim
@@ -33,7 +33,7 @@ proc declareThreadVar*(m: BModule, s: PSym, isExtern: bool) =
       m.g.nimtv.addf("$1 $2;$n", [getTypeDesc(m, s.typ), m.globals[s].r])
   else:
     if isExtern: m.s[cfsVars].add("extern ")
-    elif lfExportLib in s.locFlags: m.s[cfsVars].add("N_LIB_EXPORT_VAR ")
+    elif exfExportLib in s.extFlags: m.s[cfsVars].add("N_LIB_EXPORT_VAR ")
     else: m.s[cfsVars].add("N_LIB_PRIVATE ")
     if optThreads in m.config.globalOptions:
       m.s[cfsVars].add("NIM_THREADVAR ")

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -795,7 +795,7 @@ proc genProcHeader(m: BModule, prc: PSym, locs: openArray[TLoc]): Rope =
   var
     rettype, params: Rope
   # using static is needed for inline procs
-  if lfExportLib in prc.locFlags:
+  if exfExportLib in prc.extFlags:
     if isHeaderFile in m.flags:
       result.add "N_LIB_IMPORT "
     else:

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -66,10 +66,18 @@ type
     OnHeap                    ## location is on heap or global
                               ## (reference counting needed)
 
+  LocFlag* = enum
+    lfIndirect               ## code generator introduced a pointer
+    lfSingleUse              ## no location yet and will only be used once
+    lfEnforceDeref           ## a copyMem is required to dereference if this a
+                             ## ptr array due to C array limitations.
+                             ## See #1181, #6422, #11171
+    lfPrepareForMutation     ## string location is about to be mutated
+
   TLoc* = object
     k*: TLocKind              ## kind of location
     storage*: TStorageLoc
-    flags*: TLocFlags         ## location's flags
+    flags*: set[LocFlag]      ## location's flags
     lode*: PNode              ## Node where the location came from; can be faked
     r*: Rope                  ## rope value of location (code generators)
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1640,7 +1640,7 @@ proc defineGlobal*(globals: PGlobals, m: BModule, v: PSym) =
   ## symbol's JavaScript name.
   let p = newInitProc(globals, m)
   let name = mangleName(m, v)
-  if lfNoDecl notin v.locFlags and sfImportc notin v.flags:
+  if exfNoDecl notin v.extFlags and sfImportc notin v.flags:
     lineF(p, "var $1 = $2;$n", [name, createVar(p, v.typ, isIndirect(v))])
 
   globals.names[v.id] = name
@@ -1655,7 +1655,7 @@ proc defineGlobals*(globals: PGlobals, m: BModule, vars: openArray[PSym]) =
     ## required for emitting code
   for v in vars.items:
     let name = mangleName(m, v)
-    if lfNoDecl notin v.locFlags and sfImportc notin v.flags:
+    if exfNoDecl notin v.extFlags and sfImportc notin v.flags:
       lineF(p, "var $1 = $2;$n", [name, createVar(p, v.typ, isIndirect(v))])
 
     globals.names[v.id] = name
@@ -1706,7 +1706,7 @@ proc genVarStmt(p: PProc, n: PNode) =
     assert it[0].kind == nkSym
     let v = it[0].sym
     let name = mangleName(p.module, v)
-    if lfNoDecl notin v.locFlags and sfImportc notin v.flags:
+    if exfNoDecl notin v.extFlags and sfImportc notin v.flags:
       genLineDir(p, it)
       genVarInit(p, v, name, it[2])
 
@@ -1715,7 +1715,7 @@ proc genVarStmt(p: PProc, n: PNode) =
 
 proc genConstant*(g: PGlobals, m: BModule, c: PSym) =
   let name = mangleName(m, c)
-  if lfNoDecl notin c.locFlags:
+  if exfNoDecl notin c.extFlags:
     var p = newInitProc(g, m)
     #genLineDir(p, c.ast)
     genVarInit(p, c, name, c.ast)

--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -63,7 +63,7 @@ proc isExportedToC(c: var AliveContext; g: PackedModuleGraph; symId: int32): boo
         (symPtr.kind == skMethod):
       result = true
       # XXX: This used to be a condition to:
-      #  (sfExportc in prc.flags and lfExportLib in prc.locFlags) or
+      #  (sfExportc in prc.flags and exfExportLib in prc.extFlags) or
     if sfCompilerProc in flags:
       c.compilerProcs[g[c.thisModule].fromDisk.strings[symPtr.name]] = (c.thisModule, symId)
 

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -419,7 +419,7 @@ proc storeSym*(s: PSym; c: var PackedEncoder; m: var PackedModule): PackedItemId
       p.alignment = s.alignment
 
     p.externalName = toLitId(s.extname, m)
-    p.locFlags = s.locFlags
+    p.extFlags = s.extFlags
     c.addMissing s.typ
     p.typ = s.typ.storeType(c, m)
     c.addMissing s.owner
@@ -879,7 +879,7 @@ proc symBodyFromPacked(c: var PackedDecoder; g: var PackedModuleGraph;
   let externalName = g[si].fromDisk.strings[s.externalName]
   if externalName != "":
     result.extname = rope externalName
-  result.locFlags = s.locFlags
+  result.extFlags = s.extFlags
 
 proc loadSym(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int; s: PackedItemId): PSym =
   if s == nilItemId:

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -60,7 +60,7 @@ type
     position*: int
     offset*: int
     externalName*: LitId # instead of TLoc
-    locFlags*: TLocFlags
+    extFlags*: ExternalFlags
     annex*: PackedLib
     constraint*: NodeId
 

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -125,7 +125,7 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap,
               buf.add MirNode(kind: mnkConsume, typ: typ)
             buf.add MirNode(kind: mnkInit)
         elif {sfImportc, sfNoInit} * sym.flags == {} and
-             {lfDynamicLib, lfNoDecl} * sym.locFlags == {}:
+             {exfDynamicLib, exfNoDecl} * sym.extFlags == {}:
           # XXX: ^^ re-think this condition from first principles. Right now,
           #      it's just meant to make some tests work
           # the location doesn't have an explicit starting value. Initialize

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -132,7 +132,7 @@ proc genStmt(c: var TCtx, f: var CodeFragment, stmt: PNode) =
 proc declareGlobal(c: var TCtx, sym: PSym) =
   # we silently ignore imported globals here and let ``vmgen`` raise an
   # error when one is accessed
-  if lfNoDecl notin sym.locFlags and sfImportc notin sym.flags:
+  if exfNoDecl notin sym.extFlags and sfImportc notin sym.flags:
     # make sure the type is generated and register the global in the
     # link table
     discard getOrCreate(c, sym.typ)
@@ -151,9 +151,9 @@ proc prepare(c: var TCtx, data: var DiscoveryData) =
 
     # if a procedure's implementation is overridden with a VM callback, we
     # don't want any processing to happen for it, which we signal to the
-    # event producer via ``lfNoDecl``
+    # event producer via ``exfNoDecl``
     if c.functions[i].kind == ckCallback:
-      it.locFlags.incl lfNoDecl
+      it.extFlags.incl exfNoDecl
 
   # register the constants with the link table:
   for i, s in visit(data.constants):


### PR DESCRIPTION
## Summary

Separate the enum into two enums: one for the flags describing a
symbol's external interface and one for the actual location flags. This
fixes an implementation detail of the C code generator (location flags)
leaking into `TSym`.

## Details

The enum for the external interface flags is named `ExternalFlag` and
the location flag enum `LocFlag`. Since the latter is only relevant to
the C code generator, it is moved to `cgendata`.

The field storing the external interface flags in `TSym` and `PackedSym`
is renamed to `extFlags`. Due to the `ef` prefix being already taken by
the `TExprFlag` enum, the `ExternalFlag` enum uses the `exf` prefix.