### PR TITLE
fix(suggest): project parents non-project modules

### DIFF
--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -599,7 +599,7 @@ proc parentModule*(g: ModuleGraph; fileIdx: FileIndex): FileIndex =
   if fileIdx.int32 >= 0 and fileIdx.int32 < g.ifaces.len and g.ifaces[fileIdx.int32].module != nil:
     result = fileIdx
   else:
-    result = g.inclToMod.getOrDefault(fileIdx)
+    result = g.inclToMod.getOrDefault(fileIdx, InvalidFileIdx)
 
 proc markDirty*(g: ModuleGraph; fileIdx: FileIndex) =
   let m = g.getModule fileIdx

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -490,7 +490,9 @@ proc executeCmd*(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
       dirtyfile.isEmpty:
     discard "no need to recompile anything"
   else:
-    let modIdx = graph.parentModule(dirtyIdx)
+    var modIdx = graph.parentModule(dirtyIdx)
+    if modIdx == InvalidFileIdx:
+      modIdx = dirtyIdx
     graph.markDirty dirtyIdx
     graph.markClientsDirty dirtyIdx
     # partially recompiling the project means that that VM and JIT state

--- a/nimsuggest/tests/tisolated.nim
+++ b/nimsuggest/tests/tisolated.nim
@@ -1,8 +1,11 @@
-# Regression test for server initialazed with project file but query another
-# file that not indexed with project's graph. this covers below use cases
-# 1. a new file under project directory structure not be imported nor included
-#    by compiled files.
-# 2. a file that used by explicitly importing in another project.
+# Regression test for querying a file/module that is not the project file/module
+# or part of the transitive closure of all dependencies (via import or include).
+# In such a case the queried file is not indexed within the project's graph.
+#
+# Covered use cases:
+# 1. a new file under project directory structure not imported nor included by
+#    compiled files.
+# 2. a file that's used by explicitly importing in another project.
 
 discard """
 $nimsuggest --tester $file

--- a/nimsuggest/tests/tisolated.nim
+++ b/nimsuggest/tests/tisolated.nim
@@ -1,0 +1,11 @@
+# Regression test for server initialazed with project file but query another
+# file that not indexed with project's graph. this covers below usa cases
+# 1. a new file under project directory structure not be imported nor included
+#    by compiled files
+# 2. a file that used by explicitly importing in another project.
+
+discard """
+$nimsuggest --tester $file
+>def $path/tinclude.nim:7:14
+def;;skProc;;minclude_import.create;;proc (greeting: string, subject: string): Greet{.noSideEffect, gcsafe, locks: 0.};;*fixtures/minclude_include.nim;;3;;5;;"";;100
+"""

--- a/nimsuggest/tests/tisolated.nim
+++ b/nimsuggest/tests/tisolated.nim
@@ -1,7 +1,7 @@
 # Regression test for server initialazed with project file but query another
-# file that not indexed with project's graph. this covers below usa cases
+# file that not indexed with project's graph. this covers below use cases
 # 1. a new file under project directory structure not be imported nor included
-#    by compiled files
+#    by compiled files.
 # 2. a file that used by explicitly importing in another project.
 
 discard """


### PR DESCRIPTION
## Summary

`suggest` correctly falls back to treating the project module as the
parent module for out of project files/modules.

## Details

Prior to this change, querying the parent module for a file that is not
the project or a dependent module in the the project (via `import` or
`include`), resulted in a returning a file index of `0`. This resulted
in the parent being treated as the config file (typically first to get
indexed).

After this change, parent module querying, via `parentModule`, where no
parent is found results in an `InvalidFileIdx`. Since this is used as
part of suggest we continue to make progress by assuming the project
module is the parent module and continue semantic analysis.

As part of this change a regression test was added to ensure this
continues to work.