### PR TITLE
backend: make dynlib handling target-agnostic

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1,5 +1,4 @@
 import compiler/ast/lineinfos
-import compiler/utils/ropes
 import std/[hashes]
 
 from compiler/ast/idents import PIdent, TIdent
@@ -852,6 +851,8 @@ type
     mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
     mSymIsInstantiationOf, mNodeId, mPrivateAccess
 
+    # magics only used internally:
+    mAsgnDynlibVar
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const
@@ -1610,9 +1611,8 @@ type
   TLib* = object              ## also misused for headers!
                               ## keep in sync with PackedLib
     kind*: TLibKind
-    generated*: bool          ## needed for the backends:
     isOverriden*: bool
-    name*: Rope
+    name*: PSym
     path*: PNode              ## can be a string literal!
 
 

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -94,7 +94,7 @@ type
     globals*: Queue[PSym]
     threadvars*: Queue[PSym]
 
-    libs*: seq[PLib]
+    libs*: seq[LibId]
       ## all dynamic libraries that the alive graph depends on
 
     additional: seq[tuple[m: FileIndex, prc: PSym]]
@@ -550,7 +550,7 @@ proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
   ## necessary dynamic library is emitted into the fragment and the global
   ## storing the library handle registered with `data`.
   let
-    lib      = sym.annex
+    lib      = graph.getLib(sym.annex)
     loadProc = graph.getCompilerProc("nimGetProcAddr")
     path     = transformExpr(graph, m.idgen, m.sym, lib.path)
     extname  = newStrNode(nkStrLit, sym.extname)
@@ -588,7 +588,7 @@ proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
       # the library hasn't been loaded yet
       genLibSetup(graph, conf, lib.name, path, result)
       if path.kind in nkStrKinds: # only register statically-known dependencies
-        data.libs.add lib
+        data.libs.add sym.annex
       data.globals.add lib.name # register the global
 
     # generate the code for ``sym = cast[typ](nimGetProcAddr(lib, extname))``

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -67,6 +67,9 @@ import
 
 import std/options as std_options
 
+# XXX: reports are a legacy facility that is going to be phased out. A
+#      note on how to move forward is left at each usage site in this
+#      module
 from compiler/front/msgs import localReport
 from compiler/ast/reports import ReportKind
 from compiler/ast/reports_sem import SemReport
@@ -441,6 +444,9 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
 
   # not pretty, but here's the earliest point where we know about the set of
   # all actually-used dynamic libraries
+  # XXX: instead of reporting them here, we could return the list to the
+  #      caller, which is in a better position to decide what to do with
+  #      it
   for lib in discovery.libs.items:
     localReport(graph.config):
       SemReport(kind: rsemHintLibDependency,

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -443,7 +443,8 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
   # all actually-used dynamic libraries
   for lib in discovery.libs.items:
     localReport(graph.config):
-      SemReport(kind: rsemHintLibDependency, str: lib.path.strVal)
+      SemReport(kind: rsemHintLibDependency,
+                str: graph.getLib(lib).path.strVal)
 
   # finalize code generation for the modules and generate and emit the code
   # for the 'main' procedure:

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1929,6 +1929,17 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   of mAccessTypeField: genAccessTypeField(p, e, d)
   of mSlice: genSlice(p, e, d)
   of mTrace: discard "no code to generate"
+  of mAsgnDynlibVar:
+    # initialize the internal pointer for a dynlib global/procedure
+    var a, b: TLoc
+    initLocExpr(p, e[1][0], a)
+    initLocExpr(p, e[2], b)
+    var typ = getTypeDesc(p.module, a.t)
+    # dynlib variables are stored as pointers
+    if lfIndirect in a.flags:
+      typ.add "*"
+
+    linefmt(p, cpsStmts, "$1 = ($2)($3);$n", [a.r, typ, rdLoc(b)])
   else:
     when defined(debugMagics):
       echo p.prc.name.s, " ", p.prc.id, " ", p.prc.flags, " ", p.prc.ast[genericParamsPos].kind

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -110,9 +110,6 @@ type
     cfsTypeInit2,             ## section 2 for init of type information
     cfsTypeInit3,             ## section 3 for init of type information
     cfsDebugInit,             ## section for init of debug information
-    cfsDynLibInit,            ## section for init of dynamic library binding
-    cfsDynLibDeinit           ## section for deinitialization of dynamic
-                              ## libraries
   TCTypeKind* = enum          ## describes the type kind of a C type
     ctVoid, ctChar, ctBool,
     ctInt, ctInt8, ctInt16, ctInt32, ctInt64,

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -88,6 +88,8 @@ proc processEvent(g: PGlobals, graph: ModuleGraph, modules: BModuleList,
       g.code.add(r)
 
     processLate(g, discovery)
+  of bekImported:
+    discard "ignored for now"
 
 proc writeModules(graph: ModuleGraph, globals: PGlobals) =
   let

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -387,7 +387,8 @@ proc storeType(t: PType; c: var PackedEncoder; m: var PackedModule): PackedItemI
 proc toPackedLib(l: TLib; c: var PackedEncoder; m: var PackedModule): PackedLib =
   result.kind = l.kind
   result.isOverriden = l.isOverriden
-  result.name = storeSymLater(l.name, c, m)
+  if l.kind == libDynamic:
+    result.name = storeSymLater(l.name, c, m)
   storeNode(result, l, path)
 
 proc storeSym*(s: PSym; c: var PackedEncoder; m: var PackedModule): PackedItemId =
@@ -863,8 +864,10 @@ template loadAstBodyLazy(p, field) =
 
 proc loadLib(c: var PackedDecoder; g: var PackedModuleGraph;
              si: int; l: PackedLib): TLib =
-  result = TLib(isOverriden: l.isOverriden, kind: l.kind,
-                name: loadSym(c, g, si, l.name))
+  result = TLib(isOverriden: l.isOverriden, kind: l.kind)
+  if l.kind == libDynamic:
+    result.name = loadSym(c, g, si, l.name)
+
   loadAstBody(l, path)
 
 proc symBodyFromPacked(c: var PackedDecoder; g: var PackedModuleGraph;

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -39,9 +39,8 @@ type
 
   PackedLib* = object
     kind*: TLibKind
-    generated*: bool
     isOverriden*: bool
-    name*: LitId
+    name*: PackedItemId
     path*: NodeId
 
   PackedSym* = object

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -173,6 +173,10 @@ func constr*(s: var MirNodeSeq, typ: PType): EValue =
   s.add MirNode(kind: mnkConstr, typ: typ)
   result = EValue(typ: typ)
 
+func callOp*(s: var MirNodeSeq, typ: PType): EValue =
+  s.add MirNode(kind: mnkCall, typ: typ)
+  result = EValue(typ: typ)
+
 func temp*(s: var MirNodeSeq, typ: PType, id: TempId): EValue =
   s.add MirNode(kind: mnkTemp, typ: typ, temp: id)
   result = EValue(typ: typ)
@@ -305,6 +309,7 @@ genInputAdapter1(procLit, sym)
 genInputAdapter1(typeLit, n)
 genInputAdapter1(literal, n)
 genInputAdapter1(constr, typ)
+genInputAdapter1(callOp, typ)
 genInputAdapter2(temp, typ, id)
 genInputAdapter2(symbol, kind, sym)
 genInputAdapter2(opParam, i, typ)

--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -81,6 +81,10 @@ type
       ## the procedure for initializing the module's lifted globals
     postDestructor*: PSym
       ## the procedure for destroying the module's lifted globals
+    dynlibInit*: PSym
+      ## the procedure for loading the dynamic libraries, procedure, and
+      ## variables associated with the module
+    # finalizing dynamic libs is left to the OS
 
   ModuleList* = object
     modules*: SeqMap[FileIndex, Module]
@@ -414,6 +418,7 @@ proc setupModule*(graph: ModuleGraph, idgen: IdGenerator, m: PSym,
 
   result.preInit = createModuleOp(graph, idgen, "PreInit", m, newNode(nkEmpty), options)
   result.postDestructor = createModuleOp(graph, idgen, "PostDeinit", m, newNode(nkEmpty), options)
+  result.dynlibInit = createModuleOp(graph, idgen, "DynlibInit", m, newNode(nkEmpty), options)
 
 # Below is the `passes` interface implementation
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -935,6 +935,17 @@ proc myClose(graph: ModuleGraph; context: PPassContext, n: PNode): PNode =
   var c = PContext(context)
   if c.config.cmd == cmdIdeTools and not c.suggestionsMade:
     suggestSentinel(c)
+
+  # setup the symbols for the globals that store the handles of loaded
+  # dynamic libraries:
+  for i, it in c.libs.pairs:
+    let info = c.module.info
+    let s = newSym(skVar, c.cache.getIdent("lib" & $i), nextSymId(c.idgen),
+                   c.module, info)
+    s.typ = graph.getSysType(info, tyPointer)
+    s.flags.incl sfGlobal
+    it.name = s
+
   closeScope(c)         # close module's scope
   rawCloseScope(c)      # imported symbols; don't check for unused ones!
   reportUnusedModules(c)

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -942,12 +942,14 @@ proc myClose(graph: ModuleGraph; context: PPassContext, n: PNode): PNode =
   # setup the symbols for the globals that store the handles of loaded
   # dynamic libraries:
   for id, it in c.libs:
-    let info = c.module.info
-    let s = newSym(skVar, c.cache.getIdent("lib" & $id.index),
+    if it.kind == libDynamic:
+      let
+        info = c.module.info
+        s = newSym(skVar, c.cache.getIdent("lib" & $id.index),
                    nextSymId(c.idgen), c.module, info)
-    s.typ = graph.getSysType(info, tyPointer)
-    s.flags.incl sfGlobal
-    it.name = s
+      s.typ = graph.getSysType(info, tyPointer)
+      s.flags.incl sfGlobal
+      it.name = s
 
   storeLibs(graph, c.idgen.module)
   closeScope(c)         # close module's scope

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -187,6 +187,10 @@ proc processEvent(c: var TCtx, mlist: ModuleList, discovery: var DiscoveryData,
     # a complete procedure became available
     let r = generateCodeForProc(c, evt.sym, evt.body)
     fillProcEntry(c.functions[c.symToIndexTbl[evt.sym.id]], r)
+  of bekImported:
+    # not supported at the moment; ``vmgen`` is going to raise an
+    # error when generating a call to a dynlib procedure
+    discard "ignore"
 
 proc generateAliveProcs(c: var TCtx, config: BackendConfig,
                         discovery: var DiscoveryData, mlist: var ModuleList) =

--- a/tests/lang_objects/destructor/tdestructor_in_dynlib_expr.nim
+++ b/tests/lang_objects/destructor/tdestructor_in_dynlib_expr.nim
@@ -4,7 +4,7 @@ discard """
     Run-time expressions used with the `.dynlib` pragma are also affected by
     destructor injection
   '''
-  output: "could not load: non_existent_library_name"
+  outputsub: "could not load: non_existent_library_name"
   exitcode: 1
 """
 

--- a/tests/lang_objects/destructor/tdestructor_in_dynlib_expr.nim
+++ b/tests/lang_objects/destructor/tdestructor_in_dynlib_expr.nim
@@ -1,0 +1,37 @@
+discard """
+  targets: "c !js !vm"
+  description: '''
+    Run-time expressions used with the `.dynlib` pragma are also affected by
+    destructor injection
+  '''
+  output: "could not load: non_existent_library_name"
+  exitcode: 1
+"""
+
+import mhelper
+
+proc loadProc(r: Resource, name: cstring): pointer =
+  doAssert r.content
+  doAssert name == "imported1"
+  result = nil # the value doesn't matter
+
+# --- test custom importer calls:
+proc imported1() {.importc, dynlib: loadProc((var r = initResource(); r), "").}
+# `r` is destroyed at the end of the loader logic for `imported1`
+
+# use the procedure for the loader logic to be generated
+imported1()
+
+# --- test run-time computed library name:
+template getName(): string =
+  block:
+    doAssert numDestroy == 1, "`r` wasn't destroyed"
+    block:
+      var r2 = initResource()
+    doAssert numDestroy == 2, "`r2` wasn't destroyed"
+
+  "non_existent_library_name" # will cause an error
+
+proc imported2() {.importc, dynlib: getName().}
+
+imported2()


### PR DESCRIPTION
## Summary

Make code generation for `.dynlib` procedure/variable setup target-
agnostic and move it to the unified backend processing pipeline.
Instead of as part of the *data-init* module operator, loading dynamic
libraries and setting up the procedures and variables now happens in the
the new *dynlib-init* module operator (which is called directly after
the *data-init* operator).

This fixes run-time expressions in `.dynlib` pragmas not being subject
to destructor injection and removes the last `PNode` side-channel
(i.e., AST reaching the code generators through something else than
`genProc`).

## Details

The C code generator previously created globals for holding the handle
of loaded libraries in an ad-hoc way, with the `PLib` associated with
the symbol modified to store the generated C name.

This same approach is not possible with the unified pipeline, and
instead, more of the `TLib` related handling is moved into semantic
analysis:
- remove the `TLib.generated` field
- store a symbol instead of a raw name in `TLib.name`
- the symbol for each `PLib` of a module is generated when the module
  is closed
- adjust `PackedLib` and the related load/store logic

With this, a `TLib` is no longer modified outside of semantic analysis,
and the code generators don't need to introduce ad-hoc globals.

The queueing logic in `process` is adjusted to also consider imported
`.dynlib` procedures, with them now having dedicated processing. When
they're processed, the procedures are announced to `process`'s caller
and the loader logic is generated and emitted. The generated loader
logic is, apart from being generated as MIR code, stays as it was.

One problem is with dynlib variables. How they're represented is left to
the code generators, which means that a normal assignment cannot be used
to initialize the internal representation. For this reason, a new
internal magic (`mAsgnDynlibVar`) that is used for setting up a dynlib
procedures/variables is introduced and implemented in `cgen`.

Finally, the workarounds regarding dynlib procedures are removed from
`cbackend` and `backends` and the everything dynlib-init specific is
removed from `cgen`. Reporting dependencies on statically-known dynamic
libraries is now handled in `cbackend`.

While now theoretically possible, the JS and VM backend still don't
support dynlib procedure and variables.