### PR TITLE
remove obsolete comments related to nimsuggest

### DIFF
--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -30,7 +30,6 @@
 ## - In any case, sorting also considers scoping information. Local variables
 ##   get high priority.
 
-# included from sigmatch.nim
 
 import
   std/[
@@ -77,7 +76,6 @@ when defined(nimsuggest):
 const
   sep = '\t'
 
-#template sectionSuggest(): expr = "##begin\n" & getStackTrace() & "##end\n"
 
 template origModuleName(m: PSym): string = m.name.s
 
@@ -313,7 +311,6 @@ proc suggestSymList(c: PContext, list, f: PNode; info: TLineInfo, outputs: var S
   for i in 0..<list.len:
     if list[i].kind == nkSym:
       suggestField(c, list[i].sym, f, info, outputs)
-    #else: InternalError(list.info, "getSymFromList")
 
 proc suggestObject(c: PContext, n, f: PNode; info: TLineInfo, outputs: var Suggestions) =
   case n.kind
@@ -477,7 +474,6 @@ when defined(nimsuggest):
 
 when defined(nimsuggest):
   proc listUsages*(g: ModuleGraph; s: PSym) =
-    #echo "usages ", s.allUsages.len
     for info in s.allUsages:
       let x = if info == s.info: ideDef else: ideUse
       suggestResult(g.config, symToSuggest(g, s, isLocal=false, x, info, 100, PrefixMatch.None, false, 0))

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -15,12 +15,6 @@ when not defined(nimcore):
 import std/[strutils, os, parseopt, parseutils, sequtils, net, rdstdin]
 import experimental/sexp
 import std/options as std_options
-
-# Do NOT import suggest. It will lead to weird bugs with
-# suggestionResultHook, because suggest.nim is included by sigmatch.
-# So we import that one instead.
-
-
 import
   compiler/ast/[
     idents,


### PR DESCRIPTION
<!--- The Pull Request (=PR) message is what will get automatically used as
the commit message when the PR is merged. Make sure that no line is longer
than 72 characters -->

Removed obsolete comments related to nimsuggest from the `nimsuggest`
and `suggest` modules.