### PR TITLE
suggest: only `outline` current file symbols

### DIFF
--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -502,19 +502,9 @@ proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; i
         suggestResult(conf, symToSuggest(g, s, isLocal=false, ideDef, info, 100, PrefixMatch.None, false, 0))
     elif conf.ideCmd == ideHighlight and info.fileIndex == conf.m.trackPos.fileIndex:
       suggestResult(conf, symToSuggest(g, s, isLocal=false, ideHighlight, info, 100, PrefixMatch.None, false, 0))
-    elif conf.ideCmd == ideOutline and isDecl:
-      # if a module is included then the info we have is inside the include and
-      # we need to walk up the owners until we find the outer most module,
-      # which will be the last skModule prior to an skPackage.
-      var
-        parentFileIndex = info.fileIndex # assume we're in the correct module
-        parentModule = s.owner
-      while parentModule != nil and parentModule.kind == skModule:
-        parentFileIndex = parentModule.info.fileIndex
-        parentModule = parentModule.owner
-
-      if parentFileIndex == conf.m.trackPos.fileIndex:
-        suggestResult(conf, symToSuggest(g, s, isLocal=false, ideOutline, info, 100, PrefixMatch.None, false, 0))
+    elif conf.ideCmd == ideOutline and isDecl and info.fileIndex == conf.m.trackPos.fileIndex:
+      if "`gensym" in s.name.s: return # prevent template generated symbol show up, xxx: avoid string comparison 
+      suggestResult(conf, symToSuggest(g, s, isLocal=false, ideOutline, info, 100, PrefixMatch.None, false, 0))
 
 proc safeSemExpr*(c: PContext, n: PNode): PNode =
   # use only for idetools support!

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -503,7 +503,6 @@ proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; i
     elif conf.ideCmd == ideHighlight and info.fileIndex == conf.m.trackPos.fileIndex:
       suggestResult(conf, symToSuggest(g, s, isLocal=false, ideHighlight, info, 100, PrefixMatch.None, false, 0))
     elif conf.ideCmd == ideOutline and isDecl and info.fileIndex == conf.m.trackPos.fileIndex:
-      if "`gensym" in s.name.s: return # prevent template generated symbol show up, xxx: avoid string comparison 
       suggestResult(conf, symToSuggest(g, s, isLocal=false, ideOutline, info, 100, PrefixMatch.None, false, 0))
 
 proc safeSemExpr*(c: PContext, n: PNode): PNode =

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -495,15 +495,20 @@ proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; i
     else:
       s.addNoDup(info)
 
-    if conf.ideCmd == ideDef:
+    case conf.ideCmd
+    of ideDef:
       findDefinition(g, info, s, usageSym)
-    elif conf.ideCmd == ideDus and s != nil:
-      if isTracked(info, conf.m.trackPos, s.name.s.len):
+    of ideDus:
+      if s != nil and isTracked(info, conf.m.trackPos, s.name.s.len):
         suggestResult(conf, symToSuggest(g, s, isLocal=false, ideDef, info, 100, PrefixMatch.None, false, 0))
-    elif conf.ideCmd == ideHighlight and info.fileIndex == conf.m.trackPos.fileIndex:
-      suggestResult(conf, symToSuggest(g, s, isLocal=false, ideHighlight, info, 100, PrefixMatch.None, false, 0))
-    elif conf.ideCmd == ideOutline and isDecl and info.fileIndex == conf.m.trackPos.fileIndex:
-      suggestResult(conf, symToSuggest(g, s, isLocal=false, ideOutline, info, 100, PrefixMatch.None, false, 0))
+    of ideHighlight:
+      if info.fileIndex == conf.m.trackPos.fileIndex:
+        suggestResult(conf, symToSuggest(g, s, isLocal=false, ideHighlight, info, 100, PrefixMatch.None, false, 0))
+    of ideOutline:
+      if isDecl and info.fileIndex == conf.m.trackPos.fileIndex:
+        suggestResult(conf, symToSuggest(g, s, isLocal=false, ideOutline, info, 100, PrefixMatch.None, false, 0))
+    else:
+      discard
 
 proc safeSemExpr*(c: PContext, n: PNode): PNode =
   # use only for idetools support!

--- a/nimsuggest/tests/tinclude.nim
+++ b/nimsuggest/tests/tinclude.nim
@@ -1,6 +1,6 @@
 # import that has an include:
 # * def calls must work into and out of includes
-# * outline calls on the import must show included members
+# * outline calls on the import must not show included members
 import fixtures/minclude_import
 
 proc go() =
@@ -18,7 +18,6 @@ def;;skType;;minclude_types.Greet;;Greet;;*fixtures/minclude_types.nim;;4;;2;;""
 def;;skType;;minclude_types.Greet;;Greet;;*fixtures/minclude_types.nim;;4;;2;;"";;100
 >outline $path/fixtures/minclude_import.nim
 outline;;skProc;;minclude_import.say;;*fixtures/minclude_import.nim;;7;;5;;"";;100
-outline;;skProc;;minclude_import.create;;*fixtures/minclude_include.nim;;3;;5;;"";;100
 outline;;skProc;;minclude_import.say;;*fixtures/minclude_import.nim;;13;;5;;"";;100
 """
 


### PR DESCRIPTION
## Summary
* Change the `outline` command to only list definitions from a
  *document* (instead of from a *module*)
* This means that symbols from `include`d modules are no longer
  listed by the command

## Details
* When deciding whether to include a symbol in the list, don't search
  for the outermost module -- only inspect the symbol's immediate file
  index
* Adjust `nimsuggest/tests/tinclude.nim`

Two refactors are applied to `suggestSym`:
* Add the `symToSuggestGlobal` template for replacing the
  `suggestSym(isLocal=false)` calls sharing most of their arguments.
  This removes duplicated code and also makes the lines shorter
* The main `if` statement is replaced with a `case` statement, as
  this makes the code clearer and shorter