### PR TITLE
typerel: rework `tyGenericInvocation` handling

### DIFF
--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -433,7 +433,7 @@ proc skipToObject(t: PType; skipped: var SkippedPtr): PType =
   while r != nil:
     case r.kind
     of tyGenericInvocation:
-      r = r[0]
+      r = r.base.lastSon
     of tyRef:
       inc ptrs
       skipped = skippedRef
@@ -442,33 +442,12 @@ proc skipToObject(t: PType; skipped: var SkippedPtr): PType =
       inc ptrs
       skipped = skippedPtr
       r = r.lastSon
-    of tyGenericBody, tyGenericInst, tyAlias, tySink:
+    of tyGenericInst, tyAlias, tySink:
+      # note: don't skip ``tyGenericBody`` here
       r = r.lastSon
     else:
       break
   if r.kind == tyObject and ptrs <= 1: result = r
-
-proc isGenericSubtype(c: var TCandidate; a, f: PType, d: var int, fGenericOrigin: PType): bool =
-  assert f.kind in {tyGenericInst, tyGenericInvocation, tyGenericBody}
-  var askip = skippedNone
-  var fskip = skippedNone
-  var t = a.skipToObject(askip)
-  let r = f.skipToObject(fskip)
-  if r.isNil(): return false
-  var depth = 0
-  var last = a
-  # XXX sameObjectType can return false here. Need to investigate
-  # why that is but sameObjectType does way too much work here anyway.
-  while t != nil and r.sym != t.sym and askip == fskip:
-    t = t[0]
-    if t.isNil(): break
-    last = t
-    t = t.skipToObject(askip)
-    inc depth
-  if t != nil and askip == fskip:
-    genericParamPut(c, last, fGenericOrigin)
-    d = depth
-    result = true
 
 proc isSubtypeOfGenericInstance(c: var TCandidate; a, f: PType, fGenericOrigin: PType): int =
   ## Computes whether the resolved object-like type `a` is a subtype of `f`,
@@ -477,7 +456,7 @@ proc isSubtypeOfGenericInstance(c: var TCandidate; a, f: PType, fGenericOrigin: 
   ##
   ## In case of a subtype relationship existing, the unbound generic parameters
   ## of `f` are bound to the respective parameters of `a`.
-  assert f.kind == tyGenericInst
+  assert f.kind in {tyGenericInst, tyGenericInvocation}
   var
     askip = skippedNone
     fskip = skippedNone
@@ -499,7 +478,7 @@ proc isSubtypeOfGenericInstance(c: var TCandidate; a, f: PType, fGenericOrigin: 
          (let roota = a.skipGenericAlias; roota.base == f.base):
       # formal might still contain unresovled generic parameters, in which case
       # the ID comparison won't work as an equality check
-      for i in 1..<f.len-1:
+      for i in 1..<a.len-1:
         # don't bind generic parameters yet; binding must only happen in
         # case of a match
         if typeRel(c, f[i], roota[i], {trDontBind}) < isGeneric:
@@ -676,6 +655,10 @@ proc typeRangeRel(f: PType, lo, hi: PNode, a: PType): TTypeRelation {.noinline.}
   else:
     checkRange(firstFloat(a), lastFloat(a), getFloatValue(lo), getFloatValue(hi))
 
+proc getBound(c: TCandidate, t: PType): PType =
+  result = PType(idTableGet(c.bindings, t))
+  while result != nil and isMetaType(result):
+    result = PType(idTableGet(c.bindings, result))
 
 proc matchUserTypeClass*(m: var TCandidate; ff, a: PType): PType =
   var
@@ -712,7 +695,7 @@ proc matchUserTypeClass*(m: var TCandidate; ff, a: PType): PType =
         typeParamName = ff.base[i-1].sym.name
         typ = ff[i]
         param: PSym
-        alreadyBound = PType(idTableGet(m.bindings, typ))
+        alreadyBound = getBound(m, typ)
 
       if alreadyBound != nil: typ = alreadyBound
 
@@ -1095,7 +1078,7 @@ typeRel can be used to establish various relationships between types:
 
       case f.kind
       of tyGenericParam:
-        var prev = PType(idTableGet(c.bindings, f))
+        var prev = getBound(c, f)
         if prev != nil:
           candidate = prev
       of tyFromExpr:
@@ -1615,88 +1598,62 @@ typeRel can be used to establish various relationships between types:
         result = typeRel(c, ff, a, flags)
 
   of tyGenericInvocation:
-    var x = a.skipGenericAlias
-    let concpt = f[0].skipTypes({tyGenericBody})
-
-    # XXX: This is very hacky. It should be moved back into liftTypeParam
-    if x.kind in {tyGenericInst, tyArray} and
-      c.calleeSym != nil and
-      c.calleeSym.kind in {skProc, skFunc} and c.call != nil:
-      let inst = prepareMetatypeForSigmatch(c.c, c.bindings, c.call.info, f)
-      #echo "inferred ", typeToString(inst), " for ", f
-      return typeRel(c, inst, a, flags)
+    # a generic invocation represents an unresolved type application
+    let
+      x = a.skipGenericAlias
+      # XXX: ^^ this means argument phantom types are ignored
+      body = f.base.lastSon
+    var sp: SkippedPtr
 
     if x.kind == tyGenericInvocation:
-      if f[0] == x[0]:
+      # an unresolved type application is matched against another unresolved
+      # type application
+      if f.base == x.base:
         for i in 1..<f.len:
           let tr = typeRel(c, f[i], x[i], flags)
           if tr <= isSubtype: return
         result = isGeneric
-    elif x.kind == tyGenericInst and f[0] == x[0] and
-          x.len - 1 == f.len:
-      for i in 1..<f.len:
-        c.c.graph.config.internalAssert(x[i].kind != tyGenericParam, "wrong instantiated type!")
-
-        if typeRel(c, f[i], x[i], flags) <= isSubtype:
-          # Workaround for https://github.com/nim-lang/nim/issues/4589
-          if f[i].kind != tyTypeDesc:
-            return
-
+      # XXX: what about nested invocations (i.e., generic aliases)?
+    elif x.kind == tyGenericInst and f.base == x.base:
+      # a resolved type application is matched against an unresolved one where
+      # both are for the same generic type -> the arguments have to match
+      result = compareInvocationArguments(c, f, x, flags)
+    elif x.kind == tyGenericBody and f.base == x:
+      # this is a special case to support:
+      #   proc f[T](a: typedesc[Generic[T]])
+      #   f[int](Generic)
+      # XXX: this seems like a really bad idea, why should that work? The
+      #      procedure wants a typedesc for an instantiated type, but it gets
+      #      an (unlifted) composite-type-class
       result = isGeneric
-    else:
-      var
-        askip = skippedNone
-        fskip = skippedNone
-        depth = -1
-      let
-        genericBody = f[0]
-        aobj = x.skipToObject(askip)
-        fobj = genericBody.lastSon.skipToObject(fskip)
-      
-      if fobj != nil and aobj != nil and askip == fskip:
-        depth = isObjectSubtype(c, aobj, fobj, f)
-      
-      result = typeRel(c, genericBody, x, flags)
-      
-      if result != isNone:
-        # see tests/generics/tgeneric3.nim for an example that triggers this
-        # piece of code:
-        #
-        # proc internalFind[T,D](n: PNode[T,D], key: T): ref TItem[T,D]
-        # proc internalPut[T,D](ANode: ref TNode[T,D], Akey: T, Avalue: D,
-        #                       Oldvalue: var D): ref TNode[T,D]
-        # var root = internalPut[int, int](nil, 312, 312, oldvalue)
-        # var it1 = internalFind(root, 312) # cannot instantiate: 'D'
-        #
-        # we steal the generic parameters from the tyGenericBody:
-        for i in 1..<f.len:
-          let x = PType(idTableGet(c.bindings, genericBody[i-1]))
-          if x.isNil():
-            discard "maybe fine (for e.g. a==tyNil)"
-          else:
-            c.c.graph.config.internalAssert(
-              x.kind notin {tyGenericInvocation, tyGenericParam},
-              "wrong instantiated type!")
-            let key = f[i]
-            let old = PType(idTableGet(c.bindings, key))
-            if old.isNil():
-              put(c, key, x)
-            elif typeRel(c, old, x, flags + {trDontBind}) == isNone:
-              return isNone
-
-      if result == isNone:
-        # Here object inheriting from generic/specialized generic object
-        # crossing path with metatypes/aliases, so we need to separate them
-        # by checking sym.id
-        let genericSubtype = isGenericSubtype(c, x, f, depth, f)
-        if not (genericSubtype and aobj.sym.id != fobj.sym.id) and aOrig.kind != tyGenericBody:
-          depth = -1
-
-      if depth >= 0:
+    elif body.skipTypes({tyPtr, tyRef}).kind == tyObject and
+         x.skipToObject(sp) != nil:
+      # if its not the same object type, there can still be a subtype
+      # relationship
+      let depth = isSubtypeOfGenericInstance(c, x, f, f)
+      case depth
+      of -1:
+        result = isNone
+      of 0:
+        unreachable("already handled by the ``x.kind == tyGenericInst`` branch")
+      else:
         c.inheritancePenalty += depth
-        # bug #4863: We still need to bind generic alias crap, so
-        # we cannot return immediately:
-        result = if depth == 0: isGeneric else: isSubtype
+        result = isSubtype
+
+    elif x.kind == tyGenericInst and
+         body.kind notin {tyAnd, tyOr, tyGenericInvocation}:
+      # the formal invocation is not a generic alias and both `f` and
+      # `a` are not applications to the same generic type -> no match.
+      result = isNone
+    else:
+      # XXX: to not ignore phantom types, this branch should only be taken
+      #      when `f` is not a phantom type
+      # bind the arguments to the parameters and then match against the body
+      for i in 1..<f.len:
+        idTablePut(c.bindings, f.base[i-1], f[i])
+
+      # structural types and anything else uses "match against the generic body"
+      result = typeRel(c, body, a, flags)
   of tyAnd:
     considerPreviousT:
       result = isEqual
@@ -1886,7 +1843,7 @@ typeRel can be used to establish various relationships between types:
     elif a.kind == tyEmpty:
       result = isGeneric
     elif x.kind == tyGenericParam:
-      result = isGeneric
+      result = typeRel(c, x, a, flags)
     else:
       result = typeRel(c, x, a, flags) # check if it fits
       if result > isGeneric: result = isGeneric
@@ -1927,7 +1884,10 @@ typeRel can be used to establish various relationships between types:
       else:
         result = isNone
     elif prev.kind == tyStatic:
-      if aOrig.kind == tyStatic:
+      if prev.n == nil:
+        # must be a forwarded parameter
+        result = typeRel(c, prev, a, flags)
+      elif aOrig.kind == tyStatic:
         result = typeRel(c, prev.lastSon, a, flags)
         if result != isNone and prev.n != nil:
           if not exprStructuralEquivalent(prev.n, aOrig.n):

--- a/tests/lang_callable/generics/tgeneric_range_invocation_issue.nim
+++ b/tests/lang_callable/generics/tgeneric_range_invocation_issue.nim
@@ -1,0 +1,24 @@
+discard """
+  description: '''
+    Invoking a generic range type with a ``static`` normal parameter instead
+    of a generic parameter must work
+  '''
+  knownIssue: '''
+    The type variable in the range expression reaches the final
+    ``semtypinst.prepareNode`` call as something that is not detected as a
+    type variables
+  '''
+"""
+
+type Range[N: static int] = range[0 .. (N + 2)]
+
+proc f(A: static int, rng: Range[A]): int =
+  result = typeof(rng).high.int
+
+# test with non-range:
+doAssert f(3, 0) == 5
+# test with range:
+var a: range[7..10]
+doAssert f(3, a) == 8
+# negative test: make sure that range types not overlapping are rejected
+doAssert not compiles(f(3, b) == 5)


### PR DESCRIPTION
## Summary

Make the type relationship computation (`typeRel`) for instantiated
generic types (`tyGenericInst`) and unresolved type applications
(`tyGenericInvocation`) more consistent with each other, which, apart
from removing another dependency on `semtypinst`'s "meta-types allowed"
mode, is also a preparation for fixing the handling of phantom types.

**Fixes:**
- invocations of types like `Body[T] = T.param` and
  `Body[N] = range[0..(N+1)]` with generic parameters in routine
  signatures now work properly during parameter matching
- for the procedure with the signature `proc f[T](x: Type[Type[T]])`
  and `Type[A] = (A,)`, inferring `T` as `X` now works when passing
  a `(Type[X],)`

A temporary regression is that constraints of generic parameters are now
ignored when a non-generic-instance is matched against the invocation of
a generic type.

## Details

**Key changes:**
- `typeRel` doesn't directly use `prepareMetatypeForSigmatch` anymore,
  which is another step towards removing `semtypinst`'s "meta-types
  allowed" mode
- the `replaceTypeVarsInType` procedure is added, which replaces type
  variables without also resolving `tyGenericInvocation`s 
- `tyGenericInvocation` handling in `typeRel` is now much more similar
  to that of `tyGenericInst`

When computing the relationship with a `tyGenericInvocation` (e.g., a
`Type[T]` in a routine signature where `T` is a generic parameter) and:
- the argument type is an array type or an instantiated generic type
  (i.e., `tyGenericInst`)
- `typeRel` happens in the context of routine signature parameter type
  matching

the invocation was first resolved via `prepareMetatypeForSigmatch` and
the argument type then matched against the instantiated type. The reason
for this seems to have been being able to consistently handle generic
aliases (by skipping them) and, in the case of `array`s, that static
parameter inference works.

What `prepareMetatypeForSigmatch` does is create a fully instantiated
`tyGenericInst` for a `tyGenericInvocation`, using the "meta-types
allowed" mode of `semtypinst`. For example, the instance produced for
`Body[A] = (A, A)` with an invocation like `Body[T]` would be a `(T, T)`
type.

### Reworked handling

In order to not having to rely on the "meta-types allowed" mode, the
handling of `tyGenericInvocation` is reworked to be the following (`f`
is the formal type and `a` the argument type after generic alias are
skipped):
1. if `a` is a `tyGenericInvocation`, the behaviour is the same as
   previously
2. if `a` is a `tyGenericInst` and it's an instance of the generic type
   that the invocation invokes, their relation is that of their
   arguments (the comparison works the same as for two `tyGenericInst`)
3. if the formal invocation is of an `object` type (including `ref` and
   `ptr` versions), `f` and `a` have a sub-type relationship if `a` is a
   sub-type of `f`, otherwise there's no relation
4. if `f` is an invocation of a `and|or` type or of another
   invocation and `a` is a `tyGenericInst`, there is no relationship
   (this mirrors the `tyGenericInst`-against-`tyGenericInst` handling)
5. otherwise (i.e., none of the above were true), the type parameters in
   `f`'s body are replaced with the types passed to the invocation, and
   `a` is matched against the resulting type

The replacing in step 5. is implemented by the new
`replaceTypeParamsInType` procedure, which is similar to
`replaceTypeVarsT`, but with the important difference that:
- it doesn't instantiate `tyGenericInvocation`s
- it properly handles `tyFromExpr`, by also replacing the type
  parameters in the attached AST
- the attached AST for object, tuple, and proc types is not modified, as
  this is not needed for `typeRel` to work with the types

For the case where `a` is not a `tyGenericInst` or `tyArray`, the
important difference is that `a` is now not matched against the body of
`f` first, with the inferred parameters of `f` then being matched
against its arguments. This leads to inference working in more complex
cases, but it also means that the parameter constraints of the invoked
types are ignored. For example:

```nim
type Type[A: object] = (A,)
proc f[T](x: Type[T]) = discard

f((1,))
```
doesn't fail now, while it previously (correctly) did.

**Related changes:**
- move the logic for comparing the arguments of two `tyGenericInst`
  types into a standalone procedure and adjust it to also work with
  `tyGenericInvocation`s
- change `skipToObject` to not skip over `tyGenericBody`, as doing
  so is almost never what is wanted
- adjust `isSubtypeOfGenericInstance` to support `f` being a
  `tyGenericInvocation`
- remove the now-obsolete `isGenericSubtype`
- add a known-issue test for a pre-existing issue with generic range
  types