### PR TITLE
internal: separate VM profiler data from `ConfigRef`

### DIFF
--- a/compiler/ast/lineinfos.nim
+++ b/compiler/ast/lineinfos.nim
@@ -26,12 +26,6 @@ type
     col*: int16
     fileIndex*: FileIndex
 
-  SourceLinePosition* = tuple
-    ## Identifies a line in a source file. Only intended for use by
-    ## the profiler.
-    fileIndex: typeof(TLineInfo.fileIndex)
-    line: typeof(TLineInfo.line)
-
   LineColPair* = tuple
     line: typeof(TLineInfo.line)
     col: typeof(TLineInfo.col)

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -56,7 +56,6 @@ import
   compiler/vm/[
     compilerbridge, # Configuration file evaluation, `nim e`
     vmbackend,      # VM code generation
-    vmprofiler
   ]
 
 import compiler/ic/[
@@ -686,7 +685,7 @@ proc mainCommand*(graph: ModuleGraph) =
                            srcCodeOrigin: instLoc()))
 
   if optProfileVM in conf.globalOptions:
-    conf.writeln cmdOutUserProf, conf.dump(conf.vmProfileData)
+    conf.writeln cmdOutUserProf, dumpVmProfilerData(graph)
 
   if conf.errorCounter == 0 and conf.cmd notin {cmdTcc, cmdDump, cmdNop}:
     if conf.isEnabled(rintSuccessX):

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -161,13 +161,6 @@ type
 
   Suggestions* = seq[Suggest]
 
-  ProfileInfo* = object
-    time*: float
-    count*: int
-
-  ProfileData* = ref object
-    data*: TableRef[SourceLinePosition, ProfileInfo]
-
   StdOrrKind* = enum
     stdOrrStdout
     stdOrrStderr
@@ -303,7 +296,6 @@ type
     writeHook*: proc(conf: ConfigRef, output: string, flags: MsgFlags) {.closure.}
     structuredReportHook*: ReportHook
     astDiagToLegacyReport*: proc(conf: ConfigRef, d: PAstDiag): Report
-    vmProfileData*: ProfileData
     setMsgFormat*: proc(config: ConfigRef, fmt: MsgFormatKind) {.closure.}
       ## callback that sets the message format for legacy reporting, needs to
       ## set before CLI handling, because reports are just that awful
@@ -772,9 +764,6 @@ template newPackageCache*(): untyped =
                  else:
                    modeCaseSensitive)
 
-proc newProfileData(): ProfileData =
-  ProfileData(data: newTable[SourceLinePosition, ProfileInfo]())
-
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 
 const defaultHackController = HackController(
@@ -933,7 +922,6 @@ proc newConfigRef*(hook: ReportHook): ConfigRef =
     ),
     suggestMaxResults: 10_000,
     maxLoopIterationsVM: 10_000_000,
-    vmProfileData: newProfileData(),
     spellSuggestMax: spellSuggestSecretSauce,
   )
   initConfigRefCommon(result)

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -46,6 +46,7 @@ import
     vmjit,
     vmlegacy,
     vmops,
+    vmprofiler,
     vmtypegen,
     vmutils,
     vm
@@ -654,6 +655,14 @@ proc evalMacroCall*(module: PSym; idgen: IdGenerator; g: ModuleGraph;
   c.vm.templInstCounter = templInstCounter
 
   result = evalMacroCall(c.jit, c.vm, call, args, sym)
+
+proc dumpVmProfilerData*(graph: ModuleGraph): string =
+  ## Dumps the profiler data collected by the profiler of the VM instance
+  ## associated with `graph` to a string.
+  let c = PEvalContext(graph.vm)
+  result =
+    if c != nil: dump(graph.config, c.vm.profiler)
+    else:        ""
 
 # ----------- the VM-related compilerapi -----------
 

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -734,9 +734,24 @@ type
                              ## instruction during cleanup. -1 indicates that
                              ## no clean-up is happening
 
+  ProfileInfo* = object
+    ## Profiler data for a single procedure.
+    time*: float ## the time spent on executing instructions (exclusive)
+    count*: int  ## the number of instruction executed (exclusive)
+
+  SourceLinePosition* = tuple
+    ## Identifies a line in a source file. Only intended for use by
+    ## the profiler.
+    fileIndex: typeof(TLineInfo.fileIndex)
+    line: typeof(TLineInfo.line)
+
   Profiler* = object
+    # XXX: move this type to the ``vmprofiler`` module once possible
     tEnter*: float
     sframe*: StackFrameIndex   ## The current stack frame
+
+    data*: TableRef[SourceLinePosition, ProfileInfo]
+    # XXX: use a ``Table`` instead of a ``TableRef``
 
 func `<`*(a, b: FieldIndex): bool {.borrow.}
 func `<=`*(a, b: FieldIndex): bool {.borrow.}
@@ -866,6 +881,7 @@ proc initCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
     loopIterations: g.config.maxLoopIterationsVM,
     comesFromHeuristic: unknownLineInfo,
     callbacks: @[],
+    profiler: Profiler(data: newTable[SourceLinePosition, ProfileInfo]()),
     cache: cache,
     config: g.config,
     graph: g,


### PR DESCRIPTION
## Summary

Store the data collected by the VM profiler with the profiler itself,
instead of storing it with the global configuration state (`ConfigRef`).

This allows for moving the profiler-related data types closer to the
`vmprofiler` module, and it also shrinks the surface of `ConfigRef` and
the `options` module.

## Details

* move all profiler-related data types to `vmdef`; they should ideally
  be placed in the `vmprofiler` module, but that would currently
  introduce cyclic dependencies
* `vmprofiler.dump` now accepts a `Profiler` instance; for rendering the
  data associated with a VM context, the new
  `compilerbridge.dumpVmProfilerData` procedure is now used