### PR TITLE
vmops: decouple registration from discovery

### DIFF
--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -45,6 +45,7 @@ import
   ]
 
 from compiler/vm/vmlegacy import legacyReportsVmTracer
+from compiler/vm/vmjit import registerCallback
 
 # we support 'cmpIgnoreStyle' natively for efficiency:
 from std/strutils import cmpIgnoreStyle, contains

--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -57,7 +57,8 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
   # matches the previous behaviour)
   result.flags = {cgfAllowMeta}
   result.mode = emRepl
-  registerBasicOps(result)
+  for op in basicOps():
+    result.registerCallback(op.pattern, op.prc)
 
   proc listDirs(a: VmArgs, filter: set[PathComponent]) =
     let dir = getString(a, 0)

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -41,6 +41,7 @@ import
   compiler/vm/[
     compilerbridge,
     vmdef,
+    vmjit,
     vmops
   ]
 
@@ -171,7 +172,8 @@ proc createInterpreter*(
   vm.features = flags
   if registerOps:
     # Register basic system operations and parts of stdlib modules
-    vm.registerBasicOps()
+    for o in basicOps():
+      vm.registerCallback(o.pattern, o.prc)
   graph.vm = PEvalContext(vm: vm)
   graph.compileSystemModule()
   result = Interpreter(mainModule: m, graph: graph, scriptName: scriptName, idgen: idgen)

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -92,12 +92,16 @@ proc registerCallbacks(c: var TCtx) =
   template cb(key: string) =
     c.callbackKeys.add(IdentPattern(key))
 
-  registerBasicOps(c)
-  registerDebugOps(c)
-  registerIoReadOps(c)
-  registerIoWriteOps(c)
-  registerOsOps(c)
-  registerOs2Ops(c)
+  template register(iter: untyped) =
+    for it in iter:
+      cb(it.pattern)
+
+  register: basicOps()
+  register: debugOps()
+  register: ioReadOps()
+  register: ioWriteOps()
+  register: osOps()
+  register: os2Ops()
 
   # Used by some tests
   cb "stdlib.system.getOccupiedMem"

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -948,12 +948,6 @@ func refresh*(c: var TCtx, module: PSym; idgen: IdGenerator) =
   c.loopIterations = c.config.maxLoopIterationsVM
   c.idgen = idgen
 
-proc registerCallback*(c: var TCtx; name: string; callback: VmCallback): int {.discardable.} =
-  result = c.callbacks.len
-  c.callbacks.add(callback)
-  # XXX: for backwards compatibility, `name` is still a `string`
-  c.callbackKeys.add(IdentPattern(name))
-
 const pseudoAtomKinds* = {akObject, akArray}
 const realAtomKinds* = {low(AtomKind)..high(AtomKind)} - pseudoAtomKinds
 

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -346,6 +346,6 @@ proc registerCallback*(c: var TCtx; pattern: string; callback: VmCallback) =
   ## `pattern` is added to the VM's function table, all invocations of the
   ## procedure at run-time will invoke the callback instead.
   # XXX: consider renaming this procedure to ``registerOverride``
-  c.callbacks.add(callback)
+  c.callbacks.add(callback) # some consumers rely on preserving registration order
   c.callbackKeys.add(IdentPattern(pattern))
   assert c.callbacks.len == c.callbackKeys.len

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -343,8 +343,8 @@ proc loadProc*(jit: var JitState, c: var TCtx, sym: PSym): VmGenResult =
 proc registerCallback*(c: var TCtx; pattern: string; callback: VmCallback) =
   ## Registers the `callback` with `c`. After the ``registerCallback`` call,
   ## when a procedures of which the fully qualified identifier matches
-  ## `pattern` is added to the VM's function table, all invokes of the
-  ## procedure at run-time will invoke the override instead.
+  ## `pattern` is added to the VM's function table, all invocations of the
+  ## procedure at run-time will invoke the callback instead.
   # XXX: consider renaming this procedure to ``registerOverride``
   c.callbacks.add(callback)
   c.callbackKeys.add(IdentPattern(pattern))

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -339,3 +339,13 @@ proc loadProc*(jit: var JitState, c: var TCtx, sym: PSym): VmGenResult =
     VmGenResult.ok: (start: prc.start, regCount: prc.regCount.int)
   else:
     compile(jit, c, idx)
+
+proc registerCallback*(c: var TCtx; pattern: string; callback: VmCallback) =
+  ## Registers the `callback` with `c`. After the ``registerCallback`` call,
+  ## when a procedures of which the fully qualified identifier matches
+  ## `pattern` is added to the VM's function table, all invokes of the
+  ## procedure at run-time will invoke the override instead.
+  # XXX: consider renaming this procedure to ``registerOverride``
+  c.callbacks.add(callback)
+  c.callbackKeys.add(IdentPattern(pattern))
+  assert c.callbacks.len == c.callbackKeys.len


### PR DESCRIPTION
## Summary

Separate *discovering* overrides from *registering* them by turning the
`register` procedures into iterators that don't require a `TCtx`. This
makes the interface more flexibile, and is a preparation for moving the
the `callbackKeys` list out of `TCtx`.

## Details

As part of the changes, the used terminology is improved: a *callback*
is what the VM invokes in the end, while an *override* is a pattern +
callback to redirect to. The places where the `register` procedures
were previously used are updated to iterate the contents of the new
iterators and register the callbacks/overrides as needed.

The `registerX` procedures are turned into iterators, and the calls to
`registerCallback` in `vmops` are replaced with calls to the `override`
template, which expands to a `yield` statement. Iterators are used
instead because they're slightly more flexible, but, at least with the
current usage, constant `seq`s would have worked as well.

Although not yet clear from data placement, "overrides" are not
something that the VM implements -- rather, it's a feature of the
JIT and linker. Therefore, the `registerCallback` is moved from the
`vmdef` into the `vmjit` module, and updated to also verify that the
callbacks and patterns list stay synchronized. The
`registerAdditionalOps`, which has the intended use of registering
the additional ops for compile-time code execution is moved to
`compilerbridge`.

As the result, `vmops` is now only concerned with providing overrides,
but not with how/if they're registered.