### PR TITLE
internal: detect illegal access of locals earlier

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1113,6 +1113,8 @@ type
     # vm
     adVmError
     adVmQuit
+    # semcomptime
+    adSemUnavailableLocation
     # semcall
     adSemRawTypeMismatch
     adSemExpressionCannotBeCalled
@@ -1335,7 +1337,8 @@ type
         adSemExpectedIdentifierQuoteLimit,
         adSemExpectedRangeType,
         adSemExpectedLabel,
-        adSemContinueCannotHaveLabel:
+        adSemContinueCannotHaveLabel,
+        adSemUnavailableLocation:
       discard
     of adSemExpectedIdentifierInExpr:
       notIdent*: PNode

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -580,6 +580,7 @@ type
     rsemCannotCreateImplicitOpenarray
     rsemCannotAssignToDiscriminantWithCustomDestructor
     rsemUnavailableTypeBound
+    rsemUnavailableLocation
 
     # Identifier Lookup
     rsemUndeclaredIdentifier

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -490,6 +490,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
 
       result.add("; routine: ", r.symstr)
 
+    of rsemUnavailableLocation:
+      result = ("accessed location '$1' doesn't exist in the current " &
+               "compile-time context") % [r.ast.render]
+
     of rsemIllegalCallconvCapture:
       let s = r.symbols[0]
       let owner = r.symbols[1]
@@ -3284,7 +3288,8 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemExpectedIdentifierQuoteLimit,
       adSemExpectedRangeType,
       adSemExpectedLabel,
-      adSemContinueCannotHaveLabel:
+      adSemContinueCannotHaveLabel,
+      adSemUnavailableLocation:
     semRep = SemReport(
         location: some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -502,6 +502,7 @@ func astDiagToLegacyReportKind*(
     assert vmEvent.isSome
     astDiagVmToLegacyReportKind(vmEvent.unsafeGet)
   of adVmQuit: rvmQuit
+  of adSemUnavailableLocation: rsemUnavailableLocation
   of adSemRawTypeMismatch: rsemRawTypeMismatch
   of adSemExpressionCannotBeCalled: rsemExpressionCannotBeCalled
   of adSemCallTypeMismatch: rsemCallTypeMismatch

--- a/compiler/sem/semcomptime.nim
+++ b/compiler/sem/semcomptime.nim
@@ -1,0 +1,77 @@
+## Implements checks for whether otherwise valid code can be run at compile
+## time or in NimScript contexts.
+
+import
+  std/[
+    intsets
+  ],
+  compiler/ast/[
+    ast_query,
+    ast_types
+  ]
+
+type
+  CheckCtx = object
+    defs: IntSet ## IDs of the locals defined so far. Using a local not present
+                 ## in this set is an error
+
+proc checkAux(c: var CheckCtx, n: PNode): PNode =
+  template check(n: PNode) =
+    result = checkAux(c, n)
+    # unwind in case an error is found:
+    if result != nil:
+      return
+
+  case n.kind
+  of nkSym:
+    let s = n.sym
+    case s.kind
+    of skVar, skLet, skForVar, skTemp, skParam, skResult:
+      if sfGlobal notin s.flags and s.id notin c.defs:
+        # a local not available in the current context
+        result = n
+    else:
+      discard "ignore"
+
+  of nkForStmt:
+    for it in forLoopDefs(n):
+      c.defs.incl it.sym.id
+
+    check(n[^2])
+    check(n[^1])
+  of nkIdentDefs, nkVarTuple:
+    for it in n.names:
+      c.defs.incl it.sym.id
+
+    result = checkAux(c, n[^1])
+  of nkExceptBranch:
+    # an ``except Error as e`` branch also introduces a local
+    if isInfixAs(n[0]):
+      c.defs.incl n[0][2].sym.id
+  of callableDefs, nkNimNodeLit, nkTypeSection, nkConstSection,
+     nkTypeOfExpr, nkMixinStmt, nkBindStmt, nkImportStmt, nkImportExceptStmt,
+     nkFromStmt, nkExportStmt:
+    discard "ignore declarative nodes"
+  of nkWhenStmt:
+    # a 'when nimvm' statement; choose the first branch
+    result = checkAux(c, n[0][1])
+  of nkCast, nkConv, nkHiddenStdConv, nkHiddenSubConv:
+    result = checkAux(c, n[1])
+  else:
+    for it in n.items:
+      check(it)
+
+proc check*(n: PNode): PNode =
+  ## Given the untransformed AST `n` of a freestanding expression/statement,
+  ## looks for access of locals that aren't available in the current compile-
+  ## time context. Example:
+  ##
+  ## .. code-block:: nim
+  ##
+  ##   var x = 0
+  ##   const y = x # <- 'x' cannot be used here
+  ##
+  ## If such illegal access is found, the first offending node is returned,
+  ## 'nil' otherwise.
+  var c = CheckCtx()
+  result = checkAux(c, n)

--- a/compiler/sem/semcomptime.nim
+++ b/compiler/sem/semcomptime.nim
@@ -48,6 +48,17 @@ proc checkAux(c: var CheckCtx, n: PNode): PNode =
     # an ``except Error as e`` branch also introduces a local
     if isInfixAs(n[0]):
       c.defs.incl n[0][2].sym.id
+
+  of nkCallKinds:
+    # XXX: the ``len`` call for an arrays is uncondtionally folded away later,
+    #      which means that it's okay for the argument expression to reference
+    #      locals not declared in the current context. Until folding happens
+    #      earlier, we skip the call here
+    if n[0].kind == nkSym and n[0].sym.magic == mLengthArray:
+      return
+
+    for it in n.items:
+      check(it)
   of callableDefs, nkNimNodeLit, nkTypeSection, nkConstSection,
      nkTypeOfExpr, nkMixinStmt, nkBindStmt, nkImportStmt, nkImportExceptStmt,
      nkFromStmt, nkExportStmt:

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -32,6 +32,7 @@ import
   ],
   compiler/sem/[
     passes,
+    semcomptime,
     transf
   ],
   compiler/utils/[
@@ -545,6 +546,11 @@ proc evalConstExprAux(module: PSym, idgen: IdGenerator, g: ModuleGraph,
                       mode: TEvalMode): PNode =
   addInNimDebugUtils(g.config, "evalConstExprAux", prc, n, result)
   setupGlobalCtx(module, g, idgen)
+
+  # check whether the code accesses unavailable locations:
+  if (let r = check(n); r != nil):
+    # it does
+    return g.config.newError(r, PAstDiag(kind: adSemUnavailableLocation))
 
   let
     c = PEvalContext(g.vm)

--- a/tests/errmsgs/tunavailable_local.nim
+++ b/tests/errmsgs/tunavailable_local.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "accessed location 'x' doesn't exist in the current compile-time context"
+  line: 8
+"""
+
+proc f() =
+  var x = 1
+  const y = x + 1

--- a/tests/vm/twrongarray.nim
+++ b/tests/vm/twrongarray.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "cannot evaluate at compile time: size"
+  errormsg: "accessed location 'size' doesn't exist in the current compile-time context"
   line: 16
 """
 

--- a/tests/vm/twrongwhen.nim
+++ b/tests/vm/twrongwhen.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "cannot evaluate at compile time: x"
+  errormsg: "accessed location 'x' doesn't exist in the current compile-time context"
   line: 7
 """
 


### PR DESCRIPTION
## Summary

Move detection of inaccessible locals from `vmgen` into a pre-pass over
standalone expressions/statements passed to compile-time execution. This
makes sure that all locals reaching `transf` and the MIR phase are
valid, which is a requirement for moving away from using `PSym` for
locals in the code generators.

## Details

- implement the check for whether unavailable locals are accessed in the
  new `semcomptime` module
- integrate the check into `evalConstExprAux`, where it short-circuits
  code generation in case of an error
- add a dedicated diagnostic for using unavailable locals in compile-
  time contexts (`adSemUnavailableLocation`/`rsemUnavailableLocation`)
- adjust the tests using the old error message
- remove from `vmgen` the checks regarding whether access of a local is
  valid

Implementation-wise, the check works by traversing the AST, registering
all symbols in a set as they're declared, and then, on use, checking
whether non-global symbol are present in the set. If not, the node
with the problematic symbol is propagated back to the callsite, where it
is wrapped in an error node.

While it would be possible to integrate the check into `sempass2`, the
future of the latter isn't entirely clear and the pass is at present
also not run for standalone compile-time expressions/statements.