### PR TITLE
fix instantiation errors with generic `=deepCopy`

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -605,7 +605,6 @@ type
     rsemRawTypeMismatch
 
     rsemCannotConvertTypes
-    rsemUnresolvedGenericParameter
     rsemCannotCreateFlowVarOfType
     rsemTypeNotAllowed
 

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2009,9 +2009,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemOnOrOffExpected:
       result = "'on' or 'off' expected"
 
-    of rsemUnresolvedGenericParameter:
-      result = "unresolved generic parameter"
-
     of rsemRawTypeMismatch:
       result = "type mismatch"
 

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -31,6 +31,7 @@ import
     msgs
   ],
   compiler/utils/[
+    idioms
   ],
   compiler/sem/[
     semdata,
@@ -976,7 +977,9 @@ proc inst(g: ModuleGraph; c: PContext; t: PType; kind: TTypeAttachedOp; idgen: I
         patchBody(g, c, opInst.ast, info, a.idgen)
       setAttachedOp(g, idgen.module, t, kind, opInst)
     else:
-      localReport(g.config, info, reportSem(rsemUnresolvedGenericParameter))
+      # the type's associated ``tyGenericInst`` type was not set properly.
+      # This hints at an issue in the ``semtypinst`` module.
+      unreachable()
 
 proc createTypeBoundOps(g: ModuleGraph; c: PContext; orig: PType; info: TLineInfo;
                         idgen: IdGenerator) =

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -494,12 +494,6 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   rawAddSon(result, newbody)
   checkPartialConstructedType(cl.c.config, cl.info, newbody)
   if true:
-    let dc = cl.c.graph.getAttachedOp(newbody, attachedDeepCopy)
-    if dc != nil and sfFromGeneric notin dc.flags:
-      # 'deepCopy' needs to be instantiated for
-      # generics *when the type is constructed*:
-      cl.c.graph.setAttachedOp(cl.c.module.position, newbody, attachedDeepCopy,
-          cl.c.instTypeBoundOp(cl.c, dc, result, cl.info, attachedDeepCopy, 1))
     if newbody.typeInst == nil:
       # doAssert newbody.typeInst == nil
       newbody.typeInst = result
@@ -512,6 +506,14 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
           discard
         else:
           newbody.lastSon.typeInst = result
+
+    let dc = cl.c.graph.getAttachedOp(newbody, attachedDeepCopy)
+    if dc != nil and sfFromGeneric notin dc.flags:
+      # 'deepCopy' needs to be instantiated for generics *when the type is
+      # constructed* but *after* the type's `typeInst` field is set:
+      cl.c.graph.setAttachedOp(cl.c.module.position, newbody, attachedDeepCopy,
+          cl.c.instTypeBoundOp(cl.c, dc, result, cl.info, attachedDeepCopy, 1))
+
     # DESTROY: adding object|opt for opt[topttree.Tree]
     # sigmatch: Formal opt[=destroy.T] real opt[topttree.Tree]
     # adding myseq for myseq[system.int]

--- a/tests/system/tdeepcopy.nim
+++ b/tests/system/tdeepcopy.nim
@@ -95,10 +95,10 @@ main()
 echo "ok"
 
 block generic_deep_copy_using_instantiated_for_type:
-  # a generic ``=deepCopy`` implementation using the type instance it is
-  # instantiated for would lead to "unresolved generic parameter" errors,
-  # when the generic type also had other generic type-bound operators
-  # attached
+  # when a generic ``=deepCopy`` implementation used the type instance it
+  # is instatatied for in its body, an "unresolved generic parameter"
+  # error would occur, when the generic type also had other generic type-bound
+  # operators attached
   type Generic[T] = object
     x: T
 
@@ -108,12 +108,14 @@ block generic_deep_copy_using_instantiated_for_type:
     inc numDestroy
 
   proc `=deepCopy`[T](x: ref Generic[T]): ref Generic[T] =
-    var v = Generic[T]() # create something that requires the destroy
-                         # hook to be instantiated
+    var v = Generic[T]() # <- forces the generic `=destroy` operator to be
+                         #    instantiated
     result = x
+    # `v` is destroyed here, incrementing `numDestroy` by one
 
   let v = new(Generic[int]) # <- the deep-copy operator is instantiated here
-  # make sure the implementation works:
+
+  # make sure the operatore really works:
   let other = deepCopy(v)
   doAssert v == other
   doAssert numDestroy == 1

--- a/tests/system/tdeepcopy.nim
+++ b/tests/system/tdeepcopy.nim
@@ -115,7 +115,7 @@ block generic_deep_copy_using_instantiated_for_type:
 
   let v = new(Generic[int]) # <- the deep-copy operator is instantiated here
 
-  # make sure the operatore really works:
+  # make sure the operator really works:
   let other = deepCopy(v)
   doAssert v == other
   doAssert numDestroy == 1


### PR DESCRIPTION
## Summary

Fix "unresolved generic parameter" error occurring when instantiating
generic `=deepCopy` implementations that create locals of the
instantiated type the generic operator is instantiated for.

## Details

A generic `=deepCopy` operator attached to a generic type is
instantiated when an instance of the generic type is created. At the
end of instantiating body of the operator, the second semantic pass
(`sempass2`) lifts the type-bound operators for types used in the body.

If the type the generic `=deepCopy` operator is instantiated for is used
in the body, this means that the other type-bound operators are also
lifted already. However, if one of the other type-bound operators is
generic, this leads to `liftdestructors.inst` being called, which then
reports an `rsemUnresolvedGenericParameter` error, as `typeInst` is nil.

The reason for `typeInst` being 'nil' at this point is that
`handleGenericInvocation`, from where the generic `=deepCopy` is
instantiated, only assigns the `typeInst` field *after* the hook
is instantiated.

The `typeInst` field for an instantiation is now set *before*
instantiating the generic `=deepCopy` operator, fixing the issue. In
addition, `typeInst` not being set when trying to instantiate a generic
type-bound operator is changed to an internal error (`unreachable`)
and the `rsemUnresolvedGenericParameter` report is removed.