### PR TITLE
nimsuggest: remove `v1` implementation

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -158,7 +158,7 @@ type
     scope*:int
     localUsages*, globalUsages*: int # usage counters
     tokenLen*: int
-    version*: int
+
   Suggestions* = seq[Suggest]
 
   ProfileInfo* = object

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -292,7 +292,6 @@ type
     cCompilerPath*: string
     toCompile*: CfileList         # (*)
     suggestionResultHook*: proc (result: Suggest) {.closure.}
-    suggestVersion*: int
     suggestMaxResults*: int
     lastLineInfo*: TLineInfo
     writelnHook*: proc(

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -201,7 +201,6 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
   result.filePath = toFullPath(g.config, infox)
   result.line = toLinenumber(infox)
   result.column = toColumn(infox)
-  result.version = g.config.suggestVersion
   result.tokenLen = if section != ideHighlight:
                       s.name.s.len
                     else:

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -514,6 +514,9 @@ proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; i
 
     if conf.ideCmd == ideDef:
       findDefinition(g, info, s, usageSym)
+    elif conf.ideCmd == ideDus and s != nil:
+      if isTracked(info, conf.m.trackPos, s.name.s.len):
+        suggestResult(conf, symToSuggest(g, s, isLocal=false, ideDef, info, 100, PrefixMatch.None, false, 0))
     elif conf.ideCmd == ideHighlight and info.fileIndex == conf.m.trackPos.fileIndex:
       suggestResult(conf, symToSuggest(g, s, isLocal=false, ideHighlight, info, 100, PrefixMatch.None, false, 0))
     elif conf.ideCmd == ideOutline and isDecl:

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -238,12 +238,11 @@ proc `$`*(suggest: Suggest): string =
     result.add(sep)
     when defined(nimsuggest) and not defined(noDocgen) and not defined(leanCompiler):
       result.add(suggest.doc.escape)
-    if suggest.version == 0:
+    result.add(sep)
+    result.add($suggest.quality)
+    if suggest.section == ideSug:
       result.add(sep)
-      result.add($suggest.quality)
-      if suggest.section == ideSug:
-        result.add(sep)
-        result.add($suggest.prefix)
+      result.add($suggest.prefix)
 
 proc suggestResult(conf: ConfigRef; s: Suggest) =
   if not isNil(conf.suggestionResultHook):

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -651,7 +651,6 @@ proc processCmdLine*(pass: TCmdLinePass, argv: openArray[string]; conf: ConfigRe
         gMode = mepc
         conf.verbosity = compVerbosityMin  # Port number gotta be first.
       of "debug": conf.incl optIdeDebug
-      of "v2": conf.suggestVersion = 0
       of "tester":
         gMode = mstdin
         gEmitEof = true
@@ -772,7 +771,6 @@ else:
 
 
     proc mockCmdLine(pass: TCmdLinePass, argv: openArray[string]; conf: ConfigRef) =
-      conf.suggestVersion = 0
       let a = unixToNativePath(project)
       if dirExists(a) and not fileExists(a.addFileExt("nim")):
         conf.projectName = findProjectNimFile(conf, a)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -229,8 +229,6 @@ proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
   )
 
   conf.ideCmd = cmd
-  if cmd == ideUse and conf.suggestVersion != 0:
-    graph.resetAllModules()
   var isKnownFile = true
   let dirtyIdx = fileInfoIdx(conf, file, isKnownFile)
 
@@ -240,11 +238,9 @@ proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
   conf.m.trackPos = newLineInfo(dirtyIdx, line, col)
   conf.m.trackPosAttached = false
   conf.errorCounter = 0
-  if conf.suggestVersion == 1:
-    graph.usageSym = nil
   if not isKnownFile:
     graph.compileProject(dirtyIdx)
-  if conf.suggestVersion == 0 and conf.ideCmd in {ideUse, ideDus} and
+  if conf.ideCmd in {ideUse, ideDus} and
       dirtyfile.isEmpty:
     discard "no need to recompile anything"
   else:
@@ -255,7 +251,7 @@ proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
       if isKnownFile:
         graph.compileProject(modIdx)
   if conf.ideCmd in {ideUse, ideDus}:
-    let u = if conf.suggestVersion != 1: graph.symFromInfo(conf.m.trackPos) else: graph.usageSym
+    let u = graph.symFromInfo(conf.m.trackPos)
     if u != nil:
       listUsages(graph, u)
     else:
@@ -656,7 +652,6 @@ proc processCmdLine*(pass: TCmdLinePass, argv: openArray[string]; conf: ConfigRe
         conf.verbosity = compVerbosityMin  # Port number gotta be first.
       of "debug": conf.incl optIdeDebug
       of "v2": conf.suggestVersion = 0
-      of "v1": conf.suggestVersion = 1
       of "tester":
         gMode = mstdin
         gEmitEof = true

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -85,7 +85,6 @@ Options:
   --epc                   use emacs epc mode
   --debug                 enable debug output
   --log                   enable verbose logging to nimsuggest.log file
-  --v1                    use version 1 of the protocol; for backwards compatibility
   --refresh               perform automatic refreshes to keep the analysis precise
   --maxresults:N          limit the number of suggestions to N
   --tester                implies --stdin and outputs a line

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -654,6 +654,7 @@ proc processCmdLine*(pass: TCmdLinePass, argv: openArray[string]; conf: ConfigRe
         gMode = mepc
         conf.verbosity = compVerbosityMin  # Port number gotta be first.
       of "debug": conf.incl optIdeDebug
+      of "v2": discard
       of "tester":
         gMode = mstdin
         gEmitEof = true

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -255,7 +255,7 @@ proc runEpcTest(filename: string): int =
   for cmd in s.startup:
     if not runCmd(cmd, s.dest):
       quit "invalid command: " & cmd
-  let epccmd = s.cmd.replace("--tester", "--epc --v2 --log")
+  let epccmd = s.cmd.replace("--tester", "--epc --log")
   let cl = parseCmdLine(epccmd)
   var p = startProcess(command=cl[0], args=cl[1 .. ^1],
                        options={poStdErrToStdOut, poUsePath,


### PR DESCRIPTION
## Summary

Remove the implementation of the legacy v1 `nimsuggest` version. This
simplifies the code and thus helps with restructuring/refactoring
`nimsuggest`, which is in the process of moving to the language-server
protocol (LSP).

The `--v1` CLI option is removed from `nimsuggest`, making the `--v2`
option, which is kept for backwards compatibility, the only remaining
version option.

## Details

Since there's only a single version left, the fields for tracking the
selected version are obsolete. `suggestVersion` having the value 0 meant
that the `v2` version is selected, while a value of 1 meant that
the now-removed `v1` version is selected.

* remove the `suggestVersion` field and all its usages
* remove the `version` field from the `Suggest` type
* remove the `findUsages` procedure, which was only used with version
  `v1`