### PR TITLE
codegen: don't use `PSym` for locals

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -229,7 +229,7 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
 
     let body = generateIR(g.graph, bmod.idgen, evt.sym, evt.body)
     # emit into the procedure:
-    genStmts(p, merge(p.body, body))
+    genPartial(p, merge(p.body, body))
 
     processLate(bmod, discovery, inl, evt.module, inlineId)
   of bekProcedure:

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -109,11 +109,12 @@ func hash(x: PSym): int = hash(x.id)
 
 proc writeMangledLocals(p: BProc) =
   ## Writes the mangled names of `p`'s locals to the module's NDI file.
-  for it in p.locals.items:
-    # writing out mangled names for compiler-inserted variables (temporaries)
-    # is not necessary (lode is guaranteed to be a symbol)
-    if it.lode.sym.kind != skTemp:
-      writeMangledName(p.module.ndi, it.lode.sym, it.r, p.config)
+  for i, it in p.locals.pairs:
+    # only write a mapping for locals that have both a user-provided
+    # and mangled name (compile-time-only parameters don't have one)
+    if p.body[i].name != nil and it.r.len > 0:
+      writeMangledName(p.module.ndi, it.lode.info, p.body[i].name, it.r,
+                       p.config)
 
 func registerInline(g: var InliningData, prc: PSym): uint32 =
   ## If not already registered, registers the inline procedure `prc` with
@@ -416,10 +417,6 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
         s = it.sym
         m = g.modules[moduleId(s)]
       writeMangledName(m.ndi, s, it.name, g.config)
-      # parameters:
-      for p in it.params.items:
-        if p.k != locNone: # not all parameters have locs
-          writeMangledName(m.ndi, s, p.r, g.config)
 
     template write(loc: TLoc) =
       let s = loc.lode.sym

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -37,12 +37,10 @@ proc reportObservableStore(p: BProc; le, ri: CgNode) =
         # this must be a global -> the mutation escapes
         return true
       of cnkLocal:
-        if inTryStmt and sfUsedInFinallyOrExcept in p.body[n.local].flags:
-          # it is also an observable store if the location is used
-          # in 'except' or 'finally'
-          return true
-        # we don't own the location so it escapes
-        return false
+        # if the local is used within an 'except' or 'finally', a mutation of
+        # it through a procedure that eventually raises is also an observable
+        # store
+        return inTryStmt and sfUsedInFinallyOrExcept in p.body[n.local].flags
       of cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess:
         n = n[0]
       of cnkObjUpConv, cnkObjDownConv, cnkHiddenConv, cnkConv:

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -34,13 +34,14 @@ proc reportObservableStore(p: BProc; le, ri: CgNode) =
       # do NOT follow ``cnkDerefView`` here!
       case n.kind
       of cnkSym:
-        # we don't own the location so it escapes:
-        if n.sym.owner != p.prc:
-          return true
-        elif inTryStmt and sfUsedInFinallyOrExcept in n.sym.flags:
+        # this must be a global -> the mutation escapes
+        return true
+      of cnkLocal:
+        if inTryStmt and sfUsedInFinallyOrExcept in p.body[n.local].flags:
           # it is also an observable store if the location is used
           # in 'except' or 'finally'
           return true
+        # we don't own the location so it escapes
         return false
       of cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess:
         n = n[0]
@@ -134,11 +135,11 @@ proc fixupCall(p: BProc, le, ri: CgNode, d: var TLoc,
 
 proc genBoundsCheck(p: BProc; arr, a, b: TLoc)
 
-proc reifiedOpenArray(n: CgNode): bool {.inline.} =
+proc reifiedOpenArray(p: BProc, n: CgNode): bool {.inline.} =
   var x = n
   while x.kind in {cnkAddr, cnkHiddenAddr, cnkHiddenConv, cnkDerefView}:
     x = x.operand
-  if x.kind == cnkSym and x.sym.kind == skParam:
+  if x.kind == cnkLocal and p.locals[x.local].k == locParam:
     result = false
   else:
     result = true
@@ -165,7 +166,7 @@ proc genOpenArraySlice(p: BProc; q: CgNode; formalType, destType: PType): (Rope,
         [rdLoc(a), rdLoc(b), intLiteral(first), dest],
         lengthExpr)
   of tyOpenArray, tyVarargs:
-    if reifiedOpenArray(q[1]):
+    if reifiedOpenArray(p, q[1]):
       result = ("($3*)($1.Field0)+($2)" % [rdLoc(a), rdLoc(b), dest],
                 lengthExpr)
     else:
@@ -208,7 +209,7 @@ proc openArrayLoc(p: BProc, formalType: PType, n: CgNode): Rope =
     initLocExpr(p, if n.kind == cnkHiddenConv: n.operand else: n, a)
     case skipTypes(a.t, abstractVar+{tyStatic}).kind
     of tyOpenArray, tyVarargs:
-      if reifiedOpenArray(n):
+      if reifiedOpenArray(p, n):
         result = "$1.Field0, $1.Field1" % [rdLoc(a)]
       else:
         result = "$1, $1Len_0" % [rdLoc(a)]
@@ -368,9 +369,9 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
     genCallPattern()
     exitCall(p, ri[0], canRaise)
 
-proc notYetAlive(n: CgNode): bool {.inline.} =
+proc notYetAlive(p: BProc, n: CgNode): bool {.inline.} =
   let r = getRoot(n)
-  result = r != nil and r.locId == 0
+  result = r != nil and r.kind == cnkLocal and p.locals[r.local].k == locNone
 
 proc isInactiveDestructorCall(p: BProc, e: CgNode): bool =
   #[ Consider this example.
@@ -390,7 +391,7 @@ proc isInactiveDestructorCall(p: BProc, e: CgNode): bool =
   the 'let args = ...' statement. We exploit this to generate better
   code for 'return'. ]#
   result = e.len == 2 and e[0].kind == cnkSym and
-    e[0].sym.name.s == "=destroy" and notYetAlive(e[1].operand)
+    e[0].sym.name.s == "=destroy" and notYetAlive(p, e[1].operand)
 
 proc genAsgnCall(p: BProc, le, ri: CgNode, d: var TLoc) =
   if p.withinBlockLeaveActions > 0 and isInactiveDestructorCall(p, ri):

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -53,27 +53,26 @@ proc mangleParamName(c: ConfigRef; s: PSym): Rope =
 
     result = res.rope
 
-proc mangleLocalName(p: BProc; s: PSym): Rope =
-  assert s.kind in skLocalVars+{skTemp}
-  #assert sfGlobal notin s.flags
-  if true:
-    var key: string
-    shallowCopy(key, s.name.s.mangle)
+proc mangleLocalName(p: BProc; name: PIdent, id: LocalId): Rope =
+  if name.isNil:
+    # use the ID prefixed by an underscore, which is guaranteed to be a unique
+    # name within the procedure
+    result = "_" & $id.int
+  else:
+    # mangle the user-defiend name, also accounting for shadowed names
+    var key = name.s.mangle
     let counter = p.sigConflicts.getOrDefault(key)
-    result = key.rope
-    if s.kind == skTemp:
-      # speed up conflict search for temps (these are quite common):
-      if counter != 0: result.add "_" & rope(counter+1)
-    elif counter != 0 or isKeyword(s.name) or p.module.g.config.cppDefines.contains(key):
+    result = key
+    if counter != 0 or isKeyword(name) or p.module.g.config.cppDefines.contains(key):
       result.add "_" & rope(counter+1)
     p.sigConflicts.inc(key)
 
-proc scopeMangledParam(p: BProc; param: PSym) =
+proc scopeMangledParam(p: BProc; name: PIdent) =
   ## parameter generation doesn't have access to a ``BProc``, so we have to
   ## remember these parameter names are already in scope to be able to
   ## generate unique identifiers reliably (consider that ``var a = a`` is
   ## even an idiom in Nim).
-  var key = param.name.s.mangle
+  var key = name.s.mangle
   p.sigConflicts.inc(key)
 
 const
@@ -205,7 +204,7 @@ proc addAbiCheck(m: BModule, t: PType, name: Rope) =
 
 proc initResultParamLoc(conf: ConfigRef; param: CgNode): TLoc =
   result = initLoc(locParam, param, "Result", OnStack)
-  let t = param.sym.typ
+  let t = param.typ
   if mapReturnType(conf, t) != ctArray and isInvalidReturnType(conf, t):
     incl(result.flags, lfIndirect)
     result.storage = OnUnknown
@@ -369,7 +368,7 @@ proc prepareParameters(m: BModule, t: PType): seq[TLoc] =
       else:
         OnStack
 
-    result[i] = initLoc(locParam, toSymNode(params[i]),
+    result[i] = initLoc(locParam, newLocalRef(LocalId(i), param.info, param.typ),
                         mangleParamName(m.config, param), storage)
 
     if ccgIntroducedPtr(m.config, param, t[0]):

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -945,6 +945,13 @@ proc genProc*(m: BModule, prc: PSym, procBody: sink Body): Rope =
   genStmts(p, p.body.code)
   result = finishProc(p, prc)
 
+proc genPartial*(p: BProc, n: CgNode) =
+  ## Generates the C code for `n` and appends the result to `p`. This
+  ## is intended for CG IR that wasn't already available when calling
+  ## `startProc`.
+  synchronize(p.locals, p.body.locals)
+  genStmts(p, n)
+
 proc genProcPrototype(m: BModule, sym: PSym) =
   useHeader(m, sym)
   if exfNoDecl in sym.extFlags: return

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -42,6 +42,7 @@ import
     msgs
   ],
   compiler/utils/[
+    containers,
     platform,
     nversion,
     bitsets,
@@ -333,10 +334,34 @@ include ccgtypes
 
 # ------------------------------ Manager of temporaries ------------------
 
-template mapTypeChooser(n: CgNode): TSymKind =
-  (if n.kind == cnkSym: n.sym.kind else: skVar)
+func mapTypeChooser(p: BProc, n: CgNode): TSymKind =
+  case n.kind
+  of cnkSym:
+    n.sym.kind
+  of cnkLocal:
+    if n.local == resultId:
+      skResult
+    elif p.locals[n.local].k == locParam:
+      skParam
+    else:
+      skVar
+  else:
+    skVar
 
-template mapTypeChooser(a: TLoc): TSymKind = mapTypeChooser(a.lode)
+func mapTypeChooser(a: TLoc): TSymKind =
+  let n = a.lode
+  case n.kind
+  of cnkSym:
+    n.sym.kind
+  of cnkLocal:
+    if n.local == resultId:
+      skResult
+    elif a.k == locParam:
+      skParam
+    else:
+      skVar
+  else:
+    skVar
 
 proc addrLoc(conf: ConfigRef; a: TLoc): Rope =
   result = a.r
@@ -437,8 +462,8 @@ proc resetLoc(p: BProc, loc: var TLoc; doInitObj = true) =
   # it
   constructLoc(p, loc, doInitObj)
 
-proc initLocalVar(p: BProc, v: PSym, immediateAsgn: bool) =
-  if sfNoInit notin v.flags:
+proc initLocalVar(p: BProc, v: LocalId, immediateAsgn: bool) =
+  if sfNoInit notin p.body[v].flags:
     # we know it is a local variable and thus on the stack!
     # If ``not immediateAsgn`` it is not initialized in a binding like
     # ``var v = X`` and thus we need to init it.
@@ -475,36 +500,26 @@ proc getIntTemp(p: BProc, result: var TLoc) =
   result.lode = lodeTyp getSysType(p.module.g.graph, unknownLineInfo, tyInt)
   result.flags = {}
 
-proc localVarDecl(p: BProc; n: CgNode): Rope =
-  let s = n.sym
-  let loc = initLoc(locLocalVar, n, mangleLocalName(p, s), OnStack)
-  if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
-    result.addf("NIM_ALIGN($1) ", [rope(s.alignment)])
-  result.add getTypeDesc(p.module, s.typ, skVar)
+proc localVarDecl(p: BProc; n: CgNode, decl: Local): Rope =
+  let loc = initLoc(locLocalVar, n, mangleLocalName(p, decl.name, n.local),
+                    OnStack)
+
+  if decl.alignment > 0:
+    result.addf("NIM_ALIGN($1) ", [$decl.alignment])
+
+  result.add getTypeDesc(p.module, decl.typ, skVar)
   if true:
-    if sfRegister in s.flags: result.add(" register")
-    #elif skipTypes(s.typ, abstractInst).kind in GcTypeKinds:
-    #  decl.add(" GC_GUARD")
-    if sfVolatile in s.flags: result.add(" volatile")
-    if sfNoalias in s.flags: result.add(" NIM_NOALIAS")
+    if sfRegister in decl.flags: result.add(" register")
+    if sfVolatile in decl.flags: result.add(" volatile")
+    if sfNoalias  in decl.flags: result.add(" NIM_NOALIAS")
     result.add(" ")
     result.add(loc.r)
 
-  # XXX: inline procedure are generated multiple times, so the symbol can
-  #      already have a non-zero ``locId``
-  if s notin p.locals:
-    p.locals.forcePut(s, loc)
-  else:
-    # XXX: finally blocks are duplicated by the code generator, so we have to
-    #      be lenient here and allow the local already existing. This is a bad
-    #      idea, however; if finally clauses are implemented via code
-    #      duplication, then that duplication needs to happen prior to code
-    #      generation
-    p.locals.assign(s, loc)
+  p.locals[n.local] = loc
 
 proc assignLocalVar(p: BProc, n: CgNode) =
   let nl = if optLineDir in p.config.options: "" else: "\L"
-  let decl = localVarDecl(p, n) & ";" & nl
+  let decl = localVarDecl(p, n, p.body[n.local]) & ";" & nl
   line(p, cpsLocals, decl)
 
 include ccgthreadvars
@@ -680,20 +695,21 @@ proc closureSetup(p: BProc, prc: PSym) =
   # prc.ast[paramsPos].last contains the type we're after:
   var ls = lastSon(prc.ast[paramsPos])
   p.config.internalAssert(ls.kind == nkSym, prc.info, "closure generation failed")
-  var env = ls.sym
-  #echo "created environment: ", env.id, " for ", prc.name.s
-  assignLocalVar(p, toSymNode(ls))
+  var env = ls.sym.position + 1 # parameters start at ID 1
+
+  let n = newLocalRef(LocalId(env), ls.info, ls.typ)
+  assignLocalVar(p, n)
   # generate cast assignment:
   linefmt(p, cpsStmts, "$1 = ($2) ClE_0;$n",
-          [rdLoc(p.locals[env]), getTypeDesc(p.module, env.typ)])
+          [rdLoc(p.locals[n.local]), getTypeDesc(p.module, ls.typ)])
 
 func containsResult(n: CgNode): bool =
   result = false
   case n.kind
-  of cnkAtoms - {cnkSym}:
+  of cnkAtoms - {cnkLocal}:
     discard "ignore"
-  of cnkSym:
-    if n.sym.kind == skResult:
+  of cnkLocal:
+    if n.local == resultId:
       result = true
   of cnkWithOperand:
     result = containsResult(n.operand)
@@ -734,7 +750,7 @@ proc allPathsAsgnResult(n: CgNode): InitResultEnum =
       result = allPathsAsgnResult(it)
       if result != Unknown: return result
   of cnkAsgn, cnkFastAsgn:
-    if n[0].kind == cnkSym and n[0].sym.kind == skResult:
+    if n[0].kind == cnkLocal and n[0].local == resultId:
       if not containsResult(n[1]): result = InitSkippable
       else: result = InitRequired
     elif containsResult(n):
@@ -770,11 +786,11 @@ proc allPathsAsgnResult(n: CgNode): InitResultEnum =
     result = allPathsAsgnResult(n[0])
     # a 'repeat' loop is always executed at least once
     if result == InitSkippable: result = Unknown
-  of cnkAtoms - {cnkSym, cnkReturnStmt}:
+  of cnkAtoms - {cnkLocal, cnkReturnStmt}:
     result = Unknown
-  of cnkSym:
+  of cnkLocal:
     # some path reads from 'result' before it was written to!
-    if n.sym.kind == skResult: result = InitRequired
+    if n.local == resultId: result = InitRequired
   of cnkTryStmt:
     # We need to watch out for the following problem:
     # try:
@@ -810,19 +826,21 @@ proc startProc*(m: BModule, prc: PSym; procBody: sink Body): BProc =
     # if a prototype was emitted, the parameter list already exists
     m.procs[prc].params = prepareParameters(m, prc.typ)
 
+  synchronize(p.locals, p.body.locals)
+
   if sfPure notin prc.flags and prc.typ[0] != nil:
     m.config.internalAssert(resultPos < prc.ast.len, prc.info, "proc has no result symbol")
     let
-      res = prc.ast[resultPos].sym # get result symbol
-      resNode = newSymNode(res)
+      res = resultId
+      resNode = newLocalRef(res, prc.info, prc.typ[0])
     if not isInvalidReturnType(m.config, prc.typ[0]):
-      if sfNoInit in prc.flags: incl(res.flags, sfNoInit)
       # declare the result symbol:
       assignLocalVar(p, resNode)
-      initLocalVar(p, res, immediateAsgn=false)
+      if sfNoInit notin prc.flags:
+        initLocalVar(p, res, immediateAsgn=false)
     else:
-      p.params[0] = initResultParamLoc(p.config, resNode)
-      scopeMangledParam(p, res)
+      p.locals[res] = initResultParamLoc(p.config, resNode)
+      scopeMangledParam(p, p.body[res].name)
       # We simplify 'unsureAsgn(result, nil); unsureAsgn(result, x)'
       # to 'unsureAsgn(result, x)'
       # Sketch why this is correct: If 'result' points to a stack location
@@ -833,10 +851,14 @@ proc startProc*(m: BModule, prc: PSym; procBody: sink Body): BProc =
       elif p.body.code != nil and
            allPathsAsgnResult(p.body.code) == InitSkippable: discard
       else:
-        resetLoc(p, p.params[0])
-      if skipTypes(res.typ, abstractInst).kind == tyArray:
+        resetLoc(p, p.locals[res])
+      if skipTypes(resNode.typ, abstractInst).kind == tyArray:
         #incl(res.locFlags, lfIndirect)
-        p.params[0].storage = OnUnknown
+        p.locals[res].storage = OnUnknown
+
+  # setup the locs for the parameters:
+  for i in 1..<m.procs[prc].params.len:
+    p.locals[LocalId(i)] = m.procs[prc].params[i]
 
   # for now, we treat all compilerprocs as being able to run in a boot
   # environment where the error flag is not yet accessible. This is not quite
@@ -853,7 +875,7 @@ proc startProc*(m: BModule, prc: PSym; procBody: sink Body): BProc =
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym
     if p.params[i].k == locNone: continue
-    scopeMangledParam(p, param)
+    scopeMangledParam(p, param.name)
   closureSetup(p, prc)
 
   if sfPure notin prc.flags and optStackTrace in prc.options:
@@ -877,7 +899,7 @@ proc finishProc*(p: BProc, prc: PSym): string =
 
   if sfPure notin prc.flags and not isInvalidReturnType(p.config, prc.typ[0]):
     returnStmt = ropecg(p.module, "\treturn $1;$n",
-                        [rdLoc(p.locals[prc.ast[resultPos].sym])])
+                        [rdLoc(p.locals[resultId])])
 
   var generatedProc: Rope
   generatedProc.genCLineDir prc.info, p.config

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -178,7 +178,8 @@ type
     sigConflicts*: CountTable[string]
 
     body*: Body               ## the procedure's full body
-    locals*: SymbolMap[TLoc]  ## the locs for all locals of the procedure
+    locals*: OrdinalSeq[LocalId, TLoc]
+      ## the locs for all locals of the procedure
 
   TTypeSeq* = seq[PType]
   TypeCache* = Table[SigHash, Rope]
@@ -371,7 +372,8 @@ proc hash(n: ConstrTree): Hash =
     of cnkWithItems:
       for it in n.items:
         result = result !& hashTree(it)
-    of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic, cnkWithOperand:
+    of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic,
+       cnkWithOperand, cnkLocal:
       unreachable()
     result = !$result
 
@@ -401,7 +403,7 @@ proc `==`(a, b: ConstrTree): bool =
             if not treesEquivalent(a[i], b[i]): return
           result = true
       of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic,
-         cnkWithOperand:
+         cnkWithOperand, cnkLocal:
         # nodes that cannot appear in construction trees
         unreachable()
 

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -835,8 +835,8 @@ proc tbDef(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
   of mnkGlobal:
     # XXX: defs for globals reaching here implies that the MIR code wasn't
     #      sufficiently lowered. This should be a hard error, but the
-    #      ``--expandArc`` feature currently on this being possible, so we
-    #      allow it for now
+    #      ``--expandArc`` feature currently relies on this being possible, so
+    #      we allow it for now
     def = newEmpty()
   of mnkTemp:
     # MIR temporaries are like normal locals, with the difference that they

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -164,8 +164,9 @@ proc render(c: var RenderCtx, body: Body, ind: int, n: CgNode,
   of cnkLocal:
     let name = body[n.local].name
     if name.isNil:
-      # has no user-provided name
-      res.add ":local_"
+      # has no user-provided name. These are usually auxiliary locals, so
+      # the "aux" prefix is used
+      res.add ":aux_"
       res.addInt n.local.int
 
     renderSymbol(c, name, Symbol(kind: 1, id: n.local.int),

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -47,6 +47,9 @@ proc treeRepr*(n: CgNode): string =
       result.add n.sym.name.s
       result.add " id: "
       result.add $n.sym.itemId
+    of cnkLocal:
+      result.add "local: "
+      result.add $n.local.int
     of cnkMagic:
       result.add "magic: "
       result.add $n.magic

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -15,6 +15,8 @@ import
     idioms
   ]
 
+from compiler/ast/ast import id
+
 proc treeRepr*(n: CgNode): string =
   ## Renders the tree representation of `n` to text.
   proc treeRepr(n: CgNode, indent: int, result: var string) {.nimcall.} =
@@ -72,26 +74,49 @@ proc treeRepr*(n: CgNode): string =
   treeRepr(n, 0, result)
 
 type
+  Symbol = object
+    ## The common denomitator for representing all kinds of symbols in a way
+    ## that makes them comparable, at least within a procedure.
+    kind: uint8 ## the name-space
+    id: int     ## the ID within the name-space
+
   RenderCtx = object
-    syms: seq[PSym]
+    syms: seq[tuple[name: PIdent, sym: Symbol]]
       ## remembers the already-rendered symbols. Used to provide unique names.
 
-proc disambiguate(c: var RenderCtx, s: PSym): int =
+proc disambiguate(c: var RenderCtx, name: PIdent, s: Symbol): int =
   ## Computes and returns a number to append to the symbol name in order to
   ## make it unique in the output. This way, multiple different symbols sharing
   ## the same name can be disambiguated.
   result = 0
   for it in c.syms.items:
-    if it == s:
+    if it.sym == s:
       return
-    elif it.name.id == s.name.id: # same name?
+    elif it.name.id == name.id: # same name?
       inc result
 
-  c.syms.add s # remember the symbol
+  c.syms.add (name, s) # remember the symbol
 
-proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
+proc renderSymbol(c: var RenderCtx, name: PIdent, s: Symbol, flags: TSymFlags,
+                  res: var string) =
+  ## Appends the textual representation for the given symbol to `res`. `name`
+  ## may be 'nil', in which case only the '_cursor' postfix, if required, is
+  ## rendered.
+  if name != nil:
+    res.add name.s
+    let postfix = disambiguate(c, name, s)
+    if postfix > 0:
+      res.add "_" & $postfix
+
+  # the rendered code is currently used for the ``--expandArc`` debug feature,
+  # so we also highlight cursor locations
+  if sfCursor in flags:
+    res.add "_cursor"
+
+proc render(c: var RenderCtx, body: Body, ind: int, n: CgNode,
+            res: var string) =
   template add(s: var string, n: CgNode) =
-    render(c, ind, n, res)
+    render(c, body, ind, n, res)
 
   template indent(extra = 1) =
     if res.len > 0 and res[^1] == ' ':
@@ -130,15 +155,21 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
   of cnkAstLit:
     res.add "<ast>"
   of cnkSym:
-    res.add n.sym.name.s
-    let postfix = disambiguate(c, n.sym)
-    if postfix > 0 and n.sym.magic == mNone:
-      res.add "_" & $postfix
+    let s = n.sym
+    if s.magic == mNone:
+      renderSymbol(c, s.name, Symbol(kind: 0, id: n.sym.id), s.flags, res)
+    else:
+      # magics are never cursors nor do they need disambiguation
+      res.add s.name.s
+  of cnkLocal:
+    let name = body[n.local].name
+    if name.isNil:
+      # has no user-provided name
+      res.add ":local_"
+      res.addInt n.local.int
 
-    # the rendered code is currently used for the ``--expandArc``, so we also
-    # highlight cursor locals
-    if sfCursor in n.sym.flags:
-      res.add "_cursor"
+    renderSymbol(c, name, Symbol(kind: 1, id: n.local.int),
+                 body[n.local].flags, res)
   of cnkMagic:
     # cut off the 'm' prefix and use lower-case for the first character
     var name = substr($n.magic, 1)
@@ -275,7 +306,7 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
   of cnkRepeatStmt:
     res.add "while true:"
     indent()
-    render(c, ind + 1, n[0], res)
+    render(c, body, ind + 1, n[0], res)
   of cnkBlockStmt:
     if n[0].kind == cnkEmpty:
       res.add "block:"
@@ -284,13 +315,13 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
       res.add n[0]
       res.add ":"
     indent()
-    render(c, ind + 1, n[1], res)
+    render(c, body, ind + 1, n[1], res)
   of cnkIfStmt:
     res.add "if "
     res.add n[0]
     res.add ':'
     indent()
-    render(c, ind + 1, n[1], res)
+    render(c, body, ind + 1, n[1], res)
   of cnkCaseStmt:
     res.add "case "
     res.add n[0]
@@ -304,23 +335,23 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
 
       res.add ":"
       indent()
-      render(c, ind + 1, n[i][^1], res)
+      render(c, body, ind + 1, n[i][^1], res)
   of cnkTryStmt:
     res.add "try:"
     indent()
-    render(c, ind + 1, n[0], res)
+    render(c, body, ind + 1, n[0], res)
     for i in 1..<n.len:
       case n[i].kind
       of cnkExcept:
         newLine()
         res.add "except:"
         indent()
-        render(c, ind + 1, n[i][^1], res)
+        render(c, body, ind + 1, n[i][^1], res)
       of cnkFinally:
         newLine()
         res.add "finally:"
         indent()
-        render(c, ind + 1, n[i][0], res)
+        render(c, body, ind + 1, n[i][0], res)
       else:
         unreachable()
   of cnkStmtListExpr:
@@ -333,9 +364,9 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
   of cnkInvalid, cnkExcept, cnkFinally, cnkBranch:
     unreachable(n.kind)
 
-proc render*(n: CgNode): string =
-  ## Renders `n` to human-readable code that tries to emulate the shape of the
-  ## high-level language. The output is meant for debugging and tracing and is
-  ## not guaranteed to have a stable format.
+proc render*(body: Body): string =
+  ## Renders `body` to human-readable code that tries to emulate the shape
+  ## of the high-level language. The output is meant for debugging and tracing
+  ## and is not guaranteed to have a stable format.
   var c = RenderCtx()
-  render(c, 0, n, result)
+  render(c, body, 0, body.code, result)

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -98,14 +98,16 @@ proc isDeepConstExpr*(n: CgNode): bool =
   else:
     result = false
 
-proc getRoot*(n: CgNode): PSym =
+proc getRoot*(n: CgNode): CgNode =
   ## ``getRoot`` takes a *path* ``n``. A path is an lvalue expression
   ## like ``obj.x[i].y``. The *root* of a path is the symbol that can be
   ## determined as the owner; ``obj`` in the example.
   case n.kind
   of cnkSym:
-    if n.sym.kind in {skVar, skResult, skTemp, skLet, skForVar, skParam}:
-      result = n.sym
+    if n.sym.kind in {skVar, skLet, skForVar}:
+      result = n
+  of cnkLocal:
+    result = n
   of cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess:
     result = getRoot(n[0])
   of cnkDerefView, cnkDeref, cnkObjUpConv, cnkObjDownConv, cnkHiddenAddr,
@@ -124,13 +126,14 @@ proc isLValue*(n: CgNode): bool =
   of cnkEmpty:
     n.typ.kind == tyVar
   of cnkSym:
-    (n.sym.kind == skParam and n.sym.typ.kind in {tyVar, tySink}) or
-      n.sym.kind in {skVar, skResult, skTemp}
+    n.sym.kind == skVar
+  of cnkLocal:
+    # treat all locals as lvalues, even parameters
+    true
   of cnkFieldAccess:
     let t = skipTypes(n[0].typ, abstractInst-{tyTypeDesc})
     t.kind in {tyVar, tySink, tyPtr, tyRef} or
-      ((n[1].kind != cnkSym or sfDiscriminant notin n[1].sym.flags) and
-       isLValue(n[0]))
+      (not isDiscriminantField(n) and isLValue(n[0]))
   of cnkBracketAccess:
     let t = skipTypes(n[0].typ, abstractInst-{tyTypeDesc})
     t.kind in {tyVar, tySink, tyPtr, tyRef} or isLValue(n[0])
@@ -144,7 +147,7 @@ proc isLValue*(n: CgNode): bool =
       false
   of cnkDerefView:
     let n0 = n.operand
-    n0.typ.kind != tyLent or (n0.kind == cnkSym and n0.sym.kind == skResult)
+    n0.typ.kind != tyLent or (n0.kind == cnkLocal and n0.local == resultId)
   of cnkDeref, cnkHiddenAddr:
     true
   of cnkObjUpConv, cnkObjDownConv:

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -71,11 +71,11 @@ proc processEvent(g: PGlobals, graph: ModuleGraph, modules: BModuleList,
   of bekPartial:
     var p = partial.getOrDefault(evt.sym.id)
     if p == nil:
-      p = startProc(g, bmod, evt.sym)
+      p = startProc(g, bmod, evt.sym, Body())
       partial[evt.sym.id] = p
 
     let body = generateIR(graph, bmod.idgen, evt.sym, evt.body)
-    genStmt(p, merge(p.fullBody, body))
+    genPartial(p, merge(p.fullBody, body))
 
     processLate(g, discovery)
   of bekProcedure:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -49,13 +49,13 @@ import
     msgs
   ],
   compiler/utils/[
+    containers,
     idioms,
     int128,
     nversion,
     ropes
   ],
   compiler/backend/[
-    ccgutils,
     cgir,
     compat
   ]
@@ -121,6 +121,22 @@ type
 
     extra*: seq[PSym]
 
+  StorageFlag = enum
+    stfIndirect ## the value is stored in a single-item array
+    stfBoxed    ## the pointer value is stored as a two-element array
+
+  StorageFlags = set[StorageFlag]
+
+  Loc = object
+    ## Information about the JavaScript variable corresponding to a
+    ## |NimSkull| location.
+    ##
+    ## Future direction: ``Loc`` is intended to also be used for constants
+    ## and globals.
+    name: string
+    typ: PType
+    storage: StorageFlags
+
   PProc* = ref TProc
   TProc* = object
     prc: PSym
@@ -135,10 +151,9 @@ type
     blocks: seq[TBlock]
     extraIndent: int
 
-    params: seq[string]
-      ## mangled names of the procedure's parameters
-    localNames: Table[int, string]
-      ## mapes the symbol ID of locals to the JavaScript name
+    locals: OrdinalSeq[LocalId, Loc]
+      ## stores all relevant code generator state for the procedure's
+      ## locals
 
 const
   sfModuleInit* = sfMainModule
@@ -147,6 +162,9 @@ const
   NonMagics* = { mDotDot }
     ## magics that are treated like normal procedures by the code
     ## generator
+
+# forward declarations:
+proc setupLocalLoc(p: PProc, id: LocalId, kind: TSymKind; name = "")
 
 template config*(p: PProc): ConfigRef = p.module.config
 
@@ -271,8 +289,6 @@ func mangleName(m: BModule, s: PSym): Rope =
   if result == "":
     if s.kind == skField and s.name.s.validJsName:
       result = rope(s.name.s)
-    elif s.kind == skTemp:
-      result = rope(mangle(s.name.s))
     else:
       result = mangleJs(s.name.s)
     # From ES5 on reserved words can be used as object field names
@@ -280,29 +296,21 @@ func mangleName(m: BModule, s: PSym): Rope =
       result.add("_")
       result.add(rope(s.id))
 
-proc mangledName(p: PProc, s: PSym, info: TLineInfo): string =
-  ## Returns the cached JavaScript name for `s`.
-  ## At the time of writing, a borrowed string (``lent string``)
-  ## can't be returned because of compiler shortcomings.
-  template get(tbl: untyped): string =
-    p.module.config.internalAssert(s.id in tbl, info):
-      "symbol has no generated name: " & s.name.s
-    tbl[s.id]
-
-  case s.kind
-  of skVar, skLet, skTemp, skForVar:
-    if sfGlobal in s.flags:
-      result = get(p.g.names)
-    else:
-      result = get(p.localNames)
-  of skResult:
-    result = get(p.localNames)
-  of skParam:
-    result = p.params[s.position]
-  of routineKinds, skConst:
-    result = get(p.g.names)
+func mangleName(loc: Local, id: LocalId): string =
+  if loc.name.isNil:
+    # locals that don't have a name (e.g., temporaries) just use the
+    # ID
+    result = "_" & $id.int
   else:
-    unreachable()
+    result = mangleJs(loc.name.s)
+    result.add "_"
+    result.addInt id.int
+
+proc mangledName(p: PProc, s: PSym, info: TLineInfo): lent string =
+  ## Returns the cached JavaScript name for `s`.
+  p.module.config.internalAssert(s.id in p.g.names, info):
+    "symbol has no generated name: " & s.name.s
+  result = p.g.names[s.id]
 
 proc ensureMangledName(p: PProc, s: PSym): lent string =
   ## Looks up and returns the mangled name for the non-local symbol
@@ -341,7 +349,7 @@ proc makeJSString(s: string, escapeNonAscii = true): Rope =
 include jstypes
 
 proc gen(p: PProc, n: CgNode, r: var TCompRes)
-proc genStmt*(p: PProc, n: CgNode)
+proc genStmt(p: PProc, n: CgNode)
 
 proc useMagic(p: PProc, name: string) =
   if name.len == 0: return
@@ -803,9 +811,8 @@ proc genTry(p: PProc, n: CgNode) =
       # If some branch requires a local alias introduce it here. This is needed
       # since JS cannot do ``catch x as y``.
       if excAlias != nil:
-        let name = mangleName(p.module, excAlias.sym)
-        lineF(p, "var $1 = lastJSError;$n", name)
-        p.localNames[excAlias.sym.id] = name
+        setupLocalLoc(p, excAlias.local, skVar)
+        lineF(p, "var $1 = lastJSError;$n", p.locals[excAlias.local].name)
       genStmt(p, n[i][^1])
       lineF(p, "}$n", [])
     inc(i)
@@ -930,7 +937,7 @@ proc genAsmOrEmitStmt(p: PProc, n: CgNode) =
     case it.kind
     of cnkStrLit:
       p.body.add(it.strVal)
-    of cnkSym:
+    of cnkSym, cnkLocal:
       # for backwards compatibility we don't deref syms here :-(
       if false:
         discard
@@ -965,23 +972,19 @@ proc genIf(p: PProc, n: CgNode) =
   genStmt(p, it[1])
   lineF(p, "}$n", [])
 
-proc generateHeader(prc: PSym, params: openArray[string]): Rope =
-  ## Generates the JavaScript function header for `prc`. The parameters are
-  ## assumed to already have their mangled names set.
+proc generateHeader(params: openArray[Loc]): string =
+  ## Generates the JavaScript function parameter list for `params`.
   result = ""
 
-  let typ = prc.typ
-
-  for i in 1..<typ.n.len:
-    assert(typ.n[i].kind == nkSym)
-    var param = typ.n[i].sym
-    if isCompileTimeOnly(param.typ): continue
+  for param in params.items:
+    if param.name == "":
+      # it's a compile-time-only parameter
+      continue
     if result != "": result.add(", ")
-    let name = params[i-1]
-    result.add(name)
+    result.add(param.name)
     if mapType(param.typ) == etyBaseIndex:
       result.add(", ")
-      result.add(name)
+      result.add(param.name)
       result.add("_Idx")
 
 const
@@ -1221,23 +1224,28 @@ proc genArrayAccess(p: PProc, n: CgNode, r: var TCompRes) =
 func isBoxedPointer(v: PSym): bool =
   ## Returns whether `v` stores a pointer value boxed in an array. If not,
   ## the value is stored as two variables (base and index).
-  v.kind != skParam and {sfGlobal, sfAddrTaken} * v.flags != {}
+  sfGlobal in v.flags
+
+func isBoxedPointer(v: Loc): bool =
+  ## Returns whether `v` stores a pointer value boxed in an array. If not,
+  ## the value is stored as two variables (base and index).
+  stfBoxed in v.storage
 
 template isIndirect(x: PSym): bool =
   let v = x
-  ({sfAddrTaken, sfGlobal} * v.flags != {} and
+  (sfGlobal in v.flags and
     #(mapType(v.typ) != etyObject) and
     {sfImportc, sfExportc} * v.flags == {} and
     v.kind notin {skProc, skFunc, skConverter, skMethod, skIterator,
-                  skConst, skTemp, skLet, skParam})
+                  skConst, skLet})
 
-proc genSymAddr(p: PProc, n: CgNode, r: var TCompRes) =
+template isIndirect(x: Loc): bool =
+  stfIndirect in x.storage
+
+proc addrLoc[T: Loc|PSym](name: string, s: T, r: var TCompRes) =
   ## Generates the code for taking the address of the location identified by
   ## symbol node `n`
-  let s = n.sym
-  case s.kind
-  of skVar, skLet, skResult, skForVar, skParam:
-    let name = mangledName(p, s, n.info)
+  if true:
     r.kind = resExpr
     r.typ = etyBaseIndex
     r.res = "0"
@@ -1250,14 +1258,15 @@ proc genSymAddr(p: PProc, n: CgNode, r: var TCompRes) =
       # something that doesn't directly support having its address
       # taken (e.g. imported variable, parameter, let, etc.)
       r.address = "[$1]" % name
-  else: internalError(p.config, n.info, $("genAddr: 2", s.kind))
 
 proc genAddr(p: PProc, n: CgNode, r: var TCompRes) =
   ## Dispatches to the appropriate procedure for generating the address-of
   ## operation based on the kind of node `n`
   case n.kind
+  of cnkLocal:
+    addrLoc(p.locals[n.local].name, p.locals[n.local], r)
   of cnkSym:
-    genSymAddr(p, n, r)
+    addrLoc(mangledName(p, n.sym, n.info), n.sym, r)
   of cnkCheckedFieldAccess:
     genCheckedFieldOp(p, n, takeAddr=true, r)
   of cnkFieldAccess:
@@ -1295,11 +1304,7 @@ proc genAddr(p: PProc, n: CgNode, r: var TCompRes) =
   else:
     internalError(p.config, n.info, "genAddr: " & $n.kind)
 
-proc genSym(p: PProc, n: CgNode, r: var TCompRes) =
-  var s = n.sym
-  case s.kind
-  of skVar, skLet, skParam, skTemp, skResult, skForVar:
-    let name = mangledName(p, s, n.info)
+proc accessLoc[T: Loc|PSym](name: string, s: T, r: var TCompRes) =
     let k = mapType(s.typ)
     if k == etyBaseIndex:
       r.typ = etyBaseIndex
@@ -1317,6 +1322,13 @@ proc genSym(p: PProc, n: CgNode, r: var TCompRes) =
       r.res = "$1[0]" % [name]
     else:
       r.res = name
+
+proc genSym(p: PProc, n: CgNode, r: var TCompRes) =
+  var s = n.sym
+  case s.kind
+  of skVar, skLet, skForVar:
+    let name = mangledName(p, s, n.info)
+    accessLoc(name, s, r)
   of skConst:
     r.res = mangledName(p, s, n.info)
   of skProc, skFunc, skConverter, skMethod, skIterator:
@@ -1632,6 +1644,31 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
 
 template returnType: untyped = ~""
 
+proc storage(flags: TSymFlags, kind: TSymKind): StorageFlags =
+  ## Computes and returns based on `flags` and `kind` the storage flags
+  ## for a location.
+  if {sfAddrTaken, sfGlobal} * flags != {}:
+    if kind != skParam:
+      result.incl stfBoxed
+
+    if kind notin {skConst, skLet, skParam} and
+       {sfImportc, sfExportc} * flags == {}:
+      result.incl stfIndirect
+
+proc setupLocalLoc(p: PProc, id: LocalId, kind: TSymKind; name = "") =
+  ## Sets up the ``Loc`` for the local with `id`. `kind` is used for
+  ## computing the storage flags and a non-empty `name` overrides the
+  ## mangled name.
+  var loc = Loc(name: mangleName(p.fullBody[id], id),
+                typ: p.fullBody[id].typ,
+                storage: storage(p.fullBody[id].flags, kind))
+
+  if name != "":
+    # override with the provided name
+    loc.name = name
+
+  p.locals[id] = loc
+
 proc defineGlobal*(globals: PGlobals, m: BModule, v: PSym) =
   ## Emits the definition for the single global `v` into the top-level section,
   ## with `m` being the module the global belongs to. Also sets up the
@@ -1661,30 +1698,32 @@ proc defineGlobals*(globals: PGlobals, m: BModule, vars: openArray[PSym]) =
   # add to the top-level section:
   globals.code.add(p.body)
 
-proc genVarInit(p: PProc, v: PSym, varName: string, n: CgNode) =
+proc genVarInit(p: PProc, typ: PType, varName: string, storage: StorageFlags,
+                n: CgNode) =
   var
     a: TCompRes
     s: Rope
 
   if n.kind == cnkEmpty:
-    if not isIndirect(v) and
-      v.typ.kind in {tyVar, tyPtr, tyLent, tyRef} and mapType(v.typ) == etyBaseIndex:
+    let isIndirect = stfIndirect in storage
+    if not isIndirect and
+      typ.kind in {tyVar, tyPtr, tyLent, tyRef} and mapType(typ) == etyBaseIndex:
       lineF(p, "var $1 = null;$n", [varName])
       lineF(p, "var $1_Idx = 0;$n", [varName])
     else:
-      lineF(p, "var $1 = $2;$n", [varName, createVar(p, v.typ, isIndirect(v))])
+      lineF(p, "var $1 = $2;$n", [varName, createVar(p, typ, isIndirect)])
   else:
     gen(p, n, a)
-    case mapType(v.typ)
+    case mapType(typ)
     of etyObject, etySeq:
-      if needsNoCopy(p, n) or classifyBackendView(v.typ) == bvcSequence:
+      if needsNoCopy(p, n) or classifyBackendView(typ) == bvcSequence:
         s = a.res
       else:
         useMagic(p, "nimCopy")
         s = "nimCopy(null, $1, $2)" % [a.res, genTypeInfo(p, n.typ)]
     of etyBaseIndex:
       p.config.internalAssert(a.typ == etyBaseIndex, n.info)
-      if isBoxedPointer(v):
+      if stfBoxed in storage:
         s = "[$1, $2]" % [a.address, a.res]
       else:
         lineF(p, "var $1 = $2, $1_Idx = $3;$n",
@@ -1693,29 +1732,26 @@ proc genVarInit(p: PProc, v: PSym, varName: string, n: CgNode) =
         return
     else:
       s = a.res
-    if isIndirect(v):
+    if stfIndirect in storage:
       lineF(p, "var $1 = [$2];$n", [varName, s])
     else:
       lineF(p, "var $1 = $2;$n", [varName, s])
 
 proc genDef(p: PProc, it: CgNode) =
-  if true:
-    assert it[0].kind == cnkSym
-    let v = it[0].sym
-    let name = mangleName(p.module, v)
-    if true:
-      genLineDir(p, it)
-      genVarInit(p, v, name, it[1])
-
-    # all locals need a name:
-    p.localNames[v.id] = name
+  let
+    id   = it[0].local
+    kind = (if p.fullBody[id].isImmutable: skLet else: skVar)
+  setupLocalLoc(p, id, kind)
+  genLineDir(p, it)
+  genVarInit(p, p.locals[id].typ, p.locals[id].name, p.locals[id].storage,
+             it[1])
 
 proc genConstant*(g: PGlobals, m: BModule, c: PSym) =
   let name = mangleName(m, c)
   if exfNoDecl notin c.extFlags:
     var p = newInitProc(g, m)
     #genLineDir(p, c.ast)
-    genVarInit(p, c, name, translate(c.ast))
+    genVarInit(p, c.typ, name, storage(c.flags, skConst), translate(c.ast))
     g.constants.add(p.body)
 
   # all constants need a name:
@@ -2242,33 +2278,34 @@ proc optionalLine(p: Rope): Rope =
   else:
     return p & "\L"
 
-proc startProc*(g: PGlobals, module: BModule, prc: PSym): PProc =
+proc startProc*(g: PGlobals, module: BModule, prc: PSym, body: sink Body): PProc =
   let p = newProc(g, module, prc, prc.options)
+  p.fullBody = body
+
+  synchronize(p.locals, p.fullBody.locals)
 
   # make sure the procedure has a mangled name:
   discard ensureMangledName(p, prc)
 
-  p.params.newSeq(prc.typ.len - 1 + ord(prc.typ.callConv == ccClosure))
-  # -1 for the result type
-
-  # same for the result symbol and parameters:
+  # setup the loc for the the result variable:
   if prc.typ[0] != nil and sfPure notin prc.flags:
-    let s = prc.ast[resultPos].sym
-    p.localNames[s.id] = mangleName(p.module, s)
+    setupLocalLoc(p, resultId, skResult)
 
-  # set the mangled name for the parameters:
+  # setup the locs for the parameters:
   for i in 1..<prc.typ.n.len:
     let param = prc.typ.n[i].sym
     if not isCompileTimeOnly(param.typ):
-      p.params[i-1] = mangleName(p.module, param)
+      setupLocalLoc(p, LocalId(i), skParam)
 
   if prc.typ.callConv == ccClosure:
-    # generate the name for the hidden environment parameter. When creating a
+    # set the name for the hidden environment parameter. When creating a
     # closure object, the environment is bound to the ``this`` argument of the
     # function, hence using ``this`` for the name
     assert prc.ast[paramsPos].lastSon.kind == nkSym,
            "the hidden parameter is missing"
-    p.params[^1] = "this"
+    let s = prc.ast[paramsPos].lastSon.sym
+    # parameter IDs start at 1
+    setupLocalLoc(p, LocalId(s.position + 1), skParam, "this")
 
   result = p
 
@@ -2281,19 +2318,20 @@ proc finishProc*(p: PProc): string =
     resultAsgn = ""
 
   if prc.typ[0] != nil and sfPure notin prc.flags:
-    let resultSym = prc.ast[resultPos].sym
-    let mname = p.localNames[resultSym.id]
-    let returnAddress = not isIndirect(resultSym) and
-      resultSym.typ.kind in {tyVar, tyPtr, tyLent, tyRef} and
-        mapType(resultSym.typ) == etyBaseIndex
+    let
+      loc {.cursor.} = p.locals[resultId]
+      mname = loc.name
+    let returnAddress = not isIndirect(loc) and
+      loc.typ.kind in {tyVar, tyPtr, tyLent, tyRef} and
+        mapType(loc.typ) == etyBaseIndex
     if returnAddress:
       resultAsgn = p.indentLine(("var $# = null;$n") % [mname])
       resultAsgn.add p.indentLine("var $#_Idx = 0;$n" % [mname])
     else:
-      let resVar = createVar(p, resultSym.typ, isIndirect(resultSym))
+      let resVar = createVar(p, loc.typ, isIndirect(loc))
       resultAsgn = p.indentLine(("var $# = $#;$n") % [mname, resVar])
     var a: TCompRes
-    gen(p, newSymNode(prc.ast[resultPos].sym), a)
+    accessLoc(mname, loc, a)
     if returnAddress:
       returnStmt = "return [$#, $#];$n" % [a.address, a.res]
     else:
@@ -2304,7 +2342,7 @@ proc finishProc*(p: PProc): string =
 
   let
     name   = p.g.names[prc.id]
-    header = generateHeader(prc, p.params)
+    header = generateHeader(toOpenArray(p.locals.base, 1, prc.typ.len-1))
 
   var def: Rope
   if not prc.constraint.isNil:
@@ -2337,8 +2375,7 @@ proc finishProc*(p: PProc): string =
 
 proc genProc*(g: PGlobals, module: BModule, prc: PSym,
               body: sink Body): Rope =
-  var p = startProc(g, module, prc)
-  p.fullBody = body
+  var p = startProc(g, module, prc, body)
   p.nested: genStmt(p, p.fullBody.code)
   result = finishProc(p)
 
@@ -2394,6 +2431,8 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   case n.kind
   of cnkSym:
     genSym(p, n, r)
+  of cnkLocal:
+    accessLoc(p.locals[n.local].name, p.locals[n.local], r)
   of cnkIntLit, cnkUIntLit:
     r.res = intLiteral(getInt(n), n.typ)
     r.kind = resExpr

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -126,7 +126,7 @@ type
     prc: PSym
     fullBody*: Body
       ## the procedure's full body
-    locals, body: Rope
+    defs, body: Rope
     options: TOptions
     module: BModule
     g: PGlobals
@@ -359,7 +359,7 @@ proc getTemp(p: PProc, defineInLocals: bool = true): Rope =
   inc(p.unique)
   result = "Temporary$1" % [rope(p.unique)]
   if defineInLocals:
-    p.locals.add(p.indentLine("var $1;$n" % [result]))
+    p.defs.add(p.indentLine("var $1;$n" % [result]))
 
 type
   TMagicFrmt = array[0..1, string]
@@ -2312,7 +2312,7 @@ proc finishProc*(p: PProc): string =
             [ returnType,
               name,
               header,
-              optionalLine(p.locals),
+              optionalLine(p.defs),
               optionalLine(resultAsgn),
               optionalLine(genProcBody(p, prc)),
               optionalLine(p.indentLine(returnStmt))])
@@ -2323,7 +2323,7 @@ proc finishProc*(p: PProc): string =
     def = "\Lfunction $#($#) {$n$#$#$#$#" %
             [ name,
               header,
-              optionalLine(p.locals),
+              optionalLine(p.defs),
               optionalLine(resultAsgn),
               optionalLine(genProcBody(p, prc)),
               optionalLine(p.indentLine(returnStmt))]
@@ -2532,7 +2532,7 @@ proc genTopLevelStmt*(globals: PGlobals, m: BModule, body: sink Body) =
   p.fullBody = body
   p.unique = globals.unique
   genStmt(p, p.fullBody.code)
-  p.g.code.add(p.locals)
+  p.g.code.add(p.defs)
   p.g.code.add(p.body)
 
 proc wholeCode*(globals: PGlobals): Rope =

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2379,6 +2379,13 @@ proc genProc*(g: PGlobals, module: BModule, prc: PSym,
   p.nested: genStmt(p, p.fullBody.code)
   result = finishProc(p)
 
+proc genPartial*(p: PProc, n: CgNode) =
+  ## Generates the JavaScript code for `n` and appends the result to `p`. This
+  ## is intended for CG IR that wasn't already available when calling
+  ## `startProc`.
+  synchronize(p.locals, p.fullBody.locals)
+  genStmt(p, n)
+
 proc genStmt(p: PProc, n: CgNode) =
   var r: TCompRes
   gen(p, n, r)

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -1325,7 +1325,7 @@ proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
     # the MIR code wouldn't be very useful, so we turn it into backend IR
     # first, which we then render to text
     # XXX: this needs a deeper rethink
-    let n = generateIR(g, idgen, owner, tree, sourceMap).code
+    let n = generateIR(g, idgen, owner, tree, sourceMap)
     g.config.msgWrite("--expandArc: " & owner.name.s & "\n")
     g.config.msgWrite(render(n))
     g.config.msgWrite("\n-- end of expandArc ------------------------\n")

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -167,8 +167,10 @@ func setLen*[I; T](x: var OrdinalSeq[I, T], len: int) {.inline.} =
   setLen(base(x), len)
 
 func synchronize*[I; A; B](x: var OrdinalSeq[I, A], s: Store[I, B]) =
-  ## Synchronizes the number of elements `x` has with that of `s`. Behaviour
-  ## is undefined when `s` has less elements than `x`.
+  ## Synchronizes the number of elements `x` has with that of `s`.
+  ##
+  ## `s` must be larger than or equal in size to `x`: if this is
+  ## not the case, behaviour is undefined.
   assert x.len <= s.data.len
   x.setLen(s.data.len)
 

--- a/compiler/utils/containers.nim
+++ b/compiler/utils/containers.nim
@@ -166,6 +166,12 @@ func newSeq*[I; T](x: var OrdinalSeq[I, T], len: int) {.inline.} =
 func setLen*[I; T](x: var OrdinalSeq[I, T], len: int) {.inline.} =
   setLen(base(x), len)
 
+func synchronize*[I; A; B](x: var OrdinalSeq[I, A], s: Store[I, B]) =
+  ## Synchronizes the number of elements `x` has with that of `s`. Behaviour
+  ## is undefined when `s` has less elements than `x`.
+  assert x.len <= s.data.len
+  x.setLen(s.data.len)
+
 iterator pairs*[I; T](x: OrdinalSeq[I, T]): (I, lent T) =
   var i = 0
   while i < x.len:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -55,6 +55,7 @@ import
     options
   ],
   compiler/utils/[
+    containers,
     idioms
   ],
   compiler/vm/[
@@ -126,6 +127,12 @@ type
     label: PSym
     fixups: seq[TPosition]
 
+  LocalLoc = object
+    ## The current state for a local.
+    reg: TRegister   ## the register that holds either the handle or value
+    isIndirect: bool ## whether the local uses a handle while its value
+                     ## would fit it into a register
+
   BProc = object
     blocks: seq[TBlock]
       ## blocks; temp data structure
@@ -137,17 +144,8 @@ type
       ## no line information is directly available
     regInfo: seq[RegInfo]
 
-    addressTaken: IntSet
-      ## the set of locations (identified by their symbol id) that have their
-      ## address taken or a view of them created. This information is used to
-      ## decide whether a full VM memory location is required, or if the
-      ## value can be stored in a register directly
-
-    # XXX: the value's type should be `TRegister`, but we need a sentinel
-    #      value (-1) for `getOrDefault`, so it has to be `int`
-    locals: Table[int, int]
-      ## symbol-id -> register index. Used for looking up the corresponding
-      ## register slot of each local (including parameters and `result`)
+    locals: OrdinalSeq[LocalId, LocalLoc]
+      ## current state of all locals
 
   CodeGenCtx* = object
     ## Bundles all input, output, and other contextual data needed for the
@@ -266,19 +264,21 @@ proc genLit(c: var TCtx; n: CgNode; lit: int; dest: var TDest)
 proc genTypeLit(c: var TCtx; info: CgNode, t: PType; dest: var TDest)
 proc genType(c: var TCtx, typ: PType): int
 func fitsRegister(t: PType): bool
-func local(prc: BProc, sym: PSym): TDest {.inline.}
 proc genRegLoad(c: var TCtx, n: CgNode, dest, src: TRegister) {.inline.}
 proc genRegLoad(c: var TCtx, n: CgNode, typ: PType, dest, src: TRegister)
 
 template isUnset(x: TDest): bool = x < 0
 
+template `[]`(p: BProc, id: LocalId): LocalLoc =
+  ## Convenience shorthand.
+  p.locals[id]
 
 proc routineSignature(s: PSym): PType {.inline.} =
   ## Returns the signature type of the routine `s`
   if s.kind == skMacro: s.internal
   else:                 s.typ
 
-func underlyingLoc(n: CgNode): PSym =
+func underlyingLoc(n: CgNode): CgNode =
   ## Computes and returns the symbol of the complete location (i.e., a location
   ## not part of a compound location) that l-value expression `n` names. If no
   ## complete location is named, ``nil`` is returned.
@@ -291,34 +291,28 @@ func underlyingLoc(n: CgNode): PSym =
     of cnkStmtListExpr: root = root[^1]
     else:               break
 
-  result =
-    if root.kind == cnkSym: root.sym
-    else:                  nil
+  result = root
 
-func analyseIfAddressTaken(n: CgNode, locs: var IntSet) =
-  ## Recursively traverses the tree `n` and collects the symbols IDs of all
-  ## complete locations of which the address is taken. Note that this analysis
-  ## doesn't rely on the ``sfAddrTaken`` flag (because it's not reliable).
-  # TODO: turn this into a MIR analysis. Doing so will simplify the code, make
-  #       it less error-prone, and likely also faster
+func analyseIfAddressTaken(n: CgNode, prc: var BProc) =
+  ## Recursively traverses the tree `n` and marks locals of which the address is
+  ## taken as requiring indirection.
   case n.kind
   of cnkHiddenAddr, cnkAddr:
     # the nodes we're interested
     let loc = underlyingLoc(n.operand)
-    if loc != nil:
-      # we're only interested in locals
-      if sfGlobal notin loc.flags:
-        locs.incl(loc.id)
+    # we're only interested in locals
+    if loc.kind == cnkLocal:
+      prc[loc.local].isIndirect = true
     else:
       # the operand expression must still be anaylsed
-      analyseIfAddressTaken(n.operand, locs)
+      analyseIfAddressTaken(n.operand, prc)
   of cnkAtoms:
     discard "ignore"
   of cnkWithOperand - {cnkHiddenAddr, cnkAddr}:
-    analyseIfAddressTaken(n.operand, locs)
+    analyseIfAddressTaken(n.operand, prc)
   of cnkWithItems:
     for it in n.items:
-      analyseIfAddressTaken(it, locs)
+      analyseIfAddressTaken(it, prc)
 
 
 func isNimNode(t: PType): bool =
@@ -977,19 +971,15 @@ proc writeBackResult(c: var TCtx, info: CgNode) =
   ## If the result value fits into a register but is not stored in one
   ## (because it has its address taken, etc.), emits the code for storing it
   ## back into a register. `info` is only used to provide line information.
-  if not isEmptyType(c.prc.sym.routineSignature[0]):
-    let
-      res = c.prc.sym.ast[resultPos]
-      typ = res.typ
-
-    if fitsRegister(typ) and not isDirectView(typ) and
-       res.sym.id in c.prc.addressTaken:
+  let typ = c.prc.body[resultId].typ
+  if not isEmptyType(typ) and fitsRegister(typ) and not isDirectView(typ) and
+     c.prc[resultId].isIndirect:
       # a write-back is required. Load the value into temporary register and
       # then do a register move
       let
         tmp = c.getTemp(typ)
-        dest = local(c.prc, res.sym)
-      c.genRegLoad(info, res.typ, tmp, dest)
+        dest = c.prc[resultId].reg
+      c.genRegLoad(info, typ, tmp, dest)
       c.gABC(info, opcFastAsgnComplex, dest, tmp)
       c.freeTemp(tmp)
 
@@ -1070,11 +1060,6 @@ proc genCall(c: var TCtx; n: CgNode; dest: var TDest) =
 
 template isGlobal(s: PSym): bool = sfGlobal in s.flags
 
-func local(prc: BProc, sym: PSym): TDest {.inline.} =
-  ## Returns the register associated with the local variable `sym` (or -1 if
-  ## `sym` is not a local)
-  prc.locals.getOrDefault(sym.id, -1)
-
 proc genField(c: TCtx; n: CgNode): TRegister =
   assert n.kind == cnkSym and n.sym.kind == skField
 
@@ -1108,10 +1093,10 @@ proc genRegLoad(c: var TCtx, n: CgNode, dest, src: TRegister) {.inline.} =
 proc genCheckedObjAccessAux(c: var TCtx; n: CgNode): TRegister
 proc genSym(c: var TCtx, n: CgNode, dest: var TDest, load = true)
 
-func usesRegister(p: BProc, s: PSym): bool =
+func usesRegister(p: BProc, s: LocalId): bool =
   ## Returns whether the location identified by `s` is backed by a register
   ## (that is, whether the value is stored in a register directly)
-  fitsRegister(s.typ) and s.id notin p.addressTaken
+  fitsRegister(p.body[s].typ) and not p[s].isIndirect
 
 proc genNew(c: var TCtx; n: CgNode) =
   let dest = c.genLvalue(n[1])
@@ -1608,9 +1593,11 @@ func usesRegister(p: BProc, n: CgNode): bool =
   # XXX: instead of using a separate analysis, compute and return this as part
   #      of ``genLValue`` and
   case n.kind
+  of cnkLocal:
+    usesRegister(p, n.local)
   of cnkSym:
     let s = n.sym
-    not s.isGlobal and usesRegister(p, s)
+    not s.isGlobal and fitsRegister(s.typ)
   of cnkDeref, cnkDerefView, cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess,
      cnkConv, cnkObjDownConv, cnkObjUpConv:
     false
@@ -2125,10 +2112,9 @@ proc genDeref(c: var TCtx, n: CgNode, dest: var TDest; load = true) =
       c.genRegLoad(n, dest, dest)
     c.freeTemp(tmp)
 
-func setSlot(p: var BProc; v: PSym): TRegister {.discardable.} =
-  # XXX generate type initialization here?
-  result = getFreeRegister(p, if v.kind == skLet: slotFixedLet else: slotFixedVar, start = 1)
-  p.locals[v.id] = result
+func setSlot(p: var BProc; v: LocalId): TRegister {.discardable.} =
+  result = getFreeRegister(p, slotFixedVar, start = 1)
+  p[v].reg = result
 
 func cannotEval(c: TCtx; n: CgNode) {.noinline, noreturn.} =
   # best-effort translation to ``PNode`` for improved error messages
@@ -2262,6 +2248,8 @@ func isPtrView(n: CgNode): bool =
   case n.kind
   of cnkSym:
     sfGlobal in n.sym.flags
+  of cnkLocal:
+    false
   of cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess:
     true
   of cnkHiddenAddr, cnkCall:
@@ -2297,22 +2285,26 @@ proc genAsgnSource(c: var TCtx, n: CgNode, wantsPtr: bool): TRegister =
       c.gABC(n, opcAddr, result, tmp)
       c.freeTemp(tmp)
 
-proc genSymAsgn(c: var TCtx, le, ri: CgNode) =
-  ## Generates and emits the code for an assignment where the RHS is a symbol
-  ## node.
-  let s = le.sym
+proc genAsgnToGlobal(c: var TCtx, le, ri: CgNode) =
+  ## Generates and emits the code for an assignment where the LHS is the symbol
+  ## of a global location.
   var dest = noDest
   # we're only interested in the *handle* (i.e. identity) of the location, so
   # don't load it
   c.genSym(le, dest, load=false)
 
-  if sfGlobal in s.flags:
+  if true:
     # global views use pointers internally
     let b = genAsgnSource(c, ri, wantsPtr=true)
     c.gABC(le, opcWrLoc, dest, b)
     c.freeTemp(b)
-  else:
-    if usesRegister(c.prc, s):
+
+  c.freeTemp(dest)
+
+proc genAsgnToLocal(c: var TCtx, le, ri: CgNode) =
+  let dest = c.prc[le.local].reg
+  if true:
+    if usesRegister(c.prc, le.local):
       # if the location is backed by a register (i.e., is not in stored
       # in a memory cell), we don't use a temporary register + assignment
       # but directly write to the destination register
@@ -2329,12 +2321,10 @@ proc genSymAsgn(c: var TCtx, le, ri: CgNode) =
       # an assignment is required to the local. Views are always stored as
       # handles in this case, so a register move is used for assigning them
       let
-        opc = (if isDirectView(s.typ): opcFastAsgnComplex else: opcWrLoc)
+        opc = (if isDirectView(le.typ): opcFastAsgnComplex else: opcWrLoc)
         b = c.genx(ri)
       c.gABC(le, opc, dest, b)
       c.freeTemp(b)
-
-  c.freeTemp(dest)
 
 proc genDerefView(c: var TCtx, n: CgNode, dest: var TDest; load = true) =
   ## Generates and emits the code for a view dereference, where `n` is the
@@ -2432,7 +2422,9 @@ proc genAsgn(c: var TCtx; le, ri: CgNode; requiresCopy: bool) =
     genAsgn(c, le.operand, ri, requiresCopy)
   of cnkSym:
     checkCanEval(c, le)
-    genSymAsgn(c, le, ri)
+    genAsgnToGlobal(c, le, ri)
+  of cnkLocal:
+    genAsgnToLocal(c, le, ri)
   else:
     unreachable(le.kind)
 
@@ -2467,9 +2459,11 @@ proc useGlobal(c: var TCtx, n: CgNode): int =
 
 proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
   ## Generates and emits the code for loading either the value or handle of
-  ## the location named by symbol node `n` into the `dest` register.
-  let s = n.sym
-  if s.isGlobal:
+  ## the location named by symbol or local node `n` into the `dest` register.
+  case n.kind
+  of cnkSym:
+    # a global location
+    let s = n.sym
     let pos = useGlobal(c, n)
     if dest.isUnset:
       dest = c.getTemp(s.typ)
@@ -2481,10 +2475,10 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
       c.freeTemp(cc)
     else:
       c.gABx(n, opcLdGlobal, dest, pos)
-  else:
-      let local = local(c.prc, s)
+  of cnkLocal:
+      let local = c.prc[n.local].reg
       internalAssert(c.config, c.prc.regInfo[local].kind < slotSomeTemp)
-      if usesRegister(c.prc, s) or not load or not fitsRegister(s.typ):
+      if usesRegister(c.prc, n.local) or not load or not fitsRegister(n.typ):
         if dest.isUnset:
           dest = local
         else:
@@ -2492,26 +2486,28 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
           # register copy, which is exactly what we need here
           c.gABC(n, opcFastAsgnComplex, dest, local)
       else:
-        prepare(c, dest, s.typ)
+        prepare(c, dest, n.typ)
         c.genRegLoad(n, dest, local)
+  else:
+    unreachable()
 
 proc genSymAddr(c: var TCtx, n: CgNode, dest: var TDest) =
   ## Generates and emits the code for taking the address of the location
-  ## identified by the symbol node `n`.
-  let s = n.sym
-  if dest.isUnset:
-    dest = c.getTemp(s.typ)
-
-  if s.isGlobal:
+  ## identified by the symbol or local node `n`.
+  assert dest != noDest
+  case n.kind
+  of cnkSym:
     let
       pos = useGlobal(c, n)
       tmp = c.getTemp(slotTempComplex)
     c.gABx(n, opcLdGlobal, tmp, pos)
     c.gABC(n, opcAddr, dest, tmp)
     c.freeTemp(tmp)
-  else:
-    let local = local(c.prc, s)
+  of cnkLocal:
+    let local = c.prc[n.local].reg
     c.gABC(n, opcAddr, dest, local)
+  else:
+    unreachable()
 
 proc genArrAccessOpcode(c: var TCtx; n: CgNode; dest: var TDest; opc: TOpcode; load = true) =
   let
@@ -2682,7 +2678,7 @@ proc genAddr(c: var TCtx, src, n: CgNode, dest: var TDest) =
   ## `n`. `src` provides the type information of the destination, plus the line
   ## information to use.
   case n.kind
-  of cnkSym:
+  of cnkSym, cnkLocal:
     prepare(c, dest, src.typ)
     genSymAddr(c, n, dest)
   of cnkFieldAccess:
@@ -2754,7 +2750,7 @@ proc genLvalue(c: var TCtx, n: CgNode, dest: var TDest) =
   ## Note that in the case of locals backed by registers, `dest` will store
   ## its value instead of a handle.
   case n.kind
-  of cnkSym:
+  of cnkSym, cnkLocal:
     c.genSym(n, dest, load=false)
   of cnkFieldAccess:
     genFieldAccess(c, n, dest, load=false)
@@ -2799,8 +2795,9 @@ proc genLvalue(c: var TCtx, n: CgNode, dest: var TDest) =
     unreachable(n.kind)
 
 proc genDef(c: var TCtx; a: CgNode) =
-        let s = a[0].sym
-        assert not s.isGlobal
+        let
+          s   = a[0].local
+          typ = a[0].typ
         if true:
           let reg = setSlot(c.prc, s)
           if a[1].kind == cnkEmpty:
@@ -2809,16 +2806,16 @@ proc genDef(c: var TCtx; a: CgNode) =
             let opc = if usesRegister(c.prc, s): opcLdNullReg
                       else: opcLdNull
 
-            c.gABx(a, opc, reg, c.genType(s.typ))
+            c.gABx(a, opc, reg, c.genType(typ))
           else:
             # XXX: checking for views here is wrong but necessary
-            if not usesRegister(c.prc, s) and not isDirectView(s.typ):
+            if not usesRegister(c.prc, s) and not isDirectView(typ):
               # only setup a memory location if the local uses one
-              c.gABx(a, opcLdNull, reg, c.genType(s.typ))
+              c.gABx(a, opcLdNull, reg, c.genType(typ))
 
             # views and locals backed by registers don't need explicit
             # initialization logic here -- the assignment takes care of that
-            genSymAsgn(c, a[0], a[1])
+            genAsgnToLocal(c, a[0], a[1])
 
 proc genArrayConstr(c: var TCtx, n: CgNode, dest: var TDest) =
   if dest.isUnset: dest = c.getTemp(n.typ)
@@ -2937,7 +2934,7 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
     let s = n.sym
     checkCanEval(c, n)
     case s.kind
-    of skVar, skForVar, skTemp, skLet, skParam, skResult:
+    of skVar, skForVar, skLet:
       genSym(c, n, dest)
     of skProc, skFunc, skConverter, skMacro, skMethod, skIterator:
       if importcCond(c, s) and lookup(c.linking.callbackKeys, s) == -1:
@@ -2956,6 +2953,8 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
         c.gABx(n, opcLdCmplxConst, dest, idx)
     else:
       unreachable(s.kind)
+  of cnkLocal:
+    genSym(c, n, dest)
   of cnkCall:
     let magic = getMagic(n)
     if magic != mNone:
@@ -3076,9 +3075,10 @@ proc initProc(c: TCtx, owner: PSym, body: sink Body): BProc =
   result.bestEffort =
     if owner != nil: owner.info
     else:            c.module.info
+  result.locals.synchronize(result.body.locals)
 
   # analyse what locals require indirections:
-  analyseIfAddressTaken(result.body.code, result.addressTaken)
+  analyseIfAddressTaken(result.body.code, result)
 
 proc genStmt*(c: var TCtx; body: sink Body): Result[int, VmGenDiag] =
   c.prc = initProc(c, nil, body)
@@ -3115,19 +3115,19 @@ proc genExpr*(c: var TCtx; body: sink Body): Result[int, VmGenDiag] =
   result = typeof(result).ok(c.prc.regInfo.len)
 
 
-proc genParams(prc: var BProc; s: PSym) =
+proc genParams(prc: var BProc; signature: PType) =
+  ## Allocates the registers for the parameters and associates them with the
+  ## corresponding locs.
   let
-    params = s.routineSignature.n
+    params = signature.n
+    isClosure = signature.callConv == ccClosure
 
-  setLen(prc.regInfo, max(params.len, 1))
+  # closure procedures have an additional, hidden parameter
+  prc.regInfo.newSeq(params.len + ord(isClosure))
 
-  if not isEmptyType(s.routineSignature[0]):
-    prc.locals[s.ast[resultPos].sym.id] = 0
-    prc.regInfo[0] = RegInfo(refCount: 1, kind: slotFixedVar)
-
-  for i in 1..<params.len:
-    prc.locals[params[i].sym.id] = i
-    prc.regInfo[i] = RegInfo(refCount: 1, kind: slotFixedLet)
+  for i, it in prc.regInfo.mpairs:
+    it = RegInfo(refCount: 1, kind: slotFixedVar)
+    prc[LocalId i].reg = i
 
 proc finalJumpTarget(c: var TCtx; pc, diff: int) =
   internalAssert(
@@ -3203,9 +3203,9 @@ proc prepareParameters(c: var TCtx, info: CgNode) =
   ## to a VM memory location at the start of the procedure.
   let typ = c.prc.sym.routineSignature # the procedure's type
 
-  template setupParam(c: var TCtx, s: PSym) =
-    if fitsRegister(s.typ) and s.id in c.prc.addressTaken:
-      transitionToLocation(c, info, s.typ, local(c.prc, s))
+  template setupParam(c: var TCtx, typ: PType, loc: LocalLoc) =
+    if fitsRegister(typ) and loc.isIndirect:
+      transitionToLocation(c, info, typ, loc.reg)
 
   if typ.n.len > 1: # does it have more than zero parameters?
     # if getReturnType(c.prc.sym).skipTypes(abstractInst).kind == tyLent:
@@ -3219,43 +3219,34 @@ proc prepareParameters(c: var TCtx, info: CgNode) =
     # XXX: the above is correct, but the expection that to-be-borrowed-from
     #      parameters use pass-by-handle isn't met yet. For now, what this
     #      means is that ``proc borrow(x: int): lent int`` won't work
-    setupParam(c, typ.n[1].sym)
+    setupParam(c, typ[1], c.prc[LocalId(1)])
 
   # setup the remaining parameters:
   for i in 2..<typ.n.len:
-    setupParam(c, typ.n[i].sym)
+    setupParam(c, typ[i], c.prc[LocalId(i)])
 
 proc genProcBody(c: var TCtx): int =
     let
       s    = c.prc.sym
       body = c.prc.body.code
 
-    # iterate over the parameters and allocate space for them:
-    genParams(c.prc, s)
-
-    if s.routineSignature.callConv == ccClosure:
-      # reserve a slot for the hidden environment parameter and register the
-      # mapping
-      c.prc.regInfo.add RegInfo(refCount: 1, kind: slotFixedLet)
-      c.prc.locals[s.ast[paramsPos][^1].sym.id] = c.prc.regInfo.high
+    genParams(c.prc, s.routineSignature)
 
     # setup the result register, if necessary. Watch out for macros! Their
     # result register is setup at the start of macro evaluation
     # XXX: initializing the ``result`` of a macro should be handled through
     #      inserting the necessary code either in ``sem` or here
-    let rt = s.routineSignature[0]
+    let rt = c.prc.body[resultId].typ
     if not isEmptyType(rt) and fitsRegister(rt):
       # initialize the register holding the result
-      let r = s.ast[resultPos].sym
-
       if s.kind == skMacro:
-        if r.id in c.prc.addressTaken:
+        if c.prc[resultId].isIndirect:
           # the result variable for macros is currently initialized from outside
           # the VM, so we can't use ``opcLdNull`` here
-          transitionToLocation(c, body, rt, local(c.prc, r))
+          transitionToLocation(c, body, rt, c.prc[resultId].reg)
       else:
         let opcode =
-          if r.id in c.prc.addressTaken:
+          if c.prc[resultId].isIndirect:
             # the result variable has its address taken or a reference/view
             # to it created -> we need a VM memory location. In order for this
             # to be opaque to the callsite, a write-back is injected before
@@ -3265,8 +3256,8 @@ proc genProcBody(c: var TCtx): int =
             opcLdNullReg
 
         # only setup a location/register if the procedure's result is not a view:
-        if not isDirectView(r.typ):
-          gABx(c, body, opcode, local(c.prc, r), c.genType(r.typ))
+        if not isDirectView(rt):
+          gABx(c, body, opcode, c.prc[resultId].reg, c.genType(rt))
 
     prepareParameters(c, body)
     gen(c, body)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3080,7 +3080,7 @@ proc initProc(c: TCtx, owner: PSym, body: sink Body): BProc =
   # analyse what locals require indirections:
   analyseIfAddressTaken(result.body.code, result.addressTaken)
 
-proc genStmt*(c: var TCtx; body: Body): Result[int, VmGenDiag] =
+proc genStmt*(c: var TCtx; body: sink Body): Result[int, VmGenDiag] =
   c.prc = initProc(c, nil, body)
   let n = c.prc.body.code
 

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -3,7 +3,7 @@ discard """
   cmd: '''nim c --gc:arc --expandArc:main --expandArc:sio --hint:Performance:off $file'''
   nimout: '''--expandArc: main
 
-var :local_2
+var :aux_2
 try:
   var x_cursor = ("hi", 5)
   block label:
@@ -12,11 +12,11 @@ try:
       break label
     x_cursor = [type node](("string here", 80))
   echo([
-    var :local_4 = $(x_cursor)
-    :local_2 = :local_4
-    :local_2])
+    var :aux_4 = $(x_cursor)
+    :aux_2 = :aux_4
+    :aux_2])
 finally:
-  =destroy(:local_2)
+  =destroy(:aux_2)
 -- end of expandArc ------------------------
 --expandArc: sio
 

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -3,7 +3,7 @@ discard """
   cmd: '''nim c --gc:arc --expandArc:main --expandArc:sio --hint:Performance:off $file'''
   nimout: '''--expandArc: main
 
-var :tmp
+var :local_2
 try:
   var x_cursor = ("hi", 5)
   block label:
@@ -12,11 +12,11 @@ try:
       break label
     x_cursor = [type node](("string here", 80))
   echo([
-    var :tmp_1 = $(x_cursor)
-    :tmp = :tmp_1
-    :tmp])
+    var :local_4 = $(x_cursor)
+    :local_2 = :local_4
+    :local_2])
 finally:
-  =destroy(:tmp)
+  =destroy(:local_2)
 -- end of expandArc ------------------------
 --expandArc: sio
 

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -11,36 +11,36 @@ doing shady stuff...
   cmd: '''nim c --gc:arc --expandArc:newTarget --expandArc:delete --expandArc:p1 --expandArc:tt --hint:Performance:off --assertions:off --expandArc:extractConfig --expandArc:mergeShadowScope --expandArc:check $file'''
   nimout: '''--expandArc: newTarget
 
-var :tmp
-var :tmp_1
-var :tmp_2
+var :local_3
+var :local_4
+var :local_5
 var splat
 splat = splitFile(path)
 result = (
-  :tmp = splat.dir
+  :local_3 = splat.dir
   wasMoved(splat.dir)
-  :tmp,
-  :tmp_1 = splat.name
+  :local_3,
+  :local_4 = splat.name
   wasMoved(splat.name)
-  :tmp_1,
-  :tmp_2 = splat.ext
+  :local_4,
+  :local_5 = splat.ext
   wasMoved(splat.ext)
-  :tmp_2)
+  :local_5)
 =destroy(splat)
 -- end of expandArc ------------------------
 --expandArc: delete
 
 var sibling
-var :tmp = target[].parent[].left
-=copy(sibling, :tmp)
+var :local_3 = target[].parent[].left
+=copy(sibling, :local_3)
 var saved
-var :tmp_1 = sibling[].right
-=copy(saved, :tmp_1)
-var :tmp_2 = sibling[].right
-var :tmp_3 = saved[].left
-=copy(:tmp_2, :tmp_3)
-var :tmp_4 = sibling[].parent
-=sink(:tmp_4, saved)
+var :local_5 = sibling[].right
+=copy(saved, :local_5)
+var :local_6 = sibling[].right
+var :local_7 = saved[].left
+=copy(:local_6, :local_7)
+var :local_8 = sibling[].parent
+=sink(:local_8, saved)
 =destroy(sibling)
 -- end of expandArc ------------------------
 --expandArc: p1
@@ -49,38 +49,38 @@ var lresult
 lresult = @([123])
 var lvalue
 var lnext
-var :tmp
-:tmp = (lresult, ";")
-lvalue = :tmp[0]
-wasMoved(:tmp[0])
-lnext = :tmp[1]
-wasMoved(:tmp[1])
+var :local_4
+:local_4 = (lresult, ";")
+lvalue = :local_4[0]
+wasMoved(:local_4[0])
+lnext = :local_4[1]
+wasMoved(:local_4[1])
 result.value = move(lvalue)
-=destroy(:tmp)
+=destroy(:local_4)
 =destroy_1(lnext)
 =destroy_2(lvalue)
 -- end of expandArc ------------------------
 --expandArc: tt
 
-var :tmp
-var :tmp_1
+var :local_5
+var :local_6
 var a
-var :tmp_2
+var :local_3
 try:
   var it_cursor = x
   a = (
-    :tmp = default()
-    =copy(:tmp, it_cursor.key)
-    :tmp,
-    :tmp_1 = default()
-    =copy(:tmp_1, it_cursor.val)
-    :tmp_1)
+    :local_5 = default()
+    =copy(:local_5, it_cursor.key)
+    :local_5,
+    :local_6 = default()
+    =copy(:local_6, it_cursor.val)
+    :local_6)
   echo([
-    var :tmp_3 = $(a)
-    :tmp_2 = :tmp_3
-    :tmp_2])
+    var :local_7 = $(a)
+    :local_3 = :local_7
+    :local_3])
 finally:
-  =destroy(:tmp_2)
+  =destroy(:local_3)
   =destroy_1(a)
 -- end of expandArc ------------------------
 --expandArc: extractConfig
@@ -102,8 +102,8 @@ try:
             var line = a_cursor[i]
             splitted = split(line, " ", -1)
             if ==(splitted[0], "opt"):
-              var :tmp = splitted[1]
-              =copy(lan_ip, :tmp)
+              var :local_7 = splitted[1]
+              =copy(lan_ip, :local_7)
             echo([lan_ip])
             echo([splitted[1]])
           finally:
@@ -115,8 +115,8 @@ finally:
 
 var shadowScope
 try:
-  var :tmp = c[].currentScope
-  =copy(shadowScope, :tmp)
+  var :local_3 = c[].currentScope
+  =copy(shadowScope, :local_3)
   rawCloseScope(c)
   block label:
     var a_cursor = shadowScope[].symbols
@@ -127,13 +127,13 @@ try:
         if not(<(i, L)):
           break
         block label_2:
-          var :tmp_1
+          var :local_9
           var sym = a_cursor[i]
           addInterfaceDecl(c,
-            var :tmp_2 = sym
-            :tmp_1 = default()
-            =copy_1(:tmp_1, :tmp_2)
-            :tmp_1)
+            var :local_8 = sym
+            :local_9 = default()
+            =copy_1(:local_9, :local_8)
+            :local_9)
         inc(i, 1)
 finally:
   =destroy(shadowScope)
@@ -145,35 +145,35 @@ try:
   this[].isValid = fileExists(this[].value)
   block label:
     if dirExists(this[].value):
-      var :tmp
+      var :local_4
       par = [type node]((
-        var :tmp_1 = this[].value
-        :tmp = default()
-        =copy(:tmp, :tmp_1)
-        :tmp, ""))
+        var :local_3 = this[].value
+        :local_4 = default()
+        =copy(:local_4, :local_3)
+        :local_4, ""))
       break label
-    var :tmp_2
-    var :tmp_3
-    var :tmp_4
+    var :local_6
+    var :local_7
+    var :local_8
     par = [type node]((parentDir(this[].value),
-      :tmp_3 = splitPath(
-        var :tmp_5 = this[].value
-        :tmp_2 = default()
-        =copy(:tmp_2, :tmp_5)
-        :tmp_2)
-      :tmp_4 = :tmp_3.tail
-      wasMoved(:tmp_3.tail)
-      :tmp_4))
-    =destroy(:tmp_3)
+      :local_7 = splitPath(
+        var :local_5 = this[].value
+        :local_6 = default()
+        =copy(:local_6, :local_5)
+        :local_6)
+      :local_8 = :local_7.tail
+      wasMoved(:local_7.tail)
+      :local_8))
+    =destroy(:local_7)
   block label_1:
     if dirExists(par.dir):
-      var :tmp_6 = this[].matchDirs
-      var :tmp_7 = getSubDirs(par.dir, par.front)
-      =sink(:tmp_6, :tmp_7)
+      var :local_9 = this[].matchDirs
+      var :local_10 = getSubDirs(par.dir, par.front)
+      =sink(:local_9, :local_10)
       break label_1
-    var :tmp_8 = this[].matchDirs
-    var :tmp_9 = []
-    =sink(:tmp_8, :tmp_9)
+    var :local_11 = this[].matchDirs
+    var :local_12 = []
+    =sink(:local_11, :local_12)
 finally:
   =destroy(par)
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -11,36 +11,36 @@ doing shady stuff...
   cmd: '''nim c --gc:arc --expandArc:newTarget --expandArc:delete --expandArc:p1 --expandArc:tt --hint:Performance:off --assertions:off --expandArc:extractConfig --expandArc:mergeShadowScope --expandArc:check $file'''
   nimout: '''--expandArc: newTarget
 
-var :local_3
-var :local_4
-var :local_5
+var :aux_3
+var :aux_4
+var :aux_5
 var splat
 splat = splitFile(path)
 result = (
-  :local_3 = splat.dir
+  :aux_3 = splat.dir
   wasMoved(splat.dir)
-  :local_3,
-  :local_4 = splat.name
+  :aux_3,
+  :aux_4 = splat.name
   wasMoved(splat.name)
-  :local_4,
-  :local_5 = splat.ext
+  :aux_4,
+  :aux_5 = splat.ext
   wasMoved(splat.ext)
-  :local_5)
+  :aux_5)
 =destroy(splat)
 -- end of expandArc ------------------------
 --expandArc: delete
 
 var sibling
-var :local_3 = target[].parent[].left
-=copy(sibling, :local_3)
+var :aux_3 = target[].parent[].left
+=copy(sibling, :aux_3)
 var saved
-var :local_5 = sibling[].right
-=copy(saved, :local_5)
-var :local_6 = sibling[].right
-var :local_7 = saved[].left
-=copy(:local_6, :local_7)
-var :local_8 = sibling[].parent
-=sink(:local_8, saved)
+var :aux_5 = sibling[].right
+=copy(saved, :aux_5)
+var :aux_6 = sibling[].right
+var :aux_7 = saved[].left
+=copy(:aux_6, :aux_7)
+var :aux_8 = sibling[].parent
+=sink(:aux_8, saved)
 =destroy(sibling)
 -- end of expandArc ------------------------
 --expandArc: p1
@@ -49,38 +49,38 @@ var lresult
 lresult = @([123])
 var lvalue
 var lnext
-var :local_4
-:local_4 = (lresult, ";")
-lvalue = :local_4[0]
-wasMoved(:local_4[0])
-lnext = :local_4[1]
-wasMoved(:local_4[1])
+var :aux_4
+:aux_4 = (lresult, ";")
+lvalue = :aux_4[0]
+wasMoved(:aux_4[0])
+lnext = :aux_4[1]
+wasMoved(:aux_4[1])
 result.value = move(lvalue)
-=destroy(:local_4)
+=destroy(:aux_4)
 =destroy_1(lnext)
 =destroy_2(lvalue)
 -- end of expandArc ------------------------
 --expandArc: tt
 
-var :local_5
-var :local_6
+var :aux_5
+var :aux_6
 var a
-var :local_3
+var :aux_3
 try:
   var it_cursor = x
   a = (
-    :local_5 = default()
-    =copy(:local_5, it_cursor.key)
-    :local_5,
-    :local_6 = default()
-    =copy(:local_6, it_cursor.val)
-    :local_6)
+    :aux_5 = default()
+    =copy(:aux_5, it_cursor.key)
+    :aux_5,
+    :aux_6 = default()
+    =copy(:aux_6, it_cursor.val)
+    :aux_6)
   echo([
-    var :local_7 = $(a)
-    :local_3 = :local_7
-    :local_3])
+    var :aux_7 = $(a)
+    :aux_3 = :aux_7
+    :aux_3])
 finally:
-  =destroy(:local_3)
+  =destroy(:aux_3)
   =destroy_1(a)
 -- end of expandArc ------------------------
 --expandArc: extractConfig
@@ -102,8 +102,8 @@ try:
             var line = a_cursor[i]
             splitted = split(line, " ", -1)
             if ==(splitted[0], "opt"):
-              var :local_7 = splitted[1]
-              =copy(lan_ip, :local_7)
+              var :aux_7 = splitted[1]
+              =copy(lan_ip, :aux_7)
             echo([lan_ip])
             echo([splitted[1]])
           finally:
@@ -115,8 +115,8 @@ finally:
 
 var shadowScope
 try:
-  var :local_3 = c[].currentScope
-  =copy(shadowScope, :local_3)
+  var :aux_3 = c[].currentScope
+  =copy(shadowScope, :aux_3)
   rawCloseScope(c)
   block label:
     var a_cursor = shadowScope[].symbols
@@ -127,13 +127,13 @@ try:
         if not(<(i, L)):
           break
         block label_2:
-          var :local_9
+          var :aux_9
           var sym = a_cursor[i]
           addInterfaceDecl(c,
-            var :local_8 = sym
-            :local_9 = default()
-            =copy_1(:local_9, :local_8)
-            :local_9)
+            var :aux_8 = sym
+            :aux_9 = default()
+            =copy_1(:aux_9, :aux_8)
+            :aux_9)
         inc(i, 1)
 finally:
   =destroy(shadowScope)
@@ -145,35 +145,35 @@ try:
   this[].isValid = fileExists(this[].value)
   block label:
     if dirExists(this[].value):
-      var :local_4
+      var :aux_4
       par = [type node]((
-        var :local_3 = this[].value
-        :local_4 = default()
-        =copy(:local_4, :local_3)
-        :local_4, ""))
+        var :aux_3 = this[].value
+        :aux_4 = default()
+        =copy(:aux_4, :aux_3)
+        :aux_4, ""))
       break label
-    var :local_6
-    var :local_7
-    var :local_8
+    var :aux_6
+    var :aux_7
+    var :aux_8
     par = [type node]((parentDir(this[].value),
-      :local_7 = splitPath(
-        var :local_5 = this[].value
-        :local_6 = default()
-        =copy(:local_6, :local_5)
-        :local_6)
-      :local_8 = :local_7.tail
-      wasMoved(:local_7.tail)
-      :local_8))
-    =destroy(:local_7)
+      :aux_7 = splitPath(
+        var :aux_5 = this[].value
+        :aux_6 = default()
+        =copy(:aux_6, :aux_5)
+        :aux_6)
+      :aux_8 = :aux_7.tail
+      wasMoved(:aux_7.tail)
+      :aux_8))
+    =destroy(:aux_7)
   block label_1:
     if dirExists(par.dir):
-      var :local_9 = this[].matchDirs
-      var :local_10 = getSubDirs(par.dir, par.front)
-      =sink(:local_9, :local_10)
+      var :aux_9 = this[].matchDirs
+      var :aux_10 = getSubDirs(par.dir, par.front)
+      =sink(:aux_9, :aux_10)
       break label_1
-    var :local_11 = this[].matchDirs
-    var :local_12 = []
-    =sink(:local_11, :local_12)
+    var :aux_11 = this[].matchDirs
+    var :aux_12 = []
+    =sink(:aux_11, :aux_12)
 finally:
   =destroy(par)
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -31,28 +31,28 @@ try:
         if not(<(i, b_1)):
           break
         block label_2:
-          var :local_9
+          var :aux_9
           var i_1_cursor = i
           if ==(i_1_cursor, 2):
             return
           add(a,
-            :local_9 = default()
-            =copy(:local_9, x)
-            :local_9)
+            :aux_9 = default()
+            =copy(:aux_9, x)
+            :aux_9)
           inc(i, 1)
   block label_3:
     if cond:
-      var :local_10
+      var :aux_10
       add(a,
-        :local_10 = x
+        :aux_10 = x
         wasMoved(x)
-        :local_10)
+        :aux_10)
       break label_3
-    var :local_11
+    var :aux_11
     add(b,
-      :local_11 = x
+      :aux_11 = x
       wasMoved(x)
-      :local_11)
+      :aux_11)
 finally:
   =destroy(x)
   =destroy_1(b)

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -31,28 +31,28 @@ try:
         if not(<(i, b_1)):
           break
         block label_2:
-          var :tmp
+          var :local_9
           var i_1_cursor = i
           if ==(i_1_cursor, 2):
             return
           add(a,
-            :tmp = default()
-            =copy(:tmp, x)
-            :tmp)
+            :local_9 = default()
+            =copy(:local_9, x)
+            :local_9)
           inc(i, 1)
   block label_3:
     if cond:
-      var :tmp_1
+      var :local_10
       add(a,
-        :tmp_1 = x
+        :local_10 = x
         wasMoved(x)
-        :tmp_1)
+        :local_10)
       break label_3
-    var :tmp_2
+    var :local_11
     add(b,
-      :tmp_2 = x
+      :local_11 = x
       wasMoved(x)
-      :tmp_2)
+      :local_11)
 finally:
   =destroy(x)
   =destroy_1(b)

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -6,66 +6,66 @@ destroying O1'''
   cmd: '''nim c --gc:arc --expandArc:main --expandArc:main1 --expandArc:main2 --expandArc:main3 --hints:off --assertions:off $file'''
   nimout: '''--expandArc: main
 var data
-var :tmp
-var :tmp_1
+var :local_2
+var :local_3
 try:
-  var :tmp_2 = encode(
-      var :tmp_3 = newString(100)
-      :tmp = :tmp_3
-      cast[seq[byte]](:tmp))
-  :tmp_1 = :tmp_2
-  var :tmp_4 = cast[string](:tmp_1)
-  =copy(data, :tmp_4)
+  var :local_5 = encode(
+      var :local_4 = newString(100)
+      :local_2 = :local_4
+      cast[seq[byte]](:local_2))
+  :local_3 = :local_5
+  var :local_6 = cast[string](:local_3)
+  =copy(data, :local_6)
 finally:
-  =destroy(:tmp_1)
-  =destroy_1(:tmp)
+  =destroy(:local_3)
+  =destroy_1(:local_2)
   =destroy_1(data)
 -- end of expandArc ------------------------
 --expandArc: main1
 var s
 var data
-var :tmp
+var :local_3
 try:
   s = newString(100)
-  var :tmp_1 = encode(toOpenArrayByte(s, 0, -(len(s), 1)))
-  :tmp = :tmp_1
-  var :tmp_2 = cast[string](:tmp)
-  =copy(data, :tmp_2)
+  var :local_4 = encode(toOpenArrayByte(s, 0, -(len(s), 1)))
+  :local_3 = :local_4
+  var :local_5 = cast[string](:local_3)
+  =copy(data, :local_5)
 finally:
-  =destroy(:tmp)
+  =destroy(:local_3)
   =destroy_1(data)
   =destroy_1(s)
 -- end of expandArc ------------------------
 --expandArc: main2
 var s
 var data
-var :tmp
+var :local_3
 try:
   s = newSeq(100)
-  var :tmp_1 = encode(s)
-  :tmp = :tmp_1
-  var :tmp_2 = cast[string](:tmp)
-  =copy(data, :tmp_2)
+  var :local_4 = encode(s)
+  :local_3 = :local_4
+  var :local_5 = cast[string](:local_3)
+  =copy(data, :local_5)
 finally:
-  =destroy(:tmp)
+  =destroy(:local_3)
   =destroy_1(data)
   =destroy(s)
 -- end of expandArc ------------------------
 --expandArc: main3
 var data
-var :tmp
-var :tmp_1
+var :local_2
+var :local_3
 try:
-  var :tmp_2 = encode(
-      var :tmp_3 = newSeq(100)
-      :tmp = :tmp_3
-      :tmp)
-  :tmp_1 = :tmp_2
-  var :tmp_4 = cast[string](:tmp_1)
-  =copy(data, :tmp_4)
+  var :local_5 = encode(
+      var :local_4 = newSeq(100)
+      :local_2 = :local_4
+      :local_2)
+  :local_3 = :local_5
+  var :local_6 = cast[string](:local_3)
+  =copy(data, :local_6)
 finally:
-  =destroy(:tmp_1)
-  =destroy(:tmp)
+  =destroy(:local_3)
+  =destroy(:local_2)
   =destroy_1(data)
 -- end of expandArc ------------------------'''
 """

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -6,66 +6,66 @@ destroying O1'''
   cmd: '''nim c --gc:arc --expandArc:main --expandArc:main1 --expandArc:main2 --expandArc:main3 --hints:off --assertions:off $file'''
   nimout: '''--expandArc: main
 var data
-var :local_2
-var :local_3
+var :aux_2
+var :aux_3
 try:
-  var :local_5 = encode(
-      var :local_4 = newString(100)
-      :local_2 = :local_4
-      cast[seq[byte]](:local_2))
-  :local_3 = :local_5
-  var :local_6 = cast[string](:local_3)
-  =copy(data, :local_6)
+  var :aux_5 = encode(
+      var :aux_4 = newString(100)
+      :aux_2 = :aux_4
+      cast[seq[byte]](:aux_2))
+  :aux_3 = :aux_5
+  var :aux_6 = cast[string](:aux_3)
+  =copy(data, :aux_6)
 finally:
-  =destroy(:local_3)
-  =destroy_1(:local_2)
+  =destroy(:aux_3)
+  =destroy_1(:aux_2)
   =destroy_1(data)
 -- end of expandArc ------------------------
 --expandArc: main1
 var s
 var data
-var :local_3
+var :aux_3
 try:
   s = newString(100)
-  var :local_4 = encode(toOpenArrayByte(s, 0, -(len(s), 1)))
-  :local_3 = :local_4
-  var :local_5 = cast[string](:local_3)
-  =copy(data, :local_5)
+  var :aux_4 = encode(toOpenArrayByte(s, 0, -(len(s), 1)))
+  :aux_3 = :aux_4
+  var :aux_5 = cast[string](:aux_3)
+  =copy(data, :aux_5)
 finally:
-  =destroy(:local_3)
+  =destroy(:aux_3)
   =destroy_1(data)
   =destroy_1(s)
 -- end of expandArc ------------------------
 --expandArc: main2
 var s
 var data
-var :local_3
+var :aux_3
 try:
   s = newSeq(100)
-  var :local_4 = encode(s)
-  :local_3 = :local_4
-  var :local_5 = cast[string](:local_3)
-  =copy(data, :local_5)
+  var :aux_4 = encode(s)
+  :aux_3 = :aux_4
+  var :aux_5 = cast[string](:aux_3)
+  =copy(data, :aux_5)
 finally:
-  =destroy(:local_3)
+  =destroy(:aux_3)
   =destroy_1(data)
   =destroy(s)
 -- end of expandArc ------------------------
 --expandArc: main3
 var data
-var :local_2
-var :local_3
+var :aux_2
+var :aux_3
 try:
-  var :local_5 = encode(
-      var :local_4 = newSeq(100)
-      :local_2 = :local_4
-      :local_2)
-  :local_3 = :local_5
-  var :local_6 = cast[string](:local_3)
-  =copy(data, :local_6)
+  var :aux_5 = encode(
+      var :aux_4 = newSeq(100)
+      :aux_2 = :aux_4
+      :aux_2)
+  :aux_3 = :aux_5
+  var :aux_6 = cast[string](:aux_3)
+  =copy(data, :aux_6)
 finally:
-  =destroy(:local_3)
-  =destroy(:local_2)
+  =destroy(:aux_3)
+  =destroy(:aux_2)
   =destroy_1(data)
 -- end of expandArc ------------------------'''
 """


### PR DESCRIPTION
## Summary

Use a dedicated intermediate representation for local `var`/`let`,
parameters, and the result variable in the code generator IR.

This is the first step towards removing all `PSym` usage from the
backend/code-generators. The goal is to further decouple `sem` from the
code generators, making it possible evolve both (especially their IRs)
more independently from each other.

## Details

### General design

* `cgir.Local` stores all relevant information about a local  
* the information about all locals is owned by and stored as part of
  `Body`
* a local is referenced from the `CgNode` IR via the `cnkLocal` node,
  which stores a `LocalId` value
* the result variable and parameters are also treated as locals.
  In most cases, they don't require any extra handling, so them having
  their own data types and node kinds would only complicate things
* for simplicity, for the `Body` of a procedure, the first local slot is
  always reserved for the result variable, even if the procedure has no
  return type. At least for now, this approach makes it easier to
  ad-hoc compute the IDs for parameters from just their position, which
  is still needed in some cases

In terms of data representation, a `Local` stores the type, alignment,
flags (currently still `TSymFlags`), and the name (which may be unset).
Unlike the MIR, no special distinction is made between temporaries and
user-defined locals.

In addition, `Local` also stores whether the corresponding user-defined
local is immutable (the `isImmutable` field). This additional
information is meant to help the code generators optimize: for example, 
the JavaScript code generator doesn't use indirection for `let` locals,
even if they have their address taken.

For extending the data about locals, each code generator uses an
`OrdinalSeq[LocalId, T]` where `T` is a data type tailored to the needs
of the respective code generator. This data-oriented design allows for
easy extension without having to modify the base IR itself.

### Overview of the changes

All places where `cnkSym` nodes were previously handled are adjusted to
also handle `cnkLocal` nodes. This usually means moving the local/
parameter/result specific handling to a new `cnkLocal` branch.

Merging two bodies (`cgir.merge`) also has to take locals into account:
the list with the locals from the source body is appended to that of the
destination body, and the `cnkLocal` node in the merged source body are
updated.

The code generators (`cgen` and `jsgen`) that support incremental code-
generation for procedures need to synchronize their `OrdinalSeq` with
the body's `Store`, after a partial procedure was updated. For this
purpose, the relevant code generators are extended with the `genPartial`
procedure.

### Changes to `CgNode` rendering

* in order to properly render locals, `cgirutils.render` now requires a
  `Body` instead of only a `CgNode`
* the name disambiguation logic is generalized to support disambiguating
  the names of `PSym`- and `Local`-based symbols (through use of the new
  internal `Symbol` type)

In the output, compiler-inserted locals are now rendered as
`:aux_$LocalId` (auxiliary local) instead of `:tmp_$id`. The
`--expandArc`-using tests are adjusted accordingly.

### Initialization of `Local`s

The setup of the `Local` data for a `Body` happens in `cgirgen`:
* locals reach `cgirgen` as `PSym`s, meaning that they need to be
  translated. When appearing in 'def's, the symbol of a local is
  translated to a `Local`, a `LocalId` is allocated, and a mapping
  between the `PSym` and `LocalId` is established (via the `localsMap`)
* for procedures, `generateIR` is responsible for setting up the
  `Local`s representing the result variable and parameters
* special handling is required for `except T as e`, where `T` is an
  imported exception type: these also act as definitions of new locals

Creating or translating temporaries no longer requires creating new
`PSym`s, which also means that there's one less source of `IdGenerator`
interaction in `cgirgen`. The `IdGenerator`s should ideally be sealed at
the end of semantic analysis, and this is a step towardst this goal.

### C code-generator changes

* instead of in a `SymbolMap`, the `TLoc` for locals is stored in
  an `OrdinalSeq`
* the special handling to account for definitions of locals being
  visited multiple times for `.inline` procedures becomes obsolete and
  is removed
* `cnkLocal` nodes cannot appear in construction expressions, and
  they thus don't need special handling in `hashTree`
* testing whether a local location is uninitialized no longer relies on
  `TSym.locId`; inspect the `TLoc.k` value is enough (`locEmpty`
  signals an empty/uninitialized location)
* for detecting parameters, `reifiedOpenArray` now requires access to
  a `BProc` instance
* for detecting parameters, the `mapTypeChooser` template accepting a
  `CgNode` also requires access to a `BProc` instance
* the dispatching based on the specific symbol kind (`skParam`,
  `skTemp`, `skResult`, etc.) becomes obsolete and is removed
* the parameter and result variable setup in `cgen.startProc` is
  adjusted
* the separate handling of parameters when writing NDI files is
  removed; parameters are part of the locals now
* checking for `skTemp` symbols when writing NDI files is also not
  necessary anymore: it is replaced with checking whether the local has
  both a user-provided *and* mangled name.

Name mangling for locals with user-provided names stays the same, but
for locals without user-defined names, an underscore (`_`) plus the
stringified integer value of the `LocalId` is now used. Within a
single procedure, this simple mangling guarantees unique identifiers.

Because parameters cannot easily be distinguished from other locals,
`compat.isLvalue` now always treats them as l-values. This only affects
the code generated (without impacting observable behaviour) for object
up- and down-conversion.

### JS code-generator changes

* the new `Loc` type represents the code-generator's state for a local.
  It is made up of the mangled name and the location's storage
  description
* in order to free up the name, the `locals` field in `TProc` is renamed
  to `defs`
* `Loc` is intended to be eventually used for globals and constants too
* computing the storage mode once (`StorageFlags`) and then storing the
  result in `Loc` is simpler than storing the symbol flags and kind and
  recomputing the storage mode on each query
* `Loc`s for locals are initialized (via `setupLocalLoc`) when a
  *definition* statement is encountered: these are currently 'def' nodes
  and 'except' branches for imported exceptions
* since `storage` relies on this information, a symbol kind has to be
  passed to `setupLocalLoc`
* `genSymAddr` is restructured into the generic `addrLoc`, which works
  with both `Loc` and `PSym`
* the core part of `genSym` is extracted into the generic `accessLoc`,
  which works with both `Loc` and `PSym`
* the interface of `genVarInit` is adjusted to work for both `Loc` and
  `PSym`

Once `Loc` is used for all location in the JS code generator, the
compatibility and adapter routines can be removed.

### VM code-generator changes

* the new `LocalLoc` type represents the code-generator's state for a
  local. The type replaces the symbol-id-to-register table (`locals`)
  and the `addressTaken` set
* parameter setup (`genParams`) becomes simpler: no special handling
  for the result variable and environment parameter is needed anymore
* `genSymAsgn` is split into `genAsgnToLocal` and `genAsgnToGlobal`
* to reduce the amount of required changes, `genSym` and `genSymAddr`
  still support locals for now. This should be cleaned up separately