### PR TITLE
refactor: remove unused and duplicate imports

### DIFF
--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -5,7 +5,6 @@ import
     report_enums,
     ast_types,
     lineinfos,
-    reports_base,
     reports_base_sem,
   ],
   compiler/sem/[

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -34,11 +34,8 @@
 import
   std/[
     algorithm,
-    intsets,
     parseutils,
-    sets,
     strutils,
-    tables,
   ],
   compiler/ast/[
     ast,
@@ -65,7 +62,6 @@ import
   ],
   compiler/utils/[
     prefixmatches,
-    astrepr,
     debugutils,
     pathutils
   ]

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -41,7 +41,6 @@ from compiler/utils/astrepr import treeRepr,
 
 when defined(nimCompilerStacktraceHints):
   from std/stackframes import setFrameMsg
-  from strutils import `%`
 
 type
   # xxx: compiler execution tracing is a general thing, not semantic analysis


### PR DESCRIPTION
## Summary

Remove unused and duplicate imports, which fixes the related warnings
and hints reported by the compiler.