### PR TITLE
remove support for enum inheritance

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -371,9 +371,6 @@ type
     rsemCannotInstantiateWithParameter
     rsemCannotGenerateGenericDestructor
     rsemUndeclaredField
-    rsemInheritanceOnlyWorksWithAnEnum # I have **//ABSOLUTELY NO IDEA//**
-    # what this error means. I think I might need to add something like
-    # `rsemWTF`
     rsemExpectedOrdinal
     rsemExpectedOrdinalOrFloat
     rsemExpectedUnholyEnum # yes

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1116,9 +1116,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         "previous type completion was here: " &
         (conf $ r.symbols[0].info)
 
-    of rsemInheritanceOnlyWorksWithAnEnum:
-      result = "inheritance only works with an enum"
-
     of rsemWrongNumberOfVariables:
       result = "wrong number of variables"
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1755,10 +1755,7 @@ proc tryReadingTypeField(c: PContext, n: PNode, i: PIdent, ty: PType): PNode =
   of tyEnum:
     # look up if the identifier belongs to the enum:
     var f = PSym(nil)
-    while ty != nil:
-      f = getSymFromList(ty.n, i)
-      if f != nil: break
-      ty = ty.sons[0]         # enum inheritance
+    f = getSymFromList(ty.n, i)
     if f != nil:
       result = newSymNode(f)
       result.info = n.info

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -34,17 +34,13 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     base: PType
     identToReplace: ptr PNode
   counter = 0
-  base = nil
   result = newOrPrevType(tyEnum, prev, c)
   result.n = newNodeI(nkEnumTy, n.info)
   checkMinSonsLen(n, 1, c.config)
   if n[0].kind != nkEmpty:
-    base = semTypeNode(c, n[0][0], nil)
-    if base.kind != tyEnum:
-      localReport(c.config, n[0], reportSem(rsemInheritanceOnlyWorksWithAnEnum))
+    localReport(c.config, n[0], reportAst(rsemIllformedAst, n[0]))
 
-    counter = toInt64(lastOrd(c.config, base)) + 1
-  rawAddSon(result, base)
+  rawAddSon(result, nil) # base type; always nil
   let isPure = result.sym != nil and sfPure in result.sym.flags
   var symbols: TStrTable
   if isPure: initStrTable(symbols)


### PR DESCRIPTION
## Summary

Enum types supported an internal base type that could only be specified
in macro-generated enum types (there's no syntax for representing it),
but there aren't any tests for it, the features seems to have never
been documented anywhere, and enums that inherit from other enums are
not consistently considered in the compiler. The feature is thus
removed.

## Details

- remove support for `nkEnumTy` AST having a non-empty first slot. This
  now results in an `illformed AST` error
- remove support for enum inheritance from `tryReadingTypeField`
- remove the `rsemInheritanceOnlyWorksWithAnEnum` report