### PR TITLE
internal: cache transformations in `ModuleGraph`

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -523,7 +523,6 @@ proc transitionRoutineSymKind*(s: PSym, kind: range[skProc..skTemplate]) =
   transitionSymKindCommon(kind)
   if obj.kind in routineKinds - {skMacro} and s.kind != skMacro:
     s.gcUnsafetyReason = obj.gcUnsafetyReason
-    s.transformedBody = obj.transformedBody
 
 proc transitionToLet*(s: PSym) =
   transitionSymKindCommon(skLet)

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1613,7 +1613,6 @@ type
     of routineKinds - {skMacro}:
       #procInstCache*: seq[PInstantiation]
       gcUnsafetyReason*: PSym  ## for better error messages regarding gcsafe
-      transformedBody*: PNode  ## cached body after transf pass
     of skMacro:
       internal*: PType ## the internal signature that the macro has in a
                        ## compile-time evaluation context. Can be used to

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -170,6 +170,7 @@ proc resetForBackend*(g: ModuleGraph) =
     a.clear()
   g.methodsPerType.clear()
   g.enumToStringProcs.clear()
+  g.transformed.setLen(0)
 
 const
   cb64 = [

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -864,6 +864,10 @@ proc myOpen(graph: ModuleGraph; module: PSym;
   if module.position >= graph.libs.len:
     graph.libs.setLen(module.position + 1)
 
+  if module.position < graph.transformed.len:
+    # discard the cached transformed bodies
+    graph.transformed[module.position].reset()
+
   c.semConstExpr = semConstExpr
   c.semExpr = semExpr
   c.semTryExpr = tryExpr


### PR DESCRIPTION
## Summary

Store transformed routine bodies in the `ModuleGraph` instead of in the
associated routines' `TSym`. This makes it possible to discard the
cached transformations for selected modules, and macros can now also
have their transformed body cached. More generally, the change is a step
towards a more data-oriented symbol design.

## Details

* remove the `transformedBody` field from `TSym`
* store the transformed bodies via a `Table[int32, PNode]`, with a
  separate table instance for each module.
* read and write access is done through the new `setTransformed` and
  `getTransformed` procedures; the `transformBody` procedures are
  adjusted
* the cached transformations are discarded when a module is re-opened
  for analysis