### PR TITLE
Generally allow bracket with colon for explicit generic params

### DIFF
--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -591,11 +591,11 @@ proc setOrTableConstr(p: var Parser): ParsedNode =
   p.eat(tkCurlyRi) # skip '}'
 
 proc parseCast(p: var Parser): ParsedNode =
-  #| castExpr = 'cast' ('[' optInd typeDesc optPar ']' '(' optInd expr optPar ')') /
+  #| castExpr = 'cast' (('['|'[:') optInd typeDesc optPar ']' '(' optInd expr optPar ')') /
   #                    ('(' optInd exprColonEqExpr optPar ')')
   result = p.newNodeConsumingTok(pnkCast)
   case p.tok.tokType
-  of tkBracketLe:
+  of tkBracketLe, tkBracketLeColon:
     p.getTok
     p.optInd(result)
     result.add parseTypeDesc(p)
@@ -830,7 +830,7 @@ proc primarySuffix(p: var Parser, r: ParsedNode,
   #| primarySuffix = '(' (exprColonEqExpr comma?)* ')'
   #|       | '.' optInd symbol ('[:' exprList ']' ( '(' exprColonEqExpr ')' )?)? generalizedLit?
   #|       | DOTLIKEOP optInd symbol generalizedLit?
-  #|       | '[' optInd exprColonEqExprList optPar ']'
+  #|       | ('['|'[:') optInd exprColonEqExprList optPar ']'
   #|       | '{' optInd exprColonEqExprList optPar '}'
   #|       | &( '`'|IDENT|literal|'cast'|'addr'|'type') expr # command syntax
   result = r
@@ -859,7 +859,7 @@ proc primarySuffix(p: var Parser, r: ParsedNode,
     of tkDot:
       # progress guaranteed
       result = p.parseGStrLit(p.dotExpr(result))
-    of tkBracketLe:
+    of tkBracketLe, tkBracketLeColon:
       # progress guaranteed
       if p.tok.strongSpaceA > 0:
         result = p.commandExpr(result, mode, startTok)

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -32,7 +32,7 @@ exprList = expr ^+ comma
 exprColonEqExprList = exprColonEqExpr (comma exprColonEqExpr)* (comma)?
 qualifiedIdent = symbol ('.' optInd symbol)?
 setOrTableConstr = '{' ((exprColonEqExpr comma)* | ':' ) '}'
-castExpr = 'cast' ('[' optInd typeDesc optPar ']' '(' optInd expr optPar ')') /
+castExpr = 'cast' (('['|'[:') optInd typeDesc optPar ']' '(' optInd expr optPar ')') /
 parKeyw = 'discard' | 'include' | 'if' | 'while' | 'case' | 'try'
         | 'finally' | 'except' | 'for' | 'block' | 'const' | 'let'
         | 'when' | 'var' | 'mixin'
@@ -58,7 +58,7 @@ arrayConstr = '[' optInd (exprColonEqExpr comma?)* optPar ']'
 primarySuffix = '(' (exprColonEqExpr comma?)* ')'
       | '.' optInd symbol ('[:' exprList ']' ( '(' exprColonEqExpr ')' )?)? generalizedLit?
       | DOTLIKEOP optInd symbol generalizedLit?
-      | '[' optInd exprColonEqExprList optPar ']'
+      | ('['|'[:') optInd exprColonEqExprList optPar ']'
       | '{' optInd exprColonEqExprList optPar '}'
       | &( '`'|IDENT|literal|'cast'|'addr'|'type') expr # command syntax
 pragma = '{.' optInd (exprColonEqExpr comma?)* optPar ('.}' | '}')

--- a/tests/lang_syntax/parser/texplicit_generic_params.nim
+++ b/tests/lang_syntax/parser/texplicit_generic_params.nim
@@ -62,3 +62,7 @@ void2[:int, int](x = 1, y = 2)
 1.void2[:int, int](2)
 1.void2[:int, int](y = 2)
 
+
+discard cast[int](1)
+discard cast[:int](1)
+

--- a/tests/lang_syntax/parser/texplicit_generic_params.nim
+++ b/tests/lang_syntax/parser/texplicit_generic_params.nim
@@ -2,9 +2,14 @@ discard """
   description: "Test explicit generic params with the various call syntaxes"
 """
 
+proc null[]() = discard
 proc void0[T]() = discard
 proc void1[X](x: X) = discard
 proc void2[X, Y](x: X, y: Y) = discard
+
+
+null[]()
+null[:]()
 
 
 void0[int]()

--- a/tests/lang_syntax/parser/texplicit_generic_params.nim
+++ b/tests/lang_syntax/parser/texplicit_generic_params.nim
@@ -1,0 +1,59 @@
+discard """
+  description: "Test explicit generic params with the various call syntaxes"
+"""
+
+proc void0[T]() = discard
+proc void1[X](x: X) = discard
+proc void2[X, Y](x: X, y: Y) = discard
+
+
+void0[int]()
+void0[:int]()
+
+
+void1[int] 1
+void1[:int] 1
+#void1[int] x = 1
+#void1[:int] y = 1
+
+void1[int]: 1
+void1[:int]: 1
+
+void1[int](1)
+void1[:int](1)
+void1[int](x = 1)
+void1[:int](x = 1)
+
+1.void1[:int]()
+1.void1[:int]
+
+
+void2[int, int] 1, 2
+void2[:int, int] 1, 2
+void2[int, int] 1, y = 2
+void2[:int, int] 1, y = 2
+#void2[int, int] x = 1, 2
+#void2[:int, int] x = 1, 2
+
+void2[int, int] 1: 2
+void2[:int, int] 1: 2
+void2[int, int](1): 2
+void2[:int, int](1): 2
+void2[int, int](x = 1): 2
+void2[:int, int](x = 1): 2
+
+void2[int, int](1, 2)
+void2[:int, int](1, 2)
+void2[int, int](x = 1, 2)
+void2[:int, int](x = 1, 2)
+void2[int, int](1, y = 2)
+void2[:int, int](1, y = 2)
+void2[int, int](x = 1, y = 2)
+void2[:int, int](x = 1, y = 2)
+
+#1.void2[:int, int] 2
+#1.void2[:int, int] y = 2
+1.void2[:int, int]: 2
+1.void2[:int, int](2)
+1.void2[:int, int](y = 2)
+


### PR DESCRIPTION
## Summary
* Generally allow `[:` for passing explicit generic params

## Details
*  `[:`  brackets were only allowed with the method call syntax, now
they are allowed generally
* A test for explicit generic params with the various call syntaxes has
been added