### PR TITLE
internal: remove obsolete `rsemWarnUnsafeCode`

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -758,7 +758,6 @@ type
     rsemWarnGcUnsafeListing    = "GcUnsafe2"
     rsemProveInit              = "ProveInit"
     rsemUninit                 = "Uninit"
-    rsemWarnUnsafeCode         = "UnsafeCode"
     rsemImplicitCstringConvert = "CStringConv"
     rsemHoleEnumConvert        = "HoleEnumConv"
     rsemAnyEnumConvert         = "AnyEnumConv"

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2088,9 +2088,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemMissingMethodDispatcher:
       result = "'" & r.ast.render & "' lacks a dispatcher"
 
-    of rsemWarnUnsafeCode:
-      result = "not GC-safe: '$1'" % r.ast.render
-
     of rsemImplicitCstringConvert:
       result = "implicit conversion to 'cstring' from a non-const location: " &
         ("$1; this will become a compile time error in the future" % r.ast.render)

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -887,11 +887,6 @@ proc trackBlock(tracked: PEffects, n: PNode) =
   else:
     track(tracked, n)
 
-proc cstringCheck(tracked: PEffects; n: PNode) =
-  if n[0].typ.kind == tyCstring and (let a = skipConv(n[1]);
-      a.typ.kind == tyString and a.kind notin {nkStrLit..nkTripleStrLit}):
-    localReport(tracked.config, n.info, reportAst(rsemWarnUnsafeCode, n))
-
 proc checkLe(c: PEffects; a, b: PNode) =
   case proveLe(c.guards, a, b)
   of impUnknown:
@@ -1175,7 +1170,6 @@ proc track(tracked: PEffects, n: PNode) =
     addAsgnFact(tracked.guards, n[0], n[1])
     notNilCheck(tracked, n[1], n[0].typ)
     discriminantAsgnCheck(tracked, n)
-    when false: cstringCheck(tracked, n)
     if tracked.owner.kind != skMacro:
       createTypeBoundOps(tracked, n[0].typ, n.info)
     if n[0].kind != nkSym or not isLocalVar(tracked, n[0].sym):


### PR DESCRIPTION
## Summary

Remove the unused `cstringCheck` procedure, together with the
`rsemWarnUnsafeCode` warning.

## Details

The warning was only produced by the `cstringCheck` procedure, to which
the only call was disabled. Checking for unsafe cstring conversions is
already performed in `sempass2.track`, so the unused `cstringCheck` can
be safely removed.