### PR TITLE
fix `.line` pragma ignoring column information

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -888,7 +888,8 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "empty 'asm' statement"
 
     of rsemLinePragmaExpectsTuple:
-      result = "tuple expected"
+      result = "a tuple value of the form '(string, int, int)' is expected," &
+               " but got: '" & r.ast.render & "'"
 
     of rsemRaisesPragmaExpectsObject:
       result = "invalid type for raises/tags list"

--- a/tests/errmsgs/t9768.nim
+++ b/tests/errmsgs/t9768.nim
@@ -4,7 +4,7 @@ discard """
   nimout: '''
 stack trace: (most recent call last)
 t9768.nim(28, 33) main
-t9768.nim(23, 11) foo1
+t9768.nim(23, 12) foo1
 '''
 """
 

--- a/tests/errmsgs/twrong_line_argument.nim
+++ b/tests/errmsgs/twrong_line_argument.nim
@@ -1,0 +1,7 @@
+discard """
+  errormsg: "a tuple value of the form '(string, int, int)' is expected, but got: '(\"\",)'"
+  line: 6
+"""
+
+{.line: ("",).}:
+  discard


### PR DESCRIPTION
## Summary

Use the column information provided by the tuple value, which fixes,
for example, stack traces produced by assertion failures in compile-time
contexts pointing to the wrong column.

In addition, the tuple passed to the `.line` pragma is now verified to
have the correct number of elements, which fixes the compiler crashing
when it's a tuple with less than the expected number of elements.

## Details

In `pragmaLine`:
- don't allow `nkPar` -- all literal tuple construction expressions have
  to use `nkTupleConstr` nodes
- require the provided tuple node to have exactly three elements
- use more descriptive names instead of `x` and `y`
- use the third tuple element's value (which is required to be an
  integer value) as the column information
- build the `TLineInfo` with `newLineInfo`, which also makes sure
  that out-of-range line and column numbers are properly handled (by
  clamping them)
- use the correct node when creating errors and use `wrapError` for
  proper propagation

In addition, the error message for when the provided tuple value doesn't
have the correct shape is slightly improved, now detailing how the
tuple is required to look like.

A test (`t9768.nim`) that relied on incorrect column being set is
adjusted.