### PR TITLE
make `std/marshal` compile with `--styleCheck:error`

### DIFF
--- a/tests/stylecheck/tstyle_imports.nim
+++ b/tests/stylecheck/tstyle_imports.nim
@@ -53,7 +53,7 @@ import
   logging,
   macrocache,
   macros,
-  #marshal, # imports `typeinfo`
+  marshal,
   math,
   md5,
   memfiles,


### PR DESCRIPTION
Change names of types in `std/marshal` that start with a lower-case
letter to start with an upper-case letter, making the module compatible
with the `--styleCheck:error` mode.