### PR TITLE
sem: improve meta-type field detection

### DIFF
--- a/tests/errmsgs/t10734.nim
+++ b/tests/errmsgs/t10734.nim
@@ -5,7 +5,7 @@ discard """
 t10734.nim(17, 1) Error: invalid indentation
 t10734.nim(17, 6) Error: invalid indentation
 t10734.nim(19, 1) Error: expression expected, but found '[EOF]'
-t10734.nim(16, 5) Error: 'proc' is not a concrete type; for a callback without parameters use 'proc()'
+t10734.nim(17, 1) Error: 'proc' is not a concrete type; for a callback without parameters use 'proc()'
 t10734.nim(17, 6) Error: undeclared identifier: 'p'
 t10734.nim(15, 3) Hint: 'T' is declared but not used [XDeclaredButNotUsed]
 '''

--- a/tests/lang_callable/generics/tmetafield.nim
+++ b/tests/lang_callable/generics/tmetafield.nim
@@ -1,10 +1,10 @@
 discard """
-  cmd: "nim check $options $file"
+  cmd: "nim check $options --hints:off $file"
   action: "reject"
+  nimoutfull: true
   nimout: '''
-tmetafield.nim(26, 5) Error: 'proc' is not a concrete type; for a callback without parameters use 'proc()'
-tmetafield.nim(27, 5) Error: 'Foo' is not a concrete type
-tmetafield.nim(29, 5) Error: invalid type: 'proc' in this context: 'TBaseMed' for var
+tmetafield.nim(26, 13) Error: 'proc' is not a concrete type; for a callback without parameters use 'proc()'
+tmetafield.nim(27, 14) Error: 'Foo' is not a concrete type
 '''
 """
 

--- a/tests/lang_callable/generics/twrong_generic_object.nim
+++ b/tests/lang_callable/generics/twrong_generic_object.nim
@@ -1,6 +1,6 @@
 discard """
-  errormsg: "cannot instantiate: 'GenericNodeObj[T]'; Maybe generic arguments are missing?"
-  line: 21
+  errormsg: "'GenericNodeObj' is not a concrete type"
+  line: 14
 """
 # bug #2509
 type

--- a/tests/lang_callable/generics/twrong_generic_object_2.nim
+++ b/tests/lang_callable/generics/twrong_generic_object_2.nim
@@ -1,0 +1,10 @@
+discard """
+  errormsg: "'Generic' is not a concrete type"
+  line: 8
+"""
+
+type
+  NonGeneric = object
+    field: Generic
+
+  Generic[T] = object

--- a/tests/lang_callable/generics/twrong_generic_object_3.nim
+++ b/tests/lang_callable/generics/twrong_generic_object_3.nim
@@ -1,0 +1,19 @@
+discard """
+  errormsg: "'any' is not a concrete type"
+  line: 13
+"""
+
+# a contrived case: a non-generic recursive object type containing a meta-type
+# field is used in a generic object that is instantiated before the final type-
+# section pass is run
+
+type
+  NonGeneric = ref object
+    self: NonGeneric
+    field: any
+
+  Generic[T] = object
+    x: NonGeneric
+
+  NonGeneric2 = object
+    x: Generic[int]


### PR DESCRIPTION
## Summary

For non-generic object and tuple definitions, report meta-types being
used for fields when analyzing the field, instead of during the final
type-section pass. This reduces the amount of cascading errors and
also fixes non-generic `object` types containing meta-types reaching
type instantiation.

## Details

The final type-section pass was so far responsible for reporting errors
for meta-types used as field types. However, there were multiple
problems:
- `checkMetaFields` wasn't called for `ref object` or `ptr object`
- since the type flags were already propagated, in case of self-
  recursion, the non-generic object type was reported as being a meta-
  type itself
- if a self-recursive, non-generic `object`-type containing meta-types
  was used in a place reachable by `replaceTypeVarsT`, there was the
  potential of infinite recursion

In practice, no infinite recursion took place, as commit
https://github.com/nim-works/nimskull/commit/d89a20cc1d1ddc497807825c1a80597630e7fa63 worked around the problem by
(mis-)using the `localCache` in `semtypinst` for bailing out of the
loop.

The problem is fixed properly by moving the meta type detection into
`semRecordNodeAux` and `semTuple`, where errors are now reported and the
problematic types turned into `tyError`s. Error reporting happens via a
slightly adjusted version of `checkMetaFields` that is moved into the
`semtypes` module -- the `checkMetaFields` calls in
`typeSectionFinalPass` are removed.

So that forwarded generic types can be detected by the meta-type check,
`tyForward` types created generic types are marked with the `tfHasMeta`
flag until the full type is assigned.

Two new test for more complex meta-type field detection are added, and
existing test are adjusted to the more precise line information now used
for "not a concrete type" errors.