### PR TITLE
sem: correctly compute size for partial objects

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1807,6 +1807,10 @@ proc typeDefLeftSidePass(c: PContext, typeSection: PNode, i: int) =
         s = semIdentDef(c, name[1], skType)
         s.typ = newTypeS(tyObject, c)
         s.typ.sym = s
+        # until the type is completed, the size and alignment are treated as
+        # unknown
+        s.typ.size = szUnknownSize
+        s.typ.align = szUnknownSize
         s.flags.incl sfForward
         c.graph.packageTypes.strTableAdd s
         addInterfaceDecl(c, s)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1142,6 +1142,12 @@ proc semObjectNode(c: PContext, n: PNode, prev: PType; flags: TTypeFlags): PType
   else:
     # partial object so add things to the check
     addInheritedFields(c, check, pos, result)
+    if not incompleteType(result):
+      # this record AST represents the final addition to the object; the
+      # size can be computed now
+      result.size = szUncomputedSize
+      result.align = szUncomputedSize
+
   semRecordNodeAux(c, n[2], check, pos, result.n, result)
   if n[0].kind != nkEmpty:
     # dummy symbol for `pragma`:

--- a/tests/lang_experimental/package_level_objects/tusefoo.nim
+++ b/tests/lang_experimental/package_level_objects/tusefoo.nim
@@ -1,4 +1,6 @@
 discard """
+  targets: "c js vm"
+  knownIssue.js vm: "unfolded 'sizeof' calls are not supported"
   output: '''@[(x: 3, y: 4)]'''
 """
 
@@ -6,11 +8,20 @@ type
   mypackage.Foo = object
   Other = proc (inp: Foo)
 
+# can only be computed at run-time:
+doAssert sizeof(Foo) == sizeof((int, int))
+doAssert alignof(Foo) == alignof(int)
+
 import definefoo
 
 # after this import, Foo is a completely resolved type, so
 # we can create a sequence of it:
 var s: seq[Foo] = @[]
+
+# the size is also statically known now:
+static:
+  doAssert sizeof(Foo) == sizeof((int, int))
+  doAssert alignof(Foo) == alignof(int)
 
 s.add Foo(x: 3, y: 4)
 echo s


### PR DESCRIPTION
## Summary

Treat partial objects as having an unknown size until they're completed.
This prevents their usage in compile-time contexts prior to being
completed and fixes memory corruption issues with the C target, which
were caused by the size computed for the partial object types being
wrong.

Since the JS and VM targets don't support `sizeof`/`alignof`/`offsetof`
for incomplete types, attempting to call either magic for an incomplete
partial object will result in compiler errors.

## Details

The size and alignment for all types is computed and set for all types
at the end of a type section, and this led to the size of the incomplete
package-level (i.e., partial) objects being set already.

When a package-level object is started (that is, first added to the
`packageTypes` list), its size and alignment is now set to 'unknown',
preventing the value from being incorrectly computed and disabling
folding of `sizeof`/`alignof`/`offsetof` magics. Once finished (i.e.,
the final record AST is analyzed), the size and alignments values are
set to 'uncomputed'.

Unfortunately, this means that other aggregate types embedding partial
objects prior to them being completed are also treated as incomplete,
and, since there's currently no way to propagate the completion of a
partial object to all its users, stay as incomplete, preventing their
use with `sizeof`/`alignof`/`offset` at compile-time and with the JS and
VM targets.