### PR TITLE
internal: remove obsolete `nkExprColonExpr` detection

### DIFF
--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2957,17 +2957,10 @@ proc genTupleConstr(c: var TCtx, n: PNode, dest: var TDest) =
   if n.typ.kind != tyTypeDesc:
     c.gABx(n, opcLdNull, dest, c.genType(n.typ))
     # XXX x = (x.old, 22)  produces wrong code ... stupid self assignments
-    for i in 0..<n.len:
-      let it = n[i]
-      if it.kind == nkExprColonExpr:
-        let idx = genField(c, it[0])
-        let tmp = c.genAsgnSource(it[1], wantsPtr = true)
-        c.gABC(it[1], opcWrObj, dest, idx, tmp)
-        c.freeTemp(tmp)
-      else:
-        let tmp = c.genAsgnSource(it, wantsPtr = true)
-        c.gABC(it, opcWrObj, dest, i.TRegister, tmp)
-        c.freeTemp(tmp)
+    for i, it in n.pairs:
+      let tmp = c.genAsgnSource(it, wantsPtr = true)
+      c.gABC(it, opcWrObj, dest, i.TRegister, tmp)
+      c.freeTemp(tmp)
 
 proc genClosureConstr(c: var TCtx, n: PNode, dest: var TDest) =
   if dest.isUnset: dest = c.getTemp(n.typ)


### PR DESCRIPTION
## Summary

Remove detection of `nkExprColonExpr` nodes in the context of tuple,
array, and object construction expressions in the code generators. The
ASTs reaching the code generators are expected to have a specific shape;
violations thereof need to be treated as internal errors and should
not be silently supported.

## Details

The AST coming out of `astgen` does not contain `nkExprColonExpr` nodes
in `nkTupleConstr` trees, so the detection for them in
`ccgexprs.genTupleConstr` and `vmgen.genTupleConstr` is obsolete and
thus removed. Since `jsgen.genTupleConstr` is used for both normal
procedure-level code and constant initializers, it cannot have the
detection removed, as constant initializers do use `nkExprColonExpr`
nodes for named tuple constructions (`nkTupleConstr`).

In addition, the constant initializer AST that comes out of both
`semfold` or `vmcompilerserdes`:
- doesn't have `nkExprColonExpr` nodes in `nkBracket` (array
  construction) trees
- always has `nkExprColonExpr` nodes in `nkObjConstr` trees

Therefore, `ccgexprs.getNullValueAux` (code generation for constant
object constructions) can depend on the presence of `nkExprColonExpr`
nodes and `ccgexprs.genConstSimpleList` (code generation for constant
array constructions) on their absence.