### PR TITLE
refactor(lexer): rename away from reports

### DIFF
--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -1172,7 +1172,7 @@ proc getPrecedence*(tok: Token): int =
   of tkOr, tkXor, tkPtr, tkRef: result = 3
   else: return -10
 
-proc newlineFollows*(L: Lexer): bool =
+proc newlineFollows(L: Lexer): bool =
   var pos = L.bufpos
   while true:
     case L.buf[pos]
@@ -1526,7 +1526,7 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
         inc(L.bufpos)
   atTokenEnd()
 
-proc getIndentWidth*(fileIdx: FileIndex, inputstream: PLLStream;
+proc getIndentWidth(fileIdx: FileIndex, inputstream: PLLStream;
                      cache: IdentCache; config: ConfigRef): int =
   var lex: Lexer
   var tok: Token

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -134,10 +134,10 @@ proc getTok(p: var Parser) =
   p.lex.rawGetTok(p.tok)
 
   if p.tok.tokType == tkError:
-    p.lex.config.handleReport(p.tok.error, instLoc(-1), doAbort)
+    p.lex.config.handleLexerDiag(p.tok.error, instLoc(-1), doAbort)
 
   for d in p.lex.errorsHintsAndWarnings(lexDiagOffset):
-    p.lex.config.handleReport(d, instLoc(-1))
+    p.lex.config.handleLexerDiag(d, instLoc(-1))
 
   p.hasProgress = true
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -826,7 +826,7 @@ func lexerDiagToLegacyReport*(diag: LexerDiag): Report {.inline.} =
             msg: diagToHumanStr(diag))
   result = Report(category: repLexer, lexReport: rep)
 
-proc handleReport*(
+proc handleLexerDiag*(
     conf: ConfigRef,
     diag: LexerDiag,
     reportFrom: InstantiationInfo,


### PR DESCRIPTION
## Summary

Rename `handleReport` to `handleLexerDiag` to differentiate it from the
rest of legacy reports.

## Details

Renamed `handleReport` to `handleLexerDiag`, this not only moves away
from 'reports' terminology, but makes it easier to differentiate this
proc from the rest of legacy reports. This is also more consistent with
the `parser.handleParserDiag`.

As part of this change two procs `newlineFollows` and `getIndentWidth`
are no longer exported as they have no public consumers.