### PR TITLE
nimsuggest: move library code into `suggest`

### DIFF
--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -489,8 +489,8 @@ proc executeCmd*(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
   var isKnownFile = true
   let dirtyIdx = fileInfoIdx(conf, file, isKnownFile)
 
-  if not dirtyfile.isEmpty: msgs.setDirtyFile(conf, dirtyIdx, dirtyfile)
-  else: msgs.setDirtyFile(conf, dirtyIdx, AbsoluteFile"")
+  if dirtyfile.isEmpty: msgs.setDirtyFile(conf, dirtyIdx, AbsoluteFile"")
+  else: msgs.setDirtyFile(conf, dirtyIdx, dirtyfile)
 
   conf.m.trackPos = newLineInfo(dirtyIdx, line, col)
   conf.m.trackPosAttached = false

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -479,6 +479,7 @@ proc findTrackedNode(n: PNode; trackPos: TLineInfo): PSym =
 proc findTrackedSym*(g: ModuleGraph;): PSym =
   let m = g.getModule(g.config.m.trackPos.fileIndex)
   if m != nil and m.ast != nil:
+    # xxx: the node finding should be specialized per symbol kind
     result = findTrackedNode(m.ast, g.config.m.trackPos)
 
 proc executeCmd*(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -56,6 +56,7 @@ import
     options,
   ],
   compiler/modules/[
+    modules,
     modulegraphs,
   ],
   compiler/sem/[
@@ -66,7 +67,8 @@ import
   compiler/utils/[
     prefixmatches,
     astrepr,
-    debugutils
+    debugutils,
+    pathutils
   ]
 
 
@@ -465,6 +467,48 @@ proc isTracked*(current, trackPos: TLineInfo, tokenLen: int): bool =
     let col = trackPos.col
     if col >= current.col and col <= current.col+tokenLen-1:
       return true
+
+proc findTrackedNode(n: PNode; trackPos: TLineInfo): PSym =
+  if n.kind == nkSym:
+    if isTracked(n.info, trackPos, n.sym.name.s.len): return n.sym
+  else:
+    for i in 0 ..< safeLen(n):
+      let res = findTrackedNode(n[i], trackPos)
+      if res != nil: return res
+
+proc findTrackedSym*(g: ModuleGraph;): PSym =
+  let m = g.getModule(g.config.m.trackPos.fileIndex)
+  if m != nil and m.ast != nil:
+    result = findTrackedNode(m.ast, g.config.m.trackPos)
+
+proc executeCmd*(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
+             graph: ModuleGraph) =
+  let conf = graph.config
+  conf.ideCmd = cmd
+  var isKnownFile = true
+  let dirtyIdx = fileInfoIdx(conf, file, isKnownFile)
+
+  if not dirtyfile.isEmpty: msgs.setDirtyFile(conf, dirtyIdx, dirtyfile)
+  else: msgs.setDirtyFile(conf, dirtyIdx, AbsoluteFile"")
+
+  conf.m.trackPos = newLineInfo(dirtyIdx, line, col)
+  conf.m.trackPosAttached = false
+  conf.errorCounter = 0
+  if not isKnownFile:
+    graph.compileProject(dirtyIdx)
+  if conf.ideCmd in {ideUse, ideDus} and
+      dirtyfile.isEmpty:
+    discard "no need to recompile anything"
+  else:
+    let modIdx = graph.parentModule(dirtyIdx)
+    graph.markDirty dirtyIdx
+    graph.markClientsDirty dirtyIdx
+    # partially recompiling the project means that that VM and JIT state
+    # would become stale, which we prevent by discarding all of it:
+    graph.vm = nil
+    if conf.ideCmd != ideMod:
+      if isKnownFile:
+        graph.compileProject(modIdx)
 
 when defined(nimsuggest):
 

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -484,9 +484,9 @@ proc findTrackedSym*(g: ModuleGraph;): PSym =
 
 proc executeCmd*(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
              graph: ModuleGraph) =
-  ## executes the given suggest command for a given file,
-  ## at the position described by line and column.
-  ## If dirtyFile is non-empty, then its contents are used as part of the analysis.
+  ## executes the given suggest command, `cmd`, for a given `file`, at the
+  ## position described by `line` and `col`umn. If `dirtyFile` is non-empty,
+  ## then its contents are used as part of the analysis.
   let conf = graph.config
   conf.ideCmd = cmd
   var isKnownFile = true

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -484,6 +484,9 @@ proc findTrackedSym*(g: ModuleGraph;): PSym =
 
 proc executeCmd*(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
              graph: ModuleGraph) =
+  ## executes the given suggest command for a given file,
+  ## at the position described by line and column.
+  ## If dirtyFile is non-empty, then its contents are used as part of the analysis.
   let conf = graph.config
   conf.ideCmd = cmd
   var isKnownFile = true


### PR DESCRIPTION
<!--- The Pull Request (=PR) message is what will get automatically used as
the commit message when the PR is merged. Make sure that no line is longer
than 72 characters -->

## Summary

Extract procedures that do not rely on the command-line from the
`nimsuggest` module to the `suggest` module.

## Details

Changes:

- procedure `findNode` was moved and renamed to `findTrackedNode`
- procedure `symFromInfo` was moved and renamed to `findTrackedSym`
- the ide command execution part of `executeNoHooks` was extracted and
  moved into `executeCmd`

This makes the `suggest` module more of a reusable component for other
non-`nimsuggest` tools, e.g. the LSP server.