### PR TITLE
internal: small code generator clean-up

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2252,11 +2252,10 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
     genAsgn(p, n)
   of nkDiscardStmt:
     let ex = n[0]
-    if ex.kind != nkEmpty:
-      genLineDir(p, n)
-      var a: TLoc
-      initLocExprSingleUse(p, ex, a)
-      line(p, cpsStmts, "(void)(" & a.r & ");\L")
+    genLineDir(p, n)
+    var a: TLoc
+    initLocExprSingleUse(p, ex, a)
+    line(p, cpsStmts, "(void)(" & a.r & ");\L")
   of nkAsmStmt: genAsmStmt(p, n)
   of nkTryStmt:
     assert p.config.exc == excGoto

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -824,23 +824,6 @@ proc genBracketExpr(p: BProc; n: PNode; d: var TLoc) =
   else: internalError(p.config, n.info, "expr(nkBracketExpr, " & $ty.kind & ')')
   discard getTypeDesc(p.module, n.typ)
 
-proc isSimpleExpr(n: PNode): bool =
-  # calls all the way down --> can stay expression based
-  case n.kind
-  of nkCallKinds, nkDotExpr, nkPar, nkTupleConstr,
-      nkObjConstr, nkBracket, nkCurly, nkHiddenDeref, nkDerefExpr, nkHiddenAddr,
-      nkHiddenStdConv, nkHiddenSubConv, nkConv, nkAddr:
-    for c in n:
-      if not isSimpleExpr(c): return false
-    result = true
-  of nkStmtListExpr:
-    for i in 0..<n.len-1:
-      if n[i].kind notin {nkCommentStmt, nkEmpty}: return false
-    result = isSimpleExpr(n.lastSon)
-  else:
-    if n.isAtom:
-      result = true
-
 proc genEcho(p: BProc, n: PNode) =
   # this unusual way of implementing it ensures that e.g. ``echo("hallo", 45)``
   # is threadsafe.

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2177,13 +2177,9 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
         # local)
         putLocIntoDest(p, d, p.locals[sym])
     else: internalError(p.config, n.info, "expr(" & $sym.kind & "); unknown symbol")
-  of nkNilLit:
-    if not isEmptyType(n.typ):
-      putIntoDest(p, d, n, genLiteral(p, n))
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     putDataIntoDest(p, d, n, genLiteral(p, n))
-  of nkIntLit..nkUInt64Lit,
-     nkFloatLit..nkFloat128Lit, nkCharLit:
+  of nkIntLiterals, nkFloatLiterals, nkNilLit:
     putIntoDest(p, d, n, genLiteral(p, n))
   of nkCall:
     genLineDir(p, n) # may be redundant, it is generated in fixupCall as well

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -205,7 +205,6 @@ proc genIf(p: BProc, n: PNode) =
 proc genReturnStmt(p: BProc, t: PNode) =
   p.flags.incl beforeRetNeeded
   genLineDir(p, t)
-  if (t[0].kind != nkEmpty): genStmts(p, t[0])
   blockLeaveActions(p,
     howManyTrys    = p.nestedTryStmts.len,
     howManyExcepts = p.inExceptBlockLen)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -739,14 +739,12 @@ proc allPathsAsgnResult(n: PNode): InitResultEnum =
     elif containsResult(n):
       result = InitRequired
   of nkReturnStmt:
-    if n.len > 0:
-      if n[0].kind == nkEmpty and result != InitSkippable:
+      if true:
         # This is a bare `return` statement, if `result` was not initialized
         # anywhere else (or if we're not sure about this) let's require it to be
         # initialized. This avoids cases like #9286 where this heuristic lead to
         # wrong code being generated.
         result = InitRequired
-      else: result = allPathsAsgnResult(n[0])
   of nkIfStmt, nkIfExpr:
     var exhaustive = false
     result = InitSkippable

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -402,11 +402,6 @@ proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: TLoc,
         let tmp = defaultValueExpr(p, t, a.lode.info)
         genAssignment(p, a, tmp)
 
-proc isComplexValueType(t: PType): bool {.inline.} =
-  let t = t.skipTypes(abstractInst + tyUserTypeClasses)
-  result = t.kind in {tyArray, tySet, tyTuple, tyObject, tyOpenArray} or
-    (t.kind == tyProc and t.callConv == ccClosure)
-
 include ccgreset
 
 proc constructLoc(p: BProc, loc: var TLoc, isTemp = false; doInitObj = true) =

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2204,10 +2204,7 @@ proc convCStrToStr(p: PProc, n: PNode, r: var TCompRes) =
 proc genReturnStmt(p: PProc, n: PNode) =
   p.config.internalAssert(p.prc != nil, n.info, "genReturnStmt")
   p.beforeRetNeeded = true
-  if n[0].kind != nkEmpty:
-    genStmt(p, n[0])
-  else:
-    genLineDir(p, n)
+  genLineDir(p, n)
   lineF(p, "break BeforeRet;$n", [])
 
 proc frameCreate(p: PProc; procname, filename: Rope): Rope =

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2415,9 +2415,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       r.res = rope(n.intVal)
     r.kind = resExpr
   of nkNilLit:
-    if isEmptyType(n.typ):
-      discard
-    elif mapType(n.typ) == etyBaseIndex:
+    if mapType(n.typ) == etyBaseIndex:
       r.typ = etyBaseIndex
       r.address = rope"null"
       r.res = rope"0"

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2515,10 +2515,9 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkAsgn: genAsgn(p, n)
   of nkFastAsgn: genFastAsgn(p, n)
   of nkDiscardStmt:
-    if n[0].kind != nkEmpty:
-      genLineDir(p, n)
-      gen(p, n[0], r)
-      r.res = "var _ = " & r.res
+    genLineDir(p, n)
+    gen(p, n[0], r)
+    r.res = "var _ = " & r.res
   of nkAsmStmt: genAsmOrEmitStmt(p, n)
   of nkTryStmt: genTry(p, n)
   of nkRaiseStmt: genRaiseStmt(p, n)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2952,7 +2952,7 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
     c.loadInt(n, dest, getInt(n))
   of nkFloatKinds, nkStrKinds: genLit(c, n, dest)
   of nkNilLit:
-    if not n.typ.isEmptyType:
+    if true:
       let t = n.typ.skipTypes(abstractInst)
       internalAssert(c.config,
         t.kind in {tyPtr, tyRef, tyPointer, tyNil, tyProc, tyCstring},
@@ -2960,7 +2960,6 @@ proc gen(c: var TCtx; n: PNode; dest: var TDest) =
         $t.kind)
       if dest.isUnset: dest = c.getTemp(t)
       c.gABx(n, ldNullOpcode(t), dest, c.genType(n.typ))
-    else: unused(c, n, dest)
   of nkNimNodeLit:
     # the VM does not copy the tree when loading a ``PNode`` constant (which
     # is correct). ``NimNode``s not marked with `nfSem` can be freely modified

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -910,9 +910,6 @@ proc writeBackResult(c: var TCtx, info: PNode) =
       c.freeTemp(tmp)
 
 proc genReturn(c: var TCtx; n: PNode) =
-  if n[0].kind != nkEmpty:
-    gen(c, n[0])
-
   writeBackResult(c, n)
   c.gABC(n, opcRet)
 


### PR DESCRIPTION
## Summary

As preparation for the dedicated code-generator IR, remove unused
procedures and support for some obsolete AST shapes from all three
code generators.

## Details

The code generators still had leftover support for some AST shapes that
stopped reaching the code generators with the introduction of the MIR
phase. These were: 
* `nil`-as-a-statement
* non-bare `return` statements (i.e., return statements with a non-
  `nkEmpty` operand)
* bare `discard` statements

Support for these is removed and logic still considering them adjusted.

In addition, the `isSimpleExpr` and `isComplexValueType` procedures in
the C code generator are unused -- they're also removed.