### PR TITLE
refactor(sem): clean up `hasUnresolvedParams`

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -52,7 +52,7 @@ proc semOperand(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
 
   if result.typ != nil:
     # XXX tyGenericInst here?
-    if result.typ.kind == tyProc and hasUnresolvedParams(result, {efOperand}):
+    if result.typ.kind == tyProc and hasUnresolvedParams(result):
       result = c.config.newError(n, PAstDiag(kind: adSemProcHasNoConcreteType))
     elif result.typ.kind in {tyVar, tyLent}:
       result = newDeref(result)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -444,22 +444,8 @@ proc hasEmpty(typ: PType): bool =
     for s in typ.sons:
       result = result or hasEmpty(s)
 
-proc hasUnresolvedParams(n: PNode; flags: TExprFlags): bool =
+proc hasUnresolvedParams(n: PNode): bool =
   result = tfUnresolved in n.typ.flags
-  when false:
-    case n.kind
-    of nkSym:
-      result = isGenericRoutineStrict(n.sym)
-    of nkSymChoices:
-      for ch in n:
-        if hasUnresolvedParams(ch, flags):
-          return true
-      result = false
-    else:
-      result = false
-    if efOperand in flags:
-      if tfUnresolved notin n.typ.flags:
-        result = false
 
 proc makeDeref(n: PNode): PNode =
   var t = n.typ


### PR DESCRIPTION
## Summary

Remove disabled code from the `hasUnresolvedParams` procedure. The
code has been disabled for 7 years and is unlikely to become used
again.

## Details

* remove the disabled code block
* remove the unused `flags: TExprFlags` parameter