### PR TITLE
suggest: display name include generic parameters

### DIFF
--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -143,8 +143,7 @@ type
   Suggest* = ref object
     section*: IdeCmd
     qualifiedPath*: seq[string]
-    name*: ptr string           ## not used beyond sorting purposes; name is
-                                ## also part of 'qualifiedPath'
+    name*: string               ## display name
     filePath*: string
     line*: int                  ## Starts at 1
     column*: int                ## Starts at 0

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -107,7 +107,7 @@ proc cmpSuggestions(a, b: Suggest): int =
   cf globalUsages
   # if all is equal, sort alphabetically for deterministic output,
   # independent of hashing order:
-  result = cmp(a.name[0], b.name[0])
+  result = cmp(a.name, b.name)
 
 proc getTokenLenFromSource(conf: ConfigRef; ident: string; info: TLineInfo): int =
   let

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -106,7 +106,7 @@ proc cmpSuggestions(a, b: Suggest): int =
   cf globalUsages
   # if all is equal, sort alphabetically for deterministic output,
   # independent of hashing order:
-  result = cmp(a.name[], b.name[])
+  result = cmp(a.name[0], b.name[0])
 
 proc getTokenLenFromSource(conf: ConfigRef; ident: string; info: TLineInfo): int =
   let
@@ -156,7 +156,16 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
   if section in {ideSug, ideCon}:
     result.contextFits = inTypeContext == (s.kind in {skType, skGenericParam})
   result.scope = scope
-  result.name = addr s.name.s
+  result.name = s.name.s
+  if isGenericRoutineStrict(s):
+    let params = s.ast[genericParamsPos]
+    let len = params.safeLen
+    var genericParams = if len > 0: "[" else: ""
+    for i in 0 ..< len:
+      genericParams.add getPIdent(params[i]).s
+      if i < len - 1: genericParams.add(", ")
+    if len > 0: genericParams.add "]"
+    result.name.add genericParams
   when defined(nimsuggest):
     if section in {ideSug, ideCon}:
       result.globalUsages = s.allUsages.len
@@ -178,7 +187,6 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
     result.qualifiedPath.add('`' & s.name.s & '`')
   else:
     result.qualifiedPath.add(s.name.s)
-
   if s.typ != nil:
     result.forth = typeToString(s.typ)
   else:

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -43,6 +43,7 @@ import
     lexer,
     lineinfos,
     linter,
+    renderer,
     types,
     typesrenderer,
     wordrecg,
@@ -158,14 +159,7 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
   result.scope = scope
   result.name = s.name.s
   if isGenericRoutineStrict(s):
-    let params = s.ast[genericParamsPos]
-    let len = params.safeLen
-    var genericParams = if len > 0: "[" else: ""
-    for i in 0 ..< len:
-      genericParams.add getPIdent(params[i]).s
-      if i < len - 1: genericParams.add(", ")
-    if len > 0: genericParams.add "]"
-    result.name.add genericParams
+    result.name.add renderTree(s.ast[genericParamsPos])
   when defined(nimsuggest):
     if section in {ideSug, ideCon}:
       result.globalUsages = s.allUsages.len
@@ -187,6 +181,7 @@ proc symToSuggest(g: ModuleGraph; s: PSym, isLocal: bool, section: IdeCmd, info:
     result.qualifiedPath.add('`' & s.name.s & '`')
   else:
     result.qualifiedPath.add(s.name.s)
+
   if s.typ != nil:
     result.forth = typeToString(s.typ)
   else:


### PR DESCRIPTION
## Summary

Display names include generic parameters, resulting in generic parameter
information
being displayed for routines in IDE `outline` panel.

## Details

*  `Suggest.name`  type changed from  `ptr string`  to  `string` 
avoiding extra indirection
*  inside  `proc symToSuggest`   `Suggest.name`  includes generic
parameters for generic routines