### PR TITLE
sem: use `nkError` for `semOf`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1206,6 +1206,8 @@ type
     adSemExpectedOrdinal
     adSemConstExprExpected
     adSemExpectedRangeType
+    adSemExpectedObjectForOf
+    adSemCannotBeOfSubtype
     # semobjconstr
     adSemFieldAssignmentInvalid
     adSemFieldNotAccessible
@@ -1320,6 +1322,8 @@ type
         adSemVarForOutParamNeeded,
         adSemExprHasNoAddress,
         adSemConstExprExpected,
+        adSemExpectedObjectForOf,
+        adSemCannotBeOfSubtype,
         adSemDisallowedNilDeref,
         adSemCannotReturnTypeless,
         adSemExpectedValueForYield,

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3273,6 +3273,7 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemVarForOutParamNeeded,
       adSemExprHasNoAddress,
       adSemConstExprExpected,
+      adSemExpectedObjectForOf,
       adSemDisallowedNilDeref,
       adSemCannotReturnTypeless,
       adSemExpectedValueForYield,
@@ -3295,6 +3296,14 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind,
         ast: diag.wrongNode)
+  of adSemCannotBeOfSubtype:
+    semRep = SemReport(
+        location: some diag.location,
+        reportInst: diag.instLoc.toReportLineInfo,
+        kind: rsemCannotBeOfSubtype,
+        ast: diag.wrongNode,
+        typeMismatch: @[typeMismatch(diag.wrongNode[2].typ,
+                                     diag.wrongNode[1].typ)])
   of adSemFieldAssignmentInvalid:
     let n = diag.wrongNode
     let kind =

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -566,6 +566,8 @@ func astDiagToLegacyReportKind*(
   of adSemExpectedOrdinal: rsemExpectedOrdinal
   of adSemConstExprExpected: rsemConstExprExpected
   of adSemExpectedRangeType: rsemExpectedRange
+  of adSemExpectedObjectForOf: rsemExpectedObjectForOf
+  of adSemCannotBeOfSubtype: rsemCannotBeOfSubtype
   of adSemRecursiveDependencyIterator: rsemRecursiveDependencyIterator
   of adSemCallIndirectTypeMismatch: rsemCallIndirectTypeMismatch
   of adSemSystemNeeds: rsemSystemNeeds


### PR DESCRIPTION
## Summary

Replace `localReport` usage in `semOf` with `nkError` and also clean up
the procedure in general. In addition, fix the internal issue of
folded-to-false 'of' operations being replaced with their original
expression.

## Details

* remove the argument count guard. `semOf` is only called after overload
  resolution succeeded, meaning that the number of arguments must be
  correct
* don't analyze the operands again; they are already fully analyzed when
  `semOf` is called
* use `newIntTypeNode` instead of `newIntNode` + manual type assignment
* fix the folded-to-false AST being replaced with the original
  expression
* replaced the `localReport` usages for errors with error nodes; new
  diagnostic kinds and their associated logic are required
* add a documentation comment for `semOf`