### PR TITLE
suggest: remove unused procs `ensureIdx/Seq[T]`

### DIFF
--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -533,12 +533,6 @@ proc findDefinition(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym
     else:
       usageSym = s
 
-proc ensureIdx[T](x: var T, y: int) =
-  if x.len <= y: x.setLen(y+1)
-
-proc ensureSeq[T](x: var seq[T]) =
-  if x == nil: newSeq(x, 0)
-
 proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; isDecl=true) {.inline.} =
   ## misnamed: should be 'symDeclared'
   let conf = g.config


### PR DESCRIPTION
Remove obsolete procedures `ensureIdx[T]` and `ensureSeq[T]` from the
`suggest` module. They were introduced 10 years ago, before default
initializers were implemented and are no longer used.