### PR TITLE
internal: speed up `FileInfoIdx`-from-path lookup

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1167,9 +1167,9 @@ proc fileInfoKnown*(conf: ConfigRef; filename: AbsoluteFile): bool =
   result = conf.fileIdxTbl.hasKey(filename.string)
 
 proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool): FileIndex =
-  let hasKey = conf.fileIdxTbl.hasKey(filename.string)
-  if hasKey:
-    return conf.fileIdxTbl[filename.string]
+  result = conf.fileIdxTbl.getOrDefault(filename.string, InvalidFileIdx)
+  if result != InvalidFileIdx:
+    return
   var
     canon: AbsoluteFile
     pseudoPath = false

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -95,8 +95,8 @@ type
     writtenSemReports*: ReportSet
     lastError*: TLineInfo
     filenameToIndexTbl*: Table[string, FileIndex]
-    rawPathToIndexTbl*: TableRef[string, FileIndex] ## maps non-canonicalized paths 
-    ## of known-files to the corresponding file index
+    rawPathToIndexTbl*: Table[string, FileIndex] ## maps non-canonicalized
+    ## paths of known-files to the corresponding file index
     fileInfos*: seq[TFileInfo] ## Information about all known source files
     ## is stored in this field - full/relative paths, list of line etc.
     ## (For full list see `TFileInfo`)

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1195,8 +1195,8 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
     conf.m.fileInfos.add(newFileInfo(canon, if pseudoPath: RelativeFile filename
                                             else: relativeTo(canon, conf.projectPath)))
     conf.m.filenameToIndexTbl[canon2] = result
-  if not hasKey:
-    conf.fileIdxTbl[filename.string] = result
+
+  conf.fileIdxTbl[filename.string] = result
 
 proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile): FileIndex =
   var dummy: bool

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -114,7 +114,7 @@ proc initMsgConfig*(): MsgConfig =
   result.fileInfos = @[]
   result.errorOutputs = {eStdOut, eStdErr}
   result.filenameToIndexTbl["???"] = FileIndex(-1)
-  result.rawPathToIndexTbl = newTable[string, FileIndex]()
+  result.rawPathToIndexTbl = initTable[string, FileIndex]()
 
 func incl*(s: var ReportSet, id: NodeId) = s.ids.incl uint32(id)
 func contains*(s: var ReportSet, id: NodeId): bool = s.ids.contains uint32(id)

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -107,7 +107,7 @@ since (1, 5):
     const
       loc = instantiationInfo(fullPaths = compileOption("excessiveStackTrace"))
       msg = getMsg(loc, astToStr(assertion)).cstring
-    {.line: loc.}:
+    {.line: instantiationInfo(fullPaths = true).}:
       {.emit: ["console.assert(", assertion, ", ", msg, ");"].}
 
   func dir*(console: Console; obj: auto) {.importjs.}

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -107,7 +107,7 @@ since (1, 5):
     const
       loc = instantiationInfo(fullPaths = compileOption("excessiveStackTrace"))
       msg = getMsg(loc, astToStr(assertion)).cstring
-    {.line.}:
+    {.line: instantiationInfo(fullPaths = true).}:
       {.emit: ["console.assert(", assertion, ", ", msg, ");"].}
 
   func dir*(console: Console; obj: auto) {.importjs.}

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -107,7 +107,7 @@ since (1, 5):
     const
       loc = instantiationInfo(fullPaths = compileOption("excessiveStackTrace"))
       msg = getMsg(loc, astToStr(assertion)).cstring
-    {.line: instantiationInfo(fullPaths = true).}:
+    {.line.}:
       {.emit: ["console.assert(", assertion, ", ", msg, ");"].}
 
   func dir*(console: Console; obj: auto) {.importjs.}

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -44,7 +44,7 @@ template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]
       ploc = $loc
     bind instantiationInfo
     mixin failedAssertImpl
-    {.line: instantiationInfo(fullPaths = true).}:
+    {.line.}:
       if not cond:
         failedAssertImpl(ploc & " `" & expr & "` " & msg)
 

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -44,7 +44,7 @@ template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]
       ploc = $loc
     bind instantiationInfo
     mixin failedAssertImpl
-    {.line.}:
+    {.line: instantiationInfo(fullPaths = true).}:
       if not cond:
         failedAssertImpl(ploc & " `" & expr & "` " & msg)
 

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -44,7 +44,7 @@ template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]
       ploc = $loc
     bind instantiationInfo
     mixin failedAssertImpl
-    {.line: loc.}:
+    {.line: instantiationInfo(fullPaths = true).}:
       if not cond:
         failedAssertImpl(ploc & " `" & expr & "` " & msg)
 


### PR DESCRIPTION
## Summary

Cache the result of file-info-from-absolute-path lookups, avoiding
unnecessary filesystem IO incurred by expanding file paths. This
significantly increases the speed of the incremental compilation mode
(which performs a lot of those lookups), with compile time reductions
of up to 90% (measured with the `tstdlib_import_changed.nim` test).

## Details

Add the `rawPathToIndexTbl` table to `MsgFormat`. It associates the
unprocessed absolute file paths passed to `fileInfoIdx` with their
resolved-to `FileInfoIdx`, preventing the repeated expansion of the
same file paths.

In addition, the line overrides in the `assert` and `jsAssert`
templates are changed to use the no-argument form (`{.line.}`). The
latter is semantically equivalent to the previous `{.line: loc.}`,
while not performing an unnecessary `FileInfoIdx` -> filename ->
`FileInfoIdx` round-trip.