### PR TITLE
internal: reorder `ParsedNodeKind` for range checks

### DIFF
--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -173,8 +173,8 @@ type
     pnkIncludeStmt
     pnkExportStmt
     pnkExportExceptStmt
-    pnkConstSection
     pnkTypeSection
+    pnkConstSection
     pnkLetSection
     pnkVarSection
     pnkProcDef

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -117,7 +117,6 @@ type
     pnkPostfix
     pnkExprEqExpr
     pnkExprColonExpr
-    pnkIdentDefs
     pnkVarTuple
     pnkPar
     pnkSqrBracket
@@ -186,6 +185,7 @@ type
     pnkTemplateDef
     pnkConstDef
     pnkTypeDef
+    pnkIdentDefs
     pnkEnumTy
     pnkEnumFieldDef
     pnkObjectTy

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -117,7 +117,6 @@ type
     pnkPostfix
     pnkExprEqExpr
     pnkExprColonExpr
-    pnkVarTuple
     pnkPar
     pnkSqrBracket
     pnkCurly
@@ -183,9 +182,10 @@ type
     pnkIteratorDef
     pnkMacroDef
     pnkTemplateDef
+    pnkIdentDefs
     pnkConstDef
     pnkTypeDef
-    pnkIdentDefs
+    pnkVarTuple
     pnkEnumTy
     pnkEnumFieldDef
     pnkObjectTy

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -118,7 +118,6 @@ type
     pnkExprEqExpr
     pnkExprColonExpr
     pnkIdentDefs
-    pnkConstDef
     pnkVarTuple
     pnkPar
     pnkSqrBracket
@@ -175,6 +174,7 @@ type
     pnkExportStmt
     pnkExportExceptStmt
     pnkConstSection
+    pnkTypeSection
     pnkLetSection
     pnkVarSection
     pnkProcDef
@@ -184,7 +184,7 @@ type
     pnkIteratorDef
     pnkMacroDef
     pnkTemplateDef
-    pnkTypeSection
+    pnkConstDef
     pnkTypeDef
     pnkEnumTy
     pnkEnumFieldDef
@@ -265,6 +265,8 @@ const
   pnkFloatKinds* = {pnkFloatLit..pnkFloat128Lit}
   pnkIntKinds* = {pnkCharLit..pnkUInt64Lit}
   pnkStrKinds* = {pnkStrLit..pnkTripleStrLit}
+  pnkDeclarativeDefs* = {pnkProcDef, pnkFuncDef, pnkMethodDef, pnkIteratorDef, pnkConverterDef}
+  pnkRoutineDefs* = pnkDeclarativeDefs + {pnkMacroDef, pnkTemplateDef}
 
 func len*(node: ParsedNode): int =
   ## Number of sons of the parsed node


### PR DESCRIPTION
## Summary

Reorder `ParsedNodeKind` for range checks, and added named sets to
support querying parsed node kinds.

## Details

Reorder `ParsedNodeKind` in order to support ranges over similar kinds.
This is considered experimental as the motivation for the reodering came
from usage in `suggest` (a consumer). The ordering should be determined
by the `parser` (the producer). Creating these seemingly convenient
consumer/read side ranges end up quietly coupling the producer and
consumer(s). Which results in refactorings to a small collection of
parser modules spilling out to changes in various consumer locations. In
this case these might coincide with the parser's needs, as well.

Additionally, added `pnkDeclarativeDefs` and `pnkRoutineDefs` similar to
`PNode`'s kind, `TNodeKind`.