### PR TITLE
vmjit: use MIR-based dependency discovery

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -108,7 +108,7 @@ proc putIntoReg(dest: var TFullReg; jit: var JitState, c: var TCtx, n: PNode,
   ## Put the value that is represented by `n` (but not the node itself) into
   ## `dest`. Implicit conversion is also performed, if necessary.
   # XXX: requring access to the JIT state here is all kinds of wrong and
-  #      indicates that ``putIntoReg`` is not a good idea to being with. The
+  #      indicates that ``putIntoReg`` is not a good idea to begin with. The
   #      XXX comment below describes a good way to get out of this mess
   let t = formal.skipTypes(abstractInst+{tyStatic}-{tyTypeDesc})
 

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -87,7 +87,7 @@ proc selectRoutine*(i: Interpreter; name: string): PSym =
 proc callRoutine*(i: Interpreter; routine: PSym; args: openArray[PNode]): PNode =
   assert i != nil
   let c = PEvalContext(i.graph.vm)
-  result = execProc(c.vm, routine, args)
+  result = execProc(c.jit, c.vm, routine, args)
 
 proc getGlobalValue*(i: Interpreter; letOrVar: PSym): PNode =
   let c = PEvalContext(i.graph.vm)

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -136,8 +136,8 @@ proc declareGlobal(c: var TCtx, sym: PSym) =
     # make sure the type is generated and register the global in the
     # link table
     discard getOrCreate(c, sym.typ)
-    registerLinkItem(c.symToIndexTbl, c.linkState.newGlobals, sym,
-                      c.linkState.nextGlobal)
+    c.symToIndexTbl[sym.id] = LinkIndex(c.collectedGlobals.len)
+    c.collectedGlobals.add sym
 
 proc prepare(c: var TCtx, data: var DiscoveryData) =
   ## Registers with the link table all procedures, constants, globals,
@@ -287,8 +287,8 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
   #      Pros: no need for the `globals` and `consts` seqs
   #      Cons: (probably) higher I-cache pressure, slightly more complex logic
 
-  var globals = newSeq[PVmType](c.linkState.newGlobals.len)
-  for i, sym in c.linkState.newGlobals.pairs:
+  var globals = newSeq[PVmType](c.collectedGlobals.len)
+  for i, sym in c.collectedGlobals.pairs:
     let typ = c.typeInfoCache.lookup(conf, sym.typ)
     # the type was already created during vmgen
     globals[i] = typ.unsafeGet

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -561,25 +561,6 @@ type
   LinkIndex* = uint32 ## Depending on the context: `FunctionIndex`; index
     ## into `TCtx.globals`; index into `TCtx.complexConsts`
 
-  # XXX: design of `CodeGenInOut` is not yet final
-  LinkState* = object
-    ## Temporary state used when gathering new dependencies.
-    ##
-    ## The `newX` seqs accumulate the symbols added to `symToIndexTbl` during
-    ## code-gen, with a seq for each link-item kind. They're never reset by
-    ## `vmgen`.
-    ##
-    ## The `nextX` values hold the `LinkIndex` to use for new entries
-    ## added to `symToIndexTbl`. They're incremented after a respective
-    ## new entry is added.
-    newProcs*: seq[PSym]
-    newGlobals*: seq[PSym]
-    newConsts*: seq[PSym]
-
-    nextProc*: LinkIndex
-    nextGlobal*: LinkIndex
-    nextConst*: LinkIndex
-
   VmGenDiagKind* = enum
     # has no extra data
     vmGenDiagTooManyRegistersRequired
@@ -753,15 +734,13 @@ type
       ## for each procedure known to the VM. Indexed by `FunctionIndex`
     memory*: VmMemoryManager
 
-    # linker state:
+    # code generator state:
     symToIndexTbl*: Table[int, LinkIndex] ## keeps track of all known
       ## dependencies. Expanded during code-generation and used for looking
       ## up the link-index (e.g. `FunctionIndex`) of a symbol
 
-    linkState*: LinkState ## temporary state used by dependency collection.
-      ## Stored as part of ``TCtx`` for convenience, and to allow for memory
-      ## reuse
-    # XXX: `linkState` is eventually going to be removed
+    collectedGlobals*: seq[PSym]
+      ## leaked implementation detail of ``vmbackend.nim`` -- don't use
 
     flags*: set[CodeGenFlag] ## flags that alter the behaviour of the code
       ## generator. Initialized by the VM's callsite and queried by the JIT.

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -246,9 +246,6 @@ func analyseIfAddressTaken(n: PNode, locs: var IntSet) =
       analyseIfAddressTaken(it, locs)
 
 
-func lookupGlobal(c: TCtx, sym: PSym): int {.inline.} =
-  c.symToIndexTbl[sym.id].int
-
 func lookupConst(c: TCtx, sym: PSym): int {.inline.} =
   c.symToIndexTbl[sym.id].int
 

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -27,7 +27,6 @@ import
   compiler/mir/[
     astgen,
     mirbridge,
-    utils,
     mirgen,
     mirtrees,
     sourcemaps,


### PR DESCRIPTION
## Summary

Move the JIT-related state from `TCtx` into a standalone type and
replace usage of the custom `PNode`-based dependency discovery with that
used by the backends.

The intention is to bring the processing in `vmjit` closer to that of
the backends (because `vmjit` can also be considered a backend) and to
prepare for the introduction of a dedicated code-generator/backend IR by
removing a usage of `PNode`. In addition, decoupling the JIT state from
`TCtx` is part of the on-going project of splitting up `TCtx`.

For lifted globals used in code running at compile-time or in the
context of NimScript, there's a small difference in behaviour:
```nim
proc p() =
  var x {.global.}: int
  ...
```
`x` is now reset to its default value when control-flow reaches the
declaration -- previously it wasn't. This is likely going to change
again in the future. 

## Details

The key changes related to `TCtx`:
* introduce the `JitState` type, which represents the non-temporal JIT
  state. The compile-time evaluation context (`PEvalContext`) stores an
  instance of it
* remove `LinkState` and usages thereof; it is replaced by the
  `DiscoveryData` type also used by the backends
* as an interim solution until `vmbackend.nim` uses its own context
  type, add the `collectedGlobals` field to `TCtx` and replace usages of
  `LinkState` in `vmbackend` with it

The processing logic in `vmjit` now performs the following steps:
1. generate MIR code for the input
2. scan for definitions of globals and register them
3. rewrite definitions of globals into assignment
4. discover used constants and procedures

Apart from the missing handling of lifted globals, this is the same as
what the unified backend processing does. Step 2 and 4 were previously
implemented by the now-removed ``gatherDependencies``.

Before invoking `vmgen`, the newly discovered entities are registered
in `vmgen`'s link table, with the entities' index in the `DiscoveryData`
sequences being used as the link indices. In case of an error during
code generation, the `DiscoveryData` sequences are rolled back to their
state prior to code generation, which ensures that only entities used in
valid code are registered with `DiscoveryData`. Committing to the
entities only happens when they're loaded into the VM's execution
environment.

Rewriting the definitions of globals into assignments means that `var`
statements involving globals don't reach `vmgen` anymore and thus
that the corresponding logic in `vmgen` can be dropped.

Finally, the documentation of the `vmjit` module is updated to better
describe the module's purpose.