### PR TITLE
internal: prepare for code generator improvements

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -375,7 +375,7 @@ proc process(body: var MirFragment, ctx: PSym, graph: ModuleGraph,
   injectDestructorCalls(graph, idgen, ctx, body.tree, body.source)
 
 proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
-                  code: sink MirFragment): CgNode =
+                  code: sink MirFragment): Body =
   ## Translates the MIR code provided by `code` into ``CgNode`` IR and,
   ## if enabled, echoes the result.
   result = generateIR(graph, idgen, owner, code.tree, code.source)

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -177,6 +177,7 @@ type
     withinBlockLeaveActions*: int ## complex to explain
     sigConflicts*: CountTable[string]
 
+    body*: Body               ## the procedure's full body
     locals*: SymbolMap[TLoc]  ## the locs for all locals of the procedure
 
   TTypeSeq* = seq[PType]

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -1358,11 +1358,11 @@ proc tb(tree: TreeWithSource, cl: var TranslateCl, start: NodePosition): CgNode 
 
 
 proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
-                  tree: sink MirTree, sourceMap: sink SourceMap): CgNode =
+                  tree: sink MirTree, sourceMap: sink SourceMap): Body =
   ## Generates the ``CgNode`` IR corresponding to the input MIR code (`tree`),
   ## using `idgen` for provide new IDs when creating symbols. `sourceMap`
   ## must be the ``SourceMap`` corresponding to `tree` and is used as the
   ## provider for source position information
   var cl = TranslateCl(graph: graph, idgen: idgen, cache: graph.cache,
                        owner: owner)
-  tb(TreeWithSource(tree: tree, map: sourceMap), cl, NodePosition 0)
+  Body(code: tb(TreeWithSource(tree: tree, map: sourceMap), cl, NodePosition 0))

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -14,6 +14,7 @@ import
   ],
   compiler/backend/[
     backends,
+    cgir,
     jsgen
   ],
   compiler/front/[
@@ -74,7 +75,7 @@ proc processEvent(g: PGlobals, graph: ModuleGraph, modules: BModuleList,
       partial[evt.sym.id] = p
 
     let body = generateIR(graph, bmod.idgen, evt.sym, evt.body)
-    genStmt(p, body)
+    genStmt(p, merge(p.fullBody, body))
 
     processLate(g, discovery)
   of bekProcedure:

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -70,12 +70,12 @@ proc echoMir*(config: ConfigRef, owner: PSym, tree: MirTree) =
     writeBody(config, "-- MIR: " & owner.name.s):
       config.writeln(print(tree))
 
-proc echoOutput*(config: ConfigRef, owner: PSym, body: CgNode) =
+proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
   ## If requested via the define, renders the output IR `body` and writes the
   ## result out through ``config.writeLine``.
   if config.getStrDefine("nimShowMirOutput") == owner.name.s:
     writeBody(config, "-- output AST: " & owner.name.s):
-      config.writeln(treeRepr(body))
+      config.writeln(treeRepr(body.code))
 
 proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap,
                        outermost: bool) =
@@ -168,7 +168,7 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap,
   apply(body, prepared)
 
 proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
-                   body: PNode, options: set[GenOption]): CgNode =
+                   body: PNode, options: set[GenOption]): Body =
   ## Legacy routine. Translates the body `body` of the procedure `owner` to
   ## MIR code, and the MIR code to ``CgNode`` IR.
   echoInput(graph.config, owner, body)

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -1325,7 +1325,7 @@ proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
     # the MIR code wouldn't be very useful, so we turn it into backend IR
     # first, which we then render to text
     # XXX: this needs a deeper rethink
-    let n = generateIR(g, idgen, owner, tree, sourceMap)
+    let n = generateIR(g, idgen, owner, tree, sourceMap).code
     g.config.msgWrite("--expandArc: " & owner.name.s & "\n")
     g.config.msgWrite(render(n))
     g.config.msgWrite("\n-- end of expandArc ------------------------\n")


### PR DESCRIPTION
## Summary

Introduce the `Body` data type, meant for storing a self-contained
procedure body, and integrate it into each code generator. While only
the procedure's code is stored in `Body` so far, the idea is to have it
store all other body-related input data once moving to a data-oriented
design for the IR.

## Details

#### Architectural changes

* the code generators now require a `Body` instead of a free-standing
  `CgNode` as input, of which they take ownership
* `generateIR` returns a `Body` instance instead of a free-standing
  `CgNode` 

Each code generator stores the `Body` in its internal procedure context
type.

#### Additional C and JS code generator changes

* merge each partial body into the procedure's total body. While not
  necessary at the moment, it will be, once `Body` starts storing more
  than just the `CgNode`

#### Additional VM code generator changes

* `PProc` is turned into a non-`ref` object type, made private, and
  renamed to `BProc` (the name also used by the C code generator)
* `bestEffort` is turned from a procedure into a field of `BProc`,
  allowing the register allocation procedures to take a `BProc` as
  input, instead of the broader `TCtx`
* the setup of `BProc` plus initial address-taken analysis is moved into
  a common procedure, making procedure and expression/statement code
  generation more uniform
* both `genExpr` and `genStmt` now return the required amount of
  registers, instead of the callsite having to manually query the
  value

Instead of incrementally generating the code for partial procedures,
`vmbackend` accumulates the `CgNode` code and only invokes the code
generator once the procedures are complete, which greatly simplifies
the partial-procedure-related logic