### PR TITLE
semfold: fix conversion folding

### DIFF
--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -439,28 +439,26 @@ proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph; check = false): P
              PAstDiag(kind: adSemFoldRangeCheckForLiteralConversionFailed,
                       inputLit: a))
 
-  # if srcTyp.kind == tyUInt64 and "FFFFFF" in $n:
-  #   echo "n: ", n, " a: ", a
-  #   echo "from: ", srcTyp, " to: ", dstTyp, " check: ", check
-  #   echo getInt(a)
-  #   echo high(int64)
-  #   writeStackTrace()
+  const
+    IntegerLike = {tyInt..tyInt64, tyUInt..tyUInt64, tyChar}
+    FloatLike   = {tyFloat..tyFloat64}
+
   case dstTyp.kind
   of tyBool:
     case srcTyp.kind
-    of tyFloat..tyFloat64:
+    of FloatLike:
       result = newIntNodeT(toInt128(getFloat(a) != 0.0), n, idgen, g)
-    of tyChar, tyUInt..tyUInt64, tyInt..tyInt64:
+    of IntegerLike:
       result = newIntNodeT(toInt128(a.getOrdValue != 0), n, idgen, g)
     of tyBool, tyEnum: # xxx shouldn't we disallow `tyEnum`?
       result = a
       result.typ = n.typ
-    else: doAssert false, $srcTyp.kind
-  of tyInt..tyInt64, tyUInt..tyUInt64:
+    else: unreachable(srcTyp.kind)
+  of IntegerLike:
     case srcTyp.kind
-    of tyFloat..tyFloat64:
+    of FloatLike:
       result = newIntNodeT(toInt128(getFloat(a)), n, idgen, g)
-    of tyChar, tyUInt..tyUInt64, tyInt..tyInt64:
+    of IntegerLike, tyEnum, tyBool:
       let val = a.getOrdValue
       if check and not rangeCheck(n, val, g):
         result = rangeError(n, a, g)
@@ -469,21 +467,22 @@ proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph; check = false): P
         if dstTyp.kind in {tyUInt..tyUInt64}:
           result.transitionIntKind(nkUIntLit)
     else:
-      result = a
-      result.typ = n.typ
+      unreachable(srcTyp.kind)
     if check and result.kind in {nkCharLit..nkUInt64Lit} and
       not rangeCheck(n, getInt(result), g):
         result = rangeError(n, a, g)
-  of tyFloat..tyFloat64:
+  of FloatLike:
     case srcTyp.kind
-    of tyInt..tyInt64, tyEnum, tyBool, tyChar:
+    of IntegerLike, tyEnum, tyBool:
       result = newFloatNodeT(toFloat64(getOrdValue(a)), n, g)
+    of FloatLike:
+      result = newFloatNodeT(a.floatVal, n, g)
     else:
-      result = a
-      result.typ = n.typ
+      unreachable(srcTyp.kind)
   of tyOpenArray, tyVarargs, tyProc, tyPointer:
     discard
   else:
+    # FIXME: conversion-to-enum is missing checks
     result = a
     result.typ = n.typ
 

--- a/tests/lang_types/float/tfloats.nim
+++ b/tests/lang_types/float/tfloats.nim
@@ -151,9 +151,12 @@ template main =
         doAssert $x2 == "1.32"
       block:
         var x = 1.23456789012345'f32
-        when not defined(js): # knownIssue
-          doAssert x == 1.2345679'f32
-          doAssert $x == "1.2345679"
+        when nimvm:
+          discard # xxx, refs #12884
+        else:
+          when not defined(js):
+            doAssert x == 1.2345679'f32
+            doAssert $x == "1.2345679"
 
 static: main()
 main()

--- a/tests/lang_types/float/tfloats.nim
+++ b/tests/lang_types/float/tfloats.nim
@@ -144,22 +144,16 @@ template main =
         doAssert $(x0, x1, x2, x3) == "(1.32, 1.32, 1.32, 1.32)"
       block: # example https://github.com/nim-lang/Nim/issues/12884#issuecomment-564967962
         let x = float(1.32'f32)
-        when nimvm: discard # xxx prints 1.3
-        else:
-          when not defined(js):
-            doAssert $x == "1.3200000524520874"
+        doAssert $x == "1.32"
         doAssert $1.32 == "1.32"
         doAssert $1.32'f32 == "1.32"
         let x2 = 1.32'f32
         doAssert $x2 == "1.32"
       block:
         var x = 1.23456789012345'f32
-        when nimvm:
-          discard # xxx, refs #12884
-        else:
-          when not defined(js):
-            doAssert x == 1.2345679'f32
-            doAssert $x == "1.2345679"
+        when not defined(js): # knownIssue
+          doAssert x == 1.2345679'f32
+          doAssert $x == "1.2345679"
 
 static: main()
 main()

--- a/tests/misc/tconv.nim
+++ b/tests/misc/tconv.nim
@@ -11,6 +11,9 @@ reject:
     const x = int8(300)
 
 reject:
+    const x = char(high(int32))
+
+reject:
     const x = int64(NaN)
 
 type


### PR DESCRIPTION
## Summary

Make the logic handling folding of integer- and float-like conversion
more exhaustive and slightly simplify it. This fixes the internal issue
of literal-nodes having unexpected types, and it also fixes no range
error being reported at compile-time for some to-`char` conversion.

## Details

Folding conversions to integer, float, and bool types now considers all
valid source types, with unexpected types now being treated as a defect
instead of silently ignoring them. Named set constants are used for
this, with `tyChar` being included in the integer-like set, meaning that
to-`char` conversions are now properly subjected to range checks during
constant folding.

For the integer-like branch handling, the logic is simplified to only
perform the range check in a single place, and the unnecessary
transition-to-`nkUIntLit` removed (`newIntNodeType` already makes sure
that the node has the correct kind based on the type).

In general, this is a step towards the type of a literal-node matching
its kind. Both the C and VM code generator use the node kind for
deciding whether a float literal is a 32-bit or 64-bit one, so the
float-literal-nodes produced by constant folding now having the correct
kind fixes a bug where the emitted float literals had the wrong target-
language type (see the fixed test `tfloats.nim`).