### PR TITLE
testament: decouple production of `TestRun`s

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -548,6 +548,7 @@ proc processCategory(r: var TResults, cat: Category, targets: set[TTarget],
   else:
     var testsRun = 0
     var files: seq[string]
+    var runs: seq[TestRun]
     for file in walkDirRec(testsDir &.? cat.string):
       if isTestFile(file): files.add file
     files.sort # give reproducible order
@@ -563,7 +564,9 @@ proc processCategory(r: var TResults, cat: Category, targets: set[TTarget],
         discard "run the test"
       else:
         res = reJoined
-      testSpec r, test, res
+      produceRuns r, test, res, runs
+      run(r, runs)
+      runs.setLen(0) # prepare for the next test
       inc testsRun
     if testsRun == 0:
       const allowedDirs = ["deps", "htmldocs", "pkgs"]


### PR DESCRIPTION
## Summary

Separate production of test-run descriptions (`TestRun`) from actually
executing them, which slightly flattens the call hierarchy and
makes it easier to pass additional configuration state to execution.

## Details

Instead of directly executing the runs, `testSpec` (which is renamed to
`produceRuns`) appends the descriptions to a provided list, leaving
how to execute the runs to the callsite. The `testSpecWithNimcache`
routine is only used with custom categories, where sequential execution
is, in most cases, required, so it still executes the runs directly.

The new `run` procedure takes a slice of tests runs and executes them.
Both the legacy `testSpec` overload and `processCategory` use it for
executing the runs produced by `produceRuns`.

In theory, it is now possible to first collect the runs for all non-
special-category tests before executing any of them.