### PR TITLE
sem: assign consistent `elif`/`else` node kinds

### DIFF
--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -961,6 +961,9 @@ proc foldInAstAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Folded
     # don't process the symbol slots
     result = fromAst(n, n.len - 1)
     result.add foldInAstAux(m, n[^1], idgen, g)
+  of nkElifExpr, nkElseExpr:
+    # must not exist in statement AST
+    unreachable(n.kind)
   else:
     # XXX: type AST reaches here, but ideally this catch-all branch
     #      wouldn't be needed

--- a/tests/lang_exprs/tif_stmt_regression.nim
+++ b/tests/lang_exprs/tif_stmt_regression.nim
@@ -1,0 +1,19 @@
+discard """
+  description: '''
+    Regression test for ``if`` statements within statement-list expressions.
+    They were not being processed by constant folding
+  '''
+"""
+
+var x = (
+  # unfolded 'true'/'false' symbols lead to an internal compiler error,
+  # which is used for detecting whether folding took place here
+  if true:
+    # branch content doesn't matter, as long as it's a statement
+    var y = false
+  elif true: # also test an elif branch
+    var y = false
+  else:
+    var y = false
+  1
+)


### PR DESCRIPTION
## Summary

Always assign the node kind for `elif`/`else` AST such that whether the
expression/statement version is used is consistent with the `if` AST. In
other words, a (valid) `nkIfStmt` node now only has `nkElifBranch`/
`nkElse` nodes as immediate sub-nodes, while a `nkIfExpr` node only has
`nkElifExpr`/`nkElseExpr` nodes as immediate sub-nodes.

This affects `typed` AST, and it also fixes an internal compiler error
with `if` statements within statement-list expressions, which was caused
by the node kind discrepancy.

## Details

* in `semIf`, transition branch nodes to their statement/expression
  version, if necessary. This makes whether the statement/expression
  version is used is consistent with `nkIfExpr`/`nkIfStmt`
* this fixes `semfold.foldInAst` (the constant-folding pass) skipping
  if-statement-within-statement-list-expressions. For these,
  `nkElifExpr` and `nkElseExpr` nodes appeared as sub-nodes to
  `nkIfStmt` AST, which lead to the do-nothing catch-all being taken
  (and folding thus being skipped)
* until the catch-all branch in `foldInAst` is removed, and in
  order to prevent silent regressions, both `nkElifExpr` and `nkElse`
  are now explicitly disallowed (`unreachable`) in `foldInAst`