### PR TITLE
fix(unittest): check not capturing operands

### DIFF
--- a/tests/stdlib/metaprogramming/tunittest_impure.nim
+++ b/tests/stdlib/metaprogramming/tunittest_impure.nim
@@ -1,0 +1,54 @@
+discard """
+  targets: "c js vm"
+  knownIssue.vm: "std/streams is not supported"
+  description: '''
+    Ensure that the values of impure expressions used as operands in
+    ``check`` expression are properly captured (assigned to
+    temporaries) and, in case of failure, displayed
+  '''
+"""
+
+import std/[unittest, sequtils, strutils, exitprocs]
+
+var
+  output: seq[string] ## set after a ``check`` failure
+  wasFailure: bool
+
+type MockFormatter = ref object of OutputFormatter
+
+method failureOccurred(f: MockFormatter, checkpoints: seq[string], _: string) {.gcsafe.} =
+  # only include the printed values
+  output = filterIt(checkpoints, "Check failed:" notin it)
+  wasFailure = true
+
+# we use our own formatter:
+resetOutputFormatters()
+addOutputFormatter(MockFormatter())
+
+template verify(o: varargs[string]) =
+  ## Compares the output of the previous ``check`` failure against `o`.
+  doAssert wasFailure, "check didn't fail"
+  doAssert output == o, "got: " & $output
+  wasFailure = false
+
+proc modify(x: var int): var int =
+  inc x
+  x
+
+# --- the actual test cases
+
+var a = 0
+check a == modify(a)
+verify "a was 0", "modify(a) was 1"
+
+check (inc a; a) == (inc a; a)
+verify "\ninc a\na was 2", "\ninc a\na was 3"
+
+check [modify(a)] == [modify(a)]
+verify "[modify(a)] was [4]", "[modify(a)] was [5]"
+
+check (modify(a),) == (modify(a),)
+verify "(modify(a),) was (6,)", "(modify(a),) was (7,)"
+
+# reset the program result so that no test failure is reported
+setProgramResult(0)


### PR DESCRIPTION
## Summary

Fix the value of some operand expressions to `not`, `==`, etc. within
`check` calls not being captured, which would result in incorrect
`check` failure/success.

## Details

### Issue description

For displaying the value of the operands in case of a test failure,
the `check` macro "captures" the values of the operands prior to
evaluating the condition expression. This is implemented in
`inspectArgs` by assigning the operand expressions to temporaries and
then accessing the temporaries.

Type expressions cannot be assigned to run-time variables, so they were
guarded against, by testing for whether the nodes have `ntyTypeDesc`
as the type kind. However, since the AST passed to `check` is
untyped, this cannot work, but so far it did, due to an implementation
bug of `typeKind`, where the value returned for `typeKind` called on a
`NimNode` that has no type results in undefined behaviour.

In this specific case, the bug resulted in the `notin {ntyTypeDesc}`
expressions always to always evaluate to `false`, which in turn
disabled capturing for some expressions.

### The solution

The decision of whether to assign the expression can only happen when
the expressions are typed. A two-phase macro could be used, but that
would require larger changes to `check`, so a different solution is
chosen: instead of an assignment, `inspectArgs` emits a call to the new
`materialize` template, passing along a generated `nksTemplate` symbol.
To access the materialized (or not) value, `inspectArgs` emits calls
with the generated template symbol.

When the `materialize` calls are later expanded, a template with the
passed-long symbol is produced. Using two `materialize` overloads, one
for `typedesc`s and for everything else, doesn't work at the moment: if
the value expression is erroneous, no `materialize` template is
invoked, which would leave the gensym'ed symbol in an improper state,
later causing the compiler to crash when it attempts to use it during
overload resolution.

In addition, for improved clarity, `inspectArgs` is changed to use a
`case` statement.