### PR TITLE
codegen: introduce dedicated node kind for magics

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -44,8 +44,7 @@ template startBlock(p: BProc, start: FormatStr = "{$n",
 proc endBlock(p: BProc)
 
 proc loadInto(p: BProc, le, ri: CgNode, a: var TLoc) {.inline.} =
-  if ri.kind == cnkCall and (ri[0].kind != cnkSym or
-                             ri[0].sym.magic == mNone):
+  if ri.kind == cnkCall and getCalleeMagic(ri[0]) == mNone:
     genAsgnCall(p, le, ri, a)
   else:
     # this is a hacky way to fix #1181 (tmissingderef)::

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -577,7 +577,7 @@ proc initLocExpr(p: BProc, e: CgNode, result: var TLoc) =
 
 proc initLocExprSingleUse(p: BProc, e: CgNode, result: var TLoc) =
   initLoc(result, locNone, e, OnUnknown)
-  if e.kind == cnkCall and (e[0].kind != cnkSym or e[0].sym.magic == mNone):
+  if e.kind == cnkCall and getCalleeMagic(e[0]) == mNone:
     # We cannot check for tfNoSideEffect here because of mutable parameters.
     discard "bug #8202; enforce evaluation order for nested calls"
     # We may need to consider that 'f(g())' cannot be rewritten to 'tmp = g(); f(tmp)'

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -370,7 +370,7 @@ proc hash(n: ConstrTree): Hash =
     of cnkWithItems:
       for it in n.items:
         result = result !& hashTree(it)
-    of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt:
+    of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic:
       unreachable()
     result = !$result
 
@@ -399,7 +399,7 @@ proc `==`(a, b: ConstrTree): bool =
           for i in 0..<a.len:
             if not treesEquivalent(a[i], b[i]): return
           result = true
-      of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt:
+      of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic:
         # nodes that cannot appear in construction trees
         unreachable()
 

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -28,6 +28,8 @@ type
 
     cnkSym
     # future direction: split up ``cnkSym`` in the way the MIR does it
+    cnkMagic         ## name of a magic procedure. Only valid in the callee
+                     ## slot of ``cnkCall`` nodes
 
     cnkCall          ## a procedure call. The first operand is the procedure,
                      ## the following operands the arguments
@@ -131,7 +133,7 @@ type
 const
   AllKinds = {low(CgNodeKind)..high(CgNodeKind)}
 
-  cnkWithoutItems* = {cnkInvalid..cnkSym, cnkReturnStmt, cnkPragmaStmt}
+  cnkWithoutItems* = {cnkInvalid..cnkMagic, cnkReturnStmt, cnkPragmaStmt}
   cnkWithItems*    = AllKinds - cnkWithoutItems
 
   cnkLiterals* = {cnkIntLit, cnkUIntLit, cnkFloatLit, cnkStrLit}
@@ -151,6 +153,7 @@ type
     of cnkStrLit:     strVal*: string
     of cnkAstLit:     astLit*: PNode
     of cnkSym:        sym*: PSym
+    of cnkMagic:      magic*: TMagic
     of cnkPragmaStmt: pragma*: TSpecialWord
     of cnkWithItems:
       kids*: seq[CgNode]

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -133,7 +133,7 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
     if sfCursor in n.sym.flags:
       res.add "_cursor"
   of cnkMagic:
-    # cut of the 'm' prefix and use lower-case for the first character
+    # cut off the 'm' prefix and use lower-case for the first character
     var name = substr($n.magic, 1)
     name[0] = toLowerAscii(name[0])
     res.add name

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -47,6 +47,9 @@ proc treeRepr*(n: CgNode): string =
       result.add n.sym.name.s
       result.add " id: "
       result.add $n.sym.itemId
+    of cnkMagic:
+      result.add "magic: "
+      result.add $n.magic
     of cnkEmpty, cnkInvalid, cnkType, cnkAstLit, cnkNilLit, cnkReturnStmt:
       discard
     of cnkWithItems:
@@ -129,6 +132,11 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
     # highlight cursor locals
     if sfCursor in n.sym.flags:
       res.add "_cursor"
+  of cnkMagic:
+    # cut of the 'm' prefix and use lower-case for the first character
+    var name = substr($n.magic, 1)
+    name[0] = toLowerAscii(name[0])
+    res.add name
   of cnkType:
     if n.typ.sym != nil:
       res.add $n.typ

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1135,7 +1135,7 @@ proc genCheckedFieldOp(p: PProc, n: CgNode, takeAddr: bool, r: var TCompRes) =
   # nkCall to check if the discriminant is valid
   var checkExpr = n[1]
 
-  let negCheck = checkExpr[0].sym.magic == mNot
+  let negCheck = checkExpr[0].magic == mNot
   if negCheck:
     checkExpr = checkExpr[^1]
 
@@ -1882,7 +1882,7 @@ proc genJSArrayConstr(p: PProc, n: CgNode, r: var TCompRes) =
   r.res.add("]")
 
 proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
-  let op = n[0].sym.magic
+  let op = getCalleeMagic(n[0])
   case op
   of mAddI..mStrToStr: arith(p, n, r, op)
   of mRepr: genRepr(p, n, r)
@@ -2452,7 +2452,7 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkCall:
     if isEmptyType(n.typ):
       genLineDir(p, n)
-    if (n[0].kind == cnkSym) and (n[0].sym.magic != mNone):
+    if getCalleeMagic(n[0]) != mNone:
       genMagic(p, n, r)
     elif n[0].kind == cnkSym and sfInfixCall in n[0].sym.flags and
         n.len >= 1:
@@ -2523,8 +2523,8 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkTryStmt: genTry(p, n)
   of cnkRaiseStmt: genRaiseStmt(p, n)
   of cnkPragmaStmt: discard
-  of cnkInvalid, cnkRange, cnkBinding, cnkExcept, cnkFinally, cnkBranch,
-     cnkAstLit:
+  of cnkInvalid, cnkMagic, cnkRange, cnkBinding, cnkExcept, cnkFinally,
+     cnkBranch, cnkAstLit:
     internalError(p.config, n.info, "gen: unknown node type: " & $n.kind)
 
 proc newModule*(g: ModuleGraph; module: PSym): BModule =

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -29,7 +29,7 @@ block label:
       res = newStringOfCap(80)
       block label_1:
         while true:
-          if op(readLine(f, res)):
+          if not(readLine(f, res)):
             break
           block label_2:
             var x_cursor = res

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -18,13 +18,13 @@ var splat
 splat = splitFile(path)
 result = (
   :tmp = splat.dir
-  op(splat.dir)
+  wasMoved(splat.dir)
   :tmp,
   :tmp_1 = splat.name
-  op(splat.name)
+  wasMoved(splat.name)
   :tmp_1,
   :tmp_2 = splat.ext
-  op(splat.ext)
+  wasMoved(splat.ext)
   :tmp_2)
 =destroy(splat)
 -- end of expandArc ------------------------
@@ -52,9 +52,9 @@ var lnext
 var :tmp
 :tmp = (lresult, ";")
 lvalue = :tmp[0]
-op(:tmp[0])
+wasMoved(:tmp[0])
 lnext = :tmp[1]
-op(:tmp[1])
+wasMoved(:tmp[1])
 result.value = move(lvalue)
 =destroy(:tmp)
 =destroy_1(lnext)
@@ -69,10 +69,10 @@ var :tmp_2
 try:
   var it_cursor = x
   a = (
-    :tmp = op()
+    :tmp = default()
     =copy(:tmp, it_cursor.key)
     :tmp,
-    :tmp_1 = op()
+    :tmp_1 = default()
     =copy(:tmp_1, it_cursor.val)
     :tmp_1)
   echo([
@@ -94,7 +94,7 @@ try:
     var L = len(a_cursor)
     block label_1:
       while true:
-        if op(<(i, L)):
+        if not(<(i, L)):
           break
         block label_2:
           var splitted
@@ -124,14 +124,14 @@ try:
     var L = len(a_cursor)
     block label_1:
       while true:
-        if op(<(i, L)):
+        if not(<(i, L)):
           break
         block label_2:
           var :tmp_1
           var sym = a_cursor[i]
           addInterfaceDecl(c,
             var :tmp_2 = sym
-            :tmp_1 = op()
+            :tmp_1 = default()
             =copy_1(:tmp_1, :tmp_2)
             :tmp_1)
         inc(i, 1)
@@ -148,7 +148,7 @@ try:
       var :tmp
       par = [type node]((
         var :tmp_1 = this[].value
-        :tmp = op()
+        :tmp = default()
         =copy(:tmp, :tmp_1)
         :tmp, ""))
       break label
@@ -158,11 +158,11 @@ try:
     par = [type node]((parentDir(this[].value),
       :tmp_3 = splitPath(
         var :tmp_5 = this[].value
-        :tmp_2 = op()
+        :tmp_2 = default()
         =copy(:tmp_2, :tmp_5)
         :tmp_2)
       :tmp_4 = :tmp_3.tail
-      op(:tmp_3.tail)
+      wasMoved(:tmp_3.tail)
       :tmp_4))
     =destroy(:tmp_3)
   block label_1:

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -6,14 +6,14 @@ discard """
 var it_cursor = root
 block label:
   while true:
-    if op(not(==(it_cursor, nil))):
+    if not(not(==(it_cursor, nil))):
       break
     echo([it_cursor[].s])
     it_cursor = it_cursor[].ri
 var jt_cursor = root
 block label_1:
   while true:
-    if op(not(==(jt_cursor, nil))):
+    if not(not(==(jt_cursor, nil))):
       break
     var ri_1_cursor = jt_cursor[].ri
     echo([jt_cursor[].s])

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -28,7 +28,7 @@ try:
     var i = a_1
     block label_1:
       while true:
-        if op(<(i, b_1)):
+        if not(<(i, b_1)):
           break
         block label_2:
           var :tmp
@@ -36,7 +36,7 @@ try:
           if ==(i_1_cursor, 2):
             return
           add(a,
-            :tmp = op()
+            :tmp = default()
             =copy(:tmp, x)
             :tmp)
           inc(i, 1)
@@ -45,13 +45,13 @@ try:
       var :tmp_1
       add(a,
         :tmp_1 = x
-        op(x)
+        wasMoved(x)
         :tmp_1)
       break label_3
     var :tmp_2
     add(b,
       :tmp_2 = x
-      op(x)
+      wasMoved(x)
       :tmp_2)
 finally:
   =destroy(x)


### PR DESCRIPTION
## Summary

Add the `cnkMagic` node kind, which is meant for referencing magic
procedures,  and integrate it into the code generators. References
to magic procedures that don't use symbols during the MIR phase (i.e.,
`mnkMagic` nodes) don't require the creation of a `PSym` in `cgirgen`
now.

For compatibility with the existing implementation, the `magic` field
of symbols is still inspected during code generation, but the direction
is to have only `cnkMagic` mean "magic procedure" in the code
generators.

## Details

In the code generators, all manual `TSym.magic` lookups, outside of type
contexts, are replaced with calls to either `compat.getMagic` or the new
`compat.getCalleeMagic`. Both procedures consider both `cnkSym` and
`cnkMagic` nodes.

An internal problem that the new node fixes is "improper symbols"
reaching the code generators: a symbol created via `createMagic` is
missing much of what is need for a proper procedure symbol, such as a
type, associated AST, owner, etc. -- with `mnkMagic`, these symbols are
no longer created.

As a side-effect, `render` now uses the enum name for magic-procedure
references using `cnkMagic`; the tests using `--expandArc` are adjusted
to account for this.