### PR TITLE
compiler: don't raise when NodeJS is missing

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -104,10 +104,17 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef, argv: openArray[string]):
       case conf.backend
       of backendC: discard
       of backendJs:
-        # D20210217T215950:here this flag is needed for node < v15.0.0, otherwise
-        # tasyncjs_fail` would fail, refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-        if cmdPrefix.len == 0: cmdPrefix = findNodeJs().quoteShell
-        cmdPrefix.add " --unhandled-rejections=strict"
+        let nodejs = findNodeJs()
+        if nodejs.len > 0:
+          # D20210217T215950:here this flag is needed for node < v15.0.0, otherwise
+          # tasyncjs_fail` would fail, refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+          if cmdPrefix.len == 0: cmdPrefix = nodejs.quoteShell
+          cmdPrefix.add " --unhandled-rejections=strict"
+        else:
+          conf.logError:
+            "NodeJS not found in path. For installing it, refer to " &
+            "https://nodejs.org/en/download"
+          return
       of backendNimVm:
         if cmdPrefix.len == 0:
           cmdPrefix = changeFileExt(getAppDir() / "vmrunner", ExeExt)

--- a/compiler/utils/nodejs.nim
+++ b/compiler/utils/nodejs.nim
@@ -5,6 +5,3 @@ proc findNodeJs*(): string {.inline.} =
   result = findExe("nodejs")
   if result.len == 0:
     result = findExe("node")
-  if result.len == 0:
-    echo "Please install NodeJS first, see https://nodejs.org/en/download"
-    raise newException(IOError, "NodeJS not found in PATH: " & result)


### PR DESCRIPTION
## Summary

Don't raise an exception when the NodeJS executable cannot be found.
In case that NodeJS is missing, this fixes:
- using the documentation generator with the JS backend crashing the
  compiler when a `runnableExample` is encountered
- `testament` aborting a category when attempting to run the first JS
  test

In addition, this also means that the compiler now exits with a proper
error instead of crashing because of an unhandled exception.

## Details

This is a revert of commit https://github.com/nim-works/nimskull/commit/0ae2d1ea88fdc7b6910ddbc960c7db086be383e4.
Except for one, all callsites of `findNodeJS` expect an empty string in
case a NodeJS installation cannot be found and use that information to
handle the error themselves: `docgen` handles it by not running
`runnableExamples` and `testament` treats and reports the affected test
as failed.

The only place where a missing NodeJS installation wasn't handled, and
what the reverted commit intended to fix, is the processing of the `run`
(or `-r`) option. There, the path is now verified to not be empty and an
error is reported (via `logError`) if it is.