### PR TITLE
cgen: replace `TLoc` for procs and fields

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -162,7 +162,7 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
   for _, s in peek(discovery.procedures):
     if exfDynamicLib in s.extFlags:
       let m = g.modules[s.itemId.module.int]
-      fillProcLoc(m, newSymNode(s))
+      fillProcLoc(m, s)
       symInDynamicLib(m, s)
 
       if m != bmod:
@@ -415,9 +415,9 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
     # write the mangled names of the various entities to the NDI files
     for it in g.procs.items:
       let
-        s = it.loc.lode.sym
+        s = it.sym
         m = g.modules[moduleId(s)]
-      writeMangledName(m.ndi, s, it.loc.r, g.config)
+      writeMangledName(m.ndi, s, it.name, g.config)
       # parameters:
       for p in it.params.items:
         if p.k != locNone: # not all parameters have locs

--- a/compiler/backend/ccgreset.nim
+++ b/compiler/backend/ccgreset.nim
@@ -31,7 +31,7 @@ proc specializeResetN(p: BProc, accessor: Rope, n: PNode;
     p.config.internalAssert(n[0].kind == nkSym, n.info, "specializeResetN")
     let disc = n[0].sym
     ensureObjectFields(p.module, disc, typ)
-    lineF(p, cpsStmts, "switch ($1.$2) {$n", [accessor, p.fieldLoc(disc).r])
+    lineF(p, cpsStmts, "switch ($1.$2) {$n", [accessor, p.fieldName(disc)])
     for i in 1..<n.len:
       let branch = n[i]
       assert branch.kind in {nkOfBranch, nkElse}
@@ -42,12 +42,12 @@ proc specializeResetN(p: BProc, accessor: Rope, n: PNode;
       specializeResetN(p, accessor, lastSon(branch), typ)
       lineF(p, cpsStmts, "break;$n", [])
     lineF(p, cpsStmts, "} $n", [])
-    specializeResetT(p, "$1.$2" % [accessor, p.fieldLoc(disc).r], disc.typ)
+    specializeResetT(p, "$1.$2" % [accessor, p.fieldName(disc)], disc.typ)
   of nkSym:
     let field = n.sym
     if field.typ.kind == tyVoid: return
     ensureObjectFields(p.module, field, typ)
-    specializeResetT(p, "$1.$2" % [accessor, p.fieldLoc(field).r], field.typ)
+    specializeResetT(p, "$1.$2" % [accessor, p.fieldName(field)], field.typ)
   else: internalError(p.config, n.info, "specializeResetN()")
 
 proc specializeResetT(p: BProc, accessor: Rope, typ: PType) =

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -752,7 +752,7 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): Rope =
         discard getTypeDesc(p.module, skipTypes(sym.typ, abstractPtrs))
         p.config.internalAssert(sym.locId != 0, it.info):
           "field's surrounding type not setup"
-        res.add(p.fieldLoc(sym).r)
+        res.add(p.fieldName(sym))
       else:
         unreachable(sym.kind)
     of nkType:


### PR DESCRIPTION
## Summary

Use dedicated data types (instead of `TLoc`) for storing C-related
information about procedures and fields in `cgen`. This slightly reduces
compiler memory-usage, and it also makes the types easier to evolve.

## Details

For fields, only the mangled (or unmangled) name is relevant, all other
information stored by `TLoc` is not. Therefore, storing only a string is
enough. In addition, the `fieldLoc` procedure is renamed to `fieldName`.

For procedures, the only information that needs to be stored is the name
and the parameters' loc. As a workaround for NDI file writing needing a
`PSym` to fetch the user-provided name from, the new `ProcLoc` type also
stores the `PSym`. Once each `ProcLoc` entry is associated with a
`DiscoveryData.procedures` entry through its index, this workaround can
be removed.