### PR TITLE
internal: move MIR generation DSL to `mirconstr`

### DIFF
--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -118,11 +118,8 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap,
               buf.add MirNode(kind: mnkTemp, temp: tmp, typ: typ)
 
             argBlock(buf):
-              buf.add MirNode(kind: mnkGlobal, sym: sym, typ: typ)
-              buf.add MirNode(kind: mnkTag, effect: ekReassign, typ: typ)
-              buf.add MirNode(kind: mnkName, typ: typ)
-              buf.add MirNode(kind: mnkTemp, temp: tmp, typ: typ)
-              buf.add MirNode(kind: mnkConsume, typ: typ)
+              chain(buf): symbol(mnkGlobal, sym) => tag(ekReassign) => name()
+              chain(buf): temp(typ, tmp) => consume()
             buf.add MirNode(kind: mnkInit)
         elif {sfImportc, sfNoInit} * sym.flags == {} and
              {lfDynamicLib, lfNoDecl} * sym.locFlags == {}:
@@ -132,12 +129,9 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap,
           # it to the type's default value.
           changes.replaceMulti(buf):
             argBlock(buf):
-              buf.add MirNode(kind: mnkGlobal, sym: sym, typ: typ)
-              buf.add MirNode(kind: mnkTag, effect: ekReassign, typ: typ)
-              buf.add MirNode(kind: mnkName, typ: typ)
+              chain(buf): symbol(mnkGlobal, sym) => tag(ekReassign) => name()
               argBlock(buf): discard
-              buf.add MirNode(kind: mnkMagic, magic: mDefault, typ: typ)
-              buf.add MirNode(kind: mnkConsume, typ: typ)
+              chain(buf): magicCall(mDefault, typ) => consume()
             buf.add MirNode(kind: mnkInit)
         else:
           # just remove the def:

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -71,10 +71,6 @@ template eval*(buf: var MirNodeSeq, x: untyped): EValue =
     discardTypeCheck[Value](x)
     value
 
-template `=>`*(v: Value, sink: Sink) =
-  discard v
-  discard sink
-
 template `=>`*(a: EValue, b: SinkAndValue): Value =
   mixin value
   value = a
@@ -108,20 +104,6 @@ template `=>`*(v: Predicate, sink: SinkAndValue): Value =
 template `=>`*(v: Value, sink: SinkAndValue): Value =
   discard v
   discard sink
-  Value(false)
-
-template `=>|`*(v: Value, sink: SinkAndValue) =
-  discard v
-  discard sink
-
-template `|=>`*(sink: Sink) =
-  discard sink
-
-template `|=>`*(sink: SinkAndValue): Value =
-  discard sink
-  Value(false)
-
-template previous*(): Value =
   Value(false)
 
 template follows*(): Sink =

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -255,6 +255,9 @@ func name*(s: var MirNodeSeq, val: EValue) =
   s.add MirNode(kind: mnkName, typ: val.typ)
 
 func voidOut*(s: var MirNodeSeq, val: EValue) =
+  ## Ends the input MIR expression as a void-expression (i.e., the
+  ## computed result of the expression is discarded). Corresponds
+  ## to ``mnkVoid``.
   s.add MirNode(kind: mnkVoid)
 
 # special operators:

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -16,10 +16,76 @@ type
     ## Used to mark a procedure as generating code that acts as a sink
   SinkAndValue* = distinct bool
 
+  ChainEnd = distinct bool
+    ## Sentinel type used to mark an operator in a chain as ending the chain.
+    ## No further operators can be chained after an operator marked as
+    ## ``ChainEnd``
+
+  EValue* = object
+    ## Encapsulates information about the abstract value that results from
+    ## an operation sequence. It's used as a way to transport said information
+    ## between the generator procedures for operators.
+    typ* {.cursor.}: PType
+
+# -------- chain templates:
+# the templates that provide the context for the mini DSL
+
+template discardTypeCheck[T](x: T) =
+  ## Helper to discard the expression `x` while still requiring it to be of
+  ## the given type. The templates making use of this helper can't use typed
+  ## parameters directly, as the arguments (which require a ``value`` symbol
+  ## to exist) would be sem'-checked before the `value` symbol is injected
+  discard x
+
+template chain*(buf: var MirNodeSeq, x: untyped) =
+  ## Provides the context for chaining operators together via ``=>`` that end
+  ## in a value sink
+  block:
+    var value {.inject, used.}: EValue
+    template buffer: untyped {.inject, used.} = buf
+    discardTypeCheck[ChainEnd](x)
+
+template forward*(buf: var MirNodeSeq, x: untyped) =
+  ## Provides the context for chaining operators together via ``=>`` that end
+  ## in a *value*. This is used in places where the consuming operator can't be
+  ## expressed as part of the chain and is expected to be emitted immediately
+  ## after
+  block:
+    var value {.inject, used.}: EValue
+    template buffer: untyped {.inject, used.} = buf
+
+    type T = Value or EValue
+    discardTypeCheck[T](x)
+
+template eval*(buf: var MirNodeSeq, x: untyped): EValue =
+  ## Similar to ``forward``, but returns the resulting ``EValue`` to be used
+  ## as the input to another generator chain
+  block:
+    var value {.inject, used.}: EValue
+    template buffer: untyped {.inject, used.} = buf
+    discardTypeCheck[Value](x)
+    value
+
 template `=>`*(v: Value, sink: Sink) =
   discard v
   discard sink
 
+template `=>`*(a: EValue, b: SinkAndValue): Value =
+  mixin value
+  value = a
+  discard b
+  Value(false)
+
+template `=>`*(a: Value, b: Sink): ChainEnd =
+  discard a
+  discard b
+  ChainEnd(false)
+
+template `=>`*(a: EValue, b: Sink): ChainEnd =
+  mixin value
+  value = a
+  discard b
+  ChainEnd(false)
 template `=>`*(v: Value, sink: SinkAndValue): Value =
   discard v
   discard sink
@@ -44,6 +110,162 @@ template follows*(): Sink =
   ## either generated separately next or is already present and, in the context
   ## where ``follows`` is used, comes next
   Sink(false)
+
+# ----------- atoms:
+# The routines representing DSL operands that cannot be decomposed further.
+# They append to a provided node buffer and update the associated ``EValue``
+# instance. The routines are not very useful on their on own -- their
+# integration into the chain DSL is what makes them ergonomic to use.
+
+{.push inline.}
+
+func procLit*(s: var MirNodeSeq, sym: PSym): EValue =
+  s.add MirNode(kind: mnkProc, typ: sym.typ, sym: sym)
+  result = EValue(typ: sym.typ)
+
+func genTypeLit*(s: var MirNodeSeq, t: PType): EValue =
+  s.add MirNode(kind: mnkType, typ: t)
+  result = EValue(typ: t)
+
+func genLit*(s: var MirNodeSeq; n: PNode): EValue =
+  s.add MirNode(kind: mnkLiteral, typ: n.typ, lit: n)
+  result = EValue(typ: n.typ)
+
+func constr*(s: var MirNodeSeq, typ: PType): EValue =
+  s.add MirNode(kind: mnkConstr, typ: typ)
+  result = EValue(typ: typ)
+
+func tempNode*(s: var MirNodeSeq, typ: PType, id: TempId): EValue =
+  s.add MirNode(kind: mnkTemp, typ: typ, temp: id)
+  result = EValue(typ: typ)
+
+func magicCall*(s: var MirNodeSeq, m: TMagic, typ: PType): EValue =
+  assert typ != nil
+  s.add MirNode(kind: mnkMagic, typ: typ, magic: m)
+  result = EValue(typ: typ)
+
+# input/output:
+
+func tag*(s: var MirNodeSeq, effect: EffectKind, val: var EValue) =
+  s.add MirNode(kind: mnkTag, effect: effect, typ: val.typ)
+
+func castOp*(s: var MirNodeSeq, typ: PType, val: var EValue) =
+  s.add MirNode(kind: mnkCast, typ: typ)
+  val.typ = typ
+
+func stdConvOp*(s: var MirNodeSeq, typ: PType, val: var EValue) =
+  s.add MirNode(kind: mnkStdConv, typ: typ)
+  val.typ = typ
+
+func convOp*(s: var MirNodeSeq, typ: PType, val: var EValue) =
+  s.add MirNode(kind: mnkConv, typ: typ)
+  val.typ = typ
+
+func addrOp*(s: var MirNodeSeq, typ: PType, val: var EValue) =
+  s.add MirNode(kind: mnkAddr, typ: typ)
+  val.typ = typ
+
+func viewOp*(s: var MirNodeSeq, typ: PType, val: var EValue) =
+  s.add MirNode(kind: mnkView, typ: typ)
+  val.typ = typ
+
+func derefOp*(s: var MirNodeSeq, typ: PType, val: var EValue) =
+  s.add MirNode(kind: mnkDeref, typ: typ)
+  val.typ = typ
+
+func derefViewOp*(s: var MirNodeSeq, typ: PType, val: var EValue) =
+  s.add MirNode(kind: mnkDerefView, typ: typ)
+  val.typ = typ
+
+func pathObj*(s: var MirNodeSeq, field: PSym, val: var EValue) =
+  assert field.kind == skField
+  s.add MirNode(kind: mnkPathNamed, typ: field.typ, field: field)
+  val.typ = field.typ
+
+func pathPos*(s: var MirNodeSeq, elemType: PType, position: uint32, val: var EValue) =
+  s.add MirNode(kind: mnkPathPos, typ: elemType, position: position)
+  val.typ = elemType
+
+func pathVariant*(s: var MirNodeSeq, objType: PType, field: PSym, val: var EValue) =
+  s.add MirNode(kind: mnkPathVariant, typ: objType, field: field)
+  val.typ = objType
+
+func unaryMagicCall*(s: var MirNodeSeq, m: TMagic, typ: PType, val: var EValue) =
+  assert typ != nil
+  s.add MirNode(kind: mnkMagic, typ: typ, magic: m)
+  val.typ = typ
+
+# sinks:
+
+func arg*(s: var MirNodeSeq, val: EValue) =
+  s.add MirNode(kind: mnkArg, typ: val.typ)
+
+func consume*(s: var MirNodeSeq, val: EValue) =
+  s.add MirNode(kind: mnkConsume, typ: val.typ)
+
+func name*(s: var MirNodeSeq, val: EValue) =
+  s.add MirNode(kind: mnkName, typ: val.typ)
+
+func genVoid*(s: var MirNodeSeq, val: EValue) =
+  s.add MirNode(kind: mnkVoid)
+
+{.pop.} # inline
+
+# ----------- chain DSL adapters:
+
+template genInputAdapter1(name, arg1: untyped) =
+  template `name`*(arg1: untyped): EValue =
+    mixin buffer
+    name(buffer, arg1)
+
+template genInputAdapter2(name, arg1, arg2: untyped) =
+  template `name`*(arg1, arg2: untyped): EValue =
+    mixin buffer
+    name(buffer, arg1, arg2)
+
+template genValueAdapter1(name, arg1: untyped) =
+  template `name`*(arg1: untyped): SinkAndValue =
+    mixin value, buffer
+    name(buffer, arg1, value)
+    SinkAndValue(false)
+
+template genValueAdapter2(name, arg1, arg2: untyped) =
+  template `name`*(arg1, arg2: untyped): SinkAndValue =
+    mixin value, buffer
+    name(buffer, arg1, arg2, value)
+    SinkAndValue(false)
+
+template genSinkAdapter(name: untyped) =
+  template `name`*(): Sink =
+    mixin value, buffer
+    name(buffer, value)
+    Sink(false)
+
+# generate the adapters:
+genInputAdapter1(procLit, sym)
+genInputAdapter1(genTypeLit, n)
+genInputAdapter1(genLit, n)
+genInputAdapter1(constr, typ)
+genInputAdapter2(tempNode, typ, id)
+genInputAdapter2(magicCall, typ, id)
+
+genValueAdapter1(tag, effect)
+genValueAdapter1(castOp, typ)
+genValueAdapter1(stdConvOp, typ)
+genValueAdapter1(convOp, typ)
+genValueAdapter1(addrOp, typ)
+genValueAdapter1(viewOp, typ)
+genValueAdapter1(derefOp, typ)
+genValueAdapter1(derefViewOp, typ)
+genValueAdapter1(pathObj, field)
+genValueAdapter2(pathPos, typ, pos)
+genValueAdapter2(pathVariant, typ, field)
+genValueAdapter2(unaryMagicCall, m, typ)
+
+genSinkAdapter(arg)
+genSinkAdapter(name)
+genSinkAdapter(consume)
+genSinkAdapter(genVoid)
 
 # --------- node constructors:
 

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -1,5 +1,34 @@
-## This module contains constructor procedures for the different kinds of
-## ``MirNode``s plus convenience procedures for generating expressions.
+## This module implements a small domain-specific language (=DSL) for
+## constructing sequences of MIR code, and constructor routines for
+## ``MirNode``s.
+##
+## Chain DSL
+## ---------
+##
+## The idea is to provide a simple DSL that makes generating MIR code more
+## ergonomic than manually adding nodes to a buffer. It is entirely realized
+## via templates, and looks like this:
+##
+## .. code-block:: nim
+##
+##   chain: input() => in_out() => in_out() => sink()
+##
+## The `chain <#chain.t,MirNodeSeq,untyped>`_ template provides the context
+## for the generator routines. The ``=>`` operator does the actual chaining --
+## each call of it yields a sentinel value that informs the next ``=>``
+## invocation on how to interpet the sub-expression. The `input`, `in_out`,
+## and `sink` calls are referred to as *operands*.
+##
+## The first operand must always be an *input* (something that provides an
+## initial `EValue <#EValue>`_), the following operands must be an
+## *input-output*, and the last operand, depending on the the context,
+## either an *sink* or *input-output*.
+##
+## There are two kinds of operands:
+## - those that emit an MIR node (or sequence) and update (or return) an
+##   ``EValue``
+## - those that emit neither MIR code nor modify the ``EValue``, but
+##   instead affect how the operands following it are interpreted
 
 import
   compiler/ast/[
@@ -15,6 +44,8 @@ type
   Sink* = distinct bool
     ## Used to mark a procedure as generating code that acts as a sink
   SinkAndValue* = distinct bool
+    ## Marks a procedure as generating code that acts as a sink and
+    ## yields a value.
 
   Cond = distinct bool
     ## Marks a procedure as being a meta-operand that acts as a condition.

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -130,11 +130,11 @@ func procLit*(s: var MirNodeSeq, sym: PSym): EValue =
   s.add MirNode(kind: mnkProc, typ: sym.typ, sym: sym)
   result = EValue(typ: sym.typ)
 
-func genTypeLit*(s: var MirNodeSeq, t: PType): EValue =
+func typeLit*(s: var MirNodeSeq, t: PType): EValue =
   s.add MirNode(kind: mnkType, typ: t)
   result = EValue(typ: t)
 
-func genLit*(s: var MirNodeSeq; n: PNode): EValue =
+func literal*(s: var MirNodeSeq; n: PNode): EValue =
   s.add MirNode(kind: mnkLiteral, typ: n.typ, lit: n)
   result = EValue(typ: n.typ)
 
@@ -142,7 +142,7 @@ func constr*(s: var MirNodeSeq, typ: PType): EValue =
   s.add MirNode(kind: mnkConstr, typ: typ)
   result = EValue(typ: typ)
 
-func tempNode*(s: var MirNodeSeq, typ: PType, id: TempId): EValue =
+func temp*(s: var MirNodeSeq, typ: PType, id: TempId): EValue =
   s.add MirNode(kind: mnkTemp, typ: typ, temp: id)
   result = EValue(typ: typ)
 
@@ -223,7 +223,7 @@ func consume*(s: var MirNodeSeq, val: EValue) =
 func name*(s: var MirNodeSeq, val: EValue) =
   s.add MirNode(kind: mnkName, typ: val.typ)
 
-func genVoid*(s: var MirNodeSeq, val: EValue) =
+func voidOut*(s: var MirNodeSeq, val: EValue) =
   s.add MirNode(kind: mnkVoid)
 
 # special operators:
@@ -268,10 +268,10 @@ template genSinkAdapter(name: untyped) =
 # generate the adapters:
 genInputAdapter1(emit, n)
 genInputAdapter1(procLit, sym)
-genInputAdapter1(genTypeLit, n)
-genInputAdapter1(genLit, n)
+genInputAdapter1(typeLit, n)
+genInputAdapter1(literal, n)
 genInputAdapter1(constr, typ)
-genInputAdapter2(tempNode, typ, id)
+genInputAdapter2(temp, typ, id)
 genInputAdapter2(symbol, kind, sym)
 genInputAdapter2(opParam, i, typ)
 genInputAdapter2(magicCall, typ, id)
@@ -292,7 +292,7 @@ genValueAdapter2(unaryMagicCall, m, typ)
 genSinkAdapter(arg)
 genSinkAdapter(name)
 genSinkAdapter(consume)
-genSinkAdapter(genVoid)
+genSinkAdapter(voidOut)
 
 # --------- node constructors:
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -413,7 +413,7 @@ proc genEmpty(c: var TCtx, n: PNode): EValue =
   c.stmts.nodes.add MirNode(kind: mnkNone, typ: n.typ)
   result = EValue(typ: c.graph.getSysType(n.info, tyVoid))
 
-func nameNode(s: PSym, n: PNode): MirNode =
+func nameNode(s: PSym): MirNode =
   if sfGlobal in s.flags:
     MirNode(kind: mnkGlobal, typ: s.typ, sym: s)
   elif s.kind == skParam:
@@ -425,11 +425,8 @@ func nameNode(s: PSym, n: PNode): MirNode =
   else:
     unreachable(s.kind)
 
-func genLocation(c: var TCtx, n: PNode): EValue =
-  let mn = nameNode(n.sym, n)
-  c.stmts.nodes.add mn
-
-  result = EValue(typ: mn.typ)
+template genLocation(c: var TCtx, n: PNode): EValue =
+  c.stmts.nodes.emit(nameNode(n.sym))
 
 func emit(dest: var CodeFragment, sp: var SourceProvider, src: CodeFragment,
           span: NodeSpan): EValue =

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -12,9 +12,6 @@
 ## they're used, either a temporary or existing lvalue expression. The latter
 ## are forwarded to the generation procedures via ``Destination``.
 ##
-## To shorten the emit code and also make it a bit easier to read and
-## understand, a mini DSL realised through templates is used.
-##
 ## Origin information
 ## ==================
 ##
@@ -70,13 +67,6 @@ import
   ]
 
 type
-  EValue = object
-    ## Encapsulates information about the abstract value that results from
-    ## an operation sequence. It's used as a way to transport said information
-    ## between the generator procedures for operators
-    # XXX: maybe rename to ``Computation``?
-    typ {.cursor.}: PType
-
   NodeSpan = HOslice[NodeIndex]
     ## Refers to a span of nodes in a ``Fragment``
 
@@ -103,11 +93,6 @@ type
       node {.cursor.}: PNode
 
     flags: set[DestFlag]
-
-  ChainEnd = distinct bool
-    ## Sentinel type used to mark an operator in a chain as ending the chain.
-    ## No further operators can be chained after an operator marked as
-    ## ``ChainEnd``
 
   Block = object
     ## Information about a ``block``
@@ -362,104 +347,7 @@ func popSlice(frag: var CodeFragment, span: NodeSpan) =
   frag.nodes.setLen(span.a)
   frag.source.setLen(span.a)
 
-# -------------- DSL routines -------------
-
-template genValueAdapter(name: untyped) =
-  template `name`(): SinkAndValue =
-    mixin value, buffer
-    `name`(buffer, value)
-    SinkAndValue(false)
-
-template genValueAdapter1(name, arg1: untyped) =
-  template `name`(arg1: untyped): SinkAndValue =
-    mixin value, buffer
-    `name`(buffer, arg1, value)
-    SinkAndValue(false)
-
-template genValueAdapter2(name, arg1, arg2: untyped) =
-  template `name`(arg1, arg2: untyped): SinkAndValue =
-    mixin value, buffer
-    `name`(buffer, arg1, arg2, value)
-    SinkAndValue(false)
-
-template genSinkAdapter(name: untyped) =
-  template `name`(): Sink =
-    mixin value, buffer
-    `name`(buffer, value)
-    Sink(false)
-
-template genInputAdapter(name, arg: untyped) =
-  template `name`(c: var TCtx, arg: untyped): EValue =
-    # for backwards compatibility
-    name(c.stmts.nodes, arg)
-
-  template `name`(arg: untyped): EValue =
-    # the actual adapter
-    mixin buffer
-    name(buffer, arg)
-
-template genInputAdapter2(name, arg1, arg2: untyped) =
-  template `name`(c: var TCtx, arg1, arg2: untyped): EValue =
-    # for backwards compatibility
-    name(c.stmts.nodes, arg1, arg2)
-
-  template `name`(arg1, arg2: untyped): EValue =
-    # the actual adapter
-    mixin buffer
-    name(buffer, arg1, arg2)
-
-template `=>`(a: EValue, b: SinkAndValue): Value =
-  mixin value
-  value = a
-  discard b
-  Value(false)
-
-template `=>`(a: Value, b: Sink): ChainEnd =
-  discard a
-  discard b
-  ChainEnd(false)
-
-template `=>`(a: EValue, b: Sink): ChainEnd =
-  mixin value
-  value = a
-  discard b
-  ChainEnd(false)
-
-template discardTypeCheck[T](x: T) =
-  ## Helper to discard the expression `x` while still requiring it to be of
-  ## the given type. The templates making use of this helper can't use typed
-  ## parameters directly, as the arguments (which require a ``value`` symbol
-  ## to exist) would be sem'-checked before the `value` symbol is injected
-  discard x
-
-template chain(c: var TCtx, x: untyped) =
-  ## Provides the context for chaining operators together via ``=>`` that end
-  ## in a value sink
-  block:
-    var value {.inject, used.}: EValue
-    template buffer: untyped {.inject, used.} = c.stmts.nodes
-    discardTypeCheck[ChainEnd](x)
-
-template forward(c: var TCtx, x: untyped) =
-  ## Provides the context for chaining operators together via ``=>`` that end
-  ## in *value*. This is used in places where the consuming operator can't be
-  ## expressed as part of the chain and is expected to be emitted immediately
-  ## after
-  block:
-    var value {.inject, used.}: EValue
-    template buffer: untyped {.inject, used.} = c.stmts.nodes
-
-    type T = Value or EValue
-    discardTypeCheck[T](x)
-
-template eval(c: var TCtx, x: untyped): EValue =
-  ## Similar to ``forward``, but returns the resulting ``EValue`` to be used
-  ## as the input to another generator chain
-  block:
-    var value {.inject, used.}: EValue
-    template buffer: untyped {.inject, used.} = c.stmts.nodes
-    discardTypeCheck[Value](x)
-    value
+# -------------- convenience templates -------------
 
 template forward(v: EValue) =
   ## Acts the same as discarding the expression's result, but hints to
@@ -479,126 +367,47 @@ template stmtList(f: var CodeFragment, body: untyped) =
   f.nodes.stmtList:
     body
 
-func arg(s: var MirNodeSeq, val: EValue) =
-  s.add MirNode(kind: mnkArg, typ: val.typ)
+# for convenience, we introduce wrapper template accepting a
+# ``TCtx`` for some DSL atoms
 
-func consume(s: var MirNodeSeq, val: EValue) =
-  s.add MirNode(kind: mnkConsume, typ: val.typ)
+template chain(c: var TCtx, x: untyped) =
+  chain(c.stmts.nodes, x)
 
-func name(s: var MirNodeSeq, val: EValue) =
-  s.add MirNode(kind: mnkName, typ: val.typ)
+template eval(c: var TCtx, x: untyped): EValue =
+  eval(c.stmts.nodes, x)
 
-func genVoid(s: var MirNodeSeq, val: EValue) =
-  s.add MirNode(kind: mnkVoid)
+template forward(c: var TCtx, x: untyped) =
+  forward(c.stmts.nodes, x)
 
-func tag(s: var MirNodeSeq, effect: EffectKind, val: var EValue) =
-  s.add MirNode(kind: mnkTag, effect: effect, typ: val.typ)
+template procLit(c: var TCtx, s: PSym): EValue =
+  procLit(c.stmts.nodes, s)
 
-func modify(s: var MirNodeSeq, val: var EValue) =
-  tag(s, ekMutate, val)
+template genTypeLit(c: var TCtx, t: PType): EValue =
+  genTypeLit(c.stmts.nodes, t)
 
-func outOp(s: var MirNodeSeq, val: var EValue) =
-  tag(s, ekReassign, val)
+template genLit(c: var TCtx, n: PNode): EValue =
+  genLit(c.stmts.nodes, n)
 
-func castOp(s: var MirNodeSeq, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkCast, typ: typ)
-  val.typ = typ
+template constr(c: var TCtx, t: PType): EValue =
+  constr(c.stmts.nodes, t)
 
-func stdConvOp(s: var MirNodeSeq, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkStdConv, typ: typ)
-  val.typ = typ
+template tempNode(c: var TCtx, t: PType, id: TempId): EValue =
+  tempNode(c.stmts.nodes, t, id)
 
-func convOp(s: var MirNodeSeq, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkConv, typ: typ)
-  val.typ = typ
+template magicCall(c: var TCtx, m: TMagic, typ: PType): EValue =
+  magicCall(c.stmts.nodes, m, typ)
 
-func addrOp(s: var MirNodeSeq, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkAddr, typ: typ)
-  # don't change ownership. If the l-value is owned so is the resulting
-  # pointer
-  val.typ = typ
+template modify(): untyped =
+  tag(ekMutate)
 
-func viewOp(s: var MirNodeSeq, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkView, typ: typ)
-  val.typ = typ
+template outOp(): untyped =
+  tag(ekReassign)
 
-func derefOp(s: var MirNodeSeq, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkDeref, typ: typ)
-  val.typ = typ
+template notOp(c: var TCtx): untyped =
+  unaryMagicCall(mNot, getSysType(c.graph, c.sp.active.n.info, tyBool))
 
-func derefViewOp(s: var MirNodeSeq, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkDerefView, typ: typ)
-  val.typ = typ
-
-func pathObj(s: var MirNodeSeq, field: PSym, val: var EValue) =
-  assert field.kind == skField
-  s.add MirNode(kind: mnkPathNamed, typ: field.typ, field: field)
-  val.typ = field.typ
-
-func pathPos(s: var MirNodeSeq, elemType: PType, position: uint32, val: var EValue) =
-  s.add MirNode(kind: mnkPathPos, typ: elemType, position: position)
-  val.typ = elemType
-
-func pathVariant(s: var MirNodeSeq, objType: PType, field: PSym, val: var EValue) =
-  let objType = objType.skipTypes(abstractInstTypeClass)
-  s.add MirNode(kind: mnkPathVariant,
-                      typ: objType,
-                      field: field)
-  val.typ = objType
-
-func unaryMagicCall(s: var MirNodeSeq, m: TMagic, typ: PType, val: var EValue) =
-  assert typ != nil
-  s.add MirNode(kind: mnkMagic, typ: typ, magic: m)
-  val.typ = typ
-
-func magicCall(s: var MirNodeSeq, m: TMagic, typ: PType): EValue =
-  assert typ != nil
-  s.add MirNode(kind: mnkMagic, typ: typ, magic: m)
-  result = EValue(typ: typ)
-
-func tupleAccess(s: var MirNodeSeq, pos: uint32, typ: PType, val: var EValue) =
-  s.add MirNode(kind: mnkPathPos, typ: typ, position: pos)
-  val.typ = typ
-
-# generate the adapters:
-genSinkAdapter(arg)
-genSinkAdapter(name)
-genSinkAdapter(consume)
-genSinkAdapter(genVoid)
-
-genValueAdapter(modify)
-genValueAdapter(outOp)
-
-genValueAdapter1(castOp, typ)
-genValueAdapter1(stdConvOp, typ)
-genValueAdapter1(convOp, typ)
-genValueAdapter1(addrOp, typ)
-genValueAdapter1(viewOp, typ)
-genValueAdapter1(derefOp, typ)
-genValueAdapter1(derefViewOp, typ)
-genValueAdapter1(pathObj, field)
-genValueAdapter1(tag, effect)
-
-genValueAdapter2(pathPos, typ, pos)
-genValueAdapter2(pathVariant, typ, field)
-genValueAdapter2(tupleAccess, pos, typ)
-genValueAdapter2(unaryMagicCall, m, typ)
-
-func constr(s: var MirNodeSeq, typ: PType): EValue =
-  s.add MirNode(kind: mnkConstr, typ: typ)
-  result = EValue(typ: typ)
-
-func tempNode(s: var MirNodeSeq, typ: PType, id: TempId): EValue =
-  s.add MirNode(kind: mnkTemp, typ: typ, temp: id)
-  result = EValue(typ: typ)
-
-func procLit(s: var MirNodeSeq, sym: PSym): EValue =
-  s.add MirNode(kind: mnkProc, typ: sym.typ, sym: sym)
-  result = EValue(typ: sym.typ)
-
-func genTypeLit(s: var MirNodeSeq, t: PType): EValue =
-  s.add MirNode(kind: mnkType, typ: t)
-  result = EValue(typ: t)
+template tupleAccess(pos: uint32, elem: PType): untyped =
+  pathPos(elem, pos)
 
 proc genEmpty(c: var TCtx, n: PNode): EValue =
   c.stmts.nodes.add MirNode(kind: mnkNone, typ: n.typ)
@@ -616,26 +425,11 @@ func nameNode(s: PSym, n: PNode): MirNode =
   else:
     unreachable(s.kind)
 
-func genLocation(s: var MirNodeSeq; n: PNode): EValue =
+func genLocation(c: var TCtx, n: PNode): EValue =
   let mn = nameNode(n.sym, n)
-  s.add mn
+  c.stmts.nodes.add mn
 
   result = EValue(typ: mn.typ)
-
-proc genLit(s: var MirNodeSeq; n: PNode): EValue =
-  s.add MirNode(kind: mnkLiteral, typ: n.typ, lit: n)
-  result = EValue(typ: n.typ)
-
-genInputAdapter2(magicCall, typ, id)
-genInputAdapter(constr, typ)
-genInputAdapter2(tempNode, typ, id)
-genInputAdapter(procLit, sym)
-genInputAdapter(genTypeLit, n)
-genInputAdapter(genLit, n)
-genInputAdapter(genLocation, n)
-
-template notOp(c: var TCtx): untyped =
-  unaryMagicCall(mNot, getSysType(c.graph, c.sp.active.n.info, tyBool))
 
 func emit(dest: var CodeFragment, sp: var SourceProvider, src: CodeFragment,
           span: NodeSpan): EValue =
@@ -654,7 +448,7 @@ func emit(dest: var CodeFragment, sp: var SourceProvider, src: CodeFragment,
 func genDefault(c: var TCtx, typ: PType): EValue =
   ## Emits a call to the ``default`` operator for the given `typ`
   argBlock(c.stmts): discard
-  magicCall(c, mDefault, typ)
+  magicCall(c.stmts.nodes, mDefault, typ)
 
 proc gen(c: var TCtx; n: PNode)
 proc genx(c: var TCtx; n: PNode, consume: bool = false): EValue


### PR DESCRIPTION
## Summary

Move the routines and types that make up the DSL to the `mirconstr`
module and use the DSL in both the `injectdestructors` and `mirbridge`
module.

Apart from making the MIR code generation in both modules less complex,
manual, and error-prone, this is also significant progress towards the
MIR code coming out of the `injectdestructors` pass having proper type
information, which is a requirement for having MIR passes that run after
`injectdestructors`.

## Details

* move the `EValue` and `ChainEnd` types to `mirconstr`
* move the atomic DSL operands to `mirconstr`. The `notOp`, `modify`,
  `outOp`, and `tupleAccess` operands stay in `mirgen`
* add wrapper templates for DSL operands that `mirgen` still calls with
  a `TCtx` instance instead of a `MirNodeSeq`

As part of moving them, some operand routines that had a 'gen' prefix
are changed to not have it, making the routine names more consistent.

In addition, some cleanup in `mirconstr` is performed, and the DSL
extended a bit:
* `|=>`, `=>|`, and `previous` are removed. They were unused and didn't
  fit in with the overall design
* the `emit`, `symbol`, and `opParam` operands are added, all of which
  are only useful outside of `mirgen`

Another addition is the `predicate` meta operand, which makes it
possible to write chains where an operand is conditionally excluded:

```nim
chain(...): a() => predicate(cond) => b() => c()
```

Here, `b()` is only evaluated if `cond` evaluates to 'true'. Using two
chains plus an in-between 'if' statement was previously necessary to
achieve the same.

Finally, documentation about the DSL is added, and the
`injectdestructors` and `mirbridge` modules are changed to use the DSL
for generating MIR code. The logic from the `genInjectedSink` procedure
was previously duplicated into `genSinkFromTemporary`, but this is now
fixed.