### PR TITLE
treat `gorge`/`staticExec` as a dangerous operation

### DIFF
--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -30,6 +30,7 @@ import
   ],
   compiler/vm/[
     compilerbridge,
+    gorgeimpl,
     vmconv,
     vmdef,
     vmhooks,
@@ -140,6 +141,10 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
   cbos rawExec:
     guardEffect:
       setResult(a, osproc.execCmd getString(a, 0))
+  cbos rawExecEx:
+    setResult(a):
+      opGorge(getString(a, 0), getString(a, 1), getString(a, 2),
+              a.info, a.config)
   cbio writeFile:
     guardEffect:
       system.writeFile(getString(a, 0), getString(a, 1))

--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -142,9 +142,10 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
     guardEffect:
       setResult(a, osproc.execCmd getString(a, 0))
   cbos rawExecEx:
-    setResult(a):
-      opGorge(getString(a, 0), getString(a, 1), getString(a, 2),
-              a.info, a.config)
+    guardEffect:
+      let ret = opGorge(getString(a, 0), getString(a, 1), getString(a, 2),
+                        a.currentLineInfo, a.config)
+      writeTo(ret, a.getResultHandle(), a.mem[])
   cbio writeFile:
     guardEffect:
       system.writeFile(getString(a, 0), getString(a, 1))

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2640,7 +2640,8 @@ proc rawExecute(c: var TCtx, pc: var int): YieldReason =
       inc pc
       let rd = c.code[pc].regA
       checkHandle(regs[ra])
-      if defined(nimsuggest) or c.config.cmd == cmdCheck:
+      if defined(nimsuggest) or c.config.cmd == cmdCheck or
+         vmopsDanger notin c.config.features:
         discard "don't run staticExec for 'nim suggest'"
         regs[ra].strVal = ""
       else:

--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -145,7 +145,7 @@ var unameRes, osReleaseIDRes, releaseRes, hostnamectlRes: string
 
 template cmdRelease(cmd, cache): untyped =
   if cache.len == 0:
-    cache = (when defined(nimscript): exec(cmd) else: execProcess(cmd))
+    cache = (when defined(nimscript): exec(cmd, "") else: execProcess(cmd))
   cache
 
 template uname(): untyped = cmdRelease("uname -a", unameRes)

--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -145,7 +145,7 @@ var unameRes, osReleaseIDRes, releaseRes, hostnamectlRes: string
 
 template cmdRelease(cmd, cache): untyped =
   if cache.len == 0:
-    cache = (when defined(nimscript): gorge(cmd) else: execProcess(cmd))
+    cache = (when defined(nimscript): exec(cmd) else: execProcess(cmd))
   cache
 
 template uname(): untyped = cmdRelease("uname -a", unameRes)

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -44,6 +44,9 @@ proc getCurrentDir*(): string =
 proc rawExec(cmd: string): int {.tags: [ExecIOEffect], raises: [OSError].} =
   builtin
 
+proc rawExecEx(cmd, input, cache: string): (string, int) {.tags: [ExecIOEffect].} =
+  builtin
+
 proc paramStr*(i: int): string =
   ## Retrieves the `i`'th command line parameter.
   builtin
@@ -212,7 +215,7 @@ proc exec*(command: string, input: string, cache = ""): string {.
   ## Executes an external process. If the external process terminates with
   ## a non-zero exit code, an OSError exception is raised.
   log "exec: " & command:
-    let (output, exitCode) = gorgeEx(command, input, cache)
+    let (output, exitCode) = rawExecEx(command, input, cache)
     if exitCode != 0:
       raise newException(OSError, "FAILED: " & command)
     result = output

--- a/tests/vm/tgorge.nim
+++ b/tests/vm/tgorge.nim
@@ -1,4 +1,5 @@
 discard """
+matrix: "--experimental:vmopsDanger"
 disabled: "windows"
 """
 


### PR DESCRIPTION
## Summary

Treat both `gorge` procedure and its extended version as dangerous
operations, meaning that `--experimental:vmopsDanger` has to be
explicitly enabled for them to not be treated as no-ops.

This fixes an inconsistency: all other compile-time-available
operations that are able to modify the host's environment were
disabled without said option, but `gorge` (which can indirectly
modify the host's environment) was not.

## Details

To be able to treat `gorge` as a dangerous operation, usage of it in
the context of NimScript had to be removed, as otherwise `exec` would
be a no-op when dangerous VM operations are disabled. The extended
`exec` procedure now calls the `rawExecEx` callback (which uses the
gorge implementation internally), and a call to `gorge` in
`distros.nim` is replaced with a call to `exec`.

The `opcGorge` implementation now considers the `vmopsDanger` feature,
and the `gorgeEx` callback is included in the callbacks that are turned
into no-ops when `vmopsDanger` is not enabled. For tests that use
`gorge` or `gorgeEx`, dangerous compile-time operations are enabled.