### PR TITLE
cgir: split up `cnkBracketAccess`

### DIFF
--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -41,7 +41,7 @@ proc reportObservableStore(p: BProc; le, ri: CgNode) =
         # it through a procedure that eventually raises is also an observable
         # store
         return inTryStmt and sfUsedInFinallyOrExcept in p.body[n.local].flags
-      of cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess:
+      of cnkFieldAccess, cnkArrayAccess, cnkTupleAccess, cnkCheckedFieldAccess:
         n = n[0]
       of cnkObjUpConv, cnkObjDownConv, cnkHiddenConv, cnkConv:
         n = n.operand

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -568,7 +568,7 @@ proc lookupFieldAgain(p: BProc, ty: PType; field: PSym; r: var Rope;
   assert r != ""
   while ty != nil:
     ty = ty.skipTypes(skipPtrs)
-    assert(ty.kind in {tyTuple, tyObject})
+    assert ty.kind == tyObject
     result = lookupInRecord(ty.n, field.name)
     if result != nil:
       if resTyp != nil: resTyp[] = ty
@@ -583,12 +583,8 @@ proc genRecordField(p: BProc, e: CgNode, d: var TLoc) =
   var r = rdLoc(a)
   var f = e[1].sym
   let ty = skipTypes(a.t, abstractInst + tyUserTypeClasses)
-  if ty.kind == tyTuple:
-    # we found a unique tuple type which lacks field information
-    # so we use Field$i
-    r.addf(".Field$1", [rope(f.position)])
-    putIntoDest(p, d, e, r, a.storage)
-  else:
+  p.config.internalAssert(ty.kind == tyObject, e[0].info)
+  if true:
     var rtyp: PType
     let field = lookupFieldAgain(p, ty, f, r, addr rtyp)
     ensureObjectFields(p.module, field, rtyp)
@@ -799,16 +795,14 @@ proc genSeqElem(p: BProc, n, x, y: CgNode, d: var TLoc) =
   putIntoDest(p, d, n,
               ropecg(p.module, "$1$3[$2]", [rdLoc(a), rdCharLoc(b), dataField(p)]), a.storage)
 
-proc genBracketExpr(p: BProc; n: CgNode; d: var TLoc) =
-  var ty = skipTypes(n[0].typ, abstractVarRange + tyUserTypeClasses)
-  if ty.kind in {tyRef, tyPtr}: ty = skipTypes(ty.lastSon, abstractVarRange)
+proc genArrayLikeElem(p: BProc; n: CgNode; d: var TLoc) =
+  let ty = skipTypes(n[0].typ, abstractVar + tyUserTypeClasses)
   case ty.kind
   of tyUncheckedArray: genUncheckedArrayElem(p, n, n[0], n[1], d)
   of tyArray: genArrayElem(p, n, n[0], n[1], d)
   of tyOpenArray, tyVarargs: genOpenArrayElem(p, n, n[0], n[1], d)
   of tySequence, tyString: genSeqElem(p, n, n[0], n[1], d)
   of tyCstring: genCStringElem(p, n, n[0], n[1], d)
-  of tyTuple: genTupleElem(p, n, d)
   else: internalError(p.config, n.info, "expr(nkBracketExpr, " & $ty.kind & ')')
   discard getTypeDesc(p.module, n.typ)
 
@@ -2174,7 +2168,8 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
     else:
       let mutate = n.kind == cnkHiddenAddr and n.typ.kind == tyVar
       genAddr(p, n, mutate, d)
-  of cnkBracketAccess: genBracketExpr(p, n, d)
+  of cnkArrayAccess: genArrayLikeElem(p, n, d)
+  of cnkTupleAccess: genTupleElem(p, n, d)
   of cnkDeref, cnkDerefView: genDeref(p, n, d)
   of cnkFieldAccess: genRecordField(p, n, d)
   of cnkCheckedFieldAccess: genCheckedRecordField(p, n, d)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1795,7 +1795,7 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   of mOffsetOf:
     var dotExpr: CgNode
     case e[1].kind
-    of cnkFieldAccess:
+    of cnkFieldAccess, cnkTupleAccess:
       dotExpr = e[1]
     of cnkCheckedFieldAccess:
       dotExpr = e[1][0]
@@ -1804,8 +1804,8 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
     let t = dotExpr[0].typ.skipTypes({tyTypeDesc})
     let tname = getTypeDesc(p.module, t, skVar)
     let member =
-      if t.kind == tyTuple:
-        "Field" & rope(dotExpr[1].sym.position)
+      if dotExpr.kind == cnkTupleAccess:
+        "Field" & rope(dotExpr[1].intVal)
       else: p.fieldName(dotExpr[1].sym)
     putIntoDest(p,d,e, "((NI)offsetof($1, $2))" % [tname, member])
   of mChr: genSomeCast(p, e, d)

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -55,9 +55,10 @@ type
                      ## field with a value
 
     cnkFieldAccess
-    cnkBracketAccess
-    # future direction: split ``cnkBracketAccess`` into ``cnkArrayAccess`` (for
-    # array-like operands) and ``cnkTupleAccess`` (for tuples).
+    cnkArrayAccess
+    cnkTupleAccess
+    # future direction: merge ``cnkFieldAccess`` and ``cnkTupleAccess`` into a
+    # single node (field access by position).
     cnkCheckedFieldAccess
     # future direction: lower object access checks eariler (e.g., during the
     # MIR phase) and then remove ``cnkCheckedFieldAccess``

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -201,7 +201,7 @@ proc render(c: var RenderCtx, body: Body, ind: int, n: CgNode,
     res.add n[0]
     res.add '.'
     res.add n[1]
-  of cnkBracketAccess:
+  of cnkArrayAccess, cnkTupleAccess:
     res.add n[0]
     res.add '['
     res.add n[1]

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -108,7 +108,7 @@ proc getRoot*(n: CgNode): CgNode =
       result = n
   of cnkLocal:
     result = n
-  of cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess:
+  of cnkFieldAccess, cnkArrayAccess, cnkTupleAccess, cnkCheckedFieldAccess:
     result = getRoot(n[0])
   of cnkDerefView, cnkDeref, cnkObjUpConv, cnkObjDownConv, cnkHiddenAddr,
      cnkAddr, cnkHiddenConv, cnkConv:
@@ -134,7 +134,7 @@ proc isLValue*(n: CgNode): bool =
     let t = skipTypes(n[0].typ, abstractInst-{tyTypeDesc})
     t.kind in {tyVar, tySink, tyPtr, tyRef} or
       (not isDiscriminantField(n) and isLValue(n[0]))
-  of cnkBracketAccess:
+  of cnkArrayAccess, cnkTupleAccess:
     let t = skipTypes(n[0].typ, abstractInst-{tyTypeDesc})
     t.kind in {tyVar, tySink, tyPtr, tyRef} or isLValue(n[0])
   of cnkHiddenConv, cnkConv:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -476,7 +476,7 @@ proc maybeMakeTempAssignable(p: PProc, n: CgNode; x: TCompRes): tuple[a, tmp: Ro
     if x.tmpLoc != "" and (mapType(n.typ) == etyBaseIndex or n.kind in {cnkDerefView, cnkDeref}):
       b = "$1[0][$1[1]]" % [x.tmpLoc]
       result = (a: a, tmp: b)
-    elif x.tmpLoc != "" and n.kind == cnkBracketAccess:
+    elif x.tmpLoc != "" and n.kind == cnkArrayAccess:
       # genArrayAddr
       var
         address, index: TCompRes
@@ -973,7 +973,7 @@ proc genAsgnAux(p: PProc, x, y: CgNode, noCopyNeeded: bool) =
   var xtyp = mapType(x.typ)
 
   # disable `[]=` for cstring
-  if x.kind == cnkBracketAccess and x[0].typ.skipTypes(abstractInst).kind == tyCstring:
+  if x.kind == cnkArrayAccess and x[0].typ.skipTypes(abstractInst).kind == tyCstring:
     localReport(p.config, x.info, reportSem rsemUnexpectedArrayAssignForCstring)
 
   gen(p, x, a)
@@ -1055,11 +1055,14 @@ proc genFieldAddr(p: PProc, n: CgNode, r: var TCompRes) =
   r.typ = etyBaseIndex
   let b = if n.kind == cnkHiddenAddr: n.operand else: n
   gen(p, b[0], a)
-  if skipTypes(b[0].typ, abstractVarRange).kind == tyTuple:
+  case b.kind
+  of cnkTupleAccess:
     r.res = makeJSString("Field" & $getFieldPosition(p, b[1]))
-  else:
+  of cnkFieldAccess:
     p.config.internalAssert(b[1].kind == cnkSym, b[1].info, "genFieldAddr")
     r.res = makeJSString(ensureMangledName(p, b[1].sym))
+  else:
+    unreachable(n.kind)
   internalAssert p.config, a.typ != etyBaseIndex
   r.address = a.res
   r.kind = resExpr
@@ -1079,14 +1082,17 @@ proc genFieldAccess(p: PProc, n: CgNode, r: var TCompRes) =
       else:
         r.address = "$1[0]" % [r.res]
         r.res = "$1[1]" % [r.res]
-  if otyp.kind == tyTuple:
+  case n.kind
+  of cnkTupleAccess:
     r.res = ("$1.Field$2") %
         [r.res, getFieldPosition(p, n[1]).rope]
     mkTemp(0)
-  else:
+  of cnkFieldAccess:
     p.config.internalAssert(n[1].kind == cnkSym, n[1].info, "genFieldAccess")
     r.res = "$1.$2" % [r.res, ensureMangledName(p, n[1].sym)]
     mkTemp(1)
+  else:
+    unreachable(n.kind)
   r.kind = resExpr
 
 proc genAddr(p: PProc, n: CgNode, r: var TCompRes)
@@ -1165,14 +1171,14 @@ proc genArrayAddr(p: PProc, n: CgNode, r: var TCompRes) =
   r.kind = resExpr
 
 proc genArrayAccess(p: PProc, n: CgNode, r: var TCompRes) =
-  var ty = skipTypes(n[0].typ, abstractVarRange)
-  if ty.kind in {tyRef, tyPtr, tyLent}: ty = skipTypes(ty.lastSon, abstractVarRange)
-  case ty.kind
-  of tyArray, tyOpenArray, tySequence, tyString, tyCstring, tyVarargs:
-    genArrayAddr(p, n, r)
-  of tyTuple:
-    genFieldAddr(p, n, r)
-  else: internalError(p.config, n.info, "expr(nkBracketExpr, " & $ty.kind & ')')
+  let ty = skipTypes(n[0].typ, abstractVar)
+  internalAssert(p.config,
+                 ty.kind in {tyArray, tyOpenArray, tySequence, tyString,
+                             tyCstring, tyVarargs},
+                 n.info,
+                 "got " & $ty.kind)
+
+  genArrayAddr(p, n, r)
   r.typ = mapType(n.typ)
   p.config.internalAssert(r.res != "", n.info, "genArrayAccess")
   if ty.kind == tyCstring:
@@ -1239,17 +1245,10 @@ proc genAddr(p: PProc, n: CgNode, r: var TCompRes) =
     addrLoc(mangledName(p, n.sym, n.info), n.sym, r)
   of cnkCheckedFieldAccess:
     genCheckedFieldOp(p, n, takeAddr=true, r)
-  of cnkFieldAccess:
+  of cnkFieldAccess, cnkTupleAccess:
     genFieldAddr(p, n, r)
-  of cnkBracketAccess:
-    let kind = skipTypes(n[0].typ, abstractVarRange).kind
-    case kind
-    of tyArray, tyOpenArray, tySequence, tyString, tyCstring, tyVarargs:
-      genArrayAddr(p, n, r)
-    of tyTuple:
-      genFieldAddr(p, n, r)
-    else:
-      internalError(p.config, n[0].info, "expr(nkBracketExpr, " & $kind & ')')
+  of cnkArrayAccess:
+    genArrayAddr(p, n, r)
   of cnkDerefView, cnkDeref:
     # attemping to take the address of a deref expression -> skip both the
     # addr and deref
@@ -2494,7 +2493,8 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
       gen(p, n.operand, r)
     else:
       genDeref(p, n, r)
-  of cnkBracketAccess: genArrayAccess(p, n, r)
+  of cnkArrayAccess: genArrayAccess(p, n, r)
+  of cnkTupleAccess: genFieldAccess(p, n, r)
   of cnkFieldAccess: genFieldAccess(p, n, r)
   of cnkCheckedFieldAccess: genCheckedFieldOp(p, n, takeAddr=false, r)
   of cnkObjDownConv: downConv(p, n, r)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1581,8 +1581,8 @@ func usesRegister(p: BProc, n: CgNode): bool =
   of cnkSym:
     let s = n.sym
     not s.isGlobal and fitsRegister(s.typ)
-  of cnkDeref, cnkDerefView, cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess,
-     cnkConv, cnkObjDownConv, cnkObjUpConv:
+  of cnkDeref, cnkDerefView, cnkFieldAccess, cnkArrayAccess, cnkTupleAccess,
+     cnkCheckedFieldAccess, cnkConv, cnkObjDownConv, cnkObjUpConv:
     false
   of cnkStmtListExpr:
     usesRegister(p, n.lastSon)
@@ -2231,7 +2231,7 @@ func isPtrView(n: CgNode): bool =
     sfGlobal in n.sym.flags
   of cnkLocal:
     false
-  of cnkFieldAccess, cnkBracketAccess, cnkCheckedFieldAccess:
+  of cnkFieldAccess, cnkArrayAccess, cnkTupleAccess, cnkCheckedFieldAccess:
     true
   of cnkHiddenAddr, cnkCall:
     false
@@ -2339,19 +2339,27 @@ proc genDerefView(c: var TCtx, n: CgNode, dest: var TDest; load = true) =
 
 proc genAsgn(c: var TCtx; le, ri: CgNode; requiresCopy: bool) =
   case le.kind
-  of cnkBracketAccess:
-    let typ = le[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind
-    let dest = c.genx(le[0])
-    let idx = if typ != tyTuple: c.genIndex(le[1], le[0].typ) else: le[1].intVal
-    let tmp = c.genAsgnSource(ri, wantsPtr = true)
-    let opc = if typ in {tyString, tyCstring}: opcWrStrIdx
-              elif typ == tyTuple: opcWrObj
-              else: opcWrArr
+  of cnkArrayAccess:
+    let
+      typ = le[0].typ.skipTypes(abstractVar).kind
+      dest = c.genx(le[0])
+      idx = c.genIndex(le[1], le[0].typ)
+      tmp = c.genAsgnSource(ri, wantsPtr = true)
+      opc =
+        case typ
+        of tyString, tyCstring: opcWrStrIdx
+        else:                   opcWrArr
 
     c.gABC(le, opc, dest, idx, tmp)
     c.freeTemp(tmp)
-    if typ != tyTuple:
-      c.freeTemp(idx)
+    c.freeTemp(idx)
+    c.freeTemp(dest)
+  of cnkTupleAccess:
+    let
+      dest = c.genx(le[0])
+      tmp = c.genAsgnSource(ri, wantsPtr = true)
+    c.gABC(le, opcWrObj, dest, le[1].intVal.TRegister, tmp)
+    c.freeTemp(tmp)
     c.freeTemp(dest)
   of cnkCheckedFieldAccess:
     let objR = genCheckedObjAccessAux(c, le)
@@ -2526,15 +2534,13 @@ proc genFieldAccessAux(c: var TCtx; n: CgNode; a, b: TRegister, dest: var TDest;
     c.gABC(n, opcLdObj, dest, a, b)
     c.makeHandleReg(dest, a)
 
-proc genFieldAccess(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
+proc genFieldAccess(c: var TCtx; n: CgNode; pos: int, dest: var TDest;
+                    load = true) =
   ## Generates and emits the code for a dot-expression `n` (i.e. field access).
   ## The resulting value/handle is stored to `dest`.
-  assert n.kind == cnkFieldAccess
-  let
-    a = c.genx(n[0])
-    b = genField(c, n[1])
-
-  genFieldAccessAux(c, n, a, b, dest, load)
+  assert n.kind in {cnkFieldAccess, cnkTupleAccess}
+  let a = c.genx(n[0])
+  genFieldAccessAux(c, n, a, pos, dest, load)
   c.freeTemp(a)
 
 proc genFieldAddr(c: var TCtx, n, obj: CgNode, fieldPos: int, dest: TDest) =
@@ -2620,8 +2626,7 @@ proc genCheckedObjAccess(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
   c.freeTemp(objR)
 
 proc genArrAccess(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
-  let arrayType = n[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind
-  case arrayType
+  case n[0].typ.skipTypes(abstractVar).kind
   of tyString, tyCstring:
     if load:
       # no need to pass `load`; the result of a string access is always
@@ -2631,22 +2636,16 @@ proc genArrAccess(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
       # use the ``opcLdArr`` operation to get a handle to the ``char``
       # location
       genArrAccessOpcode(c, n, dest, opcLdArr, load=false)
-  of tyTuple:
-    let a = genx(c, n[0])
-    genFieldAccessAux(c, n, a, n[1].intVal, dest, load)
-    c.freeTemp(a)
   of tyArray, tySequence, tyOpenArray, tyVarargs, tyUncheckedArray:
     genArrAccessOpcode(c, n, dest, opcLdArr, load)
   else:
     unreachable()
 
-proc genBracketAddr(c: var TCtx, n: CgNode, dest: var TDest) =
+proc genArrayAddr(c: var TCtx, n: CgNode, dest: var TDest) =
   ## Generates the code for loading the address of a bracket expression (i.e.
   ## ``addr x[0]``)
   assert not dest.isUnset
-  case n[0].typ.skipTypes(abstractInst-{tyTypeDesc}).kind
-  of tyTuple:
-    genFieldAddr(c, n, n[0], n[1].intVal.int, dest)
+  case n[0].typ.skipTypes(abstractInst).kind
   of tyString, tyCstring:
     genArrAccessOpcode(c, n, dest, opcLdStrIdxAddr)
   of tyArray, tySequence, tyOpenArray, tyVarargs:
@@ -2665,9 +2664,12 @@ proc genAddr(c: var TCtx, src, n: CgNode, dest: var TDest) =
   of cnkFieldAccess:
     prepare(c, dest, src.typ)
     genFieldAddr(c, n, n[0], genField(c, n[1]), dest)
-  of cnkBracketAccess:
+  of cnkArrayAccess:
     prepare(c, dest, src.typ)
-    genBracketAddr(c, n, dest)
+    genArrayAddr(c, n, dest)
+  of cnkTupleAccess:
+    prepare(c, dest, src.typ)
+    genFieldAddr(c, n, n[0], n[1].intVal.TRegister, dest)
   of cnkCheckedFieldAccess:
     prepare(c, dest, src.typ)
 
@@ -2734,11 +2736,13 @@ proc genLvalue(c: var TCtx, n: CgNode, dest: var TDest) =
   of cnkSym, cnkLocal:
     c.genSym(n, dest, load=false)
   of cnkFieldAccess:
-    genFieldAccess(c, n, dest, load=false)
+    genFieldAccess(c, n, genField(c, n[1]), dest, load=false)
   of cnkCheckedFieldAccess:
     genCheckedObjAccess(c, n, dest, load=false)
-  of cnkBracketAccess:
+  of cnkArrayAccess:
     genArrAccess(c, n, dest, load=false)
+  of cnkTupleAccess:
+    genFieldAccess(c, n, n[1].intVal.int, dest, load=false)
   of cnkConv:
     # if a conversion reaches here, it must be an l-value conversion. They
     # don't map to any bytecode, so we skip them
@@ -2977,9 +2981,10 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
   of cnkAsgn, cnkFastAsgn:
     unused(c, n, dest)
     genAsgn(c, n[0], n[1], n.kind == cnkAsgn)
-  of cnkFieldAccess: genFieldAccess(c, n, dest)
+  of cnkFieldAccess: genFieldAccess(c, n, genField(c, n[1]), dest)
   of cnkCheckedFieldAccess: genCheckedObjAccess(c, n, dest)
-  of cnkBracketAccess: genArrAccess(c, n, dest)
+  of cnkArrayAccess: genArrAccess(c, n, dest)
+  of cnkTupleAccess: genFieldAccess(c, n, n[1].intVal.int, dest)
   of cnkDeref: genDeref(c, n, dest)
   of cnkAddr: genAddr(c, n, n.operand, dest)
   of cnkDerefView:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2536,8 +2536,8 @@ proc genFieldAccessAux(c: var TCtx; n: CgNode; a, b: TRegister, dest: var TDest;
 
 proc genFieldAccess(c: var TCtx; n: CgNode; pos: int, dest: var TDest;
                     load = true) =
-  ## Generates and emits the code for a dot-expression `n` (i.e. field access).
-  ## The resulting value/handle is stored to `dest`.
+  ## Generates and emits the code for the record-like access `n`. The handle
+  ## value is written to the `dest` register.
   assert n.kind in {cnkFieldAccess, cnkTupleAccess}
   let a = c.genx(n[0])
   genFieldAccessAux(c, n, a, pos, dest, load)

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -14,14 +14,14 @@ doing shady stuff...
 var splat
 splat = splitFile(path)
 result = (
-  var :aux_3 = splat.dir
-  wasMoved(splat.dir)
+  var :aux_3 = splat[0]
+  wasMoved(splat[0])
   :aux_3,
-  var :aux_4 = splat.name
-  wasMoved(splat.name)
+  var :aux_4 = splat[1]
+  wasMoved(splat[1])
   :aux_4,
-  var :aux_5 = splat.ext
-  wasMoved(splat.ext)
+  var :aux_5 = splat[2]
+  wasMoved(splat[2])
   :aux_5)
 =destroy(splat)
 -- end of expandArc ------------------------
@@ -68,10 +68,10 @@ try:
   it_cursor = x
   a = (
     :aux_4 = default()
-    =copy(:aux_4, it_cursor.key)
+    =copy(:aux_4, it_cursor[0])
     :aux_4,
     :aux_5 = default()
-    =copy(:aux_5, it_cursor.val)
+    =copy(:aux_5, it_cursor[1])
     :aux_5)
   echo([
     :aux_6 = $(a)
@@ -150,14 +150,14 @@ try:
         var :aux_6 = default()
         =copy(:aux_6, :aux_5)
         :aux_6)
-      var :aux_8 = :aux_7.tail
-      wasMoved(:aux_7.tail)
+      var :aux_8 = :aux_7[1]
+      wasMoved(:aux_7[1])
       :aux_8))
     =destroy(:aux_7)
   block :label_0:
-    if dirExists(par.dir):
+    if dirExists(par[0]):
       var :aux_9 = this[].matchDirs
-      var :aux_10 = getSubDirs(par.dir, par.front)
+      var :aux_10 = getSubDirs(par[0], par[1])
       =sink(:aux_9, :aux_10)
       break :label_0
     var :aux_11 = this[].matchDirs


### PR DESCRIPTION
## Summary

Split the `cnkBracketAccess` operation into array-like access
(`cnkArrayAccess`) and tuple access (`cnkTupleAccess`). This reduces
the amount of dispatching on type kinds in the code generators.

## Details

* add the `cnkTupleAccess` and `cnkArrayAccess` nodes/operations; the
  `cnkBracketAccess` one is removed
* update all usage sites of the now-removed `cnkBracketAccess`
* translate all MIR positional field access into `cnkTupleAccess`; this
  ensures that tuple access always uses the same code generation logic,
  and it also allows for removing the tuple handling from `cgen`'s
  record-access logic (at least for now)
* adjust the `mOffsetOf` lowering in `cgen` to consider tuple access
* remove obsolete (`tyRef` and `tyPtr`) and sometimes unnecessarily
  broad (`abstractVarRange` instead of `abstractVar`) type-skipping
  from the code generation logic for array-like access