### PR TITLE
internal: use dedicated context type for `vmbackend`

### DIFF
--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -152,9 +152,9 @@ template `[]`*[I; T](x: OrdinalSeq[I, T], i: I): untyped =
 template `[]=`*[I; T](x: OrdinalSeq[I, T], i: I, item: T): untyped =
   (seq[T])(x)[ord i] = item
 
-func add*[I; T](x: OrdinalSeq[I, T], item: sink T): I {.inline.} =
+func add*[I; T](x: var OrdinalSeq[I, T], item: sink T): I {.inline.} =
   (seq[T])(x).add item
-  result = I(x.high)
+  result = I(seq[T](x).high)
 
 func newSeq*[I; T](x: var OrdinalSeq[I, T], len: int) {.inline.} =
   newSeq((seq[T])(x), len)

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -143,18 +143,22 @@ func merge*[I; T](dst: var Store[I, T], src: sink Store[I, T]): Option[I] =
 
 # ---------- OrdinalSeq API ------------
 
+template base*[I; T](x: OrdinalSeq[I, T]): seq[T] =
+  ## Returns underlying seq of `x`.
+  seq[T](x)
+
 template len*[I; T](x: OrdinalSeq[I, T]): int =
-  (seq[T])(x).len
+  base(x).len
 
 template `[]`*[I; T](x: OrdinalSeq[I, T], i: I): untyped =
-  (seq[T])(x)[ord i]
+  base(x)[ord i]
 
 template `[]=`*[I; T](x: OrdinalSeq[I, T], i: I, item: T): untyped =
-  (seq[T])(x)[ord i] = item
+  base(x)[ord i] = item
 
 func add*[I; T](x: var OrdinalSeq[I, T], item: sink T): I {.inline.} =
-  (seq[T])(x).add item
-  result = I(seq[T](x).high)
+  base(x).add item
+  result = I(base(x).high)
 
 func newSeq*[I; T](x: var OrdinalSeq[I, T], len: int) {.inline.} =
-  newSeq((seq[T])(x), len)
+  newSeq(base(x), len)

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -162,3 +162,12 @@ func add*[I; T](x: var OrdinalSeq[I, T], item: sink T): I {.inline.} =
 
 func newSeq*[I; T](x: var OrdinalSeq[I, T], len: int) {.inline.} =
   newSeq(base(x), len)
+
+func setLen*[I; T](x: var OrdinalSeq[I, T], len: int) {.inline.} =
+  setLen(base(x), len)
+
+iterator pairs*[I; T](x: OrdinalSeq[I, T]): (I, lent T) =
+  var i = 0
+  while i < x.len:
+    yield (I(i), x[I(i)])
+    inc i

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -142,18 +142,6 @@ func fillProcEntry*(e: var FuncTableEntry, info: CodeInfo) {.inline.} =
   e.start = info.start
   e.regCount = info.regCount.uint16
 
-proc registerProc*(c: var TCtx, prc: PSym): FunctionIndex =
-  ## Registers the procedure in the function table if it wasn't already. In
-  ## both cases, an index into the function table is returned. Whether a
-  ## procedure will resolve to a callback is decided on it's addition to the
-  ## function table
-  let next = LinkIndex(c.functions.len)
-
-  result = c.symToIndexTbl.mgetOrPut(prc.id, next).FunctionIndex
-  if result == next.FunctionIndex:
-    # a new entry:
-    c.functions.add(initProcEntry(c, prc))
-
 proc lookupProc*(c: var TCtx, prc: PSym): FunctionIndex {.inline.} =
   ## Returns the function-table index corresponding to the provided `prc`
   ## symbol. Behaviour is undefined if `prc` has no corresponding function-

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -735,9 +735,6 @@ type
       ## dependencies. Expanded during code-generation and used for looking
       ## up the link-index (e.g. `FunctionIndex`) of a symbol
 
-    collectedGlobals*: seq[PSym]
-      ## leaked implementation detail of ``vmbackend.nim`` -- don't use
-
     flags*: set[CodeGenFlag] ## flags that alter the behaviour of the code
       ## generator. Initialized by the VM's callsite and queried by the JIT.
     # XXX: `flags` is code generator / JIT state, and needs to be moved out of


### PR DESCRIPTION
## Summary

Add and use a dedicated type for the contextual state of the VM code-
generation orchestrator. This removes the hard coupling between
`vmbackend` and `vmdef.TCtx` and is another preparation for splitting up
the latter.

## Details

The new `GenCtx` type replaces `TCtx` as the contextual-state type
for the orchestrator. For now, `GenCtx` still stores an instance of
`TCtx`, as the latter currently contains the code generator state.

In preparation for splitting up `TCtx`, usage of its `idgen` and
`functions` fields are removed from `vmbackend.nim`. The ID generator is
directly passed to procedures that need one, and the function table
(`functions`) is now stored in `GenCtx` -- prior to serializing the VM
environment, the function table stored with `GenCtx`'s is moved into the
`TCtx` instance.

With the new dedicated type for the orchestrator, the collected globals
don't have to be stored in `TCtx` anymore. The `collectedGlobals` field
is made part of `GenCtx` and is renamed to just `globals`.

### Misc

- add the `base` template for `OrdinalSeq` and use it to reduce the
  noise in the `OrdinalSeq` routines
- fix the `add` template for `OrdinalSeq`