### PR TITLE
internal: don't instantiate concepts when lifting types

### DIFF
--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1365,9 +1365,15 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
       return
 
     if body.lastSon.kind == tyUserTypeClass:
-      let expanded = instGenericContainer(c, info, paramType,
-                                          allowMetaTypes = true)
-      result = recurse(expanded, true)
+      # turn the user-type-class invocation into a ``tyUserTypeClassInst``,
+      # making handling of the type easier for ``typeRel``
+      result = copyType(paramType, nextTypeId(c.idgen), body.owner)
+      result.kind = tyUserTypeClassInst
+      # an unresolved ``tyUserTypeClassInst`` currently expects the
+      # ``tyUserTypeClass`` as the last element
+      result.sons.add body.lastSon
+
+      result = recurse(result, true)
 
   of tyUserTypeClasses, tyBuiltInTypeClass, tyCompositeTypeClass,
      tyAnd, tyOr, tyNot:


### PR DESCRIPTION
## Summary

Don't instantiate invocations of generic concepts when lifting types
(`liftParamType`). Instead, only turn the invocation into a
`tyUserTypeClassInst` type.

This removes a usage of `semtypinst`'s "meta-types allowed" mode, and is
thus a step towards removing the latter.

## Details

Instead of using `instGenericContainer(allowedMetaTypes = true)` for
lifting the invocation of generic concepts into a `tyUserTypeClassInst`,
the invocation is now copied, transitioned to a `tyUserTypeClassInst`,
and then has the underlying `tyUserTypeClass` the invocation applies to
added as the last element.

The above is **not** the same as what `instGenericContainer` did. Most
importantly, generic invocations used as arguments to the invocation
are not instantiated. In practice, this means that a parameter type like
`Concept[Generic[T]]` will reach `typeRel` and subsequently
`matchUserTypeClass` as

 `(UserTypeClassInst (...) (GenericInvocation (...) (...)) (...))`

instead of as

`(UserTypeClassInst (...) (GenericInst (...) (...) (...)) (...))`

The `tyGenericInvocation` has the `tfHasMeta` flag included and a
`tyInferred` is thus later created when matching against the concept,
which is correct. Since `typeRel` does support resolving `tyInferred`
types that have a `tyGenericInvocation` as the base, this doesn't cause
problems.

<!-- Note: section break (`---`) onwards is not in CI merge commit

## Notes for Reviewers
* leave additional context for reviewers
* maybe specific requests or areas of focus

Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go