### PR TITLE
fix object subtype-relation between generic instances

### DIFF
--- a/tests/typerel/tphantom_type_as_base.nim
+++ b/tests/typerel/tphantom_type_as_base.nim
@@ -73,3 +73,24 @@ block with_ptr_object:
   proc p(x: ptr Sub): int = 3
   # the more precise overload matches:
   doAssert p(addr obj) == 3
+
+block with_intermediate_non_object_base:
+  # test the case where an intermediate base type is a ``ref`` or
+  # ``ptr`` while formal type is not
+  type
+    Root[T] = object of RootObj
+
+    First   = ref object of Root[int]
+    Second  = object of First
+
+    GFirst[T] = ref object of Root[T]
+    GSecond   = object of GFirst[float]
+
+  proc p(x: Root[int]): int = 1
+  proc p(x: Root[float]): int = 2
+
+  # test with non-generic intermediate base:
+  doAssert p(Second()) == 1
+
+  # test with generic intermediate base:
+  doAssert p(GSecond()) == 2


### PR DESCRIPTION
## Summary

Fix a bug with the subtype-of-generic-object logic that caused generic
instances of object-like types to be treated as unrelated when one of
their in-between types is a `ref`/`ptr` type while the formal type is
not (or vice versa). Refer to the added test for an example of where
this issue surfaced.

## Details

The mistake was considering the skipped ptr/ref at each inheritance
step, while it must only be considered once for the formal and original
actual type. This properly considers `ref` and `ptr` types being used
as object base types.

In addition to the fix, the documentation of and inside
`isSubtypeOfGenericInstance` is slightly improved.