### PR TITLE
fix(sem): `nimsuggest` crashing for ill-formed AST

### DIFF
--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -672,15 +672,14 @@ proc reportAndFail*(
   var rep = r
   fillReportAndHandleVmTrace(conf, rep, reportFrom)
 
-  let userAction = conf.report(rep)
-  case userAction
+  case conf.report(rep)
   of doAbort:
-    quit 1
+    quit(conf, false)
   of doDefault:
-    let (action, trace) = errorActions(conf, rep, userAction)
+    let (action, trace) = errorActions(conf, rep, doRaise)
     case action
     of doAbort:
-      quit 1
+      quit(conf, trace)
     of doRaise, doNothing:
       raiseRecoverableError("report")
     of doDefault:

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -659,7 +659,7 @@ template globalReport*(conf: ConfigRef, report: ReportTypes) =
 proc reportAndForceRaise*(
   conf: ConfigRef, r: Report, reportFrom: InstantiationInfo) =
   ## always call `raiseRecoverableError` except if `doAbort` was returned
-  ## by the structuredReportHook.
+  ## by the `structuredReportHook`.
   var rep = r
   fillReport(rep, reportFrom)
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -600,10 +600,10 @@ proc report*(conf: ConfigRef, node: PNode): TErrorHandling =
   assert node.kind == nkError
   return conf.report(conf.astDiagToLegacyReport(conf, node.diag))
 
-proc fillReport(r: var Report, reportFrom: InstantiationInfo) =
+proc fillReport(c: ConfigRef, r: var Report, reportFrom: InstantiationInfo) =
   r.reportFrom = toReportLineInfo(reportFrom)
   if r.category in { repSem, repVM } and r.location.isSome():
-    r.context = conf.getContext(r.location.get())
+    r.context = c.getContext(r.location.get())
 
 proc handleReport*(
     conf: ConfigRef,
@@ -611,7 +611,7 @@ proc handleReport*(
     reportFrom: InstantiationInfo,
     eh: TErrorHandling = doNothing) {.noinline.} =
   var rep = r
-  fillReport(rep, reportFrom)
+  fillReport(conf, rep, reportFrom)
   if rep.category == repVM and rep.vmReport.trace != nil:
     handleReport(conf, wrap(rep.vmReport.trace[]), reportFrom)
 
@@ -661,7 +661,7 @@ proc reportAndForceRaise*(
   ## always call `raiseRecoverableError` except if `doAbort` was returned
   ## by the `structuredReportHook`.
   var rep = r
-  fillReport(rep, reportFrom)
+  fillReport(conf, rep, reportFrom)
 
   if rep.category == repVM and rep.vmReport.trace != nil:
     reportAndForceRaise(conf, wrap(rep.vmReport.trace[]), reportFrom)

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -658,8 +658,9 @@ template globalReport*(conf: ConfigRef, report: ReportTypes) =
 
 proc reportAndForceRaise*(
   conf: ConfigRef, r: Report, reportFrom: InstantiationInfo) =
-  ## always call `raiseRecoverableError` except if `doAbort` was returned
-  ## by the `structuredReportHook`.
+  ## Similar to `handleReport`, but, unless overridden with aborting
+  ## (`doAbort`) by the structured report hook, always raises a recoverable
+  ## error.
   var rep = r
   fillReport(conf, rep, reportFrom)
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -611,6 +611,7 @@ proc fillReportAndHandleVmTrace(c: ConfigRef, r: var Report,
   r.reportFrom = toReportLineInfo(reportFrom)
   if r.category in { repSem, repVM } and r.location.isSome():
     r.context = c.getContext(r.location.get())
+
   if r.category == repVM and r.vmReport.trace != nil:
     handleReport(c, wrap(r.vmReport.trace[]), reportFrom)
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -606,7 +606,8 @@ proc report*(conf: ConfigRef, node: PNode): TErrorHandling =
   assert node.kind == nkError
   return conf.report(conf.astDiagToLegacyReport(conf, node.diag))
 
-proc fillReportAndHandleVmReport(c: ConfigRef, r: var Report, reportFrom: InstantiationInfo) =
+proc fillReportAndHandleVmTrace(c: ConfigRef, r: var Report,
+                                reportFrom: InstantiationInfo) =
   r.reportFrom = toReportLineInfo(reportFrom)
   if r.category in { repSem, repVM } and r.location.isSome():
     r.context = c.getContext(r.location.get())

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -669,7 +669,7 @@ proc reportAndForceRaise*(
   ## (`doAbort`) by the structured report hook, always raises a recoverable
   ## error.
   var rep = r
-  fillReportAndHandleVmReport(conf, rep, reportFrom)
+  fillReportAndHandleVmTrace(conf, rep, reportFrom)
 
   case conf.report(rep)
   of doAbort:

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -41,6 +41,12 @@ from compiler/ast/reports_sem import SemReport
 export InstantiationInfo
 export TErrorHandling
 
+proc handleReport*(
+    conf: ConfigRef,
+    r: Report,
+    reportFrom: InstantiationInfo,
+    eh: TErrorHandling = doNothing) {.noinline.}
+
 template toStdOrrKind(stdOrr): untyped =
   if stdOrr == stdout: stdOrrStdout else: stdOrrStderr
 
@@ -605,7 +611,7 @@ proc fillReportAndHandleVmReport(c: ConfigRef, r: var Report, reportFrom: Instan
   if r.category in { repSem, repVM } and r.location.isSome():
     r.context = c.getContext(r.location.get())
   if r.category == repVM and r.vmReport.trace != nil:
-    handleReport(conf, wrap(r.vmReport.trace[]), reportFrom)
+    handleReport(c, wrap(r.vmReport.trace[]), reportFrom)
 
 proc handleReport*(
     conf: ConfigRef,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -663,11 +663,11 @@ proc reportAndForceRaise*(
 
   if rep.category == repVM and rep.vmReport.trace != nil:
     reportAndForceRaise(conf, wrap(rep.vmReport.trace[]), reportFrom)
-  let
-    userAction = conf.report(rep)
-  case userAction
-  of doAbort:   quit 1
-  else: raiseRecoverableError("report")
+  case conf.report(rep)
+  of doAbort:
+    quit 1
+  of doRaise, doDefault, doNothing:
+    raiseRecoverableError("report")
 
 template reportAndForceRaise*(
   conf: ConfigRef; info: TLineInfo, report: ReportTypes) =

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -620,7 +620,7 @@ proc handleReport*(
     reportFrom: InstantiationInfo,
     eh: TErrorHandling = doNothing) {.noinline.} =
   var rep = r
-  fillReportAndHandleVmReport(conf, rep, reportFrom)
+  fillReportAndHandleVmTrace(conf, rep, reportFrom)
 
   let
     userAction = conf.report(rep)

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -1065,13 +1065,13 @@ proc markIndirect*(c: PContext, s: PSym) {.inline.} =
 
 proc checkSonsLen*(n: PNode, length: int; conf: ConfigRef) =
   if n.len != length:
-    conf.reportAndForceRaise(n.info, reportAst(
+    conf.reportAndFail(n.info, reportAst(
       rsemIllformedAst, n,
       str = "Expected $1 elements, but found $2" % [$length, $n.len]))
 
 proc checkMinSonsLen*(n: PNode, length: int; conf: ConfigRef) =
   if n.len < length:
-    conf.reportAndForceRaise(n.info, reportAst(
+    conf.reportAndFail(n.info, reportAst(
       rsemIllformedAst, n,
       str = "Expected at least $1 elements, but found $2" % [$length, $n.len]))
 

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -1065,13 +1065,13 @@ proc markIndirect*(c: PContext, s: PSym) {.inline.} =
 
 proc checkSonsLen*(n: PNode, length: int; conf: ConfigRef) =
   if n.len != length:
-    conf.globalReport(n.info, reportAst(
+    conf.reportAndForceRaise(n.info, reportAst(
       rsemIllformedAst, n,
       str = "Expected $1 elements, but found $2" % [$length, $n.len]))
 
 proc checkMinSonsLen*(n: PNode, length: int; conf: ConfigRef) =
   if n.len < length:
-    conf.globalReport(n.info, reportAst(
+    conf.reportAndForceRaise(n.info, reportAst(
       rsemIllformedAst, n,
       str = "Expected at least $1 elements, but found $2" % [$length, $n.len]))
 

--- a/nimsuggest/tests/terror_handling.nim
+++ b/nimsuggest/tests/terror_handling.nim
@@ -5,10 +5,7 @@
 import std/macros
 
 macro t1(): untyped =
-  result = newNimNode(nnkForStmt)
-  result.add(ident("i")) 
-  result.add newNimNode(nnkCall)
-  result.add nnkDiscardStmt.newTree(newEmptyNode())
+  newNimNode(nnkCall) # an call AST with not enough sub-nodes
 
 t1()
 

--- a/nimsuggest/tests/terror_handling.nim
+++ b/nimsuggest/tests/terror_handling.nim
@@ -16,5 +16,5 @@ t1()
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Error;;$file;;8;;23;;"illformed AST: ()";;0
+chk;;skUnknown;;;;Error;;$file;;10;;23;;"illformed AST: ()";;0
 """

--- a/nimsuggest/tests/terror_handling.nim
+++ b/nimsuggest/tests/terror_handling.nim
@@ -13,5 +13,5 @@ t1()
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Error;;$file;;10;;23;;"illformed AST: ()";;0
+chk;;skUnknown;;;;Error;;$file;;8;;12;;"illformed AST: ()";;0
 """

--- a/nimsuggest/tests/terror_handling.nim
+++ b/nimsuggest/tests/terror_handling.nim
@@ -1,0 +1,18 @@
+# Test ill formed AST will not causes crash and subsequent errors
+
+import std/macros
+
+macro t1(): untyped =
+  result = newNimNode(nnkForStmt)
+  result.add(ident("i")) 
+  result.add newNimNode(nnkCall)
+  result.add nnkDiscardStmt.newTree(newEmptyNode())
+
+t1()
+
+#[!]#
+discard """
+$nimsuggest --tester $file
+>chk $1
+chk;;skUnknown;;;;Error;;$file;;8;;23;;"illformed AST: ()";;0
+"""

--- a/nimsuggest/tests/terror_handling.nim
+++ b/nimsuggest/tests/terror_handling.nim
@@ -1,4 +1,6 @@
-# Test ill formed AST will not causes crash and subsequent errors
+# Ensure that AST not having the correct number of nodes doesn't cause
+# crashes. This a regression test for `checkSonsMinLen` and
+# `checkSonsLen` not aborting analysis.
 
 import std/macros
 


### PR DESCRIPTION
## Summary

Fix `nimsuggest`, and other tooling that uses a custom structured
report hook, crashing when encountering ill-formed AST that has the
wrong number of nodes.

## Details

Many of the semantic analysis procedures first verify that the input
`PNode` has the right number of child nodes. This is done via the
`checkSonsLen` and `checkMinSonsLen` procedures, with the expectation
being that both raise an `ERecoverableError` (through `globalReport`)
when the check fails.

However, since reporting the error happens via `handleReport`, it's
possible that the error handling strategy is overridden with a mode 
(e.g., `doNothing`) that results in execution to continue without any
exception being raised. `nimsuggest` sets the error handling mode to
`doNothing`, which then resulted in `checkSonsLen` and
`checkMinSonsLen` not ending the active routine, usually leading to
`IndexDefect`s or other crashes.

As an interim solution, the `reportAndFail` procedure is introduced.
`reportAndForceRaise` works similar to similar to `handleReport`, but
it ensures that *at least* an exception is raised -- both
`checkSonsLen` and `checkMinSonsLen` use it to ensure that the calling
routine is exited.