### PR TITLE
jsgen: fix incorrect `float32`-literal behaviour

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -21,6 +21,9 @@ Check `mapType` for the details.
 """
 
 import
+  system/[
+    formatfloat
+  ],
   std/[
     sets,
     math,
@@ -49,9 +52,6 @@ import
     idioms,
     nversion,
     ropes
-  ],
-  compiler/sem/[
-    rodutils,
   ],
   compiler/backend/[
     ccgutils,
@@ -2449,7 +2449,11 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       r.res = rope"Infinity"
     of fcNegInf:
       r.res = rope"-Infinity"
-    else: r.res = rope(f.toStrMaxPrecision)
+    else:
+      if n.typ.skipTypes(abstractRange).kind == tyFloat32:
+        r.res.addFloatRoundtrip(f.float32)
+      else:
+        r.res.addFloatRoundtrip(f)
     r.kind = resExpr
   of nkCall:
     if isEmptyType(n.typ):

--- a/tests/lang_types/float/tfloats.nim
+++ b/tests/lang_types/float/tfloats.nim
@@ -154,12 +154,8 @@ template main =
         doAssert $x2 == "1.32"
       block:
         var x = 1.23456789012345'f32
-        when nimvm:
-          discard # xxx, refs #12884
-        else:
-          when not defined(js):
-            doAssert x == 1.2345679'f32
-            doAssert $x == "1.2345679"
+        doAssert x == 1.2345679'f32
+        doAssert $x == "1.2345679"
 
 static: main()
 main()


### PR DESCRIPTION
## Summary

Narrow the value of 32-bit float-literal nodes prior to rendering them,
which fixes `float32` literals having an unexpected run-time value
when their value as-written is not fully representable with the
precision of a 32-bit float.

## Details

Instead of using `toStrMaxPrecision`, which would add an unwanted `f`
suffix, rendering the float value to text is done by directly calling
`addFloatRoundtrip`, which `toStrMaxPrecision` uses internally.