### PR TITLE
vmprofiler: use `Table` instead of `TableRef`

### DIFF
--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -750,8 +750,7 @@ type
     tEnter*: float
     sframe*: StackFrameIndex   ## The current stack frame
 
-    data*: TableRef[SourceLinePosition, ProfileInfo]
-    # XXX: use a ``Table`` instead of a ``TableRef``
+    data*: Table[SourceLinePosition, ProfileInfo]
 
 func `<`*(a, b: FieldIndex): bool {.borrow.}
 func `<=`*(a, b: FieldIndex): bool {.borrow.}
@@ -881,7 +880,6 @@ proc initCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
     loopIterations: g.config.maxLoopIterationsVM,
     comesFromHeuristic: unknownLineInfo,
     callbacks: @[],
-    profiler: Profiler(data: newTable[SourceLinePosition, ProfileInfo]()),
     cache: cache,
     config: g.config,
     graph: g,


### PR DESCRIPTION
## Summary

Store the collected profiler data in a `Table` instead of a `TableRef`,
and also change rendering the data to not mutate the `Profiler`
instance anymore. The extra indirection is unnecessary and required
the table to be initialized explicitly.

## Details

* change `data` to use a `Table` instead of a `TableRef`
* remove the profiler setup code from `initCtx`
* rewrite `vmprofiler.dump` to not modify the table anymore (which was
  a hidden mutation). The entries are now first added to a sorted
  temporary list, which is then rendered-to-text afterwards