### PR TITLE
treat `when` within generic objects as generic

### DIFF
--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -944,7 +944,9 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
           if e.kind != nkIntLit: discard "don't report followup error"
           elif e.intVal != 0 and branch == nil: branch = it[1]
         else:
-          it[0] = forceBool(c, semExprWithType(c, it[0]))
+          it[0] = semGenericStmt(c, it[0])
+          # ensure that all type variables have their symbol bound:
+          discard fixupTypeVars(c, it[0])
       of nkElse:
         checkSonsLen(it, 1, c.config)
         if branch == nil: branch = it[0]

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3084,10 +3084,24 @@ exceptions:
   translated by the compiler, the other statements are not checked for
   semantics! However, each condition is checked for semantics.
 
-The `when` statement enables conditional compilation techniques. As
-a special syntactic extension, the `when` construct is also available
+The `when` statement enables conditional compilation techniques.
+
+When statement inside `object`
+------------------------------
+
+As a special syntactic extension, the `when` construct is also available
 within `object` definitions.
 
+At which point the `when` construct is evaluated and collapsed depends on
+whether the object has generic parameters:
+* if it does not, the conditions are evaluated and a branch is chosen
+  when inside the definition
+* it it does, all condition expressions are treated as generic expressions
+  that are only instantiated, and a branch chosen, when the object type is
+  instantiated
+
+Same as for `when` statements outside of `object` definitions, each condition
+is checked for semantics and evaluated.
 
 When nimvm statement
 --------------------

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3093,10 +3093,10 @@ As a special syntactic extension, the `when` construct is also available
 within `object` definitions.
 
 At which point the `when` construct is evaluated and collapsed depends on
-whether the object has generic parameters:
-* if it does not, the conditions are evaluated and a branch is chosen
+whether the object is *generic*:
+* if it is not, the conditions are evaluated and a branch is chosen
   when inside the definition
-* it it does, all condition expressions are treated as generic expressions
+* if it is, all condition expressions are treated as generic expressions
   that are only instantiated, and a branch chosen, when the object type is
   instantiated
 


### PR DESCRIPTION
## Summary

Clarify the specification regarding how `when` statements within generic
object definitions work and adjust the implementation accordingly.

`when` statements inside generic object definitions are now treated as
generic. This is a breaking change, but it makes using generic
parameters in more complex expressions possible. Most notably,
`isnot` now works properly inside generic objects' `when` conditions.

## Details

* process `nkElifBranch` conditions of `nkWhenStmt` nodes within generic
  objects via `semGenericStmt` when analyzing the definition
* remove the redundant AST checks in `replaceObjBranches` and
  `replaceTypeVarsN`; the  already take place in `semRecordNode`
* use `semConstBoolExpr` instead of `semConstExpr` when evaluating
  generic `when` conditions
* `semConstBoolExpr` not returning an `nkIntLit` happens in case of
  cascading errors, so don't treat this as an internal error