### PR TITLE
tool: nimsuggest remove `terse` flag

### DIFF
--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -39,7 +39,6 @@ type
     optEmbedOrigSrc           ## embed the original source in the generated
                               ## code also: generate header file
     optIdeDebug               ## idetools: debug mode
-    optIdeTerse               ## idetools: use terse descriptions
     optExcessiveStackTrace    ## fully qualified module filenames
     optShowAllMismatches      ## show all overloading resolution candidates
     optWholeProject           ## for 'doc': output any dependency

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -170,27 +170,26 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
       if u.fileIndex == info.fileIndex: inc c
     result.localUsages = c
   result.symkind = byte s.kind
-  if optIdeTerse notin g.config.globalOptions:
-    result.qualifiedPath = @[]
-    if not isLocal and s.kind != skModule:
-      let ow = s.owner
-      if ow != nil and ow.kind != skModule and ow.owner != nil:
-        let ow2 = ow.owner
-        result.qualifiedPath.add(ow2.origModuleName)
-      if ow != nil:
-        result.qualifiedPath.add(ow.origModuleName)
-    if s.name.s[0] in OpChars + {'[', '{', '('} or
-       s.name.id in ord(wAddr)..ord(wYield):
-      result.qualifiedPath.add('`' & s.name.s & '`')
-    else:
-      result.qualifiedPath.add(s.name.s)
+  result.qualifiedPath = @[]
+  if not isLocal and s.kind != skModule:
+    let ow = s.owner
+    if ow != nil and ow.kind != skModule and ow.owner != nil:
+      let ow2 = ow.owner
+      result.qualifiedPath.add(ow2.origModuleName)
+    if ow != nil:
+      result.qualifiedPath.add(ow.origModuleName)
+  if s.name.s[0] in OpChars + {'[', '{', '('} or
+      s.name.id in ord(wAddr)..ord(wYield):
+    result.qualifiedPath.add('`' & s.name.s & '`')
+  else:
+    result.qualifiedPath.add(s.name.s)
 
-    if s.typ != nil:
-      result.forth = typeToString(s.typ)
-    else:
-      result.forth = ""
-    when defined(nimsuggest) and not defined(noDocgen) and not defined(leanCompiler):
-      result.doc = extractDocComment(g, s)
+  if s.typ != nil:
+    result.forth = typeToString(s.typ)
+  else:
+    result.forth = ""
+  when defined(nimsuggest) and not defined(noDocgen) and not defined(leanCompiler):
+    result.doc = extractDocComment(g, s)
   let infox =
     if useSuppliedInfo or section in {ideUse, ideHighlight, ideOutline}:
       info

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -485,7 +485,6 @@ proc execCmd(cmd: string; graph: ModuleGraph; cachedMsgs: CachedMsgs) =
     sentinel()
     quit()
   of "debug": toggle optIdeDebug
-  of "terse": toggle optIdeTerse
   of "known": conf.ideCmd = ideKnown
   of "project": conf.ideCmd = ideProject
   else: err()


### PR DESCRIPTION
<!--- The Pull Request (=PR) message is what will get automatically used as
the commit message when the PR is merged. Make sure that no line is longer
than 72 characters -->

## Summary

Remove `terse` flag from `nimsuggest`. It's not used by any of the
existing extensions, nor is it tested.

## Details

The option itself is rather arbitrary in what it filters and the design
is confusing in terms of determining what should and shouldn't qualify.