### PR TITLE
refactor(lookups): simpler identifier error handling

### DIFF
--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -782,20 +782,6 @@ proc lookUp*(c: PContext, n: PNode): PSym =
   when false:
     if result.kind == skStub: loadStub(result)
 
-proc errorExpectedIdentifier(
-    c: PContext, ident: PIdent, n: PNode, exp: PNode = nil
-  ): PSym {.inline.} =
-  ## create an error symbol for non-identifier in identifier position within an
-  ## expression (`exp`). non-nil `exp` leads to better error messages.
-  let ast =
-    if exp.isNil:
-      c.config.newError(n, PAstDiag(kind: adSemExpectedIdentifier))
-    else:
-      c.config.newError(exp):
-        PAstDiag(kind: adSemExpectedIdentifierInExpr, notIdent: n)
-
-  result = newQualifiedLookUpError(c, ident, n.info, ast)
-
 proc errorUndeclaredIdentifierWithHint*(
     c: PContext; n: PNode; name: string,
     candidates: seq[SemSpellCandidate] = @[]
@@ -865,21 +851,8 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
       amb = false
       (ident, errNode) = considerQuotedIdent(c, n)
 
-    if isNotFound(c.cache, ident):
-      let
-        wrongNode =
-          if n.kind == nkAccQuoted and n.len == 1:
-            n[0]
-          else:
-            n
-        errExprCtx =
-          if n != wrongNode:
-            n
-          else:
-            nil
-          ## expression within which the error occurred
-        
-      result = errorExpectedIdentifier(c, ident, wrongNode, errExprCtx)
+    if errNode != nil:
+      result = newQualifiedLookUpError(c, ident, n.info, errNode)
     elif checkModule in flags:
       result = searchInScopes(c, ident, amb)
       # xxx: search in scopes can return an skError -- this happens because


### PR DESCRIPTION
## Summary

Simplify identifier error handling in `qualifiedLookUp`, removing a
duplication of how errors for potentially quoted identifier are
produced.

## Details

* replace the `isNotFound` test and subsequent `nkError` creation with
  directly using the `errNode` returned by `considerQuotedIdent`
* remove the now obsolete `errorExpectedIdentifier` procedure

There is a small difference in the "wrong node" selection now, but the
previous logic in `qualifiedLookUp` was incorrect (the erroneous node
is the `nkAccQuoted`, not its element), so this is an improvement in
error precision.