### PR TITLE
internal: always-on logging of generated VM bytecode

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -838,7 +838,6 @@ type
     #----------------------------  Debug reports  ----------------------------#
     rdbgVmExecTraceFull
     rdbgVmExecTraceMinimal
-    rdbgVmCodeListing
 
     rdbgOptionsPush
     rdbgOptionsPop

--- a/compiler/ast/reports_debug.nim
+++ b/compiler/ast/reports_debug.nim
@@ -6,7 +6,6 @@
 
 import
   compiler/ast/[
-    ast_types,
     lineinfos,
     reports_base,
     report_enums,
@@ -17,22 +16,6 @@ import
   compiler/vm/vm_enums
 
 type
-  DebugVmCodeEntry* = object
-    isTarget*: bool
-    info*: TLineInfo
-    pc*: int
-    idx*: int
-    case opc*: TOpcode:
-      of opcConv, opcCast:
-        types*: tuple[tfrom, tto: PType]
-      of opcLdConst, opcAsgnConst:
-        ast*: PNode
-      else:
-        discard
-    ra*: int
-    rb*: int
-    rc*: int
-
   DebugReport* = object of DebugReportBase
     case kind*: ReportKind
       of rdbgOptionsPush, rdbgOptionsPop:
@@ -50,13 +33,6 @@ type
         vmgenExecMinimal*: tuple[
           info: TLineInfo,
           opc: TOpcode
-        ]
-
-      of rdbgVmCodeListing:
-        vmgenListing*: tuple[
-          sym: PSym,
-          ast: PNode,
-          entries: seq[DebugVmCodeEntry]
         ]
 
       else:

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2769,57 +2769,6 @@ proc reportBody*(conf: ConfigRef, r: DebugReport): string =
       tern(exec.rc == rkNone, "", $exec.rc)
     )
 
-  of rdbgVmCodeListing:
-    result.add "Code listing"
-    let l = r.vmgenListing
-
-    if not l.sym.isNil():
-      result.addf(
-        " for the '$#' $#\n\n",
-        l.sym.name.s,
-        conf.toStr(l.sym.info))
-    else:
-      result.add "\n\n"
-
-    for e in r.vmgenListing.entries:
-      if e.isTarget:
-        result.add("L:", e.pc, "\n")
-
-      func `$<`[T](arg: T): string = alignLeft($arg, 5)
-      func `$<`(opc: TOpcode): string = alignLeft(opc.toStr, 12)
-
-      var line: string
-
-      case e.opc
-      of {opcIndCall, opcIndCallAsgn}:
-        line.addf("  $# r$# r$# #$#", $<e.opc, $<e.ra, $<e.rb, $<e.rc)
-      of {opcConv, opcCast}:
-        line.addf(
-          "  $# r$# r$# $# $#",
-          $<e.opc,
-          $<e.ra,
-          $<e.rb,
-          $<e.types[0].typeToString(),
-          $<e.types[1].typeToString())
-      elif e.opc < firstABxInstr:
-        line.addf("  $# r$# r$# r$#", $<e.opc, $<e.ra, $<e.rb, $<e.rc)
-      elif e.opc in relativeJumps + {opcTry}:
-        line.addf("  $# r$# L$#", $<e.opc, $<e.ra, $<e.idx)
-      elif e.opc in {opcExcept}:
-        line.addf("  $# $# $#", $<e.opc, $<e.ra, $<e.idx)
-      elif e.opc in {opcLdConst, opcAsgnConst}:
-        line.addf(
-          "  $# r$# $# $#",
-          $<e.opc, $<e.ra, $<e.ast.renderTree(), $<e.idx)
-      else:
-        line.addf("  $# r$# $#", $<e.opc, $<e.ra, $<e.idx)
-
-      result.add(
-        line,
-        tern(line.len <= 48, repeat(" ", 48 - line.len), ""),
-        toStr(conf, e.info),
-        "\n")
-
 proc reportFull*(conf: ConfigRef, r: DebugReport): string =
   assertKind r
   result = reportBody(conf, r)

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -713,25 +713,7 @@ func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
     ## evaluation` context. `sem` and `semexprs` in particular will clear
     ## `conf.m.errorOutputs` as a signal for this. For more details see the
     ## comment for `MsgConfig.errorOutputs`.
-
-  if (r.kind == rdbgVmCodeListing) and (
-    (
-     # If special expand target is not defined, debug all generated code
-     ("expandVmListing" notin conf.symbols)
-    ) or (
-     # Otherwise check if listing target is not nil, and it's name is the
-     # name we are targeting.
-     (not r.debugReport.vmgenListing.sym.isNil()) and
-     (
-       r.debugReport.vmgenListing.sym.name.s ==
-       conf.symbols["expandVmListing"]
-  ))):
-    return writeForceEnabled
-
-  elif r.kind == rdbgVmCodeListing:
-    return writeDisabled
-
-  elif (
+  if (
     (conf.isEnabled(r) and r.category == repDebug and compTimeCtx)
     # Force write of the report messages using regular stdout if compTimeCtx
     # is enabled
@@ -824,11 +806,6 @@ proc computeNotesVerbosity(): tuple[
   when defined(nimVMDebugExecute):
     result.base.incl {
       rdbgVmExecTraceFull # execution of the generated code listings
-    }
-
-  when defined(nimVMDebugGenerate):
-    result.base.incl {
-      rdbgVmCodeListing    # immediately generated code listings
     }
 
   result.main[compVerbosityMax] =

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -76,9 +76,6 @@ from compiler/ast/report_enums import ReportKind
 #      the ground that can cover.
 from compiler/ast/reports import Report, wrap
 
-when defined(nimVMDebugGenerate):
-  import compiler/vm/vmutils
-
 # XXX: instead of `assert` a special `vmAssert` could be used for internal
 #      checks. This would allow for also reporting things like the current
 #      executed instruction

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -40,7 +40,6 @@ Define                        Enables
 `nimDebugUtils`               Allows for semantic analysis execution tracing and more
 `nimDebugUnreportedErrors`    Enable unreported error debugging
 `nimVMDebugExecute`           Print out every instruction executed by the VM
-`nimVMDebugGenerate`          List VM code generated for every procedure called at compile-time
 `nimCompilerStacktraceHints`  Add extra information (node location + kind) to some
 ============================= =======
 
@@ -447,11 +446,14 @@ respective name.
 VM Codegen and Execution
 ========================
 
-VM code generation prints all of the generated procedures. If this is not
-needed (which would be the majority of use cases) you can add
-`--define:expandVmListing=vmTarget`:option: to print only the code
-generated for this proc. For example (generated listing might not match
-exactly)
+For echoing the VM bytecode generated for compile-time procedures and macros,
+`--define:expandVmListing=vmTarget`:option: can be passed to the compiler (no
+special build of the compiler is required). The bytecode for all routines of
+which the name is `vmTarget` is then echoed to the standard output. Leaving
+`vmTarget` empty enables echoing for *all* VM bytecode that is generated as
+part of compile-time execution.
+
+For example (generated listing might not match exactly)
 
 .. code-block:: nim
 
@@ -474,7 +476,7 @@ exactly)
 
 .. code-block:: literal
 
-    Code listing for the 'vmTarget' file.nim(6, 6)
+    Code listing for 'vmTarget' file.nim(6, 6)
 
       LdConst      r3     $     1279                system.nim(2005, 30)
       LdObj        r6     r1     r0                 file.nim(7, 11)


### PR DESCRIPTION
## Summary

Always include support for logging the VM bytecode generated during
compile-time execution in the compiler. `-d:expandVmListing` is re-used
for selecting what to output. In addition, the feature is decoupled from
the legacy reporting machinery.

The goal is improve the debugging experience when working on the VM, by
not having to temporarily re-build the compiler with
`nimVMDebugGenerate` when wanting to log the the generated bytecode.

## Details

* move rendering of VM code listing from `cli_reporter` to `vmutils`,
  with some minor code-style adjustments applied
* add the `logBytecode` procedure to the `compilerbridge` module. It is
  responsible for deciding what to render, invoking the renderer, and
  writing the result to the output (via `msgWrite`)
* call `logBytecode` whenever new bytecode becomes available
* remove the `rdbgVmCodeListing` report, the data types related to it,
  and the special handling for it in `options`
* change `codeListing` to be a proc, as it doesn't adhere to the
  "strict funcs" requirements
* remove all usages of `nimVMDebugGenerate`
* update the feature's documentation in `debug.rst`

The key difference that allows for always including the logging support
is that a code listing is only created when it's meant to be rendered.
Previously, a listing was created for *all* code (even if it was only
discarded afterwards), which introduced non-negligible overhead.