### PR TITLE
pragmas: remove obsolete built-in pragmas

### DIFF
--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -38,14 +38,14 @@ type
     wUncheckedAssign = "uncheckedAssign",
 
     wImmediate = "immediate", wConstructor = "constructor", wDestructor = "destructor",
-    wDelegator = "delegator", wOverride = "override", wImportCompilerProc = "importCompilerProc",
+    wOverride = "override", wImportCompilerProc = "importCompilerProc",
     wImportc = "importc", wImportJs = "importjs", wExportc = "exportc",
     wExportNims = "exportnims",
     wIncompleteStruct = "incompleteStruct", # deprecated
     wCompleteStruct = "completeStruct", wRequiresInit = "requiresInit", wAlign = "align",
     wNodecl = "nodecl", wPure = "pure", wSideEffect = "sideEffect", wHeader = "header",
     wNoSideEffect = "noSideEffect", wGcSafe = "gcsafe", wNoreturn = "noreturn",
-    wNosinks = "nosinks", wMerge = "merge", wLib = "lib", wDynlib = "dynlib",
+    wNosinks = "nosinks", wLib = "lib", wDynlib = "dynlib",
     wCompilerProc = "compilerproc", wCore = "core", wProcVar = "procvar",
     wBase = "base", wUsed = "used", wFatal = "fatal", wError = "error", wWarning = "warning",
     wHint = "hint",
@@ -67,7 +67,6 @@ type
     wSinkInference = "sinkInference", wWarnings = "warnings",
     wHints = "hints", wOptimization = "optimization", wRaises = "raises",
     wWrites = "writes", wReads = "reads", wSize = "size", wEffects = "effects", wTags = "tags",
-    wDeadCodeElimUnused = "deadCodeElim",  # deprecated, dead code elim always happens
     wSafecode = "safecode", wPackage = "package",
     wNoRewrite = "norewrite", wNoDestroy = "nodestroy", wPragma = "pragma",
     wCompileTime = "compileTime", wNoInit = "noinit", wPassc = "passc", wPassl = "passl",
@@ -78,7 +77,7 @@ type
     wWrite = "write", wGensym = "gensym", wInject = "inject", wDirty = "dirty",
     wInheritable = "inheritable", wThreadVar = "threadvar", wEmit = "emit",
     wAsmNoStackFrame = "asmNoStackFrame", wImplicitStatic = "implicitStatic",
-    wGlobal = "global", wCodegenDecl = "codegenDecl", wUnchecked = "unchecked",
+    wGlobal = "global", wCodegenDecl = "codegenDecl",
     wGuard = "guard", wLocks = "locks", wExplain = "explain",
 
     wAuto = "auto", wBool = "bool", wCatch = "catch", wChar = "char",

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -73,18 +73,18 @@ const
     ## common pragmas for declarations, to a good approximation
   procPragmas* = declPragmas + {FirstCallConv..LastCallConv,
     wMagic, wNoSideEffect, wSideEffect, wNoreturn, wNosinks, wDynlib, wHeader,
-    wCompilerProc, wCore, wProcVar, wVarargs, wCompileTime, wMerge,
+    wCompilerProc, wCore, wProcVar, wVarargs, wCompileTime,
     wBorrow, wImportCompilerProc, wThread,
     wAsmNoStackFrame, wDiscardable, wNoInit, wCodegenDecl,
-    wGensym, wInject, wRaises, wEffectsOf, wTags, wLocks, wDelegator, wGcSafe,
+    wGensym, wInject, wRaises, wEffectsOf, wTags, wLocks, wGcSafe,
     wStackTrace, wLineTrace, wNoDestroy}
   converterPragmas* = procPragmas
   methodPragmas* = procPragmas+{wBase}-{wOverride}
   templatePragmas* = {wDeprecated, wError, wGensym, wInject, wDirty,
-    wDelegator, wExportNims, wUsed, wPragma}
+    wExportNims, wUsed, wPragma}
   macroPragmas* = declPragmas + {FirstCallConv..LastCallConv,
     wMagic, wNoSideEffect, wCompilerProc, wCore,
-    wDiscardable, wGensym, wInject, wDelegator}
+    wDiscardable, wGensym, wInject}
   iteratorPragmas* = declPragmas + {FirstCallConv..LastCallConv, wNoSideEffect, wSideEffect,
     wMagic, wBorrow,
     wDiscardable, wGensym, wInject, wRaises, wEffectsOf,
@@ -98,7 +98,6 @@ const
     wLineDir, wStackTrace, wLineTrace, wOptimization, wHint, wWarning, wError,
     wFatal, wDefine, wUndef, wCompile, wLink, wPush, wPop,
     wPassl, wPassc, wLocalPassc,
-    wDeadCodeElimUnused,  # deprecated, always on
     wDebugger, wProfiler,
     wDeprecated,
     wFloatChecks, wInfChecks, wNanChecks, wPragma, wEmit,
@@ -1189,9 +1188,6 @@ proc applySymbolPragma(c: PContext, sym: PSym, it: PNode): PNode =
       of wGlobal:
         result = noVal(c, it)
         sym.flags.incl {sfGlobal, sfPure}
-      of wMerge:
-        # only supported for backwards compat, doesn't do anything anymore
-        result = noVal(c, it)
       of wHeader:
         let path = getStrLitNode(c, it) # the path or an error
         if path.isError:
@@ -1463,9 +1459,6 @@ proc applyStmtPragma(c: PContext, owner: PSym, it: PNode, k: TSpecialWord): PNod
   ## is ill-formed (e.g. missing arguments) or the evaluation failed, an error
   ## is returned.
   case k
-  of wDeadCodeElimUnused:
-    # TODO: the pragma is a no-op. Either reinstate or remove it
-    result = noVal(c, it)
   of wUsed:
     result = noVal(c, it)
     # XXX: an escaping mutation if the the pragma is used inside a ``compiles``

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -989,25 +989,25 @@ proc newStringOfCap*(cap: Natural): string {.
   ## be achieved with the `&` operator or with `add`.
 
 proc `&`*(x: string, y: char): string {.
-  magic: "ConStrStr", noSideEffect, merge.}
+  magic: "ConStrStr", noSideEffect.}
   ## Concatenates `x` with `y`.
   ##
   ## .. code-block:: Nim
   ##   assert("ab" & 'c' == "abc")
 proc `&`*(x, y: char): string {.
-  magic: "ConStrStr", noSideEffect, merge.}
+  magic: "ConStrStr", noSideEffect.}
   ## Concatenates characters `x` and `y` into a string.
   ##
   ## .. code-block:: Nim
   ##   assert('a' & 'b' == "ab")
 proc `&`*(x, y: string): string {.
-  magic: "ConStrStr", noSideEffect, merge.}
+  magic: "ConStrStr", noSideEffect.}
   ## Concatenates strings `x` and `y`.
   ##
   ## .. code-block:: Nim
   ##   assert("ab" & "cd" == "abcd")
 proc `&`*(x: char, y: string): string {.
-  magic: "ConStrStr", noSideEffect, merge.}
+  magic: "ConStrStr", noSideEffect.}
   ## Concatenates `x` with `y`.
   ##
   ## .. code-block:: Nim


### PR DESCRIPTION
## Summary

Remove the built-in no-op pragmas `delegator`, `deadCodeElim`,
`unchecked`, and `merge`. They have been no-ops for a long time, and
removing them means that their names are now available to be used by
user-defined pragmas.

## Details

* remove usage of the no-op `merge` pragma from `system.&`
* remove the pragmas' corresponding `TSpecialWord` enum value:
  `wDelegator`, `wDeadCodeElimUnused`, `wUnchecked`, `wMerge`