### PR TITLE
semtypinst: fix the type instantiation cache

### DIFF
--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -150,7 +150,6 @@ proc instGenericContainer(c: PContext, info: TLineInfo, header: PType): PType =
     cl: TReplTypeVars
 
   initIdTable(cl.symMap)
-  initIdTable(cl.localCache)
   cl.typeMap = LayeredIdTable()
   initIdTable(cl.typeMap.topLayer)
 
@@ -223,7 +222,6 @@ proc instantiateProcType(c: PContext, pt: TIdTable,
     # twrong_field_caching requires these 'resetIdTable' calls:
     if i > 1:
       resetIdTable(cl.symMap)
-      resetIdTable(cl.localCache)
 
     # take a note of the original type. If't a free type or static parameter
     # we'll need to keep it unbound for the `fitNode` operation below...
@@ -290,7 +288,6 @@ proc instantiateProcType(c: PContext, pt: TIdTable,
     addDecl(c, param)
 
   resetIdTable(cl.symMap)
-  resetIdTable(cl.localCache)
   cl.isReturnType = true
   result[0] = replaceTypeVarsT(cl, result[0])
   cl.isReturnType = false

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -98,9 +98,6 @@ type
     c*: PContext
     typeMap*: LayeredIdTable  # map PType to PType
     symMap*: TIdTable         # map PSym to PSym
-    localCache*: TIdTable     # local cache for remembering already replaced
-                              # types. Used as a work-around for instantiation
-                              # cache issues
     info*: TLineInfo
     skipTypedesc*: bool       # whether we should skip typeDescs
     isReturnType*: bool
@@ -653,7 +650,6 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
   of tyUserTypeClassInst:
     bailout()
     result = instCopyType(cl, t)
-    idTablePut(cl.localCache, t, result)
     for i in 1..<result.len:
       result[i] = replaceTypeVarsT(cl, result[i])
     propagateToOwner(result, result.lastSon)
@@ -668,7 +664,6 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
       bailout()
       result = instCopyType(cl, t)
       result.size = -1 # needs to be recomputed
-      idTablePut(cl.localCache, t, result)
 
       for i in 0..<result.len:
         if result[i] != nil:
@@ -807,7 +802,6 @@ proc replaceTypeParamsInType*(c: PContext, pt: TIdTable, t: PType): PType =
 proc initTypeVars*(p: PContext, typeMap: LayeredIdTable, info: TLineInfo;
                    owner: PSym): TReplTypeVars =
   initIdTable(result.symMap)
-  initIdTable(result.localCache)
   result.typeMap = typeMap
   result.info = info
   result.c = p

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -458,9 +458,8 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
 
   # not cached yet
   result = newType(tyGenericInst, nextTypeId(cl.c.idgen), t[0].owner)
-  # make sure the 'not-nil' flag (which is essentialy a type modifier) is
-  # already present on the instance prior to caching
-  result.flags = header.flags * {tfNotNil}
+  # inherit the flags relevant to type equality before recursing:
+  result.flags = header.flags * eqTypeFlags
   # be careful not to propagate unnecessary flags here (don't use rawAddSon)
   result.sons = @[header[0]]
 

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -10,9 +10,6 @@
 ## This module does the instantiation of generic types.
 
 import
-  std/[
-    strutils
-  ],
   compiler/ast/[
     ast,
     astalgo,
@@ -64,26 +61,23 @@ proc checkConstructedType*(conf: ConfigRef; info: TLineInfo, typ: PType) =
       if t[0].kind != tyObject or tfFinal in t[0].flags:
         localReport(info, errInheritanceOnlyWithNonFinalObjects)
 
-proc searchInstTypes*(g: ModuleGraph; key: PType): PType =
+proc searchInstTypes(g: ModuleGraph; key: PType): PType =
   let genericTyp = key[0]
   if not (genericTyp.kind == tyGenericBody and
       genericTyp.sym != nil): return
 
   for inst in typeInstCacheItems(g, genericTyp.sym):
     if inst.id == key.id: return inst
-    if inst.len < key.len:
-      # XXX: This happens for prematurely cached
-      # types such as Channel[empty]. Why?
-      # See the notes for PActor in handleGenericInvocation
-      return
+    assert inst.len >= key.len
     if not sameFlags(inst, key):
       continue
 
     block matchType:
-      for j in 1..high(key.sons):
-        # XXX sameType is not really correct for nested generics?
+      # compare the arguments. If all are equal, we've got a cache hit,
+      # otherwise we don't
+      for j in 1..<key.len:
         if not compareTypes(inst[j], key[j],
-                            flags = {ExactGenericParams, PickyCAliases}):
+                            flags = {PickyCAliases}):
           break matchType
 
       return inst
@@ -423,72 +417,73 @@ proc instCopyType*(cl: var TReplTypeVars, t: PType): PType =
     result.flags.excl tfHasAsgn
 
 proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
-  # tyGenericInvocation[A, tyGenericInvocation[A, B]]
-  # is difficult to handle:
-  var body = t[0]
+  ## Evaluates a type application (a ``tyGenericInvocation``) and returns
+  ## the resulting ``tyGenericInst``. The result is cached, and evaluating
+  ## the type application again won't create a new instance, but will instead
+  ## return the cached instance.
+  let body = t.base
   cl.c.config.internalAssert(body.kind == tyGenericBody, cl.info, "no generic body")
   var header = t
-  # search for some instantiation here:
-  result = searchInstTypes(cl.c.graph, t)
-
-  if result != nil and sameFlags(result, t):
-    when defined(reportCacheHits):
-      echo "Generic instantiation cached ", typeToString(result), " for ", typeToString(t)
-    return
-  for i in 1..<t.len:
-    var x = t[i]
-    if x.kind in {tyGenericParam}:
-      x = lookupTypeVar(cl, x)
-      if x != nil:
-        if header == t: header = instCopyType(cl, t)
-        header[i] = x
-        propagateToOwner(header, x)
-    else:
-      propagateToOwner(header, x)
-
-  if header != t:
-    # search again after first pass:
-    result = searchInstTypes(cl.c.graph, header)
-    if result != nil and sameFlags(result, t):
-      when defined(reportCacheHits):
-        echo "Generic instantiation cached ", typeToString(result), " for ",
-          typeToString(t), " header ", typeToString(header)
-      return
-  else:
-    header = instCopyType(cl, t)
-
-  result = newType(tyGenericInst, nextTypeId(cl.c.idgen), t[0].owner)
-  result.flags = header.flags
-  # be careful not to propagate unnecessary flags here (don't use rawAddSon)
-  result.sons = @[header[0]]
-  # ugh need another pass for deeply recursive generic types (e.g. PActor)
-  # we need to add the candidate here, before it's fully instantiated for
-  # recursive instantions:
-  cacheTypeInst(cl.c, result)
 
   let oldSkipTypedesc = cl.skipTypedesc
   cl.skipTypedesc = true
 
-  cl.typeMap = newTypeMapLayer(cl)
-
+  # instantiate all invocation arguments:
   for i in 1..<t.len:
-    let x = replaceTypeVarsT(cl, header[i])
-    assert x.kind != tyGenericInvocation
-    header[i] = x
-    propagateToOwner(header, x)
-    cl.typeMap.put(body[i-1], x)
+    let it = t[i]
+    var x =
+      if it.kind == tyGenericParam:
+        lookupTypeVar(cl, it)
+      else:
+        replaceTypeVarsT(cl, it)
+
+    if x.kind == tyTypeDesc:
+      # we want the unwrapped type in argument positions
+      x = x.base
+
+    if x != it:
+      if header == t:
+        # optimization: only create a copy when something changes. We only
+        # use the header for the cache lookup, so an exact replica suffices
+        header = exactReplica(t)
+      header[i] = x
+      propagateToOwner(header, x)
+
+  cl.skipTypedesc = oldSkipTypedesc
+
+  # search the instance cache for the type:
+  result = searchInstTypes(cl.c.graph, header)
+  if result != nil:
+    when defined(reportCacheHits):
+      echo "Generic instantiation cached ", typeToString(result), " for ",
+        typeToString(t), " header ", typeToString(header)
+    return
+
+  # not cached yet
+  result = newType(tyGenericInst, nextTypeId(cl.c.idgen), t[0].owner)
+  # make sure the 'not-nil' flag (which is essentialy a type modifier) is
+  # already present on the instance prior to caching
+  result.flags = header.flags * {tfNotNil}
+  # be careful not to propagate unnecessary flags here (don't use rawAddSon)
+  result.sons = @[header[0]]
 
   for i in 1..<t.len:
     # if one of the params is not concrete, we cannot do anything
     # but we already raised an error!
     rawAddSon(result, header[i], propagateHasAsgn = false)
 
-  if body.kind == tyError:
-    return
+  # cache the incomplete instance *before* instantiating the body, so that
+  # recursive instantiation works
+  cacheTypeInst(cl.c, result)
+
+  cl.typeMap = newTypeMapLayer(cl)
+
+  for i in 1..<t.len:
+    # bind the arguments to the body's parameters
+    cl.typeMap.put(body[i-1], header[i])
 
   let bbody = lastSon body
   var newbody = replaceTypeVarsT(cl, bbody)
-  cl.skipTypedesc = oldSkipTypedesc
   newbody.flags = newbody.flags + (t.flags + body.flags - tfInstClearedFlags)
   result.flags = result.flags + newbody.flags - tfInstClearedFlags
 
@@ -587,15 +582,9 @@ proc propagateFieldFlags(t: PType, n: PNode) =
 proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
   template bailout =
     if cl.recursionLimit > 100:
-      # bail out, see bug #2509. But note this caching is in general wrong,
-      # look at this example where TwoVectors should not share the generic
-      # instantiations (bug #3112):
-
-      # type
-      #   Vector[N: static[int]] = array[N, float64]
-      #   TwoVectors[Na, Nb: static[int]] = (Vector[Na], Vector[Nb])
-      result = PType(idTableGet(cl.localCache, t))
-      if result != nil: return result
+      # too nested instantiation
+      cl.c.config.localReport(cl.info, reportTyp(rsemCannotInstantiate, t))
+      return errorType(cl.c)
     inc cl.recursionLimit
 
   result = t

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -471,9 +471,6 @@ type
     # future work: split everything related to the *production* of types into
     # a type placed in ``vmtypegen``
     lut*: Table[ItemId, PVmType] ## `PType`-id -> `PVmType` mappings
-    genericInsts*: Table[ItemId, seq[(PType, PVmType)]] ##
-      ## 'generic type' -> 'known instantiations' mappings. Needed to make
-      ## sure that all same instantations map to the same VmType
 
     structs*: TypeTable ## All structural types created by ``vmtypegen``
 

--- a/tests/lang_callable/generics/twrong_instantiated_type.nim
+++ b/tests/lang_callable/generics/twrong_instantiated_type.nim
@@ -1,0 +1,38 @@
+discard """
+  description: "Regression tests for a generic type instantiation cache issue"
+"""
+
+type
+  Container[O] = object
+    # 3.) for ``Container[Generic[T]]``, `O` was replaced with the resolved
+    #     ``Generic[int]``, but since there were only unfinished
+    #     ``Container[]`` instances in the cache so far, another new unfinished
+    #     instance is commited to the cache and attempted to be resolved. This
+    #     led to infinite recursion, which was eventually bailed out of via a
+    #     recursion limit
+    val: seq[Container[O]]
+
+  Generic[T] = object
+    n: Container[Generic[T]] # 2.) since the argument wasn't resolved early, the
+                             #     cache lookup failed, and a new unfinished
+                             #     ``Container[int]`` was commited to the cache
+
+  Head[T] = object
+    a: Container[Generic[T]] # 1.) a ``Container[]`` was commited to the cache
+                             #     here
+    b: Container[T] # 4.) a ``Container[int]`` instance is attempted to be
+                    #     created. However, since the recursion counter is only
+                    #     incremented and never reset, this is treated as too
+                    #     deep recusion and the locally cached
+                    #     ``Container[Generic[int]]`` was used
+
+var head = Head[int]()
+static:
+  doAssert typeof(head.a.val[0]) is Container[Generic[int]]
+  doAssert typeof(head.b.val[0]) is Container[int]
+  # both fields have a different type, and comparison must thus not work
+  doAssert(not compiles(head.a.val == head.b.val))
+
+# test that the variable can be used at run-time:
+head.a.val.add Container[Generic[int]]()
+head.b.val.add Container[int]()


### PR DESCRIPTION
## Summary

Fix a severe issue with the type instantiation cache that led to the
wrong types being sometimes retrieved from the cache and multiple,
redundant instances of the same type being created. With the fix, an
important compiler-internal invariant is now true: if two `PType`s
representing nominal types have a different `itemId`, they are not the
same (in terms of type equality).

## Details

The generic type instantiation cache is used when a type application
(`tyGenericInvocation`) is evaluated (`handleGenericInvocation`). The
latter previously operated as follows:
1. the invocation as-is is looked-up in the cache. If the lookup
   succeeds (which is only possible for invocations where all arguments
   are concrete types), the cached resolved instance is returned,
   otherwise, the procedure proceeds
2. immediate type parameters used as arguments are replaced (e.g., the
   `T` for `Invoc[T]`, but not for `Invoc[Invoc[T]]`) and the
3. the modified invocation is looked-up in the cache again. On success,
   the cached resolved instance is returned. In case of no success, the
   invocation is treated as producing a not-yet-seen-before resolved
   instance

In practice, this meant that all invocations where the arguments were
not immediate `tyGenericParam`eters and concrete types always resulted
in cache misses and thus new, and possibly duplicate, instances.

Since the presence of an unfinished instance of a generic type being
present in the cache always resulted in a cache miss (the
`inst.len < key.len` check), recursive generic instantiation would lead
to infinite recursion that was only bailed out of through (mis)-use of
the `localCache` table. However, since `localCache` only remembered the
most recent `PType` associated with a generic type, and the recursion
limit counter isn't reset, this, in turn, would lead to the wrong type
being committed to the global instance cache in contrived scenarios.

### Reworked Implementation

The arguments are now fully resolved prior to cache lookup, and there's
only a single lookup instead of two. A different way to look at it is
that instantiation now happens inside-to-outside instead of outside-to-
inside.

* only inherit the flags relevant for type equality from the
  invocation -- the other flags are inherited from the resolved type-
  arguments. Inheriting all flags from the invocation like was done
  previously would cause the `tfHasMeta` being erroneously included on
  the type in case of recursive generic types
* remove the unnecessary `body.kind == tyError` check. There's an
  internal assertion at the start of `handleGenericInvocation` that
  makes the check redundant
* remove the `localCache` table; it's not needed anymore
* un-export the `searchInstTypes` procedure
* for robustness, and to prevent too deep generic type recursion, keep
  the recursion limit for type instantiations

### Removed Workarounds

Tow workarounds where necessitated by multiple `PType` instances of the
same nominal type existing:
- `sameType` had to fall back to structural type equivalence for
  `tyObject` and `tyDistinct` types that resulted from generic
  invocations (indicated by the `tfFromGeneric` flag)
- the VM's type creation logic had to canonicalize `tyObject` types so
  as to not create duplicate `VmType` instances for the same object

Both workarounds are obsolete now and thus removed.