### PR TITLE
sem: reject illegal `break`/`continue` statements

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1629,11 +1629,8 @@ type
       bitsize*: int
       alignment*: int # for alignment
     of skLabel:
-      context*: int           ## disambiguates the context (e.g., the procedure)
-                              ## the label is part of. If the `context` value
-                              ## of a label differs from that of the current
-                              ## context, the label is not part of the current
-                              ## context
+      context*: int           ## the ID (i.e., index) of the execution context
+                              ## this label is part of
     else: nil
     magic*: TMagic
     typ*: PType

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1629,6 +1629,12 @@ type
       guard*: PSym
       bitsize*: int
       alignment*: int # for alignment
+    of skLabel:
+      context*: int           ## disambiguates the context (e.g., the procedure)
+                              ## the label is part of. If the `context` value
+                              ## of a label differs from that of the current
+                              ## context, the label is not part of the current
+                              ## context
     else: nil
     magic*: TMagic
     typ*: PType

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1009,7 +1009,7 @@ type
                                           # | TODO: these enum values duplicate
                                           # |       `VmGenDiagKind` vmgen enum
     adVmGenTooManyRegistersRequired       # |       defined in the `vmdef`
-    adVmGenCannotFindBreakTarget          # |       module. There should be a
+                                          # |       module. There should be a
     adVmGenNotUnused                      # |       way to cross-reference data
                                           # |       without introducing direct
                                           # |       import or type
@@ -1026,8 +1026,7 @@ type
 
   AstDiagVmGenError* = object
     case kind*: AstDiagVmGenKind:
-      of adVmGenTooManyRegistersRequired,
-          adVmGenCannotFindBreakTarget:
+      of adVmGenTooManyRegistersRequired:
         discard
       of adVmGenNotUnused,
           adVmGenCannotEvaluateAtComptime:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -225,7 +225,6 @@ type
     rvmOpcParseExpectedExpression
     rvmTooManyRegistersRequired
     rvmMissingImportcCompleteStruct
-    rvmCannotFindBreakTarget
     rvmNotUnused
     rvmUserError
     rvmTooLargetOffset

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3003,9 +3003,6 @@ proc reportBody*(conf: ConfigRef, r: VMReport): string =
     else:
       assert false
 
-  of rvmCannotFindBreakTarget:
-    result = "VM problem: cannot find 'break' target"
-
   of rvmNotUnused:
     result = "not unused"
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -398,7 +398,6 @@ func astDiagVmGenToLegacyReportKind*(
   case diag
   of adVmGenMissingImportcCompleteStruct: rvmMissingImportcCompleteStruct
   of adVmGenTooManyRegistersRequired: rvmTooManyRegistersRequired
-  of adVmGenCannotFindBreakTarget: rvmCannotFindBreakTarget
   of adVmGenNotUnused: rvmNotUnused
   of adVmGenTooLargeOffset: rvmTooLargetOffset
   of adVmGenCodeGenUnhandledMagic: rvmCannotGenerateCode

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -529,7 +529,7 @@ proc hasCycle(n: PNode): bool =
 
 proc tryConstExpr(c: PContext, n: PNode): PNode =
   addInNimDebugUtils(c.config, "tryConstExpr", n, result)
-  pushExecCon(c, isStatic=false)
+  pushExecCon(c, {})
   let e = semExprWithType(c, n)
   popExecCon(c)
   if e.isError:
@@ -631,7 +631,7 @@ proc semConstExpr(c: PContext, n: PNode): PNode =
   # TODO: propagate the error upwards instead of reporting it here. Also
   #       remove the error correction -- that should be done at the callsite,
   #       if needed
-  pushExecCon(c, isStatic=false)
+  pushExecCon(c, {})
   let e = semExprWithType(c, n)
   popExecCon(c)
   if e.isError:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -529,9 +529,9 @@ proc hasCycle(n: PNode): bool =
 
 proc tryConstExpr(c: PContext, n: PNode): PNode =
   addInNimDebugUtils(c.config, "tryConstExpr", n, result)
-  pushStaticContext(c)
+  pushWrapperContext(c, isStatic=false)
   let e = semExprWithType(c, n)
-  popStaticContext(c)
+  popWrapperContext(c)
   if e.isError:
     return
 
@@ -631,9 +631,9 @@ proc semConstExpr(c: PContext, n: PNode): PNode =
   # TODO: propagate the error upwards instead of reporting it here. Also
   #       remove the error correction -- that should be done at the callsite,
   #       if needed
-  pushStaticContext(c)
+  pushWrapperContext(c, isStatic=false)
   let e = semExprWithType(c, n)
-  popStaticContext(c)
+  popWrapperContext(c)
   if e.isError:
     localReport(c.config, e)
     return n

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -529,9 +529,9 @@ proc hasCycle(n: PNode): bool =
 
 proc tryConstExpr(c: PContext, n: PNode): PNode =
   addInNimDebugUtils(c.config, "tryConstExpr", n, result)
-  pushWrapperContext(c, isStatic=false)
+  pushExecCon(c, isStatic=false)
   let e = semExprWithType(c, n)
-  popWrapperContext(c)
+  popExecCon(c)
   if e.isError:
     return
 
@@ -631,9 +631,9 @@ proc semConstExpr(c: PContext, n: PNode): PNode =
   # TODO: propagate the error upwards instead of reporting it here. Also
   #       remove the error correction -- that should be done at the callsite,
   #       if needed
-  pushWrapperContext(c, isStatic=false)
+  pushExecCon(c, isStatic=false)
   let e = semExprWithType(c, n)
-  popWrapperContext(c)
+  popExecCon(c)
   if e.isError:
     localReport(c.config, e)
     return n
@@ -905,10 +905,8 @@ proc recoverContext(c: PContext) =
   # requires far less code.
   c.currentScope = c.topLevelScope
   while getCurrOwner(c).kind != skModule: popOwner(c)
-  while c.p != nil and c.p.next != nil: c.p = c.p.next
-  # sanity check: the recovered context needs to be that of the module's top-
-  # level code
-  assert c.p == nil or c.p.owner.kind == skModule
+  while c.p != nil and c.p.owner.kind != skModule: c.p = c.p.next
+  c.executionCons.setLen(1)
 
 proc myProcess(context: PPassContext, n: PNode): PNode {.nosinks.} =
   ## Entry point for the semantic analysis pass, this proc is part of the

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -905,7 +905,10 @@ proc recoverContext(c: PContext) =
   # requires far less code.
   c.currentScope = c.topLevelScope
   while getCurrOwner(c).kind != skModule: popOwner(c)
-  while c.p != nil and c.p.owner.kind != skModule: c.p = c.p.next
+  while c.p != nil and c.p.next != nil: c.p = c.p.next
+  # sanity check: the recovered context needs to be that of the module's top-
+  # level code
+  assert c.p == nil or c.p.owner.kind == skModule
 
 proc myProcess(context: PPassContext, n: PNode): PNode {.nosinks.} =
   ## Entry point for the semantic analysis pass, this proc is part of the

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -529,7 +529,9 @@ proc hasCycle(n: PNode): bool =
 
 proc tryConstExpr(c: PContext, n: PNode): PNode =
   addInNimDebugUtils(c.config, "tryConstExpr", n, result)
+  pushStaticContext(c)
   let e = semExprWithType(c, n)
+  popStaticContext(c)
   if e.isError:
     return
 
@@ -629,8 +631,9 @@ proc semConstExpr(c: PContext, n: PNode): PNode =
   # TODO: propagate the error upwards instead of reporting it here. Also
   #       remove the error correction -- that should be done at the callsite,
   #       if needed
-
+  pushStaticContext(c)
   let e = semExprWithType(c, n)
+  popStaticContext(c)
   if e.isError:
     localReport(c.config, e)
     return n

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -72,6 +72,13 @@ type
     caseContext*: seq[tuple[n: PNode, idx: int]]
     localBindStmts*: seq[PNode]
 
+    context*: int
+      ## provides the value for the ``TSym.context`` field of label symbols.
+      ##
+      ## written:
+      ##  - semdata: when creating a proc context
+      ## read:
+      ##  - semexprs: for setting the context value for label symbols
     inStaticContext*: bool
       ## whether we're in a ``static`` block/expression or in an statement/
       ## expression intended for compile-time evaluation
@@ -745,10 +752,9 @@ proc lastOptionEntry*(c: PContext): POptionEntry =
 
 proc pushProcCon*(c: PContext, owner: PSym) {.inline.} =
   c.config.internalAssert(owner != nil, "owner is nil")
-  var x: PProcCon
-  new(x)
-  x.owner = owner
-  x.next = c.p
+  var x = PProcCon(owner: owner, next: c.p)
+  if c.p != nil:
+    x.context = c.p.context + 1
   c.p = x
 
 proc popProcCon*(c: PContext) {.inline.} = c.p = c.p.next

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1177,9 +1177,9 @@ proc semStaticExpr(c: PContext, n: PNode): PNode =
   ## at compile-time, producing either the AST representation of the resulting
   ## value or an error.
   openScope(c)
-  pushStaticContext(c)
+  pushWrapperContext(c, isStatic=true)
   var a = semExprWithType(c, n)
-  popStaticContext(c)
+  popWrapperContext(c)
   closeScope(c)
   a = foldInAst(c.module, a, c.idgen, c.graph)
   if a.kind == nkError or a.findUnresolvedStatic != nil:

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3244,6 +3244,10 @@ proc semBlock(c: PContext, n: PNode; flags: TExprFlags): PNode =
           elif labl.owner == nil:
             labl.owner = c.p.owner
 
+          # the symbol might be a pre-existing one coming from a template or
+          # macro, meaning that we always have to set the context value here:
+          labl.context = c.p.context
+
           suggestSym(c.graph, lablNode.info, labl, c.graph.usageSym)
           styleCheckDef(c.config, labl)
 

--- a/compiler/sem/semfields.nim
+++ b/compiler/sem/semfields.nim
@@ -141,7 +141,7 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
       let r = typeMismatch(c.config, calli.info, tupleTypeA, tupleTypeB, calli)
       if r.kind == nkError:
         localReport(c.config, r)
-  inc(c.p.nestedLoopCounter)
+  inc(c.execCon.nestedLoopCounter)
   if tupleTypeA.kind == tyTuple:
     var loopBody = n[^1]
     for i in 0..<tupleTypeA.len:
@@ -165,7 +165,7 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
       semForObjectFields(fc, t.n, n, stmts)
       if t[0] == nil: break
       t = skipTypes(t[0], skipPtrs)
-  dec(c.p.nestedLoopCounter)
+  dec(c.execCon.nestedLoopCounter)
   # for TR macros this 'while true: ...; break' loop is pretty bad, so
   # we avoid it now if we can:
   if containsNode(stmts, {nkBreakStmt}):

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -95,9 +95,9 @@ proc branchVals(c: PContext, caseNode: PNode, caseIdx: int,
         result.excl(val)
 
 proc findUsefulCaseContext(c: PContext, discrimator: PNode): (PNode, int) =
-  for i in countdown(c.p.caseContext.high, 0):
+  for i in countdown(c.execCon.caseContext.high, 0):
     let
-      (caseNode, index) = c.p.caseContext[i]
+      (caseNode, index) = c.execCon.caseContext[i]
       skipped = caseNode[0].skipHidden
     if skipped.kind == nkSym and skipped.sym == discrimator.sym:
       return (caseNode, index)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1056,7 +1056,7 @@ proc semNormalizedConst(c: PContext, n: PNode): PNode =
       block:
         # don't evaluate here since the type compatibility check below may add
         # a converter
-        pushExecCon(c, isStatic=true)
+        pushExecCon(c, {ecfStatic})
         let temp = semExprWithType(c, defInitPart)
         popExecCon(c)
 
@@ -3253,7 +3253,7 @@ proc semStaticStmt(c: PContext, n: PNode): PNode =
   #echo "semStaticStmt"
   #writeStackTrace()
   openScope(c)
-  pushExecCon(c, isStatic=true)
+  pushExecCon(c, {ecfStatic, ecfExplicit})
   var a = semStmt(c, n[0], {})
   popExecCon(c)
   closeScope(c)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -39,7 +39,8 @@ proc semBreakStmt(c: PContext, n: PNode): ElaborateAst =
       result[0] = s.ast
     of skLabel:
       # make sure the label is okay to use:
-      if s.kind == skLabel and s.owner.id == c.p.owner.id:
+      if s.kind == skLabel and s.context == c.p.context and
+         s.owner.id == c.p.owner.id:
         incl(s.flags, sfUsed)
         suggestSym(c.graph, n.info, s, c.graph.usageSym)
       else:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1056,9 +1056,9 @@ proc semNormalizedConst(c: PContext, n: PNode): PNode =
       block:
         # don't evaluate here since the type compatibility check below may add
         # a converter
-        pushStaticContext(c)
+        pushWrapperContext(c, isStatic=true)
         let temp = semExprWithType(c, defInitPart)
-        popStaticContext(c)
+        popWrapperContext(c)
 
         case temp.kind
         of nkSymChoices:
@@ -3253,9 +3253,9 @@ proc semStaticStmt(c: PContext, n: PNode): PNode =
   #echo "semStaticStmt"
   #writeStackTrace()
   openScope(c)
-  pushStaticContext(c)
+  pushWrapperContext(c, isStatic=true)
   var a = semStmt(c, n[0], {})
-  popStaticContext(c)
+  popWrapperContext(c)
   closeScope(c)
   a = foldInAst(c.module, a, c.idgen, c.graph)
   result = shallowCopy(n)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1648,7 +1648,7 @@ proc semStmtListType(c: PContext, n: PNode, prev: PType): PType =
     result = nil
 
 proc semBlockType(c: PContext, n: PNode, prev: PType): PType =
-  inc(c.p.nestedBlockCounter)
+  inc(c.execCon.nestedBlockCounter)
   checkSonsLen(n, 2, c.config)
   openScope(c)
   if n[0].kind notin {nkEmpty, nkSym}:
@@ -1657,7 +1657,7 @@ proc semBlockType(c: PContext, n: PNode, prev: PType): PType =
   n[1].typ = result
   n.typ = result
   closeScope(c)
-  dec(c.p.nestedBlockCounter)
+  dec(c.execCon.nestedBlockCounter)
 
 proc semGenericParamInInvocation(c: PContext, n: PNode): PType =
   result = semTypeNode(c, n, nil)

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -523,7 +523,6 @@ type
   VmGenDiagKind* = enum
     # has no extra data
     vmGenDiagTooManyRegistersRequired
-    vmGenDiagCannotFindBreakTarget
     # has ast data
     vmGenDiagNotUnused
     vmGenDiagCannotEvaluateAtComptime
@@ -574,8 +573,7 @@ type
       of vmGenDiagNotUnused,
           vmGenDiagCannotEvaluateAtComptime:
         ast*: PNode
-      of vmGenDiagTooManyRegistersRequired,
-          vmGenDiagCannotFindBreakTarget:
+      of vmGenDiagTooManyRegistersRequired:
         discard
 
   VmEventKind* = enum

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -678,7 +678,8 @@ proc genBreak(c: var TCtx; n: CgNode) =
       if c.prc.blocks[i].label == n[0].sym:
         c.prc.blocks[i].fixups.add lab1
         return
-    fail(n.info, vmGenDiagCannotFindBreakTarget)
+    # the corresponding block seems to be missing?
+    unreachable("break target is missing")
   else:
     c.prc.blocks[c.prc.blocks.high].fixups.add lab1
 
@@ -3299,7 +3300,6 @@ func vmGenDiagToAstDiagVmGenError*(diag: VmGenDiag): AstDiagVmGenError {.inline.
   let kind =
     case diag.kind
     of vmGenDiagTooManyRegistersRequired: adVmGenTooManyRegistersRequired
-    of vmGenDiagCannotFindBreakTarget: adVmGenCannotFindBreakTarget
     of vmGenDiagNotUnused: adVmGenNotUnused
     of vmGenDiagCannotEvaluateAtComptime: adVmGenCannotEvaluateAtComptime
     of vmGenDiagMissingImportcCompleteStruct: adVmGenMissingImportcCompleteStruct
@@ -3333,6 +3333,5 @@ func vmGenDiagToAstDiagVmGenError*(diag: VmGenDiag): AstDiagVmGenError {.inline.
         AstDiagVmGenError(
           kind: kind,
           ast: diag.ast)
-      of vmGenDiagTooManyRegistersRequired,
-          vmGenDiagCannotFindBreakTarget:
+      of vmGenDiagTooManyRegistersRequired:
         AstDiagVmGenError(kind: kind)

--- a/compiler/vm/vmlegacy.nim
+++ b/compiler/vm/vmlegacy.nim
@@ -21,7 +21,6 @@ func vmGenDiagToLegacyReportKind(diag: VmGenDiagKind): ReportKind {.inline.} =
   case diag
   of vmGenDiagMissingImportcCompleteStruct: rvmMissingImportcCompleteStruct
   of vmGenDiagTooManyRegistersRequired: rvmTooManyRegistersRequired
-  of vmGenDiagCannotFindBreakTarget: rvmCannotFindBreakTarget
   of vmGenDiagNotUnused: rvmNotUnused
   of vmGenDiagTooLargeOffset: rvmTooLargetOffset
   of vmGenDiagCodeGenUnhandledMagic: rvmCannotGenerateCode

--- a/tests/lang_exprs/compiles/tcompiles_context.nim
+++ b/tests/lang_exprs/compiles/tcompiles_context.nim
@@ -1,0 +1,43 @@
+discard """
+  description: '''
+    Ensure that the code passed to a ``compiles`` is compiled as if appearing
+    within the nearest explicit execution context
+  '''
+"""
+
+# the ``break`` statement passed to the ``compiles`` procedure is
+# wrapped in an ``if true:``, otherwise the code would not be
+# syntactically valid
+
+proc f(x: static bool): bool =
+  x
+
+# ``when`` condition
+block label:
+  # the ``when`` condition opens a new context, but it's implicit
+  when compiles(if true: break label):
+    discard "all fine"
+  else:
+    {.error: "`compiles` failed".}
+
+# ``compiles`` within nested implicit contexts
+block label:
+  # each initializer expression happens within a new context, but they're
+  # implicit
+  const a = (const b = compiles(if true: break label); b)
+  doAssert a
+
+# ``compiles`` within implicit contexts created for arguments
+block label:
+  # the separate context the argument expression is anaylzed within
+  # is *implicit*, so the ``break label`` statement is analyzed as if
+  # within the context the ``block label`` is also part of
+  doAssert f(compiles(if true: break label))
+
+block label:
+  static:
+    # a ``static`` block opens an *explicit* context
+    doAssert not compiles(if true: break label)
+
+  # a coercion to ``static`` also opens an *explicit* context
+  doAssert static(not compiles(if true: break label))

--- a/tests/lang_stmts/controlflow/tinvalid_control_flow.nim
+++ b/tests/lang_stmts/controlflow/tinvalid_control_flow.nim
@@ -1,0 +1,67 @@
+discard """
+  action: reject
+  cmd: "nim check $options --hints:off $file"
+  description: '''
+    Test detection of invalid control-flow across the compile-/run-time
+    boundary
+  '''
+"""
+
+# control flow across the compile-/run-time boundary cannot work, and is thus
+# disallowed
+
+block unlabeled_break:
+  while true:
+    # initializer of constant:
+    const c = (if true: break; 1) #[tt.Error
+                        ^ invalid control flow: break]#
+    # static expression:
+    var a = static(if true: break; 1) #[tt.Error
+                            ^ invalid control flow: break]#
+    # static statement:
+    static:
+      break #[tt.Error
+      ^ invalid control flow: break]#
+
+block labeled_break:
+  # initializer of constant:
+  const c = ((if true: break labeled_break); 1) #[tt.Error
+                       ^ invalid control flow: labeled_break]#
+  # static expression:
+  var a = static(if true: break labeled_break; 1) #[tt.Error
+                          ^ invalid control flow: labeled_break]#
+  # static statement:
+  static:
+    break labeled_break #[tt.Error
+    ^ invalid control flow: labeled_break]#
+
+block continue_statement:
+  while true:
+    # initializer of constant:
+    const c = (if true: continue; 1) #[tt.Error
+                        ^ invalid control flow: continue]#
+    # static expression:
+    var a = static(if true: continue; 1) #[tt.Error
+                            ^ invalid control flow: continue]#
+    # static statement:
+    static:
+      continue #[tt.Error
+      ^ invalid control flow: continue]#
+
+# a static expression/statement or constant expression nested inside another
+# compile-time context happens at a different phase/stage, meaning that
+# control-flow crossing from one into the other is also invalid
+
+block break_across_compile_time_contexts:
+  static:
+    while true:
+      # initializer of constant:
+      const c = (if true: break; 1) #[tt.Error
+                          ^ invalid control flow: break]#
+      # static expression:
+      var a = static(if true: break; 1) #[tt.Error
+                              ^ invalid control flow: break]#
+      # static statement:
+      static:
+        break #[tt.Error
+        ^ invalid control flow: break]#

--- a/tests/lang_stmts/controlflow/tinvalid_control_flow_2.nim
+++ b/tests/lang_stmts/controlflow/tinvalid_control_flow_2.nim
@@ -1,0 +1,42 @@
+
+discard """
+  action: reject
+  cmd: "nim check $options --hints:off $file"
+  description: '''
+    Test detection of invalid control-flow across the compile-/run-time
+    boundary
+  '''
+  knownIssue: '''
+    yield and return crossing the compile-/run-time boundary are not
+    rejected
+  '''
+"""
+
+# XXX: integrate these test cases into ``tinvalid_control_flow.nim`` once they
+#      start working
+
+block return_statement:
+  proc p() =
+    # initializer of constant:
+    const c = (if true: return; 1) #[tt.Error
+                        ^ 'return' not allowed here]#
+    # static expression:
+    var a = static(if true: return; 1) #[tt.Error
+                            ^ 'return' not allowed here]#
+    # static statement:
+    static:
+      return #[tt.Error
+      ^ 'return' not allowed here]#
+
+block yield_statement:
+  iterator p(): int =
+    # initializer of constant:
+    const c = (if true: yield 1; 1) #[tt.Error
+                        ^ 'yield' only allowed in an iterator]#
+    # static expression:
+    var a = static(if true: yield 1; 1) #[tt.Error
+                            ^ 'yield' only allowed in an iterator]#
+    # static statement:
+    static:
+      return #[tt.Error
+      ^ 'yield' only allowed in an iterator]#


### PR DESCRIPTION
## Summary

Detect and report errors for `break` and `continue` statements where the
resulting control-flow would cross from compile-time into run-time
contexts or from one compile-time context into another.

**Breaking changes**:
- a `compiles` cannot be used within a `static` block/expression to
  detect whether a `break`/`continue` is valid outside of the block/
  expression

**Fixes:**
- the compiler crashing for illegal `continue` statements
- the compiler crashing for illegal labeled `break` statements

`return` and `yield` statements within static contexts are still not
rejected properly.

## Details

For checking whether an unlabeled `break` or `continue` statement is
valid, there are two counters in `TProcCon` that track whether analysis
happens inside a `block` or loop.

Since semantic analysis for expressions/statements intended for compile-
time execution happens with the same `TProcCon` as the rest of the
enclosing routine, `break` and `continue` statements where the target is
outside of the compile-time context are not rejected. Target-less
`nkContinueStmt` nodes then cause a crash when reaching `transf`, while
target-less unlabeled `nkBreakStmt` nodes are detected by `vmgen`, which
then raises a code generation error.

### Introduce `ExecutionCon`

Whether analysis currently happens within a loop or block is a property
of the *execution context*, which is something that is currently
represented by a `TProcCon`.

Since not only modules and routine definitions can start an execution
context, it makes sense to separate execution-context-related state from
`TProcCon`. The properties describing an *execution context* are moved
into the new type  `ExecutionCon` (the same nomenclature as for
`TProcCon` is used), which is stored in a separate stack
(`executionCons`) within `PContext`.

The moved properties include the loop counter (`nestedLoopCounter`),
block counter (`nestedBlockCounter`), case context stack
(`caseContext`), and static-context counter (`inStaticContext`). Since
an execution context is either static or not, `inStaticContext` is
turned into a flag (`ExecutionConFlag`).

There are other properties, such as `resultSym`, for which it could make
sense to make them part of the `ExecutionCon`, but this is left to future
work.

Same as with other stacks, the `ExecutionCon` stack also needs to be
saved/restored in `tryExpr`.

### Using `ExecutionCon`

To keep the previous behaviour of both modules and routine definitions
starting a new execution context, pushing and popping a `TProcCon`
(`pushProcCon`/`popProcCon`) also pushes or pops an `ExecutionCon`. 

In addition, a new execution is also pushed whenever a new compile-time
context starts:
- `semStaticStmt`; a `static: stmt` block statement
- `semStaticExpr`; a `static(expr)` expression
- `semNormalizedConst`; for a `const`'s initializer expression
- `semConstExpr`/`tryConstExpr`; all implicit constant expression,
  such as `when` conditions, `array`-type index expressions, etc. 

After the compile-time expression/statement is analyzed, the execution
context is popped from the stack again.

The context is created as a static context (`ecfStatic`) where the
`inStaticContext` counter was previously implemented. Using `ecfStatic`
in `semConstExpr` and `tryConstExpr` would make sense too, but that'd be
a more far-reaching change.

### Implicit vs. explicit contexts

A distinction is made between implicit and explicit contexts. The idea
here is that it should still be possible to use a `when compiles(...)`
for checking whether a statement/expression is valid in the surrounding
context; since a new execution is now started for constant expression
(the `when` condition), `break` or `continue` statements part of the
tested statement/expression would be treated as illegal.

Explicit execution contexts are opened where this is immediately
visible in the code:
- modules and non-template routine definitions
- `static` blocks
- coercions to compile-time evaluation (e.g., `static(...)`)

All other execution contexts are implicit.

A new rule is added to `compiles`: the AST is analyzed as if it were
part of the nearest enclosing explicit context. This keeps much of the
previous semantics intact.

For the implementation, `semCompiles` pops all `ExecutionCon` items
representing implicit contexts from the stack until the active execution
context is an explicit one. Once the `compiles` is done, the stack is
restored.

### Detecting illegal `break`/`continue`

`continue` and unlabeled `break` statements within compile-time context
and without a corresponding target are automatically detected by way of
each `ExecutionCon` having its own set of loop/block counter values.

However, checking whether a labeled `break`s is valid only takes into
account the owner of the label symbol: if it's the same as the owner of
the current `TProcCon`, the `break` is valid, otherwise it's not. Since
two executions context can be part of the same procedure definition,
labeled breaks crossing from one into aren't detected.

To be able to detect labeled `break` crossing execution contexts, an
`skLabel` symbol now stores a context ID, which is an index into the
`executionCons` stack.

On definition of a label, the label's context ID is set to the index of
the active `ExecutionCon`. When checking whether a labeled `break` is
valid, the label's context ID is compared to the active `ExecutionCon`
index: if both are the same, the `break` is valid, otherwise it's not.

### Cleanup

Since all invalid 'break' statements are rejected in sem and don't reach
`vmgen`, the `vmGenDiagCannotFindBreakTarget` error,
`adVmGenCannotFindBreakTarget` diagnostic, and
`rsemCannotFindBreakTarget` report are all obsolete and thus removed.