### PR TITLE
internal: `astrepr.debug` now useful for `PType`

### DIFF
--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -1248,7 +1248,7 @@ template debug*(it: PType) =
 
                   # trfShowNodeTypes,
                   trfShowNodeLineInfo, trfShowNodeFlags}
-  debugAux(implicitDebugConfRef, it, implicitTReprConf, instLoc())
+  debugAux(implicitDebugConfRef, it, conf, instLoc())
 
 template debug*(it: PIdent) =
   ## Print tree representation of a PIdent for compiler debugging

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -1234,7 +1234,20 @@ template debug*(it: PSym) =
 
 template debug*(it: PType) =
   ## Print tree representation of a PType for compiler debugging
-  # TODO: customize the TReprConf here
+  # TODO: create a PType specific implicitTReprConf
+  var conf = implicitTReprConf
+  conf.flags = conf.flags +
+                {
+                  trfShowTypeAst, trfShowTypeId,
+
+                  trfShowTypeFlags
+                } -
+                {
+                  trfShowTypeSym, trfShowSymLineInfo,
+                  trfShowSymFlags, trfShowSymMagic,
+
+                  # trfShowNodeTypes,
+                  trfShowNodeLineInfo, trfShowNodeFlags}
   debugAux(implicitDebugConfRef, it, implicitTReprConf, instLoc())
 
 template debug*(it: PIdent) =


### PR DESCRIPTION
## Summary

`astrepr.debug` overload for `PType` now provides more tailored output,
reducing spam and surfacing more useful information.

## Details

Previously, `astrepr.debug` used a generic `implicitTReprConf` when
generating output. This meant continually fiddling with that set and/or
having largely useless/spammy output for `PType` vs `PSym` vs `PNode`,
etc. Now the `PType` overload has its own config that can be tailored
for types.