### PR TITLE
Refactor report hook

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3984,7 +3984,7 @@ proc legacyReportBridge*(conf: ConfigRef, diag: PAstDiag): Report =
   # TODO: will use conf soon
   astDiagToLegacyReport(conf, diag)
 
-proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
+proc reportHook*(conf: ConfigRef, r: Report, rh: TErrorHandling): TErrorHandling =
   ## Default implementation of the report hook. Dispatches into
   ## `reportBody` for report, which then calls respective (for each report
   ## category) `reportBody` overloads defined above

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -276,10 +276,10 @@ proc quit(conf: ConfigRef; withTrace: bool) {.gcsafe.} =
       if stackTraceAvailable():
         discard conf.report(InternalReport(
           kind: rintStackTrace,
-          trace: getStackTraceEntries()))
+          trace: getStackTraceEntries()), doNothing)
       else:
         discard conf.report(InternalReport(
-          kind: rintMissingStackTrace))
+          kind: rintMissingStackTrace), doNothing)
   quit 1
 
 proc errorActions(
@@ -594,11 +594,11 @@ func astDiagToLegacyReportKind*(diag: PAstDiag): ReportKind {.inline.} =
   else:
     astDiagToLegacyReportKind(diag.kind)
 
-proc report*(conf: ConfigRef, node: PNode): TErrorHandling =
+proc report*(conf: ConfigRef, node: PNode, rh: TErrorHandling): TErrorHandling =
   ## Write out report from the nkError node
   # xxx: legacy report temporarily here until we can rip it out
   assert node.kind == nkError
-  return conf.report(conf.astDiagToLegacyReport(conf, node.diag))
+  return conf.report(conf.astDiagToLegacyReport(conf, node.diag), rh)
 
 proc handleReport*(
     conf: ConfigRef,
@@ -614,7 +614,7 @@ proc handleReport*(
     handleReport(conf, wrap(rep.vmReport.trace[]), reportFrom)
 
   let
-    userAction = conf.report(rep)
+    userAction = conf.report(rep, eh)
     (action, trace) =
       case userAction
       of doDefault:

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -184,7 +184,7 @@ type
              ## argument
     pimFile  ## the main module is a file
 
-  ReportHook* = proc(conf: ConfigRef, report: Report): TErrorHandling {.closure.}
+  ReportHook* = proc(c: ConfigRef, r: Report, rh: TErrorHandling): TErrorHandling {.closure.}
 
   HackController* = object
     ## additional configuration switches to control the behavior of the
@@ -542,12 +542,12 @@ proc getReportHook*(conf: ConfigRef): ReportHook =
   ## Get active report hook
   conf.structuredReportHook
 
-proc report*(conf: ConfigRef, inReport: Report): TErrorHandling =
+proc report*(conf: ConfigRef, inReport: Report, rh: TErrorHandling): TErrorHandling =
   ## Write `inReport`
   assert inReport.kind != repNone, "Cannot write out empty report"
   assert(conf.structuredReportHook != nil,
          "Cannot write report with empty report hook")
-  return conf.structuredReportHook(conf, inReport)
+  return conf.structuredReportHook(conf, inReport, rh)
 
 proc canReport*(conf: ConfigRef, id: NodeId): bool =
   ## Check whether report with given ID can actually be written out, or it
@@ -561,16 +561,16 @@ proc canReport*(conf: ConfigRef, node: PNode): bool =
   true # xxx: short circuit this nonsense
 
 template report*[R: ReportTypes](
-    conf: ConfigRef, inReport: R): TErrorHandling =
+    conf: ConfigRef, inReport: R, rh: TErrorHandling): TErrorHandling =
   ## Pass structured report object into `conf.structuredReportHook`,
   ## converting to `Report` variant and updaing instantiation info.
-  report(conf, wrap(inReport, instLoc()))
+  report(conf, wrap(inReport, instLoc()), rh)
 
 template report*[R: ReportTypes](
-    conf: ConfigRef, tinfo: TLineInfo, inReport: R): TErrorHandling =
+    conf: ConfigRef, tinfo: TLineInfo, inReport: R, rh: TErrorHandling): TErrorHandling =
   ## Write out new report, updating it's location info using `tinfo` and
   ## it's instantiation info with `instantiationInfo()` of the template.
-  report(conf, wrap(inReport, instLoc(), tinfo))
+  report(conf, wrap(inReport, instLoc(), tinfo), rh)
 
 # REFACTOR: we shouldn't need to dig into the internalReport and query severity
 #           directly

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -136,7 +136,7 @@ proc sexp*(t: PSym): SexpNode =
   ])
 
 
-proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
+proc reportHook*(conf: ConfigRef, r: Report, rh: TErrorHandling): TErrorHandling =
   writeConf = conf
   let wkind = conf.writabilityKind(r)
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2734,7 +2734,7 @@ proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     # Remove the error hook so nimsuggest doesn't report errors there
     let tempHook = c.graph.config.structuredReportHook
     c.graph.config.structuredReportHook =
-      proc(conf: ConfigRef, report: Report): TErrorHandling = discard
+      proc(conf: ConfigRef, report: Report, rh: TErrorHandling): TErrorHandling = discard
 
   let oldErrorCount = c.config.errorCounter
   let oldErrorMax = c.config.errorMax

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -748,7 +748,7 @@ proc matchUserTypeClass*(m: var TCandidate; ff, a: PType): PType =
   # match data. When nkError is implemented this needs to be removed.
   let tmpHook = c.config.getReportHook()
   c.config.setReportHook(
-    proc(conf: ConfigRef, report: Report): TErrorHandling =
+    proc(conf: ConfigRef, report: Report, rh: TErrorHandling): TErrorHandling =
       if report.category == repSem:
         diagnostics.add report.semReport
   )

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -184,7 +184,7 @@ proc destroyInterpreter*(i: Interpreter) =
 
 proc registerErrorHook*(
     i: Interpreter,
-    hook: proc (config: ConfigRef, report: Report): TErrorHandling {.gcsafe.}
+    hook: proc (config: ConfigRef, report: Report, rh: TErrorHandling): TErrorHandling {.gcsafe.}
   ) =
   i.graph.config.structuredReportHook = hook
 

--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -369,7 +369,7 @@ proc parseCode*(code: string, cache: IdentCache, config: ConfigRef,
   let oldHook = config.structuredReportHook
 
   config.structuredReportHook = proc(
-      conf: ConfigRef, report: Report
+      conf: ConfigRef, report: Report, rh: TErrorHandling
   ): TErrorHandling =
     # @haxscramper: QUESTION This check might be affected by current severity
     # configurations, maybe it makes sense to do a hack-in that would
@@ -378,7 +378,7 @@ proc parseCode*(code: string, cache: IdentCache, config: ConfigRef,
         conf.severity(report) == rsevError:
       raise TemporaryExceptionHack(report: report)
     else:
-      return oldHook(conf, report)
+      return oldHook(conf, report, rh)
 
   try:
     let ast = parseString(code, cache, config, filename, line).toPNode()

--- a/nimsuggest/tests/terror_handling.nim
+++ b/nimsuggest/tests/terror_handling.nim
@@ -1,0 +1,18 @@
+# Test ill formed AST will not causes crash and subsequent errors
+
+import std/macros
+
+macro t1(): untyped =
+  result = newNimNode(nnkForStmt)
+  result.add(ident("i")) 
+  result.add newNimNode(nnkCall)
+  result.add nnkDiscardStmt.newTree(newEmptyNode())
+
+t1()
+
+#[!]#
+discard """
+$nimsuggest --tester $file
+>chk $1
+chk;;skUnknown;;;;Error;;$file;;8;;23;;"illformed AST: ()";;0
+"""

--- a/tests/compilerapi/tcompilerapi.nim
+++ b/tests/compilerapi/tcompilerapi.nim
@@ -47,7 +47,7 @@ proc initInterpreter(script: string, hook: ReportHook): Interpreter =
 
 type VMQuit = object of CatchableError
 
-proc vmReport(config: ConfigRef, report: Report): TErrorHandling {.gcsafe.} =
+proc vmReport(config: ConfigRef, report: Report, rh: TErrorHandling): TErrorHandling {.gcsafe.} =
   if config.severity(report) == rsevError and
      config.errorCounter >= config.errorMax:
 

--- a/tests/compilerunits/confread/tcli_parsing.nim
+++ b/tests/compilerunits/confread/tcli_parsing.nim
@@ -24,7 +24,7 @@ import
 
 var reported: seq[Report]
 
-proc hook(conf: ConfigRef, report: Report): TErrorHandling =
+proc hook(conf: ConfigRef, report: Report, rh: TErrorHandling): TErrorHandling =
   reported.add report
   return doNothing
 

--- a/tests/compilerunits/confread/treport_filtering.nim
+++ b/tests/compilerunits/confread/treport_filtering.nim
@@ -41,7 +41,7 @@ from compiler/ast/reports_debug import DebugReport
 
 var reported: seq[Report]
 
-proc hook(conf: ConfigRef, report: Report): TErrorHandling =
+proc hook(conf: ConfigRef, report: Report, rh: TErrorHandling): TErrorHandling =
   reported.add report
   return doNothing
 


### PR DESCRIPTION
## Summary
* The `structuredReportHook` procedure now takes a third parameter `TErrorHandling`. 
* The `structuredReportHook` previously only been used for certain cases, such as always returning `doNothing` when used with `nimsuggest`. In fact, we do not need `doDefault` or `doAbort` since they may unexpectedly call `quit`. However, we do need to properly handle `doRaise`, which is reported from `globalReport` and can prevent compilation in command line mode when it comes across an ill-formed AST or other errors that prevent code compilation. Therefore, we should reuse this logic to prevent `nimsuggest` from continuing to compile code that could cause crashes due to nil access or subsequent errors caused by ill-formed code.

## Details


---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
Earlier, the test case code would encounter a fatal error and fail to report it. 
Now it runs smoothly and successfully reports the error, so I believe this change has been addressed.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
