### PR TITLE
fix(sem): crash due to ill-formed `if` AST

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -164,6 +164,7 @@ proc semIf(c: PContext, n: PNode; flags: TExprFlags): PNode =
       if it[0].isError:
         hasError = true
     else:
+      hasError = true
       semReportIllformedAst(
         c.config, it,
         "Expected one or two subnodes for if statement, but found " & $it.len)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -165,9 +165,7 @@ proc semIf(c: PContext, n: PNode; flags: TExprFlags): PNode =
         hasError = true
     else:
       hasError = true
-      semReportIllformedAst(
-        c.config, it,
-        "Expected one or two subnodes for if statement, but found " & $it.len)
+      result[i] = c.config.newError(it, PAstDiag(kind: adSemIllformedAst))
 
   if hasError:
     result = c.config.wrapError(result)

--- a/tests/lang_callable/macros/tif_ill_formed.nim
+++ b/tests/lang_callable/macros/tif_ill_formed.nim
@@ -2,17 +2,16 @@ discard """
   description: '''
     Ensure that ill-formed if-statement AST created by macros is detected
   '''
-  cmd: "nim check $options $file"
+  cmd: "nim check --msgFormat:sexp --filenames=canonical --hints:off $options $file"
+  nimoutformat: sexp
   action: reject
-  nimout: '''
-tif_ill_formed.nim(13, 15) Error: illformed AST:  else: <<0th child missing for nkElseExpr >>
-'''
 """
 import std/macros
 
 macro t1(): untyped =
   result =
     nnkIfStmt.newTree(
-      newNimNode(nnkElseExpr))
+      newNimNode(nnkElseExpr)) #[tt.Error
+               ^ (SemIllformedAst)]#
 
 t1()

--- a/tests/lang_callable/macros/tif_ill_formed.nim
+++ b/tests/lang_callable/macros/tif_ill_formed.nim
@@ -12,6 +12,6 @@ macro t1(): untyped =
   result =
     nnkIfStmt.newTree(
       newNimNode(nnkElseExpr)) #[tt.Error
-               ^ illformed AST:  else: <<0th child missing for nkElseExpr >>]#
+                ^ illformed AST:  else: <<0th child missing for nkElseExpr >>]#
 
 t1()

--- a/tests/lang_callable/macros/tif_ill_formed.nim
+++ b/tests/lang_callable/macros/tif_ill_formed.nim
@@ -1,0 +1,16 @@
+discard """
+  cmd: "nim check $options $file"
+  action: reject
+  nimout: '''
+tif_ill_formed.nim(13, 15) Error: illformed AST:  else: <<0th child missing for nkElseExpr >>
+'''
+"""
+import std/macros
+
+macro t1(): untyped =
+  result = newTree(nnkIfStmt)
+  result.add(
+    newNimNode(nnkElseExpr)
+  )
+
+t1()

--- a/tests/lang_callable/macros/tif_ill_formed.nim
+++ b/tests/lang_callable/macros/tif_ill_formed.nim
@@ -8,9 +8,8 @@ tif_ill_formed.nim(13, 15) Error: illformed AST:  else: <<0th child missing for 
 import std/macros
 
 macro t1(): untyped =
-  result = newTree(nnkIfStmt)
-  result.add(
-    newNimNode(nnkElseExpr)
-  )
+  result =
+    nnkIfStmt.newTree(
+      newNimNode(nnkElseExpr))
 
 t1()

--- a/tests/lang_callable/macros/tif_ill_formed.nim
+++ b/tests/lang_callable/macros/tif_ill_formed.nim
@@ -2,8 +2,8 @@ discard """
   description: '''
     Ensure that ill-formed if-statement AST created by macros is detected
   '''
-  cmd: "nim check --msgFormat:sexp --filenames=canonical --hints:off $options $file"
-  nimoutformat: sexp
+  cmd: "nim check --hints:off $options $file"
+  nimoutfull: "true"
   action: reject
 """
 import std/macros

--- a/tests/lang_callable/macros/tif_ill_formed.nim
+++ b/tests/lang_callable/macros/tif_ill_formed.nim
@@ -1,4 +1,7 @@
 discard """
+  description: '''
+    Ensure that ill-formed if-statement AST created by macros is detected
+  '''
   cmd: "nim check $options $file"
   action: reject
   nimout: '''

--- a/tests/lang_callable/macros/tif_ill_formed.nim
+++ b/tests/lang_callable/macros/tif_ill_formed.nim
@@ -12,6 +12,6 @@ macro t1(): untyped =
   result =
     nnkIfStmt.newTree(
       newNimNode(nnkElseExpr)) #[tt.Error
-               ^ (SemIllformedAst)]#
+               ^ illformed AST:  else: <<0th child missing for nkElseExpr >>]#
 
 t1()


### PR DESCRIPTION
## Summary

Fix the compiler crashing when encountering ill-formed `nkIfStmt`/
`nkIfExpr` AST and the maximum error count is larger than 1.

## Details

* in `semIf`, create an error node for the ill-formed branch instead of
  creating and reporting a `Report`
* this enables proper `nkError` propagation, which disables the second
  pass, preventing the invalid AST from being indexed into (this caused
  either an `IndexDefect` or `FieldDefect`)
* in addition, this also removes another use of immediate reporting via
  `handleReport`/`localReport`