### PR TITLE
internal: compiler trace free of legacy reports

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -21,9 +21,6 @@ type
 
     repVM = "VM" ## Report related to embedded virtual machine
 
-    repDbgTrace = "Trace" ## compiler execution expansion traces for debugging
-    ## or understaning the compiler
-
     repDebug = "Debug" ## Side channel for the compiler debug report. Helper
     ## messages designed specifically to aid development of the compiler
 
@@ -848,15 +845,6 @@ type
     rcmdRunnableExamplesSuccess = "Success"
     # hints END !! add reports BEFORE the last enum !!
 
-    #----------------------------  Trace reports  ----------------------------#
-
-    rdbgTraceDefined # first ! trace begin
-    rdbgTraceUndefined
-    rdbgTraceStart
-    rdbgTraceStep
-    rdbgTraceLine
-    rdbgTraceEnd # last ! trace end
-
     #----------------------------  Debug reports  ----------------------------#
     rdbgVmExecTraceFull
     rdbgVmExecTraceMinimal
@@ -925,8 +913,6 @@ type
 
   CmdReportKind* = range[rcmdFailedExecution .. rcmdRunnableExamplesSuccess]
 
-  DbgTraceReportKind* = range[rdbgTraceDefined .. rdbgTraceEnd]
-  
   DebugReportKind* = range[rdbgVmExecTraceFull .. rdbgOptionsPop]
 
   BackendReportKind* = range[rbackCannotWriteScript .. rbackLinking]
@@ -977,9 +963,6 @@ const
   rcmdWarningKinds* = default(set[ReportKind])
   rcmdHintKinds* = {rcmdCompiling .. rcmdRunnableExamplesSuccess}
 
-  #--------------------------------  trace  --------------------------------#
-  repDbgTraceKinds* = {low(DbgTraceReportKind) .. high(DbgTraceReportKind)}
-
   #--------------------------------  debug  --------------------------------#
   repDebugKinds* = {low(DebugReportKind) .. high(DebugReportKind)}
 
@@ -1019,7 +1002,6 @@ const
 
   repTraceKinds*: ReportKinds =
     {rvmStackTrace, rintStackTrace} +
-    repDbgTraceKinds +
     repDebugKinds
 
   repHintKinds*: ReportKinds    =
@@ -1073,7 +1055,6 @@ static:
       set[ReportKind](repParserKinds) +
       set[ReportKind](repInternalKinds) +
       set[ReportKind](repExternalKinds) +
-      set[ReportKind](repDbgTraceKinds) +
       set[ReportKind](repDebugKinds) +
       set[ReportKind](repBackendKinds) +
       set[ReportKind](repCmdKinds) +

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -64,7 +64,6 @@ type
     SemReport      |
     VMReport       |
     CmdReport      |
-    TraceSemReport |
     DebugReport    |
     InternalReport |
     BackendReport  |
@@ -87,9 +86,6 @@ type
 
       of repCmd:
         cmdReport*: CmdReport
-
-      of repDbgTrace:
-        dbgTraceReport*: TraceSemReport
 
       of repDebug:
         debugReport*: DebugReport
@@ -116,7 +112,6 @@ static:
     echo "size of ParserReport   ", sizeof(ParserReport)
     echo "size of SemReport      ", sizeof(SemReport)
     echo "size of CmdReport      ", sizeof(CmdReport)
-    echo "size of DbgTraceReport ", sizeof(TraceSemReport)
     echo "size of DebugReport    ", sizeof(DebugReport)
     echo "size of InternalReport ", sizeof(InternalReport)
     echo "size of BackendReport  ", sizeof(BackendReport)
@@ -138,7 +133,6 @@ template eachCategory*(report: Report, field: untyped): untyped =
     of repCmd:      report.cmdReport.field
     of repVM:       report.vmReport.field
     of repSem:      report.semReport.field
-    of repDbgTrace: report.dbgTraceReport.field
     of repDebug:    report.debugReport.field
     of repInternal: report.internalReport.field
     of repBackend:  report.backendReport.field
@@ -179,14 +173,12 @@ func `reportFrom=`*(report: var Report, loc: ReportLineInfo) =
   of repSem:      report.semReport.reportFrom = loc
   of repVM:       report.vmReport.reportFrom = loc
   of repDebug:    report.debugReport.reportFrom = loc
-  of repDbgTrace: report.dbgTraceReport.reportFrom = loc
   of repInternal: report.internalReport.reportFrom = loc
   of repBackend:  report.backendReport.reportFrom = loc
   of repExternal: report.externalReport.reportFrom = loc
 
 func category*(kind: ReportKind): ReportCategory =
   case kind
-  of repDbgTraceKinds: result = repDbgTrace
   of repDebugKinds:    result = repDebug
   of repInternalKinds: result = repInternal
   of repExternalKinds: result = repExternal
@@ -230,7 +222,6 @@ func severity*(
       of repInternal: report.internalReport.severity()
       of repBackend:  report.backendReport.severity()
       of repDebug:    report.debugReport.severity()
-      of repDbgTrace: report.dbgTraceReport.severity()
       of repExternal: report.externalReport.severity()
 
 func toReportLineInfo*(iinfo: InstantiationInfo): ReportLineInfo =
@@ -275,10 +266,6 @@ func wrap*(rep: sink BackendReport): Report =
 func wrap*(rep: sink CmdReport): Report =
   assert rep.kind in repCmdKinds, $rep.kind
   Report(category: repCmd, cmdReport: rep)
-
-func wrap*(rep: sink TraceSemReport): Report =
-  assert rep.kind in repDbgTraceKinds, $rep.kind
-  Report(category: repDbgTrace, dbgTraceReport: rep)
 
 func wrap*(rep: sink DebugReport): Report =
   assert rep.kind in repDebugKinds, $rep.kind

--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -207,76 +207,6 @@ type
 
       else:
         discard
-  
-  # xxx: compiler execution tracing is a general thing, not semantic analysis
-  #      specific. The types below to be renamed with prefix `Trace` are
-  #      general and should move accordingly. This will require further
-  #      refactoring of all the report types prefixed with `Debug`... sigh.
-
-  # TODO: rename to `TraceStepDirection` or something, it's not sem specific
-  DebugSemStepDirection* = enum semstepEnter, semstepLeave
-  
-  # TODO: rename to `TraceStepKind` or something, it's not sem specific
-  DebugSemStepKind* = enum
-    stepNodeToNode
-    stepNodeToSym
-    stepIdentToSym
-    stepSymNodeToNode
-    stepNodeFlagsToNode
-    stepNodeTypeToNode
-    stepTypeTypeToType
-    stepResolveOverload
-    stepNodeSigMatch
-    stepWrongNode
-    stepError
-    stepTrack
-
-  DebugCallableCandidate* = object
-    ## stripped down version of `sigmatch.TCandidate`
-    state*: string
-    callee*: PType
-    calleeSym*: PSym
-    calleeScope*: int
-    call*: PNode
-    error*: SemCallMismatch
-
-  DebugSemStep* = object
-    direction*: DebugSemStepDirection
-    level*: int
-    name*: string
-    node*: PNode ## Depending on the step direction this field stores
-                 ## either input or output node
-    steppedFrom*: ReportLineInfo
-    sym*: PSym
-    case kind*: DebugSemStepKind
-      of stepIdentToSym:
-        ident*: PIdent
-
-      of stepNodeTypeToNode, stepTypeTypeToType:
-        typ*: PType
-        typ1*: PType
-
-      of stepNodeFlagsToNode:
-        flags*: TExprFlags
-      
-      of stepNodeSigMatch, stepResolveOverload:
-        filters*: TSymKinds
-        candidate*: DebugCallableCandidate
-        errors*: seq[SemCallMismatch]
-
-      else:
-        discard
-  
-  TraceSemReport* = object of DebugReportBase
-    case kind*: ReportKind:
-      of rdbgTraceStep:
-        semstep*: DebugSemStep
-
-      of rdbgTraceLine, rdbgTraceStart:
-        ctraceData*: tuple[level: int, entries: seq[StackTraceEntry]]
-
-      else:
-        discard
 
 
 func severity*(report: SemReport): ReportSeverity =
@@ -308,7 +238,6 @@ func reportAst*(
     kind: ReportKind,
     ast: PNode, str: string = "", typ: PType = nil, sym: PSym = nil
   ): SemReport =
-
   SemReport(kind: kind, ast: ast, str: str, typ: typ, sym: sym)
 
 func reportTyp*(
@@ -316,21 +245,14 @@ func reportTyp*(
     typ: PType, ast: PNode = nil, sym: PSym = nil, str: string = ""
   ): SemReport =
   SemReport(kind: kind, typ: typ, ast: ast, sym: sym, str: str)
-
 func reportStr*(
     kind: ReportKind,
     str: string, ast: PNode = nil, typ: PType = nil, sym: PSym = nil
   ): SemReport =
-
   SemReport(kind: kind, ast: ast, str: str, typ: typ, sym: sym)
 
 func reportSym*(
     kind: ReportKind,
     sym: PSym, ast: PNode = nil, str: string = "", typ: PType = nil,
   ): SemReport =
-
   SemReport(kind: kind, ast: ast, str: str, typ: typ, sym: sym)
-
-
-func severity*(report: TraceSemReport): ReportSeverity {.inline.} =
-  rsevTrace

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -709,8 +709,7 @@ type
 
 func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
   const forceWrite =
-    {rsemExpandArc} + # Not considered a hint for now
-    repDbgTraceKinds  # Unconditionally write debug tracing information
+    {rsemExpandArc} # Not a hint, just legacy reports overeach
 
   let compTimeCtx = conf.m.errorOutputs == {}
     ## indicates whether we're in a `compiles` or `constant expression
@@ -732,10 +731,7 @@ func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
   ))):
     return writeForceEnabled
 
-  elif r.kind == rdbgVmCodeListing or (
-    # Optionally Ignore context stacktrace
-    r.kind == rdbgTraceLine and not conf.hack.semStack
-  ):
+  elif r.kind == rdbgVmCodeListing:
     return writeDisabled
 
   elif (
@@ -839,11 +835,6 @@ proc computeNotesVerbosity(): tuple[
     result.base.incl {
       rdbgVmCodeListing    # immediately generated code listings
     }
-
-  when defined(nimDebugUtils):
-    # By default enable only semantic debug trace reports - other changes
-    # might be put in there *temporarily* to aid the debugging.
-    result.base.incl repDbgTraceKinds
 
   result.main[compVerbosityMax] =
     result.base + repWarningKinds + repHintKinds - {

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -169,7 +169,6 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
           s.addFields(r.semReport, f & "node")
         else:
           s.addFields(r.semReport, f)
-      of repDbgTrace: s.addFields(r.dbgTraceReport, f)
       of repDebug:    s.addFields(r.debugReport, f)
       of repInternal: s.addFields(r.internalReport, f)
       of repBackend:  s.addFields(r.backendReport, f)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -48,7 +48,6 @@ import
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_sem import SemReport,
-  TraceSemReport,
   reportAst,
   reportSem,
   reportStr,
@@ -635,8 +634,8 @@ proc processDefine(c: PContext, n: PNode): PNode =
     let str = n[1].ident.s
     if defined(nimDebugUtils) and
        cmpIgnoreStyle(str, "nimCompilerDebug") == 0:
-      c.config.localReport(
-        n.info, TraceSemReport(kind: rdbgTraceDefined))
+      c.config.outputTrace(CompilerTrace(kind: compilerTraceDefined,
+                                         srcLoc: n.info))
 
     defineSymbol(c.config, str)
     n
@@ -651,8 +650,8 @@ proc processUndef(c: PContext, n: PNode): PNode =
     let str = n[1].ident.s
     if defined(nimDebugUtils) and
        cmpIgnoreStyle(str, "nimCompilerDebug") == 0:
-      c.config.localReport(
-        n.info, TraceSemReport(kind: rdbgTraceUndefined))
+      c.config.outputTrace(CompilerTrace(kind: compilerTraceUndefined,
+                                         srcLoc: n.info))
 
     undefSymbol(c.config, str)
     n

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -44,9 +44,8 @@ import
     idioms
   ]
 
-# xxx: reports are a code smell meaning data types are misplaced, for example
-#      DebugCallableCandidate
-from compiler/ast/reports_sem import SemReport, DebugCallableCandidate,
+# xxx: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport,
   reportAst,
   reportSym
 from compiler/ast/report_enums import ReportKind,

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -128,7 +128,7 @@ proc myLog(conf: ConfigRef, s: string, flags: MsgFlags = {}) =
 proc reportHook(conf: ConfigRef, report: Report): TErrorHandling =
   result = doNothing
   case report.category
-  of repCmd, repDebug, repDbgTrace, repInternal, repExternal:
+  of repCmd, repDebug, repInternal, repExternal:
     myLog(conf, $report)
   of repParser, repLexer, repSem, repVM:
     if report.category == repSem and


### PR DESCRIPTION
## Summary

Legacy reports were being used to output compiler tracing, this was a
mistake, it made tracing slow and complicated, and added yet more
complexity to the legacy reports. This functionality moved from
`reports_sem` and other such modules into `debugutils`.

## Details

This is largely a lift-and-shift movement, data types and procedures are
moved over, chiefly `TraceSemReport` and `reportBody`.

Along with this move legacy reports cruft like `ReportLineInfo` and
inheriting from any legacy reports objects were removed. As well as a
key rename of `TraceSemReport` to `CompilerTrace`.

A large number of modules were impacted, thankfully mostly removing
dependencies. They already imported `debugutils` so the transition
simplifies consumers.

Finally, defaulted intermediate stacktraces between detailed traces as
the entire point of this is to see _what_ the compiler is doing, this
was a poor default.