### PR TITLE
nimsuggest: clean up `nimsuggest.nim.cfg`

### DIFF
--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -15,7 +15,5 @@ define:nimcore
   define:"nimMaxHeap=4000"
 @end
 
-#define:booting
-#define:noDocgen
 --path:"$config/.."
 --threads:on

--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -4,8 +4,6 @@ gc:orc
 
 hint[XDeclaredButNotUsed]:off
 
-path:"$lib/packages/docutils"
-
 define:useStdoutAsStdmsg
 define:nimsuggest
 define:nimcore


### PR DESCRIPTION
## Summary

Remove obsolete and disabled configuration options from the
`nimsuggest.nim.cfg` configuration file.

## Details

* remove adding `lib/packages/docutils` to the import paths; imports
  in the compiler and tools should not (and do not) rely on extra
  import paths besides the compiler root and library directory
* remove the outdated and disabled defines for the `booting` and
  `noDocgen` symbols

The `useStdoutAsStdmsg` define, while also obsolete, is kept for
consistency with the compiler and `nimfix`, both which also define
this conditional symbol.