### PR TITLE
make `.cursor` fields work according to spec

### DIFF
--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -165,9 +165,7 @@ proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool) 
     if c.filterDiscriminator != nil: return
     let f = n.sym
     let b = if c.kind == attachedTrace: y else: y.dotField(f)
-    if (sfCursor in f.flags and f.typ.skipTypes(abstractInst).kind in {tyRef, tyProc} and
-        c.g.config.selectedGC in {gcArc, gcOrc}) or
-        enforceDefaultOp:
+    if sfCursor in f.flags or enforceDefaultOp:
       defaultOp(c, f.typ, body, x.dotField(f), b)
     else:
       fillBody(c, f.typ, body, x.dotField(f), b)

--- a/tests/arc/tnon_ref_cursor_in_object.nim
+++ b/tests/arc/tnon_ref_cursor_in_object.nim
@@ -1,0 +1,49 @@
+discard """
+  targets: "c js vm"
+  description: "Ensure that `.cursor` works for non-ref types when used on object fields"
+"""
+
+type
+  Resource = object
+    value: int
+
+  Object = object
+    r {.cursor.}: Resource
+    s {.cursor.}: seq[Resource]
+
+var numDestroy = 0
+
+proc `=copy`(x: var Resource, y: Resource) {.error.} # disallow full copies
+proc `=destroy`(x: var Resource) =
+  inc numDestroy
+
+proc test() =
+  # perform the test in procedure so that globals aren't used (their different
+  # semantics with regards to destruction would interfere)
+  var
+    r = Resource(value: 1) # initialize a resource
+    s = @[Resource(value: 2)]
+
+  # make sure no copy is required in the initializer expression:
+  var o = Object(r: r, s: s)
+
+  # copying the object doesn't perform a full copy of the cursor fields:
+  var o2 = o
+  discard addr(o2) # prevent `o2` from being turned into a cursor
+
+  # check that the fields were shallow-copied:
+  doAssert o2.r.value == 1
+  doAssert o2.s[0].value == 2
+
+  # make sure no copy is required with normal field assignments:
+  o.r = r
+  o.s = s
+
+
+  # when `o` and `o2` are destroyed, their destructor must not be called on
+  # their fields
+
+test()
+
+# one call for the `r` local and one for the object in `s`
+doAssert numDestroy == 2

--- a/tests/lang_callable/iter/tcursor_local_in_closure_iter.nim
+++ b/tests/lang_callable/iter/tcursor_local_in_closure_iter.nim
@@ -1,0 +1,37 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Regression test for making sure ``.cursor`` locals work in closure
+    iterators
+  '''
+"""
+
+type Value = distinct int
+
+var numDestroy = 0
+
+proc `=destroy`(x: var Value) =
+  inc numDestroy
+
+iterator iter(s: seq[Value]): int {.closure.} =
+  # because it is used across yields, `s2` is lifted into the iterator's
+  # environment. Since non-ref cursors in object didn't have their hooks
+  # disabled inside the environments lifted hooks, this led to double
+  # frees
+  var s2 {.cursor.} = s
+  var i = 0
+  let L = s2.len
+  while i < L:
+    yield s2[i].int
+    inc i
+
+proc test() =
+  var s = @[Value(1), Value(2)]
+  let cl = iter
+  # make sure resuming the iterator works:
+  doAssert cl(s) == 1
+  doAssert cl(s) == 2
+  doAssert cl(s) == 0
+
+test()
+doAssert numDestroy == 2


### PR DESCRIPTION
## Summary

Don't inject lifetime hook calls for `.cursor` fields when lifting
hooks, making the `.cursor` pragma on object fields behave as described
in the specification.

This also fixes double frees and other ownership issues for closure
iterators that contained `.cursor` locals.

## Details

The specification says that the `.cursor` annotation prevents
construction/destruction pairs, and while this was already true for all
cursor locals and assignments to cursor fields, inside lifted hooks it
was only true for `ref` and `proc` fields when `--gc:arc|orc` was used.

The special-casing of `ref` and `proc` and in `fillBodyObj` is removed,
meaning that hook calls are now always prevented for all cursor fields.

A direct test for cursor fields is added plus a test for cursor locals
lifted into closure iterator environments (where the previous behaviour
caused double frees for non-`ref`/non-`proc` fields).