### PR TITLE
fix(typeops): do not copy non-existent type fields

### DIFF
--- a/tests/lang_objects/destructor/ttypeops_misc.nim
+++ b/tests/lang_objects/destructor/ttypeops_misc.nim
@@ -1,0 +1,18 @@
+discard """
+"""
+
+block ensure_lifting_is_not_confused_by_type_wrappers:
+  ## previously this led to a code gen bug where a non-existent hidden type
+  ## field was being copied. the various wrappers alias/distinct weren't being
+  ## skipped when testing to see if the underlying type was an object.
+  type
+    Object = object
+      x: string # force `Object` to require lifetime hooks
+    Alias = Object
+    Distinct = distinct Alias
+
+  proc test(y: Distinct) =
+    var x = y
+    discard (addr x) # prevent `x` being turned into a cursor
+
+  test(default(Distinct))

--- a/tests/lang_objects/destructor/ttypeops_misc.nim
+++ b/tests/lang_objects/destructor/ttypeops_misc.nim
@@ -5,9 +5,15 @@ block ensure_lifting_is_not_confused_by_type_wrappers:
   ## previously this led to a code gen bug where a non-existent hidden type
   ## field was being copied. the various wrappers alias/distinct weren't being
   ## skipped when testing to see if the underlying type was an object.
+  type WithHooks = object
+
+  proc `=destroy`(x: var WithHooks) =
+    # force `WithHooks` to require lifetime hooks
+    discard
+
   type
     Object = object
-      x: string # force `Object` to require lifetime hooks
+      x: WithHooks # make sure that `Object` gets a synthesized copy hook
     Alias = Object
     Distinct = distinct Alias
 


### PR DESCRIPTION
## Summary

During liftdestructors, do not produce hidden type field copies for
types without such fields, preventing invalid code from being generated.

## Details

`liftdestructors` produces symbols as it proceeds via `produceSym`. This
procedure not only produces a symbol, but ensures it's initialized,
type operations ("destructors") are attached, and necessary ops called.
One such operation is copying of the hidden type field for objects types
that have them.

This latter opertation was guarded by `isObjLackingTypeField` that
expects any type passed to it be unwrapped (i.e. removing `tyDistinct`,
`tyAlias`, etc). That wasn't the case and so `liftdestructors` was
producing copy operations for hidden type fields that didn't exist. Now
the type passed to `isObjLackingTypeField` is first unwrapped.

A test, `ttypeops_misc`, has also been added for this (contributed by
@zerbina).