### PR TITLE
sem: propagate errors through `semWhile`

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3830,7 +3830,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkConstSection: result = semConstLetOrVar(c, n, skConst)
   of nkTypeSection: result = semTypeSection(c, n)
   of nkDiscardStmt: result = semDiscard(c, n)
-  of nkWhileStmt: result = semWhile(c, n, flags)
+  of nkWhileStmt: result = c.config.extract(semWhile(c, n, flags))
   of nkTryStmt, nkHiddenTryStmt: result = semTry(c, n, flags)
   of nkBreakStmt: result = c.config.extract(semBreakStmt(c, n))
   of nkContinueStmt: result = semContinueStmt(c, n)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -74,19 +74,19 @@ proc semAsm(c: PContext, n: PNode): PNode =
     result[0] = err
     result = c.config.wrapError(result)
 
-proc semWhile(c: PContext, n: PNode; flags: TExprFlags): PNode =
-  result = n
+proc semWhile(c: PContext, n: PNode; flags: TExprFlags): ElaborateAst =
+  result.initWith(n)
   checkSonsLen(n, 2, c.config)
   openScope(c)
-  n[0] = forceBool(c, semExprWithType(c, n[0]))
+  result[0] = forceBool(c, semExprWithType(c, n[0]))
   inc(c.p.nestedLoopCounter)
-  n[1] = semStmt(c, n[1], flags)
+  result[1] = semStmt(c, n[1], flags)
   dec(c.p.nestedLoopCounter)
   closeScope(c)
-  if n[1].typ == c.enforceVoidContext:
+  if result[1].typ == c.enforceVoidContext:
     result.typ = c.enforceVoidContext
   elif efInTypeof in flags:
-    result.typ = n[1].typ
+    result.typ = result[1].typ
 
 proc semProc(c: PContext, n: PNode): PNode
 


### PR DESCRIPTION
## Summary

Enable `nkError` propagation for `semWhile` and also change the
procedure to not modify the input AST.

## Details

For automatic error propagation, `semWhile` now returns an
`ElaborateAst` instead of a raw `PNode`.