### PR TITLE
stdlib: clean up `coloredResult`

### DIFF
--- a/lib/experimental/colortext.nim
+++ b/lib/experimental/colortext.nim
@@ -700,27 +700,18 @@ template coloredResult*(indentationStep: int = 2): untyped =
   ##
   ##       aux(node)
   ##
-  ## Injected procs
+  ## Injected routines
   ##
+  ## - `addf(string, varargs)`
   ## - `add(string)`, `add(string, string)`
   ## - `addIndent(int)`, `addi(int, string)`
-  ## - `endResult()` - return colored result. Required for proper work
-  ##   of the code in the compile-time context, otherwise modification
-  ##   of the  `addr result` does not work properly.
-  static:
-    when not declared(result):
-      {.error: "'coloredResult' template can only be called inside of the procedure returning 'ColText' as a result, or other environment that has `var result: ColText` defined."}
+  when not declared(result):
+    {.error: "'coloredResult' template can only be called in an environment " &
+             "where a `result` variable is available"}
 
   var outPtr {.used.}: ptr ColText = addr result
 
-  template endResult(): untyped {.used.} =
-    when nimvm:
-      return outPtr[]
-
-    else:
-      return
-
-  proc addf(format: string, args: varargs[ColText, toColText]) =
+  template addf(format: string, args: varargs[untyped]) {.used.} =
     outPtr[].addf(format, args)
 
   template add(arg: untyped): untyped {.used.} = outPtr[].add arg

--- a/tests/stdlib/algorithm/tcolortext.nim
+++ b/tests/stdlib/algorithm/tcolortext.nim
@@ -50,7 +50,6 @@ let exp: int
     add "1" + fgRed
     addi 2, "2"
     add "]"
-    endResult()
 
   let col = reesc($colres())
   let want = r"[    0\e[31m1\e[39m    2]"


### PR DESCRIPTION
## Summary

Slightly refactor the implementation of the `colortext.coloredResult`
template and remove its obsolete `endResult` helper template.

## Details

- mention the injected `addf` routine in the documentation
- remove the unnecessary `static` block around the `.error` directive
- shorten the compile-time error message for when no `result` variable
  exists
- remove the `endResult` helper template; the `vmgen` bug that
  necessitated it is fixed
- turn the `addf` procedure into a template and mark it as `.used`,
  preventing `XDeclaredButNotUsed` warnings