### PR TITLE
internal: consider column for `TLineInfo` equality

### DIFF
--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -26,7 +26,9 @@ type
     col*: int16
     fileIndex*: FileIndex
 
-  FileLinePar* = tuple
+  SourceLinePosition* = tuple
+    ## Identifies a line in a source file. Only intended for use by
+    ## the profiler.
     fileIndex: typeof(TLineInfo.fileIndex)
     line: typeof(TLineInfo.line)
 

--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -26,6 +26,10 @@ type
     col*: int16
     fileIndex*: FileIndex
 
+  FileLinePar* = tuple
+    fileIndex: typeof(TLineInfo.fileIndex)
+    line: typeof(TLineInfo.line)
+
   LineColPair* = tuple
     line: typeof(TLineInfo.line)
     col: typeof(TLineInfo.col)

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -315,11 +315,7 @@ proc errorActions(
     elif eh == doRaise:
       result = (doRaise, false)
 
-
 proc `==`*(a, b: TLineInfo): bool =
-  result = a.line == b.line and a.fileIndex == b.fileIndex
-
-proc exactEquals*(a, b: TLineInfo): bool =
   result = a.fileIndex == b.fileIndex and a.line == b.line and a.col == b.col
 
 proc getContext*(conf: ConfigRef; lastinfo: TLineInfo): seq[ReportContext] =

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -315,9 +315,6 @@ proc errorActions(
     elif eh == doRaise:
       result = (doRaise, false)
 
-proc `==`*(a, b: TLineInfo): bool =
-  result = a.fileIndex == b.fileIndex and a.line == b.line and a.col == b.col
-
 proc getContext*(conf: ConfigRef; lastinfo: TLineInfo): seq[ReportContext] =
   ## Get list of context context entries from the current message context
   ## information. Context messages can later be used in the

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -166,7 +166,7 @@ type
     count*: int
 
   ProfileData* = ref object
-    data*: TableRef[TLineInfo, ProfileInfo]
+    data*: TableRef[FileLinePar, ProfileInfo]
 
   StdOrrKind* = enum
     stdOrrStdout
@@ -774,7 +774,7 @@ template newPackageCache*(): untyped =
                    modeCaseSensitive)
 
 proc newProfileData(): ProfileData =
-  ProfileData(data: newTable[TLineInfo, ProfileInfo]())
+  ProfileData(data: newTable[FileLinePar, ProfileInfo]())
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -774,7 +774,7 @@ template newPackageCache*(): untyped =
                    modeCaseSensitive)
 
 proc newProfileData(): ProfileData =
-  ProfileData(data: newTable[FileLinePar, ProfileInfo]())
+  ProfileData(data: newTable[SourceLinePosition, ProfileInfo]())
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -166,7 +166,7 @@ type
     count*: int
 
   ProfileData* = ref object
-    data*: TableRef[FileLinePar, ProfileInfo]
+    data*: TableRef[SourceLinePosition, ProfileInfo]
 
   StdOrrKind* = enum
     stdOrrStdout

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1775,7 +1775,7 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
   when defined(nimsuggest):
     if c.config.cmd == cmdIdeTools:
       suggestExpr(c, n)
-      if exactEquals(c.config.m.trackPos, n[1].info): suggestExprNoCheck(c, n)
+      if c.config.m.trackPos == n[1].info: suggestExprNoCheck(c, n)
 
   let s = qualifiedLookUp(c, n, {checkAmbiguity, checkUndeclared, checkModule})
   if s.isError:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1691,7 +1691,7 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
     setCaseContextIdx(c, i)
     var x = n[i]
     when defined(nimsuggest):
-      if c.config.ideCmd == ideSug and exactEquals(c.config.m.trackPos, x.info) and caseTyp.kind == tyEnum:
+      if c.config.ideCmd == ideSug and c.config.m.trackPos == x.info and caseTyp.kind == tyEnum:
         suggestEnum(c, x, caseTyp)
     case x.kind
     of nkOfBranch:

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -57,5 +57,6 @@ proc dump*(conf: ConfigRef, pd: ProfileData): string =
       break
     result.add  "  " & align($int(infoMax.time * 1e6), 10) &
                        align($int(infoMax.count), 10) & "  " &
-                       toMsgFilename(conf, flMax.fileIndex) & "(" & $flMax.line & ")" & "\n"
+    result.toLocation(toMsgFilename(conf, flMax.fileIndex), flMax.line, 0)
+    result.add "\n"
     data.del flMax

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -57,5 +57,8 @@ proc dump*(conf: ConfigRef, pd: ProfileData): string =
       break
     result.add  "  " & align($int(infoMax.time * 1e6), 10) &
                        align($int(infoMax.count), 10) & "  " &
-                       toMsgFilename(conf, newLineInfo(flMax.fileIndex, flMax.line.int, 0)) & "\n"
+                       toMsgFilename(conf, newLineInfo(flMax.fileIndex,
+                                                       flMax.line.int,
+                                                       -1)) &
+                       "\n"
     data.del flMax

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -57,6 +57,5 @@ proc dump*(conf: ConfigRef, pd: ProfileData): string =
       break
     result.add  "  " & align($int(infoMax.time * 1e6), 10) &
                        align($int(infoMax.count), 10) & "  " &
-    result.toLocation(toMsgFilename(conf, flMax.fileIndex), flMax.line, 0)
-    result.add "\n"
+                       toMsgFilename(conf, newLineInfo(flMax.fileIndex, flMax.line.int, 0)) & "\n"
     data.del flMax

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -48,7 +48,7 @@ proc dump*(conf: ConfigRef, pd: ProfileData): string =
   result = "\nprof:     µs    #instr  location\n"
   for i in 0..<32:
     var infoMax: ProfileInfo
-    var flMax: FileLinePar
+    var flMax: SourceLinePosition
     for fl, info in data:
       if info.time > infoMax.time:
         infoMax = info

--- a/compiler/vm/vmprofiler.nim
+++ b/compiler/vm/vmprofiler.nim
@@ -28,7 +28,7 @@ proc leaveImpl(prof: var Profiler, c: TCtx) {.noinline.} =
   while frameIdx >= 0:
     let frame = c.sframes[frameIdx]
     if frame.prc != nil:
-      let li = frame.prc.info
+      let li = (frame.prc.info.fileIndex, frame.prc.info.line)
       if li notin data:
         data[li] = ProfileInfo()
       data[li].time += tLeave - prof.tEnter
@@ -48,7 +48,7 @@ proc dump*(conf: ConfigRef, pd: ProfileData): string =
   result = "\nprof:     µs    #instr  location\n"
   for i in 0..<32:
     var infoMax: ProfileInfo
-    var flMax: TLineInfo
+    var flMax: FileLinePar
     for fl, info in data:
       if info.time > infoMax.time:
         infoMax = info
@@ -57,5 +57,5 @@ proc dump*(conf: ConfigRef, pd: ProfileData): string =
       break
     result.add  "  " & align($int(infoMax.time * 1e6), 10) &
                        align($int(infoMax.count), 10) & "  " &
-                       conf.toFileLineCol(flMax) & "\n"
+                       toMsgFilename(conf, flMax.fileIndex) & "(" & $flMax.line & ")" & "\n"
     data.del flMax


### PR DESCRIPTION
## Summary

Change the default equality operation for `TLineInfo` to also consider
the column, effectively changing the meaning of `TLineInfo` to "source
position info". Places in the compiler that relied on the old behaviour
are adjusted.

In most cases, a `TLineInfo` is already treated as a "source position",
so having the `==` operator reflect that makes sense. The `hash`
procedure also already considered the column, too.

## Details

The custom `==` implementation for `TLineInfo` is removed, which means
that the default implementation (value equality) is used. `exactEquals`
is redundant now: its usages are replaced with `==` and the procedure
itself is removed.

### Changed usage sites

The VM profiler implementation (`vmprofiler`) relied on the old equality
behaviour, as it uses `TLineInfo` as the key for a table that associates
profiler data with a source *line*. Here, `TLineInfo` usage is replaced
with the new `SourceLinePosition` tuple, which is a `TLineInfo` without
the column information.

For rendering the profiler data, a temporary `TLineInfo` instance is
created, but with the column set to -1. This means that the text output
now links to the source line *without* including a column position.

### Other relevant usage sites

There are two other places where the different equality behaviour
causes a visible change in compiler behaviour, but that are not
adjusted because the new behaviour is better:
- with reporting "nil dereference" warnings (`nilcheck.derefWarning`):
  warnings are now reported one per line+column, instead of one per
  line
- providing error/warning context (`msgs.getContext`, "instantiated
  from" messages): if there are multiple surrounding instantiation
  contexts on the same line (but in different columns), they are now all
  shown, instead of only the first one