### PR TITLE
internal: use custom rendering for `--expandArc`

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -818,7 +818,6 @@ type
 
     rsemEffectsListingHint
     rsemExpandMacro = "ExpandMacro" ## Trace macro expansion progress
-    rsemExpandArc = "ExpandArc"
 
     rsemCompilesReport
     rsemNonMatchingCandidates

--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -151,7 +151,7 @@ type
       of rsemReportTwoSym + rsemReportOneSym + rsemReportListSym:
         symbols*: seq[PSym]
 
-      of rsemExpandMacro, rsemPattern, rsemExpandArc:
+      of rsemExpandMacro, rsemPattern:
         expandedAst*: PNode
 
       of rsemLockLevelMismatch, rsemMethodLockMismatch:

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -1,0 +1,273 @@
+## Non-essential code-generator IR related routines.
+
+import
+  std/[
+    strutils
+  ],
+  compiler/ast/[
+    ast_types,
+    ast_query,
+    typesrenderer
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+from compiler/ast/renderer import renderTree, TRenderFlag
+
+type
+  RenderCtx = object
+    syms: seq[PSym]
+      ## remembers the already-rendered symbols. Used to provide unique names.
+
+proc disambiguate(c: var RenderCtx, s: PSym): int =
+  ## Computes and returns a number to append to the symbol name in order to
+  ## make it unique in the output. This way, multiple different symbols sharing
+  ## the same name can be disambiguated.
+  result = 0
+  for it in c.syms.items:
+    if it == s:
+      return
+    elif it.name.id == s.name.id: # same name?
+      inc result
+
+  c.syms.add s # remember the symbol
+
+proc render(c: var RenderCtx, ind: int, n: PNode, res: var string) =
+  template add(s: var string, n: PNode) =
+    render(c, ind, n, res)
+
+  template indent(extra = 1) =
+    if res.len > 0 and res[^1] == ' ':
+      # remove trailing space
+      res.setLen(res.len - 1)
+    res.add "\n"
+    res.add repeat("  ", ind + extra)
+
+  template newLine() =
+    indent(0)
+
+  template renderList(n: PNode, sep: untyped; start: int = 0; fin: int = 0) =
+    ## Renders the items in the slice ``start..<n.len - fin``
+    for i in start..<n.len-fin:
+      if i > start:
+        sep
+      res.add n[i]
+
+  template renderList(n: PNode, sep: string; start: int = 0; fin: int = 0) =
+    ## Renders the items in the slice ``start..<n.len - fin``
+    renderList(n, res.add(sep), start, fin)
+
+  case n.kind
+  of nkIntLit..nkInt64Lit:
+    res.addInt n.intVal
+  of nkCharLit, nkUIntLit..nkUInt64Lit:
+    res.addInt cast[BiggestUInt](n.intVal)
+  of nkFloatLit..nkFloat128Lit:
+    res.add $n.floatVal
+  of nkStrLiterals:
+    res.add '"'
+    res.add n.strVal
+    res.add '"'
+  of nkNilLit:
+    res.add "nil"
+  of nkNimNodeLit:
+    res.add "<ast>"
+  of nkSym:
+    res.add n.sym.name.s
+    let postfix = disambiguate(c, n.sym)
+    if postfix > 0 and n.sym.magic == mNone:
+      res.add "_" & $postfix
+
+    # the rendered code is currently used for the ``--expandArc``, so we also
+    # highlight cursor locals
+    if sfCursor in n.sym.flags:
+      res.add "_cursor"
+  of nkType:
+    if n.typ.sym != nil:
+      res.add $n.typ
+    else:
+      res.add "[type node]"
+  of nkCheckedFieldExpr, nkHiddenAddr, nkHiddenDeref, nkHiddenStdConv, nkChckRange, nkChckRange64, nkChckRangeF:
+    res.add n[0]
+  of nkAddr:
+    res.add "addr "
+    res.add n[0]
+  of nkDerefExpr:
+    res.add n[0]
+    res.add "[]"
+  of nkDotExpr:
+    res.add n[0]
+    res.add '.'
+    res.add n[1]
+  of nkBracketExpr:
+    res.add n[0]
+    res.add '['
+    res.add n[1]
+    res.add ']'
+  of nkRange:
+    res.add n[0]
+    res.add ".."
+    res.add n[1]
+  of nkCast:
+    res.add "cast["
+    res.add $n[0].typ
+    res.add "]("
+    res.add n[1]
+    res.add ")"
+  of nkStringToCString:
+    res.add "cstring("
+    res.add n[0]
+    res.add ')'
+  of nkCStringToString:
+    res.add "string("
+    res.add n[0]
+    res.add ')'
+  of nkConv:
+    res.add n[0]
+    res.add '('
+    res.add n[1]
+    res.add ')'
+  of nkObjUpConv, nkObjDownConv:
+    res.add $n.typ
+    res.add "("
+    res.add n[0]
+    res.add ")"
+  of nkExprColonExpr:
+    res.add n[0]
+    res.add ": "
+    res.add n[1]
+  of nkCall:
+    res.add n[0]
+    res.add '('
+    let ind = ind + 1
+    renderList(n, ", ", 1)
+    res.add ')'
+
+  of nkObjConstr:
+    res.add $n[0].typ
+    res.add '('
+    renderList(n, ", ", 1)
+    res.add ')'
+  of nkTupleConstr, nkClosure:
+    res.add '('
+    renderList(n, ", ")
+    res.add ')'
+  of nkBracket:
+    res.add '['
+    renderList(n, ", ")
+    res.add ']'
+  of nkCurly:
+    res.add '{'
+    renderList(n, ", ")
+    res.add '}'
+
+  of nkAsgn, nkFastAsgn:
+    res.add n[0]
+    res.add " = "
+    let ind = ind + 1
+    res.add n[1]
+  of nkVarSection, nkLetSection:
+    for i, def in n.pairs:
+      if i > 0:
+        newLine()
+      res.add "var "
+      res.add def[0]
+      if def[2].kind != nkEmpty:
+        res.add " = "
+        let ind = ind + 1
+        res.add def[2]
+  of nkPragma:
+    # re-use the ``PNode`` rendering
+    res.add renderTree(n, {renderIr, renderNoComments})
+  of nkReturnStmt:
+    res.add "return"
+  of nkDiscardStmt:
+    res.add "discard "
+    res.add n[0]
+  of nkBreakStmt:
+    if n[0].kind == nkEmpty:
+      res.add "break"
+    else:
+      res.add "break "
+      res.add n[0]
+  of nkRaiseStmt:
+    if n[0].kind == nkEmpty:
+      res.add "raise"
+    else:
+      res.add "raise "
+      res.add n[0]
+  of nkAsmStmt:
+    res.add "asm "
+    let ind = ind + 1
+    renderList(n, ", ")
+    res.add ""
+  of nkWhileStmt:
+    res.add "while true:"
+    indent()
+    render(c, ind + 1, n[1], res)
+  of nkBlockStmt:
+    if n[0].kind == nkEmpty:
+      res.add "block:"
+    else:
+      res.add "block "
+      res.add n[0]
+      res.add ":"
+    indent()
+    render(c, ind + 1, n[1], res)
+  of nkIfStmt:
+    res.add "if "
+    res.add n[0][0]
+    res.add ':'
+    indent()
+    render(c, ind + 1, n[0][1], res)
+  of nkCaseStmt:
+    res.add "case "
+    res.add n[0]
+    for i in 1..<n.len:
+      newLine()
+      case n.kind
+      of nkOfBranch:
+        res.add "of "
+        renderList(n[i], ", ", 1, 1)
+      of nkElse:
+        res.add "else"
+      else:
+        unreachable()
+
+      res.add ":"
+      indent()
+      render(c, ind + 1, n[i][^1], res)
+  of nkTryStmt:
+    res.add "try:"
+    indent()
+    render(c, ind + 1, n[0], res)
+    for i in 1..<n.len:
+      case n[i].kind
+      of nkExceptBranch:
+        newLine()
+        res.add "except:"
+        indent()
+        render(c, ind + 1, n[i][^1], res)
+      of nkFinally:
+        newLine()
+        res.add "finally:"
+        indent()
+        render(c, ind + 1, n[i][0], res)
+      else:
+        unreachable()
+  of nkStmtListExpr:
+    newLine()
+    renderList(n, newLine())
+  of nkStmtList:
+    renderList(n, newLine())
+  of nkWithSons + nkWithoutSons - codegenExprNodeKinds -
+     {nkExprColonExpr, nkRange} + {nkEmpty}:
+    unreachable(n.kind)
+
+proc render*(n: PNode): string =
+  ## Renders `n` to human-readable code that tries to emulate the shape of the
+  ## high-level language. The output is meant for debugging and tracing and is
+  ## not guaranteed to have a stable format.
+  var c = RenderCtx()
+  render(c, 0, n, result)

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -520,17 +520,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
          r.typ.kind == tyProc:
         result.add(" = ", typeToString(r.typ, preferDesc))
 
-
-    of rsemExpandArc:
-      result.add(
-        "--expandArc: ",
-        r.symstr,
-        "\n",
-        r.expandedAst.renderTree({renderIr, renderNoComments}),
-        "\n",
-        "-- end of expandArc ------------------------"
-      )
-
     of rsemCannotBorrow:
       result.add(
         "cannot borrow ",
@@ -2238,7 +2227,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
 
 const standalone = {
-  rsemExpandArc, # Original compiler did not consider it as a hint
   rvmStackTrace, # Always associated with extra report
   rsemDiagnostics, # Wraps other reports
 }

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -708,9 +708,6 @@ type
     writeForceEnabled
 
 func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
-  const forceWrite =
-    {rsemExpandArc} # Not a hint, just legacy reports overeach
-
   let compTimeCtx = conf.m.errorOutputs == {}
     ## indicates whether we're in a `compiles` or `constant expression
     ## evaluation` context. `sem` and `semexprs` in particular will clear
@@ -743,9 +740,7 @@ func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
 
   elif (
     # Not explicitly enabled
-    not conf.isEnabled(r) and
-    # And not added for forced write
-    r.kind notin forceWrite
+    not conf.isEnabled(r)
   ) or (
     # Or we are in the special hack mode for `compiles()` processing
     compTimeCtx

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -12,17 +12,17 @@ try:
       break label
     x_cursor = [type node](("string here", 80))
   echo([
-    var :tmp_1 = `$`(x_cursor)
+    var :tmp_1 = $(x_cursor)
     :tmp = :tmp_1
     :tmp])
 finally:
-  `=destroy`(:tmp)
+  =destroy(:tmp)
 -- end of expandArc ------------------------
 --expandArc: sio
 
 block label:
   var filename_cursor = "debug.txt"
-  var f = open(filename_cursor, fmRead, 8000)
+  var f = open(filename_cursor, 0, 8000)
   try:
     var res
     try:
@@ -35,7 +35,7 @@ block label:
             var x_cursor = res
             echo([x_cursor])
     finally:
-      `=destroy`(res)
+      =destroy(res)
   finally:
     close(f)
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -23,27 +23,27 @@ var :tmp_2
 :tmp_2 = splat.ext
 op(splat.ext)
 result = (:tmp, :tmp_1, :tmp_2)
-`=destroy`(splat)
+=destroy(splat)
 -- end of expandArc ------------------------
 --expandArc: delete
 
 var sibling
 var :tmp = target[].parent[].left
-`=copy`(sibling, :tmp)
+=copy(sibling, :tmp)
 var saved
 var :tmp_1 = sibling[].right
-`=copy`(saved, :tmp_1)
+=copy(saved, :tmp_1)
 var :tmp_2 = sibling[].right
 var :tmp_3 = saved[].left
-`=copy`(:tmp_2, :tmp_3)
+=copy(:tmp_2, :tmp_3)
 var :tmp_4 = sibling[].parent
-`=sink`(:tmp_4, saved)
-`=destroy`(sibling)
+=sink(:tmp_4, saved)
+=destroy(sibling)
 -- end of expandArc ------------------------
 --expandArc: p1
 
 var lresult
-lresult = `@`([123])
+lresult = @([123])
 var lvalue
 var lnext
 var :tmp
@@ -53,33 +53,32 @@ op(:tmp[0])
 lnext = :tmp[1]
 op(:tmp[1])
 result.value = move(lvalue)
-`=destroy`(:tmp)
-`=destroy_1`(lnext)
-`=destroy_2`(lvalue)
+=destroy(:tmp)
+=destroy_1(lnext)
+=destroy_2(lvalue)
 -- end of expandArc ------------------------
 --expandArc: tt
 
-var
-  :tmp
-  :tmp_1
+var :tmp
+var :tmp_1
 var a
 var :tmp_2
 try:
   var it_cursor = x
   a = (
     :tmp = op()
-    `=copy`(:tmp, it_cursor.key)
+    =copy(:tmp, it_cursor.key)
     :tmp,
     :tmp_1 = op()
-    `=copy`(:tmp_1, it_cursor.val)
+    =copy(:tmp_1, it_cursor.val)
     :tmp_1)
   echo([
-    var :tmp_3 = `$`(a)
+    var :tmp_3 = $(a)
     :tmp_2 = :tmp_3
     :tmp_2])
 finally:
-  `=destroy`(:tmp_2)
-  `=destroy_1`(a)
+  =destroy(:tmp_2)
+  =destroy_1(a)
 -- end of expandArc ------------------------
 --expandArc: extractConfig
 
@@ -92,29 +91,29 @@ try:
     var L = len(a_cursor)
     block label_1:
       while true:
-        if op(`<`(i, L)):
+        if op(<(i, L)):
           break
         block label_2:
           var splitted
           try:
             var line = a_cursor[i]
             splitted = split(line, " ", -1)
-            if `==`(splitted[0], "opt"):
+            if ==(splitted[0], "opt"):
               var :tmp = splitted[1]
-              `=copy`(lan_ip, :tmp)
+              =copy(lan_ip, :tmp)
             echo([lan_ip])
             echo([splitted[1]])
           finally:
-            `=destroy`(splitted)
+            =destroy(splitted)
         inc(i, 1)
 finally:
-  `=destroy_1`(lan_ip)
+  =destroy_1(lan_ip)
 --expandArc: mergeShadowScope
 
 var shadowScope
 try:
   var :tmp = c[].currentScope
-  `=copy`(shadowScope, :tmp)
+  =copy(shadowScope, :tmp)
   rawCloseScope(c)
   block label:
     var a_cursor = shadowScope[].symbols
@@ -122,19 +121,19 @@ try:
     var L = len(a_cursor)
     block label_1:
       while true:
-        if op(`<`(i, L)):
+        if op(<(i, L)):
           break
         block label_2:
           var :tmp_1
           var sym = a_cursor[i]
-          addInterfaceDecl(c):
+          addInterfaceDecl(c,
             var :tmp_2 = sym
             :tmp_1 = op()
-            `=copy_1`(:tmp_1, :tmp_2)
-            :tmp_1
-          inc(i, 1)
+            =copy_1(:tmp_1, :tmp_2)
+            :tmp_1)
+        inc(i, 1)
 finally:
-  `=destroy`(shadowScope)
+  =destroy(shadowScope)
 -- end of expandArc ------------------------
 --expandArc: check
 
@@ -147,34 +146,33 @@ try:
       par = [type node]((
         var :tmp_1 = this[].value
         :tmp = op()
-        `=copy`(:tmp, :tmp_1)
+        =copy(:tmp, :tmp_1)
         :tmp, ""))
       break label
-    var
-      :tmp_2
-      :tmp_3
-      :tmp_4
+    var :tmp_2
+    var :tmp_3
+    var :tmp_4
     par = [type node]((parentDir(this[].value),
-      :tmp_3 = splitPath do:
+      :tmp_3 = splitPath(
         var :tmp_5 = this[].value
         :tmp_2 = op()
-        `=copy`(:tmp_2, :tmp_5)
-        :tmp_2
+        =copy(:tmp_2, :tmp_5)
+        :tmp_2)
       :tmp_4 = :tmp_3.tail
       op(:tmp_3.tail)
       :tmp_4))
-    `=destroy`(:tmp_3)
+    =destroy(:tmp_3)
   block label_1:
     if dirExists(par.dir):
       var :tmp_6 = this[].matchDirs
       var :tmp_7 = getSubDirs(par.dir, par.front)
-      `=sink`(:tmp_6, :tmp_7)
+      =sink(:tmp_6, :tmp_7)
       break label_1
     var :tmp_8 = this[].matchDirs
     var :tmp_9 = []
-    `=sink`(:tmp_8, :tmp_9)
+    =sink(:tmp_8, :tmp_9)
 finally:
-  `=destroy`(par)
+  =destroy(par)
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -6,14 +6,14 @@ discard """
 var it_cursor = root
 block label:
   while true:
-    if op(not(`==`(it_cursor, nil))):
+    if op(not(==(it_cursor, nil))):
       break
     echo([it_cursor[].s])
     it_cursor = it_cursor[].ri
 var jt_cursor = root
 block label_1:
   while true:
-    if op(not(`==`(jt_cursor, nil))):
+    if op(not(==(jt_cursor, nil))):
       break
     var ri_1_cursor = jt_cursor[].ri
     echo([jt_cursor[].s])

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -12,8 +12,8 @@ block label:
     add(a, x)
     break label
   add(b, x)
-`=destroy`(b)
-`=destroy`(a)
+=destroy(b)
+=destroy(a)
 -- end of expandArc ------------------------
 --expandArc: tfor
 
@@ -28,35 +28,35 @@ try:
     var i = a_1
     block label_1:
       while true:
-        if op(`<`(i, b_1)):
+        if op(<(i, b_1)):
           break
         block label_2:
           var :tmp
           var i_1_cursor = i
-          if `==`(i_1_cursor, 2):
+          if ==(i_1_cursor, 2):
             return
-          add(a):
+          add(a,
             :tmp = op()
-            `=copy`(:tmp, x)
-            :tmp
+            =copy(:tmp, x)
+            :tmp)
           inc(i, 1)
   block label_3:
     if cond:
       var :tmp_1
-      add(a):
+      add(a,
         :tmp_1 = x
         op(x)
-        :tmp_1
+        :tmp_1)
       break label_3
     var :tmp_2
-    add(b):
+    add(b,
       :tmp_2 = x
       op(x)
-      :tmp_2
+      :tmp_2)
 finally:
-  `=destroy`(x)
-  `=destroy_1`(b)
-  `=destroy_1`(a)
+  =destroy(x)
+  =destroy_1(b)
+  =destroy_1(a)
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -5,41 +5,38 @@ discard """
 destroying O1'''
   cmd: '''nim c --gc:arc --expandArc:main --expandArc:main1 --expandArc:main2 --expandArc:main3 --hints:off --assertions:off $file'''
   nimout: '''--expandArc: main
-
 var data
 var :tmp
 var :tmp_1
 try:
-  var :tmp_2 = encode do:
-    var :tmp_3 = newString(100)
-    :tmp = :tmp_3
-    cast[[type node]](:tmp)
+  var :tmp_2 = encode(
+      var :tmp_3 = newString(100)
+      :tmp = :tmp_3
+      cast[seq[byte]](:tmp))
   :tmp_1 = :tmp_2
   var :tmp_4 = cast[string](:tmp_1)
-  `=copy`(data, :tmp_4)
+  =copy(data, :tmp_4)
 finally:
-  `=destroy`(:tmp_1)
-  `=destroy_1`(:tmp)
-  `=destroy_1`(data)
+  =destroy(:tmp_1)
+  =destroy_1(:tmp)
+  =destroy_1(data)
 -- end of expandArc ------------------------
 --expandArc: main1
-
 var s
 var data
 var :tmp
 try:
   s = newString(100)
-  var :tmp_1 = encode(toOpenArrayByte(s, 0, `-`(len(s), 1)))
+  var :tmp_1 = encode(toOpenArrayByte(s, 0, -(len(s), 1)))
   :tmp = :tmp_1
   var :tmp_2 = cast[string](:tmp)
-  `=copy`(data, :tmp_2)
+  =copy(data, :tmp_2)
 finally:
-  `=destroy`(:tmp)
-  `=destroy_1`(data)
-  `=destroy_1`(s)
+  =destroy(:tmp)
+  =destroy_1(data)
+  =destroy_1(s)
 -- end of expandArc ------------------------
 --expandArc: main2
-
 var s
 var data
 var :tmp
@@ -48,29 +45,28 @@ try:
   var :tmp_1 = encode(s)
   :tmp = :tmp_1
   var :tmp_2 = cast[string](:tmp)
-  `=copy`(data, :tmp_2)
+  =copy(data, :tmp_2)
 finally:
-  `=destroy`(:tmp)
-  `=destroy_1`(data)
-  `=destroy`(s)
+  =destroy(:tmp)
+  =destroy_1(data)
+  =destroy(s)
 -- end of expandArc ------------------------
 --expandArc: main3
-
 var data
 var :tmp
 var :tmp_1
 try:
-  var :tmp_2 = encode do:
-    var :tmp_3 = newSeq(100)
-    :tmp = :tmp_3
-    :tmp
+  var :tmp_2 = encode(
+      var :tmp_3 = newSeq(100)
+      :tmp = :tmp_3
+      :tmp)
   :tmp_1 = :tmp_2
   var :tmp_4 = cast[string](:tmp_1)
-  `=copy`(data, :tmp_4)
+  =copy(data, :tmp_4)
 finally:
-  `=destroy`(:tmp_1)
-  `=destroy`(:tmp)
-  `=destroy_1`(data)
+  =destroy(:tmp_1)
+  =destroy(:tmp)
+  =destroy_1(data)
 -- end of expandArc ------------------------'''
 """
 


### PR DESCRIPTION
## Summary

Report the output for `--expandArc` via manual `msgWrite` calls instead
of using `localReport` and use custom render-to-text logic for the
`PNode` tree. The rendering logic is kept simple, and while the
output of `--expandArc` stays largely the same, it doesn't represent
valid NimSkull code anymore.

This is a preparation for the introduction of a code-generator IR, as
with it, `astgen` is not going to output `PNode` AST anymore, meaning
that `renderTree` cannot be used there.

## Details

The `rsemExpandArc` report is removed and everything associated with it.
While it could be kept, the general direction it to move aways from
reports for compiler tracing, and so `msgWrite` is instead used. This
also helps with getting around cyclic imports once the new IR is
introduced.

The rendering logic is a simplified version of `renderTree`, with
more complex text-layouting and conditional logic removed. The supported
AST shapes are similar to that of the planned initial version of the
code-generator IR, and the routines are added to the new `cgirutils`
module.

In order for changes to the `expandArc`-using tests to stay small, the
rendered output is kept compatible with that of
`renderTree(n, {renderIr, renderNoComment})`, where reasonable.