### PR TITLE
transf: lower all unlabeled `break` statements

### DIFF
--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -142,7 +142,6 @@ type
     label*: Rope              ## generated text for the label
                               ## nil if label is not used
     sections*: TCProcSections ## the code belonging
-    isLoop*: bool             ## whether block is a loop
     nestedTryStmts*: int16    ## how many try statements is it nested into
     nestedExceptStmts*: int16 ## how many except statements is it nested into
     frameLen*: int16
@@ -166,8 +165,6 @@ type
                               ## bool is true when are in the except part of a try block
     labels*: Natural          ## for generating unique labels in the C proc
     blocks*: seq[TBlock]      ## nested blocks
-    breakIdx*: int            ## the block that will be exited
-                              ## with a regular break
     options*: TOptions        ## options that should be used for code
                               ## generation; this is the same as prc.options
                               ## unless prc == nil

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -104,7 +104,7 @@ type
 
     tempMap: SeqMap[TempId, PSym]
       ## maps a ``TempId`` to ``PSym`` created for it
-    labelMap: SeqMap[uint32, PSym]
+    labelMap: SeqMap[LabelId, PSym]
       ## maps a block-label name to the ``PSym`` created for it
 
     params: Values
@@ -878,7 +878,7 @@ proc tbSingleStmt(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
   of mnkBlock:
     let sym = newSym(skLabel, cl.cache.getIdent("label"), cl.idgen.nextSymId(),
                      cl.owner, info)
-    cl.labelMap[n.label[]] = sym
+    cl.labelMap[n.label] = sym
 
     result = newStmt(cnkBlockStmt, info,
                      newSymNode(sym), # the label
@@ -915,11 +915,7 @@ proc tbSingleStmt(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
 
     leave(tree, cr)
   of mnkBreak:
-    let label =
-      if n.label.isSome: newSymNode(cl.labelMap[n.label[]])
-      else:              newEmpty()
-
-    result = newStmt(cnkBreakStmt, info, [label])
+    result = newStmt(cnkBreakStmt, info, [newSymNode(cl.labelMap[n.label])])
   of mnkReturn:
     result = newNode(cnkReturnStmt, info)
   of mnkPNode:

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -248,11 +248,8 @@ proc render(c: var RenderCtx, ind: int, n: CgNode, res: var string) =
     res.add "discard "
     res.add n[0]
   of cnkBreakStmt:
-    if n[0].kind == cnkEmpty:
-      res.add "break"
-    else:
-      res.add "break "
-      res.add n[0]
+    res.add "break "
+    res.add n[0]
   of cnkRaiseStmt:
     if n[0].kind == cnkEmpty:
       res.add "raise"

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -271,7 +271,7 @@ func nextTempId(c: var TCtx): TempId =
   inc c.numTemps
 
 func nextLabel(c: var TCtx): LabelId =
-  result = LabelId(c.numLabels + 1)
+  result = LabelId(c.numLabels)
   inc c.numLabels
 
 # ----------- CodeFragment API -------------
@@ -1676,20 +1676,15 @@ proc gen(c: var TCtx, n: PNode) =
     gen(c, n.lastSon)
   of nkBreakStmt:
     var id: LabelId
-    case n[0].kind
-    of nkSym:
+    block search:
       let sym = n[0].sym
       # find the block with the matching label and use its ``LabelId``:
       for b in c.blocks.items:
         if b.label.id == sym.id:
           id = b.id
-          break
+          break search
 
-      assert id.isSome, "break target missing"
-    of nkEmpty:
-      id = NoLabel
-    else:
-      unreachable()
+      unreachable "break target missing"
 
     c.stmts.add MirNode(kind: mnkBreak, label: id)
   of nkVarSection, nkLetSection:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1238,7 +1238,7 @@ proc genVarSection(c: var TCtx, n: PNode) =
 
 proc genWhile(c: var TCtx, n: PNode) =
   ## Generates the code for a ``nkWhile`` node.
-  assert isTrue(n[0]), "`n` wasn't properly stransformed"
+  assert isTrue(n[0]), "`n` wasn't properly transformed"
   c.stmts.subTree MirNode(kind: mnkRepeat):
     scope(c.stmts):
       c.gen(n[1])

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1240,26 +1240,11 @@ proc genVarSection(c: var TCtx, n: PNode) =
 
 
 proc genWhile(c: var TCtx, n: PNode) =
-  ## Generates the code for a ``nkWhile`` node. Because no conditional loops
-  ## exist in the MIR, the the condition is translated to a ``break`` statement
-  ## inside an ``if``
-  c.stmts.add MirNode(kind: mnkRepeat)
-
-  scope(c.stmts):
-    # don't emit a branch for ``while true: ...``
-    if not isTrue(n[0]):
-      forward(c): genx(c, n[0]) => notOp(c) # condition
-      c.stmts.subTree MirNode(kind: mnkIf):
-        c.stmts.add MirNode(kind: mnkBreak)
-
-    # use a nested scope for the body. This is important for scope finalizers,
-    # as exiting the loop via the ``break`` emitted above (i.e. the loop
-    # condition is false) must not run the finalizers (if present) for the
-    # loop's body
+  ## Generates the code for a ``nkWhile`` node.
+  assert isTrue(n[0]), "`n` wasn't properly stransformed"
+  c.stmts.subTree MirNode(kind: mnkRepeat):
     scope(c.stmts):
       c.gen(n[1])
-
-  c.stmts.add endNode(mnkRepeat)
 
 proc genBlock(c: var TCtx, n: PNode, dest: Destination) =
   ## Generates and emits the MIR code for a ``block`` expression or statement

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -44,8 +44,7 @@ type
     ## is that temporaries are allowed to be elided (by an optimization pass,
     ## for example) if it's deemed to have no effect on the codes' semantics
   LabelId* = distinct uint32
-    ## ID of a label, used to identify a block (``mnkBlock``). The default
-    ## value is empty state and means "absence of label"
+    ## ID of a label, used to identify a block (``mnkBlock``).
 
   MirNodeKind* = enum
     ## Users of ``MirNodeKind`` should not depend on the absolute or relative
@@ -224,11 +223,8 @@ type
               ## Once control-flow reaches the end of a ``block``, it is
               ## transferred to the next statement/operation following the
               ## block
-    mnkBreak  ## if a non-nil label is provided, transfers control-flow to the
-              ## statement/operation following after the ``block`` with the
-              ## given label. If no label is provided, control-flow is
-              ## transferred to the exit of the enclosing ``repeat`` (it is
-              ## required that there exists one)
+    mnkBreak  ## transfers control-flow to the statement/operation following
+              ## after the ``block`` with the given label
     mnkReturn ## if the code-fragment represents the body of a procedure,
               ## transfers control-flow back to the caller
 
@@ -289,11 +285,8 @@ type
     of mnkOpParam:
       param*: uint32 ## the 0-based index of the enclosing region's parameter
     of mnkBlock, mnkBreak:
-      label*: LabelId ## for a block, its label. A block always must always
-                      ## have a valid label ('none' is disallowed).
-                      ## for a break, the label of the block to break out of.
-                      ## May be 'none', in which case it means "exit the
-                      ## enclosing 'repeat'"
+      label*: LabelId ## for a block, the label that identifies the block;
+                      ## for a break, the label of the block to break out of
     of mnkEnd:
       start*: MirNodeKind ## the kind of the corresponding start node
     of mnkPNode:
@@ -375,20 +368,8 @@ const
   SymbolLike* = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal}
     ## Nodes for which the `sym` field is available
 
-  NoLabel* = LabelId(0)
-
 func `==`*(a, b: TempId): bool {.borrow.}
 func `==`*(a, b: LabelId): bool {.borrow.}
-
-func isSome*(x: LabelId): bool {.inline.} =
-  x.uint32 != 0
-
-func isNone*(x: LabelId): bool {.inline.} =
-  x.uint32 == 0
-
-template `[]`*(x: LabelId): uint32 =
-  assert x.uint32 != 0
-  uint32(x) - 1
 
 # make ``NodeInstance`` available to be used with ``OptIndex``:
 template indexLike*(_: typedesc[NodeInstance]) = discard

--- a/compiler/sem/closureiters.nim
+++ b/compiler/sem/closureiters.nim
@@ -27,13 +27,12 @@ Should be transformed to:
 .. code-block:: nim
 
     STATE0:
-      if a > 0:
-        echo "hi"
-        :state = 1 # Next state
-        return a # yield
-      else:
+      if not (a > 0):
         :state = 2 # Next state
         break :stateLoop # Proceed to the next state
+      echo "hi"
+      :state = 1 # Next state
+      return a # yield
     STATE1:
       dec a
       :state = 0 # Next state
@@ -156,7 +155,8 @@ import
     ast,
     idents,
     renderer,
-    lineinfos
+    lineinfos,
+    trees
   ],
   compiler/modules/[
     magicsys,
@@ -169,6 +169,9 @@ import
   compiler/sem/[
     lowerings,
     lambdalifting
+  ],
+  compiler/utils/[
+    idioms,
   ]
 
 type
@@ -180,7 +183,6 @@ type
     curExcSym: PSym # Current exception
 
     states: seq[tuple[label: int, body: PNode]] # The resulting states
-    blockLevel: int # Temp used to transform break and continue stmts
     stateLoopLabel: PSym # Label to break on, when jumping between states.
     exitStateIdx: int # index of the last state
     tempVarId: int # unique name counter
@@ -281,41 +283,15 @@ proc hasYields(n: PNode): bool =
         result = true
         break
 
-proc transformBreaksAndContinuesInWhile(ctx: var Ctx, n: PNode, before, after: PNode): PNode =
-  result = n
-  case n.kind
-  of nkSkip:
-    discard
-  of nkWhileStmt: discard # Do not recurse into nested whiles
-  of nkContinueStmt:
-    result = before
-  of nkBlockStmt:
-    inc ctx.blockLevel
-    result[1] = ctx.transformBreaksAndContinuesInWhile(result[1], before, after)
-    dec ctx.blockLevel
-  of nkBreakStmt:
-    if ctx.blockLevel == 0:
-      result = after
-  else:
-    for i in 0..<n.len:
-      n[i] = ctx.transformBreaksAndContinuesInWhile(n[i], before, after)
-
 proc transformBreaksInBlock(ctx: var Ctx, n: PNode, label, after: PNode): PNode =
   result = n
   case n.kind
   of nkSkip:
     discard
-  of nkBlockStmt, nkWhileStmt:
-    inc ctx.blockLevel
-    result[1] = ctx.transformBreaksInBlock(result[1], label, after)
-    dec ctx.blockLevel
   of nkBreakStmt:
-    if n[0].kind == nkEmpty:
-      if ctx.blockLevel == 0:
-        result = after
-    else:
-      if label.kind == nkSym and n[0].sym == label.sym:
-        result = after
+    assert n[0].kind == nkSym
+    if label.kind == nkSym and n[0].sym == label.sym:
+      result = after
   else:
     for i in 0..<n.len:
       n[i] = ctx.transformBreaksInBlock(n[i], label, after)
@@ -766,23 +742,9 @@ proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
       result.add(n)
 
   of nkWhileStmt:
-    var condNeedsSplit = false
-    n[0] = ctx.lowerStmtListExprs(n[0], condNeedsSplit)
+    assert isTrue(n[0])
     var bodyNeedsSplit = false
     n[1] = ctx.lowerStmtListExprs(n[1], bodyNeedsSplit)
-
-    if condNeedsSplit or bodyNeedsSplit:
-      needsSplit = true
-
-      if condNeedsSplit:
-        let (st, ex) = exprToStmtList(n[0])
-        let brk = newTree(nkBreakStmt, ctx.g.emptyNode)
-        let branch = newTree(nkElifBranch, ctx.g.newNotCall(ex), brk)
-        let check = newTree(nkIfStmt, branch)
-        let newBody = newTree(nkStmtList, st, check, n[1])
-
-        n[0] = boolLit(ctx, n[0].info, true)
-        n[1] = newBody
 
   of nkDotExpr, nkCheckedFieldExpr:
     var ns = false
@@ -916,33 +878,21 @@ proc transformClosureIteratorBody(ctx: var Ctx, n: PNode, gotoOut: PNode): PNode
       n.add(elseBranch)
 
   of nkWhileStmt:
-    # while e:
+    # while true:
     #   s
     # ->
     # BEGIN_STATE:
-    #   if e:
-    #     s
-    #     goto BEGIN_STATE
-    #   else:
-    #     goto OUT
-
+    #   s
+    #   goto BEGIN_STATE
+    assert isTrue(n[0])
     result = newNodeI(nkGotoState, n.info)
 
     let s = newNodeI(nkStmtList, n.info)
     discard ctx.newState(s, result)
 
     var body = addGotoOut(n[1], result)
-
-    body = ctx.transformBreaksAndContinuesInWhile(body, result, gotoOut)
     body = ctx.transformClosureIteratorBody(body, result)
-
-    let elifBranch = newTreeI(nkElifBranch, n.info):
-      [n[0], body]
-    let elseBranch = newTreeI(nkElse, n.info):
-      gotoOut
-    let ifNode = newTreeI(nkIfStmt, n.info):
-      [elifBranch, elseBranch]
-    s.add(ifNode)
+    s.add(body)
 
   of nkBlockStmt:
     result[1] = addGotoOut(result[1], gotoOut)
@@ -1355,27 +1305,26 @@ proc preprocess(c: var PreprocessContext; n: PNode): PNode =
     if f.kind == nkFinally:
       discard c.finallys.pop()
 
-  of nkWhileStmt, nkBlockStmt:
+  of nkBlockStmt:
     c.blocks.add((n, c.finallys.len))
     for i in 0 ..< n.len:
       result[i] = preprocess(c, n[i])
     discard c.blocks.pop()
 
   of nkBreakStmt:
-    if c.blocks.len == 0:
-      discard
-    else:
+    assert c.blocks.len > 0
+    if true:
       var fin = -1
-      if n[0].kind == nkEmpty:
-        fin = c.blocks[^1][1]
-      elif n[0].kind == nkSym:
+      block search:
         for i in countdown(c.blocks.high, 0):
-          if c.blocks[i][0].kind == nkBlockStmt and c.blocks[i][0][0].kind == nkSym and
+          if c.blocks[i][0][0].kind == nkSym and
               c.blocks[i][0][0].sym == n[0].sym:
             fin = c.blocks[i][1]
-            break
+            break search
 
-      if fin >= 0:
+        unreachable("missing break target")
+
+      if true:
         result = newNodeI(nkStmtList, n.info)
         for i in countdown(c.finallys.high, fin):
           var vars = FreshVarsContext(tab: initTable[int, PSym](), config: c.config, info: n.info, idgen: c.idgen)

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -848,7 +848,8 @@ proc ensureEnvParam*(graph: ModuleGraph, idgen: IdGenerator, prc: PSym) =
 
 # ------------------- iterator transformation --------------------------------
 
-proc liftForLoop*(g: ModuleGraph; body: PNode; idgen: IdGenerator; owner: PSym): PNode =
+proc liftForLoop*(g: ModuleGraph; body: PNode; idgen: IdGenerator;
+                  owner, breakLabel: PSym): PNode =
   # problem ahead: the iterator could be invoked indirectly, but then
   # we don't know what environment to create here:
   #
@@ -935,8 +936,7 @@ proc liftForLoop*(g: ModuleGraph; body: PNode; idgen: IdGenerator; owner: PSym):
   let elifBranch = newNodeI(nkElifBranch, body.info)
   elifBranch.add(bs)
 
-  let br = newNodeI(nkBreakStmt, body.info)
-  br.add(g.emptyNode)
+  let br = newTreeI(nkBreakStmt, body.info, newSymNode(breakLabel, body.info))
 
   elifBranch.add(br)
   ibs.add(elifBranch)

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -305,15 +305,10 @@ func computeCfg*(tree: MirTree): ControlFlowGraph =
 
     of mnkBreak:
       let label = n.label
-      var target: NodePosition
-      if label.isNone:
-        # unnamed break - exit the enclosing loop
-        target = findParent(tree, i, mnkRepeat)
-      else:
-        # goto the exit of the block with the matching label
-        target = findParent(tree, i, mnkBlock)
-        while tree[target].label != label:
-          target = findParent(tree, target-1, mnkBlock)
+      # goto the exit of the block with the matching label
+      var target = findParent(tree, i, mnkBlock)
+      while tree[target].label != label:
+        target = findParent(tree, target-1, mnkBlock)
 
       goto i, findEnd(tree, target)
     of mnkReturn:

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -708,7 +708,8 @@ proc transformFor(c: PTransf, n: PNode): PNode =
     result[1] = n
     result[1][^1] = transformLoopBody(c, n[^1])
     result[1][^2] = transform(c, n[^2])
-    result[1] = lambdalifting.liftForLoop(c.graph, result[1], c.idgen, getCurrOwner(c))
+    result[1] = lambdalifting.liftForLoop(c.graph, result[1], c.idgen,
+                                          getCurrOwner(c), labl)
     discard c.breakSyms.pop
   else:
     var stmtList = newNodeI(nkStmtList, n.info)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -650,9 +650,8 @@ proc genRepeat(c: var TCtx; n: CgNode) =
   #   jmp lab1
   # lab2:
   let lab1 = c.genLabel
-  withBlock(nil):
-    c.gen(n[0])
-    c.jmpBack(n, lab1)
+  c.gen(n[0])
+  c.jmpBack(n, lab1)
 
 proc genBlock(c: var TCtx; n: CgNode) =
   let oldRegisterCount = c.prc.regInfo.len
@@ -672,15 +671,12 @@ proc genBlock(c: var TCtx; n: CgNode) =
 
 proc genBreak(c: var TCtx; n: CgNode) =
   let lab1 = c.xjmp(n, opcJmp)
-  if n[0].kind == cnkSym:
-    #echo cast[int](n[0].sym)
+  block search:
     for i in countdown(c.prc.blocks.len-1, 0):
       if c.prc.blocks[i].label == n[0].sym:
         c.prc.blocks[i].fixups.add lab1
-        return
+        break search
     fail(n.info, vmGenDiagCannotFindBreakTarget)
-  else:
-    c.prc.blocks[c.prc.blocks.high].fixups.add lab1
 
 proc genIf(c: var TCtx, n: CgNode) =
   #  if (!expr1) goto lab1;

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -30,7 +30,7 @@ block label:
       block label_1:
         while true:
           if not(readLine(f, res)):
-            break
+            break label_1
           block label_2:
             var x_cursor = res
             echo([x_cursor])

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -95,7 +95,7 @@ try:
     block label_1:
       while true:
         if not(<(i, L)):
-          break
+          break label_1
         block label_2:
           var splitted
           try:
@@ -125,7 +125,7 @@ try:
     block label_1:
       while true:
         if not(<(i, L)):
-          break
+          break label_1
         block label_2:
           var :tmp_1
           var sym = a_cursor[i]

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -7,17 +7,19 @@ var it_cursor = root
 block label:
   while true:
     if not(not(==(it_cursor, nil))):
-      break
-    echo([it_cursor[].s])
-    it_cursor = it_cursor[].ri
+      break label
+    block label_1:
+      echo([it_cursor[].s])
+      it_cursor = it_cursor[].ri
 var jt_cursor = root
-block label_1:
+block label_2:
   while true:
     if not(not(==(jt_cursor, nil))):
-      break
-    var ri_1_cursor = jt_cursor[].ri
-    echo([jt_cursor[].s])
-    jt_cursor = ri_1_cursor
+      break label_2
+    block label_3:
+      var ri_1_cursor = jt_cursor[].ri
+      echo([jt_cursor[].s])
+      jt_cursor = ri_1_cursor
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -29,25 +29,26 @@ try:
     block label_1:
       while true:
         if not(<(i, b_1)):
-          break
+          break label_1
         block label_2:
-          var :tmp
-          var i_1_cursor = i
-          if ==(i_1_cursor, 2):
-            return
-          add(a,
-            :tmp = default()
-            =copy(:tmp, x)
-            :tmp)
+          block label_3:
+            var :tmp
+            var i_1_cursor = i
+            if ==(i_1_cursor, 2):
+              return
+            add(a,
+              :tmp = default()
+              =copy(:tmp, x)
+              :tmp)
           inc(i, 1)
-  block label_3:
+  block label_4:
     if cond:
       var :tmp_1
       add(a,
         :tmp_1 = x
         wasMoved(x)
         :tmp_1)
-      break label_3
+      break label_4
     var :tmp_2
     add(b,
       :tmp_2 = x

--- a/tests/compiler/tmir_exec.nim
+++ b/tests/compiler/tmir_exec.nim
@@ -167,20 +167,22 @@ block:
   # test CFG creation for ``while true: break``
   let tree = @[
     MirNode(kind: mnkStmtList),
+    MirNode(kind: mnkBlock, label: LabelId(0)),
     MirNode(kind: mnkRepeat),
-    MirNode(kind: mnkBreak, label: NoLabel),
+    MirNode(kind: mnkBreak, label: LabelId(0)),
+    MirNode(kind: mnkEnd),
     MirNode(kind: mnkEnd),
     MirNode(kind: mnkReturn),
     MirNode(kind: mnkEnd)]
   let cfg = computeCfg(tree)
 
   doAssert cfg == parseCfg("""
-    0: join -> 1
-    goto 1  -> 2
-    loop 0  -> 3
-    1: join -> 3
-    goto 2  -> 4
-    2: join -> 6
+    0: join -> 2
+    goto 1  -> 3
+    loop 0  -> 4
+    1: join -> 5
+    goto 2  -> 6
+    2: join -> 8
   """)
 
 # -------------- test for the traversal routines


### PR DESCRIPTION
## Summary

Fix the cases where unlabeled `break` statements were inserted by
`transf`, which means that unlabeled `break` statements now no longer
exist after the main `transf` pass. This allows for:

* removing unlabeled `break` support from the MIR and `CgNode` IR
* simplifying code generation and MIR processing
* simplifying the `closureiters` transformation

Replacing `skLabel` usage in the code generators also becomes easier.

## Details

Since they're directly associated with a `block`, labeled `break`
statements are easier to handle for analysis and code generation. For
this reason, `transf` already transforms all unlabeled `break`
statements into labeled ones, by:
- assigning labels to `block`s that don't have a user-provided one
- wrapping `while` and `for` statements with named `block`s

However, there were two occurrences where unlabeled `break` statements
(`(nkBreakStmt (nkEmpty))`) were *injected* by `transf`:
- for the exit of `for` statements of closure iterators (`liftForLoop`)
- by the `closureiters` transformation when turning `while cond` loops
  into `while true` loops (although not strictly part of `transf`)

As a consequence, unlabeled `break` reached all the way into the code
generators, requiring dedicated support by the MIR, MIR processing, and
code generation.

While `mirgen` could lower unlabeled `break` statements, the association
of a `while` to its surrounding injected `block` no longer exists, and
`mirgen` is generally not well suited for non-local (i.e., not applying
to a single node) transformations.

Instead, the occurrences where unlabeled `break` statements are inserted
are adjusted. For the `for` statement, the label of the wrapper-block is
passed to `liftForLoop`, where the injected `nkBreakStmt` can then use
it. However, for the other occurrence, a more complex solution is
needed.

Since the `while` lowering the `closureiters` pass conditionally applies
(which is where the unlabeled `break` is injected) is the same as the
one `mirgen` automatically applies when generating `repeat` statements,
the transformation from `mirgen.genWhile` is turned into a `PNode`-based
transformation that is applied in `transf.transformWhile`. Some extra
adjustments are required:
- `PNode` doesn't have a dedicated "scope" construct like the MIR does.
  It is emulated via a `nkBlockStmt`
- the closure-iterator transformation doesn't support `yield` statements
  within `if`/`elif` conditions, so directly placing the former `while`
  condition into an `if` condition would regress on `yield` support. Prior
  to  placing the expression into the `if` condition, `nkStmtListExpr`s
  are thus first unpacked into the loop body

Only `while true` loops exist after the main `transf` pass now.

```nim
  while cond:
    body
  # is transformed into:
  block label:
    while true:
      if not cond:
        break label
      block: # a separate scope is needed for the clean-up semantics
        body
```

### `closureiters` simplifications

Multiple simplifications are possible now that neither unlabeled
`break`s nor `while` loops with non-`true`-literal conditions exist
at the point when the `closureiters` pass is run.

* remove `transformBreaksAndContinuesInWhile`, which handled unlabeled
  `break`s and `continue` statements in `while` loops
* remove the now-obsolete statement-list lowering logic for
  `nkWhileStmt`s (`lowerStmtListExprs`)
* remove the `nkWhileStmt` condition handling from the to-basic-block
  transformation (`transformClosureIteratorBody`)
* remove the `nkWhileStmt` handling from preprocessing (`preprocess`)

### MIR simplifications

* remove the "unset" sentinel value support from `LabelId`; all breaks
  in the MIR are labeled now
* remove everything related to unlabeled MIR breaks from MIR processing
  (`mirexec` and `cgirgen`)

### Code generator simplifications

Each code generator required special handling for associating unlabeled
`break`s with their targeted construct (`while` or `block`), with
`cgen` and `jsgen` being affected the most. All of it is removed.

As a side effect, the output of `jsgen` for loops slightly improves: no
extra `Label:` is emitted around every `while`.