### PR TITLE
build `nimsuggest_testing` for local testing

### DIFF
--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -348,7 +348,8 @@ proc main() =
   if not nimsug.fileExists():
     # xxx: ideally compiling a test binary should be done in `koch`
     const args = "c -o:bin/nimsuggest_testing -d:release nimsuggest/nimsuggest"
-    discard execShellCmd(getCurrentCompilerExe() & " " & args)
+    let cmd = getCurrentCompilerExe() & " " & args
+    doAssert execShellCmd(getCurrentCompilerExe() & " " & args) == 0, cmd
 
   doAssert nimsug.fileExists, nimsug
   var failures = 0

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -26,7 +26,6 @@ import std/compilesettings
 proc parseTest(filename: string; epcMode=false): Test =
   const cursorMarker = "#[!]#"
   let nimsug = "bin" / addFileExt("nimsuggest_testing", ExeExt)
-  doAssert nimsug.fileExists, nimsug
   const libpath = querySetting(libPath)
   result.filename = filename
   result.dest = getTempDir() / extractFilename(filename)
@@ -345,6 +344,12 @@ proc runTest(filename: string): int =
   result = report.len
 
 proc main() =
+  let nimsug = "bin" / addFileExt("nimsuggest_testing", ExeExt)
+  if not nimsug.fileExists():
+    const args = "c -o:bin/nimsuggest_testing -d:release nimsuggest/nimsuggest"
+    discard execShellCmd(getCurrentCompilerExe() & " " & args)
+
+  doAssert nimsug.fileExists, nimsug
   var failures = 0
   if os.paramCount() > 0:
     let x = os.paramStr(1)

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -346,6 +346,7 @@ proc runTest(filename: string): int =
 proc main() =
   let nimsug = "bin" / addFileExt("nimsuggest_testing", ExeExt)
   if not nimsug.fileExists():
+    # xxx: ideally compiling a test binary should be done in `koch`
     const args = "c -o:bin/nimsuggest_testing -d:release nimsuggest/nimsuggest"
     discard execShellCmd(getCurrentCompilerExe() & " " & args)
 


### PR DESCRIPTION
<!--- The Pull Request (=PR) message is what will get automatically used as
the commit message when the PR is merged. Make sure that no line is longer
than 72 characters -->

## Summary

Make local nimsuggest testing easier by having the nimsuggest `tester`
build the `nimsuggest_testing` binary as part of the run.

## Details

Previous `nimsuggest_testing` is built in CI environment which meant it
is not available when running tests locally. Now if `tester` can't find
the `nimsuggest_testing` binary, it's built before running any tests.

To test locally, as per the module comments:
> When debugging, to run a single test, use for e.g.:
> `nim r nimsuggest/tester.nim nimsuggest/tests/tsug_accquote.nim`