### PR TITLE
ci: use treeless clones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - name: Enable annotations
         run: echo "::add-matcher::.github/nim-problem-matcher.json"
@@ -153,6 +154,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: ./.github/actions/download-compiler
 
@@ -201,6 +203,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: ./.github/actions/download-compiler
 
@@ -220,6 +223,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: ./.github/actions/download-compiler
 
@@ -332,6 +336,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: ./.github/actions/download-compiler
 
@@ -393,6 +398,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       - uses: ./.github/actions/download-compiler
 

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -70,6 +70,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
         # reprotest will manipulate the time which may cause bootstrapping
         # source download to fail due to SSL errors. Download this beforehand


### PR DESCRIPTION
## Summary
With the release of actions/checkout@v4.1.0, partial clone is now
supported.

This feature allows us to clone only the latest files but with all of
git history attached, giving us full commit tags and the lower cost of 
`--depth=1` .

At the time of writing, this dropped CI clone time from over 60s to just
3-9s.

For a primer on treeless clones, see:
https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/