### PR TITLE
fix(sem): named param errors no longer crash

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -275,10 +275,8 @@ proc argTypeToString(arg: PNode; prefer: TPreferedDesc): string =
     for i in 1 ..< arg.len:
       result.add(" | ")
       result.add typeToString(arg[i].typ, prefer)
-
   elif arg.typ == nil:
     result = "void"
-
   else:
     result = arg.typ.typeToString(prefer)
 
@@ -288,17 +286,17 @@ proc describeArgs(conf: ConfigRef, args: seq[PNode]; prefer = preferName): strin
     if arg.kind == nkExprEqExpr:
       result.add renderTree(arg[0])
       result.add ": "
-      if arg.typ.isNil and arg.kind notin {nkStmtList, nkDo}:
-        assert false, (
+      if arg.typ.isNil and arg[1].kind notin {nkStmtList, nkDo}:
+        assert false, ($arg.id.int & " " & $arg.kind & " " &
           "call `semcall.maybeResemArgs` on report construciton site - " &
             "this is a temporary hack that is necessary to actually provide " &
             "proper types for error reports.")
-
     else:
-      if arg.typ.isNil and arg.kind notin {
-           nkStmtList, nkDo, nkElse, nkOfBranch, nkElifBranch, nkExceptBranch
-      }:
-        assert false, "call `semcall.maybeResemArgs` on report construction site"
+      if arg.typ.isNil and arg.kind notin {nkStmtList, nkDo, nkElse,
+                                           nkOfBranch, nkElifBranch,
+                                           nkExceptBranch}:
+        assert false, ($arg.id.int & " " & $arg.kind & " " &
+                  " call `semcall.maybeResemArgs` on report construction site")
 
     if arg.typ != nil and arg.typ.kind == tyError:
       return

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -102,7 +102,6 @@ proc maybeResemArgs*(c: PContext, n: PNode, startIdx: int = 1): seq[PNode] =
       if arg.typ.isNil: # and arg.kind notin {nkStmtList, nkDo}:
         # XXX we really need to 'tryExpr' here!
         arg = c.semOperand(c, n[i][1])
-        arg = n[i][1]
         n[i].typ = arg.typ
         n[i][1] = arg
     of nkStmtList, nkDo, nkElse, nkOfBranch, nkElifBranch, nkExceptBranch:

--- a/tests/lang_callable/namedparams/tnamedparams_error_handling.nim
+++ b/tests/lang_callable/namedparams/tnamedparams_error_handling.nim
@@ -1,0 +1,9 @@
+discard """
+  description: "Regression test to ensure named param errors are reported"
+  errormsg: "type mismatch: got <x: int literal(1), y: seq[empty]>"
+  line: 9
+"""
+
+proc f(y: seq[string]) = return
+
+f(x=1, y = @[])


### PR DESCRIPTION
## Summary

Errors in named parameter call sites no longer cause the compiler to
crash.

## Details

A logic error in `semcall.maybeResemArgs` overwrote `results` with
incorrect data leading to a crash. This has been fixed.

In addition added some extra information to assertions that originally
led to the discovery of this error in order to assist debugging these
sorts of issues more quickly in the future.

A regression test was added to ensure errors in named parameters no
longer crash the compiler.

A few minor formatting and stylistic clean-ups were made in related
code.