### PR TITLE
codegen: lower `swap` via a MIR pass

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1379,23 +1379,6 @@ proc makeAddr(n: CgNode; idgen: IdGenerator): CgNode =
 proc genSetLengthStr(p: BProc, e: CgNode, d: var TLoc) =
   binaryStmtAddr(p, e, d, "setLengthStrV2")
 
-proc genSwap(p: BProc, e: CgNode, d: var TLoc) =
-  # swap(a, b) -->
-  # temp = a
-  # a = b
-  # b = temp
-  var a, b, tmp: TLoc
-  getTemp(p, skipTypes(e[1].typ, abstractVar), tmp)
-  initLoc(a, locNone, e[1], OnUnknown)
-  initLoc(b, locNone, e[2], OnUnknown)
-  a.flags.incl lfPrepareForMutation
-  b.flags.incl lfPrepareForMutation
-  expr(p, e[1], a) # eval a
-  expr(p, e[2], b) # eval b
-  genAssignment(p, tmp, a)
-  genAssignment(p, a, b)
-  genAssignment(p, b, tmp)
-
 proc rdSetElemLoc(conf: ConfigRef; a: TLoc, typ: PType): Rope =
   # read a location of an set element; it may need a subtraction operation
   # before the set operation
@@ -1776,7 +1759,6 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   of mAddI..mPred: binaryArithOverflow(p, e, d, op)
   of mGetTypeInfo: genGetTypeInfo(p, e, d)
   of mGetTypeInfoV2: genGetTypeInfoV2(p, e, d)
-  of mSwap: genSwap(p, e, d)
   of mInc, mDec:
     const opr: array[mInc..mDec, string] = ["+=", "-="]
     const fun64: array[mInc..mDec, string] = ["nimAddInt64", "nimSubInt64"]

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1067,20 +1067,6 @@ proc genFastAsgn(p: PProc, n: CgNode) =
   let noCopy = n[0].typ.skipTypes(abstractInst).kind in {tySequence, tyString}
   genAsgnAux(p, n[0], n[1], noCopyNeeded=noCopy)
 
-proc genSwap(p: PProc, n: CgNode) =
-  var a, b: TCompRes
-  gen(p, n[1], a)
-  gen(p, n[2], b)
-  var tmp = p.getTemp(false)
-  if mapType(skipTypes(n[1].typ, abstractVar)) == etyBaseIndex:
-    let tmp2 = p.getTemp(false)
-    p.config.internalAssert(a.typ == etyBaseIndex and b.typ == etyBaseIndex, n.info, "genSwap")
-    lineF(p, "var $1 = $2; $2 = $3; $3 = $1;$n",
-             [tmp, a.address, b.address])
-    tmp = tmp2
-  lineF(p, "var $1 = $2; $2 = $3; $3 = $1;",
-           [tmp, a.res, b.res])
-
 proc getFieldPosition(p: PProc; f: CgNode): int =
   case f.kind
   of cnkIntLit: result = int(f.intVal)
@@ -1886,7 +1872,6 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
   case op
   of mAddI..mStrToStr: arith(p, n, r, op)
   of mRepr: genRepr(p, n, r)
-  of mSwap: genSwap(p, n)
   of mAppendStrCh:
     binaryExpr(p, n, r, "addChar",
         "addChar($1, $2);")

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -345,6 +345,9 @@ func magic*(m: TMagic, typ: PType; n: PNode = nil): MirNode {.inline.} =
 template endNode*(k: MirNodeKind): MirNode =
   MirNode(kind: mnkEnd, start: k)
 
+func opParamNode*(index: uint32, typ: PType): MirNode {.inline.} =
+  MirNode(kind: mnkOpParam, typ: typ, param: index)
+
 # --------- tree generation utilities:
 
 template subTree*(tree: var MirTree, n: MirNode, body: untyped) =

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -148,7 +148,7 @@ iterator search(tree: MirTree, kinds: static set[MirNodeKind]): NodePosition =
     inc i
 
 iterator search(tree: MirTree, magic: static TMagic): NodePosition =
-  ## Returns in order appearance the positions of all ``mnkMagic`` nodes
+  ## Returns in appearance order the positions of all ``mnkMagic`` nodes
   ## that match `magic`.
   var i = 0
   while i < tree.len:

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -147,6 +147,15 @@ iterator search(tree: MirTree, kinds: static set[MirNodeKind]): NodePosition =
       yield NodePosition(i)
     inc i
 
+iterator search(tree: MirTree, magic: static TMagic): NodePosition =
+  ## Returns in order appearance the positions of all ``mnkMagic`` nodes
+  ## that match `magic`.
+  var i = 0
+  while i < tree.len:
+    if tree[i].kind == mnkMagic and tree[i].magic == magic:
+      yield NodePosition(i)
+    inc i
+
 iterator uses(tree: MirTree, start, last: NodePosition): OpValue =
   ## Returns in an unspecified order all values used for reads/writes
   ## in the code range ``start..last``. Tags are already skipped.
@@ -478,6 +487,38 @@ proc fixupCallArguments(tree: MirTree, config: ConfigRef,
       of AllNodeKinds - ArgumentNodes:
         unreachable()
 
+proc lowerSwap(tree: MirTree, changes: var Changeset) =
+  ## Lowers a ``swap(a, b)`` call into:
+  ##
+  ## ..code-block:: nim
+  ##
+  ##   let tmp = a
+  ##   a = b
+  ##   b = tmp
+  ##
+  ## where all assignments are shallow.
+  for i in search(tree, mSwap):
+    let
+      typ = tree[operand(tree, Operation i, 0)].typ
+      temp = MirNode(kind: mnkTemp, typ: typ, temp: changes.getTemp())
+    changes.seek(i)
+    changes.replaceMulti(buf):
+      buf.subTree MirNode(kind: mnkRegion):
+        # the temporary doesn't need to own the value, so use ``DefCursor``
+        buf.add opParamNode(0, typ)
+        buf.subTree MirNode(kind: mnkDefCursor):
+          buf.add temp
+        # we're just swapping the values, no full copy is needed
+        argBlock(buf):
+          chain(buf): opParam(0, typ) => tag(ekReassign) => name()
+          chain(buf): opParam(1, typ) => arg()
+        buf.add MirNode(kind: mnkFastAsgn)
+        argBlock(buf):
+          chain(buf): opParam(1, typ) => tag(ekReassign) => name()
+          chain(buf): emit(temp) => arg()
+        buf.add MirNode(kind: mnkFastAsgn)
+    changes.remove() # remove the 'void' sink
+
 proc applyPasses*(tree: var MirTree, source: var SourceMap, prc: PSym,
                   config: ConfigRef, target: TargetBackend) =
   ## Applies all applicable MIR passes to the body (`tree` and `source`) of
@@ -499,3 +540,6 @@ proc applyPasses*(tree: var MirTree, source: var SourceMap, prc: PSym,
       # XXX: use the fixup pass for all targets. Both the VM and JavaScript
       #      targets are also affected
       fixupCallArguments(tree, config, c)
+
+  batch:
+    lowerSwap(tree, c)

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -617,9 +617,6 @@ func undoConversions(buf: var MirNodeSeq, tree: MirTree, src: OpValue) =
     p = previous(tree, p)
     buf.add MirNode(kind: mnkConv, typ: tree[p].typ)
 
-func opParamNode(index: uint32, typ: PType): MirNode {.inline.} =
-  MirNode(kind: mnkOpParam, typ: typ, param: index)
-
 template voidCallWithArgs(buf: var MirNodeSeq, body: untyped) =
   argBlock(buf):
     body

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -29,6 +29,7 @@ import
   compiler/mir/[
     mirbridge,
     mirgen,
+    mirpasses,
     mirtrees,
     sourcemaps,
   ],
@@ -190,6 +191,7 @@ proc genStmt*(jit: var JitState, c: var TCtx; n: PNode): VmGenResult =
   # `n` is expected to have been put through ``transf`` already
   var (tree, sourceMap) = generateMirCode(c, n, isStmt = true)
   discoverGlobalsAndRewrite(jit.discovery, tree, sourceMap)
+  applyPasses(tree, sourceMap, c.module, c.config, targetVm)
   discoverFrom(jit.discovery, MagicsToKeep, tree)
   register(c, jit.discovery)
 
@@ -225,6 +227,7 @@ proc genExpr*(jit: var JitState, c: var TCtx, n: PNode): VmGenResult =
   #
   #     If `c` is defined at the top-level, then `x` is a "global" variable
   discoverGlobalsAndRewrite(jit.discovery, tree, sourceMap)
+  applyPasses(tree, sourceMap, c.module, c.config, targetVm)
   discoverFrom(jit.discovery, MagicsToKeep, tree)
   register(c, jit.discovery)
 
@@ -264,6 +267,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   #      to be decided how lifted globals should work in compile-time and
   #      interpreted contexts
   discoverGlobalsAndRewrite(jit.discovery, tree, sourceMap)
+  applyPasses(tree, sourceMap, s, c.config, targetVm)
   discoverFrom(jit.discovery, MagicsToKeep, tree)
   register(c, jit.discovery)
 

--- a/tests/magics/tswap.nim
+++ b/tests/magics/tswap.nim
@@ -1,5 +1,6 @@
 discard """
-  targets: "vm"
+  targets: "c js vm"
+  description: "Tests for the `swap` magic"
 """
 
 # https://github.com/nim-lang/nim/issues/2946

--- a/tests/stdlib/strings/tdouble_evaluation_bug.nim
+++ b/tests/stdlib/strings/tdouble_evaluation_bug.nim
@@ -1,13 +1,10 @@
 discard """
-  targets: "c !js vm"
+  targets: "c js vm"
   description: '''
     Regression test for a double-evaluation bug involving assignment to or
     creating view of string characters
   '''
 """
-
-# knownIssue: double evaluation bug with arguments to ``swap`` when using
-# the JavaScript backend
 
 block:
   # for a string access used as the argument to a ``swap`` call, the string


### PR DESCRIPTION
## Summary

Implement the lowering of `swap` as a MIR pass instead of directly in
each code generator. This removes the amount of code duplication in the
compiler and fixes a double-evaluation bug for call-expression `swap`
operands when using the JS backend.

MIR passes are now also applied for code run at compile time.

## Details

The MIR passes were previously not applied to code processed by `vmjit`
(compile-time code NimScript execution), which is fixed now.

To be able to efficiently detect and lower the call with a MIR pass,
`mSwap` is transformed into the MIR magic call representation (which
uses `mnkMagic` instead of `mnkCall`). The lowering pass then only has
to search for the `mnkMagic` node and replace it.

Implementation-wise, a `swap` call is lowered into shallow assignments
(`mnkFastAsgn`). For the C target, the code that is later generated
stays the same; for the VM target, the efficiency slightly increases for
operands that aren't locals; and for the JS target, efficiency regresses
for operands of aggregate types. The latter is the case because the
JavaScript code generator currently ignores shallow assignments
(`cnkFastAsgn`) and performs full copies.