### PR TITLE
vm: Remove `mStaticExec` and `opcGorge`

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -617,7 +617,7 @@ proc isSinkType*(t: PType): bool {.inline.} =
   t.kind == tySink
 
 const magicsThatCanRaise* = {
-  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho,
+  mNone, mSlurp, mParseExprToAst, mParseStmtToAst, mEcho,
   mChckRange }
 
 proc canRaiseConservative*(fn: PNode): bool =

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -743,7 +743,6 @@ type
     mLow, mHigh, mSizeOf, mAlignOf, mOffsetOf, mTypeTrait,
     mIs, mOf, mAddr, mType, mTypeOf,
     mPlugin, mEcho, mShallowCopy, mSlurp,
-    mStaticExec ## deprecated, remove me
     mStatic,
     mParseExprToAst, mParseStmtToAst, mExpandToAst, mQuoteAst,
     mInc, mDec, mOrd,

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1999,7 +1999,7 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
   of mDefault: genDefault(p, n, r)
   of mWasMoved: genReset(p, n)
   of mEcho: genEcho(p, n, r)
-  of mNLen..mNError, mSlurp, mStaticExec:
+  of mNLen..mNError, mSlurp:
     localReport(p.config, n.info, reportSym(
       rsemConstExpressionExpected, n[0].sym))
 

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2630,8 +2630,6 @@ proc rawExecute(c: var TCtx, pc: var int): YieldReason =
       checkHandle(regs[rb])
       regs[ra].strVal = opSlurp($regs[rb].strVal, c.debug[pc],
                                      c.module, c.config)
-    of opcGorge:
-      unreachable("no longer an opcode/magic")
 
     of opcParseExprToAst, opcParseStmtToAst:
       decodeBC(rkNimNode)

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -118,7 +118,6 @@ type
     opcNctPut, opcNctLen, opcNctGet, opcNctHasNext, opcNctNext, opcNodeId,
 
     opcSlurp,
-    opcGorge,                 ## deprecated to be removed
     opcParseExprToAst,
     opcParseStmtToAst,
     opcNGetLineInfo, opcNSetLineInfo,

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1939,7 +1939,6 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
     c.gABC(n, opcTypeTrait, dest, tmp)
     c.freeTemp(tmp)
   of mSlurp: genUnaryABC(c, n, dest, opcSlurp)
-  of mStaticExec: unreachable("no longer a magic")
   of mNLen: genUnaryABI(c, n, dest, opcLenSeq, nimNodeFlag)
   of mGetImpl: genUnaryABC(c, n, dest, opcGetImpl)
   of mGetImplTransf: genUnaryABC(c, n, dest, opcGetImplTransf)


### PR DESCRIPTION
## Summary
* Remove `mStaticExec` and `opcGorge` as only the csources compiler
  needs to have them in order to bootstrap 

## Details
* Follow up to 'vm: convert gorge and staticExec to vmops #878'