### PR TITLE
internal: reduce surface area of fatal reports

### DIFF
--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -364,9 +364,7 @@ proc atom(g: TSrcGen; n: PNode): string =
     if (n.typ != nil) and (n.typ.sym != nil): result = n.typ.sym.name.s
     else: result = "[type node]"
   else:
-    g.config.localReport InternalReport(
-      kind: rintUnreachable, msg: "renderer.atom " & $n.kind)
-    result = ""
+    g.config.internalError("renderer.atom " & $n.kind)
 
 proc lcomma(g: TSrcGen; n: PNode, start: int = 0, theEnd: int = - 1): int =
   assert(theEnd < 0)
@@ -1638,8 +1636,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
     gsub(g, n.sons[0], c)
   else:
     #nkNone, nkExplicitTypeListCall:
-    g.config.localReport InternalReport(
-      kind: rintUnreachable, msg: "renderer.gsub(" & $n.kind & ')')
+    g.config.internalError("renderer.gsub(" & $n.kind & ')')
 
 proc renderTree*(n: PNode, renderFlags: TRenderFlags = {}): string =
   if n == nil: return "<nil tree>"

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -71,15 +71,10 @@ type
     repNone
 
     #--------------------------  Internal reports  ---------------------------#
-    # Internal reports being
+    # Internal reports begin
     # fatal errors begin
-    rintUnknown ## Unknown internal report kind
-    rintFatal ## Explicitly fatal compiler error
-
     rintUnreachable ## State in the compiler code that must not be reached
     rintAssert ## Failed internal assert in the compiler
-
-    rintIce ## Internal compilation error
     # fatal end
 
     # errors being
@@ -909,7 +904,7 @@ type
 
   ExternalReportKind* = range[rextCmdRequiresFile .. rextPath]
 
-  InternalReportKind* = range[rintUnknown .. rintEchoMessage]
+  InternalReportKind* = range[rintUnreachable .. rintEchoMessage]
 
 
 const
@@ -972,8 +967,8 @@ const
   repInternalKinds*: ReportKinds = {
     low(InternalReportKind) .. high(InternalReportKind)}
 
-  rintFatalKinds* = {rintUnknown .. rintIce} ## Fatal internal compilation
-                                             ## reports
+  rintFatalKinds* = {rintUnreachable .. rintAssert} ## Fatal internal compilation
+                                                ## reports
   rintErrorKinds* = {rintCannotOpenFile .. rintNotImplemented}
   rintWarningKinds* = {rintWarnCannotOpenFile .. rintWarnFileChanged}
   rintHintKinds* = {rintSource .. rintSuccessX}

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -35,9 +35,6 @@ import
     modulegraphs,
   ]
 
-# TODO: switch to internalError/Assert or better yet emit the appropriate
-#       diagnostic/event/telemetry data instead, then drop this dependency
-from compiler/ast/reports_internal import InternalReport
 from compiler/ast/report_enums import ReportKind
 
 from compiler/ast/reports_sem import SemReport,

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -565,10 +565,7 @@ proc firstFloat*(t: PType): BiggestFloat =
      tyStatic, tyInferred, tyUserTypeClasses:
     firstFloat(lastSon(t))
   else:
-    newPartialConfigRef().localReport InternalReport(
-      kind: rintUnreachable,
-      msg: "invalid kind for firstFloat(" & $t.kind & ')')
-    NaN
+    unreachable("invalid kind for firstFloat(" & $t.kind & ')')
 
 proc lastFloat*(t: PType): BiggestFloat =
   case t.kind
@@ -582,10 +579,7 @@ proc lastFloat*(t: PType): BiggestFloat =
      tyStatic, tyInferred, tyUserTypeClasses:
     lastFloat(lastSon(t))
   else:
-    newPartialConfigRef().localReport InternalReport(
-      kind: rintUnreachable,
-      msg: "invalid kind for firstFloat(" & $t.kind & ')')
-    NaN
+    unreachable("invalid kind for firstFloat(" & $t.kind & ')')
 
 proc floatRangeCheck*(x: BiggestFloat, t: PType): bool =
   case t.kind
@@ -601,10 +595,7 @@ proc floatRangeCheck*(x: BiggestFloat, t: PType): bool =
      tyStatic, tyInferred, tyUserTypeClasses:
     floatRangeCheck(x, lastSon(t))
   else:
-    newPartialConfigRef().localReport InternalReport(
-      kind: rintUnreachable,
-      msg: "invalid kind for floatRangeCheck(" & $t.kind & ')')
-    false
+    unreachable("invalid kind for floatRangeCheck(" & $t.kind & ')')
 
 # -------------- type equality -----------------------------------------------
 

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2632,15 +2632,6 @@ To create a stacktrace, rerun compilation with './koch temp $1 <file>'
     of rintCannotOpenFile, rintWarnCannotOpenFile:
       result = "cannot open file: $1" % r.file
 
-    of rintUnknown:
-      result = "unknown"
-
-    of rintFatal:
-      result = "fatal"
-
-    of rintIce:
-      result = r.msg
-
     of rintNotUsingNimcore:
       result = "Nim tooling must be built using -d:nimcore"
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -703,27 +703,9 @@ template localReport*(conf: ConfigRef, report: Report) =
 
 # xxx: `internalError` and `internalAssert` in conjunction with `handleReport`,
 #      and the whole concept of "reports" indicating error handling action at a
-#      callsite, is *terrible*. Since neither will necessarily raise/end
-#      execution of the current routine, which may lead to NPEs and the like.
-
-template internalError*(
-    conf: ConfigRef, repKind: InternalReportKind, fail: string): untyped =
-  ## Causes an internal error; but does not necessarily raise/end the currently
-  ## executing routine.
-  conf.handleReport(
-    wrap(InternalReport(kind: repKind, msg: fail), instLoc()),
-    instLoc(),
-    doAbort)
-
-template internalError*(
-    conf: ConfigRef, info: TLineInfo,
-    repKind: InternalReportKind, fail: string): untyped =
-  ## Causes an internal error; but does not necessarily raise/end the currently
-  ## executing routine.
-  conf.handleReport(
-    wrap(InternalReport(kind: repKind, msg: fail), instLoc(), info),
-    instLoc(),
-    doAbort)
+#      callsite, is *terrible*. While it will result in the compiler exiting,
+#      it is currently implemented very indirectly, through
+#      ``isCompilerFatal``.
 
 proc doInternalUnreachable*(conf: ConfigRef, info: TLineInfo, msg: string,
                             instLoc: InstantiationInfo) {.noreturn, inline.} =

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -35,11 +35,6 @@ from compiler/ast/reports_sem import reportStr,
   reportSymbols,
   reportTyp
 
-# TODO: at least use internalAssert/Error better still have its own data type
-#       for diag/event/telemetry
-from compiler/ast/reports_internal import InternalReport
-# from compiler/ast/report_enums import ReportKind
-
 export createMagic
 
 proc nilOrSysInt*(g: ModuleGraph): PType = g.sysTypes[tyInt]

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -102,19 +102,14 @@ proc getSysType*(g: ModuleGraph; info: TLineInfo; kind: TTypeKind): PType =
     of tyPointer: result = sysTypeFromName("pointer")
     of tyNil: result = newSysType(g, tyNil, g.config.target.ptrSize)
     else:
-      g.config.localReport InternalReport(
-        kind: rintUnreachable, msg: "request for typekind: " & $kind)
+      g.config.internalError("request for typekind: " & $kind)
     g.sysTypes[kind] = result
   if result.kind != kind:
     if kind == tyFloat64 and result.kind == tyFloat: discard # because of aliasing
     else:
-      g.config.localReport InternalReport(
-        kind: rintUnreachable,
-        msg: "wanted: " & $kind & " got: " & $result.kind)
+      g.config.internalError("wanted: " & $kind & " got: " & $result.kind)
   if result == nil:
-    g.config.localReport InternalReport(
-      kind: rintUnreachable,
-      msg: "type not found: " & $kind)
+    g.config.internalError("type not found: " & $kind)
 
 proc resetSysTypes*(g: ModuleGraph) =
   g.systemModule = nil

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -728,8 +728,7 @@ proc setIntLitType*(c: PContext; result: PNode) =
     else:
       result.typ = getSysType(c.graph, result.info, tyInt64)
   else:
-    c.config.internalError(
-      result.info, rintUnreachable, "invalid int size")
+    c.config.internalError(result.info, "invalid int size")
 
 proc makeInstPair*(s: PSym, inst: PInstantiation): TInstantiationPair =
   result.genericSym = s


### PR DESCRIPTION
## Summary

Change all reporting of fatal `InternalReport` errors to use
`internalError` and remove unused `InternalReport` report kinds
representing fatal errors. This hides another report dependency, and
all
existing reporting of fatal internal reports now going through a single
procedure makes it easier to remove the `Report` usage later on.

## Details

* change `globalReport` and `localReport` usage with `rintUnreachable`
  to use `internalError`
* remove the now-unused `internalError` overloads accepting an
  `InternalReportKind`
* three occurrences in the `types` module are replaced with using
  `unreachable`, removing the construction of a partial `ConfigRef`
* the `rintUnknown`, `rintIce`, and `rintFatal` report kinds are
  removed -- they were unused, and it's unlikely that they'll become
  used again