### PR TITLE
add a warning for conversions in `in` calls

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -768,6 +768,7 @@ type
     rsemResultUsed             = "ResultUsed"
     rsemGenericMethodsDeprecated
     rsemSuspiciousEnumConv     = "EnumConv"
+    rsemSuspiciousContainsConv = "ContainsConv"
     rsemUnsafeSetLen           = "UnsafeSetLen"
     rsemUnsafeDefault          = "UnsafeDefault"
     rsemUntypedParamsFollwedByMoreSpecificType

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1502,6 +1502,11 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemSuspiciousEnumConv:
       result = "suspicious code: enum to enum conversion"
 
+    of rsemSuspiciousContainsConv:
+      result = "suspicious code: element value in `in` or `contains` " &
+               "call requires implicit conversion. This could result in run-" &
+               "time range defects"
+
     of rsemStringOrIdentNodeExpected:
       result = "string or ident node expected"
 

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -406,6 +406,12 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       prc = getToStringProc(c.graph, n[1].typ.skipTypes(abstractRange))
     result = n
     result[0] = newSymNode(prc, info)
+  of mInSet:
+    result = n
+    # report warnings for ``in``/``contains`` calls where the element value
+    # requires an implicit conversion. This is usually not what one wants
+    if n[2].kind in {nkHiddenSubConv, nkHiddenStdConv}:
+      localReport(c.config, n[2], SemReport(kind: rsemSuspiciousContainsConv))
   of mIsPartOf: result = semIsPartOf(c, n, flags)
   of mTypeTrait: result = semTypeTraits(c, n)
   of mAstToStr:

--- a/tests/magics/tin_op_warning.nim
+++ b/tests/magics/tin_op_warning.nim
@@ -1,0 +1,18 @@
+discard """
+  description: '''
+    Make sure that warnings are reported for suspicious, implicit conversions
+    of the `in` operand.
+  '''
+  action: compile
+"""
+
+var x = 1
+
+# in both cases, there be no issue at run-time, but `x` could be very well be
+# some arbitrary value
+
+discard x in {1, 2} #[tt.Hint
+        ^ suspicious code]#
+
+discard contains({1, 2}, x) #[tt.Warning
+                         ^  suspicious code]#


### PR DESCRIPTION
## Summary

Report a warning (`SuspiciousContainsConv`) when the element operand of
an `in` or `contains` call requires an implicit conversion. This is
usually not what one wants or expects, and whether this can result in
run-time range defects currently depends on the used backend.

## Details

* add the `rsemSuspiciousContainsConv` report kind
* detect the conversion and report the warning in
  `magicsAfterOverloadResolution`. This is the earliest place where the
  potential issue can be detected