### PR TITLE
fix(sigmatch): built-in type-class constraint issue

### DIFF
--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -1737,7 +1737,8 @@ typeRel can be used to establish various relationships between types:
                              not effectiveArgType.isEmptyContainer
       if typeClassMatches or
         (targetKind in {tyProc, tyPointer} and effectiveArgType.kind == tyNil):
-        put(c, f, a)
+        if doBind:
+          put(c, f, a)
         return isGeneric
       else:
         return isNone

--- a/tests/lang_types/typeclass/ttypeclass_multi_use.nim
+++ b/tests/lang_types/typeclass/ttypeclass_multi_use.nim
@@ -49,7 +49,7 @@ doAssert not compiles(test({1}, {'2'}))
 doAssert test(range[0..1](0), range[3..4](3)) == 8
 doAssert test((ptr int)(nil), (ptr float)(nil)) == 9
 doAssert test((ref int)(nil), (ref float)(nil)) == 10
-doAssert not compiles(test(@[1], @[""]))
+doAssert not compiles(test(@[1], @[""])) # == 11
 doAssert test((proc(a: int))(nil), (proc(a: float))(nil)) == 12
-doAssert not compiles(test1(arr1, arr2))
+doAssert not compiles(test1(arr1, arr2)) # == 13
 doAssert not compiles(test1((ptr UncheckedArray[int])(nil), (ptr UncheckedArray[float])(nil)))

--- a/tests/lang_types/typeclass/ttypeclass_multi_use.nim
+++ b/tests/lang_types/typeclass/ttypeclass_multi_use.nim
@@ -1,0 +1,55 @@
+discard """
+  description: '''
+    Regression test for ensuring that type-class constraints work when applied
+    to multiple generic type parameters at the same time
+  '''
+"""
+
+type
+  Object1 = object
+  Object2 = object
+
+  Enum1 = enum a
+  Enum2 = enum b
+
+  Distinct1 = distinct int
+  Distinct2 = distinct int
+
+var
+  arr1 = [1]
+  arr2 = [""]
+
+# for this test, it's important that the ``a, b: Z`` syntax is used, and not
+# the ``a: Z, b: Z`` one
+
+proc test[A, B: distinct](a: A, b: B): int = 1
+proc test[A, B: enum](a: A, b: B): int = 2
+proc test1[A, B: Ordinal](a: A, b: B): int = 3
+proc test[A, B: array](a: A, b: B): int = 4
+proc test[A, B: tuple](a: A, b: B): int = 5
+proc test[A, B: object](a: A, b: B): int = 6
+proc test[A, B: set](a: A, b: B): int = 7
+proc test[A, B: range](a: A, b: B): int = 8
+proc test[A, B: ptr](a: A, b: B): int = 9
+proc test[A, B: ref](a: A, b: B): int = 10
+proc test[A, B: seq](a: A, b: B): int = 11
+proc test[A, B: proc](a: A, b: B): int = 12
+proc test1[A, B: openArray](a: A, b: B): int = 13
+proc test1[A, B: UncheckedArray](a: ptr A, b: ptr B): int = 14
+
+# XXX: not all built-in type classes work properly at the moment
+
+doAssert test(Distinct1(1), Distinct2(1)) == 1
+doAssert test(a, b) == 2
+doAssert test1(1, 'c') == 3
+doAssert not compiles(test(arr1, arr2))
+doAssert test((1,), ("",)) == 5
+doAssert test(Object1(), Object2()) == 6
+doAssert not compiles(test({1}, {'2'}))
+doAssert test(range[0..1](0), range[3..4](3)) == 8
+doAssert test((ptr int)(nil), (ptr float)(nil)) == 9
+doAssert test((ref int)(nil), (ref float)(nil)) == 10
+doAssert not compiles(test(@[1], @[""]))
+doAssert test((proc(a: int))(nil), (proc(a: float))(nil)) == 12
+doAssert not compiles(test1(arr1, arr2))
+doAssert not compiles(test1((ptr UncheckedArray[int])(nil), (ptr UncheckedArray[float])(nil)))


### PR DESCRIPTION
## Summary

Fix overload resolution failing for procedures with signatures like
`proc p[A, B: <built-in-type-class>](a: A, b: B)` where the types used
as the arguments are not equal.

## Details

For type relation (`typeRel`) analysis between a type and a generic
type parameter constraint, binding types to type-classes is disabled
(the `trDontBind` flag is passed), but the logic for
`tyBuiltInTypeClass` ignored the request and always bound the actual
type to the type-class.

Since in `[A, B: <built-in-type-class>]`, the `tyBuiltInTypeClass`
`PType` instance used as the constraints is the same, once `A` was
bound, `B` effectively acted as being constrained to `A`, which caused
a type relation failure when the type passed to `B` is not equal to
that passed to `A`.

The `typeRel` logic for `tyBuiltInTypeClass` now respects the
`trDontBind` flag, fixing the issue. However, not all built-in type-
classes use the `tyBuiltInTypeClass` type at the moment (fixing that is
outside the scope of this commit), so for those that don't, the issue
persists.