### PR TITLE
koch: fix crash in `koch.py`

### DIFF
--- a/koch.py
+++ b/koch.py
@@ -47,7 +47,7 @@ def run(*args: Any, cwd: Optional[Path] = None, replace=False) -> None:
     print("Running:", run_args, flush=True)
     completed = subprocess.run(run_args, check=(not replace), cwd=cwd)
     if replace:
-        quit(completed.returncode)
+        sys.exit(completed.returncode)
 
 
 def capture(*args: Any) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary

Don't rely on the presence of the `site` module by using `quit` -- use
`sys.exit` instead. This fixes the script not exiting gracefully when
the used python environment doesn't provide the `site` module.