### PR TITLE
internal: fix the meaning of up/down conversion

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -933,14 +933,14 @@ proc inheritanceDiff*(a, b: PType): int =
     x = skipTypes(x, skipPtrs)
     if sameObjectTypes(x, b): return
     x = x[0]
-    dec(result)
+    inc(result)
   var y = b
   result = 0
   while y != nil:
     y = skipTypes(y, skipPtrs)
     if sameObjectTypes(y, a): return
     y = y[0]
-    inc(result)
+    dec(result)
   result = high(int)
 
 proc commonSuperclass*(a, b: PType): PType =
@@ -1038,7 +1038,7 @@ proc compatibleEffectsAux(se, re: PNode): bool =
   for r in items(re):
     block search:
       for s in items(se):
-        if safeInheritanceDiff(r.typ, s.typ) <= 0:
+        if safeInheritanceDiff(s.typ, r.typ) <= 0:
           break search
       return false
   result = true

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -696,10 +696,10 @@ proc wrapInHiddenAddr(cl: TranslateCl, n: CgNode): CgNode =
   result =
     if n.typ.skipTypes(abstractInst).kind != tyVar:
       newOp(cnkHiddenAddr, n.info, makeVarType(cl.owner, n.typ, cl.idgen), n)
-    elif inner.kind == cnkObjDownConv and
+    elif inner.kind == cnkObjUpConv and
          inner.operand.typ.kind != tyVar:
-      # TODO: ``nkHiddenSubConv`` nodes for objects (which are later
-      #       transformed into ``nkObjDownConv`` nodes) are in some cases
+      # TODO: ``nkHiddenSubConv`` nodes for objects (which later result
+      #       in ``cnkObjUpConv`` nodes) are in some cases
       #       incorrectly typed as ``var`` somewhere in the compiler
       #       (presumably during sem). Fix the underlying problem and remove
       #       the special case here

--- a/compiler/backend/cgmeth.nim
+++ b/compiler/backend/cgmeth.nim
@@ -77,7 +77,7 @@ proc methodCall*(n: PNode; conf: ConfigRef): PNode =
     result[0].sym = disp
     # change the arguments to up/downcasts to fit the dispatcher's parameters:
     for i in 1..<result.len:
-      result[i] = genConv(result[i], disp.typ[i], true, conf)
+      result[i] = genConv(result[i], disp.typ[i], false, conf)
   else:
     localReport(conf, n.info, reportAst(
       rsemMissingMethodDispatcher, result[0]))
@@ -105,7 +105,7 @@ proc sameMethodBucket(a, b: PSym; multiMethods: bool): MethodResult =
       if aa.kind == tyObject and result != Invalid:
         result = Yes
     elif aa.kind == tyObject and bb.kind == tyObject and (i == 1 or multiMethods):
-      let diff = inheritanceDiff(bb, aa)
+      let diff = inheritanceDiff(aa, bb)
       if diff < 0:
         if result != Invalid:
           result = Yes
@@ -236,7 +236,7 @@ proc cmpSignatures(a, b: PSym, relevantCols: IntSet): int =
     if contains(relevantCols, col):
       var aa = skipTypes(a.typ[col], skipPtrs)
       var bb = skipTypes(b.typ[col], skipPtrs)
-      var d = inheritanceDiff(aa, bb)
+      var d = inheritanceDiff(bb, aa)
       if (d != high(int)) and d != 0:
         return d
 
@@ -298,7 +298,7 @@ proc genDispatcher(g: ModuleGraph; methods: seq[PSym], relevantCols: IntSet) =
     call.add newSymNode(curr)
     for col in 1..<paramLen:
       call.add genConv(newSymNode(base.typ.n[col].sym),
-                           curr.typ[col], false, g.config)
+                           curr.typ[col], true, g.config)
     var ret: PNode
     if retTyp != nil:
       var a = newNodeI(nkFastAsgn, base.info)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2185,7 +2185,7 @@ proc genConv(p: PProc, n: CgNode, r: var TCompRes) =
     # TODO: What types must we handle here?
     discard
 
-proc upConv(p: PProc, n: CgNode, r: var TCompRes) =
+proc downConv(p: PProc, n: CgNode, r: var TCompRes) =
   gen(p, n.operand, r)        # XXX
 
 proc genRangeChck(p: PProc, n: CgNode, r: var TCompRes) =
@@ -2514,8 +2514,8 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkBracketAccess: genArrayAccess(p, n, r)
   of cnkFieldAccess: genFieldAccess(p, n, r)
   of cnkCheckedFieldAccess: genCheckedFieldOp(p, n, takeAddr=false, r)
-  of cnkObjDownConv: gen(p, n.operand, r)
-  of cnkObjUpConv: upConv(p, n, r)
+  of cnkObjDownConv: downConv(p, n, r)
+  of cnkObjUpConv: gen(p, n.operand, r)
   of cnkCast: genCast(p, n, r)
   of cnkStringToCString: convStrToCStr(p, n, r)
   of cnkCStringToString: convCStrToStr(p, n, r)

--- a/compiler/sem/closureiters.nim
+++ b/compiler/sem/closureiters.nim
@@ -689,7 +689,7 @@ proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
       result = newTreeI(nkStmtList, n.info):
         [st, n]
 
-  of nkCast, nkHiddenStdConv, nkHiddenSubConv, nkConv, nkObjDownConv,
+  of nkCast, nkHiddenStdConv, nkHiddenSubConv, nkConv, nkObjUpConv,
       nkDerefExpr, nkHiddenDeref:
     var ns = false
     for i in ord(n.kind == nkCast)..<n.len:

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -333,10 +333,10 @@ proc semOf(c: PContext, n: PNode): PNode =
     elif b.kind != tyObject or a.kind != tyObject:
       result = newError(c.config, n, PAstDiag(kind: adSemExpectedObjectOfType))
     else:
-      let diff = inheritanceDiff(a, b)
+      let diff = inheritanceDiff(b, a)
       # | returns: 0 iff `a` == `b`
-      # | returns: -x iff `a` is the x'th direct superclass of `b`
-      # | returns: +x iff `a` is the x'th direct subclass of `b`
+      # | returns: -x iff `a` is the x'th direct subclass of `b`
+      # | returns: +x iff `a` is the x'th direct superclass of `b`
       # | returns: `maxint` iff `a` and `b` are not compatible at all
       if diff <= 0:
         # optimize to true:

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -522,7 +522,7 @@ proc catches(tracked: PEffects, e: PType) =
   var i = tracked.bottom
   while i < L:
     # r supertype of e?
-    if safeInheritanceDiff(tracked.graph.excType(tracked.exc[i]), e) <= 0:
+    if safeInheritanceDiff(e, tracked.graph.excType(tracked.exc[i])) <= 0:
       tracked.exc[i] = tracked.exc[L-1]
       dec L
     else:
@@ -1410,10 +1410,10 @@ proc track(tracked: PEffects, n: PNode) =
 proc subtypeRelation(g: ModuleGraph; spec, real: PNode): bool =
   if spec.typ.kind == tyOr:
     for t in spec.typ.sons:
-      if safeInheritanceDiff(g.excType(real), t) <= 0:
+      if safeInheritanceDiff(t, g.excType(real)) <= 0:
         return true
   else:
-    return safeInheritanceDiff(g.excType(real), spec.typ) <= 0
+    return safeInheritanceDiff(spec.typ, g.excType(real)) <= 0
 
 proc checkRaisesSpec(
     g: ModuleGraph,


### PR DESCRIPTION
## Summary

The meaning of up- and down-conversions and the corresponding nodes was
inverted within the compiler. Up-conversion is changed to mean
"conversion to base type" (going up in the hierarchy), while down-
conversion is changed to mean "conversion to derived type" (going down
in the hierarchy).

This doesn't change program semantics, but the change is visible to
macros accepting typed AST, where `nkObjDownConv` and `nkObjUpConv` now
have the correct meaning.

## Details

The core of the problem was `inheritanceDiff` now doing what the
document comment said: the parent/base types of `a` were traversed
first (which checks whether `a` is a *subtype* of `b`), with each step
decrementing the counter (negative result). However, the procedure's
documentation said that `a` being a subtype of `b` results in a
*positive* return value, not a *negative*  one.

`inheritanceDiff` is fixed, and all callsites are adjusted:
* for all usage sites of `inheritanceDiff` and `safeInheritanceDiff`
  where the result is not used for a) producing `nkObjDownConv` or
  `nkObjUpConv` nodes, or b) only checking for an relation at all,
  the arguments are reversed
* the correct node kinds were used (although their meaning was
  inverted) when producing  `nkObjDownConv` / `nkObjUpConv`  (and their
code
  generator version), so no change is required there
* for `cgmeth.genConv`, whether only a down-conversion is allowed is
  adjusted at the callsites: when patching method calls, only down-
  conversions are allowed (sub-type to base), while when generating the
  dispatcher, only up-conversion (base to sub-type) are allowed

For the code generators, the implementations of `cgen.downConv` and
`cgen.upConv` are swapped, and `jsgen.upConv` is renamed to
`jsgen.downConv`.

Except for one occurrence in the previous `cgen.downConv`, one in
`closureiters`, and one in `wrapInHiddenAddr`, `nkObjDownConv`/
`nkObjUpConv` (and their code generator versions) are always used
together, so only the three mentioned occurrences need to be changed:
in each case, the node kind is replaced with its respective
counterparts.