### PR TITLE
internal: less generic-expression workarounds

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1046,13 +1046,13 @@ type
     adVmGenCannotFindBreakTarget          # |       module. There should be a
     adVmGenNotUnused                      # |       way to cross-reference data
                                           # |       without introducing direct
-    adVmGenCannotGenerateCode             # |       import or type
+                                          # |       import or type
     adVmGenCannotEvaluateAtComptime       # |       dependencies. Likely this
                                           # |       involves data oriented
     adVmGenMissingImportcCompleteStruct   # |       design, use of handles and
     adVmGenCodeGenUnhandledMagic          # |       the like, along with
                                           # |       breaking up the coupling
-    adVmGenCodeGenUnexpectedSym           # |       within the `compiler/vm`
+                                          # |       within the `compiler/vm`
     adVmGenCannotImportc                  # |       package between pure VM and
     adVmGenTooLargeOffset                 # |       the VM for the compiler.
     adVmGenCannotCallMethod               # |
@@ -1064,14 +1064,12 @@ type
           adVmGenCannotFindBreakTarget:
         discard
       of adVmGenNotUnused,
-          adVmGenCannotGenerateCode,
           adVmGenCannotEvaluateAtComptime:
         ast*: PNode
       of adVmGenMissingImportcCompleteStruct,
           adVmGenCodeGenUnhandledMagic:
         magic*: TMagic
-      of adVmGenCodeGenUnexpectedSym,
-          adVmGenCannotImportc,
+      of adVmGenCannotImportc,
           adVmGenTooLargeOffset,
           adVmGenCannotCallMethod:
         sym*: PSym

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3968,22 +3968,16 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         kind: kind,
         location: some location,
         reportInst: diag.instLoc.toReportLineInfo)
-    of adVmGenCodeGenUnexpectedSym,
-        adVmGenCannotImportc,
+    of adVmGenCannotImportc,
         adVmGenCannotCallMethod,
         adVmGenTooLargeOffset:
       vmRep = VMReport(
-        str: case diag.vmGenErr.kind
-              of adVmGenCodeGenUnexpectedSym:
-                "Unexpected symbol for VM code - " & $diag.vmGenErr.sym.kind
-              else:
-                "",
+        str: "",
         sym: diag.vmGenErr.sym,
         location: some location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind)
     of adVmGenNotUnused,
-        adVmGenCannotGenerateCode,
         adVmGenCannotEvaluateAtComptime:
       vmRep = VMReport(
         ast: diag.vmGenErr.ast,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -421,9 +421,7 @@ func astDiagVmGenToLegacyReportKind*(
   of adVmGenCannotFindBreakTarget: rvmCannotFindBreakTarget
   of adVmGenNotUnused: rvmNotUnused
   of adVmGenTooLargeOffset: rvmTooLargetOffset
-  of adVmGenCannotGenerateCode: rvmCannotGenerateCode
   of adVmGenCodeGenUnhandledMagic: rvmCannotGenerateCode
-  of adVmGenCodeGenUnexpectedSym: rvmCannotGenerateCode
   of adVmGenCannotCast: rvmCannotCast
   of adVmGenCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of adVmGenCannotImportc: rvmCannotImportc

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -567,13 +567,11 @@ type
     vmGenDiagCannotFindBreakTarget
     # has ast data
     vmGenDiagNotUnused
-    vmGenDiagCannotGenerateCode
     vmGenDiagCannotEvaluateAtComptime
     # has magic data
     vmGenDiagMissingImportcCompleteStruct
     vmGenDiagCodeGenUnhandledMagic
     # has sym data
-    vmGenDiagCodeGenUnexpectedSym
     vmGenDiagCannotImportc
     vmGenDiagTooLargeOffset
     vmGenDiagCannotCallMethod
@@ -586,7 +584,7 @@ type
     #       diag construction functions -- see: `vmgen.fail`
 
   VmGenDiagKindSymRelated* =
-    range[vmGenDiagCodeGenUnexpectedSym..vmGenDiagCannotCallMethod]
+    range[vmGenDiagCannotImportc..vmGenDiagCannotCallMethod]
     # TODO: this is a somewhat silly type, the range allows creating type safe
     #       diag construction functions -- see: `vmgen.fail`
 
@@ -605,8 +603,7 @@ type
     location*: TLineInfo        ## diagnostic location
     instLoc*: InstantiationInfo ## instantiation in VM Gen's source
     case kind*: VmGenDiagKind
-      of vmGenDiagCodeGenUnexpectedSym,
-          vmGenDiagCannotImportc,
+      of vmGenDiagCannotImportc,
           vmGenDiagTooLargeOffset,
           vmGenDiagCannotCallMethod:
         sym*: PSym
@@ -616,7 +613,6 @@ type
           vmGenDiagCodeGenUnhandledMagic:
         magic*: TMagic
       of vmGenDiagNotUnused,
-          vmGenDiagCannotGenerateCode,
           vmGenDiagCannotEvaluateAtComptime:
         ast*: PNode
       of vmGenDiagTooManyRegistersRequired,

--- a/compiler/vm/vmlegacy.nim
+++ b/compiler/vm/vmlegacy.nim
@@ -24,9 +24,7 @@ func vmGenDiagToLegacyReportKind(diag: VmGenDiagKind): ReportKind {.inline.} =
   of vmGenDiagCannotFindBreakTarget: rvmCannotFindBreakTarget
   of vmGenDiagNotUnused: rvmNotUnused
   of vmGenDiagTooLargeOffset: rvmTooLargetOffset
-  of vmGenDiagCannotGenerateCode: rvmCannotGenerateCode
   of vmGenDiagCodeGenUnhandledMagic: rvmCannotGenerateCode
-  of vmGenDiagCodeGenUnexpectedSym: rvmCannotGenerateCode
   of vmGenDiagCannotCast: rvmCannotCast
   of vmGenDiagCannotEvaluateAtComptime: rvmCannotEvaluateAtComptime
   of vmGenDiagCannotImportc: rvmCannotImportc
@@ -57,22 +55,16 @@ func vmGenDiagToLegacyVmReport*(diag: VmGenDiag): VMReport {.inline.} =
         kind: kind,
         location: std_options.some diag.location,
         reportInst: diag.instLoc.toReportLineInfo)
-    of vmGenDiagCodeGenUnexpectedSym,
-        vmGenDiagCannotImportc,
+    of vmGenDiagCannotImportc,
         vmGenDiagCannotCallMethod,
         vmGenDiagTooLargeOffset:
       VMReport(
-        str: case diag.kind
-              of vmGenDiagCodeGenUnexpectedSym:
-                "Unexpected symbol for VM code - " & $diag.sym.kind
-              else:
-                "",
+        str: "",
         sym: diag.sym,
         location: std_options.some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind)
     of vmGenDiagNotUnused,
-        vmGenDiagCannotGenerateCode,
         vmGenDiagCannotEvaluateAtComptime:
       VMReport(
         ast: diag.ast,


### PR DESCRIPTION
## Summary

Prevent expressions-depending-on-unresolved-type-variables passed to
`tryConstExpr` from reaching into the compile-time evaluation machinery.
This allows for removing multiple workarounds from `mirgen` and `vmgen`.

## Details

Before `tryConstExpr` passes the expression to `evalConstExpr`, it now
first checks whether the expression either contains unresolved generic
parameters or is an unresolved type-parameter-lookup (e.g., `T.param`).
If either is the case, `nil` (which signals that the expression cannot
be evaluated at compile-time) is returned without passing the
expression to `evalConstExpr`.

While this approach is fundamentally also a workaround (expressions
containing unresolved generic parameters shouldn't be passed to
`tryConstExpr` in the first place), it at least prevents unresolved
expressions from reaching into `transf`, `mirgen`, and `vmgen`.

`mirgen` now doesn't have to push unresolved generic parameters or
type-parameter-lookups as `mnkLiteral`s through the MIR phase, and
`vmgen` doesn't have to special-case them. More generally, `vmgen` can
now treat unexpected nodes reaching it as a defect (via `unreachable`).

Since `vmGenDiagCodeGenUnexpectedSym` and `vmGenDiagCannotGenerateCode`
are now unused, they are, together with everything related to them,
removed.