### PR TITLE
fix(sigmatch): AST corruption of bracket calls

### DIFF
--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -3126,7 +3126,9 @@ proc matches*(c: PContext, n: PNode, m: var TCandidate) =
 
   if m.magic in {mArrGet, mArrPut}:
     m.state = csMatch
-    m.call = n
+    # in case of a match, the top-level call node needs to be modifiable
+    m.call = copyNode(n)
+    m.call.sons = n.sons
 
     # Note the following doesn't work as it would produce ambiguities.
     # We hack system.nim instead: https://github.com/nim-lang/nim/issues/8049.

--- a/tests/lang_callable/overload/tbracket_call_corruption.nim
+++ b/tests/lang_callable/overload/tbracket_call_corruption.nim
@@ -6,7 +6,7 @@ proc op(x: int) =
   discard
 
 template overload(x: untyped) =
-  # this is the overload that is picked. It's definition has to come
+  # this is the overload that is picked. Its definition has to come
   # first, so that it's processed first during overload resolution
   op(x) # this failed with an "expected `int` but got `T`" error
 

--- a/tests/lang_callable/overload/tbracket_call_corruption.nim
+++ b/tests/lang_callable/overload/tbracket_call_corruption.nim
@@ -1,0 +1,30 @@
+discard """
+  description: "Regression test for `[]` calls causing AST corruption"
+"""
+
+proc op(x: int) =
+  discard
+
+template overload(x: untyped) =
+  # this is the overload that is picked. It's definition has to come
+  # first, so that it's processed first during overload resolution
+  op(x) # this failed with an "expected `int` but got `T`" error
+
+template overload(x: bool) =
+  # an overload that must not match
+  discard
+
+# test with an explicit bracket call:
+overload(`[]`([0], 0))
+
+# test with an implicit bracket call in a generic:
+proc f[T]() =
+  overload([0][0])
+
+f[int]()
+
+# test with an implicit bracket call in a template:
+template t() =
+  overload([0][0])
+
+t()


### PR DESCRIPTION
## Summary

Fix explicit bracket calls (`[](...)`) and bracket expressions in
generic procedures or templates causing AST corruption.

A concrete example where this caused problems is when a bracket call is
used as the argument to an `untyped` parameter of an overloaded
template where there exist overloads with typed parameters but none
of them matches.

## Details

### Problem description

For bracket calls, the overload set contains the `mArrGet` or `mArrPut`
magics -- these always match.

For `mArrGet`  and `mArrPut` candidates, `sigmatch.matches` assigns the
*original* call AST, which is a problem when the candidate is the one
picked in the end: `semResolvedCall` expects a call AST that it can
freely modify, but since the original AST is used, the modifications
show up in unintended places (such as on the AST for earlier processed
candidates).

Due to bracket expression (`nkBracketExpr`) rewriting performed for the
bodies of templates and generic procedures, bracket expressions within
those were also affected.

### The solution

In order to uphold the expectation that the immediate call AST of a
`TCandidate`  can be modified if the candidate represents a match,
change
`matches` to create a shallow copy of the call node for a `mArrGet`/
`mArrPut` match.