### PR TITLE
CI: use strict mode for compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         run: echo "::add-matcher::.github/nim-problem-matcher.json"
 
       - name: Build release binaries
-        run: ./koch.py runCI
+        run: ./koch.py all-strict
 
       - name: Upload workspace to artifacts
         uses: ./.github/actions/upload-compiler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         run: echo "::add-matcher::.github/nim-problem-matcher.json"
 
       - name: Build release binaries
-        run: ./koch.py all
+        run: ./koch.py runCI
 
       - name: Upload workspace to artifacts
         uses: ./.github/actions/upload-compiler

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -306,7 +306,10 @@ cppDefine = "NAN_INFINITY"
 cppDefine = "INF"
 cppDefine = "NAN"
 
-@if nimStrictMode:
+# TODO: remove ``nimKochBootstrap`` check once the csources compiler is
+#       updated. The current version doesn't properly support warnings/hints
+#       promoted to errors
+@if nimStrictMode and not nimKochBootstrap:
   @if nimHasWarningAsError:
     warningAsError:UnusedImport:on
   @end

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -307,14 +307,11 @@ cppDefine = "INF"
 cppDefine = "NAN"
 
 @if nimStrictMode:
-  # xxx add more flags here, and use `-d:nimStrictMode` in more contexts in CI.
-
-  # pending bug #14246, enable this:
-  # @if nimHasWarningAsError:
-  #   warningAsError:UnusedImport
+  @if nimHasWarningAsError:
+    warningAsError:UnusedImport:on
+  @end
 
   @if nimHasHintAsError:
-    # hint:ConvFromXtoItselfNotNeeded
     hintAsError:ConvFromXtoItselfNotNeeded:on
     # future work: XDeclaredButNotUsed
   @end


### PR DESCRIPTION
## Summary

Extend `nimStrictMode` to error on unused imports, and enable
`nimStrictMode` when compiling the compiler and core tools during CI
runs.

The idea is to have this help with catching bugs and preventing
leftover debug code being merged, while not complicating local
development. Over time, `nimStrictMode` should promote more warnings
and hints to errors.

## Details

* treat `UnusedImport` warnings as an error when `nimStrictMode` is
  enabled
* remove the obsolete `runCI` koch command
* introduce the new `all-strict` koch command, which does the same
  as `all`, except that it enables strict mode
* when building the compiler and tools in strict mode, use an
  `--errorMax` of 3, so that compilation doesn't abort after the first
  error
* run `all-strict` instead of `all` in the CI

Due to a bug, the current csources compiler doesn't properly support
warnings/hints promoted to errors, so `nimStrictMode` is turned into a
no-op when `nimKochBootstrap` is defined (this define is set for the
first iteration of bootstrapping). This is a temporary workaround,
which can be removed after the next csources update.