### PR TITLE
sem: improve and rework `semobjconstr`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1239,11 +1239,8 @@ type
     adSemConstExprExpected
     adSemExpectedRangeType
     # semobjconstr
-    adSemFieldAssignmentInvalidNeedSpace
     adSemFieldAssignmentInvalid
     adSemFieldNotAccessible
-    adSemFieldOkButAssignedValueInvalid
-    adSemObjectConstructorIncorrect
     adSemObjectRequiresFieldInitNoDefault
     adSemExpectedObjectType
     adSemExpectedObjectOfType
@@ -1364,9 +1361,7 @@ type
         adSemNamedExprNotAllowed,
         adSemNoReturnTypeDeclared,
         adSemReturnNotAllowed,
-        adSemFieldAssignmentInvalidNeedSpace,
         adSemFieldAssignmentInvalid,
-        adSemObjectConstructorIncorrect,
         adSemExpectedObjectType,
         adSemFoldOverflow,
         adSemFoldDivByZero,
@@ -1514,9 +1509,6 @@ type
       wrongFldInfo*: TLineInfo
     of adSemFieldNotAccessible:
       inaccessible*: PSym
-    of adSemFieldOkButAssignedValueInvalid:
-      targetField*: PSym
-      initVal*: PNode
     of adSemObjectRequiresFieldInitNoDefault:
       missing*: seq[PSym]
       objTyp*: PType
@@ -1829,17 +1821,6 @@ type
 type
   TExprFlag* = enum
     efLValue, efWantIterator, efInTypeof,
-    efNeedStatic,
-      ## Use this in contexts where a static value is mandatory
-    efPreferStatic,
-      ## Use this in contexts where a static value could bring more
-      ## information, but it's not strictly mandatory. This may become
-      ## the default with implicit statics in the future.
-    efPreferNilResult,
-      ## Use this if you want a certain result (e.g. static value),
-      ## but you don't want to trigger a hard error. For example,
-      ## you may be in position to supply a better error message
-      ## to the user.
     efWantStmt, efAllowStmt, efExplain,
     efWantValue, efOperand, efNoSemCheck,
     efNoEvaluateGeneric, efInCall, efFromHlo, efNoSem2Check,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -599,10 +599,6 @@ type
       ## object field assignment invalid syntax
     rsemFieldAssignmentInvalidNeedSpace
       ## object field assignment invalid syntax, need space after colon
-    rsemFieldOkButAssignedValueInvalid
-      ## object field assignment, where the field name is ok, but value is not
-    rsemObjectConstructorIncorrect
-      ## one or more issues encountered with object constructor
 
     # General Type Checks
     rsemExpressionHasNoType

--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -74,7 +74,6 @@ type
       of rsemExpectedIdentifierInExpr,
          rsemExpectedIdentifierWithExprContext,
          rsemExpectedOrdinal,
-         rsemFieldOkButAssignedValueInvalid,
          rsemUseOrDiscardExpr,
          rsemOnlyDeclaredIdentifierFoundIsError,
          rsemCantConvertLiteralToRange:

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -581,11 +581,8 @@ func astDiagToLegacyReportKind*(
   of adSemCannotMixTypesAndValuesInTuple: rsemCannotMixTypesAndValuesInTuple
   of adSemNoReturnTypeDeclared: rsemNoReturnTypeDeclared
   of adSemReturnNotAllowed: rsemReturnNotAllowed
-  of adSemFieldAssignmentInvalidNeedSpace: rsemFieldAssignmentInvalidNeedSpace
   of adSemFieldAssignmentInvalid: rsemFieldAssignmentInvalid
   of adSemFieldNotAccessible: rsemFieldNotAccessible
-  of adSemFieldOkButAssignedValueInvalid: rsemFieldOkButAssignedValueInvalid
-  of adSemObjectConstructorIncorrect: rsemObjectConstructorIncorrect
   of adSemObjectRequiresFieldInitNoDefault: rsemObjectRequiresFieldInitNoDefault
   of adSemExpectedObjectType: rsemExpectedObjectType
   of adSemExpectedObjectOfType: rsemExpectedObjectType

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -220,7 +220,7 @@ proc checkConstructFields(c: PContext, n: PNode,
                                                 constrCtx.initExpr)
       var discriminatorVal = if discrimAssign.isNil: nil else: discrimAssign[1]
 
-      if discriminatorVal != nil and discriminator.kind != nkError:
+      if discriminatorVal != nil and discriminatorVal.kind != nkError:
         discriminatorVal = discriminatorVal.skipHidden
         if discriminatorVal.kind notin nkLiterals and (
             not isOrdinalType(discriminatorVal.typ, true) or

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -465,14 +465,15 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
 
     result[i][1] = fitNodeConsiderViewType(c, it[0].typ, val, val.info)
 
-    # now check whether it's legal for the field to appear in the construction
+    # now check whether it's legal for the field to appear in the construction.
+    # Visibility errors take precedence over multiple initializations
     if not fieldVisible(c, it[0].sym):
       result[i][0] = newError(c.config, it[0]):
         PAstDiag(kind: adSemFieldNotAccessible, inaccessible: it[0].sym)
     elif containsOrIncl(seen, it[0].sym.id):
       # duplicate field initialization
       result[i][0] = newError(c.config, it[0]):
-        PAstDiag(kind: adSemFieldInitTwice)
+        PAstDiag(kind: adSemFieldInitTwice, dupFld: it[0].sym.name)
 
   # now verify that the language rules requiring a complex type traversal are
   # not violated. These are:

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -54,88 +54,24 @@ proc mergeInitStatus(existing: var InitStatus, newStatus: InitStatus) =
   of initUnknown:
     discard
 
-proc invalidObjConstr(c: PContext, n: PNode): PNode =
-  newError(c.config, n):
-    if n.kind == nkInfix and n[0].kind == nkIdent and n[0].ident.s[0] == ':':
-      PAstDiag(kind: adSemFieldAssignmentInvalidNeedSpace)
-    else:
-      PAstDiag(kind: adSemFieldAssignmentInvalid)
-
 proc locateFieldInInitExpr(c: PContext, field: PSym, initExpr: PNode): PNode =
-  ## Returns the assignment nkExprColonExpr node, nkError if malformed, or nil
-  let fieldId = field.name.id
+  ## Returns the assignment ``nkExprColonExpr`` node, or nil, if there's none
+  ## for `field`.
   for i in 1..<initExpr.len:
-    let
-      e = initExpr[i]
-      valid = e.kind == nkExprColonExpr
-      partiallyValid = e.kind == nkError and
-                       e.errorKind == adSemFieldOkButAssignedValueInvalid
-      atLeastPartiallyValid = valid or partiallyValid
-      assignment = if partiallyValid: e[wrongNodePos] else: e
-      match =
-        if atLeastPartiallyValid:
-          let
-            (ident, errNode) = considerQuotedIdent(c, assignment[0])
-            validIdent = errNode.isNil
-          validIdent and fieldId == ident.id
-        else:
-          false
-
-    if match: # found it!
-      return e # return the error so we can handle it later
-    elif not atLeastPartiallyValid:
-      result = invalidObjConstr(c, assignment)
-      initExpr[i] = result # remember the error and bail early
-      return
+    let e = initExpr[i]
+    case e.kind
+    of nkExprColonExpr:
+      if e[0].kind == nkSym and e[0].sym.id == field.id:
+        # found it!
+        return e
+      # continue searching
+    of nkError:
+      discard "skip errors"
     else:
-      discard # keep looking
+      unreachable()
 
-proc semExprFlagDispatched(c: PContext, n: PNode, flags: TExprFlags): PNode =
-  if efNeedStatic in flags:
-    if efPreferNilResult in flags:
-      return tryConstExpr(c, n)
-    else:
-      return semConstExpr(c, n)
-  else:
-    result = semExprWithType(c, n, flags)
-    if efPreferStatic in flags:
-      var evaluated = getConstExpr(c.module, result, c.idgen, c.graph)
-      if evaluated != nil: return evaluated
-      evaluated = evalAtCompileTime(c, result)
-      if evaluated != nil: return evaluated
-
-proc semConstrField(c: PContext, flags: TExprFlags,
-                    field: PSym, initExpr: PNode): PNode =
-  let assignment = locateFieldInInitExpr(c, field, initExpr)
-  if assignment != nil:
-    result = assignment
-    if nfSem in result.flags:
-      return
-    if not fieldVisible(c, field):
-      result = newError(
-        c.config, initExpr,
-        PAstDiag(kind: adSemFieldNotAccessible, inaccessible: field))
-
-      result.typ = errorType(c)
-      return
-    if result.kind == nkError and
-       result.errorKind != adSemFieldOkButAssignedValueInvalid:
-      return # result is the assignment error
-
-    var initValue = semExprFlagDispatched(c, result[1], flags)
-    if initValue != nil:
-      initValue = fitNodeConsiderViewType(c, field.typ, initValue, result.info)
-    result[0] = newSymNode(field)
-    result[1] = initValue
-    result.flags.incl nfSem
-    if initValue != nil and initValue.kind == nkError:
-      result = newError(
-        c.config,
-        result,
-        PAstDiag(kind: adSemFieldOkButAssignedValueInvalid,
-                        targetField: field,
-                        initVal: initValue))
-
+  # assignment for field is missing
+  result = nil
 
 proc caseBranchMatchesExpr(branch, matched: PNode): bool =
   for i in 0..<branch.len-1:
@@ -190,16 +126,8 @@ iterator directFieldsInRecList(recList: PNode): PNode =
 
 proc fieldsPresentInInitExpr(c: PContext, fieldsRecList, initExpr: PNode): seq[PSym] =
   for field in directFieldsInRecList(fieldsRecList):
-    let
-      assignment = locateFieldInInitExpr(c, field.sym, initExpr)
-      found = assignment != nil
-    if found:
-      case assignment.kind:
-      of nkError:
-        discard # XXX: figure out whether errors should be represented and how
-      else:
-        # more than just nkExprColonExpr is handled by this
-        result.add field.sym
+    if locateFieldInInitExpr(c, field.sym, initExpr) != nil:
+      result.add field.sym
 
 proc collectMissingFields(c: PContext, fieldsRecList: PNode,
                           constrCtx: var ObjConstrContext) =
@@ -207,25 +135,23 @@ proc collectMissingFields(c: PContext, fieldsRecList: PNode,
     if constrCtx.needsFullInit or
        sfRequiresInit in r.sym.flags or
        r.sym.typ.requiresInit:
-      let assignment = locateFieldInInitExpr(c, r.sym, constrCtx.initExpr)
-      if assignment == nil or
-         assignment.kind == nkError and
-         assignment.errorKind != adSemFieldOkButAssignedValueInvalid:
+      if locateFieldInInitExpr(c, r.sym, constrCtx.initExpr).isNil:
         constrCtx.missingFields.add r.sym
 
-proc semConstructFields(c: PContext, n: PNode,
-                        constrCtx: var ObjConstrContext,
-                        flags: TExprFlags): InitStatus =
+proc checkConstructFields(c: PContext, n: PNode,
+                          constrCtx: var ObjConstrContext): InitStatus =
   result = initUnknown
 
   case n.kind
   of nkRecList:
     for field in n:
-      let status = semConstructFields(c, field, constrCtx, flags)
+      let status = checkConstructFields(c, field, constrCtx)
       mergeInitStatus(result, status)
 
   of nkRecCase:
     template fieldsPresentInBranch(branchIdx: int): seq[PSym] =
+      # XXX: this is related to diagnostics rendering, it should not be
+      #      located here, but rather in the rendering layer
       let branch = n[branchIdx]
       let fields = branch[^1]
       fieldsPresentInInitExpr(c, fields, constrCtx.initExpr)
@@ -243,7 +169,7 @@ proc semConstructFields(c: PContext, n: PNode,
 
     for i in 1..<n.len:
       let innerRecords = n[i][^1]
-      let status = semConstructFields(c, innerRecords, constrCtx, flags)
+      let status = checkConstructFields(c, innerRecords, constrCtx)
       if status notin {initNone, initUnknown}:
         mergeInitStatus(result, status)
         if selectedBranch != -1:
@@ -290,16 +216,11 @@ proc semConstructFields(c: PContext, n: PNode,
         localReport(c.config, discriminatorVal.info, rep)
 
       let branchNode = n[selectedBranch]
-      let flags = {efPreferStatic, efPreferNilResult}
-      let discrimAssign = semConstrField(c, flags,
-                                         discriminator.sym,
-                                         constrCtx.initExpr)
-      if discrimAssign != nil and discrimAssign.kind == nkError:
-        mergeInitStatus(result, initError)
-        return
+      let discrimAssign = locateFieldInInitExpr(c, discriminator.sym,
+                                                constrCtx.initExpr)
       var discriminatorVal = if discrimAssign.isNil: nil else: discrimAssign[1]
 
-      if discriminatorVal != nil:
+      if discriminatorVal != nil and discriminator.kind != nkError:
         discriminatorVal = discriminatorVal.skipHidden
         if discriminatorVal.kind notin nkLiterals and (
             not isOrdinalType(discriminatorVal.typ, true) or
@@ -310,6 +231,8 @@ proc semConstructFields(c: PContext, n: PNode,
 
       if discriminatorVal == nil:
         badDiscriminatorError()
+      elif discriminatorVal.kind == nkError:
+        mergeInitStatus(result, initError)
       elif discriminatorVal.kind == nkSym:
         let (ctorCase, ctorIdx) = findUsefulCaseContext(c, discriminatorVal)
         if ctorCase == nil:
@@ -366,12 +289,8 @@ proc semConstructFields(c: PContext, n: PNode,
 
     else:
       result = initNone
-      let discrimAssign = semConstrField(c, flags + {efPreferStatic},
-                                         discriminator.sym,
-                                         constrCtx.initExpr)
-      if discrimAssign != nil and discrimAssign.kind == nkError:
-        mergeInitStatus(result, initError)
-        return
+      let discrimAssign = locateFieldInInitExpr(c, discriminator.sym,
+                                                constrCtx.initExpr)
 
       let discriminatorVal = if discrimAssign.isNil: nil else: discrimAssign[1]
       if discriminatorVal == nil:
@@ -382,6 +301,8 @@ proc semConstructFields(c: PContext, n: PNode,
         let defaultValue = newIntLit(c.graph, constrCtx.initExpr.info, 0)
         let matchedBranch = n.pickCaseBranch defaultValue
         collectMissingFields matchedBranch
+      elif discriminatorVal.kind == nkError:
+        mergeInitStatus(result, initError)
       else:
         result = initPartial
         if discriminatorVal.kind == nkIntLit:
@@ -396,31 +317,22 @@ proc semConstructFields(c: PContext, n: PNode,
 
   of nkSym:
     let field = n.sym
-    let assignment = semConstrField(c, flags, field, constrCtx.initExpr)
+    let assignment = locateFieldInInitExpr(c, field, constrCtx.initExpr)
+    # error or not, if the field has an assginment, we treat it as
+    # fully initialized
     result =
-      if assignment != nil:
-        if assignment.kind == nkError:
-          initError
-        else:
-          let initVal = assignment[1]
-          if initVal != nil:
-            # assignment should cover all error cases already
-            initFull
-          else:
-            initNone
-      else:
-        initNone
+      if assignment != nil: initFull
+      else:                 initNone
 
   else:
-    c.config.internalAssert false
+    unreachable(n.kind)
 
-proc semConstructTypeAux(c: PContext,
-                         constrCtx: var ObjConstrContext,
-                         flags: TExprFlags): InitStatus =
+proc checkConstructTypeAux(c: PContext,
+                           constrCtx: var ObjConstrContext): InitStatus =
   result = initUnknown
   var t = constrCtx.typ
   while true:
-    let status = semConstructFields(c, t.n, constrCtx, flags)
+    let status = checkConstructFields(c, t.n, constrCtx)
     mergeInitStatus(result, status)
     if status in {initPartial, initNone, initUnknown}:
       collectMissingFields c, t.n, constrCtx
@@ -434,10 +346,6 @@ proc semConstructTypeAux(c: PContext,
       return
     constrCtx.needsFullInit = constrCtx.needsFullInit or
                               tfNeedsFullInit in t.flags
-  if result == initError:
-    constrCtx.initExpr = newError(
-      c.config, constrCtx.initExpr,
-      PAstDiag(kind: adSemObjectConstructorIncorrect))
 
 proc initConstrContext(t: PType, initExpr: PNode): ObjConstrContext =
   ObjConstrContext(
@@ -449,7 +357,7 @@ proc initConstrContext(t: PType, initExpr: PNode): ObjConstrContext =
 proc computeRequiresInit(c: PContext, t: PType): bool =
   assert t.kind == tyObject
   var constrCtx = initConstrContext(t, newNode(nkObjConstr))
-  let initResult = semConstructTypeAux(c, constrCtx, {})
+  let initResult = checkConstructTypeAux(c, constrCtx)
   constrCtx.missingFields.len > 0
 
 proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode =
@@ -462,7 +370,7 @@ proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode =
   case objType.kind
   of tyObject:
     var constrCtx = initConstrContext(objType, newNodeI(nkObjConstr, n.info))
-    let initResult = semConstructTypeAux(c, constrCtx, {})
+    let initResult = checkConstructTypeAux(c, constrCtx)
     if constrCtx.missingFields.len > 0:
       result = c.config.newError(
                   n,
@@ -496,12 +404,84 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
                     PAstDiag(kind: adSemExpectedObjectOfType,
                              expectedObjTyp: t))
 
-  # Check if the object is fully initialized by recursively testing each
-  # field (if this is a case object, initialized fields in two different
-  # branches will be reported as an error):
+  proc lookupInType(typ: PType, field: PIdent): PSym =
+    ## Searches for a field with the given identifier (`field`) in the object
+    ## type hierarchy of `typ`.
+    var typ = typ
+    while typ != nil:
+      typ = typ.skipTypes(skipPtrs)
+      result = lookupInRecord(typ.n, field)
+      if result != nil:
+        return
+      typ = typ.base
+
+  # phase 1: verify that the AST is valid and has unambiguous meaning
+  for i in 1..<n.len:
+    let it = n[i]
+
+    if it.kind != nkExprColonExpr or it.len != 2 or
+       it[0].kind notin nkIdentKinds:
+      # the AST is invalid; skip
+      result[i] = newError(c.config, it):
+        PAstDiag(kind: adSemFieldAssignmentInvalid)
+      continue
+
+    # don't perform anything like fitting the type or folding the expression
+    # here; we just want the typed AST
+    let
+      (ident, err) = considerQuotedIdent(c, it[0])
+      field =
+        if err.isNil:
+          let s = lookupInType(t, ident)
+          if s != nil:
+            newSymNode(s, it[0].info)
+          else:
+            newError(c.config, it[0]):
+              PAstDiag(kind: adSemUndeclaredField, givenSym: t.sym, symTyp: t)
+        else:
+          err
+
+    let elem = shallowCopy(it)
+    elem[0] = field
+    elem[1] = semExprWithType(c, it[1])
+    result[i] = elem
+
+  # phase 2: ensure that the valid parts of the typed construction expression
+  # adhere to the language rules. For the first pass, we only consider the
+  # rules that don't require a complex type traversal
+  var seen = initIntSet()
+  for i in 1..<result.len:
+    let it = result[i]
+    if it.kind == nkError or it[0].kind == nkError:
+      continue # invalid AST or no valid field symbol; ignore
+
+    # post-process the initializer expression:
+    var val = it[1]
+    if sfDiscriminant in it[0].sym.flags:
+      # we prefer a compile-time-known value
+      val = getConstExpr(c.module, val, c.idgen, c.graph)
+      if val == nil:
+        val = evalAtCompileTime(c, it[1])
+
+    result[i][1] = fitNodeConsiderViewType(c, it[0].typ, val, val.info)
+
+    # now check whether it's legal for the field to appear in the construction
+    if not fieldVisible(c, it[0].sym):
+      result[i][0] = newError(c.config, it[0]):
+        PAstDiag(kind: adSemFieldNotAccessible, inaccessible: it[0].sym)
+    elif containsOrIncl(seen, it[0].sym.id):
+      # duplicate field initialization
+      result[i][0] = newError(c.config, it[0]):
+        PAstDiag(kind: adSemFieldInitTwice)
+
+  # now verify that the language rules requiring a complex type traversal are
+  # not violated. These are:
+  # 1. all fields of the object that are required to be initialized are
+  #    initialized
+  # 2. an initialized discriminated field's branch must be proven to be active
   var constrCtx = initConstrContext(t, result)
   let
-    initResult = semConstructTypeAux(c, constrCtx, flags)
+    initResult = checkConstructTypeAux(c, constrCtx)
     missedFields = constrCtx.missingFields.len > 0
     constructionError = initResult == initError
   var hasError = constructionError or missedFields
@@ -515,66 +495,18 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
       constrCtx.missingFields,
       typ = t))
 
-  if constructionError:
-    result = constrCtx.initExpr
-    return
-
-  # Since we were traversing the object fields, it's possible that
-  # not all of the fields specified in the constructor was visited.
-  # We'll check for such fields here:
-  for i in 1..<result.len:
-    let field = result[i]
-    if nfSem notin field.flags:
-      # handle various error cases first
-      case field.kind
-      of nkError:
-        # skip nkError so we report it later
-        continue
-      of nkExprColonExpr:
-        # process later in the loop
-        discard
-      else:
-        let e =
-          if field.kind == nkError:
-            field
-          else:
-            invalidObjConstr(c, field)
-        # XXX: shouldn't report errors here, since creating and reporting split
-        #      need to cascade an nkError instead
-        localReport(c.config, e)
+  if not hasError:
+    # we're not tracking the error nodes and thus have to look for
+    # them here
+    for i in 1..<n.len:
+      let it = result[i]
+      if it.kind == nkError or nkError in {it[0].kind, it[1].kind}:
         hasError = true
-        continue
-
-      let (id, err) = considerQuotedIdent(c, field[0])
-      if err != nil:
-        localReport(c.config, err)
-      # This node was not processed. There are two possible reasons:
-      # 1) It was shadowed by a field with the same name on the left
-      for j in 1..<i:
-        let (prevId, err) = considerQuotedIdent(c, result[j][0])
-        if err != nil:
-          localReport(c.config, err)
-        if prevId.id == id.id:
-          localReport(c.config, field.info, reportAst(
-            rsemFieldInitTwice, result[j][0]))
-
-          hasError = true
-          break
-      # 2) No such field exists in the constructed type
-
-      localReport(c.config, field[0], reportStr(
-        rsemUndeclaredField, id.s, typ = t, sym = t.sym))
-
-      hasError = true
-      break
+        break
 
   if initResult == initFull:
     incl result.flags, nfAllFieldsSet
 
   # wrap in an error see #17437
   if hasError:
-    result = newError(
-      c.config, result,
-      PAstDiag(kind: adSemObjectConstructorIncorrect))
-
-    result.typ = errorType(c)
+    result = wrapError(c.config, result)

--- a/tests/errmsgs/tobject_constr.nim
+++ b/tests/errmsgs/tobject_constr.nim
@@ -1,0 +1,52 @@
+discard """
+  description: '''
+    Ensures that errors are correctly reported for literal object construction
+    expressions
+  '''
+  cmd: "nim check --hints:off $file"
+  action: reject
+  nimoutFull: true
+  nimout: '''
+tobject_constr.nim(49, 15) Error: The fields 'd' and 'f' cannot be initialized together, because they are from conflicting branches in the case object.
+tobject_constr.nim(52, 15) Error: a case selecting discriminator 'f' with value 'false' appears in the object construction, but the field(s) c are in conflict with this value.
+tobject_constr.nim(35, 16) Error: undeclared field: 'v' for type tobject_constr.Object [type declared in tobject_constr.nim(25, 3)]
+tobject_constr.nim(38, 22) Error: field initialized twice: 'a'
+tobject_constr.nim(42, 22) Error: Invalid field assignment 'x'
+tobject_constr.nim(42, 25) Error: Invalid field assignment 'y'
+tobject_constr.nim(42, 28) Error: undeclared field: 'v' for type tobject_constr.Object [type declared in tobject_constr.nim(25, 3)]
+tobject_constr.nim(45, 19) Error: type mismatch: got <string> but expected 'int'
+tobject_constr.nim(45, 26) Error: undeclared identifier: 'v'
+tobject_constr.nim(49, 19) Error: type mismatch: got <string> but expected 'bool'
+tobject_constr.nim(52, 26) Error: Invalid field assignment 'v'
+'''
+"""
+
+type
+  Object = object
+    a: int
+    b: int
+    case c: bool
+    of false:
+      d: int
+    of true:
+      f: int
+
+# not an existing field:
+discard Object(v: 0, a: 0)
+
+# duplicate field assignment:
+discard Object(a: 0, a: 1)
+
+# incorrect syntax. Well-formed but semantically invalid
+# assignments are still reported
+discard Object(a: 0, x, y, v: 0)
+
+# type error + error in assignemnt-source expression:
+discard Object(a: "", b: v)
+
+# discriminator assignment is invalid, but a "conflicting branch" can be and
+# is still detected and reported
+discard Object(c: "", d: 1, f: 2)
+
+# incorrect syntax + conflicting selected branch:
+discard Object(c: false, v, f: 2)

--- a/tests/lang_objects/objects/t17437.nim
+++ b/tests/lang_objects/objects/t17437.nim
@@ -4,7 +4,6 @@ discard """
   nimout: '''
 t17437.nim(18, 16) Error: undeclared identifier: 'x'
 t17437.nim(18, 19) Error: Invalid field assignment 'y'
-t17437.nim(18, 12) Error: Invalid object constructor: 'V(x: x, y)'
 '''
 """
 

--- a/tests/lang_objects/objects/t17437.nim
+++ b/tests/lang_objects/objects/t17437.nim
@@ -7,6 +7,7 @@ t17437.nim(18, 19) Error: Invalid field assignment 'y'
 '''
 """
 
+
 # bug #17437 invalid object construction should result in error
 
 type


### PR DESCRIPTION
## Summary

Rework the semantic analysis of `nkObjConstr` nodes. The logic is now
simpler, compile-time evaluation happens from left to right, non-follow-
up errors are not dropped, and less follow-up errors are reported.

## Details

The idea is to split the processing into two phases:
1. AST validation and semantic analysis (i.e. figuring out the meaning)
2. filling in the gaps (e.g., fitting types) and making sure language
   rules are not violated

### Phase 1

During the first phase, for each slot, it is verified that the AST has
the expected shape and that a field with the given name exists in the
used object type; the initializer expression is also semantically
analyzed.

If the AST for a field assignment is not as expected, it is not analyzed
further. Compared to the previous logic, the "invalid field assignment"
error is not specialized further -- this is left to error message
rendering (currently `astDiagToLegacyReport`), thus making
`adSemFieldAssignmentInvalidNeedSpace` obsolete.

Errors in phase 1 do *not* short-circuit the second phase.

### Phase 2

The second phase is split up into two parts:
1. post-processing of the initializer expression and basic validity
  checks that only need the object construction expression
2. validity checks that also need to consider the object type

The post-processing includes (if possible) folding the initializer for
discriminators and fitting the expression's type to the formal type; the
basic validity checks are the field visibility and duplicated field
checks. Errors nodes produces here are placed directly into the
temporary AST.

This allows for dropping the `semExprFlagDispatched` procedure and the
`efPreferStatic`, `efPreferNilResult`, and `efPreferStatic` expression
flags.

Running the checks that require traversal/inspection of the object type
re-uses the pre-existing `semConstructTypeAux` and `semConstructFields`
(both which have their `sem` prefix replaced by `check`). Both only
inspect the construction expression now (no sem-checking or modification
is performed) and rely on the field assignments that reach them to either
be an `nkError` node or valid, which significantly simplifies error
handling. 

Since it is obsolete now, the `rsemFieldOkButAssignedValueInvalid` is
removed. A specialized wrapper for incorrect object constructions is not
needed (the generic wrapper suffices), so
`adSemObjectConstructorInvalid` is also removed.