### PR TITLE
Fix merge workflow

### DIFF
--- a/.github/workflows/slash-command-merge.yml
+++ b/.github/workflows/slash-command-merge.yml
@@ -55,7 +55,7 @@ jobs:
               return;
             }
 
-            const formatPR = require('../../tools/ci_format_pr_description.js');
+            const formatPR = require('./tools/ci_format_pr_description.js');
 
             let [ body, body_tail ] = pr_info.body.split(/^---\s*$/m, 2);
             body = formatPR.formatPRdescription(body, 72);


### PR DESCRIPTION
## Summary
* Fix the import path of the PR description formatter in the merge
workflow, as the path is treated as relative to the repo root and
not the workflow file 

Fixes the issue introduced in
https://github.com/nim-works/nimskull/commit/4cd20fac354d19a5f63803866234ca261c3c084c
and observed in
https://github.com/nim-works/nimskull/pull/925#issuecomment-1736448152
