### PR TITLE
sem: perform constant folding in sem

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1220,7 +1220,6 @@ type
     adSemInvalidBoolDefine
     adSemFoldOverflow       # xxx: remove 'Fold' from name?
     adSemFoldDivByZero      # xxx: remove 'Fold' from name?
-    adSemInvalidRangeConversion
     adSemFoldCannotComputeOffset
     adSemCompilerOptionInvalid
     adSemCompilerOptionArgInvalid
@@ -1332,7 +1331,6 @@ type
         adSemExpectedObjectType,
         adSemFoldOverflow,
         adSemFoldDivByZero,
-        adSemInvalidRangeConversion,
         adSemFoldCannotComputeOffset,
         adSemExpectedIdentifierQuoteLimit,
         adSemExpectedRangeType,

--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -34,9 +34,8 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
     assert(t.n[i].kind == nkSym)
     let field = t.n[i].sym
     let val = if field.ast == nil: field.name.s else: field.ast.strVal
-    caseStmt.add newTree(nkOfBranch, newSymNode(field),
+    caseStmt.add newTree(nkOfBranch, newIntTypeNode(field.position, t),
       newTree(nkStmtList, newTree(nkFastAsgn, newSymNode(res), newStrNode(val, info))))
-    #newIntTypeNode(nkIntLit, field.position, t)
 
   let body = newTreeI(nkStmtList, info): caseStmt
 

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -344,7 +344,6 @@ type
     # means and how to reproduce it in the example code.
     rsemSemfoldOverflow
     rsemSemfoldDivByZero
-    rsemSemfoldInvalidConversion
     rsemInvalidIntdefine
     rsemInvalidBooldefine
 

--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -160,7 +160,6 @@ type
       of rsemTypeMismatch,
          rsemSuspiciousEnumConv,
          rsemTypeKindMismatch,
-         rsemSemfoldInvalidConversion,
          rsemCannotConvertTypes,
          rsemImplicitObjConv,
          rsemIllegalConversion,

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -751,10 +751,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemInvalidBooldefine:
       result = "{.booldefine.} const was set to an invalid bool: '" & r.str & "'"
 
-    of rsemSemfoldInvalidConversion:
-      result = "conversion from $1 to $2 is invalid" % [
-        typeToString(r.actualType()), typeToString(r.formalType())]
-
     of rsemIllformedAst:
       result = "illformed AST: " & render(r.ast)
 
@@ -3311,14 +3307,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       reportInst: diag.instLoc.toReportLineInfo,
       kind: kind,
       ast: n)
-  of adSemInvalidRangeConversion:
-    semRep = SemReport(
-        location: some diag.location,
-        reportInst: diag.instLoc.toReportLineInfo,
-        kind: rsemSemfoldInvalidConversion,
-        ast: diag.wrongNode,
-        typeMismatch: @[typeMismatch(diag.wrongNode[0].typ,
-                                     diag.wrongNode.typ)])
   of adSemInvalidControlFlow:
     semRep = SemReport(
         location: some diag.location,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -596,7 +596,6 @@ func astDiagToLegacyReportKind*(
   of adSemInvalidBoolDefine: rsemInvalidBooldefine
   of adSemFoldOverflow: rsemSemfoldOverflow
   of adSemFoldDivByZero: rsemSemfoldDivByZero
-  of adSemInvalidRangeConversion: rsemSemfoldInvalidConversion
   of adSemFoldCannotComputeOffset: rsemCantComputeOffsetof
   of adSemDefNameSym: rsemExpectedIdentifier
   of adSemCompilerOptionInvalid: rsemCompilerOptionInvalid

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -142,7 +142,7 @@ proc genContainerOf(c: var TLiftCtx; objType: PType, field, x: PSym): PNode =
 
   let minusExpr = genBuiltin(c, mSubI, "-", castExpr1)
   minusExpr.typ = intType
-  minusExpr.add offsetOf
+  minusExpr.add foldOffsetOf(c.g.config, offsetOf, offsetOf)
 
   let objPtr = makePtrType(objType.owner, objType, c.idgen)
   result = newTreeIT(nkCast, c.info, objPtr):
@@ -632,7 +632,8 @@ proc atomicRefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     addDestructorCall(c, elemType, actions, genDeref(tmp, nkDerefExpr))
     var alignOf = genBuiltin(c, mAlignOf, "alignof", newNodeIT(nkType, c.info, elemType))
     alignOf.typ = getSysType(c.g, c.info, tyInt)
-    actions.add callCodegenProc(c.g, "nimRawDispose", c.info, tmp, alignOf)
+    actions.add callCodegenProc(c.g, "nimRawDispose", c.info, tmp,
+                                foldAlignOf(c.g.config, alignOf, alignOf))
   else:
     addDestructorCall(c, elemType, newNodeI(nkStmtList, c.info), genDeref(tmp, nkDerefExpr))
     actions.add callCodegenProc(c.g, "nimDestroyAndDispose", c.info, tmp)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -41,6 +41,7 @@ import
   ],
   compiler/sem/[
     semdata,
+    semfold,
     lookups
   ],
   compiler/backend/[
@@ -375,8 +376,10 @@ proc expectDynlibNode(c: PContext, n: PNode): PNode =
     # For the OpenGL wrapper we support:
     # {.dynlib: myGetProcAddr(...).}
     result = c.semExpr(c, n[1])
-    if result.kind == nkSym and result.sym.kind == skConst:
-      result = result.sym.ast # look it up
+    # this is AST that later gets passed to code generation, so we have
+    # perform constant folding
+    result = foldInAst(c.module, result, c.idgen, c.graph)
+    # XXX: sempass2 is missing here...
     if result.typ == nil or result.typ.kind notin {tyPointer, tyString, tyProc}:
       result = c.config.newError(n, PAstDiag(kind: adSemStringLiteralExpected))
 

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -376,7 +376,7 @@ proc expectDynlibNode(c: PContext, n: PNode): PNode =
     # For the OpenGL wrapper we support:
     # {.dynlib: myGetProcAddr(...).}
     result = c.semExpr(c, n[1])
-    # this is AST that later gets passed to code generation, so we have
+    # this is AST that later gets passed to code generation, so we have to
     # perform constant folding
     result = foldInAst(c.module, result, c.idgen, c.graph)
     # XXX: sempass2 is missing here...

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -537,7 +537,7 @@ proc tryConstExpr(c: PContext, n: PNode): PNode =
   #      not the expression is constant), but it is inconsitent with the
   #      above, where errors are treated as "not a constant expression"
   result = foldInAst(c.module, e, c.idgen, c.graph)
-  if (let f = getConstExpr2(c.module, result, c.idgen, c.graph); f != nil):
+  if (let f = getConstExprError(c.module, result, c.idgen, c.graph); f != nil):
     return f
 
   proc containsUnresolvedTypeVar(n: PNode): bool {.nimcall.} =
@@ -602,7 +602,7 @@ proc evalConstExpr(c: PContext, n: PNode): PNode =
   # the expression. This is a bit more efficient than doing it the other way
   # around
   result = foldInAst(c.module, n, c.idgen, c.graph)
-  if (let f = getConstExpr2(c.module, result, c.idgen, c.graph); f != nil):
+  if (let f = getConstExprError(c.module, result, c.idgen, c.graph); f != nil):
     # constant folding was successful or resulted in an error
     return f
 

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -281,6 +281,7 @@ proc semGenericArgs(c: PContext, n: PNode): PNode =
         result[i] = evaluated
       else:
         # sigmatch expects the non-type generic arugments to use ``tyStatic``
+        let opr = copyTree(evaluated)
         opr.typ = newTypeS(tyStatic, c)
         opr.typ.sons = @[evaluated.typ]
         opr.typ.n = evaluated

--- a/compiler/sem/semcomptime.nim
+++ b/compiler/sem/semcomptime.nim
@@ -48,17 +48,6 @@ proc checkAux(c: var CheckCtx, n: PNode): PNode =
     # an ``except Error as e`` branch also introduces a local
     if isInfixAs(n[0]):
       c.defs.incl n[0][2].sym.id
-
-  of nkCallKinds:
-    # XXX: the ``len`` call for an arrays is uncondtionally folded away later,
-    #      which means that it's okay for the argument expression to reference
-    #      locals not declared in the current context. Until folding happens
-    #      earlier, we skip the call here
-    if n[0].kind == nkSym and n[0].sym.magic == mLengthArray:
-      return
-
-    for it in n.items:
-      check(it)
   of callableDefs, nkNimNodeLit, nkTypeSection, nkConstSection,
      nkTypeOfExpr, nkMixinStmt, nkBindStmt, nkImportStmt, nkImportExceptStmt,
      nkFromStmt, nkExportStmt:
@@ -73,7 +62,7 @@ proc checkAux(c: var CheckCtx, n: PNode): PNode =
       check(it)
 
 proc check*(n: PNode): PNode =
-  ## Given the untransformed AST `n` of a freestanding expression/statement,
+  ## Given the constant-folded AST `n` of a freestanding expression/statement,
   ## looks for access of locals that aren't available in the current compile-
   ## time context. Example:
   ##

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -982,5 +982,6 @@ proc getConstExprError*(m: PSym, n: PNode, idgen: IdGenerator,
                         g: ModuleGraph): PNode =
   ## If `n` is an error, returns the error. Otherwise returns the folded
   ## value, or nil, if `n` isn't constant.
-  if n.kind == nkError: n
-  else:                 getConstExpr(m, n, idgen, g)
+  case n.kind
+  of nkError: n
+  else:       getConstExpr(m, n, idgen, g)

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -77,7 +77,7 @@ proc prepareWrite(f: var Folded) =
     f.node = shallowCopy(orig)
     f.wasCopied = true
     # only copy the nodes up-to `num`, the rest
-    # is copied manually
+    # are copied manually
     for i in 0..<f.i:
       f.node[i] = orig[i]
 

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -791,7 +791,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
   #    if a == nil: return nil
   #    result[i][1] = a
   #  incl(result.flags, nfAllConst)
-  of nkPar, nkTupleConstr:
+  of nkTupleConstr:
     # tuple constructor
     result = copyNode(n)
     if (n.len > 0) and (n[0].kind == nkExprColonExpr):
@@ -808,20 +808,6 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
         if a == nil: return nil
         result.add a
     incl(result.flags, nfAllConst)
-  of nkChckRangeF, nkChckRange64, nkChckRange:
-    let a = getConstExpr(m, n[0], idgen, g)
-    if a == nil: return
-    if leValueConv(n[1], a) and leValueConv(a, n[2]):
-      # a <= x and x <= b
-      result = foldConv(n, a, idgen, g, check=false)
-    else:
-      result = g.config.newError(n,
-                                 PAstDiag(kind: adSemInvalidRangeConversion))
-  of nkStringToCString, nkCStringToString:
-    let a = getConstExpr(m, n[0], idgen, g)
-    if a == nil: return
-    result = a
-    result.typ = n.typ
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     let a = getConstExpr(m, n[1], idgen, g)
     if a == nil: return

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -978,7 +978,8 @@ proc foldInAst*(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): PNode =
   else:
     result = f.node
 
-proc getConstExpr2*(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): PNode =
+proc getConstExprError*(m: PSym, n: PNode, idgen: IdGenerator,
+                        g: ModuleGraph): PNode =
   ## If `n` is an error, returns the error. Otherwise returns the folded
   ## value, or nil, if `n` isn't constant.
   if n.kind == nkError: n

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -42,6 +42,65 @@ from compiler/front/msgs import internalError
 
 from system/memory import nimCStrLen
 
+type
+  Folded = object
+    ## Helper type for tracking/passing contextual state during constant
+    ## folding.
+    node: PNode     ## the AST of the processed expression/statement
+    i: int          ## where to insert the next node
+    wasCopied: bool ## whether a copy was created. If it was, the node can
+                    ## be modified
+    hasError: bool
+
+const
+  ExpressionNodes = nkCallKinds + nkLiterals + {
+    nkSym, nkEmpty, nkNimNodeLit, nkNilLit,
+
+    nkRange, nkBracket, nkCurly, nkObjConstr, nkTupleConstr,
+
+    nkDotExpr, nkCheckedFieldExpr, nkBracketExpr, nkHiddenDeref, nkDerefExpr,
+    nkAddr, nkHiddenAddr,
+
+    nkCast, nkConv, nkHiddenStdConv, nkHiddenSubConv,
+    nkTypeOfExpr,
+
+    nkIfExpr, nkBlockExpr, nkStmtListExpr, nkError}
+    ## apart from the call node kinds, nodes that appear exclusively in
+    ## expression contexts
+
+func fromAst(n: PNode, num: int): Folded =
+  result = Folded(node: n, i: num, hasError: false)
+
+proc prepareWrite(f: var Folded) =
+  if not f.wasCopied:
+    let orig = f.node
+    f.node = shallowCopy(orig)
+    f.wasCopied = true
+    # only copy the nodes up-to `num`, the rest
+    # is copied manually
+    for i in 0..<f.i:
+      f.node[i] = orig[i]
+
+proc add(x: var Folded, y: sink Folded) =
+  ## Appends `y` to `x` and propagates the const-ness.
+  if x.node[x.i] != y.node:
+    prepareWrite(x)
+    x.node[x.i] = y.node
+
+  inc x.i
+  # propagate the error flag
+  x.hasError = x.hasError or y.hasError
+
+proc add(f: var Folded, n: PNode) =
+  ## Appends `n` to `f`, where `n` is known to be constant.
+  if f.node[f.i] != n:
+    prepareWrite(f)
+    f.node[f.i] = n
+
+  inc f.i
+  # propagate the error flag
+  f.hasError = f.hasError or n.isError
+
 proc errorType*(g: ModuleGraph): PType =
   ## creates a type representing an error state
   result = newType(tyError, nextTypeId(g.idgen), g.owners[^1])
@@ -78,7 +137,6 @@ proc newStrNodeT*(strVal: string, n: PNode; g: ModuleGraph): PNode =
 proc getConstExpr*(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode
   # evaluates the constant expression or returns nil if it is no constant
   # expression
-proc evalOp*(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): PNode
 
 proc checkInRange(conf: ConfigRef; n: PNode, res: Int128): bool =
   res in firstOrd(conf, n.typ)..lastOrd(conf, n.typ)
@@ -156,7 +214,7 @@ proc pickIntRange(a, b: PType): PType =
 proc isIntRangeOrLit(t: PType): bool =
   result = isIntRange(t) or isIntLit(t)
 
-proc evalOp(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
+proc evalOp*(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
   # b and c may be nil
   result = nil
   case m
@@ -794,3 +852,148 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
       result = getConstExpr(m, n[i], idgen, g)
   else:
     discard # xxx: should we return nil for nkError?
+
+proc foldInAstAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Folded
+
+proc foldConstExprAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Folded =
+  ## Folds the sub-expressions of `n` and, if possible, `n` itself. If
+  ## `wantValue` is 'true', statements part of the expression are not
+  ## processed and constants are always inlined, regardless of complexity.
+  ##
+  ## For simplicity, `n` doesn't have to be an expression.
+  result = Folded(node: n, i: 0)
+
+  # first step: fold the sub-expressions
+  case n.kind
+  of nkEmpty, nkLiterals, nkNimNodeLit, nkNilLit:
+    # short-circuit the following ``getConstExpr`` call, so that no
+    # unnecessary copy of the node is created
+    return
+  of nkSym:
+    discard "may be folded away"
+  of nkTypeOfExpr:
+    # XXX: could be folded into an ``nkType`` here...
+    discard
+  of nkBracket, nkCurly, nkTupleConstr, nkRange, nkAddr, nkHiddenAddr,
+     nkHiddenDeref, nkDerefExpr, nkBracketExpr, nkCallKinds, nkIfExpr,
+     nkElifExpr, nkElseExpr, nkElse, nkElifBranch:
+    for it in n.items:
+      result.add foldConstExprAux(m, it, idgen, g)
+  of nkCast, nkConv, nkHiddenStdConv, nkHiddenSubConv, nkBlockExpr:
+    # the first slot only holds the type/label, which we don't need to traverse
+    # into / fold
+    result.add n[0]
+    result.add foldConstExprAux(m, n[1], idgen, g)
+  of nkDotExpr:
+    # don't traverse into the field node
+    result.add foldConstExprAux(m, n[0], idgen, g)
+    result.add n[1]
+  of nkCheckedFieldExpr:
+    # only the first sub-node is relevant
+    let x = foldConstExprAux(m, n[0], idgen, g)
+    if x.node.kind notin {nkDotExpr, nkError}:
+      # collapse away checked-field expressions where the wrapped
+      # node is not a dot-expression anymore
+      return x
+
+    result.add x
+    for i in 1..<n.len:
+      result.add n[i]
+  of nkObjConstr:
+    result.add n[0] # skip the type slot
+    for i in 1..<n.len:
+      result.add foldConstExprAux(m, n[i], idgen, g)
+  of nkStmtListExpr:
+    for i in 0..<n.len-1:
+      result.add foldInAstAux(m, n[i], idgen, g)
+    # the last node is an expression
+    result.add foldConstExprAux(m, n[^1], idgen, g)
+  of nkExprColonExpr:
+    # comes here from tuple/object constructions
+    result.add n[0]
+    result.add foldConstExprAux(m, n[1], idgen, g)
+    return
+  of nkError:
+    # XXX: this should become an internal error once errors are properly
+    #      wrapped everywhere
+    result.hasError = true
+  else:
+    # this is either something statement-like (coming from ``void`` arguments
+    # to procedures) or type AST (coming from ``typedesc`` arguments)
+    result = foldInAstAux(m, n, idgen, g)
+    return
+
+  if result.hasError:
+    # don't attempt folding if the AST contains errors
+    return
+
+  # constants can be inlined here, but only if they cannot result in a cast
+  # in the back-end (e.g. ``cast[pointer](someProc)``). In addition, so as to
+  # not interfere with the documentation generator, statement-list expressions
+  # are not folded if they have a comment in the first position
+  let exprIsPointerCast = n.kind in {nkCast, nkConv, nkHiddenStdConv} and
+                          n.typ != nil and
+                          n.typ.kind == tyPointer
+  if not exprIsPointerCast and
+     not (n.kind == nkStmtListExpr and n[0].kind == nkCommentStmt):
+    var cnst = getConstExpr(m, result.node, idgen, g)
+    # we inline constants if they are not complex constants:
+    if cnst != nil and not dontInlineConstant(n, cnst):
+      result.node = cnst
+      result.hasError = cnst.kind == nkError
+
+proc foldInAstAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Folded =
+  ## Folds all constant expression in the statement or expression `n`.
+  case n.kind
+  of ExpressionNodes:
+    result = foldConstExprAux(m, n, idgen, g)
+  of callableDefs, nkTypeSection, nkConstSection, nkMixinStmt, nkBindStmt,
+     nkPragma, nkImportStmt, nkExportStmt, nkFromStmt, nkImportExceptStmt,
+     nkBreakStmt, nkContinueStmt:
+    # skip declarative nodes and control-flow statements that don't contain
+    # fold-able expressions
+    result = Folded(node: n)
+  of nkStmtList, nkIfStmt, nkCaseStmt, nkWhileStmt, nkWhenStmt, nkTryStmt,
+     nkDefer, nkLetSection, nkVarSection, nkYieldStmt, nkReturnStmt,
+     nkDiscardStmt, nkRaiseStmt, nkAsmStmt, nkAsgn, nkFastAsgn, nkFinally,
+     nkElifBranch, nkElse, nkOfBranch:
+    # something that's either a statement or not evaluatable. We still
+    # want to process the sub-nodes
+    result = Folded(node: n)
+    for it in n.items:
+      result.add foldInAstAux(m, it, idgen, g)
+
+  of nkPragmaBlock, nkBlockStmt:
+    result = fromAst(n, n.len - 1)
+    result.add foldInAstAux(m, n[^1], idgen, g)
+  of nkForStmt:
+    # don't process the symbol slots
+    result = fromAst(n, n.len - 2)
+    result.add foldInAstAux(m, n[^2], idgen, g)
+    result.add foldInAstAux(m, n[^1], idgen, g)
+  of nkIdentDefs, nkVarTuple, nkExceptBranch:
+    # don't process the symbol slots
+    result = fromAst(n, n.len - 1)
+    result.add foldInAstAux(m, n[^1], idgen, g)
+  else:
+    # XXX: type AST reaches here, but ideally this catch-all branch
+    #      wouldn't be needed
+    result = Folded(node: n)
+
+proc foldInAst*(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): PNode =
+  ## Performs constant folding on all expressions appearing in the statement or
+  ## expression `n`. If nothing changed, `n` is returned, a new AST otherwise.
+  if n.kind == nkError:
+    return n # already an error -> nothing to do
+
+  let f = foldInAstAux(m, n, idgen, g)
+  if f.hasError:
+    result = g.config.wrapError(f.node)
+  else:
+    result = f.node
+
+proc getConstExpr2*(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): PNode =
+  ## If `n` is an error, returns the error. Otherwise returns the folded
+  ## value, or nil, if `n` isn't constant.
+  if n.kind == nkError: n
+  else:                 getConstExpr(m, n, idgen, g)

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -115,6 +115,7 @@ proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
       b = semProcBody(c, b)
     result.ast[bodyPos] = hloBody(c, b)
     excl(result.flags, sfForward)
+    result.ast[bodyPos] = foldInAst(c.module, result.ast[bodyPos], c.idgen, c.graph)
     trackProc(c, result, result.ast[bodyPos])
     dec c.inGenericInst
 

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -35,14 +35,12 @@ import
   ],
   compiler/utils/[
     debugutils,
-    astrepr,
     idioms
   ],
   compiler/sem/[
     varpartitions,
     typeallowed,
     guards,
-    semfold,
     semdata,
     nilcheck,
   ]
@@ -946,11 +944,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
   if n.typ != nil:
     if tracked.owner.kind != skMacro and n.typ.skipTypes(abstractVar).kind != tyOpenArray:
       createTypeBoundOps(tracked, n.typ, n.info)
-  let asConstExpr = getConstExpr(tracked.ownerModule, n, tracked.c.idgen, tracked.graph)
-  if asConstExpr.isError:
-    track(tracked, asConstExpr)     # will emit errors
-    return
-  elif asConstExpr == nil:
+  if true:
     if a.kind == nkCast and a[1].typ.kind == tyProc:
       a = a[1]
     # XXX: in rare situations, templates and macros will reach here after

--- a/tests/exception/testindexerroroutput_runner.nim
+++ b/tests/exception/testindexerroroutput_runner.nim
@@ -1,5 +1,9 @@
 discard """
   description: "test runner for testindexerroroutput.nims"
+  knownIssue: '''
+    the conversion in the array-index position is folded first, resulting in a
+    range error instead of an index error
+  '''
   joinable: false
   target: native
 """

--- a/tests/lang_callable/macros/tmacrostmt.nim
+++ b/tests/lang_callable/macros/tmacrostmt.nim
@@ -119,7 +119,7 @@ proc fn_unsafeaddr(x: int): int =
 
 static:
   let fn1s = "proc fn1(x, y: int): int =\n  result = 2 * (x + y)\n"
-  let fn2s = "proc fn2(x, y: float): float =\n  result = (y + 2 * x) / (x - y)\n"
+  let fn2s = "proc fn2(x, y: float): float =\n  result = (y + 2.0 * x) / (x - y)\n"
   let fn3s = "proc fn3(x, y: int): bool =\n  result = ((x and 3) div 4 or x mod (y xor -1)) == 0 or not contains([1, 2], y)\n"
   let fn4s = "proc fn4(x: int): int =\n  if x mod 2 == 0:\n    return x + 2\n  else:\n    return 0\n"
   let fn5s = "proc fn5(a, b: float): float =\n  result = -a * a / (b * b)\n"

--- a/tests/lang_objects/objvariant/tcheckedfield1.nim
+++ b/tests/lang_objects/objvariant/tcheckedfield1.nim
@@ -1,10 +1,10 @@
 discard """
-  nimout: "tcheckedfield1.nim(39, 6) Warning: cannot prove that field 'x.s' is accessible [ProveField]"
+  matrix: "--hints:off"
+  nimout: "tcheckedfield1.nim(52, 6) Warning: cannot prove that field 'x.s' is accessible [ProveField]\n"
+  nimoutfull: true
   action: run
   output: "abc abc"
 """
-
-import strutils
 
 {.warning[ProveField]: on.}
 {.experimental: "notnil".}
@@ -26,7 +26,7 @@ proc getData(x: PList not nil) =
 
 var head: PList
 
-proc processList() =
+proc processList() {.used.} =
   var it = head
   while it != nil:
     getData(it)

--- a/tests/misc/tinvalidarrayaccess.nim
+++ b/tests/misc/tinvalidarrayaccess.nim
@@ -4,7 +4,7 @@ discard """
     the conversion in the array-index position is folded first, resulting in a
     range error instead of an index error
   '''
-  line: 23
+  line: 22
 """
 block:
   try:

--- a/tests/misc/tinvalidarrayaccess.nim
+++ b/tests/misc/tinvalidarrayaccess.nim
@@ -1,6 +1,10 @@
 discard """
   errormsg: "index 2 not in 0 .. 1"
-  line: 18
+  knownIssue: '''
+    the conversion in the array-index position is folded first, resulting in a
+    range error instead of an index error
+  '''
+  line: 23
 """
 block:
   try:

--- a/tests/misc/tinvalidarrayaccess2.nim
+++ b/tests/misc/tinvalidarrayaccess2.nim
@@ -1,6 +1,10 @@
 discard """
   errormsg: "index 3 not in 0 .. 1"
-  line: 9
+  knownIssue: '''
+    the conversion in the array-index position is folded first, resulting in a
+    range error instead of an index error
+  '''
+  line: 13
 """
 
 # Note: merge in tinvalidarrayaccess.nim pending https://github.com/nim-lang/Nim/issues/9906

--- a/tests/misc/trangechecks.nim
+++ b/tests/misc/trangechecks.nim
@@ -46,3 +46,11 @@ echo expected == 4
 var
   x45 = "hello".cstring
   p = x45.len.int32
+
+static:
+  # test that out-of-range errors with arguments to `range` parameters can
+  # be detected with ``compiles``
+  proc f(x: range[1..4]) =
+    discard
+
+  doAssert not compiles(f(0))

--- a/tests/vm/taccess_checks.nim
+++ b/tests/vm/taccess_checks.nim
@@ -82,7 +82,7 @@ static:
 
 static:
   var s = newSeq[int](4)
-  let p = cast[ptr array[5, int]](addr s[0])
+  let p = cast[ptr array[6, int]](addr s[0])
   # XXX: should report a `VMAccessOutOfBounds` but actually reports a
   #      `VMAccessTypeMismatch`. See `tsafety_checks_issues2`
   let v = p[][5] #[tt.Error


### PR DESCRIPTION
## Summary

Perform constant folding at the end of the first semantic pass, prior to
`sempass2`. Inlining constants and folding constant expression can
produce errors and, more generally, decides program behaviour, meaning
that performing these steps in `transf` is too late. In addition to
reducing the amount of repeated work for the compiler, this change
should also make further improvements to `semfold` easier.

**Fixes/Improvements**:
- the compiler doesn't crash when errors are detected during constant
  folding
- static range, array index, conversion, and other constant folding
  errors can now be detected via `compiles`, and they're now also
  reported with `nim check`
- legacy not-nil annotations and the `ProveInit` warnings now work
  better and more reliably in code using enum values

**Breaking changes**:
- the AST returned by `getImpl` now contains the result of constant
  folding

## Details

The core of the change is the introduction of `foldInAst` and
`foldConstExprAux` (the 'Aux' postfix is used to make the future
introduction of a public `foldConstExpr` easier). They implement a
depth-first traversal of the AST and inline/fold constants in almost the
same way as `transf` previously did. Compared to `transf`, they do
support error propagation.

### Implementation of the pass

A standard AST traversal is used, but expressions and statements are
separated as a preparation for further changes to the pass. The
introduced `Folded` type both tracks whether there's an error in a tree
and also implements a simple copy-on-write mechanism that prevents
unnecessary copies when nothing changes in a sub-tree. Same as `transf`,
`getConstExpr` is called on each sub-expression, with the result being
inlined, if allowed.

### Differences to `transf`

* statement-list expressions where the first sub-node is a doc comment
  are not folded away -- the documentation generator still needs them
* `getConstExpr` is not called on nodes of literal values (`nkIntLit`,
  `nkStrLit`, etc.) as that would only introduce unnecessary copies
  (potentially forcing a whole tree to be copied)

### Updating the compiler

* all places where AST is passed on to either `sempass2` or `transf`
  now run the constant folding pass (`foldInAst`)
* since the AST is passed on to the VM (and thus `transf`) in case the
  expression is not fully constant, `evalConstExpr` and `tryConstExpr`
  first run the folding pass before calling `getConstExpr`. This is
  slightly more efficient than the other way around
* `getConstExpr2` is a convenience wrapper around `getConstExpr` that
  allows passing in `nkError` nodes

With constant expressions being already folded in AST reaching
`sempass2`, two simplifications are possible:
* `sempass2` doesn't have to tentatively fold a call in order to know
  whether a call expression should be analyzed or not
* `semcomptime` doesn't have to special-case `mLengthArray` magics

Since the constant folding pass is now *not* run for the bodies of
lifted operations (e.g., lifetime hooks), the lifting has to make sure
that the output can be consumed by logic that expects constant-folded
AST:
* `liftdestructors` attempts to directly fold `offsetOf` and `alignOf`
* `genEnumToStrProc` inserts enum literals directly as `nkIntLit`
  instead of as `skEnumField` symbols

In `semGenericArgs`, a defensive copy is of the evaluated constant
expression is created prior to assigning the created `static` type. This
prevents recursive types when `opr` is the exact same node as
`evaluated`.

Finally, the `semfold` integration is removed from `transf`. The logic
for collapsing `nkCheckedFieldExpr`s is obsolete (done by the folding
pass) and the labels in `nkOfBranch` trees can be ignored.

### Other changes

* remove support for folding `nkChckRange`, `nkStringToCString`, and
  `nkCStringToString` nodes -- these nodes are first introduced in
  `transf`, which folding now happens prior to
* remove `adSemfoldInvalidConversion` diagnostic and report associated
  with range-conversion folding errors
* remove a leftover usage of `nkPar` for meaning "tuple constructor"

The `guards` module (which implements facts and implications used in
guarded data-flow analysis) already supported enum operation (e.g.,
`==`, `in`, etc.) but since enum values reached `sempass2` as
`skEnumField` symbols (which `guards` doesn't understand), facts
involving enum values generally didn't apply/work. With enum values now
lowered into integer literals, `guards` can automatically work with
them. An existing test for the `guards` module that now works properly
is update and changed in way so that silent regressions are prevented.

Since `nkHiddenConv` nodes in the index slot of `nkBracketExpr` nodes
now still exist when folding (the nodes are removed in `transf`),
different errors are produced for static out-of-bounds array access. The
associated tests are marked as known issues until it's clearer how this
should ideally work.