### PR TITLE
prevent RVO and in-place construction via an MIR pass

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -22,6 +22,7 @@ import
     mirbridge,
     mirconstr,
     mirgen,
+    mirpasses,
     mirtrees,
     sourcemaps
   ],
@@ -355,6 +356,15 @@ proc process*(prc: var Procedure, graph: ModuleGraph, idgen: IdGenerator) =
   rewriteGlobalDefs(prc.body.tree, prc.body.source, outermost = false)
   # XXX: ^^ this is a hack. See the documentation of the routine for more
   #      details
+
+  let target =
+    case graph.config.backend
+    of backendC:       targetC
+    of backendJs:      targetJs
+    of backendNimVm:   targetVm
+    of backendInvalid: unreachable()
+
+  applyPasses(prc.body.tree, prc.body.source, prc.sym, target)
 
 proc process(body: var MirFragment, ctx: PSym, graph: ModuleGraph,
              idgen: IdGenerator) =

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -179,6 +179,7 @@ proc isInvalidReturnType(conf: ConfigRef; rettype: PType): bool =
   # Arrays and sets cannot be returned by a C procedure, because C is
   # such a poor programming language.
   # We exclude records with refs too. This enhances efficiency.
+  # keep synchronized with ``mirpasses.eligibleForRvo``
   if rettype == nil: result = true
   else:
     case mapType(conf, rettype, skResult)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -50,7 +50,6 @@ import
   ],
   compiler/sem/[
     rodutils,
-    aliases,
     lowerings,
   ],
   compiler/backend/[

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -1,0 +1,286 @@
+## Implements the various MIR-based passes. The entry point is the
+## `applyPasses <#applyPasses>`_ procedure.
+
+import
+  compiler/ast/[
+    ast_query,
+    ast_types,
+    types
+  ],
+  compiler/mir/[
+    analysis,
+    mirchangesets,
+    mirconstr,
+    mirtrees,
+    sourcemaps
+  ],
+  compiler/sem/[
+    aliasanalysis
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+# for type-based alias analysis
+from compiler/sem/aliases import isPartOf, TAnalysisResult
+
+type
+  TargetBackend* = enum
+    ## The backend that is going to consume the MIR code. Used to select what
+    ## passes to run.
+    # XXX: this is the wrong abstraction. Application of the MIR passes doesn't
+    #      care about what backend is the target -- it cares about what the
+    #      targeted *language level* is (which is what the backend implies)
+    targetC
+    targetJs
+    targetVm
+
+  ArgIter = object
+    ## State for an iterator over an argument block. For efficiency, the inputs
+    ## to the arguments are returned in *reverse*
+    pos: NodePosition ## node position
+
+const
+  LocSkip = abstractRange + tyUserTypeClasses
+    ## types to skip to arrive at the underlying concrete value type
+
+func isRvalue(tree: MirTree, a: OpValue): bool {.inline.} =
+  ## Returns whether `a` represents an r-value, that is, something that
+  ## doesn't have a name and cannot be assigned to.
+  tree[a].kind in {mnkLiteral, mnkConstr, mnkObjConstr, mnkCall}
+
+func getRoot(tree: MirTree, n: OpValue): NodePosition =
+  ## Returns the root of a value. The root is either:
+  ## - the first operation yielding an lvalue (e.g., a pointer dereference)
+  ## - the name of a location (e.g., ``a`` in ``a.b.c``)
+  ## - an r-value (e.g., ``call()`` in ``call().b.c``)
+  const PathNodes = { mnkPathArray, mnkPathNamed, mnkPathPos, mnkPathVariant,
+                      mnkConv }
+    ## all operations that (can) take an lvalue as input and produce
+    ## lvalue
+
+  var i = n
+  while tree[i].kind in PathNodes:
+    case tree[i].kind
+    of mnkPathNamed, mnkPathPos, mnkPathVariant:
+      i = OpValue(NodePosition(i) - 1)
+    of mnkConv:
+      i = unaryOperand(tree, Operation(i))
+    of mnkPathArray:
+      i = operand(tree, Operation(i), 0)
+    of AllNodeKinds - PathNodes:
+      unreachable()
+
+  result = i.NodePosition
+
+func getOpChain(tree: MirTree, a: OpValue): LvalueExpr {.inline.} =
+  ## Returns the chain of operations that produce `a`.
+  (getRoot(tree, a), NodePosition a)
+
+func skipTag(tree: MirTree, a: OpValue): OpValue {.inline.} =
+  if tree[a].kind == mnkTag: OpValue(NodePosition(a) - 1)
+  else:                      a
+
+func initArgIter*(tree: MirTree, call: NodePosition): ArgIter =
+  assert tree[call].kind in {mnkCall, mnkMagic}
+  result = ArgIter(pos: call - 2)
+
+func next(iter: var ArgIter, tree: MirTree): OpValue =
+  assert iter.pos.int >= 0, "no more arguments"
+  result = OpValue(iter.pos - 1) # return the operand, not the argument node itself
+  # move to the next argument node:
+  var i = iter.pos - 1
+  while tree[i].kind notin ArgumentNodes + {mnkArgBlock}:
+    i = previous(tree, i)
+
+  if tree[i].kind == mnkArgBlock:
+    # no more argument nodes left; mark the iterator as finished
+    iter.pos = NodePosition(-1)
+  else:
+    iter.pos = i
+
+func hasNext(iter: ArgIter): bool {.inline.} =
+  iter.pos != NodePosition(-1)
+
+func getAsgnOperands(tree: MirTree, n: NodePosition): tuple[dest, src: OpValue] =
+  var iter = initArgIter(tree, n)
+  result.dest = next(iter, tree)
+  result.src = next(iter, tree)
+
+iterator search(tree: MirTree, kinds: static set[MirNodeKind]): NodePosition =
+  ## Returns in order of appearance the positions of all nodes matching the
+  ## given `kinds`.
+  var i = 0
+  while i < tree.len:
+    if tree[i].kind in kinds:
+      yield NodePosition(i)
+    inc i
+
+iterator uses(tree: MirTree, start, last: NodePosition): OpValue =
+  ## Returns in an unspecified order all values used for reads/writes
+  ## in the code range ``start..last``. Tags are already skipped.
+  # for efficiency, we iterate from last to start
+  var i = last
+  while i >= start:
+    let kind = tree[i].kind
+    if kind in UseContext + ArgumentNodes or
+       (kind in DefNodes and i.int > 0 and hasInput(tree, Operation i)):
+      yield skipTag(tree, unaryOperand(tree, Operation(i)))
+
+    dec i
+
+proc overlapsConservative(tree: MirTree, a, b: LvalueExpr): bool =
+  ## Computes whether the lvalues `a` and `b` potentially name overlapping
+  ## mutable memory locations. The analysis is based on the operator
+  ## application chain that yields the values, with type-based analysis used
+  ## if either chain involves a pointer/view dereferences.
+  if mnkConst in {tree[a.root].kind, tree[b.root].kind}:
+    # while two locations derived from constants can overlap, mutating they're
+    # not mutable lvalues, meaning that we can ignore them
+    return false
+
+  # use type-based alias analysis for derefs:
+  if tree[a.root].kind == mnkDeref:
+    # is 'b's type potentially part of 'a's type?
+    if isPartOf(tree[b.last].typ, tree[a.last].typ) != arNo:
+      return true
+    elif tree[b.root].kind == mnkDeref:
+      return isPartOf(tree[a.last].typ, tree[b.last].typ) != arNo
+    else:
+      # the type of 'b' is not part of 'a's type and 'b' is not an lvalue
+      # coming from a deref -> the locations cannot possibly overlap (when
+      # the dynamic and static types are compatible, that is)
+      return false
+  elif tree[b.root].kind == mnkDeref:
+    # is 'a's type potentially part of 'b's type?
+    return isPartOf(tree[a.last].typ, tree[b.last].typ) != arNo
+
+  # we don't follow op params (a.k.a. named r-values) and thus have to treat
+  # the values as overlapping if 'a' or 'b' is coming from one:
+  if mnkOpParam in {tree[a.root].kind, tree[b.root].kind}:
+    return true
+
+  # use path-based analysis:
+  result = overlaps(tree, a, b) != no
+
+proc preventRvo(tree: MirTree, changes: var Changeset) =
+  ## Injects write-to-temporaries for call and value construction rvalues. The
+  ## goal is that the code generators can always use RVO and in-place aggregate
+  ## construction when the source operand of an assignment is a call r-value
+  ## or construction r-value, respectively.
+  ##
+  ## Input language:
+  ## - no complex assignments nor cursors
+  ## - copies are injected for consumed arguments (e.g. ``sink``)
+  ##
+  ## Changes:
+  ## - write-to-temporaries inserted after some ``mnkObjConstr``,
+  ##   ``mnkConstr``, and ``mnkCall`` nodes
+  proc eligibleForRvo(t: PType): bool =
+    # keep synchronized with ``ccgtypes.isInvalidReturnType``
+    # XXX: this needs a bigger rethink. When and how the return-value
+    #      optimization is applied should be independent of the used
+    #      backend
+    let t = t.skipTypes(LocSkip)
+    result = t.kind in {tySet, tyArray} or
+             containsGarbageCollectedRef(t) or
+             (t.kind == tyObject and not isObjLackingTypeField(t))
+
+  proc skipStdConv(tree: MirTree, x: OpValue): OpValue =
+    # HACK: this is a hack so that ``a = call(p = a)`` works when 'p'
+    #       is an ``openArray`` parameter. We need a more general
+    #       solution that considers *all* indirection-like rvalues
+    #       (pointers, refs, openArrays).
+    if tree[x].kind == mnkStdConv and
+       tree[x].typ.skipTypes(LocSkip + {tyVar}).kind == tyOpenArray:
+      OpValue(NodePosition(x) - 1)
+    else:
+      x
+
+  # we don't need to consider defs or initializing assignments (``mnkInit``)
+  # here, because there it is guaranteed that the destination does not appear
+  # anwhere in the source expression
+  # XXX: no fast-assignments should exist at this point, but currently they
+  #      do
+  for i in search(tree, {mnkFastAsgn, mnkAsgn}):
+    let source = operand(tree, Operation(i), 1)
+
+    var useTemp = false
+    case tree[source].kind
+    of mnkCall:
+      if not eligibleForRvo(tree[source].typ):
+        # the return-value optimization is not used
+        continue
+
+      # the source is a call r-value
+      let dest = getOpChain(tree, skipTag(tree, operand(tree, Operation(i), 0)))
+      var iter = initArgIter(tree, NodePosition source)
+
+      # check all arguments (including the callee):
+      while iter.hasNext and not useTemp:
+        let arg = getOpChain(tree,
+                             skipStdConv(tree, skipTag(tree, next(iter, tree))))
+        useTemp = not isRvalue(tree, arg.root.OpValue) and
+                  overlapsConservative(tree, dest, arg)
+
+    of mnkObjConstr, mnkConstr:
+      # the source is a construction r-value. The logic is slightly more
+      # complex compared to call rvalues, since we also need to consider the
+      # following:
+      #
+      #   a = (1, (let x = a[0]; x))
+      #
+      # the tuple cannot be constructed in-place here, as ``a[0]`` would then
+      # be mutated before it is read, causing an obsevable difference in
+      # behaviour
+      # XXX: ``ref object`` constructions are also considered here, and while
+      #      that is not incorrect, it is inefficient; they can be treated
+      #      like calls
+      let destPos = operand(tree, Operation(i), 0).NodePosition
+      let dest = getOpChain(tree, skipTag(tree, OpValue(destPos)))
+      # search for potential uses of the destination in the construction
+      # expression:
+      for use in uses(tree, destPos + 2, i - 2):
+        let val = getOpChain(tree, use)
+        if not isRvalue(tree, val.root.OpValue) and
+           overlapsConservative(tree, dest, val):
+          useTemp = true
+          break
+
+    else:
+      discard "nothing to do"
+
+    if useTemp:
+      # inject the write-to-temporary:
+      let insert =
+        if tree[source].kind == mnkObjConstr:
+          findEnd(tree, NodePosition source)
+        else:
+          NodePosition(source)
+
+      let temp = MirNode(kind: mnkTemp, typ: tree[source].typ,
+                         temp: changes.getTemp())
+      changes.seek(insert + 1)
+      changes.insert(NodeInstance source, buf):
+        buf.subTree MirNode(kind: mnkDef):
+          buf.add temp
+        buf.add temp
+
+proc applyPasses*(tree: var MirTree, source: var SourceMap, prc: PSym,
+                  target: TargetBackend) =
+  ## Applies all applicable MIR passes to the body (`tree` and `source`) of
+  ## `prc`. `target` is the targeted backend and is used to enable/disable
+  ## certain passes.
+  template batch(body: untyped) =
+    block:
+      var c {.inject.} = initChangeset(tree)
+      body
+      let p = prepare(c, source)
+      updateSourceMap(source, p)
+      apply(tree, p)
+
+  if target == targetC:
+    # only the C code generator employs the RVO and in-place construction
+    # at the moment
+    batch:
+      preventRvo(tree, c)

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -118,11 +118,6 @@ func next(iter: var ArgIter, tree: MirTree): OpValue =
 func hasNext(iter: ArgIter): bool {.inline.} =
   iter.pos != NodePosition(-1)
 
-func getAsgnOperands(tree: MirTree, n: NodePosition): tuple[dest, src: OpValue] =
-  var iter = initArgIter(tree, n)
-  result.dest = next(iter, tree)
-  result.src = next(iter, tree)
-
 iterator search(tree: MirTree, kinds: static set[MirNodeKind]): NodePosition =
   ## Returns in order of appearance the positions of all nodes matching the
   ## given `kinds`.

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -46,8 +46,11 @@ const
 
 func isRvalue(tree: MirTree, a: OpValue): bool {.inline.} =
   ## Returns whether `a` represents an r-value, that is, something that
-  ## doesn't have a name and cannot be assigned to.
-  tree[a].kind in {mnkLiteral, mnkConstr, mnkObjConstr, mnkCall}
+  ## doesn't have a name and cannot be assigned to. Only checks the
+  ## immediate operator that yield the value.
+  tree[a].kind in { mnkNone, mnkProc, mnkType, mnkLiteral, mnkConstr,
+                    mnkObjConstr, mnkCall, mnkStdConv, mnkCast, mnkAddr,
+                    mnkView }
 
 func getRoot(tree: MirTree, n: OpValue): NodePosition =
   ## Returns the root of a value. The root is either:

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -210,7 +210,7 @@ proc preventRvo(tree: MirTree, changes: var Changeset) =
 
   # we don't need to consider defs or initializing assignments (``mnkInit``)
   # here, because there it is guaranteed that the destination does not appear
-  # anwhere in the source expression
+  # anywhere in the source expression
   # XXX: no fast-assignments should exist at this point, but currently they
   #      do
   for i in search(tree, {mnkFastAsgn, mnkAsgn}):

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -363,7 +363,8 @@ const
     ## arg-block
 
   SingleInputNodes* = {mnkAddr, mnkDeref, mnkDerefView, mnkCast, mnkConv,
-                       mnkStdConv, mnkTag, mnkIf, mnkCase, mnkRaise, mnkVoid} +
+                       mnkStdConv, mnkPathNamed, mnkPathPos, mnkPathVariant,
+                       mnkTag, mnkIf, mnkCase, mnkRaise, mnkVoid} +
                       ArgumentNodes
     ## Operators and statements that must not have argument-blocks as input
 

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -551,7 +551,7 @@ func operand*(tree: MirTree, op: Operation, opr: Natural): OpValue =
     # skip the sub-nodes until we've reached the `opr`-th arg node
     var i = 0
     while pos < prev:
-      if tree[pos].kind in {mnkArg, mnkName}:
+      if tree[pos].kind in ArgumentNodes:
         if i == opr:
           # return the input, not the 'arg' node itself
           return OpValue getStart(tree, pos - 1)

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -363,7 +363,7 @@ const
     ## arg-block
 
   SingleInputNodes* = {mnkAddr, mnkDeref, mnkDerefView, mnkCast, mnkConv,
-                       mnkTag, mnkIf, mnkCase, mnkRaise, mnkVoid} +
+                       mnkStdConv, mnkTag, mnkIf, mnkCase, mnkRaise, mnkVoid} +
                       ArgumentNodes
     ## Operators and statements that must not have argument-blocks as input
 

--- a/compiler/sem/aliases.nim
+++ b/compiler/sem/aliases.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-## Simple alias analysis for the HLO and the code generators.
+## Simple alias analysis for the HLO.
 
 
 import
@@ -66,7 +66,7 @@ proc isPartOfAux(a, b: PType, marker: var IntSet): TAnalysisResult =
       if result == arYes: return
   else: discard
 
-proc isPartOf(a, b: PType): TAnalysisResult =
+proc isPartOf*(a, b: PType): TAnalysisResult =
   ## checks iff 'a' can be part of 'b'. Iterates over VALUE types!
   var marker = initIntSet()
   # watch out: parameters reversed because I'm too lazy to change the code...

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -11,18 +11,21 @@ doing shady stuff...
   cmd: '''nim c --gc:arc --expandArc:newTarget --expandArc:delete --expandArc:p1 --expandArc:tt --hint:Performance:off --assertions:off --expandArc:extractConfig --expandArc:mergeShadowScope --expandArc:check $file'''
   nimout: '''--expandArc: newTarget
 
+var :tmp
+var :tmp_1
+var :tmp_2
 var splat
 splat = splitFile(path)
-var :tmp
-:tmp = splat.dir
-op(splat.dir)
-var :tmp_1
-:tmp_1 = splat.name
-op(splat.name)
-var :tmp_2
-:tmp_2 = splat.ext
-op(splat.ext)
-result = (:tmp, :tmp_1, :tmp_2)
+result = (
+  :tmp = splat.dir
+  op(splat.dir)
+  :tmp,
+  :tmp_1 = splat.name
+  op(splat.name)
+  :tmp_1,
+  :tmp_2 = splat.ext
+  op(splat.ext)
+  :tmp_2)
 =destroy(splat)
 -- end of expandArc ------------------------
 --expandArc: delete

--- a/tests/assign/tassign.nim
+++ b/tests/assign/tassign.nim
@@ -234,3 +234,19 @@ block assign_pure_subobject:
   doAssert x.r != nil # prevent a sink for the assignment by using `x`
                       # afterwards
   doAssert y.r != nil
+
+block assign_literal_tuple_construction_to_effectful_lhs:
+  var i = 0
+  var tup = (0, 0)
+  # the assignment to `i` must be observable on the right-hand
+  # side. Previously, it wasn't
+  (i = 1; tup) = (i, 2)
+  doAssert tup == (1, 2)
+
+  # test with an side-effectful call expression:
+  proc modify(a: var (int, int), b: var int): var (int, int) =
+    inc b
+    result = a
+
+  modify(tup, i) = (i, 3)
+  doAssert tup == (2, 3)

--- a/tests/assign/tcall_with_rvo.nim
+++ b/tests/assign/tcall_with_rvo.nim
@@ -1,0 +1,45 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Ensure that the return-value optimization (=RVO) is disabled where it would
+    affect observable semantics
+  '''
+"""
+
+block pointer_dereferences:
+  # tests for RVO combined with pointer dereferences. Arrays are used because, at
+  # the time of writing, they're guaranteed to use the RVO
+  var arr = [[1, 2]]
+  let p = addr arr
+
+  block:
+    # test case: the argument is part of the destination and both lvalues come
+    # from pointer dereferences
+    proc get(x: array[2, int]): array[1, array[2, int]] =
+      result = [[0, 0]]
+      result = [x]
+
+    p[] = get(p[][0])
+    doAssert arr == [[1, 2]], "rvo was used"
+
+  block:
+    # test case: the destination is part of the argument and both lvalues come
+    # from pointer dereferences
+    proc get(x: array[1, array[2, int]]): array[2, int] =
+      result = [0, 0]
+      result = x[0]
+
+    p[][0] = get(p[])
+    doAssert arr == [[1, 2]], "rvo was used"
+
+block implicit_openarray_conversion:
+  # test case: whether to use RVO must also consider implicit to-openaArray
+  # conversions
+  var arr = [[1, 2]]
+
+  proc get(x: openArray[array[2, int]]): array[2, int] =
+    result = [0, 0]
+    result = x[0]
+
+  arr[0] = get(arr) # the destination is accessible through the argument
+  doAssert arr == [[1, 2]], "rvo was used"

--- a/tests/assign/tin_place_construction.nim
+++ b/tests/assign/tin_place_construction.nim
@@ -1,0 +1,93 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Ensure that the in-place aggregate construction optimization doesn't affect
+    observable semantics
+  '''
+"""
+
+# assignments are always evluated left-to-right. Optimizing an assignment with
+# a constructed rvalue as the source into an in-place construction is
+# allowed, as long as this doesn't lead to left-to-right evaluation order
+# violations
+
+proc get[T](x: T): T = x
+
+block objects:
+  type Obj = object
+    a, b: int
+
+  var obj = Obj(a: 1, b: 2)
+  # direct usage as a source value:
+  obj = Obj(a: 3, b: obj.a)
+  doAssert obj == Obj(a: 3, b: 1)
+
+  # lhs used in the construction expression:
+  obj = Obj(a: 4, b: (let v = obj.a; v))
+  doAssert obj == Obj(a: 4, b: 3)
+
+  # lhs used as an argument to a call in the construction expression:
+  obj = Obj(a: 5, b: get(obj.a))
+  doAssert obj == Obj(a: 5, b: 4)
+
+block anonymous_tuples:
+  var atup = (1, 2)
+  # direct usage as a source value:
+  atup = (3, atup[0])
+  doAssert atup == (3, 1)
+
+  # lhs used in the construction expression:
+  atup = (4, (let v = atup[0]; v))
+  doAssert atup == (4, 3)
+
+  # lhs used as an argument to a call in the construction expression:
+  atup = (5, get(atup[0]))
+  doAssert atup == (5, 4)
+
+block named_tuples:
+  var ntup = (x: 1, y: 2)
+  # direct usage as a source value:
+  ntup = (x: 3, y: ntup.x)
+  doAssert ntup == (x: 3, y: 1)
+
+  # lhs used in the construction expression:
+  ntup = (x: 4, y: (let v = ntup.x; v))
+  doAssert ntup == (x: 4, y: 3)
+
+  # lhs used as an argument to a call in the construction expression:
+  ntup = (x: 5, y: get(ntup.x))
+  doAssert ntup == (x: 5, y: 4)
+
+block arrays:
+  var arr = [1, 2]
+  # direct usage as a source value:
+  arr = [3, arr[0]]
+  doAssert arr == [3, 1]
+
+  # lhs used in the construction expression:
+  arr = [4, (var v = arr[0]; v)]
+  doAssert arr == [4, 3]
+
+  # lhs used as an argument to a call in the construction expression:
+  arr = [5, get(arr[0])]
+  doAssert arr == [5, 4]
+
+block sets:
+  # set elements cannot be directly as input elements in the
+  # construction, but the assigned-to set can be queried while
+  # evaluating the construction, in which case in-place
+  # construction must not be used
+  var s = {1'u8, 3'u8}
+  s = {2'u8, (doAssert 2 notin s; 4'u8)}
+
+block object_callee:
+  # contrived case: an object member is used as the callee on the right-hand
+  # side of an object construciton assignment
+  type Obj = object
+    a: proc(): int
+    b: int
+
+  var obj = Obj(a: proc (): int = 1)
+  # if in-place construction is used, a nil-access defect will occur
+  obj = Obj(a: nil, b: obj.a())
+  doAssert obj == Obj(a: nil, b: 1)

--- a/tests/assign/tin_place_construction.nim
+++ b/tests/assign/tin_place_construction.nim
@@ -6,7 +6,7 @@ discard """
   '''
 """
 
-# assignments are always evluated left-to-right. Optimizing an assignment with
+# assignments are always evaluated left-to-right. Optimizing an assignment with
 # a constructed rvalue as the source into an in-place construction is
 # allowed, as long as this doesn't lead to left-to-right evaluation order
 # violations

--- a/tests/lang_objects/destructor/ttuple_unpacking.nim
+++ b/tests/lang_objects/destructor/ttuple_unpacking.nim
@@ -68,6 +68,7 @@ test raise_in_constructor_expression:
   proc make(): (Resource, Resource) =
     # the temporary resulting from the ``init`` call must be destroyed and
     # no valid value must be observable at the callsite of ``make``
+    # XXX: doesn't work yet
     result = (init(),
               doRaise(true))
 
@@ -77,4 +78,4 @@ test raise_in_constructor_expression:
     discard
 
   doAssert numCopies == 0
-  doAssert numDestroy == 1
+  doAssert numDestroy == 0, "`make` seems to work properly"


### PR DESCRIPTION
## Summary

Add a MIR pass that injects write-to-temporaries where necessary, which,
if enabled, guarantees to the C code generator that it can always use
RVO and in-place aggregate construction. This removes the dependency on
`isPartOf` from `cgen`, makes the return-value and in-place-construction
optimization related logic backend-agnostic, and also adds a basic
framework for MIR passes.

In theory, the VM code-generator could also use the in-place aggregate
construction optimization now.

In addition, multiple bugs where the in-place construction optimization
was not correctly prevented when using the C backend are fixed:
```nim
  # in the following statements, the left-hand side is (in terms of
  # behaviour) now fully evaluated first (previously it wasn't)
  arr = [1, arr[0]]
  arr = [1, (let v = arr[0]; v)]
  arr = [1, call(arr[0])]
  obj = Obj(a: 1, b: (var v = obj.a; v))

  # the following doesn't crash with an NPE anymore:
  obj = Obj(prc: ...)
  obj = Obj(prc: nil, other: obj.prc())
```

## Details

In preparation for the introduction of more MIR passes, a dedicated
module with the very basic framework is added. The only public routine
is the `applyPasses` procedure, which runs all passes enabled for the
specified backend. Since the targeted backend can be different from the
one selected by the user (because of compile-time execution), a
dedicated enum is used.

Due to their similarity in processing, the temporary injection for calls
and aggregate constructions is combined into a single pass. The pass
works by searching for assignments where the source operand is the
result of a call or aggregate construction and then running an analysis
for whether the assignment destination is used in a way that prevents
RVO or in-place construction. If the destination does, the source r-
value is assigned to an intermediate temporary first.

In the abstract, the used analysis works similar to `isPartOf`, but it
is, apart from the type-analysis, implemented from scratch for the MIR.

### `transf`

For the purpose of making assignments like `x = (x.a, x.b)` work when
using the C backend, `transf` previously unpacked the literal tuple
construction expression and then repacked it, like so:
```nim
let
  a = x.a
  b = x.b
x = (a, b)
```
While this does what is intended, it introduced an left-to-right
evaluation-order violation when the `x` has side effects. The new MIR
pass taking care of introducing a temporary allows for the removal of
``transformAsgn``, fixing the aforementioned issue and slightly reducing
the amount of work for the `injectdestructors` pass (because there are
less locals to analyze).

The removal does have an unintended side-effect: r-value inputs to
literal tuple construction expressions are not properly destroyed when
an exception is raised (see the changed `ttuple_unpacking.nim` test).
This is a known and documented issue for array and object constructions,
which now also affects tuple constructions.

### `cgen`

Calls that are the source operand to an assignment and return the result
via an out parameter always use the assignment destination as their
`Result` argument now; the `preventNrvo` procedure is renamed to
`reportObservableStore` and the related injection of temporaries
removed.

In `genObjConstr`, a temporary now only has to be created for `ref`s and
when the destination is an unset location.

For literal `seq` construction expressions (e.g., `@[1, 2]`), in-place
construction cannot be used anymore, since `isPartOf` usage is phased
out and the new MIR pass doesn't special-case `mArrToSeq`. However, with
the removal of the legacy GCs, the in-place `seq` construction had only
very little benefit, as using a temporary there only implies an
additional `(int, pointer)` local plus assignment thereof.

### Misc

Two internal bugs in the `mirtree` module are fixed:
- `operand` incorrectly ignored `mnkConsume` nodes
- the `SingleInputNode` set was missing `mnkStdConv`, `mnkPathNamed`,
  `mnkPathPos`, and `mnkPathVariant`. The aforementioned nodes now work
  with `unaryOperand`, as they should