### PR TITLE
make the "log all VM bytecode" debug feature work

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -109,7 +109,11 @@ proc logBytecode(c: TCtx, owner: PSym, start: int) =
   ## into text that is then written to the standard output.
   const Symbol = "expandVmListing"
   if owner != nil and c.config.isDefined(Symbol):
-    if c.config.getDefined(Symbol) == owner.name.s:
+    let name = c.config.getDefined(Symbol)
+    # if no value is specified for the conditional sym (i.e.,
+    # ``--define:expandVmListing``), `name` is 'true', which we interpret
+    # as "log everything"
+    if name == "true" or name == owner.name.s:
       let listing = codeListing(c, start)
       c.config.msgWrite: renderCodeListing(c.config, owner, listing)
 


### PR DESCRIPTION
## Summary

Correctly treat specifying no value for the `expandVmListing`
conditional symbol as meaning "log all VM bytecode", making the debug
feature work as described in the documentation.

## Details

Testing for the "no value specified" case was missing in `logBytecode`.
Specifying no value for a conditional symbol result in it being assigned
the string "true", so detection has to take this into account.

This does mean that `--define:expandVmListing` and
`--define:expandVmListing:true` mean the same thing, but given that
'true' is seldomly used as a procedure name, this is unlikely to be a
problem in practice.