### PR TITLE
warn if `untyped` params followed by non-`untyped`

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -777,6 +777,7 @@ type
     rsemSuspiciousEnumConv     = "EnumConv"
     rsemUnsafeSetLen           = "UnsafeSetLen"
     rsemUnsafeDefault          = "UnsafeDefault"
+    rsemUntypedParamsFollwedByMoreSpecificType
     rsemBindDeprecated
     rsemObservableStores       = "ObservableStores"
     rsemUseOfGc                = "GcMem" # last !

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1595,6 +1595,9 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemAlignRequiresPowerOfTwo:
       result = "power of two expected"
 
+    of rsemUntypedParamsFollwedByMoreSpecificType:
+      result = "non-untyped param must not appear after an untyped param"
+
     of rsemNoReturnHasReturn:
       result = "???"
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1464,7 +1464,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
           t.kind == tyVarargs and t.len > 0 and t[0].kind == tyUntyped
 
       if untypedParamPos == 0:
-        if typ.isUntyped:
+        if isUntyped(typ):
           untypedParamPos = i
       elif not isUntyped(typ):
         localReport(c.config, a[^2],

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5446,8 +5446,8 @@ Typed vs untyped parameters
 ---------------------------
 
 An `untyped` parameter means that symbol lookups and type resolution is not
-performed before the expression is passed to the template. This means that
-*undeclared* identifiers, for example, can be passed to the template:
+performed before the expression is passed to the template. This allows
+*undeclared* identifiers, for example, to be passed to the template:
 
 .. code-block:: nim
     :test: "nim c $1"
@@ -5477,6 +5477,10 @@ template. For historical reasons, templates can be explicitly annotated with
 an `immediate` pragma and then these templates do not take part in
 overloading resolution and the parameters' types are *ignored* by the
 compiler. Explicit immediate templates are now deprecated.
+
+An `untyped` parameter may not be followed by a parameter(s) of a more specific
+type -- presently this generates a warning, but in the future this will be an
+error.
 
 **Note**: For historical reasons, `stmt` was an alias for `typed` and
 `expr` was an alias for `untyped`, but they are removed.

--- a/tests/lang_callable/overload/tuntyped_param_not_followed_by_typed.nim
+++ b/tests/lang_callable/overload/tuntyped_param_not_followed_by_typed.nim
@@ -1,0 +1,22 @@
+discard """
+description: "Ensures untyped params aren't followed by typed ones"
+cmd: "nim check --hints:off $file"
+nimout: '''
+tuntyped_param_not_followed_by_typed.nim(15, 29) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
+tuntyped_param_not_followed_by_typed.nim(18, 37) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
+tuntyped_param_not_followed_by_typed.nim(21, 46) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
+'''
+"""
+
+
+
+
+
+template foo(a: untyped, b: int) =
+  discard
+
+template foo(a: int, b: untyped, c: int) =
+  discard
+
+template foo(a: int, b: varargs[untyped], c: int) =
+  discard

--- a/tests/lang_callable/overload/tuntyped_param_not_followed_by_typed.nim
+++ b/tests/lang_callable/overload/tuntyped_param_not_followed_by_typed.nim
@@ -1,13 +1,13 @@
 discard """
 description: "Ensures untyped params aren't followed by typed ones"
 cmd: "nim check --hints:off $file"
+targets: "c"
 nimout: '''
 tuntyped_param_not_followed_by_typed.nim(15, 29) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
 tuntyped_param_not_followed_by_typed.nim(18, 37) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
 tuntyped_param_not_followed_by_typed.nim(21, 46) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
 '''
 """
-
 
 
 

--- a/tests/lang_callable/overload/tuntyped_param_not_followed_by_typed.nim
+++ b/tests/lang_callable/overload/tuntyped_param_not_followed_by_typed.nim
@@ -2,13 +2,13 @@ discard """
 description: "Ensures untyped params aren't followed by typed ones"
 cmd: "nim check --hints:off $file"
 targets: "c"
+action: "compile"
 nimout: '''
 tuntyped_param_not_followed_by_typed.nim(15, 29) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
 tuntyped_param_not_followed_by_typed.nim(18, 37) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
 tuntyped_param_not_followed_by_typed.nim(21, 46) Warning: non-untyped param must not appear after an untyped param [rsemUntypedParamsFollwedByMoreSpecificType]
 '''
 """
-
 
 
 


### PR DESCRIPTION
## Summary

Emit a warning if an `untyped`, or `varargs[untyped]`, parameter is
followed by a non-`untyped` parameter. This will eventually become an
error, as it violates the principle where previously analysed AST cannot
be "unanalysed" during overload dispatch resolution.

## Details

`semtypes.semProcTypeNode` to emit a warning if an `untyped`, or
`varargs[untyped]`, parameter is followed by a non-`untyped` parameter.
This is a new warning message so new entries were required in legacy
reports, unfortunately.

The manual has been updated to indicate the future direction where this
will become an error.
Finally added a test to ensure that warnings are generated as required.

As part of converting it to an error the warning will be used to track
down all APIs/signatures that require updating.