### PR TITLE
fix the `ConversionConv` warnings

### DIFF
--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -243,40 +243,44 @@ template reportHere*[R: ReportTypes](report: R): R =
 
     tmp
 
+template `in`[T](val: T, r: typedesc[range]): bool =
+  let v = val
+  v >= low(r) and v <= high(r)
+
 func wrap*(rep: sink LexerReport): Report =
-  assert rep.kind in repLexerKinds, $rep.kind
+  assert rep.kind in LexerReportKind, $rep.kind
   Report(category: repLexer, lexReport: rep)
 
 func wrap*(rep: sink ParserReport): Report =
-  assert rep.kind in repParserKinds, $rep.kind
+  assert rep.kind in ParserReportKind, $rep.kind
   Report(category: repParser, parserReport: rep)
 
 func wrap*(rep: sink VMReport): Report =
-  assert rep.kind in repVMKinds, $rep.kind
+  assert rep.kind in VMReportKind, $rep.kind
   Report(category: repVM, vmReport: rep)
 
 func wrap*(rep: sink SemReport): Report =
-  assert rep.kind in repSemKinds, $rep.kind
+  assert rep.kind in SemReportKind, $rep.kind
   Report(category: repSem, semReport: rep)
 
 func wrap*(rep: sink BackendReport): Report =
-  assert rep.kind in repBackendKinds, $rep.kind
+  assert rep.kind in BackendReportKind, $rep.kind
   Report(category: repBackend, backendReport: rep)
 
 func wrap*(rep: sink CmdReport): Report =
-  assert rep.kind in repCmdKinds, $rep.kind
+  assert rep.kind in CmdReportKind, $rep.kind
   Report(category: repCmd, cmdReport: rep)
 
 func wrap*(rep: sink DebugReport): Report =
-  assert rep.kind in repDebugKinds, $rep.kind
+  assert rep.kind in DebugReportKind, $rep.kind
   Report(category: repDebug, debugreport: rep)
 
 func wrap*(rep: sink InternalReport): Report =
-  assert rep.kind in repInternalKinds, $rep.kind
+  assert rep.kind in InternalReportKind, $rep.kind
   Report(category: repInternal, internalReport: rep)
 
 func wrap*(rep: sink ExternalReport): Report =
-  assert rep.kind in repExternalKinds, $rep.kind
+  assert rep.kind in ExternalReportKind, $rep.kind
   Report(category: repExternal, externalReport: rep)
 
 func wrap*[R: ReportTypes](rep: sink R, iinfo: InstantiationInfo): Report =

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2081,7 +2081,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       let (op, err) = considerQuotedIdent(c, n[0])
       if err != nil:
         localReport(c.config, err)
-      if op.id in {ord(wAnd), ord(wOr)} or op.s == "|":
+      if op.id == ord(wAnd) or op.id == ord(wOr) or op.s == "|":
         checkSonsLen(n, 3, c.config)
         var
           t1 = semTypeNode(c, n[1], nil)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -243,8 +243,6 @@ func fail(
   magic: TMagic,
   loc:   InstantiationInfo = instLoc()
   ) {.noinline, noreturn.} =
-  assert kind in {vmGenDiagMissingImportcCompleteStruct,
-                  vmGenDiagCodeGenUnhandledMagic}, "Diag needs magic field"
   raiseVmGenError(
     VmGenDiag(kind: kind, magic: magic),
     info,

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -59,14 +59,14 @@ func writeUInt*(h: LocHandle, val: BiggestInt) {.inline.} =
 
 # TODO: rename to writeIntBits
 func writeInt*(r: var VmMemoryRegion, val: BiggestInt) {.inline.} =
-  assert int8(r.len) in {1, 2, 4, 8}
+  assert int8(r.len) in {1'i8, 2, 4, 8}
   # TODO: use `reinterpretWrite` here
   copyMem(addr r[0], unsafeAddr val, r.len)
 
 
 func readIntBits*(r: VmMemoryRegion): BiggestInt {.inline.} =
   let l = r.len
-  assert int8(l) in {1, 2, 4, 8}
+  assert int8(l) in {1'i8, 2, 4, 8}
   result = 0
   copyMem(addr result, unsafeAddr r[0], r.len)
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -312,6 +312,7 @@ cppDefine = "NAN"
 @if nimStrictMode and not nimKochBootstrap:
   @if nimHasWarningAsError:
     warningAsError:UnusedImport:on
+    warningAsError:ContainsConv:on
   @end
 
   @if nimHasHintAsError:

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -235,7 +235,8 @@ proc tryExec*(db: DbConn, query: SqlQuery,
   var stmt: sqlite3.PStmt
   if prepare_v2(db, q.cstring, q.len.cint, stmt, nil) == SQLITE_OK:
     let x = step(stmt)
-    if x in {SQLITE_DONE, SQLITE_ROW}:
+    case x
+    of SQLITE_DONE, SQLITE_ROW:
       result = finalize(stmt) == SQLITE_OK
     else:
       discard finalize(stmt)
@@ -244,7 +245,8 @@ proc tryExec*(db: DbConn, query: SqlQuery,
 proc tryExec*(db: DbConn, stmtName: SqlPrepared): bool {.
               tags: [ReadDbEffect, WriteDbEffect].} =
     let x = step(stmtName.PStmt)
-    if x in {SQLITE_DONE, SQLITE_ROW}:
+    case x
+    of SQLITE_DONE, SQLITE_ROW:
       result = true
     else:
       discard finalize(stmtName.PStmt)

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -352,20 +352,20 @@ func is1xx*(code: HttpCode): bool {.inline, since: (1, 5).} =
   runnableExamples:
     doAssert is1xx(HttpCode(103))
 
-  code.int in {100 .. 199}
+  code.int in 100 .. 199
 
 func is2xx*(code: HttpCode): bool {.inline.} =
   ## Determines whether `code` is a 2xx HTTP status code.
-  code.int in {200 .. 299}
+  code.int in 200 .. 299
 
 func is3xx*(code: HttpCode): bool {.inline.} =
   ## Determines whether `code` is a 3xx HTTP status code.
-  code.int in {300 .. 399}
+  code.int in 300 .. 399
 
 func is4xx*(code: HttpCode): bool {.inline.} =
   ## Determines whether `code` is a 4xx HTTP status code.
-  code.int in {400 .. 499}
+  code.int in 400 .. 499
 
 func is5xx*(code: HttpCode): bool {.inline.} =
   ## Determines whether `code` is a 5xx HTTP status code.
-  code.int in {500 .. 599}
+  code.int in 500 .. 599

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2465,7 +2465,7 @@ proc rawCreateDir(dir: string): bool {.noWeirdTarget.} =
     let res = mkdir(dir, 0o777)
     if res == 0'i32:
       result = true
-    elif errno in {EEXIST, ENOSYS}:
+    elif errno == EEXIST or errno == ENOSYS:
       result = false
     else:
       raiseOSError(osLastError(), dir)

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -754,7 +754,8 @@ when defined(windows) and not defined(useNimRtl):
       if poInteractive in result.options: close(result)
       const errInvalidParameter = 87.int
       const errFileNotFound = 2.int
-      if lastError.int in {errInvalidParameter, errFileNotFound}:
+      case lastError.int
+      of errInvalidParameter, errFileNotFound:
         raiseOSError(lastError,
             "Requested command not found: '$1'. OS error:" % command)
       else:

--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -189,7 +189,8 @@ elif defined(linux) and not defined(emscripten):
       elif readBytes > 0:
         inc(result, readBytes)
       else:
-        if osLastError().int in {EINTR, EAGAIN}:
+        case osLastError().int
+        of EINTR, EAGAIN:
           discard
         else:
           result = -1

--- a/tests/lang_syntax/parser/tstmtlists.nim
+++ b/tests/lang_syntax/parser/tstmtlists.nim
@@ -143,7 +143,7 @@ proc square2(inSeq: seq[float]): seq[float] =
 
 proc cstringCheck(tracked: int; n: int) =
   if true == false and (let a = high(int); let b = high(int);
-      a.int8 == 8 and a.int8 notin {3..9}):
+      a.int8 == 8 and a.int8 notin 3..9):
     echo(tracked, n)
 
 template dim: int =


### PR DESCRIPTION
## Summary

Fix all `ConversionConv` warnings in the compiler and standard library
and most of the warnings in the tests (some are false positives). This
is a preparation for disabling the range check omission for `in` calls.

## Details

This is a best-effort fix, the warnings were found by:
* searching and going over all `in`, `notin`, and `contains` calls
  that use a set construction expression
* searching for potential usage in macros by looking for `"in"`,
  `"notin"`, and `"contains"` usage
* temporarily turning the warning into an error and running the whole
  test suite

A lot of problematic `in` usages were found and resolved, but it's
possible that some remain.

How the problematic `in` calls are resolved depends on the usage:
* if the element operand's range fits into the set, the constructed set
  is coerced to the right type (which removes the implicit conversion)
* `in` calls using single-slice sets (`{a..b}`) are changed to use the
  slice directly
* `in` calls with small sets use `or` chains (which is also what the
  code would currently be lowered to in the end)
* others usages are changed to use `case` statements