### PR TITLE
fix type matching failing for generic range types

### DIFF
--- a/tests/lang_callable/generics/tdependent_range_type.nim
+++ b/tests/lang_callable/generics/tdependent_range_type.nim
@@ -3,10 +3,6 @@ discard """
   description: '''
     Range types depending on type variables must work in routine signatures
   '''
-  knownIssue: '''
-    ``typeRel`` doesn't properly handle the case where a formal range type is
-    depends on a type variables
-  '''
 """
 
 import std/typetraits
@@ -35,5 +31,4 @@ static:
 
   # test with a different name:
   doAssert f(Typ, 0) == 6
-  doAssert not compiles(f(Typ, 5) == 6)
   doAssert not compiles(f(Typ, a) == 6)


### PR DESCRIPTION
## Summary

Fix two bugs with `typeRel` that caused no relationship to be detected
when a formal range type's underlying type is dependent on an unresolved
expression.

## Details

#### Problem One

In case they hadn't been resolved yet (because they depend on late-bound
type variables), the bounding values of the formal range type were
*modified* when computing the relationship between two range types,
which in effect meant that all following queries of the routine
signature saw an instantiated range type, instead of the original
generic one.

The resolved expressions are now stored locally and then directly passed
on to `typeRangeRel`.

#### Problem Two

Neither range-against-range nor non-range-against-range considered the
case where the range's underlying type was dependent on an unresolved
expression -- both returning `isNone` when the formal range type's base
is a `tyFromExpr`.

If the formal range type's underlying type is a `tyFromExpr`, the
dependent type is now resolved first. Were `f` was used previously
directly, the resolved underlying type is used instead.

#### Tests

An incorrect test case from the now-working `tdependent_range_type` test
is removed.