### PR TITLE
vmgen: remove diagnostics representing internal errors

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1045,13 +1045,13 @@ type
     adVmGenTooManyRegistersRequired       # |       defined in the `vmdef`
     adVmGenCannotFindBreakTarget          # |       module. There should be a
     adVmGenNotUnused                      # |       way to cross-reference data
-    adVmGenNotAFieldSymbol                # |       without introducing direct
+                                          # |       without introducing direct
     adVmGenCannotGenerateCode             # |       import or type
     adVmGenCannotEvaluateAtComptime       # |       dependencies. Likely this
-    adVmGenInvalidObjectConstructor       # |       involves data oriented
+                                          # |       involves data oriented
     adVmGenMissingImportcCompleteStruct   # |       design, use of handles and
     adVmGenCodeGenUnhandledMagic          # |       the like, along with
-    adVmGenCodeGenGenericInNonMacro       # |       breaking up the coupling
+                                          # |       breaking up the coupling
     adVmGenCodeGenUnexpectedSym           # |       within the `compiler/vm`
     adVmGenCannotImportc                  # |       package between pure VM and
     adVmGenTooLargeOffset                 # |       the VM for the compiler.
@@ -1064,16 +1064,13 @@ type
           adVmGenCannotFindBreakTarget:
         discard
       of adVmGenNotUnused,
-          adVmGenNotAFieldSymbol,
           adVmGenCannotGenerateCode,
-          adVmGenCannotEvaluateAtComptime,
-          adVmGenInvalidObjectConstructor:
+          adVmGenCannotEvaluateAtComptime:
         ast*: PNode
       of adVmGenMissingImportcCompleteStruct,
           adVmGenCodeGenUnhandledMagic:
         magic*: TMagic
-      of adVmGenCodeGenGenericInNonMacro,
-          adVmGenCodeGenUnexpectedSym,
+      of adVmGenCodeGenUnexpectedSym,
           adVmGenCannotImportc,
           adVmGenTooLargeOffset,
           adVmGenCannotCallMethod:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -228,7 +228,6 @@ type
     rvmCannotFindBreakTarget
     rvmNotUnused
     rvmUserError
-    rvmNotAFieldSymbol
     rvmTooLargetOffset
     rvmUnhandledException
     rvmCannotGenerateCode
@@ -238,7 +237,6 @@ type
     ## this report is largely meaningless, and used only to raise exception.
     rvmCannotEvaluateAtComptime
     rvmCannotImportc
-    rvmInvalidObjectConstructor
     rvmCannotCallMethod
     rvmCallingNonRoutine
     rvmCannotModifyTypechecked

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2966,14 +2966,8 @@ proc reportBody*(conf: ConfigRef, r: VMReport): string =
   of rvmMissingImportcCompleteStruct:
     result = "'$1' requires '.importc' types to be '.completeStruct'" % r.str
 
-  of rvmNotAFieldSymbol:
-    result = "no field symbol"
-
   of rvmCannotImportc:
     result = "cannot 'importc' variable/proc at compile time: " & r.symstr
-
-  of rvmInvalidObjectConstructor:
-    result = "invalid object constructor"
 
   of rvmStackTrace:
     result = "stack trace: (most recent call last)\n"
@@ -3986,15 +3980,12 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         kind: kind,
         location: some location,
         reportInst: diag.instLoc.toReportLineInfo)
-    of adVmGenCodeGenGenericInNonMacro,
-        adVmGenCodeGenUnexpectedSym,
+    of adVmGenCodeGenUnexpectedSym,
         adVmGenCannotImportc,
         adVmGenCannotCallMethod,
         adVmGenTooLargeOffset:
       vmRep = VMReport(
         str: case diag.vmGenErr.kind
-              of adVmGenCodeGenGenericInNonMacro:
-                "Attempt to generate VM code for generic parameter in non-macro proc"
               of adVmGenCodeGenUnexpectedSym:
                 "Unexpected symbol for VM code - " & $diag.vmGenErr.sym.kind
               else:
@@ -4004,10 +3995,8 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind)
     of adVmGenNotUnused,
-        adVmGenNotAFieldSymbol,
         adVmGenCannotGenerateCode,
-        adVmGenCannotEvaluateAtComptime,
-        adVmGenInvalidObjectConstructor:
+        adVmGenCannotEvaluateAtComptime:
       vmRep = VMReport(
         ast: diag.vmGenErr.ast,
         kind: kind,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -420,16 +420,13 @@ func astDiagVmGenToLegacyReportKind*(
   of adVmGenTooManyRegistersRequired: rvmTooManyRegistersRequired
   of adVmGenCannotFindBreakTarget: rvmCannotFindBreakTarget
   of adVmGenNotUnused: rvmNotUnused
-  of adVmGenNotAFieldSymbol: rvmNotAFieldSymbol
   of adVmGenTooLargeOffset: rvmTooLargetOffset
   of adVmGenCannotGenerateCode: rvmCannotGenerateCode
   of adVmGenCodeGenUnhandledMagic: rvmCannotGenerateCode
-  of adVmGenCodeGenGenericInNonMacro: rvmCannotGenerateCode
   of adVmGenCodeGenUnexpectedSym: rvmCannotGenerateCode
   of adVmGenCannotCast: rvmCannotCast
   of adVmGenCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of adVmGenCannotImportc: rvmCannotImportc
-  of adVmGenInvalidObjectConstructor: rvmInvalidObjectConstructor
   of adVmGenCannotCallMethod: rvmCannotCallMethod
 
 func astDiagToLegacyReportKind*(

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -586,15 +586,12 @@ type
     vmGenDiagCannotFindBreakTarget
     # has ast data
     vmGenDiagNotUnused
-    vmGenDiagNotAFieldSymbol
     vmGenDiagCannotGenerateCode
     vmGenDiagCannotEvaluateAtComptime
-    vmGenDiagInvalidObjectConstructor
     # has magic data
     vmGenDiagMissingImportcCompleteStruct
     vmGenDiagCodeGenUnhandledMagic
     # has sym data
-    vmGenDiagCodeGenGenericInNonMacro
     vmGenDiagCodeGenUnexpectedSym
     vmGenDiagCannotImportc
     vmGenDiagTooLargeOffset
@@ -603,12 +600,12 @@ type
     vmGenDiagCannotCast
 
   VmGenDiagKindAstRelated* =
-    range[vmGenDiagNotUnused..vmGenDiagInvalidObjectConstructor]
+    range[vmGenDiagNotUnused..vmGenDiagCannotEvaluateAtComptime]
     # TODO: this is a somewhat silly type, the range allows creating type safe
     #       diag construction functions -- see: `vmgen.fail`
 
   VmGenDiagKindSymRelated* =
-    range[vmGenDiagCodeGenGenericInNonMacro..vmGenDiagCannotCallMethod]
+    range[vmGenDiagCodeGenUnexpectedSym..vmGenDiagCannotCallMethod]
     # TODO: this is a somewhat silly type, the range allows creating type safe
     #       diag construction functions -- see: `vmgen.fail`
 
@@ -627,8 +624,7 @@ type
     location*: TLineInfo        ## diagnostic location
     instLoc*: InstantiationInfo ## instantiation in VM Gen's source
     case kind*: VmGenDiagKind
-      of vmGenDiagCodeGenGenericInNonMacro,
-          vmGenDiagCodeGenUnexpectedSym,
+      of vmGenDiagCodeGenUnexpectedSym,
           vmGenDiagCannotImportc,
           vmGenDiagTooLargeOffset,
           vmGenDiagCannotCallMethod:
@@ -639,10 +635,8 @@ type
           vmGenDiagCodeGenUnhandledMagic:
         magic*: TMagic
       of vmGenDiagNotUnused,
-          vmGenDiagNotAFieldSymbol,
           vmGenDiagCannotGenerateCode,
-          vmGenDiagCannotEvaluateAtComptime,
-          vmGenDiagInvalidObjectConstructor:
+          vmGenDiagCannotEvaluateAtComptime:
         ast*: PNode
       of vmGenDiagTooManyRegistersRequired,
           vmGenDiagCannotFindBreakTarget:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1058,8 +1058,7 @@ func local(prc: PProc, sym: PSym): TDest {.inline.} =
   prc.locals.getOrDefault(sym.id, -1)
 
 proc genField(c: TCtx; n: PNode): TRegister =
-  if n.kind != nkSym or n.sym.kind != skField:
-    fail(n.info, vmGenDiagNotAFieldSymbol, ast = n)
+  assert n.kind == nkSym and n.sym.kind == skField
 
   let s = n.sym
   if s.position > high(typeof(result)):
@@ -2921,7 +2920,8 @@ proc genObjConstr(c: var TCtx, n: PNode, dest: var TDest) =
 
   for i in 1..<n.len:
     let it = n[i]
-    if it.kind == nkExprColonExpr and it[0].kind == nkSym:
+    assert it.kind == nkExprColonExpr and it[0].kind == nkSym
+    if true:
       let idx = genField(c, it[0])
       var tmp: TRegister
       var opcode: TOpcode
@@ -2945,8 +2945,6 @@ proc genObjConstr(c: var TCtx, n: PNode, dest: var TDest) =
         opcode = opcInitDisc
       c.gABC(it[1], opcode, dest, idx, tmp)
       c.freeTemp(tmp)
-    else:
-      fail(n.info, vmGenDiagInvalidObjectConstructor, it)
 
   if t.kind == tyRef:
     swap(refTemp, dest)
@@ -3384,13 +3382,10 @@ func vmGenDiagToAstDiagVmGenError*(diag: VmGenDiag): AstDiagVmGenError {.inline.
     of vmGenDiagTooManyRegistersRequired: adVmGenTooManyRegistersRequired
     of vmGenDiagCannotFindBreakTarget: adVmGenCannotFindBreakTarget
     of vmGenDiagNotUnused: adVmGenNotUnused
-    of vmGenDiagNotAFieldSymbol: adVmGenNotAFieldSymbol
     of vmGenDiagCannotGenerateCode: adVmGenCannotGenerateCode
     of vmGenDiagCannotEvaluateAtComptime: adVmGenCannotEvaluateAtComptime
-    of vmGenDiagInvalidObjectConstructor: adVmGenInvalidObjectConstructor
     of vmGenDiagMissingImportcCompleteStruct: adVmGenMissingImportcCompleteStruct
     of vmGenDiagCodeGenUnhandledMagic: adVmGenCodeGenUnhandledMagic
-    of vmGenDiagCodeGenGenericInNonMacro: adVmGenCodeGenGenericInNonMacro
     of vmGenDiagCodeGenUnexpectedSym: adVmGenCodeGenUnexpectedSym
     of vmGenDiagCannotImportc: adVmGenCannotImportc
     of vmGenDiagTooLargeOffset: adVmGenTooLargeOffset
@@ -3400,8 +3395,7 @@ func vmGenDiagToAstDiagVmGenError*(diag: VmGenDiag): AstDiagVmGenError {.inline.
   {.cast(uncheckedAssign).}: # discriminants on both sides lead to saddness
     result =
       case diag.kind
-      of vmGenDiagCodeGenGenericInNonMacro,
-          vmGenDiagCodeGenUnexpectedSym,
+      of vmGenDiagCodeGenUnexpectedSym,
           vmGenDiagCannotImportc,
           vmGenDiagTooLargeOffset,
           vmGenDiagCannotCallMethod:
@@ -3419,10 +3413,8 @@ func vmGenDiagToAstDiagVmGenError*(diag: VmGenDiag): AstDiagVmGenError {.inline.
           kind: kind,
           magic: diag.magic)
       of vmGenDiagNotUnused,
-          vmGenDiagNotAFieldSymbol,
           vmGenDiagCannotGenerateCode,
-          vmGenDiagCannotEvaluateAtComptime,
-          vmGenDiagInvalidObjectConstructor:
+          vmGenDiagCannotEvaluateAtComptime:
         AstDiagVmGenError(
           kind: kind,
           ast: diag.ast)

--- a/compiler/vm/vmlegacy.nim
+++ b/compiler/vm/vmlegacy.nim
@@ -23,16 +23,13 @@ func vmGenDiagToLegacyReportKind(diag: VmGenDiagKind): ReportKind {.inline.} =
   of vmGenDiagTooManyRegistersRequired: rvmTooManyRegistersRequired
   of vmGenDiagCannotFindBreakTarget: rvmCannotFindBreakTarget
   of vmGenDiagNotUnused: rvmNotUnused
-  of vmGenDiagNotAFieldSymbol: rvmNotAFieldSymbol
   of vmGenDiagTooLargeOffset: rvmTooLargetOffset
   of vmGenDiagCannotGenerateCode: rvmCannotGenerateCode
   of vmGenDiagCodeGenUnhandledMagic: rvmCannotGenerateCode
-  of vmGenDiagCodeGenGenericInNonMacro: rvmCannotGenerateCode
   of vmGenDiagCodeGenUnexpectedSym: rvmCannotGenerateCode
   of vmGenDiagCannotCast: rvmCannotCast
   of vmGenDiagCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of vmGenDiagCannotImportc: rvmCannotImportc
-  of vmGenDiagInvalidObjectConstructor: rvmInvalidObjectConstructor
   of vmGenDiagCannotCallMethod: rvmCannotCallMethod
 
 template magicToString(m: TMagic): string =
@@ -60,15 +57,12 @@ func vmGenDiagToLegacyVmReport*(diag: VmGenDiag): VMReport {.inline.} =
         kind: kind,
         location: std_options.some diag.location,
         reportInst: diag.instLoc.toReportLineInfo)
-    of vmGenDiagCodeGenGenericInNonMacro,
-        vmGenDiagCodeGenUnexpectedSym,
+    of vmGenDiagCodeGenUnexpectedSym,
         vmGenDiagCannotImportc,
         vmGenDiagCannotCallMethod,
         vmGenDiagTooLargeOffset:
       VMReport(
         str: case diag.kind
-              of vmGenDiagCodeGenGenericInNonMacro:
-                "Attempt to generate VM code for generic parameter in non-macro proc"
               of vmGenDiagCodeGenUnexpectedSym:
                 "Unexpected symbol for VM code - " & $diag.sym.kind
               else:
@@ -78,10 +72,8 @@ func vmGenDiagToLegacyVmReport*(diag: VmGenDiag): VMReport {.inline.} =
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind)
     of vmGenDiagNotUnused,
-        vmGenDiagNotAFieldSymbol,
         vmGenDiagCannotGenerateCode,
-        vmGenDiagCannotEvaluateAtComptime,
-        vmGenDiagInvalidObjectConstructor:
+        vmGenDiagCannotEvaluateAtComptime:
       VMReport(
         ast: diag.ast,
         kind: kind,


### PR DESCRIPTION
## Summary

Remove `vmgen`-related diagnostics that were about violations of
internal expectations/requirements. Detecting and reporting these kinds
of issues should not use diagnostics and reports, but rather `assert`
and `unreachable`.

## Details

The removed internal diagnostics are `adVmGenNotAFieldSymbol`,
`adGenDiagInvalidObjectConstructor`, and
`adVmGenCodeGenGenericInNonMacro` (which was unused).

All `nkDotExpr` (not-a-field-symbol diagnostic) and `nkObjConstr`
(invalid-object-constructor diagnostic) trees reaching `vmgen` are
produced by `astgen`, meaning that if they have an unexpected structure,
`astgen` doesn't work as it should, which is a severe internal error.