### PR TITLE
testament: support per-target `knownIssue`s

### DIFF
--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -127,7 +127,16 @@ Test execution options
 
 - ``knownIssue`` description of the test that currently fails but should
   execute successfully; it is a known bug that must be fixed in the future.
-  Can be used several times in specification.
+  Can be used several times in specification. One can also specify the
+  affected targets.
+
+  .. code-block:: nim
+
+    knownIssue.vm: "..."   # the test only fails with the vm target
+    knownIssue.c js: "..." # the fails with both the c and js target
+
+  A standalone ``knownIssue`` key means that all selected targets are
+  affected by the issue(s).
 
 Compiler output assertions
 --------------------------

--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -133,7 +133,7 @@ Test execution options
   .. code-block:: nim
 
     knownIssue.vm: "..."   # the test only fails with the vm target
-    knownIssue.c js: "..." # the fails with both the c and js target
+    knownIssue.c js: "..." # fails with both the c and js target
 
   A standalone ``knownIssue`` key means that all selected targets are
   affected by the issue(s).

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -1063,22 +1063,20 @@ proc testSpecHelper(r: var TResults, run: var TestRun) =
   r.addResult(run, res.expected, res.given, res.success,
               addr given, res.compare)
 
-proc targetHelper(r: var TResults, run: var TestRun) =
-  inc(r.total)
-  if run.target notin gTargets:
-    r.addResult(run, "", "", reDisabled)
-    inc(r.skipped)
-  elif simulate:
-    inc count
-    msg Undefined: "testSpec count: " & $count & " expected: " & $run.expected
-  else:
-    testSpecHelper(r, run)
-
 proc run(r: var TResults, runs: var openArray[TestRun]) =
   ## Executes the given `runs`.
   for run in runs.mitems:
     run.startTime = epochTime()
-    targetHelper(r, run)
+    inc(r.total)
+    # XXX: remove the usage of globals here
+    if run.target notin gTargets:
+      r.addResult(run, "", "", reDisabled)
+      inc(r.skipped)
+    elif simulate:
+      inc count
+      msg Undefined: "testSpec count: " & $count & " expected: " & $run.expected
+    else:
+      testSpecHelper(r, run)
 
 func nativeTarget(): TTarget {.inline.} =
   targetC

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -592,7 +592,7 @@ proc addResult(
       debugInfo: run.debugInfo,
       outCompare: outCompare,
       success: success,
-      knownIssues: if isNil(output): @[] else: run.test.spec.knownIssues,
+      knownIssues: run.test.spec.knownIssues[run.target],
       inCurrentBatch: run.test.inCurrentBatch,
       expected: expected,
       given: given
@@ -603,7 +603,7 @@ proc addResult(
 proc addResult(r: var TResults, test: TTest, reason: TResultEnum) =
   ## Report test failure/skip etc to backend, end user (write to command-line)
   ## and so on.
-  const allowedTestStatus = {reInvalidSpec, reDisabled, reKnownIssue, reJoined}
+  const allowedTestStatus = {reInvalidSpec, reDisabled, reJoined}
   doAssert reason in allowedTestStatus,
            "Test: $1 with status: $2, should have ran" %
               [test.getName(), $reason]
@@ -611,7 +611,6 @@ proc addResult(r: var TResults, test: TTest, reason: TResultEnum) =
     given =
       case reason
       of reInvalidSpec: test.spec.parseErrors
-      of reKnownIssue: test.spec.knownIssues.join("\n")
       else: ""
     param = ReportParams(
       duration: epochTime() - test.startTime,
@@ -623,7 +622,7 @@ proc addResult(r: var TResults, test: TTest, reason: TResultEnum) =
       debugInfo: "",
       success: reason,
       inCurrentBatch: test.inCurrentBatch,
-      knownIssues: test.spec.knownIssues,
+      knownIssues: @[],
       expected: "",
       given: given,
       outCompare: nil
@@ -1043,7 +1042,7 @@ proc testSpecHelper(r: var TResults, run: var TestRun) =
     if timeout > 0.0 and duration > timeout:
       res.success = reTimeout
 
-  if run.expected.knownIssues.len > 0:
+  if run.expected.knownIssues[run.target].len > 0:
     # the test has known issue(s) and is expected to fail
     if res.success == reSuccess:
       # it didn't fail
@@ -1063,7 +1062,7 @@ proc testSpecHelper(r: var TResults, run: var TestRun) =
   r.addResult(run, res.expected, res.given, res.success,
               addr given, res.compare)
 
-proc run(r: var TResults, runs: var openArray[TestRun]) =
+proc run(r: var TResults, runs: var openArray[TestRun], runKnownIssues: bool) =
   ## Executes the given `runs`.
   for run in runs.mitems:
     run.startTime = epochTime()
@@ -1071,6 +1070,10 @@ proc run(r: var TResults, runs: var openArray[TestRun]) =
     # XXX: remove the usage of globals here
     if run.target notin gTargets:
       r.addResult(run, "", "", reDisabled)
+      inc(r.skipped)
+    elif run.expected.knownIssues[run.target].len > 0 and not runKnownIssues:
+      # tests with known issues are not tried
+      r.addResult(run, "", "", reKnownIssue)
       inc(r.skipped)
     elif simulate:
       inc count
@@ -1116,8 +1119,6 @@ proc computeEarly(spec: TSpec, inCurrentBatch: bool): TResultEnum =
     reDisabled # manually skipped
   elif not inCurrentBatch:
     reDisabled
-  elif spec.knownIssues.len > 0:
-    reKnownIssue
   else:
     reSuccess
 
@@ -1166,7 +1167,7 @@ proc testSpec(r: var TResults, test: TTest) =
   let res = computeEarly(test.spec, test.inCurrentBatch)
   var runs: seq[TestRun]
   produceRuns r, test, res, runs
-  run(r, runs)
+  run(r, runs, false)
 
 proc testSpecWithNimcache(
     r: var TResults, test: TTest; nimcache: string) {.used.} =

--- a/tests/lang_callable/closure/tinfer_closure_for_nestedproc.nim
+++ b/tests/lang_callable/closure/tinfer_closure_for_nestedproc.nim
@@ -1,10 +1,10 @@
 discard """
   action: compile
-  target: "!vm"
+  knownIssue.vm: '''
+    The `strtabs` module imports the ``std/os`` module, which isn't
+    yet supported for the VM target
+  '''
 """
-
-# knownIssue: the `strtabs` module imports the ``std/os`` module, which isn't
-#             yet supported for the VM target
 
 # bug #9441
 import std/strtabs

--- a/tests/lang_callable/generics/tobjecttyperel.nim
+++ b/tests/lang_callable/generics/tobjecttyperel.nim
@@ -1,5 +1,8 @@
 discard """
-  target: "!vm"
+  knownIssue.vm: '''
+    Fails for the VM target because ``cgirgen`` emits the incorrect conversion
+    operator for ``ref`` types involving generics.
+  '''
   output: '''(peel: 0, color: 15)
 (color: 15)
 17
@@ -8,10 +11,6 @@ discard """
 cool
 test'''
 """
-
-# knownIssue: fails for the VM target because ``cgirgen`` emits the
-#             incorrect conversion operator for ``ref`` types involving
-#             generics
 
 # bug #5241
 type

--- a/tests/lang_callable/generics/treentranttypes.nim
+++ b/tests/lang_callable/generics/treentranttypes.nim
@@ -1,5 +1,5 @@
 discard """
-target: "!vm"
+knownIssue.vm: '''"same" output but float formatting is off'''
 output: '''
 (10, ("test", 1.2))
 3x3 Matrix [[0.0, 2.0, 3.0], [2.0, 0.0, 5.0], [2.0, 0.0, 5.0]]
@@ -16,8 +16,6 @@ output: '''
 @[1, 2]@[3, 4]
 '''
 """
-
-# disabled on VM: "same" output but float formatting is off (knownIssue)
 
 # https://github.com/nim-lang/Nim/issues/5962
 

--- a/tests/lang_callable/method/tmultim.nim
+++ b/tests/lang_callable/method/tmultim.nim
@@ -1,5 +1,8 @@
 discard """
-  target: "!vm"
+  knownIssue.vm: '''
+    The ``of`` operator only considers the static type when using the
+    VM backend
+  '''
   joinable: false
   output: '''
 collide: unit, thing
@@ -12,9 +15,6 @@ collide: thing, unit |
 do nothing
 '''
 """
-
-# knownIssue: the ``of`` operator only considers the static type when using
-#             the VM backend
 
 # tmultim2
 type

--- a/tests/lang_callable/template/template_issues.nim
+++ b/tests/lang_callable/template/template_issues.nim
@@ -1,5 +1,5 @@
 discard """
-target: "!vm"
+knownIssue.vm: true
 output: '''
 0
 a
@@ -11,8 +11,6 @@ false
 true
 '''
 """
-
-# VM disabled: needs a deeper dive (knownIssue)
 
 import std/[macros, json]
 

--- a/tests/lang_callable/template/template_various.nim
+++ b/tests/lang_callable/template/template_various.nim
@@ -1,5 +1,5 @@
 discard """
-target: "!vm"
+knownIssue.vm: "std/streams and/or std/os don't work for the VM"
 output: '''
 i2416
 33
@@ -34,8 +34,6 @@ bar7
 -1-1-1
 '''
 """
-
-# disabled on VM: std/streams and/or std/os don't work for the VM (knownIssue)
 
 import std/macros
 

--- a/tests/lang_experimental/views/tprocedural_views.nim
+++ b/tests/lang_experimental/views/tprocedural_views.nim
@@ -1,13 +1,14 @@
 discard """
-  targets: "c js !vm"
+  targets: "c js vm"
   description: '''
     Tests for indirect calls where the callee is an expression evaluating to a
     view
   '''
+  knownIssue.vm: '''
+    Semantic analysis produces incorrect AST for tuple initialization, causing
+    VM access violation errors at run-time
+  '''
 """
-
-# knownIssue: semantic analysis produces incorrect AST for tuple initialization,
-#             causing VM access violation errors at run-time
 
 {.experimental: "views".}
 

--- a/tests/lang_experimental/views/tviews_in_object.nim
+++ b/tests/lang_experimental/views/tviews_in_object.nim
@@ -1,13 +1,12 @@
 discard """
-  targets: "c !js vm"
+  targets: "c js vm"
   matrix: "--experimental:views"
   description: '''
     Tests for direct single-location views used as the type of
     object fields. Only read access is tested here.
   '''
+  knownIssue.js: "multiple problems with the JavaScript code generator"
 """
-
-# knownIssue: multiple problems with the JavaScript code generator
 
 # note: all the tests here are run in the context of procedures; tests for
 # views in the context of top-level code should go elsewhere

--- a/tests/lang_objects/destructor/tlvalue_conversions.nim
+++ b/tests/lang_objects/destructor/tlvalue_conversions.nim
@@ -3,11 +3,10 @@ discard """
     Tests for assignments of types with lifetime hooks where l-value
     conversions are involved
   '''
-  targets: "c !js !vm"
+  targets: "c js vm"
   matrix: "--gc:arc --cursorInference:off"
+  knownIssue.js vm: "`--gc:arc` is not supported"
 """
-
-# knownIssues: both the JS and VM target don't yet support ``--gc:arc``:option:
 
 import mhelper
 

--- a/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
+++ b/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
@@ -1,13 +1,14 @@
 discard """
-  targets: "c !js vm"
+  targets: "c js vm"
   description: '''
     Ensures that case statements work with uint operands and of-branch values
     not representable with the same-sized signed integer type
   '''
+  knownIssue.js: '''
+    Compiles correctly for JS, but doesn't work at run-time because
+    of the improper large integer support
+  '''
 """
-
-# knownIssue: compiles correctly for JS, but doesn't work at run-time because
-#             of the improper large integer support
 
 proc test[T: uint64|uint; S]() =
   const Border = T(high(S)) # the highest possible signed integer value

--- a/tests/lang_stmts/for_stmt/tforloop_tuple_unpacking.nim
+++ b/tests/lang_stmts/for_stmt/tforloop_tuple_unpacking.nim
@@ -1,9 +1,8 @@
 discard """
   description: "Tests for tuple unpacking done by for-loops"
-  targets: "c !js vm"
+  targets: "c js vm"
+  knownIssue.js: "fails for the JS back-end with an internal compiler error"
 """
-
-# knownIssue: fails for the JS back-end with an internal compiler error
 
 type
   Tup = tuple

--- a/tests/lang_types/sink/tmove_from_lvalue_conversion.nim
+++ b/tests/lang_types/sink/tmove_from_lvalue_conversion.nim
@@ -1,14 +1,15 @@
 discard """
-  targets: "c !js !vm"
+  targets: "c js vm"
   matrix: "--gc:orc"
   description: '''
     Destrutively moving from an up- or down converted `ref` value passed as a
     `sink` parameter must work
   '''
+  knownIssue.js vm: '''
+    Destructor-using refs (read, arc/orc support) are not yet implemented for
+    the JS/VM
+  '''
 """
-
-# knownIssue: destructor-using refs (read, arc/orc support) are not yet
-#             implemented for the JS/VM target
 
 type
   A = object of RootObj

--- a/tests/lang_types/var/tvar_arguments.nim
+++ b/tests/lang_types/var/tvar_arguments.nim
@@ -8,8 +8,6 @@ discard """
   '''
 """
 
-# knownIssue: ``vmgen`` generates incorrect code in some cases
-
 template disableIf(cond: bool, body: untyped) =
   when defined(tryBrokenSpecification) or not cond:
     body

--- a/tests/misc/tfield_defect_message.nim
+++ b/tests/misc/tfield_defect_message.nim
@@ -1,10 +1,12 @@
 discard """
-  targets: "c js !vm"
+  targets: "c js vm"
   description: "Tests for ensuring that ``FieldDefect``'s messages are correct"
+  knownIssue.vm: '''
+    ``FieldDefect``s are not currently catchable with the VM target,
+    not even for debugging purposes
+  '''
 """
 
-# knownIssue: ``FieldDefect``s are not currently catchable with the VM target,
-#             not even for debugging purposes
 
 type
   Enum = enum

--- a/tests/misc/tnumeric_conversions.nim
+++ b/tests/misc/tnumeric_conversions.nim
@@ -1,9 +1,8 @@
 discard """
-  targets: "c !js vm"
+  targets: "c js vm"
   description: "Tests for conversion between the primitive numeric types"
+  knownIssue.js: "full-range integers aren't supported yet"
 """
-
-# knownIssue: the JavaScript target doesn't yet support full-range integers
 
 block negative_float64_to_uint:
   # has the same result as converting to a signed int of the same width first,

--- a/tests/overflw/toverflw.nim
+++ b/tests/overflw/toverflw.nim
@@ -1,12 +1,10 @@
 discard """
   output: "ok"
-  targets: "c js !vm"
+  targets: "c js vm"
   matrix: "--overflowchecks:off"
   description: "Test the ability to detect overflows"
+  knownIssue.vm: "bound checks are always performed"
 """
-
-# knownIssue: when using the VM backend, bound checks are currently always
-#             performed
 
 {.push overflowChecks: on.}
 

--- a/tests/stdlib/algorithm/tsequtils.nim
+++ b/tests/stdlib/algorithm/tsequtils.nim
@@ -1,8 +1,7 @@
 discard """
-  targets: "c js !vm"
+  targets: "c js vm"
+  knownIssue.vm: "internal VM crash at run-time"
 """
-
-# knownIssue: disable for the VM due to an internal VM crash at run-time. Needs to be investigated further
 
 # xxx move all tests under `main`
 import std/[sequtils, strutils]

--- a/tests/stdlib/strings/tdouble_evaluation_bug.nim
+++ b/tests/stdlib/strings/tdouble_evaluation_bug.nim
@@ -1,13 +1,13 @@
 discard """
-  targets: "c !js vm"
+  targets: "c js vm"
   description: '''
     Regression test for a double-evaluation bug involving assignment to or
     creating view of string characters
   '''
+  knownIssue.js: '''
+    double evaluation bug with arguments to ``swap``
+  '''
 """
-
-# knownIssue: double evaluation bug with arguments to ``swap`` when using
-# the JavaScript backend
 
 block:
   # for a string access used as the argument to a ``swap`` call, the string

--- a/tests/stdlib/types/sets/trange_crosses_int64_bounds.nim
+++ b/tests/stdlib/types/sets/trange_crosses_int64_bounds.nim
@@ -1,13 +1,14 @@
 discard """
-  targets: "c vm !js"
+  targets: "c vm js"
   description: '''
     Test the `incl`, `contains`, and set construction operation for sets where
     the element range crosses the signed 64-bit integer upper bound
   '''
+  knownIssue.js: '''
+    sets with sets with elements beyond 2^53-1 don't work the JavaScript
+    backend
+  '''
 """
-
-# knownIssue: sets with elements beyond 2^53-1 don't work the JavaScript
-#             backend
 
 const
   Low  = uint64(high(int64))

--- a/tests/stdlib/types/tresults.nim
+++ b/tests/stdlib/types/tresults.nim
@@ -1,12 +1,9 @@
 discard """
   description: "Tests for the std/experimental/results module"
-  targets: "c !js"
+  targets: "c js vm"
+  knownIssue.js: "code-gen issue that seems to be related to sink parameters"
+  knownIssue.vm: "code-gen issues"
 """
-
-# knownIssue: fails on the JS back-end due to a code-gen issue. The issue
-#             seems to be related to sink parameters
-
-# knownIssue: fails for the VM back-end due to code-gen issues
 
 # This file was based on the ``test.nim`` file
 # from https://github.com/disruptek/badresults

--- a/tests/vm/tdata_serdes.nim
+++ b/tests/vm/tdata_serdes.nim
@@ -1,11 +1,8 @@
 discard """
   description: "Tests for the serialization/deserialization"
-  targets: "c !js"
+  targets: "c js"
+  knownIssue.js: "Fails due to code-gen issues"
 """
-
-# knownIssue: fails with JS backend due to code-gen issues as well as due to
-#             `transf` working differently regarding closures when compiling
-#             for the JS backend (even for code being transformed for the VM)
 
 # This test file tests four things:
 # * VM representation -> PNode tree representation (via `deserialize`)


### PR DESCRIPTION
## Summary

Add support for per-target `knownIssue` specification to testament.

Previously, only the full test (including all targets) could be marked
as a "known issue". To emulate per-target `knownIssue`s, tests had to
explicitly disable the target for which the test was failing and add a
separate comment, but this has the issue of `--tryfailing` not applying.

The `knownIssue` key in the test specifications now supports a
*sub-key*, like so: `knownIssue.target`, where `target` is one of `c`,
`js`, or `vm`. A `knownIssue` key without a sub-key means "applies to
all targets", and specifying multiple targets works by separating them
via spaces.

## Details

At the core of the changes is that `knownIssues` are now per-target
instead of per-spec. The spec parser already supports dots in keys, so
the only addition there is splitting the parsed key string into the main
and sub part prior to processing the key.

Since "has known issue" is now a per-run attribute instead of a per-spec
one, disabling a test early by returning `reKnownIssue` from
`computeEarly` cannot work anymore -- everything related to whole-spec
known issues is removed. Instead, test-run descriptions are now always
generated, but then later skipped by `run` (which now accepts a
`runKnownIssues` parameter) if they have known issues and trying those
is disabled.

Since skipped "known issue" test runs would have no associated "known
issue" information in the backend otherwise, `addResult` for `TestRun`
now always includes the runs "known issues" information.

Tests using the disable + comment approach are adjusted to use per-
target `knownIssue`s, but without checking whether the issue is still
current.