### PR TITLE
internal: faster `ConfigRef` access

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -317,36 +317,36 @@ template `[]`*(conf: ConfigRef, idx: FileIndex): TFileInfo =
   conf.m.fileInfos[idx.uint32]
 
 template passField(fieldname, fieldtype: untyped): untyped =
-  proc `fieldname`*(conf: ConfigRef): fieldtype =
+  template `fieldname`*(conf: ConfigRef): fieldtype =
     conf.active.fieldname
 
-  proc `fieldname=`*(conf: ConfigRef, val: fieldtype) =
+  template `fieldname=`*(conf: ConfigRef, val: fieldtype) =
     conf.active.fieldname = val
 
 template passSetField(fieldname, fieldtype, itemtype: untyped): untyped =
   passField(fieldname, fieldtype)
 
-  proc incl*(conf: ConfigRef, item: itemtype | fieldtype) =
+  template incl*(conf: ConfigRef, item: itemtype | fieldtype) =
     conf.active.fieldname.incl item
 
-  proc excl*(conf: ConfigRef, item: itemtype | fieldtype) =
+  template excl*(conf: ConfigRef, item: itemtype | fieldtype) =
     conf.active.fieldname.excl item
 
 template passStrTableField(fieldname: untyped): untyped =
   passField(fieldname, StringTableRef)
 
-  proc `fieldname Set`*(conf: ConfigRef, key: string, value: string) =
+  template `fieldname Set`*(conf: ConfigRef, key: string, value: string) =
     conf.active.fieldname[key] = value
 
-  proc `fieldname Get`*(conf: ConfigRef, key: string): string =
+  template `fieldname Get`*(conf: ConfigRef, key: string): string =
     conf.active.fieldname[key]
 
-  proc `fieldname Del`*(conf: ConfigRef, key: string) =
+  template `fieldname Del`*(conf: ConfigRef, key: string) =
     conf.active.fieldname.del key
 
 template passSeqField(fieldname, itemtype: untyped): untyped =
   passField(fieldname, seq[itemtype])
-  proc `fieldname Add`*(conf: ConfigRef, item: itemtype | seq[itemtype]) =
+  template `fieldname Add`*(conf: ConfigRef, item: itemtype | seq[itemtype]) =
     conf.active.fieldname.add item
 
 passField backend,            TBackend


### PR DESCRIPTION
## Summary

Replace the accessor procedures for `ConfigRef` with templates,
resulting in a small improvement to the compiler's performance.

With a `-d:release` compiler, the time it takes to build the compiler
(excluding the C compilation step) is reduced by ~6% (14.4 compared to
15.3 seconds on the measured-with machine).

## Details

The active configuration accessor procedures for `ConfigRef` didn't use
`lent` (for the access wrappers) and `sink` (for assignment wrapper)
annotations, meaning that each read access introduced an unnecessary
full copy and each assignment introduced a potentially unnecessary full
copy.

Turning the procedures into templates showed to result in slightly
faster code compared to using `lent`, `sink`, and `.inline`, hence them
being turned into templates. Using the accessors is now as fast as
manually accessing the `active` configuration state, and no unnecessary
copies are introduced anymore.