### PR TITLE
stdlib: simplify the `genEnumCaseStmt` macro

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -173,8 +173,7 @@ proc putIntoReg(dest: var TFullReg; jit: var JitState, c: var TCtx, n: PNode,
     dest.initLocReg(typ, c.memory)
     c.serialize(n, dest.handle)
   of tyProc:
-    # XXX: a hack required to uphold some expectations. For example,
-    #      `genEnumCaseStmt` would fail without this. Procedural types as
+    # XXX: a hack required to uphold some expectations. Procedural types as
     #      static macro arguments are underspecified
     let pt =
       if t.callConv == ccClosure and n.kind == nkSym:


### PR DESCRIPTION
## Summary

Reduce the amount of macro features the `genEnumCaseStmt` statement
macro relies on, by leveraging overload resolution and non-macro
compile-time evaluation. Using less advanced macro features helps with
the eventual re-design of the macro API.

## Details

The `genEnumCaseStmt` is used for generating a string-parsing case
statement. There were multiple problems with its implementation:
1. it relied on the type API, of which the future is uncertain
2. it duplicated the compiler's enum-to-string logic
3. it used a `static` procedural value as a parameter, which are
   currently very under-specified

The implementations is improved as follows:
* split `genEnumCaseStmt` into an outer template and inner macro
* prevent passing arbitrary `typedesc`s by using a constraint on the
  `typedesc`
* the list of enum values plus their corresponding string values are
  collected via a compile-time procedure (`collect`) instead of via
  type introspection
* for getting the tuple list into the auxiliary macro, the `collect`
  call is coerced to a static expression and the auxiliary macro uses a
  `typed` parameter
* the auxiliary macro doesn't require any type introspection; it only
  needs to iterate over the array construction expression passed to it
* the `enumFullRange` macro is moved above the `genEnumCaseStmt`
  template; the `collect` procedure needs it in order to support enums
  with holes

The immediate `genEnumCaseStmt` implementation is now independent of
the type API, enum type AST, and the compiler's enum-to-string
translation. A downside is that the "ambiguous enum" error no longer
points to the problematic field in the type.

In addition to the refactoring, the documentation of `genEnumCaseStmt`
is also slightly improved.