### PR TITLE
codegen: don't use `PSym` for labels

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2208,7 +2208,7 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
   of cnkRaiseStmt: genRaiseStmt(p, n)
   of cnkPragmaStmt: discard
   of cnkInvalid, cnkType, cnkAstLit, cnkMagic, cnkRange, cnkBinding, cnkExcept,
-     cnkFinally, cnkBranch:
+     cnkFinally, cnkBranch, cnkLabel:
     internalError(p.config, n.info, "expr(" & $n.kind & "); unknown node kind")
 
 proc getDefaultValue(p: BProc; typ: PType; info: TLineInfo): Rope =

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -139,6 +139,9 @@ type
   BProc* = ref TCProc
   TBlock* = object
     id*: int                  ## the ID of the label; positive means that it
+    blk*: int                 ## the ``BlockId`` + 1 of the block.
+                              ## '0' if the ``TBlock`` doesn't correspond to a
+                              ## ``cnkBlockStmt``
     label*: Rope              ## generated text for the label
                               ## nil if label is not used
     sections*: TCProcSections ## the code belonging
@@ -370,7 +373,7 @@ proc hash(n: ConstrTree): Hash =
       for it in n.items:
         result = result !& hashTree(it)
     of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic,
-       cnkWithOperand, cnkLocal:
+       cnkWithOperand, cnkLocal, cnkLabel:
       unreachable()
     result = !$result
 
@@ -400,7 +403,7 @@ proc `==`(a, b: ConstrTree): bool =
             if not treesEquivalent(a[i], b[i]): return
           result = true
       of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic,
-         cnkWithOperand, cnkLocal:
+         cnkWithOperand, cnkLocal, cnkLabel:
         # nodes that cannot appear in construction trees
         unreachable()
 

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -33,6 +33,7 @@ type
     cnkAstLit        ## a ``NimNode`` literal
 
     cnkSym
+    cnkLabel         ## name of a block
     cnkLocal         ## reference to a local
     # future direction: split up ``cnkSym`` in the way the MIR does it
     cnkMagic         ## name of a magic procedure. Only valid in the callee
@@ -164,6 +165,10 @@ type
     name*: PIdent
       ## either the user-defined name or 'nil'
 
+  BlockId* = distinct uint32
+    ## Identifies a block within another block -- the IDs are **not** unique
+    ## within a ``Body``. An outermost block has ID 0, a block within the
+    ## block ID 1, etc.
   LocalId* = distinct uint32
     ## Identifies a local within a procedure.
 
@@ -182,6 +187,7 @@ type
     of cnkAstLit:     astLit*: PNode
     of cnkSym:        sym*: PSym
     of cnkMagic:      magic*: TMagic
+    of cnkLabel:      label*: BlockId
     of cnkLocal:      local*: LocalId
     of cnkPragmaStmt: pragma*: TSpecialWord
     of cnkWithOperand: operand*: CgNode
@@ -258,6 +264,7 @@ func newLocalRef*(id: LocalId, info: TLineInfo, typ: PType): CgNode =
   CgNode(kind: cnkLocal, info: info, typ: typ, local: id)
 
 proc `==`*(x, y: LocalId): bool {.borrow.}
+proc `==`*(x, y: BlockId): bool {.borrow.}
 
 proc merge*(dest: var Body, source: Body): CgNode =
   ## Merges `source` into `dest` by appending the former to the latter.

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -49,6 +49,9 @@ proc treeRepr*(n: CgNode): string =
       result.add n.sym.name.s
       result.add " id: "
       result.add $n.sym.itemId
+    of cnkLabel:
+      result.add "label: "
+      result.addInt n.label.int
     of cnkLocal:
       result.add "local: "
       result.add $n.local.int
@@ -161,6 +164,9 @@ proc render(c: var RenderCtx, body: Body, ind: int, n: CgNode,
     else:
       # magics are never cursors nor do they need disambiguation
       res.add s.name.s
+  of cnkLabel:
+    res.add ":label_"
+    res.addInt n.label.int
   of cnkLocal:
     let name = body[n.local].name
     if name.isNil:

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -6,10 +6,10 @@ discard """
 var :aux_2
 try:
   var x_cursor = ("hi", 5)
-  block label:
+  block :label_0:
     if cond:
       x_cursor = [type node](("different", 54))
-      break label
+      break :label_0
     x_cursor = [type node](("string here", 80))
   echo([
     var :aux_4 = $(x_cursor)
@@ -26,10 +26,10 @@ try:
   var res
   try:
     res = newStringOfCap(80)
-    block label:
+    block :label_0:
       while true:
         if not(readLine(f, res)):
-          break label
+          break :label_0
         var x_cursor = res
         echo([x_cursor])
   finally:

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -91,10 +91,10 @@ try:
   var a_cursor = txt
   var i = 0
   var L = len(a_cursor)
-  block label:
+  block :label_0:
     while true:
       if not(<(i, L)):
-        break label
+        break :label_0
       var splitted
       try:
         var line = a_cursor[i]
@@ -119,10 +119,10 @@ try:
   var a_cursor = shadowScope[].symbols
   var i = 0
   var L = len(a_cursor)
-  block label:
+  block :label_0:
     while true:
       if not(<(i, L)):
-        break label
+        break :label_0
       var :aux_9
       var sym = a_cursor[i]
       addInterfaceDecl(c,
@@ -139,7 +139,7 @@ finally:
 var par
 try:
   this[].isValid = fileExists(this[].value)
-  block label:
+  block :label_0:
     if dirExists(this[].value):
       var :aux_4
       par = [type node]((
@@ -147,7 +147,7 @@ try:
         :aux_4 = default()
         =copy(:aux_4, :aux_3)
         :aux_4, ""))
-      break label
+      break :label_0
     var :aux_6
     var :aux_7
     var :aux_8
@@ -161,12 +161,12 @@ try:
       wasMoved(:aux_7.tail)
       :aux_8))
     =destroy(:aux_7)
-  block label_1:
+  block :label_0:
     if dirExists(par.dir):
       var :aux_9 = this[].matchDirs
       var :aux_10 = getSubDirs(par.dir, par.front)
       =sink(:aux_9, :aux_10)
-      break label_1
+      break :label_0
     var :aux_11 = this[].matchDirs
     var :aux_12 = []
     =sink(:aux_11, :aux_12)

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -4,17 +4,17 @@ discard """
   nimout: '''--expandArc: traverse
 
 var it_cursor = root
-block label:
+block :label_0:
   while true:
     if not(not(==(it_cursor, nil))):
-      break label
+      break :label_0
     echo([it_cursor[].s])
     it_cursor = it_cursor[].ri
 var jt_cursor = root
-block label_1:
+block :label_0:
   while true:
     if not(not(==(jt_cursor, nil))):
-      break label_1
+      break :label_0
     var ri_1_cursor = jt_cursor[].ri
     echo([jt_cursor[].s])
     jt_cursor = ri_1_cursor

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -7,10 +7,10 @@ var a
 var b
 var x
 x = f()
-block label:
+block :label_0:
   if cond:
     add(a, x)
-    break label
+    break :label_0
   add(b, x)
 =destroy(b)
 =destroy(a)
@@ -25,10 +25,10 @@ try:
   var a_1 = 0
   var b_1 = 4
   var i = a_1
-  block label:
+  block :label_0:
     while true:
       if not(<(i, b_1)):
-        break label
+        break :label_0
       var :aux_9
       var i_1_cursor = i
       if ==(i_1_cursor, 2):
@@ -38,14 +38,14 @@ try:
         =copy(:aux_9, x)
         :aux_9)
       inc(i, 1)
-  block label_1:
+  block :label_0:
     if cond:
       var :aux_10
       add(a,
         :aux_10 = x
         wasMoved(x)
         :aux_10)
-      break label_1
+      break :label_0
     var :aux_11
     add(b,
       :aux_11 = x


### PR DESCRIPTION
## Summary

In the code generators, represent block labels with a dedicated type
and
node, instead of using  `PSym`  for that. This is an internal-only
change,
and another step towards removing all `PSym` usage from the code
generators.

## Details

* add the `cnkLabel` node kind to `CgNode`
* it stores a  `BlockId` , and appears as sub-node for both 
`cnkBlockStmt` 
  and `cnkBreakStmt`
* a `BlockId` is not a unique ID within a `Body` -- instead it
  identifies the enclosing `block` for a `break`. This matches how the
  code generators previously used `skLabel` symbols
* `cgirgen` now no longer queries or modifies the identifier cache
  (`IdentCache`), so all usages of the type are removed. The `idents`
  import is turned into a narrow import

The code generators are updated accordingly:

* `cgen` uses its `blocks` stack not only for `cnkBlockStmt`s, but for
  C blocks (`{}`) in general. Therefore, `TBlock` stores the  `BlockId`
  offset by 1, leaving '0' to mean "not corresponding to a
  `cnkBlockStmt`"
* `jsgen` uses the `BlockId` as an index into the `blocks` stack, which
  is now a `seq[int]` (the previously used `TBlock` type had only a
  single field)
* `vmgen` also uses the `BlockId` as an index into its `blocks` stack,
  making the previous search logic obsolete. The `withBlock` and
  `popBlocks` routines were only used in a single place -- they're
  inlined and removed. In addition, the `blocks` stack embeds the
  ending list directly, removing the need for the `TBlock` type