### PR TITLE
msgs: more decision making in handleReport

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3981,17 +3981,8 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
   ## `reportBody` for report, which then calls respective (for each report
   ## category) `reportBody` overloads defined above
   assertKind r
-  let wkind = conf.writabilityKind(r)
-  # debug reports can be both enabled and force enabled. So adding a case here
-  # is not really useful, since report writability kind does not necessarily
-  # dictate how it is written, just whether it can/must/cannot be written.
-  # xxx: the above convoluted comment brought to you by _glaring_ design flaws!
-  if wkind == writeDisabled:
-    return
-  else:
-    if wkind == writeForceEnabled:
-      echo conf.reportFull(r)
-    elif r.kind == rsemProcessing and conf.hintProcessingDots:
+  if true:
+    if r.kind == rsemProcessing and conf.hintProcessingDots:
       # xxx: the report hook is handling processing dots output, why? this whole
       #      infrastructure is overwrought. seriously, they're not hints, they're
       #      progress indicators.

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -294,6 +294,9 @@ type
     ## textual output from the compiler goes through this callback.
     writeHook*: proc(conf: ConfigRef, output: string, flags: MsgFlags) {.closure.}
     structuredReportHook*: ReportHook
+      ## callback that is invoked when an enabled report is passed to report
+      ## handling. The callback is meant to handle rendering/displaying of
+      ## the report
     astDiagToLegacyReport*: proc(conf: ConfigRef, d: PAstDiag): Report
     setMsgFormat*: proc(config: ConfigRef, fmt: MsgFormatKind) {.closure.}
       ## callback that sets the message format for legacy reporting, needs to
@@ -706,26 +709,16 @@ func writabilityKind*(conf: ConfigRef, r: Report): ReportWritabilityKind =
     ## evaluation` context. `sem` and `semexprs` in particular will clear
     ## `conf.m.errorOutputs` as a signal for this. For more details see the
     ## comment for `MsgConfig.errorOutputs`.
-  if (
-    (conf.isEnabled(r) and r.category == repDebug and compTimeCtx)
+  if r.category == repDebug and compTimeCtx:
     # Force write of the report messages using regular stdout if compTimeCtx
     # is enabled
-  ):
-    return writeForceEnabled
-
-  elif (
-    # Not explicitly enabled
-    not conf.isEnabled(r)
-  ) or (
+    writeForceEnabled
+  elif compTimeCtx:
     # Or we are in the special hack mode for `compiles()` processing
-    compTimeCtx
-  ):
-
     # Return without writing
-    return writeDisabled
-
+    writeDisabled
   else:
-    return writeEnabled
+    writeEnabled
 
 const
   oldExperimentalFeatures* = {dotOperators, callOperator}

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -138,11 +138,7 @@ proc sexp*(t: PSym): SexpNode =
 
 proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
   writeConf = conf
-  let wkind = conf.writabilityKind(r)
-
-  if wkind == writeDisabled:
-    return
-  else:
+  if true:
     var s = newSList()
     s.add newSSymbol(multiReplace($r.kind, {
       "rsem": "Sem",
@@ -174,7 +170,4 @@ proc reportHook*(conf: ConfigRef, r: Report): TErrorHandling =
       of repBackend:  s.addFields(r.backendReport, f)
       of repExternal: s.addFields(r.externalReport, f)
 
-    if wkind == writeForceEnabled:
-      echo s.toLine().toString(conf.useColor)
-    else:
-      conf.writeln(s.toLine().toString(conf.useColor))
+    conf.writeln(s.toLine().toString(conf.useColor))

--- a/nimsuggest/tests/tchk1.nim
+++ b/nimsuggest/tests/tchk1.nim
@@ -21,10 +21,6 @@ chk;;skUnknown;;;;Error;;$file;;12;;0;;"identifier expected, but found \'keyword
 chk;;skUnknown;;;;Error;;$file;;14;;0;;"nestable statement requires indentation";;0
 chk;;skUnknown;;;;Error;;$file;;12;;0;;"implementation of \'foo\' expected";;0
 chk;;skUnknown;;;;Error;;$file;;17;;0;;"invalid indentation";;0
-chk;;skUnknown;;;;Hint;;$file;;20;;95;;"Hint: line too long [LineTooLong]";;0
-chk;;skUnknown;;;;Hint;;$file;;21;;83;;"Hint: line too long [LineTooLong]";;0
-chk;;skUnknown;;;;Hint;;$file;;28;;97;;"Hint: line too long [LineTooLong]";;0
-chk;;skUnknown;;;;Hint;;$file;;29;;98;;"Hint: line too long [LineTooLong]";;0
 chk;;skUnknown;;;;Hint;;$file;;12;;9;;"\'foo\' is declared but not used [XDeclaredButNotUsed]";;0
 chk;;skUnknown;;;;Hint;;$file;;14;;5;;"\'main\' is declared but not used [XDeclaredButNotUsed]";;0
 """

--- a/tests/misc/twarning_as_error_regression.nim
+++ b/tests/misc/twarning_as_error_regression.nim
@@ -1,0 +1,20 @@
+discard """
+  description: '''
+    Regression test for warnings and hints promoted to errors counting as
+    reported (and thus leading to compilation aborting) even if disabled
+  '''
+  matrix: "--warning:Deprecated:on --warningAsError:Deprecated --hint:XDeclaredButNotUsed:on --hintAsError:XDeclaredButNotUsed"
+  action: compile
+"""
+
+{.push hint[XDeclaredButNotUsed]:off.}
+block:
+  var x = 0 # must not quit the compiler
+{.pop.}
+
+proc p() {.deprecated, used.} =
+  discard
+
+{.push warning[Deprecated]:off.}
+p() # must not quit the compiler
+{.pop.}


### PR DESCRIPTION
## Summary

* fix hints/warnings promoted to errors always counting towards the
  maximum error count, even if the hint/warning is currently disabled
* fix disabled warnings and hints being reported by `nimsuggest chk`

## Details

Processing of a `Report` previously worked as follows:
1. `handleReport` pre-processes the report
2. the report is passed to the report hook
3. the hook outputs the report if it determines that the report should
   be rendered and displayed
4. `handleReport` determines the error handling strategy
5. error handling is performed

This has two problems:
1. the responsibility of deciding whether a report should be output is
   left to the hook, which also means that the hook needs access to all
   state necessary to make the decision
2. error handling always takes place, even if the report is disabled

Report handling is split up, and the responsibilities are shifted:
1. if a report is disabled (`isEnabled` returns false), `handleReport`
   is a no-op
2. deciding writability is now the responsibility of `handleReport`
   (i.e., the compiler), with the report hook only invoked if the
   report is eligible for being displayed
3. computing writability no longer takes into account whether the
   report is enabled (since writeability is only decided *after* it is
   known that a report is enabled)
4. `handleReport` now handles the "forcefully enabled" case, by
   temporarily overriding the `writeln` hook with something that always
   echoes the message (this mirrors the previous behaviour of the
   report hook implementations)

In short, more responsibility regarding reports shift into a single
place (`handleReport`), with the report hook now only being invoked for
reports that should be displayed. Centralizing `Report` handling is a
step towards eventually removing/replacing `Report`s.

Since the the report hook used by `nimsuggest` doesn't consider
writeability ( `writabilityKind` ), this fixes all produced warnings
being
reported by `chk`, even those that are disabled.

Finally, disabled reports no longer triggering error handling fixes
disabled warnings promoted to errors being able to abort compilation.