### PR TITLE
support `uint64` for case statement operands

### DIFF
--- a/compiler/ast/nimsets.nim
+++ b/compiler/ast/nimsets.nim
@@ -84,12 +84,12 @@ proc toBitSet*(conf: ConfigRef; s: PNode): TBitSet =
   inclTreeSet(result, conf, s)
 
 proc toTreeSet*(conf: ConfigRef; s: TBitSetView, settype: PType, info: TLineInfo): PNode =
+  let
+    elemType = settype[0]
+    first = firstOrd(conf, elemType)
   var
-    a, b, e, first: BiggestInt # a, b are interval borders
-    elemType: PType
-    n: PNode
-  elemType = settype[0]
-  first = firstOrd(conf, elemType).toInt64
+    a, b, e: BiggestInt # a, b are interval borders
+
   result = newNodeI(nkCurly, info)
   result.typ = settype
   result.info = info
@@ -107,12 +107,12 @@ proc toTreeSet*(conf: ConfigRef; s: TBitSetView, settype: PType, info: TLineInfo
       if a == b:
         result.add aa
       else:
-        n = newNodeI(nkRange, info)
+        var n = newNodeI(nkRange, info, 2)
         n.typ = elemType
-        n.add aa
+        n[0] = aa
         let bb = newIntTypeNode(b + first, elemType)
         bb.info = info
-        n.add bb
+        n[1] = bb
         result.add n
       e = b
     inc(e)

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -542,7 +542,7 @@ proc branchHasTooBigRange(b: PNode): bool =
   for it in b:
     # last son is block
     if (it.kind == nkRange) and
-        it[1].intVal - it[0].intVal > RangeExpandLimit:
+        getInt(it[1]) - getInt(it[0]) > RangeExpandLimit:
       return true
 
 proc ifSwitchSplitPoint(p: BProc, n: PNode): int =
@@ -563,10 +563,13 @@ proc genCaseRange(p: BProc, branch: PNode) =
             genLiteral(p, branch[j][0]),
             genLiteral(p, branch[j][1])])
       else:
-        var v = copyNode(branch[j][0])
-        while v.intVal <= branch[j][1].intVal:
-          lineF(p, cpsStmts, "case $1:$n", [genLiteral(p, v)])
-          inc(v.intVal)
+        let
+          typ   = branch[j][0].typ
+          upper = getInt(branch[j][1])
+        var v = getInt(branch[j][0])
+        while v <= upper:
+          lineF(p, cpsStmts, "case $1:$n", [intLiteral(p, v, typ)])
+          inc(v)
     else:
       lineF(p, cpsStmts, "case $1:$n", [genLiteral(p, branch[j])])
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -564,6 +564,7 @@ proc genStmts*(p: BProc, t: PNode)
 proc expr(p: BProc, n: PNode, d: var TLoc)
 proc putLocIntoDest(p: BProc, d: var TLoc, s: TLoc)
 proc intLiteral(i: BiggestInt): Rope
+proc intLiteral(p: BProc, i: Int128, ty: PType): Rope
 proc genLiteral(p: BProc, n: PNode): Rope
 proc raiseExit(p: BProc)
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -825,10 +825,16 @@ proc genRaiseStmt(p: PProc, n: PNode) =
     useMagic(p, "reraiseException")
     line(p, "reraiseException();\L")
 
+func intLiteral(v: Int128, typ: PType): string =
+  if typ.kind == tyBool:
+    if v == Zero: "false"
+    else:         "true"
+  else:           $v
+
 proc genCaseJS(p: PProc, n: PNode) =
   var
     cond: TCompRes
-    totalRange = 0
+    totalRange = Zero
   genLineDir(p, n)
   gen(p, n[0], cond)
   let stringSwitch = skipTypes(n[0].typ, abstractVar).kind == tyString
@@ -845,15 +851,15 @@ proc genCaseJS(p: PProc, n: PNode) =
       for j in 0..<it.len - 1:
         let e = it[j]
         if e.kind == nkRange:
-          var v = copyNode(e[0])
-          inc(totalRange, int(e[1].intVal - v.intVal))
+          let upper = getInt(e[1])
+          var v = getInt(e[0])
+          totalRange += upper - v
           if totalRange > 65535:
             localReport(p.config, n.info, BackendReport(kind: rbackJsTooCaseTooLarge))
 
-          while v.intVal <= e[1].intVal:
-            gen(p, v, cond)
-            lineF(p, "case $1:$n", [cond.rdLoc])
-            inc(v.intVal)
+          while v <= upper:
+            lineF(p, "case $1:$n", [intLiteral(v, e[0].typ)])
+            inc v
         else:
           if stringSwitch:
             case e.kind
@@ -2409,10 +2415,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkSym:
     genSym(p, n, r)
   of nkCharLit..nkUInt64Lit:
-    if n.typ.kind == tyBool:
-      r.res = if n.intVal == 0: rope"false" else: rope"true"
-    else:
-      r.res = rope(n.intVal)
+    r.res = intLiteral(getInt(n), n.typ)
     r.kind = resExpr
   of nkNilLit:
     if isEmptyType(n.typ):

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1660,7 +1660,7 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
   var typ = commonTypeBegin
   var hasElse = false
   let caseTyp = skipTypes(n[0].typ, abstractVar-{tyTypeDesc})
-  const shouldChckCovered = {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32, tyBool}
+  const shouldChckCovered = {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt64, tyBool}
   case caseTyp.kind
   of shouldChckCovered:
     chckCovered = true

--- a/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
+++ b/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
@@ -1,10 +1,13 @@
 discard """
-  targets: "c js vm"
+  targets: "c !js vm"
   description: '''
     Ensures that case statements work with uint operands and of-branch values
     not representable with the same-sized signed integer type
   '''
 """
+
+# knownIssue: compiles correctly for JS, but doesn't work at run-time because
+#             of the improper large integer support
 
 proc test[T: uint64|uint; S]() =
   const Border = T(high(S)) # the highest possible signed integer value

--- a/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
+++ b/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
@@ -1,0 +1,37 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Ensures that case statements work with uint operands and of-branch values
+    not representable with the same-sized signed integer type
+  '''
+"""
+
+proc test[T: uint64|uint; S]() =
+  const Border = T(high(S)) # the highest possible signed integer value
+
+  proc inRange(x: T): int {.noinline.} = # don't fold at compile-time
+    type Range = range[Border-5..Border+5]
+      # work-around so that the set construction expression compiles
+
+    case x
+    of (high(T)-3)..high(T):        0 # range that's fully beyond the border
+    of (Border-4)..(Border+4):      1 # range that crosses the border
+    of {Range(Border-5), Border+5}: 2 # set with values in and beyond the border
+    else:                           3
+
+  doAssert inRange(0) == 3
+  doAssert inRange(high(T)) == 0
+  when defined(vm):
+    # knownIssue: ranges in of-branches that cross the signed/unsigned border
+    #             don't work correctly in the VM, due to their values being
+    #             treated as signed integers
+    doAssert inRange(Border) == 3
+    doAssert inRange(Border+1) == 3
+  else:
+    doAssert inRange(Border) == 1
+    doAssert inRange(Border+1) == 1
+  doAssert inRange(Border-5) == 2
+  doAssert inRange(Border+5) == 2
+
+test[uint64, int64]()
+test[uint, int]()


### PR DESCRIPTION
## Summary

Allow `uint64` values to be used as `case`-statement operands and fix
multiple compiler crashes with `uint` `of`-branch labels outside the
`int64` range. Previously, trying to use a `uint64` value with case
statements resulted in a "selector must be of an ordinal type" error.

* `uint64` values can now be used as `case`-statement operands (outside
  of objects)
* literal set constructors in `of`-branches don't crash the compiler
  when the range of the element value crosses `high(int64)`
* when using the C or JS backend, `..` ranges in `of`-branches don't
  crash the compiler when the lower bound is less-than-or-equal to,
  and the upper bound greater than `high(int64)`
* when using the JS backend, unsigned integer literals beyond
  `high(int64)` are not treated as `-1 - high(uint64) - value`
  anymore

## Details

`uint64` being disallowed as `case`-statement operands seems to have
been a leftover from when `uint64` was not considered an ordinal type.
Since it is considered an ordinal type now, not allowing it there is
inconsistent.

The compiler crashes were all caused by signed integer overflow
defects. All integer values are stored as `BiggestInt` (signed) in
`PNode`, even unsigned values. Prior to working with them, they have to
be either casted to an unsigned integer (in case the node represents
an unsigned value) or turned into an `Int128` value via `getOrdValue`/
`getInt` (both which take care of properly reinterpreting the value).

This was missing in `toTreeSet`, which is called when removing
duplicate elements from set literals used as `of`-branch labels.
Instead of turning the sets' lower bound (`firstOrd`) into a signed
integer, the value is now kept as an `Int128`, fixing the overflow
defect.

The other problems where with the C and JavaScript code generators,
both which were using the nodes `intVal` directly when iterating over
`nkRange`s -- they now use `Int128` values. In order to not having
to create a temporary `PNode`, the integer-literal rendering logic
for both code generators is moved to standalone procedures that take
an `Int128` value directly (which for the JavaScript backend fixes
large unsigned values being inverted).

Instead of inferring the integer type from the node kind, `cgen` now
requires all integer literals to be typed, which is preparation for the
code-generator IR.

When using the VM backend, `of`-branches with ranges crossing
`high(int64)` still don't work correctly, as the VM uses signed
integers for the comparisons. Fixing this requires a larger rethinking
of the VM's case statement support, and it is thus left as is for now.