### PR TITLE
Reduce TNode size by removing unused node flags

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -63,8 +63,7 @@ const
   PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
   
   PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
-                                      nfDotSetter, nfDotField,
-                                      nfIsRef, nfIsPtr, nfLL,
+                                      nfDotSetter, nfDotField, nfLL,
                                       nfFromTemplate, nfDefaultRefsParam}
   
   namePos*          = 0 ## Name of the type/proc-like node

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1533,8 +1533,9 @@ type
         discard
 
   TNode*{.final, acyclic.} = object # on a 32bit machine, this takes 32 bytes
+                                    # on a 64bit machine, this takes 40 bytes
     typ*: PType
-    id*: NodeId
+    id*: NodeId  # placed after `typ` field to save space due to field alignment
     info*: TLineInfo
     flags*: TNodeFlags
     case kind*: TNodeKind

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -604,8 +604,6 @@ type
     nfDotField  ## the call can use a dot operator
     nfDotSetter ## the call can use a setter dot operarator
     nfExplicitCall ## `x.y()` was used instead of x.y
-    nfIsRef     ## this node is a 'ref' node; used for the VM
-    nfIsPtr     ## this node is a 'ptr' node; used for the VM
     nfFromTemplate ## a top-level node returned from a template
     nfDefaultParam ## an automatically inserter default parameter
     nfDefaultRefsParam ## a default param value references another parameter
@@ -1535,8 +1533,8 @@ type
         discard
 
   TNode*{.final, acyclic.} = object # on a 32bit machine, this takes 32 bytes
-    id*: NodeId
     typ*: PType
+    id*: NodeId
     info*: TLineInfo
     flags*: TNodeFlags
     case kind*: TNodeKind


### PR DESCRIPTION
## Summary
* Removed two node flags unused after the VM rework, which reduced the
size of  `TNodeFlags`  to 2 bytes
* Moved the  `id`  field below  `typ`  because  `typ`  requires an
alignment of 8 bytes, while  `id`  has a size of 8 bytes
* The two changes above combined result in reducing the size of  `TNode` 
from 48 to 40 bytes on a x86_64 system

## Details
* More node flags can be removed/moved from  `TNodeFlag` , but that
won't reduce the size of  `TNode`  further (unless they are reduced to
only 8 node flags), so I'll make a seperate PR for those