### PR TITLE
refactoring suggest hooks, Config.writeHook default to msgs.msgWrite

### DIFF
--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -55,10 +55,6 @@ proc flushDot*(conf: ConfigRef) =
 
 const gCmdLineInfo* = newLineInfo(commandLineIdx, 1, 1)
 
-proc suggestWriteln*(conf: ConfigRef; s: string) =
-  if eStdOut in conf.m.errorOutputs:
-    writelnHook(conf, s)
-
 proc msgQuit*(x: int8) = quit x
 proc msgQuit*(x: string) = quit x
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -145,10 +145,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef, argv: openArray[string]):
 when not defined(selftest):
   var conf = newConfigRef(cli_reporter.reportHook)
   conf.astDiagToLegacyReport = cli_reporter.legacyReportBridge
-  conf.writeHook =
-    proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
-      msgs.msgWrite(conf, msg, flags)
-
+  conf.writeHook = msgs.msgWrite
   conf.writelnHook =
     proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
       conf.writeHook(conf, msg & "\n", flags)

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -245,8 +245,6 @@ proc `$`*(suggest: Suggest): string =
 proc suggestResult(conf: ConfigRef; s: Suggest) =
   if not isNil(conf.suggestionResultHook):
     conf.suggestionResultHook(s)
-  else:
-    conf.suggestWriteln($s)
 
 proc produceOutput(a: var Suggestions; conf: ConfigRef) =
   if conf.ideCmd in {ideSug, ideCon}:
@@ -258,9 +256,6 @@ proc produceOutput(a: var Suggestions; conf: ConfigRef) =
   if not isNil(conf.suggestionResultHook):
     for s in a:
       conf.suggestionResultHook(s)
-  else:
-    for s in a:
-      conf.suggestWriteln($s)
 
 proc filterSym(s: PSym; prefix: PNode; res: var PrefixMatch): bool {.inline.} =
   proc prefixMatch(s: PSym; n: PNode): PrefixMatch =

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -357,9 +357,7 @@ func vmEventToLegacyVmReport(
 proc main*(args: seq[string]): int =
   let config = newConfigRef(cli_reporter.reportHook)
   config.astDiagToLegacyReport = cli_reporter.legacyReportBridge
-  config.writeHook =
-    proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
-      msgs.msgWrite(conf, msg, flags)
+  config.writeHook = msgs.msgWrite
   config.writelnHook =
     proc(conf: ConfigRef, msg: string, flags: MsgFlags) =
       conf.writeHook(conf, msg & "\n", flags)


### PR DESCRIPTION
<!--- The Pull Request (=PR) message is what will get automatically used as
the commit message when the PR is merged. Make sure that no line is longer
than 72 characters -->

## Summary

Remove `msgs.suggestWriteln` and unnecessary callback wrapper for
`ConfigRef.writeHook` registration.

## Details 
* Remove procedure `suggestWriteln` and its call in `suggest`,
`suggestWriteln` wraps around `writelnHook`, `writelnHook` original 
purpose is write message to stdio or some like that, not for suggest result.
* `config.writeHook` assign to `msgs.msgWrite` directly in `nim.nim` and 
  `vmrunner.nim`, now not a wrapper procedure  around it.