### PR TITLE
suggest: `symToSuggest` limit data per `IdeCmd`

### DIFF
--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -203,10 +203,10 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
   result.filePath = toFullPath(g.config, infox)
   result.line = toLinenumber(infox)
   result.column = toColumn(infox)
-  if section in {ideHighlight}:
-    result.tokenLen = getTokenLenFromSource(g.config, s.name.s, infox)
-  else:
-    result.tokenLen = s.name.s.len
+  result.tokenLen = if section != ideHighlight:
+                      s.name.s.len
+                    else:
+                      getTokenLenFromSource(g.config, s.name.s, infox)
 
 proc `$`*(suggest: Suggest): string =
   result = $suggest.section

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -193,7 +193,7 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
   else:
     result.forth = ""
   when defined(nimsuggest) and not defined(noDocgen) and not defined(leanCompiler):
-    if section in {ideSug, ideCon, ideDef, ideChk}:
+    if section != ideHighlight:
       result.doc = extractDocComment(g, s)
   let infox =
     if useSuppliedInfo or section in {ideUse, ideHighlight, ideOutline}:


### PR DESCRIPTION
## Summary

`suggest.symToSuggest` now restrict data fetched based on the `IdeCmd`
given. Meaning some `Suggest` fields are only filled in/used given
specific `IdeCmd`(s), avoiding unnecessary processing.

## Details

* Fill `contextFits`,`globalUsages`,`localUsages` fields when `IdeCmd` in 
`{ideSug, ideCon}`. they're used in `cmpSuggestions` -> `produceOutput`.
* Fill `doc` field when `IdeCmd` is not `ideHighlight`. `ideHighlight`
  results don't render the documentation comment, see `$(Suggest)`