### PR TITLE
suggest: discard the compile-time evaluation state

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -230,6 +230,7 @@ proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
 
   conf.ideCmd = cmd
   if cmd == ideUse and conf.suggestVersion != 0:
+    graph.vm = nil # discard the VM and JIT state
     graph.resetAllModules()
   var isKnownFile = true
   let dirtyIdx = fileInfoIdx(conf, file, isKnownFile)
@@ -251,6 +252,9 @@ proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
     let modIdx = graph.parentModule(dirtyIdx)
     graph.markDirty dirtyIdx
     graph.markClientsDirty dirtyIdx
+    # partially recompiling the project means that that VM and JIT state
+    # would become stale, which we prevent by discarding all of it:
+    graph.vm = nil
     if conf.ideCmd != ideMod:
       if isKnownFile:
         graph.compileProject(modIdx)


### PR DESCRIPTION
## Summary

Discard the state of the VM and JIT prior to executing a `nimsuggest`
command, which fixes VM-related crashes and misbehaviour caused by the
VM's internal environment state becoming stale when partially
recompiling the project.

## Details

If a module is recompiled, which is what happens when executing
`nimsuggest` commands, the module's ID generator is effectively reset,
meaning that the IDs of symbols and types are in the same ID space as
those used during the previous compilation. This is a problem for the
JIT and the VM's caches, both which use the IDs to identify symbols and
types.

Prior to executing a `nimsuggest` command that later causes the
recompilation of a module, all compile-time execution state is now
discarded first (by assigning 'nil' to `graph.vm`).

As a consequence, it becomes possible for compile-time-only routines
to be passed to `transformBody` multiple times, which is problematic if
they contain inner closure procedures (who must only be processed by
the destructive lambda-lifting pass once). When in the context of
`nimsuggest`, compile-time-only routines are now also cached, fixing this
follow-up problem.

While using a new module ID would also fix the problem, it would not
fix the problem of recompilation causing the accumulation of obsolete
VM environment and JIT state (e.g., bytecode, RTTI, etc.).