### PR TITLE
cgen: replace `TNodeTable` usage with `Table`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -65,7 +65,7 @@ proc genLiteral(p: BProc, n: PNode, ty: PType): Rope =
   of nkNilLit:
     let k = if ty == nil: tyPointer else: skipTypes(ty, abstractVarRange).kind
     if k == tyProc and skipTypes(ty, abstractVarRange).callConv == ccClosure:
-      let id = nodeTableTestOrSet(p.module.dataCache, n, p.module.labels)
+      let id = getOrPut(p.module.dataCache, n, p.module.labels)
       result = p.module.tmpBase & rope(id)
       if id == p.module.labels:
         # not found in cache:
@@ -132,7 +132,7 @@ proc genSetNode(p: BProc, n: PNode): Rope =
   var size = int(getSize(p.config, n.typ))
   let cs = toBitSet(p.config, n)
   if size > 8:
-    let id = nodeTableTestOrSet(p.module.dataCache, n, p.module.labels)
+    let id = getOrPut(p.module.dataCache, n, p.module.labels)
     result = p.module.tmpBase & rope(id)
     if id == p.module.labels:
       # not found in cache:
@@ -998,7 +998,7 @@ proc genNewSeqOfCap(p: BProc; e: PNode; d: var TLoc) =
 proc rawConstExpr(p: BProc, n: PNode; d: var TLoc) =
   let t = n.typ
   discard getTypeDesc(p.module, t) # so that any fields are initialized
-  let id = nodeTableTestOrSet(p.module.dataCache, n, p.module.labels)
+  let id = getOrPut(p.module.dataCache, n, p.module.labels)
   fillLoc(d, locData, n, p.module.tmpBase & rope(id), OnStatic)
   if id == p.module.labels:
     # expression not found in the cache:
@@ -2113,7 +2113,7 @@ proc downConv(p: BProc, n: PNode, d: var TLoc) =
 proc exprComplexConst(p: BProc, n: PNode, d: var TLoc) =
   let t = n.typ
   discard getTypeDesc(p.module, t) # so that any fields are initialized
-  let id = nodeTableTestOrSet(p.module.dataCache, n, p.module.labels)
+  let id = getOrPut(p.module.dataCache, n, p.module.labels)
   let tmp = p.module.tmpBase & rope(id)
 
   if id == p.module.labels:

--- a/compiler/backend/ccgliterals.nim
+++ b/compiler/backend/ccgliterals.nim
@@ -25,7 +25,7 @@ proc genStringLiteralDataOnlyV2(m: BModule, s: string; result: Rope; isConst: bo
        rope(if isConst: "const" else: "")])
 
 proc genStringLiteralV2(m: BModule; n: PNode; isConst: bool): Rope =
-  let id = nodeTableTestOrSet(m.dataCache, n, m.labels)
+  let id = getOrPut(m.dataCache, n, m.labels)
   if id == m.labels:
     let pureLit = getTempName(m)
     genStringLiteralDataOnlyV2(m, n.strVal, pureLit, isConst)
@@ -42,7 +42,7 @@ proc genStringLiteralV2(m: BModule; n: PNode; isConst: bool): Rope =
           rope(if isConst: "const" else: "")])
 
 proc genStringLiteralV2Const(m: BModule; n: PNode; isConst: bool): Rope =
-  let id = nodeTableTestOrSet(m.dataCache, n, m.labels)
+  let id = getOrPut(m.dataCache, n, m.labels)
   var pureLit: Rope
   if id == m.labels:
     pureLit = getTempName(m)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -27,7 +27,6 @@ import
     types,
     typesrenderer,
     wordrecg,
-    treetab,
     renderer,
     lineinfos,
     astmsgs,
@@ -1233,7 +1232,7 @@ proc rawNewModule*(g: BModuleList; module: PSym, filename: AbsoluteFile): BModul
   result.module = module
   result.typeInfoMarker = initTable[SigHash, Rope]()
   result.sigConflicts = initCountTable[SigHash]()
-  initNodeTable(result.dataCache)
+  result.dataCache = initTable[ConstrTree, int]()
   result.typeStack = @[]
   result.typeNodesName = getTempName(result)
   # no line tracing for the init sections of the system module so that we

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -345,7 +345,7 @@ iterator items*[T](m: SymbolMap[T]): lent T =
     yield it
 
 proc hash(n: ConstrTree): Hash =
-  ## Computes a hash over the structure of `tree`. The hash function is
+  ## Computes a hash over the structure of a tree (`n`). The hash function is
   ## intended to be used with ``Table``, so two different trees are not
   ## guaranteed to produce a different hash, but the same hash *must* be
   ## produced for two structurally equal trees.

--- a/tests/lang_exprs/tlifted_constants_with_float.nim
+++ b/tests/lang_exprs/tlifted_constants_with_float.nim
@@ -1,0 +1,47 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Regression test for two constant array construction expressions being
+    lifted into the *same* constant, despite their float contents having
+    different bit representations
+  '''
+"""
+
+import std/math
+
+type Obj = object
+  x: float
+
+proc test() =
+  # use a wrapper procedure in order to test with locals, and not globals
+  var
+    a = [-0.0, 0.0]
+    b = [0.0, 0.0]
+
+  # the array values are compile-time known, meaning that they can be lifted
+  # into constants, but they must not be erroneously collapsed into a single
+  # one
+  doAssert classify(a[0]) == fcNegZero
+  doAssert classify(a[1]) == fcZero
+  doAssert classify(b[0]) == fcZero
+  doAssert classify(b[1]) == fcZero
+
+  # for completeness, also test with tuples and objects:
+  var
+    c = (-0.0, 0.0)
+    d = (0.0, 0.0)
+
+  doAssert classify(c[0]) == fcNegZero
+  doAssert classify(c[1]) == fcZero
+  doAssert classify(d[0]) == fcZero
+  doAssert classify(d[1]) == fcZero
+
+  # test with objects:
+  var
+    e = Obj(x: -0.0)
+    f = Obj(x: 0.0)
+
+  doAssert classify(e.x) == fcNegZero
+  doAssert classify(f.x) == fcZero
+
+test()


### PR DESCRIPTION
## Summary

Replace the usage of `TNodeTable` with `Table` in `cgen`. This is a
preparation for moving away from `TNode` in the code generators.

In addition, the change allowed for fixing an issue with the
structural comparison logic that led to `-0.0` and `0.0` being treated
as equal and thus not-equal array construction expressions (e.g.
`[-0.0, 0.0]` and `[0.0, 0.0]`) collapsed into the the same constant
when using the C backend.

## Details

The implementation of `TNodeTable` is almost exactly the same as that of
`Table`, with the largest difference being that `TNodeTable` uses the
`key` and not its stored hash for testing whether a slot is empty. To
be able to use a `PNode` as the key, a distinct type (`ConstrTree`; for
"construction tree") is created that has a structural hash and
structural equality operator.

Both operators are based on the previously used `hashTree` and
`treesEquivalent` procedures from the `treetab` module, with adjustments
made for the specific use case:
- `nkIdent` nodes don't reach the code generator (and thus don't need to
  be considered)
- nodes of integer kind always have their value hashed, as opposed to
  the value being used as the hash (which means a hash is also computed
  for >= 2^32 values when using a 32-bit compiler)
- the bit pattern of floats are compared, not the values themselves

The last change fixes the aforementioned issue with two non-bit-pattern-
equal values resulting from constant array construction expressions
using into the same constant.