### PR TITLE
nimscript: fix compiler crash with `.header` procs

### DIFF
--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -199,7 +199,10 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
 
   var m = graph.makeModule(scriptName)
   incl(m.flags, sfMainModule)
-  var vm = setupVM(m, cache, scriptName.string, graph, graph.idgen)
+  # use a dedicated ID generator for the module; don't reuse the graph's
+  let idgen = idGeneratorFromModule(m)
+
+  var vm = setupVM(m, cache, scriptName.string, graph, idgen)
   let disallowDanger =
     defined(nimsuggest) or graph.config.cmd == cmdCheck or
     vmopsDanger notin graph.config.features
@@ -217,6 +220,6 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   graph.vm = PEvalContext(vm: vm)
 
   graph.compileSystemModule()
-  discard graph.processModule(m, graph.idgen, stream)
+  discard graph.processModule(m, idgen, stream)
 
   undefSymbol(conf, "nimscript")

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -89,6 +89,11 @@ import stdlib/os/tosenv
 echo "Nimscript imports are successful."
 
 block:
+  # a procedure with a .header (or .dynlib) pragma defined directly inside
+  # the executed NimScript file would crash the compiler
+  proc test() {.importc, header: "ignore".}
+
+block:
   doAssert "./foo//./bar/".normalizedPath == "foo/bar".unixToNativePath
 block:
   doAssert $3'u == "3"


### PR DESCRIPTION
## Summary

Fix the compiler crashing when running NimScript files that directly
contain procedure definitions using the `.header` or `.dynlib` pragma.

## Details

The module of a NimScript didn't use its own `IdGenerator`, but instead
re-used the `IdGenerator` instance belonging to the `ModuleGraph`. Apart
from leading to all symbols created as part of semantically analysing
the module being not attached to any module, this also caused an
`IndexDefect` when processing a `.header`/`.dynlib` pragma, as there the
module ID provided by the `IdGenerator` (which is -1 for the
`ModuleGraph`'s) is used as an index into to the `TLib` storage.

A dedicated `IdGenerator` is now created for a NimScript file, both
fixing the crash and guaranteeing that the module ID provided by a
`PContext`'s ID generator is a valid `FileIndex`.