### PR TITLE
internal: keep composite type-classes unresolved

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -512,10 +512,11 @@ type
 
     tyCompositeTypeClass
       ## Type such as seq[Number]
-      ## The notes for tyUserTypeClassInst apply here as well
+      ## Similar to ``tyUserTypeClassInst``, this type will also bind
+      ## types.
       ## sons[0]: the original expression used by the user.
-      ## sons[1]: fully expanded and instantiated meta type
-      ## (potentially following aliases)
+      ## sons[1]: the lifted meta-type to match against (at present, this is
+      ##          always a ``tyGenericInvocation``)
 
     tyInferred
       ## In the initial state `base` stores a type class constraining

--- a/compiler/ast/typesrenderer.nim
+++ b/compiler/ast/typesrenderer.nim
@@ -206,7 +206,7 @@ proc typeToString*(typ: PType, prefer: TPreferedDesc = preferName): string =
           result = typeToString(t.lastSon)
         of tyCompositeTypeClass:
           # avoids showing `A[any]` in `proc fun(a: A)` with `A = object[T]`
-          result = typeToString(t.lastSon.lastSon)
+          result = typeToString(t[0])
         else:
           result = t.sym.name.s
         if prefer == preferMixed and result != t.sym.name.s:

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -450,20 +450,15 @@ proc inferWithMetatype(c: PContext, formal: PType,
     if formal.kind == tyCompositeTypeClass:
       # passing the composite type-class to ``generateTypeInstance`` would
       # get us the matched source type, which is not what we want here
-      # (especially in the presense of ``distinct``s). We want the instantiated
-      # base type.
+      # (especially in the presense of ``distinct``s); we want the
+      # result of applying the invocation
       doAssert formal[0].kind == tyGenericBody
-      let inst = formal[1] ## the fully instantiated meta type
-      assert inst.kind == tyGenericInst
+      doAssert formal[1].kind == tyGenericInvocation
 
-      var invocation = newTypeS(tyGenericInvocation, c)
-      invocation.sons = @[formal[0]] # don't propagte the flags
-      # add the instance arguments as the invocation parameters:
-      for i in 1..<inst.len-1:
-        invocation.rawAddSon(inst[i])
-
-      # evaluate the invocation:
-      result.typ = generateTypeInstance(c, m.bindings, arg.info, invocation)
+      # `typeRel` populated the type environment (`m.bindings`) with the
+      # types bound to the type variables used in the invocation -- we can
+      # directly instantiate it
+      result.typ = generateTypeInstance(c, m.bindings, arg.info, formal[1])
     else:
       result.typ = generateTypeInstance(c, m.bindings, arg.info, formal)
   else:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1324,11 +1324,8 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
       result.rawAddSon paramType.lastSon
       return addImplicitGeneric(c, result, paramTypId, info, genericParams, paramName)
 
-    let x = instGenericContainer(c, paramType.sym.info, result,
-                                  allowMetaTypes = true)
+    let x = result
     result = newTypeWithSons(c, tyCompositeTypeClass, @[paramType, x])
-    #result = newTypeS(tyCompositeTypeClass, c)
-    #for i in 0..<x.len: result.rawAddSon(x[i])
     result = addImplicitGeneric(c, result, paramTypId, info, genericParams, paramName)
 
   of tyGenericInst:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -1752,22 +1752,8 @@ typeRel can be used to establish various relationships between types:
 
   of tyCompositeTypeClass:
     considerPreviousT:
-      let
-        roota = a.skipGenericAlias
-        rootf = f.lastSon.skipGenericAlias
-      if a.kind == tyGenericInst and roota.base == rootf.base:
-        for i in 1..<rootf.len-1:
-          let
-            ff = rootf[i]
-            aa = roota[i]
-          result = typeRel(c, ff, aa, flags)
-          if result == isNone:
-            return
-          if ff.kind == tyRange and result != isEqual:
-            return isNone
-      else:
-        result = typeRel(c, rootf.lastSon, a, flags)
-      if result != isNone:
+      assert f.lastSon.kind == tyGenericInvocation
+      if typeRel(c, f.lastSon, a, flags) != isNone:
         put(c, f, a)
         result = isGeneric
 

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -1652,9 +1652,12 @@ typeRel can be used to establish various relationships between types:
         if matched != nil: isGeneric
         else:              isNone
     elif x.kind == tyGenericInst and
-         body.kind notin {tyAnd, tyOr, tyGenericInvocation}:
+         body.kind notin {tyAnd, tyOr, tyGenericInvocation, tyDistinct}:
       # the formal invocation is not a generic alias and both `f` and
       # `a` are not applications to the same generic type -> no match.
+      # An exception is ``tyDistinct``: for the "coerce distincts" mode to
+      # work, we have match the instance against the meta-instantiated
+      # body (i.e., the branch below)
       result = isNone
     else:
       # XXX: to not ignore phantom types, this branch should only be taken

--- a/tests/typerel/tgeneric_type_relation.nim
+++ b/tests/typerel/tgeneric_type_relation.nim
@@ -1,0 +1,21 @@
+discard """
+  action: compile
+  description: "Specification tests for the relationship between generic types"
+"""
+
+type
+  GenericA[T] = (T, T)
+  GenericB[T] = (T, T)
+
+static:
+  # generic types use name equivalence: they are equal if they have the same
+  # *name* and their parameters are equal:
+  doAssert GenericA[int] is GenericA[int]
+  doAssert GenericA[int] isnot GenericA[float]
+  # all instances of a generic type are part of the implicit type-class
+  # covering all instances of the generic type:
+  doAssert GenericA[int] is GenericA
+
+  # if the name is different, the types are not equal:
+  doAssert GenericA[int] isnot GenericB[int]
+  doAssert GenericA[int] isnot GenericB


### PR DESCRIPTION
## Summary

Change composite type-classes (`tyCompositeTypeClass`) to store an
unresolved type application (`tyGenericInvocation`) instead of a fully
resolved and instantiated meta-type (`tyGenericInst`). This removes the
last usage of `semtypinst`'s "meta-types allowed" mode, meaning that
the latter can be removed now.

As part of the change, a type relation bug is fixed: generic
instantiations were incorrectly treated as having a 'generic'
relationship with composite type-classes of different generics that had
the same structure. For example, `A[int] is B` returned 'true' when
`A[T] = (T,)` and `B[T] = (T,)`.

## Details

* update the documentation of `tyCompositeTypeClass`
* in type lifting (`liftParamType`), don't resolve the invocation lifted
  from the `tyGenericBody`, but instead store the invocation in the
  `tyCompositeTypeClass` directly
* update `typesrenderer` to render a `tyCompositeTypeClass` as the
  original type expression (which is stored in the first slot)
* partially resolve the invocations stored in `tyCompositeTypeClass`
  when skipping them during `.borrow` handling, approximating how
  the skipped type would have looked previously

### Parametric aliases of parametric `concept`s

* support non-lifted invocations of parametric user type-classes
  (`concept`) with `matchUserTypeClass`
* in `typeRel`, dispatch to `matchUserTypeClass` when matching against
  such invocations

Invocations of parametric `concept`s without arguments are lifted into
`tyUserTypeClassInst` instead of `tyCompositeTypeClass`, but for
parametric aliases of parametric `concept`s (e.g.,
`Type[T] = Concept[T]` where a `Concept` is a parametric concept), this
is not case, meaning that `tyGenericInvocation`s where the body is a
`tyUserTypeClass` reach `typeRel`.

Parametric aliases of parametric `concept`s in the composite type-class
case were previously handled by way of them being resolved to
`tyUserTypeClassInst` as part of `instGenericContainer`, but without the
latter, they now need to be handled in `typeRel`, which is what changes
detailed above implement.

However, there is a problem. A `tyUserTypeClassInst` can bind types
for later retrieval, while a `tyGenericInvocation` cannot. While a
solution is going to be needed at some point, no user-facing regression
is introduced with the changes here, as `tyCompositeTypeClass` types in
routine signatures act as type variables (they're replaced with their
bound type during instantiation) and for conversions-to-composite-type-
classes (e.g., `Generic(x)`), the type bound to the resolved
`tyUserTypeClassInst` was already ignored previously.

### Type relation changes

The `typeRel` logic for `tyCompositeTypeClass` is changed back to how it
was prior to e97d640ce8a8f16112a3e17241ed89c993f83fee, which is both
now-necessary (for proper matching against a `tyGenericInvocation`'s)
and fixes a type relation bug. By skipping the first instance, that
commit changed generic instantiation to be treated as having a 'generic'
relationship with different but structurally equal generic types, which
seems to have been an unintended side-effect. A test is added for the
fixed behaviour is added.

Coercions to distinct generic types are kept working by allowing generic
instances to be matched against the partially-resolved body of a
generic distinct type -- if `coerceDistincts` is 'false', the call to
`typeRel` with `formal = tyDistinct` is going to return `isNone`.