### PR TITLE
remove `ConfigRef.projectMainIdx2`

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -445,7 +445,7 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
     # XXX: the header is just a normal C file artifact of ``generateCode``,
     #      don't store it with ``BModuleList``
     g.generatedHeader = generateHeader(g, inl, discovery,
-                                       mlist[graph.config.projectMainIdx2].sym)
+                                       mlist[graph.config.projectMainIdx].sym)
 
   # not pretty, but here's the earliest point where we know about the set of
   # all actually-used dynamic libraries

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -151,7 +151,7 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
     globals.code.add finishProc(p)
 
   # wrap up:
-  let main = modules[graph.config.projectMainIdx2]
+  let main = modules[graph.config.projectMainIdx]
   reset(modules) # we don't need the data anymore
 
   generateCodeForMain(globals, graph, main, mlist)

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -256,7 +256,6 @@ type
     inputMode*: ProjectInputMode    ## how the main module is sourced
     lastMsgWasDot*: set[StdOrrKind] ## the last compiler message was a single '.'
     projectMainIdx*: FileIndex      ## the canonical path id of the main module
-    projectMainIdx2*: FileIndex     ## consider merging with projectMainIdx
     commandLineSrcIdx*: FileIndex   ## used by `commands` to base paths off for
                                     ## path, lib, and other additions; default
                                     ## to `lineinfos.commandLineIdx` and

--- a/compiler/ic/cbackend.nim
+++ b/compiler/ic/cbackend.nim
@@ -189,7 +189,7 @@ proc generateCode*(g: ModuleGraph) =
   # make sure that, at least, the main module comes last (the other modules
   # are closed in the wrong order):
   for i, pos in mlist.modulesClosed.pairs:
-    if pos == g.config.projectMainIdx2:
+    if pos == g.config.projectMainIdx:
       # move to the end:
       delete(mlist.modulesClosed, i)
       mlist.modulesClosed.add(pos)

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -111,7 +111,7 @@ proc newModule(graph: ModuleGraph; fileIdx: FileIndex): PSym =
 
 proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags, fromModule: PSym = nil): PSym =
   var flags = flags
-  if fileIdx == graph.config.projectMainIdx2: flags.incl sfMainModule
+  if fileIdx == graph.config.projectMainIdx: flags.incl sfMainModule
   result = graph.getModule(fileIdx)
 
   template processModuleAux(moduleStatus) =
@@ -200,7 +200,6 @@ proc compileProject*(graph: ModuleGraph; projectFileIdx = InvalidFileIdx) =
 
   let systemFileIdx = fileInfoIdx(conf, conf.libpath / RelativeFile"system.nim")
   let projectFile = if projectFileIdx == InvalidFileIdx: conf.projectMainIdx else: projectFileIdx
-  conf.projectMainIdx2 = projectFile
 
   let packSym = getPackage(graph, projectFile)
   graph.config.mainPackageId = packSym.getnimblePkgId


### PR DESCRIPTION
## Summary

Remove  `ConfigRef.projectMainIdx2` , this has no user facing impact,
it's
just poor design/implementation.

## Details

Remove  `ConfigRef.projectMainIdx2` , which was used to handle cases
where
a project was being recompiled during  `suggest`  but with a dirty
project
module, or a module outside of the scope of the project. It's
ultimately
unnecessary as module, not project, recompilation should be sufficient.

All usages were in the `modules.compileProject` and have been replaced
with `ConfigRef.projectMainIdx`.