### PR TITLE
codegen: remove the `cnkChckRange` node kinds

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -609,7 +609,8 @@ proc isSinkType*(t: PType): bool {.inline.} =
   t.kind == tySink
 
 const magicsThatCanRaise* = {
-  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
+  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho,
+  mChckRange }
 
 proc canRaiseConservative*(fn: PNode): bool =
   if fn.kind == nkSym and fn.sym.magic notin magicsThatCanRaise:

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -814,6 +814,9 @@ type
 
     # magics only used internally:
     mAsgnDynlibVar
+    mChckRange
+      ## chckRange(v, lower, upper); conversion + range check -- returns
+      ## either the type-converted value or raises a defect
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -80,9 +80,6 @@ type
                      ## different type
 
     # ---- special conversions kept for compatibility
-    cnkChckRangeF      ## range check for floats
-    cnkChckRange64     ## range check for 64-bit ints
-    cnkChckRange       ## range check for ints
     cnkStringToCString ## string to cstring
     cnkCStringToString ## cstring to string
     # future direction: lower these coversion operations during the MIR

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -146,7 +146,7 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
       res.add $n.typ
     else:
       res.add "[type node]"
-  of cnkCheckedFieldAccess, cnkChckRange, cnkChckRange64, cnkChckRangeF:
+  of cnkCheckedFieldAccess:
     res.add n[0]
   of cnkHiddenAddr, cnkDerefView, cnkHiddenConv:
     res.add n.operand

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -36,6 +36,8 @@ import
     idioms
   ]
 
+from compiler/ast/ast_query import magicsThatCanRaise
+
 type
   Opcode = enum
     opFork ## branching control-flow that cannot introduce a cycle
@@ -111,11 +113,6 @@ type
       ## next
     i: NodePosition
       ## points to the next item to yield
-
-# TODO: copied from ``ast_query.nim``. Either export the original or use a
-#       different approach - duplicating the constant is not acceptable
-const magicsThatCanRaise = {
-  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
 
 func incl[T](s: var seq[T], v: sink T) =
   ## If not present already, adds `v` to the sorted ``seq`` `s`

--- a/tests/lang_objects/destructor/tdestruction_when_checks_failed.nim
+++ b/tests/lang_objects/destructor/tdestruction_when_checks_failed.nim
@@ -1,0 +1,35 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Ensure that locals are destroyed when the only exceptional control-flow
+    leaving their scope is due to Defects raised by failed run-time checks
+  '''
+  knownIssue.vm: "defects raised due to failed run-time checks cannot be caught"
+"""
+
+type Object = object
+
+var numDestroy = 0
+
+proc `=destroy`(x: var Object) =
+  inc numDestroy
+
+# with how destructor injection works at the time of writing, when a scope is
+# only left through structured control-flow, no hidden ``try`` statement is
+# injected. The tests here make sure that the unstructured control-flow arising
+# from run-time checks is properly considered
+
+block range_checks:
+  proc test(x: int) =
+    var obj = Object() # obj stores an alive value that needs to be destroyed
+    discard range[0..1](x)
+
+  var raised = false
+  numDestroy = 0
+  try:
+    test(2) # provoke a range-check failure
+  except:
+    raised = true
+
+  doAssert raised, "no defect was raised?"
+  doAssert numDestroy == 1, "the destructor wasn't called"

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -102,17 +102,12 @@ block: # #14350, #16674, #16686 for JS
     doAssert nil2 == cstring("")
 
 block:
-  when defined(js): # bug #18591
-    let a1 = -1'i8
-    let a2 = uint8(a1)
-    # if `uint8(a1)` changes meaning to `cast[uint8](a1)` in future, update this test;
-    # until then, this is the correct semantics.
-    let a3 = $a2
-    doAssert a2 < 3
-    doAssert a3 == "-1"
-    proc intToStr(a: uint8): cstring {.importjs: "(# + \"\")".}
-    doAssert $intToStr(a2) == "-1"
-  else:
+  when true:
+    block:
+      # bug https://github.com/nim-lang/nim/issues/18591
+      let x = -1'i8
+      let y = uint8(x)
+      doAssert $y == "255"
     block:
       let x = -1'i8
       let y = uint32(x)


### PR DESCRIPTION
## Summary

Replace the `cnkChckRange` node kinds with a magic call that is already
inserted during MIR synthesis (`mirgen`) and remove all decision making
regarding range-checks from the code generators.

This is a step towards moving decision making regarding run-time checks
fully into late semantic analysis. In addition, this fixes destructors
not being run for scopes where the only escaping unstructured control-
flow is due to range checks.

## Details

A new internal magic is added for representing conversions-with-range-
checks during the MIR and code generation phase: `mChckRange`. `mirgen`
translates `nkChckRange`, `nkChckRange64`, and `nkChckRangeF` to the
new magic, but only if its not a to-unsigned conversion and range checks
are enabled for the current owner.

For now, these guards mirror those previously used in the code
generators, but the direction is to move to a correct-by-construction
approach and only inject `nkChckRange` nodes where range checks should
be performed.

The `mChckRange` magic is included in the `magicsThatCanRaise` set, and
the duplicate set of the same name is removed from `mirexec`. As a
consequence, the exceptional control-flow arising from failed range
checks is now picked up on by MIR-based data- and control-flow analysis.
However, since the set is constant, this also means that range-check
calls will be treated as raising even when panics are enabled. This is a
known problem with magics that needs to be solved at one point.

Multiple things are now obsolete and thus removed:
- the `cnkChckRange` node kinds
- the `cgirgen` logic for producing `cnkChckRange` nodes (which was
  originally duplicated from the logic in `transf.transformConv`)
- the code generator handling for `cnkChckRange`. Parts of it are
  re-used for implementing `mChckRange` support

Two additional problems are fixed as a side-effect of the changes:
- the VM code generator now respects the `rangeChecks` option in
  the same way as the other code generator
- disabled range checks (either via the `rangeChecks` option or
  because the target type is unsigned) are not treated as no-op
  by the JS code generator, but instead use unchecked conversions
  (the `tdollars.nim` test is adjusted accordingly), in line with
  the other code generators