### PR TITLE
fix(suggest): file level cmds don't leak internal syms

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -308,7 +308,7 @@ type
 
 const 
   IdeLocCmds* = {ideSug, ideCon, ideDef, ideUse, ideDus}
-    ## source location awared IDE commands
+    ## IDE commands requiring source locations, related `MsgConfig.trackPos`
 
 template `[]`*(conf: ConfigRef, idx: FileIndex): TFileInfo =
   conf.m.fileInfos[idx.uint32]

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -307,7 +307,8 @@ type
       unreportedErrors*: OrderedTable[NodeId, PNode]
 
 const 
-  IdeLocCmds* = {ideSug, ideCon, ideDef, ideUse, ideDus, ideHighlight} ## source location awared IDE commands 
+  IdeLocCmds* = {ideSug, ideCon, ideDef, ideUse, ideDus}
+    ## source location awared IDE commands
 
 template `[]`*(conf: ConfigRef, idx: FileIndex): TFileInfo =
   conf.m.fileInfos[idx.uint32]

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -306,6 +306,9 @@ type
     when defined(nimDebugUnreportedErrors):
       unreportedErrors*: OrderedTable[NodeId, PNode]
 
+const 
+  IdeLocCmds* = {ideSug, ideCon, ideDef, ideUse, ideDus, ideHighlight} ## source location awared IDE commands 
+
 template `[]`*(conf: ConfigRef, idx: FileIndex): TFileInfo =
   conf.m.fileInfos[idx.uint32]
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -167,7 +167,9 @@ proc deltaTrace(stopProc, indent: string, entries: seq[StackTraceEntry])
 template semIdeForTemplateOrGenericCheck(conf, n, requiresCheck) =
   # we check quickly if the node is where the cursor is
   when defined(nimsuggest):
-    if n.info.fileIndex == conf.m.trackPos.fileIndex and n.info.line == conf.m.trackPos.line:
+    if conf.m.trackPos.col != -1 and
+       n.info.fileIndex == conf.m.trackPos.fileIndex and
+       n.info.line == conf.m.trackPos.line:
       requiresCheck = true
 
 template semIdeForTemplateOrGeneric(c: PContext; n: PNode;

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -164,21 +164,20 @@ proc deltaTrace(stopProc, indent: string, entries: seq[StackTraceEntry])
     echo:
       "$1| $2 $3($4)" % [indent, $e.procname, $e.filename, $e.line]
 
-template semIdeForTemplateOrGenericCheck(conf, n, requiresCheck) =
-  # we check quickly if the node is where the cursor is
+template semIdeForTemplateOrGenericCheck(conf, n, cursorInBody) =
+  # use only for idetools support; detecting cursor in generic or template body
+  # if so call `semIdeForTemplateOrGeneric` for semantic checking
   when defined(nimsuggest):
-    if conf.ideCmd in {ideSug, ideCon} and
+    if conf.ideCmd in IdeLocCmds and
        n.info.fileIndex == conf.m.trackPos.fileIndex and
        n.info.line == conf.m.trackPos.line:
-      requiresCheck = true
+      cursorInBody = true
 
 template semIdeForTemplateOrGeneric(c: PContext; n: PNode;
-                                    requiresCheck: bool) =
-  # use only for idetools support; this is pretty slow so generics and
-  # templates perform some quick check whether the cursor is actually in
-  # the generic or template.
+                                    cursorInBody: bool) =
+  # provide incomplete information for idetools support in generic or template
   when defined(nimsuggest):
-    if c.config.cmd == cmdIdeTools and requiresCheck:
+    if c.config.cmd == cmdIdeTools and cursorInBody:
       #if optIdeDebug in gGlobalOptions:
       #  echo "passing to safeSemExpr: ", renderTree(n)
       discard safeSemExpr(c, n)

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -167,7 +167,7 @@ proc deltaTrace(stopProc, indent: string, entries: seq[StackTraceEntry])
 template semIdeForTemplateOrGenericCheck(conf, n, requiresCheck) =
   # we check quickly if the node is where the cursor is
   when defined(nimsuggest):
-    if conf.m.trackPos.col != -1 and
+    if conf.ideCmd in {ideSug, ideCon} and
        n.info.fileIndex == conf.m.trackPos.fileIndex and
        n.info.line == conf.m.trackPos.line:
       requiresCheck = true

--- a/nimsuggest/tests/toutline_generic.nim
+++ b/nimsuggest/tests/toutline_generic.nim
@@ -1,0 +1,11 @@
+from typetraits import supportsCopyMem
+
+proc tgeneric[T](x: var T) =
+  when supportsCopyMem(T):
+    discard
+
+discard """
+$nimsuggest --tester $file
+>outline $path/toutline_generic.nim
+outline;;skProc;;toutline_generic.tgeneric;;*;;3;;5;;"";;100
+"""

--- a/nimsuggest/tests/toutline_generic.nim
+++ b/nimsuggest/tests/toutline_generic.nim
@@ -9,7 +9,7 @@ template templ() =
   var x = 0 #[!]#
   return # <- when no cursor is provided, this triggered `x` being reported
 
-# try both with and without a specified cursor position
+# try both with and without a specified cursor position, they should be the same
 
 discard """
 $nimsuggest --tester $file

--- a/nimsuggest/tests/toutline_generic.nim
+++ b/nimsuggest/tests/toutline_generic.nim
@@ -1,11 +1,27 @@
-from typetraits import supportsCopyMem
+# Regression test for symbols within template and generic bodies being
+# wrongfully reported by `outline`.
 
-proc tgeneric[T](x: var T) =
-  when supportsCopyMem(T):
-    discard
+proc generic[T]() =
+  var x = 0 #[!]#
+  return # <- when no cursor is provided, this triggered `x` being reported
+
+template templ() =
+  var x = 0 #[!]#
+  return # <- when no cursor is provided, this triggered `x` being reported
+
+# try both with and without a specified cursor position
 
 discard """
 $nimsuggest --tester $file
+>outline $1
+outline;;skProc;;toutline_generic.generic;;*;;4;;5;;"";;100
+outline;;skTemplate;;toutline_generic.templ;;*;;9;;9;;"";;100
+
+>outline $2
+outline;;skProc;;toutline_generic.generic;;*;;4;;5;;"";;100
+outline;;skTemplate;;toutline_generic.templ;;*;;9;;9;;"";;100
+
 >outline $path/toutline_generic.nim
-outline;;skProc;;toutline_generic.tgeneric;;*;;3;;5;;"";;100
+outline;;skProc;;toutline_generic.generic;;*;;4;;5;;"";;100
+outline;;skTemplate;;toutline_generic.templ;;*;;8;;9;;"";;100
 """

--- a/nimsuggest/tests/toutline_generic.nim
+++ b/nimsuggest/tests/toutline_generic.nim
@@ -15,11 +15,11 @@ discard """
 $nimsuggest --tester $file
 >outline $1
 outline;;skProc;;toutline_generic.generic;;*;;4;;5;;"";;100
-outline;;skTemplate;;toutline_generic.templ;;*;;9;;9;;"";;100
+outline;;skTemplate;;toutline_generic.templ;;*;;8;;9;;"";;100
 
 >outline $2
 outline;;skProc;;toutline_generic.generic;;*;;4;;5;;"";;100
-outline;;skTemplate;;toutline_generic.templ;;*;;9;;9;;"";;100
+outline;;skTemplate;;toutline_generic.templ;;*;;8;;9;;"";;100
 
 >outline $path/toutline_generic.nim
 outline;;skProc;;toutline_generic.generic;;*;;4;;5;;"";;100


### PR DESCRIPTION
## Summary

Suggest commands related to the whole file (i.e. outline), and not
cursor positions, no longer include symbols from inside template and
generic routines.

## Details

`semIdeForTemplateOrGenericCheck`  is used to detect whether the cursor
is within a generic routine or template body, before this change it
didn't validate which suggest command was invoked ( `ideCmd` ). This
resulted in  `safeSemExpr`  being run and potentially reporting symbols
from inside such routines. This led to commands such as  `outline` 
containing symbols from the routine bodies polluting module level
results.

`semIdeForTemplateOrGenericCheck`  has now been updated to check the
command against the newly added  `ideLocCmds`  constant, which includes
commands that require cursor position tracking ( `ideSug` ,  `ideCon` , 
`ideDef` ,  `ideUse` ,  `ideDus` ), preventing the unexpected analysis
and pollution of module level results.

A regression test was added to ensure that accidentally providing cursor
tracking information to module level commands doesn't change the
results.