### PR TITLE
vm: pass data for compiler interfacing in `VmArgs`

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2028,7 +2028,11 @@ proc rawExecute(c: var TCtx, pc: var int): YieldReason =
                  currentLineInfo: c.debug[pc],
                  typeCache: addr c.typeInfoCache,
                  mem: addr c.memory,
-                 heap: addr c.heap))
+                 heap: addr c.heap,
+                 graph: c.graph,
+                 config: c.config,
+                 cache: c.cache,
+                 idgen: c.idgen))
       of ckDefault:
         # the instruction may be executed a second time, so everything leading
         # up to the yield (i.e. ``return``) must not modify any VM state

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -437,6 +437,12 @@ type
     mem*: ptr VmMemoryManager
     heap*: ptr VmHeap
 
+    # compiler interfacing:
+    graph*: ModuleGraph
+    config*: ConfigRef
+    cache*: IdentCache
+    idgen*: IdGenerator
+
   IdentPattern* = distinct string ## A matcher pattern for a fully qualified
                                   ## symbol identifier
   VmCallback* = proc (args: VmArgs) {.closure.}


### PR DESCRIPTION
## Summary

Provide the data for interfacing with the compiler in the `VmArgs`
object, which allows for making the callbacks registered by `vmops`
independent of the `TCtx` instance they're first registered with.

## Details

Closing over fields of the registered-with-`TCtx` is replaced with
accessing the corresponding `VmArgs` fields.

While the `ConfigRef` instance stored with `TCtx` is always the same
as the one stored in `TCtx`'s `graph`, a `ModuleGraph` is not always
present (for example, when the VM runs in standalone mode), meaning
that the `ConfigRef` instance has to also be passed in `VmArgs`.

In addition to making the callbacks context-independent, this change 
also means that the callbacks in `vmops` aren't (first-class) closures
anymore. To prevent them from accidentally capturing something again,
all manual callback procedures in `vmops` are assigned the `.nimcall`
calling convention.