### PR TITLE
ci: Remove comments from PR description before merging

### DIFF
--- a/.github/workflows/slash-command-merge.yml
+++ b/.github/workflows/slash-command-merge.yml
@@ -52,7 +52,7 @@ jobs:
             }
 
             let [ body, body_tail ] = pr_info.body.split(/^---\s*$/m, 2);
-            body = body.replace(/<\!--.*?-->/sg, "");
+            body = body.replace(/<\!--.*?-->/s, "");
             body = body.trimEnd();
             body_tail = body_tail?.trimEnd() || '';
             // Only runs when the PR is still open and is not staged for merging.

--- a/.github/workflows/slash-command-merge.yml
+++ b/.github/workflows/slash-command-merge.yml
@@ -52,6 +52,7 @@ jobs:
             }
 
             let [ body, body_tail ] = pr_info.body.split(/^---\s*$/m, 2);
+            body = body.replace(/<\!--.*?-->/sg, "");
             body = body.trimEnd();
             body_tail = body_tail?.trimEnd() || '';
             // Only runs when the PR is still open and is not staged for merging.


### PR DESCRIPTION
Remove HTML comments from the PR description before merging, as otherwise
they can end up in the final commit message.