### PR TITLE
fix(renderer): `hasCom` childless node crash

### DIFF
--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -536,7 +536,7 @@ proc hasCom(n: PNode): bool =
   if n.comment.len > 0: return true
   case n.kind
   of nkWithoutSons: discard
-  else:
+  of nkWithSons:
     for i in 0..<n.len:
       if hasCom(n[i]): return true
 

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -535,7 +535,7 @@ proc hasCom(n: PNode): bool =
   if n.isNil: return false
   if n.comment.len > 0: return true
   case n.kind
-  of nkEmpty..nkNilLit: discard
+  of nkWithoutSons: discard
   else:
     for i in 0..<n.len:
       if hasCom(n[i]): return true


### PR DESCRIPTION
## Summary

Fix compiler crash due to `renderer.hasCom` attempting to access `sons`
on `PNode`s without children.

## Details

This happened because `hasCom` was checking guarding with the
`nkEmpty..nkNilLit`  range, instead of constant  `nkWithoutSons` . The
prior
range didn't include  `nkNone`  and  `nkError` . The implementation now
uses
an exhaustive case to avoid such errors in the future.