### PR TITLE
move `msgs.log` to `nimsuggest`

### DIFF
--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -272,12 +272,6 @@ proc msgWrite*(conf: ConfigRef; s: string, flags: MsgFlags = {}) =
       when defined(windows):
         flushFile(stderr)
 
-proc log*(s: string) =
-  var f: File
-  if open(f, getHomeDir() / "nimsuggest.log", fmAppend):
-    f.writeLine(s)
-    close(f)
-
 proc quit(conf: ConfigRef; withTrace: bool) {.gcsafe.} =
   if conf.isDefined("nimDebug"):
     quitOrRaise(conf)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -114,7 +114,9 @@ proc writelnToChannel(line: string) =
 proc sugResultHook(s: Suggest) =
   results.send(s)
 
-proc log*(s: string) =
+proc log(s: string) =
+  ## Appends `s` as new line to the `nimsuggest.log` file in the user's home
+  ## directory. 
   var f: File
   if open(f, getHomeDir() / "nimsuggest.log", fmAppend):
     f.writeLine(s)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -114,6 +114,12 @@ proc writelnToChannel(line: string) =
 proc sugResultHook(s: Suggest) =
   results.send(s)
 
+proc log*(s: string) =
+  var f: File
+  if open(f, getHomeDir() / "nimsuggest.log", fmAppend):
+    f.writeLine(s)
+    close(f)
+
 proc myLog(conf: ConfigRef, s: string, flags: MsgFlags = {}) =
   if gLogging:
     log(s)


### PR DESCRIPTION
Move the `log` procedure, which is only intended for use by the
`nimsuggest` tool, from the `msgs` module to `nimsuggest`.