### PR TITLE
 fix(sem): crash on wrong symbol in definition slot

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -516,9 +516,6 @@ template transitionSymKindCommon*(k: TSymKind) =
   when defined(nimsuggest):
     s.allUsages = obj.allUsages
 
-proc transitionSymKindCommon*(s: PSym, kind: TSymKind) =
-  transitionSymKindCommon(kind)
-
 proc transitionGenericParamToType*(s: PSym) =
   transitionSymKindCommon(skType)
 

--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -516,6 +516,9 @@ template transitionSymKindCommon*(k: TSymKind) =
   when defined(nimsuggest):
     s.allUsages = obj.allUsages
 
+proc transitionSymKindCommon*(s: PSym, kind: TSymKind) =
+  transitionSymKindCommon(kind)
+
 proc transitionGenericParamToType*(s: PSym) =
   transitionSymKindCommon(skType)
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -431,7 +431,11 @@ proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
         n.sym.owner = currOwner # xxx: modifying the sym owner is suss
         n
       else:
-        let recoverySym = newSym(kind, n.sym.name, nextSymId c.idgen, currOwner, info)
+        # a symbol with the wrong kind is transplanted into a definition
+        # position. Create a new symbol instead of a copy in order to prevent
+        # follow-up errors due to the symbol's flags, type, etc.
+        let recoverySym = newSym(kind, n.sym.name, nextSymId c.idgen,
+                                 currOwner, info)
         c.config.makeError(n, recoverySym, ExpectedKindMismatch)
   of nkIdent, nkAccQuoted:
     # xxx: sym choices qualify here, but shouldn't those be errors in

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -432,7 +432,7 @@ proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
         n
       else:
         let recoverySym = copySym(n.sym, nextSymId c.idgen)
-        recoverySym.transitionRoutineSymKind(kind)
+        recoverySym.transitionSymKindCommon(kind)
         recoverySym.owner = currOwner
         c.config.makeError(n, recoverySym, ExpectedKindMismatch)
   of nkIdent, nkAccQuoted:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -431,9 +431,7 @@ proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
         n.sym.owner = currOwner # xxx: modifying the sym owner is suss
         n
       else:
-        let recoverySym = copySym(n.sym, nextSymId c.idgen)
-        recoverySym.transitionSymKindCommon(kind)
-        recoverySym.owner = currOwner
+        let recoverySym = newSym(kind, n.sym.name, nextSymId c.idgen, currOwner, info)
         c.config.makeError(n, recoverySym, ExpectedKindMismatch)
   of nkIdent, nkAccQuoted:
     # xxx: sym choices qualify here, but shouldn't those be errors in

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -688,7 +688,10 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
       c.config.semReportIllformedAst(
         n, "Expected two nodes for postfix expression, but found " & $n.len)
   else:
-    result = getDefNameSymOrRecover(newSymGNode(kind, n, c))
+    let sym = newSymGNode(kind, n, c)
+    if sym.kind == nkError:
+      localReport(c.config, sym)
+    result = getDefNameSymOrRecover(sym)
 
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym =

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -690,6 +690,7 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
   else:
     let sym = newSymGNode(kind, n, c)
     if sym.kind == nkError:
+      # XXX: replace with propagating the error
       localReport(c.config, sym)
     result = getDefNameSymOrRecover(sym)
 

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -59,8 +59,8 @@ replaceName(nskMacro):
     discard
 
 macro t1(): untyped =
-  # test wrong symbol kind passed in non-routine context
-  # correctly report error
+  # test that an error is correctly reported when inserting the wrong symbol
+  # into a non-routine definition
   let b = genSym(nskLet, ident = "a")#[tt.Error
                ^ (SemSymbolKindMismatch)]#
   result = newVarStmt(b, newLit 1)

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -59,8 +59,10 @@ replaceName(nskMacro):
     discard
 
 macro t1(): untyped =
+  # test wrong symbol kind passed in non-routine context
+  # correctly report error
   let b = genSym(nskLet, ident = "a")#[tt.Error
                ^ (SemSymbolKindMismatch)]#
-  result = newProc(b)
+  result = newVarStmt(b, newLit 1)
 
 t1()

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -57,3 +57,9 @@ replaceName(nskMacro):
   template t() = #[tt.Error
           ^ (SemSymbolKindMismatch)]#
     discard
+
+macro t1(): untyped =
+  let a = genSym(ident = "a")
+  result = newVarStmt(a, newLit 1)
+
+t1()

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -59,7 +59,8 @@ replaceName(nskMacro):
     discard
 
 macro t1(): untyped =
-  let a = genSym(ident = "a")
-  result = newVarStmt(a, newLit 1)
+  let b = genSym(nskLet, ident = "a")#[tt.Error
+               ^ (SemSymbolKindMismatch)]#
+  result = newProc(b)
 
 t1()


### PR DESCRIPTION
## Summary

Fix the compiler either crashing or reporting no error when a symbol
of the wrong kind is placed into a definition position through a macro
or template.

## Details

When error-correcting, `newSymGNode` transitioned the symbol to the
expected kind with `transitionRoutineSymKind`. If the expected kind
is not that of a routine, this led to a `RangeDefect`, assuming that
the compiler was built with range checks.

Instead, a new symbol is now created, re-using the identifier of the
input one. Besides fixing the `RangeDefect` being raised, this also
prevents follow-up errors that may be caused by the flags, type, or
other state of the known-to-be-incorrect input symbol.

In addition, the `nkError` from `newSymGNode` was dropped in
`semIdentVis` when no export marker is present, resulting in no error
being reported there at all. The error is now `localReport`ed prior to
returning the recovery symbol.