### PR TITLE
internal: data-oriented storage for `TLib`

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -29,6 +29,9 @@ import
   std/[
     strutils,
     tables # For symbol table mapping
+  ],
+  experimental/[
+    dod_helpers
   ]
 
 export ast_types, ast_idgen, ast_query, int128
@@ -324,7 +327,7 @@ proc assignType*(dest, src: PType) =
   if src.sym != nil:
     if dest.sym != nil:
       dest.sym.flags.incl src.sym.flags-{sfExported}
-      if dest.sym.annex == nil: dest.sym.annex = src.sym.annex
+      if dest.sym.annex.isNone: dest.sym.annex = src.sym.annex
       dest.sym.extFlags.incl src.sym.extFlags
       if dest.sym.extname.len == 0:
         dest.sym.extname = src.sym.extname

--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -29,9 +29,6 @@ import
   std/[
     strutils,
     tables # For symbol table mapping
-  ],
-  experimental/[
-    dod_helpers
   ]
 
 export ast_types, ast_idgen, ast_query, int128
@@ -327,7 +324,7 @@ proc assignType*(dest, src: PType) =
   if src.sym != nil:
     if dest.sym != nil:
       dest.sym.flags.incl src.sym.flags-{sfExported}
-      if dest.sym.annex.isNone: dest.sym.annex = src.sym.annex
+      if dest.sym.annex.isNil: dest.sym.annex = src.sym.annex
       dest.sym.extFlags.incl src.sym.extFlags
       if dest.sym.extname.len == 0:
         dest.sym.extname = src.sym.extname

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1,7 +1,6 @@
 import compiler/ast/lineinfos
 import compiler/utils/ropes
 import std/[hashes]
-import experimental/dod_helpers
 
 from compiler/ast/idents import PIdent, TIdent
 
@@ -45,15 +44,10 @@ type
 
 type
   NodeId* = distinct int32
-  LibId* = distinct uint32
 
 proc `==`*(a, b: NodeId): bool {.borrow.}
 proc hash*(a: NodeId): Hash {.borrow.}
 proc `$`*(a: NodeId): string {.borrow.}
-
-template indexLike*(_: typedesc[LibId]) =
-  # makes ``LibId`` available to use with ``opt``
-  discard
 
 type
   TNodeKind* = enum
@@ -1621,6 +1615,20 @@ type
     name*: Rope
     path*: PNode              ## can be a string literal!
 
+  LibId* = object
+    ## Identifies a ``TLib`` instance. The default value means 'none'.
+    # XXX: ideally, a ``LibId`` would be a single 32-bit index into the
+    #      surrounding module, but this is not possible at the moment, because
+    #      of how aliased structural types work.
+    #
+    #        type A {.header: ... .} = int # declared in module 'A'
+    #        type B = A                    # declared in module 'B'
+    #
+    #      Here, 'B' is not a ``tyAlias`` type, but rather a ``tyInt``, with
+    #      the symbol information from 'A' (including the ``LibId``) copied
+    #      over.
+    module*: int32   ## the ID of the module the lib object is part
+    index*: uint32   ## 1-based index. Zero means 'none'
 
   CompilesId* = int ## id that is used for the caching logic within
                     ## ``system.compiles``. See the seminst module.
@@ -1695,7 +1703,7 @@ type
                               ## generation
     locId*: uint32            ## associates the symbol with a loc in the C code
                               ## generator. 0 means unset.
-    annex*: opt(LibId)        ## additional fields (seldom used, so we use a
+    annex*: LibId             ## additional fields (seldom used, so we use a
                               ## reference to another object to save space)
     constraint*: PNode        ## additional constraints like 'lit|result'; also
                               ## misused for the codegenDecl pragma in the hope
@@ -1897,3 +1905,5 @@ proc `comment=`*(n: PNode, a: string) =
     gconfig.comments.del(n.id)
 
 proc setUseIc*(useIc: bool) = gconfig.useIc = useIc
+
+func isNil*(id: LibId): bool = id.index == 0

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1,6 +1,7 @@
 import compiler/ast/lineinfos
 import compiler/utils/ropes
 import std/[hashes]
+import experimental/dod_helpers
 
 from compiler/ast/idents import PIdent, TIdent
 
@@ -44,10 +45,15 @@ type
 
 type
   NodeId* = distinct int32
+  LibId* = distinct uint32
 
 proc `==`*(a, b: NodeId): bool {.borrow.}
 proc hash*(a: NodeId): Hash {.borrow.}
 proc `$`*(a: NodeId): string {.borrow.}
+
+template indexLike*(_: typedesc[LibId]) =
+  # makes ``LibId`` available to use with ``opt``
+  discard
 
 type
   TNodeKind* = enum
@@ -1633,7 +1639,6 @@ type
 
   PScope* = ref TScope
 
-  PLib* = ref TLib
   TSym* {.acyclic.} = object of TIdObj # Keep in sync with PackedSym
     ## proc and type instantiations are cached in the generic symbol
     case kind*: TSymKind
@@ -1690,7 +1695,7 @@ type
                               ## generation
     locId*: uint32            ## associates the symbol with a loc in the C code
                               ## generator. 0 means unset.
-    annex*: PLib              ## additional fields (seldom used, so we use a
+    annex*: opt(LibId)        ## additional fields (seldom used, so we use a
                               ## reference to another object to save space)
     constraint*: PNode        ## additional constraints like 'lit|result'; also
                               ## misused for the codegenDecl pragma in the hope

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -36,6 +36,9 @@ import
   compiler/utils/[
     containers,
     idioms
+  ],
+  experimental/[
+    dod_helpers
   ]
 
 type
@@ -565,7 +568,8 @@ proc preprocessDynlib(graph: ModuleGraph, idgen: IdGenerator,
   #       be removed once handling of dynlib procedures and globals is fully
   #       implemented in the ``process`` iterator
   if exfDynamicLib in sym.extFlags:
-    if sym.annex.path.kind in nkStrKinds:
+    let lib = addr graph.libs[moduleId(sym)][sym.annex[]]
+    if lib.path.kind in nkStrKinds:
       # it's a string, no need to transform nor scan it
       discard
     else:
@@ -575,12 +579,12 @@ proc preprocessDynlib(graph: ModuleGraph, idgen: IdGenerator,
         t: MirTree
         m: SourceMap
 
-      generateCode(graph, {}, sym.annex.path, t, m)
+      generateCode(graph, {}, lib.path, t, m)
       for dep in deps(t, {}): # just ignore magics here
         if dep.kind in routineKinds + {skConst}:
           deps.add dep
 
-      sym.annex.path = generateAST(graph, idgen, sym.owner, t, m)
+      lib.path = generateAST(graph, idgen, sym.owner, t, m)
 
 proc preprocessDynlib(graph: ModuleGraph, mlist: ModuleList,
                       data: var DiscoveryData) =

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -36,9 +36,6 @@ import
   compiler/utils/[
     containers,
     idioms
-  ],
-  experimental/[
-    dod_helpers
   ]
 
 type
@@ -568,7 +565,7 @@ proc preprocessDynlib(graph: ModuleGraph, idgen: IdGenerator,
   #       be removed once handling of dynlib procedures and globals is fully
   #       implemented in the ``process`` iterator
   if exfDynamicLib in sym.extFlags:
-    let lib = addr graph.libs[moduleId(sym)][sym.annex[]]
+    let lib = addr graph.getLib(sym.annex)
     if lib.path.kind in nkStrKinds:
       # it's a string, no need to transform nor scan it
       discard

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -11,7 +11,7 @@
 
 # ------------------------- Name Mangling --------------------------------
 
-import compiler/sem/sighashes, compiler/modules/modulegraphs
+import compiler/sem/sighashes
 
 proc isKeyword(w: PIdent): bool =
   # Nim and C++ share some keywords

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -35,13 +35,13 @@ import
   ],
   compiler/modules/[
     magicsys,
+    modulegraphs
   ],
   compiler/front/[
     options,
     msgs
   ],
   compiler/utils/[
-    containers,
     platform,
     nversion,
     bitsets,
@@ -59,8 +59,7 @@ import
     ccgutils,
     cgendata
   ],
-  experimental/[
-    dod_helpers
+  compiler/plugins/[
   ]
 
 # xxx: reports are a code smell meaning data types are misplaced...
@@ -147,7 +146,7 @@ proc isSimpleConst(typ: PType): bool =
 
 proc useHeader(m: BModule, sym: PSym) =
   if exfHeader in sym.extFlags:
-    let str = getStr(m.g.graph.libs[sym.itemId.module][sym.annex[]].path)
+    let str = getStr(m.g.graph.getLib(sym.annex).path)
     m.includeHeader(str)
 
 proc cgsym(m: BModule, name: string): Rope
@@ -686,7 +685,7 @@ proc mangleDynLibProc(sym: PSym): Rope =
     result = rope(strutils.`%`("Dl_$1_", $sym.id))
 
 proc symInDynamicLib*(m: BModule, sym: PSym) =
-  var lib = addr m.g.graph.libs[sym.itemId.module][sym.annex[]]
+  var lib = addr m.g.graph.getLib(sym.annex)
   let isCall = isGetProcAddr(lib[])
   let extname = sym.extname
   if not isCall: loadDynamicLib(m, lib[])
@@ -725,7 +724,7 @@ proc symInDynamicLib*(m: BModule, sym: PSym) =
   m.s[cfsVars].addf("$2 $1;$n", [tmp, getTypeDesc(m, sym.typ, skVar)])
 
 proc varInDynamicLib(m: BModule, sym: PSym) =
-  var lib = addr m.g.graph.libs[sym.itemId.module][sym.annex[]]
+  var lib = addr m.g.graph.getLib(sym.annex)
   let extname = sym.extname
   loadDynamicLib(m, lib[])
   let tmp = mangleDynLibProc(sym)

--- a/compiler/ic/cbackend.nim
+++ b/compiler/ic/cbackend.nim
@@ -131,6 +131,7 @@ proc generateCode*(g: ModuleGraph) =
   # XXX: these state changes were already applied during semantic analysis,
   #      but ``resetForBackend`` (unnecessarily) throws them away again
   for i in 0..high(g.packed):
+    replayLibs(g, i)
     replayBackendRoutines(g, i)
 
   var alive = computeAliveSyms(g.packed, g, g.config)

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -25,7 +25,6 @@ import
     options
   ],
   compiler/utils/[
-    containers,
     ropes,
     pathutils
   ]
@@ -1097,10 +1096,10 @@ proc loadSymFromId*(config: ConfigRef, cache: IdentCache;
     result = loadSym(decoder, g, module, id)
 
 proc loadLibs*(config: ConfigRef, cache: IdentCache,
-               g: var PackedModuleGraph, module: int): Store[LibId, TLib] =
+               g: var PackedModuleGraph, module: int): seq[TLib] =
   setupDecoder()
   for it in g[module].fromDisk.libs.items:
-    discard result.add(loadLib(decoder, g, module, it))
+    result.add(loadLib(decoder, g, module, it))
 
 proc translateId*(id: PackedItemId; g: PackedModuleGraph; thisModule: int; config: ConfigRef): ItemId =
   if id.module == LitId(0):

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -25,6 +25,7 @@ import
     options
   ],
   compiler/utils/[
+    containers,
     ropes,
     pathutils
   ]
@@ -69,6 +70,7 @@ type
     attachedOps*: seq[(TTypeAttachedOp, PackedItemId, PackedItemId)]
     methodsPerType*: seq[(PackedItemId, int, PackedItemId)]
     enumToStringProcs*: seq[(PackedItemId, PackedItemId)]
+    libs*: seq[PackedLib]
 
     emittedTypeInfo*: seq[string]
     backendFlags*: set[ModuleBackendFlag]
@@ -383,9 +385,7 @@ proc storeType(t: PType; c: var PackedEncoder; m: var PackedModule): PackedItemI
     # fill the reserved slot, nothing else:
     m.types[t.uniqueId.item] = p
 
-proc toPackedLib(l: PLib; c: var PackedEncoder; m: var PackedModule): PackedLib =
-  ## the plib hangs off the psym via the .annex field
-  if l.isNil: return
+proc toPackedLib(l: TLib; c: var PackedEncoder; m: var PackedModule): PackedLib =
   result.kind = l.kind
   result.generated = l.generated
   result.isOverriden = l.isOverriden
@@ -424,7 +424,7 @@ proc storeSym*(s: PSym; c: var PackedEncoder; m: var PackedModule): PackedItemId
     p.typ = s.typ.storeType(c, m)
     c.addMissing s.owner
     p.owner = s.owner.safeItemId(c, m)
-    p.annex = toPackedLib(s.annex, c, m)
+    p.annex = s.annex
 
     # fill the reserved slot, nothing else:
     m.syms[s.itemId.item] = p
@@ -558,6 +558,10 @@ proc storeAttachedOp*(c: var PackedEncoder; m: var PackedModule, kind: TTypeAtta
   ## Records a type-bound operator attachment action to module `m`.
   m.attachedOps.add((kind, storeTypeLater(t, c, m), storeSymLater(s, c, m)))
 
+proc storeLib*(c: var PackedEncoder, m: var PackedModule, lib: TLib) =
+  m.libs.add toPackedLib(lib, c, m)
+  flush c, m
+
 proc loadError(err: RodFileError; filename: AbsoluteFile; config: ConfigRef;) =
   case err
   of cannotOpen:
@@ -626,6 +630,7 @@ proc loadRodFile*(filename: AbsoluteFile; m: var PackedModule; config: ConfigRef
   loadSeqSection attachedOpsSection, m.attachedOps
   loadSeqSection methodsPerTypeSection, m.methodsPerType
   loadSeqSection enumToStringProcsSection, m.enumToStringProcs
+  loadSeqSection libsSection, m.libs
   loadSeqSection typeInfoSection, m.emittedTypeInfo
 
   f.loadSection backendFlagsSection
@@ -692,6 +697,7 @@ proc saveRodFile*(filename: AbsoluteFile; encoder: var PackedEncoder; m: var Pac
   storeSeqSection attachedOpsSection, m.attachedOps
   storeSeqSection methodsPerTypeSection, m.methodsPerType
   storeSeqSection enumToStringProcsSection, m.enumToStringProcs
+  storeSeqSection libsSection, m.libs
   storeSeqSection typeInfoSection, m.emittedTypeInfo
 
   f.storeSection backendFlagsSection
@@ -852,14 +858,10 @@ template loadAstBodyLazy(p, field) =
     result.field = loadProcHeader(c, g, si, g[si].fromDisk.bodies, NodePos p.field)
 
 proc loadLib(c: var PackedDecoder; g: var PackedModuleGraph;
-             si, item: int32; l: PackedLib): PLib =
-  # XXX: hack; assume a zero LitId means the PackedLib is all zero (empty)
-  if l.name.int == 0:
-    result = nil
-  else:
-    result = PLib(generated: l.generated, isOverriden: l.isOverriden,
-                  kind: l.kind, name: rope g[si].fromDisk.strings[l.name])
-    loadAstBody(l, path)
+             si: int; l: PackedLib): TLib =
+  result = TLib(generated: l.generated, isOverriden: l.isOverriden,
+                kind: l.kind, name: rope g[si].fromDisk.strings[l.name])
+  loadAstBody(l, path)
 
 proc symBodyFromPacked(c: var PackedDecoder; g: var PackedModuleGraph;
                        s: PackedSym; si, item: int32; result: PSym) =
@@ -869,7 +871,7 @@ proc symBodyFromPacked(c: var PackedDecoder; g: var PackedModuleGraph;
     loadAstBodyLazy(s, ast)
   else:
     loadAstBody(s, ast)
-  result.annex = loadLib(c, g, si, item, s.annex)
+  result.annex = s.annex
 
   if s.kind in {skLet, skVar, skField, skForVar}:
     result.guard = loadSym(c, g, si, s.guard)
@@ -1094,6 +1096,12 @@ proc loadSymFromId*(config: ConfigRef, cache: IdentCache;
     setupDecoder()
     result = loadSym(decoder, g, module, id)
 
+proc loadLibs*(config: ConfigRef, cache: IdentCache,
+               g: var PackedModuleGraph, module: int): Store[LibId, TLib] =
+  setupDecoder()
+  for it in g[module].fromDisk.libs.items:
+    discard result.add(loadLib(decoder, g, module, it))
+
 proc translateId*(id: PackedItemId; g: PackedModuleGraph; thisModule: int; config: ConfigRef): ItemId =
   if id.module == LitId(0):
     ItemId(module: thisModule.int32, item: id.item)
@@ -1234,6 +1242,10 @@ proc rodViewer*(rodfile: AbsoluteFile; config: ConfigRef, cache: IdentCache) =
       echo "  ", m.strings[m.syms[i].name], " local ID: ", i, " kind ", m.syms[i].kind
     else:
       echo "  <anon symbol?> local ID: ", i, " kind ", m.syms[i].kind
+
+  echo "all lib objects"
+  for it in m.libs.items:
+    echo "  kind: ", it.kind, " name: ", it.name, " path: ", it.path
 
   echo "symbols: ", m.syms.len, " types: ", m.types.len,
     " top level nodes: ", m.topLevel.nodes.len, " other nodes: ", m.bodies.nodes.len,

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -13,6 +13,7 @@
 ## it is superior.
 
 import std/[hashes, tables, strtabs]
+import experimental/[dod_helpers]
 import compiler/ic/bitabs
 import compiler/ast/ast, compiler/front/options
 
@@ -61,7 +62,7 @@ type
     offset*: int
     externalName*: LitId # instead of TLoc
     extFlags*: ExternalFlags
-    annex*: PackedLib
+    annex*: opt(LibId)
     constraint*: NodeId
 
   PackedType* = object

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -13,7 +13,6 @@
 ## it is superior.
 
 import std/[hashes, tables, strtabs]
-import experimental/[dod_helpers]
 import compiler/ic/bitabs
 import compiler/ast/ast, compiler/front/options
 
@@ -62,7 +61,7 @@ type
     offset*: int
     externalName*: LitId # instead of TLoc
     extFlags*: ExternalFlags
-    annex*: opt(LibId)
+    annex*: LibId
     constraint*: NodeId
 
   PackedType* = object

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -61,7 +61,7 @@ type
     offset*: int
     externalName*: LitId # instead of TLoc
     extFlags*: ExternalFlags
-    annex*: LibId
+    annex*: tuple[module: LitId, index: uint32]
     constraint*: NodeId
 
   PackedType* = object

--- a/compiler/ic/replayer.nim
+++ b/compiler/ic/replayer.nim
@@ -186,3 +186,11 @@ proc replayGenericCacheInformation*(g: ModuleGraph; module: int) =
   for it in mitems(g.packed[module].fromDisk.pureEnums):
     let symId = FullId(module: module, packed: PackedItemId(module: LitId(0), item: it))
     g.ifaces[module].pureEnums.add LazySym(id: symId, sym: nil)
+
+proc replayLibs*(g: ModuleGraph, module: int) =
+  ## Loads the packed library information for `module` into `g`.
+  # XXX: libs are not really replayed state changes...
+  if module >= g.libs.len:
+    g.libs.setLen(module + 1)
+
+  g.libs[module] = loadLibs(g.config, g.cache, g.packed, module)

--- a/compiler/ic/rodfiles.nim
+++ b/compiler/ic/rodfiles.nim
@@ -93,6 +93,7 @@ type
     attachedOpsSection
     methodsPerTypeSection
     enumToStringProcsSection
+    libsSection
     typeInfoSection  # required by the backend
     backendFlagsSection
     aliveSymsSection # beware, this is stored in a `.alivesyms` file.

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -29,6 +29,7 @@ import
     idents,
   ],
   compiler/utils/[
+    containers,
     pathutils,
     btrees,
     ropes,
@@ -97,6 +98,8 @@ type
     methodsPerType*: Table[ItemId, seq[(int, LazySym)]] # Type ID, attached methods
     enumToStringProcs*: Table[ItemId, LazySym]
     emittedTypeInfo*: Table[string, FileIndex]
+
+    libs*: seq[Store[LibId, TLib]] ## indexed by module position
 
     startupPackedConfig*: PackedConfig
     packageSyms*: TStrTable
@@ -376,6 +379,10 @@ proc getToStringProc*(g: ModuleGraph; t: PType): PSym =
 
 proc setToStringProc*(g: ModuleGraph; t: PType; value: PSym) =
   g.enumToStringProcs[t.itemId] = LazySym(sym: value)
+
+proc storeLib*(g: ModuleGraph, module: int, lib: TLib) =
+  if g.config.symbolFiles != disabledSf:
+    storeLib(g.encoders[module], g.packed[module].fromDisk, lib)
 
 iterator methodsForGeneric*(g: ModuleGraph; t: PType): (int, PSym) =
   if g.methodsPerType.contains(t.itemId):

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -144,6 +144,7 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags, fr
       registerModuleById(graph, m)
       replayStateChanges(graph.packed[m.int].module, graph)
       replayGenericCacheInformation(graph, m.int)
+      replayLibs(graph, m.int)
   elif graph.isDirty(result):
     result.flags.excl sfDirty
     # reset module fields:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -46,7 +46,6 @@ import
     msgs
   ],
   compiler/utils/[
-    containers,
     ropes,
     platform,
     nversion,
@@ -939,10 +938,7 @@ proc myClose(graph: ModuleGraph; context: PPassContext, n: PNode): PNode =
   var c = PContext(context)
   if c.config.cmd == cmdIdeTools and not c.suggestionsMade:
     suggestSentinel(c)
-
-  for it in c.libs.items:
-    storeLib(graph, c.module.position, it)
-
+  storeLibs(graph, c.idgen.module)
   closeScope(c)         # close module's scope
   rawCloseScope(c)      # imported symbols; don't check for unused ones!
   reportUnusedModules(c)

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -46,6 +46,7 @@ import
     msgs
   ],
   compiler/utils/[
+    containers,
     ropes,
     platform,
     nversion,
@@ -829,6 +830,9 @@ proc myOpen(graph: ModuleGraph; module: PSym;
 
   graph.config.internalAssert(c.p == nil, module.info, "sem.myOpen")
 
+  if module.position >= graph.libs.len:
+    graph.libs.setLen(module.position + 1)
+
   c.semConstExpr = semConstExpr
   c.semExpr = semExpr
   c.semTryExpr = tryExpr
@@ -935,6 +939,10 @@ proc myClose(graph: ModuleGraph; context: PPassContext, n: PNode): PNode =
   var c = PContext(context)
   if c.config.cmd == cmdIdeTools and not c.suggestionsMade:
     suggestSentinel(c)
+
+  for it in c.libs.items:
+    storeLib(graph, c.module.position, it)
+
   closeScope(c)         # close module's scope
   rawCloseScope(c)      # imported symbols; don't check for unused ones!
   reportUnusedModules(c)


### PR DESCRIPTION
## Summary

Replace storing `TLib` objects as `ref`s in `TSym` with storing all
`TLib` instances belonging to a module in a sequence that a `TSym` then
stores an index-like reference into.

This makes serializing the symbols and associated `TLib` instances
easier: instead of storing a `PackedLib` for *each* packed symbol, the
packed symbols now only store a module+index tuple.

## Details

For simplicity, the list with the libs for a module is stored in a
separate `seq` in `ModuleGraph`. The list cannot be stored in
`PContext`, as it needs to be accessible after semantic analysis, at
which point `PContext` is already gone.

While the handle to the `TLib` instance stored with `TSym` would
ideally be a single index into the `TLib` list of the module a
symbol is attached to, the way symbols of aliased structural types
currently work (the aliased type's `TSym` content is partially
copied) makes this not possible, meaning that a symbol also has to
store the ID of the module the referenced `TLib` instance is part
of.

Storing the `TLib` objects for a module happens when the module is
closed. While not strictly necessary at the moment, this is a
preparation for storing a `PSym` in `TLib.name` that is only setup
when the module is closed.

Aside from reducing the size of rodfiles, not storing a `PackedLib`
for each `PackedSym` also fixes another inefficiency, namely that
each deserialized `TSym` got a unique, possibly duplicated, `TLib`
instance.