### PR TITLE
semtypinst: remove the "meta-types allowed" mode

### DIFF
--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -140,8 +140,7 @@ proc sideEffectsCheck(c: PContext, s: PSym) =
         {sfNoSideEffect, sfSideEffect}:
       localReport(s.info, errXhasSideEffects, s.name.s)
 
-proc instGenericContainer(c: PContext, info: TLineInfo, header: PType,
-                          allowMetaTypes = false): PType =
+proc instGenericContainer(c: PContext, info: TLineInfo, header: PType): PType =
   internalAssert(
     c.config,
     header.kind == tyGenericInvocation,
@@ -157,7 +156,6 @@ proc instGenericContainer(c: PContext, info: TLineInfo, header: PType,
 
   cl.info = info
   cl.c = c
-  cl.allowMetaTypes = allowMetaTypes
 
   # We must add all generic params in scope, because the generic body
   # may include tyFromExpr nodes depending on these generic params.

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1744,8 +1744,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
 
         result = newOrPrevType(tyError, prev, c)
       else:
-        result = instGenericContainer(c, n.info, result,
-                                      allowMetaTypes = false)
+        result = instGenericContainer(c, n.info, result)
 
   # special check for generic object with
   # generic/partial specialized parent


### PR DESCRIPTION
## Summary

With all users of the mode gone, the mode itself is removed, preventing
it from becoming accidentally relied on again.

## Details

* remove all usages of the `TReplTypeVars.allowMetaTypes` field
* perform some small clean-up of unused code
* remove the `allowedMetaTypes` field itself
* remove the `allowedMetaTypes` parameter from `instGenericContainer`

Closes https://github.com/nim-works/nimskull/issues/846