### PR TITLE
internal: split `vmgen`/linker state from `TCtx`

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -702,7 +702,7 @@ proc getGlobalValue*(c: TCtx; s: PSym): PNode =
   ## Does not perform type checking, so ensure that `s.typ` matches the
   ## global's type
   internalAssert(c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
-  let slotIdx = c.globals[c.symToIndexTbl[s.id]]
+  let slotIdx = c.globals[c.linking.symToIndexTbl[s.id]]
   let slot = c.heap.slots[slotIdx]
 
   result = c.deserialize(slot.handle, s.typ, s.info)
@@ -710,7 +710,7 @@ proc getGlobalValue*(c: TCtx; s: PSym): PNode =
 proc setGlobalValue*(c: var TCtx; s: PSym, val: PNode) =
   ## Does not do type checking so ensure the `val` matches the `s.typ`
   internalAssert(c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
-  let slotIdx = c.globals[c.symToIndexTbl[s.id]]
+  let slotIdx = c.globals[c.linking.symToIndexTbl[s.id]]
   let slot = c.heap.slots[slotIdx]
 
   c.serialize(val, slot.handle)

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -832,8 +832,8 @@ func init*(enc: var PackedEncoder, types: seq[PVmType]) =
 func storeEnv*(enc: var PackedEncoder, dst: var PackedEnv, c: TCtx) =
   ## Stores all relevant data provided by `c` into `dst`. Previously stored
   ## data (except `nodes`, `numbers`, and `strings`) is thrown away. The only
-  ## parts of `dst` not touched by `storeEnv` are: `cconsts`, `globals`,
-  ## `code`, and `entryPoint`. These have to be filled in separately.
+  ## parts of `dst` not touched by `storeEnv` are: `cconsts`, `globals`, and
+  ## `entryPoint`. These have to be filled in separately.
   # store all types:
   dst.types.newSeq(c.types.len - 1) # -1 since the invalid type is not included
   for i in 1..<c.types.len:
@@ -868,6 +868,8 @@ func storeEnv*(enc: var PackedEncoder, dst: var PackedEnv, c: TCtx) =
       of ckDefault:  (x.start.uint32, x.regCount.uint32)
 
     (d, x.sig, t1, t2, x.kind, a, b)
+
+  dst.code = c.code
 
   mapList(dst.debug, c.debug, d):
     dst.infos.getOrIncl(d).uint32

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -32,7 +32,8 @@ import
     pathutils # for `AbsoluteFile`
   ],
   compiler/vm/[
-    vmdef
+    vmdef,
+    vmlinker
   ]
 
 from compiler/vm/vmaux import findRecCase, findMatchingBranch
@@ -870,12 +871,6 @@ func storeEnv*(enc: var PackedEncoder, dst: var PackedEnv, c: TCtx) =
 
   mapList(dst.debug, c.debug, d):
     dst.infos.getOrIncl(d).uint32
-
-  # TODO: add support for either `distinct string` or custom `storePrim`
-  #       overloads (or both) to `rodfiles`. Due to the lack of both, we
-  #       have to perform a manual copy instead of a move here
-  mapList(dst.callbacks, c.callbackKeys, c):
-    c.string
 
   mapList(dst.files, c.config.m.fileInfos, fi):
     fi.fullPath.string

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -41,6 +41,7 @@ import
     vmdef,
     vmgen,
     vmlegacy,
+    vmlinker,
     vmobjects,
     vmops,
     vmtypegen
@@ -81,7 +82,7 @@ type
 func growBy[T](x: var seq[T], n: Natural) {.inline.} =
   x.setLen(x.len + n)
 
-proc registerCallbacks(c: var TCtx) =
+proc registerCallbacks(linking: var LinkerData) =
   ## Registers callbacks for various functions, so that no code is
   ## generated for them and that they can (must) be overridden by the runner
 
@@ -90,7 +91,7 @@ proc registerCallbacks(c: var TCtx) =
   # complain if there's a mismatch
 
   template cb(key: string) =
-    c.callbackKeys.add(IdentPattern(key))
+    linking.callbackKeys.add(IdentPattern(key))
 
   template register(iter: untyped) =
     for it in iter:
@@ -106,12 +107,18 @@ proc registerCallbacks(c: var TCtx) =
   # Used by some tests
   cb "stdlib.system.getOccupiedMem"
 
+func setLinkIndex(c: var GenCtx, s: PSym, i: LinkIndex) =
+  assert s.id notin c.gen.linking.symToIndexTbl
+  c.gen.linking.symToIndexTbl[s.id] = i
+
+proc initProcEntry(c: var GenCtx, prc: PSym): FuncTableEntry {.inline.} =
+  initProcEntry(c.gen.linking, c.graph.config, c.gen.typeInfoCache, prc)
+
 proc registerProc(c: var GenCtx, prc: PSym): FunctionIndex =
   ## Adds an empty function-table entry for `prc` and registers the latter
   ## in the link table.
-  assert prc.id notin c.gen.symToIndexTbl
-  let idx = c.functions.add(initProcEntry(c.gen, prc))
-  c.gen.symToIndexTbl[prc.id] = idx
+  let idx = c.functions.add(c.initProcEntry(prc))
+  setLinkIndex(c, prc, idx)
   result = FunctionIndex(idx)
 
 proc appendCode(c: var TCtx, f: CodeFragment) =
@@ -154,7 +161,7 @@ proc declareGlobal(c: var GenCtx, sym: PSym) =
   if exfNoDecl notin sym.extFlags and sfImportc notin sym.flags:
     # make sure the type is generated and register the global in the
     # link table
-    c.gen.symToIndexTbl[sym.id] = c.globals.add(getOrCreate(c.gen, sym.typ))
+    setLinkIndex(c, sym, c.globals.add(getOrCreate(c.gen, sym.typ)))
 
 proc prepare(c: var GenCtx, data: var DiscoveryData) =
   ## Registers with the link table all procedures, constants, globals,
@@ -164,8 +171,8 @@ proc prepare(c: var GenCtx, data: var DiscoveryData) =
   c.functions.setLen(data.procedures.len)
   for i, it in peek(data.procedures):
     let idx = LinkIndex(i)
-    c.functions[idx] = c.gen.initProcEntry(it)
-    c.gen.symToIndexTbl[it.id] = idx
+    c.functions[idx] = c.initProcEntry(it)
+    setLinkIndex(c, it, idx)
 
     # if a procedure's implementation is overridden with a VM callback, we
     # don't want any processing to happen for it, which we signal to the
@@ -175,7 +182,7 @@ proc prepare(c: var GenCtx, data: var DiscoveryData) =
 
   # register the constants with the link table:
   for i, s in visit(data.constants):
-    c.gen.symToIndexTbl[s.id] = LinkIndex(i)
+    setLinkIndex(c, s, LinkIndex(i))
 
   for _, s in visit(data.globals):
     declareGlobal(c, s)
@@ -205,7 +212,7 @@ proc processEvent(c: var GenCtx, mlist: ModuleList, discovery: var DiscoveryData
   of bekProcedure:
     # a complete procedure became available
     let r = generateCodeForProc(c.gen, idgen, evt.sym, evt.body)
-    fillProcEntry(c.functions[c.gen.symToIndexTbl[evt.sym.id]], r)
+    fillProcEntry(c.functions[lookup(c.gen.linking, evt.sym)], r)
   of bekImported:
     # not supported at the moment; ``vmgen`` is going to raise an
     # error when generating a call to a dynlib procedure
@@ -254,15 +261,13 @@ proc generateCodeForMain(c: var GenCtx, config: BackendConfig,
   fillProcEntry(c.functions[result.LinkIndex], r)
 
 func storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
-                routineSymLookup: sink Table[int, LinkIndex],
+                linking: sink LinkerData,
                 consts: seq[(PVmType, PNode)], globals: seq[PVmType]) =
   ## Stores the previously gathered complex constants and globals into `dst`
 
   var denc: DataEncoder
   denc.startEncoding(dst)
-  # XXX: `sink` is used for `routineSymLookup` in order to get around a
-  #      deep copy
-  denc.routineSymLookup = routineSymLookup
+  denc.routineSymLookup = move linking.symToIndexTbl
 
   # complex constants (i.e. non-literals):
   mapList(dst.cconsts, consts, it):
@@ -275,6 +280,12 @@ func storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
   # done in VM bytecode
   mapList(dst.globals, globals, it):
     enc.typeMap[it]
+
+  # TODO: add support for either `distinct string` or custom `storePrim`
+  #       overloads (or both) to `rodfiles`. Due to the lack of both, we
+  #       have to perform a manual copy instead of a move here
+  mapList(dst.callbacks, linking.callbackKeys, c):
+    c.string
 
 proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
   ## The backend's entry point. Orchestrates code generation and linking. If
@@ -293,7 +304,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
 
   # register the extra ops so that code generation isn't performed for the
   # corresponding procs:
-  registerCallbacks(c.gen)
+  registerCallbacks(c.gen.linking)
 
   # generate code for all alive routines:
   var discovery: DiscoveryData
@@ -322,7 +333,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
 
   enc.init(c.gen.types)
   storeEnv(enc, env, c.gen)
-  storeExtra(enc, env, c.gen.symToIndexTbl, consts, base(c.globals))
+  storeExtra(enc, env, c.gen.linking, consts, base(c.globals))
   env.code = move c.gen.code
   env.entryPoint = entryPoint
 

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -72,7 +72,6 @@ type
                  ## changing the type in the future (distinct/width)
 
   TRegister* = range[0..regAMask.int]
-  TDest* = range[-1..regAMask.int]
   TInstr* = distinct TInstrType
 
   NumericConvKind* = enum
@@ -82,10 +81,6 @@ type
     nckIToF, nckUToF
     nckFToF ## float-to-float
     nckToB  ## float or int to bool
-
-  TBlock* = object
-    label*: PSym
-    fixups*: seq[TPosition]
 
   TEvalMode* = enum           ## reason for evaluation
     emRepl,                   ## evaluate because in REPL mode
@@ -102,21 +97,6 @@ type
     allowCast,                ## allow unsafe language feature: 'cast'
     allowInfiniteLoops        ## allow endless loops
   TSandboxFlags* = set[TSandboxFlag]
-
-  TSlotKind* = enum   # We try to re-use slots in a smart way to
-                      # minimize allocations; however the VM supports arbitrary
-                      # temporary slot usage. This is required for the parameter
-                      # passing implementation.
-    slotEmpty,        ## slot is unused
-    slotFixedVar,     ## slot is used for a fixed var/result (requires copy then)
-    slotFixedLet,     ## slot is used for a fixed param/let
-    slotTempUnknown,  ## slot but type unknown (argument of proc call)
-    slotTempInt,      ## some temporary int
-    slotTempFloat,    ## some temporary float
-    slotTempStr,      ## some temporary string
-    slotTempComplex,  ## some complex temporary (s.node field is used)
-    slotTempHandle,   ## some temporary handle into an object/array
-    slotTempPerm      ## slot is temporary but permanent (hack)
 
   CodeInfo* = tuple
     start: int ## The position where the bytecode starts
@@ -402,29 +382,6 @@ type
       strSlices*: seq[Slice[ConstantId]] ## Stores the ids of string constants
                                          ## as a storage optimization
 
-  RegInfo* = object
-    refCount*: uint16
-    locReg*: uint16 ## if the register stores a handle, `locReg` is the
-                    ## register storing the backing location
-    kind*: TSlotKind
-
-  PProc* = ref object
-    blocks*: seq[TBlock]    # blocks; temp data structure
-    sym*: PSym
-    regInfo*: seq[RegInfo]
-
-    addressTaken*: IntSet
-      ## the set of locations (identified by their symbol id) that have their
-      ## address taken or a view of them created. This information is used to
-      ## decide whether a full VM memory location is required, or if the
-      ## value can be stored in a register directly
-
-    # XXX: the value's type should be `TRegister`, but we need a sentinel
-    #      value (-1) for `getOrDefault`, so it has to be `int`
-    locals*: Table[int, int] ## symbol-id -> register index. Used for looking
-                             ## up the corresponding register slot of each
-                             ## local (including parameters and `result`)
-
   VmArgs* = object
     ra*, rb*, rc*: Natural
     slots*: ptr UncheckedArray[TFullReg]
@@ -511,6 +468,8 @@ type
 
   TypeInfoCache* = object
     ## An append-only cache for everything type related
+    # future work: split everything related to the *production* of types into
+    # a type placed in ``vmtypegen``
     lut*: Table[ItemId, PVmType] ## `PType`-id -> `PVmType` mappings
     genericInsts*: Table[ItemId, seq[(PType, PVmType)]] ##
       ## 'generic type' -> 'known instantiations' mappings. Needed to make
@@ -556,8 +515,8 @@ type
   #        reused across compiler invocations (relevant for IC). Not mutated
   #        by the execution engine
   #      - code and debug information
-  #      - 'vmgen' state: auxiliary data used during code generation, reused
-  #        across vmgen invocations for efficiency
+  #      - (DONE) 'vmgen' state: auxiliary data used during code generation,
+  #        reused across vmgen invocations for efficiency
 
   CodeGenFlag* = enum
     cgfAllowMeta ## If not present, type or other meta expressions are
@@ -710,12 +669,6 @@ type
   VmRawStackTrace* = seq[tuple[sym: PSym, pc: PrgCtr]]
 
   TCtx* = object
-    # XXX: TCtx stores three different things:
-    #  - VM execution state
-    #  - VM environment (code, constants, type data, etc.)
-    #  - vmgen context/state
-    # These should be encapsulated into standalone types
-
     code*: seq[TInstr]
     debug*: seq[TLineInfo]  # line info for every instruction; kept separate
                             # to not slow down interpretation
@@ -735,8 +688,7 @@ type
 
     flags*: set[CodeGenFlag] ## flags that alter the behaviour of the code
       ## generator. Initialized by the VM's callsite and queried by the JIT.
-    # XXX: `flags` is code generator / JIT state, and needs to be moved out of
-    #      ``TCtx``
+    # XXX: ^^ make this a part of the JIT state as soon as possible
 
     linking*: LinkerData
     # XXX: ^^ should be made part of the JIT state but ``vmcompilerserdes``
@@ -752,7 +704,6 @@ type
     activeExceptionTrace*: VmRawStackTrace ##
       ## the stack-trace of where the exception was raised from
 
-    prc*: PProc
     module*: PSym
     callsite*: PNode
     mode*: TEvalMode
@@ -789,8 +740,6 @@ type
   Profiler* = object
     tEnter*: float
     sframe*: StackFrameIndex   ## The current stack frame
-
-  TPosition* = distinct int
 
 func `<`*(a, b: FieldIndex): bool {.borrow.}
 func `<=`*(a, b: FieldIndex): bool {.borrow.}
@@ -916,7 +865,6 @@ proc initCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
     debug: @[],
     globals: @[],
     constants: @[],
-    prc: PProc(blocks: @[]),
     module: module,
     loopIterations: g.config.maxLoopIterationsVM,
     comesFromHeuristic: unknownLineInfo,
@@ -937,15 +885,11 @@ proc initCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
 func refresh*(c: var TCtx, module: PSym; idgen: IdGenerator) =
   addInNimDebugUtils(c.config, "refresh")
   c.module = module
-  c.prc = PProc(blocks: @[])
   c.loopIterations = c.config.maxLoopIterationsVM
   c.idgen = idgen
 
 const pseudoAtomKinds* = {akObject, akArray}
 const realAtomKinds* = {low(AtomKind)..high(AtomKind)} - pseudoAtomKinds
-
-const
-  slotSomeTemp* = slotTempUnknown
 
 # flag is used to signal opcSeqLen if node is NimNode.
 const nimNodeFlag* = 16

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3039,7 +3039,8 @@ proc genStmt*(c: var TCtx; n: CgNode): Result[void, VmGenDiag] =
   c.config.internalAssert(d < 0, n.info, "VM problem: dest register is set")
   result = typeof(result).ok()
 
-proc genExpr*(c: var TCtx; n: CgNode): Result[TRegister, VmGenDiag] =
+proc genExpr*(c: var TCtx; n: CgNode): Result[void, VmGenDiag] =
+  ## Generates and emits the code for a standalone expression.
   analyseIfAddressTaken(n, c.prc.addressTaken)
 
   var d: TDest = -1
@@ -3052,8 +3053,11 @@ proc genExpr*(c: var TCtx; n: CgNode): Result[TRegister, VmGenDiag] =
   # expression
   c.config.internalAssert(d != noDest, n.info):
     "VM problem: dest register is not set"
+  # standalone expressions are treated as nullary procedures that
+  # directly return the value
+  c.gABC(n, opcRet, d)
 
-  result = typeof(result).ok(TRegister(d))
+  result = typeof(result).ok()
 
 
 proc genParams(prc: PProc; s: PSym) =

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -81,7 +81,7 @@ func swapState(c: var TCtx, gen: var CodeGenCtx) =
   template swap(field: untyped) =
     swap(c.field, gen.field)
 
-  # inpute parameters:
+  # input parameters:
   swap(graph)
   swap(config)
   swap(mode)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -241,7 +241,7 @@ proc genExpr*(jit: var JitState, c: var TCtx, n: PNode): VmGenResult =
     rewind(jit.discovery)
     return VmGenResult.err(r.takeErr)
 
-  c.gABC(n, opcRet, r.unsafeGet)
+  c.gABC(n, opcEof)
   updateEnvironment(c, jit.discovery)
 
   result = VmGenResult.ok: (start: start, regCount: c.prc.regInfo.len)

--- a/compiler/vm/vmlinker.nim
+++ b/compiler/vm/vmlinker.nim
@@ -1,0 +1,57 @@
+## Implements types and procedures related to mapping symbols to their in-VM
+## IDs.
+
+import
+  std/[
+    strutils,
+    tables
+  ],
+  compiler/ast/[
+    ast_types
+  ]
+
+from compiler/ast/ast import id
+from compiler/ast/idents import cmpIgnoreStyle
+
+type
+  LinkIndex* = uint32
+    ## Identifies a linker-relevant entity. There are three namespaces, one
+    ## for procedures, one for globals, and one for constants -- which
+    ## namespace an index is part of is stored separately.
+
+  IdentPattern* = distinct string
+    ## A matcher pattern for a fully qualified symbol identifier
+
+  LinkerData* = object
+    ## All data required for mapping symbols to the entities they represent
+    ## inside the VM (procedures, globals, constants).
+    symToIndexTbl*: Table[int, LinkIndex]
+      ## the link table. Keeps track of all symbols known to the linker
+    callbackKeys*: seq[IdentPattern]
+      ## the matcher patterns used for implementing overrides
+
+func matches(s: PSym; x: IdentPattern): bool =
+  var s = s
+  for part in rsplit(string(x), '.'):
+    if s == nil or (part.cmpIgnoreStyle(s.name.s) != 0 and part != "*"):
+      return false
+    s = if sfFromGeneric in s.flags: s.owner.owner else: s.owner
+    while s != nil and s.kind == skPackage and s.owner != nil: s = s.owner
+  result = true
+
+func lookup*(patterns: seq[IdentPattern]; s: PSym): int =
+  ## Tries to find and return the index of the pattern matching `s`. If none
+  ## is found, -1 is returned
+  var i = 0
+  # XXX: `pairs` doesn't use `lent`, so a manual implementation of `pairs`
+  #      is used
+  for p in patterns.items:
+    if s.matches(p): return i
+    inc i
+
+  result = -1
+
+func lookup*(data: LinkerData, s: PSym): LinkIndex {.inline.} =
+  ## Returns the link-index for the symbol `s`, which must exist in the link
+  ## table.
+  data.symToIndexTbl[s.id]

--- a/compiler/vm/vmtypegen.nim
+++ b/compiler/vm/vmtypegen.nim
@@ -792,7 +792,6 @@ proc getOrCreate*(
 
   genAllTypes(c, typ, cl)
 
-# TODO: move this one to `vmgen`
 proc getOrCreate*(c: var TCtx, typ: PType): PVmType {.inline.} =
   var cl: GenClosure
   getOrCreate(c.typeInfoCache, c.config, typ, cl)


### PR DESCRIPTION
## Summary

Move much of the data and associated types for the VM code generator and
linker into `vmgen` and the new `vmlinker` module. Having the code-
generation-related state in the `vmgen` module, means that the VM code-
generator state can now depend on modules that should not be a
transitive dependency (through `vmdef`) of all other VM-related modules.

## Details

The linker-related types `IdentPattern` and `LinkIndex` plus the
routines for working with them are moved to the `vmlinker` module -- the
linker-related state is moved into the new `LinkerData` type. Due
`vmcompilerserdes` currently requiring access to the link table, the
`LinkerData` instance has to be still stored with `TCtx` instead of
the more correct `JitState`.

For the VM code generator, all relevant types, except for the
diagnostics, are moved from `vmdef` into `vmgen`. The `TCtx` used by
`vmgen` is now an alias to the new `CodeGenCtx` type, which stores all
the input, output, and other contextual state required for code
generation.

When using `vmjit`, much of the data read or written to by the code
generator is part of the VM execution environment (`TCtx`), and in order
to not having to either use pointers or pass all of it along as
procedure parameters, the relevant data is swapped between `TCtx` and
`CodeGenCtx` both *before* and *after* invoking the code generator.
`vmjit.genExpr` is slightly adjusted for this to work uniformly across
the `genX` procedures: it now also emits an `Eof` instruction.

`vmbackend` now stores an instance of `CodeGenCtx` instead of `TCtx`.
Once code generation is finished, a temporary VM execution environment
is set-up, populated, and then serialized.

Finally, `vmrunner` is updated to not rely on (now non-existent)
`TCtx.callbackKeys` field. The list of expected override patterns is
instead taken from the packed context and passed to `registerCallbacks`
directly.