### PR TITLE
jsgen: better code generation for labeled blocks

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -897,12 +897,12 @@ proc genBlock(p: PProc, n: CgNode) =
     var sym = n[0].sym
     sym.position = idx+1
   let labl = p.unique
-  lineF(p, "Label$1: do {$n", [labl.rope])
+  lineF(p, "Label$1: {$n", [labl.rope])
   setLen(p.blocks, idx + 1)
   p.blocks[idx].id = - p.unique # negative because it isn't used yet
   genStmt(p, n[1])
   setLen(p.blocks, idx)
-  lineF(p, "} while (false);$n", [labl.rope])
+  lineF(p, "}$n", [labl.rope])
 
 proc genBreakStmt(p: PProc, n: CgNode) =
   var idx: int
@@ -2252,9 +2252,9 @@ proc genProcBody(p: PProc, prc: PSym): Rope =
   else:
     result = ""
   if p.beforeRetNeeded:
-    result.add p.indentLine(~"BeforeRet: do {$n")
+    result.add p.indentLine(~"BeforeRet: {$n")
     result.add p.body
-    result.add p.indentLine(~"} while (false);$n")
+    result.add p.indentLine(~"}$n")
   else:
     result.add(p.body)
   if prc.typ.callConv == ccSysCall:


### PR DESCRIPTION
## Summary

Instead of `Label: do {} while(false)`, emit a `Label: {}` for labeled
block statements. This shrinks the size of the generated code.

## Details

ECMAScript 5 (that is, the version targeted by the JS code generator)
allows attaching labels to blocks (`{}`), which is less code than using
a do-while statement.

In theory, the wrapping curlies could be elided if the content of the
`cnkBlockStmt`/procedure is a statement (and thus can be labeled
directly), but this would presently introduce a not-immediately-obvious
dependency between the emitting code (e.g., `genBlock`) and code
generation for the statement (e.g.,  `genRepeatStmt` ), so in order to
not
hinder evolution of `jsgen`, this optimization is not applied for now.