### PR TITLE
fix(sem): detect illegal implicit to-float conversions

### DIFF
--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -524,13 +524,16 @@ proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
     else:
       result = newIntNodeT(val, n, idgen, g)
   of FloatLike:
-    case srcTyp.kind
-    of IntegerLike, tyEnum, tyBool:
-      result = newFloatNodeT(toFloat64(getOrdValue(a)), n, g)
-    of FloatLike:
-      result = newFloatNodeT(a.floatVal, n, g)
+    let val =
+      case srcTyp.kind
+      of IntegerLike, tyEnum, tyBool: toFloat64(getOrdValue(a))
+      of FloatLike:                   a.floatVal
+      else:                           unreachable(srcTyp.kind)
+
+    if floatRangeCheck(val, n.typ):
+      result = newFloatNodeT(val, n, g)
     else:
-      unreachable(srcTyp.kind)
+      result = rangeError(n, a, g)
   of tyOpenArray, tyVarargs, tyProc, tyPointer:
     discard
   else:

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -485,7 +485,7 @@ proc getAppType(n: PNode; g: ModuleGraph): PNode =
   else:
     result = newStrNodeT("console", n, g)
 
-proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph; check = false): PNode =
+proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
   let dstTyp = skipTypes(n.typ, abstractRange - {tyTypeDesc})
   let srcTyp = skipTypes(a.typ, abstractRange - {tyTypeDesc})
 
@@ -519,7 +519,7 @@ proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph; check = false): P
       of FloatLike:                   toInt128(getFloat(a))
       else:                           unreachable(srcTyp.kind)
 
-    if check and not rangeCheck(n, val, g):
+    if not rangeCheck(n, val, g):
       result = rangeError(n, a, g)
     else:
       result = newIntNodeT(val, n, idgen, g)
@@ -811,7 +811,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     let a = getConstExpr(m, n[1], idgen, g)
     if a == nil: return
-    result = foldConv(n, a, idgen, g, check=true)
+    result = foldConv(n, a, idgen, g)
   of nkDerefExpr, nkHiddenDeref:
     let a = getConstExpr(m, n[0], idgen, g)
     if a != nil and a.kind == nkNilLit:

--- a/tests/misc/tconv.nim
+++ b/tests/misc/tconv.nim
@@ -43,6 +43,10 @@ reject:
 reject:
     const x = FloatRange(NaN)
 
+reject:
+    # test with an implicit conversion without a ``const``
+    var x: FloatRange = -1 # implicit conversion required
+
 block:
     const x = float32(NaN)
 


### PR DESCRIPTION
## Summary

Fix a constant folding regression where constant, implicit to-float
conversions weren't checked for range errors.

## Details

`foldConv` didn't check for to-float conversion errors, which meant
that no more range checks were performed when folding after constant
folding moved before `transf` (refer to
https://github.com/nim-works/nimskull/pull/865).

Implicit to-float conversions appearing directly in `const` definitions
were not affected, as `fitRemoveHiddenConv` performs a range check.

* remove the obsolete `check` parameter from `foldConv` -- it's always
  set to 'true'
* perform a range check with `floatRangeCheck` for to-float conversion