### PR TITLE
fix(sem): crash on errors in deref expressions

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1948,11 +1948,12 @@ proc semDeref(c: PContext, n: PNode): PNode =
         else:
           nil # xxx: should probably be an error type; derefing a non-ptr/ref
 
-    case derefTarget.kind
+    result[0] = semmedTarget
+
+    case semmedTarget.kind
     of nkError:
       result = c.config.wrapError(result)
     else:
-      result[0] = semmedTarget
       result.typ = derefType
 
       if isTargetConstNil:

--- a/tests/errmsgs/tnested_errors.nim
+++ b/tests/errmsgs/tnested_errors.nim
@@ -5,9 +5,9 @@ action: reject
 nimout: '''
 tnested_errors.nim(15, 12) Error: undeclared identifier: 'b'
 tnested_errors.nim(16, 11) Error: undeclared identifier: 'b'
+tnested_errors.nim(21, 9) Error: undeclared identifier: 'b'
 '''
 """
-
 
 
 
@@ -16,3 +16,6 @@ var a = if b:
           b
         else:
           1
+
+# errors in the target expression of dereference expressions were lost
+discard b[]


### PR DESCRIPTION
## Summary

Fix the compiler crashing when the target sub-expression of a
dereference expressions (`a[]`) is erroneous.

## Details

The error propagation in `semDerefEval` correctly detected that the
target expression is erroneous, but didn't update the `result` with the
erroneous tree prior to wrapping `result` in an error. Since
`wrapError` requires an `nkError` to be located somewhere in the
wrapped tree, this triggered an assertion failure.

In addition, errors during folding (`getConstExpr` returning an
`nkError`) weren't accounted for. This is fixed by testing
`semmedTarget` (not `derefTarget`) for being erroneous.