### PR TITLE
internal: fix `MirNode`s missing type information

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1112,7 +1112,7 @@ proc genLocDef(c: var TCtx, n: PNode) =
         else:                   mnkLocal
 
       {.cast(uncheckedAssign).}:
-        c.stmts.add MirNode(kind: kind, sym: s)
+        c.stmts.add MirNode(kind: kind, typ: s.typ, sym: s)
 
 proc genLocInit(c: var TCtx, symNode: PNode, initExpr: PNode) =
   ## Generates the code for a location definition. `sym` is the symbol of the
@@ -1892,9 +1892,10 @@ proc generateCode*(graph: ModuleGraph, owner: PSym, options: set[GenOption],
     # processing and analysis
     let params = owner.typ.n
     for i in 1..<params.len:
-      if params[i].sym.typ.isSinkTypeForParam():
+      let s = params[i].sym
+      if s.typ.isSinkTypeForParam():
         c.stmts.subTree MirNode(kind: mnkDef):
-          c.stmts.add MirNode(kind: mnkParam, sym: params[i].sym)
+          c.stmts.add MirNode(kind: mnkParam, typ: s.typ, sym: s)
 
   gen(c, body)
 


### PR DESCRIPTION
## Summary

Fix some nodes produced by `injectdestructors` having no type assigned,
which would cause problems for MIR passes expecting the types to be set.

## Details

The `mnkOpParam` nodes produced by `injectdestructors` were all missing
type information. All manual constructions of an ``mnkOpParam`` are
replaced with a call to the new constructor routine `opParamNode`, which
explicitly requires a type being passed.

A second problem was with the entity name nodes of `mnkDef`s not having
type information. While this is not a problem by itself (they are not
directly queried for types), it becomes one when the node is copied into
contexts where the nodes are required to have type information,
something that the `injectdestructors` pass does. `mirgen` now also sets
the type for entity name nodes appearing in 'def' contexts, which fixes
the issue.