### PR TITLE
`semProcAux` `hasError` cover `fixupInstantiatedSymbols`

### DIFF
--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -119,15 +119,20 @@ proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
     trackProc(c, result, result.ast[bodyPos])
     dec c.inGenericInst
 
-proc fixupInstantiatedSymbols(c: PContext, s: PSym) =
+proc fixupInstantiatedSymbols(c: PContext, s: PSym): bool =
+  result = true
   for i in 0..<c.generics.len:
     if c.generics[i].genericSym.id == s.id:
-      var oldPrc = c.generics[i].inst.sym
+      var 
+        oldPrc = c.generics[i].inst.sym
+        n = oldPrc.ast
+      if n.kind == nkError:
+        result = false
+        continue
       pushProcCon(c, oldPrc)
       pushOwner(c, oldPrc)
       pushInfoContext(c.config, oldPrc.info)
       openScope(c)
-      var n = oldPrc.ast
       n[bodyPos] = copyTree(getBody(c.graph, s))
       instantiateBody(c, n, oldPrc.typ.n, oldPrc, s)
       closeScope(c)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2810,7 +2810,8 @@ proc semProcAux(c: PContext, n: PNode, validPragmas: TSpecialWords,
         result[bodyPos] = semGenericStmt(c, n[bodyPos])
         closeScope(c)
         if s.magic == mNone:
-          fixupInstantiatedSymbols(c, s)
+          if not fixupInstantiatedSymbols(c, s):
+            hasError = true
       if s.kind == skMethod: semMethodPrototype(c, s, result)
       popProcCon(c)
   else:


### PR DESCRIPTION
## Summary
* `semProcAux` `hasError` cover `fixupInstantiatedSymbols`
* Instantiated symbol's AST may be the `nkError` kind that cause`n[bodyPos]` raise `FieldDefect`

## Details
* `fixupInstantiatedSymbols` now returns `false` if instantiated symbol's AST is `nkError` kind during iteration


---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
