### PR TITLE
better dependent-expression support for range types

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -272,6 +272,14 @@ proc isMetaType*(t: PType): bool =
 proc isUnresolvedStatic*(t: PType): bool =
   return t.kind == tyStatic and t.n == nil
 
+proc isUnresolvedSym*(s: PSym): bool =
+  result = s.kind == skGenericParam
+  if not result and s.typ != nil:
+    result = tfInferrableStatic in s.typ.flags or
+        (s.kind == skParam and s.typ.isMetaType) or
+        (s.kind == skType and
+        s.typ.flags * {tfGenericTypeParam, tfImplicitTypeParam} != {})
+
 template fileIdx*(c: PSym): FileIndex =
   assert c.kind == skModule, "this should be used only on module symbols"
   c.position.FileIndex

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -869,14 +869,6 @@ proc fixAbstractType(c: PContext, n: PNode): PNode =
 proc isAssignable(c: PContext, n: PNode; isUnsafeAddr=false): TAssignableResult =
   result = parampatterns.isAssignable(c.p.owner, n, isUnsafeAddr)
 
-proc isUnresolvedSym(s: PSym): bool =
-  result = s.kind == skGenericParam
-  if not result and s.typ != nil:
-    result = tfInferrableStatic in s.typ.flags or
-        (s.kind == skParam and s.typ.isMetaType) or
-        (s.kind == skType and
-        s.typ.flags * {tfGenericTypeParam, tfImplicitTypeParam} != {})
-
 proc hasUnresolvedArgs(c: PContext, n: PNode): bool =
   # Checks whether an expression depends on generic parameters that
   # don't have bound values yet. E.g. this could happen in situations
@@ -1582,7 +1574,7 @@ proc readTypeParameter(c: PContext, typ: PType,
                        paramName: PIdent, info: TLineInfo): PNode =
   # Note: This function will return emptyNode when attempting to read
   # a static type parameter that is not yet resolved (e.g. this may
-  # happen in proc signatures such as `proc(x: T): array[T.sizeParam, U]`
+  # happen in types such as ``type Typ[T] = arary[T.sizeParam, int]``)
   if typ.kind in {tyUserTypeClass, tyUserTypeClassInst}:
     for statement in typ.n:
       case statement.kind

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2275,7 +2275,7 @@ proc semInferredLambda(c: PContext, pt: TIdTable, n: PNode): PNode {.nosinks.} =
   #incl(s.flags, sfFromGeneric)
   #s.owner = original
 
-  n = replaceTypesInBody(c, pt, n, original)
+  n = instantiateTypesInBody(c, pt, n, original)
   result = n
   s.ast = result
   n[namePos].sym = s

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -802,7 +802,7 @@ proc replaceTypeVarsInBody*(c: PContext, pt: TIdTable, n: PNode): PNode =
   ## the generic AST `n`, with unbound type variables being ignored. Generic
   ## types are not instantiated and static expression not evaluated.
   ##
-  ## Use this procedure instead of ``instantiateTypesInBody`` when its not
+  ## Use this procedure instead of ``instantiateTypesInBody`` when it's not
   ## guaranteed whether all type variables have been resolved.
   template lookup(t: PType): PType = PType(idTableGet(pt, t))
 

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -828,8 +828,12 @@ proc tryResolvingStaticExpr(c: var TCandidate, n: PNode,
   # Here, N-1 will be initially nkStaticExpr that can be evaluated only after
   # N is bound to a concrete value during the matching of the first param.
   # This proc is used to evaluate such static expressions.
-  let instantiated = replaceTypesInBody(c.c, c.bindings, n, nil,
-                                        allowMetaTypes = allowUnresolved)
+  let instantiated =
+    if allowUnresolved:
+      replaceTypeVarsInBody(c.c, c.bindings, n)
+    else:
+      instantiateTypesInBody(c.c, c.bindings, n, nil)
+
   result = c.c.semExpr(c.c, instantiated)
 
 proc inferStaticParam*(c: var TCandidate, lhs: PNode, rhs: BiggestInt): bool =

--- a/tests/lang_callable/generics/tdependent_range_type.nim
+++ b/tests/lang_callable/generics/tdependent_range_type.nim
@@ -1,0 +1,39 @@
+discard """
+  action: compile
+  description: '''
+    Range types depending on type variables must work in routine signatures
+  '''
+  knownIssue: '''
+    ``typeRel`` doesn't properly handle the case where a formal range type is
+    depends on a type variables
+  '''
+"""
+
+import std/typetraits
+
+proc typeNameLen(x: typedesc): int =
+  x.name.len
+
+proc f(t: typedesc, rng: range[-typeNameLen(t) .. typeNameLen(t)]): int =
+  result = rng.type.high - rng.type.low
+
+type
+  MyType = object # only provides the name
+  Typ    = object # shorter name
+
+static:
+  # test non-range argument type:
+  doAssert f(MyType, 0) == 12
+
+  # check that the formal range is available when computing the type
+  # relationship formal and argument type:
+  var a: range[4..8] # overlapping range -> matches
+  doAssert f(MyType, a) == 12
+
+  var b: range[10..12] # doesn't overlap -> no match
+  doAssert not compiles(f(MyType, b) == 12)
+
+  # test with a different name:
+  doAssert f(Typ, 0) == 6
+  doAssert not compiles(f(Typ, 5) == 6)
+  doAssert not compiles(f(Typ, a) == 6)

--- a/tests/lang_callable/generics/tgeneric_backtrack_type_inference.nim
+++ b/tests/lang_callable/generics/tgeneric_backtrack_type_inference.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "\'vectFunc\' doesn't have a concrete type, due to unspecified generic parameters."
+  errormsg: "type mismatch: got <proc (x: vector[vectFunc.T]): vector[vectFunc.T], vector[3]>"
   line: 36
   description: '''
     . From https://github.com/nim-lang/Nim/issues/6137


### PR DESCRIPTION
## Summary

Fix complex type-variable-dependent expressions not working reliably
for range and array-index types used in routine signatures.
Internally, expressions in both contexts are now first treated as
generic, and using `replaceTypesInBody` for expressions with
potentially unbound type variables is removed.

**Language changes:**
- syntax macros and templates (i.e., those where all parameters are 
  `untyped`) used in range- and index-type expression are expanded
  before all further analysis (and thus typed macros/template, static
  expressions, etc.)
- typed macros and templates used in range- and index-type expressions
  depending on type variables are potentially expanded multiple times

**Fixes:**
- type-variable-dependent range and array-index types in routine
  signatures can now be arbitrarily complex (refer to the added tests
  for an example of what is now possible)

## Details

**Overview:**
- all expressions used with range types and in array-index positions
  now use the generic pre-pass
- type-variable-dependent expressions in range type constructors are
  now always generic expressions (i.e., symbols are looked up, but
  not AST is not typed)
- `replaceTypesInBody` is renamed to `instantiateTypesInBody` and
  support for unresolved type variables is removed -- the new
  `replaceTypeVarsInBody` now has to be used for that case

Semantic analysis has very basic, scattered support for expressions
depending on unresolved type variables, allowing `semExprWithType` to
be used for typing expressions in range and array type constructors.
However, in more complex cases, this usually results in errors with
unclear descriptions. Until more complete support for typing expressions
depending on unresolved type variables is implemented, it is more
robust to treat them as fully generic.

### Analyzing the expressions

Both `semRangeAux` and `semArrayIndex` now always run the generic pre-
pass first (`semGenericStmt`, which also expands syntax macros), which
is required for detecting whether unresolved type variables are used.
When no unresolved type variables exist in the analyzed expression, it
is directly passed on to `semExprWithType`.

The procedure for querying whether a symbol is that of an unresolved
type variable (`isUnresolvedSym`), is moved to the `ast_query`
module.

Looking for unresolved type variables is combined with making sure that
all type variables are referenced in the AST via their symbols
(`fixupTypeVars`) -- something that is not always already the case. Some
type variables not having their symbol bound would mean that the later
pass for replacing type variables cannot detect them.

As an unintended side-effect of using `semGenericStmt`, unrelated
symbols are marked as used, which is what causes the different error
message in `tgeneric_backtrack_type_inference.nim` (the presence of the
`sfUsed` flag for generic parameters of routines decides whether a
routine is marked with `tfUnresolved`).

### Processing the generic expressions

For processing generic expressions used in the context of `static`
parameter inference, where unbound type variables are possible, the
`replaceTypeVarsInBody` procedure is introduced. While using 
`replaceTypesInBody` with `allowMetaTypes = true` would have sufficed,
this is intended as a step towards removing the "meta-types allowed"
mode from `semtypinst`.

Implementation-wise, `replaceTypeVarsInBody` is similar to `prepareNode`,
with the differences being that `replaceTypeVarsInBody`:
- does not instantiates or traverses into any types
- only considers symbol nodes referring to type variables

Expression already having a type are not analyzed again when used as call
operands, and thus two compromises are required for the generic-expression
approach to work:
- both `prepareNode` and `replaceTypeVarsInBody` have to mirror
  how `semSym` assigns types to symbol nodes of type variables (`fixType`
  implements this)
- `replaceTypeVarsInBody` has to remove from the expression the types
  previously assigned by both `semRangeAux` and `semArrayIndex`

`replaceTypesInBody` is renamed to `instantiateTypesInBody`. In addition,
the unnecessarily exported `replaceTypeVarsN` is un-exported.

### Misc

- restore the name of the `tgenericshardcases` test, which was
  erroneously changed to `tsharedcases` during a test suite cleanup