### PR TITLE
fix(sem): generic parameters not being resolved

### DIFF
--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -138,6 +138,15 @@ proc fixupInstantiatedSymbols(c: PContext, s: PSym) =
       pushOwner(c, oldPrc)
       pushInfoContext(c.config, oldPrc.info)
       openScope(c)
+      # also add the instantiated symbols of the generic parameters
+      # to the scope:
+      for j, it in s.ast[genericParamsPos].pairs:
+        let
+          orig = it.sym
+          typ  = c.generics[i].inst.concreteTypes[j]
+        addDecl(c, instantiateGenericParam(c, orig.typ, typ, orig.name,
+                                           orig.info))
+
       var n = oldPrc.ast
       n[bodyPos] = copyTree(getBody(c.graph, s))
       instantiateBody(c, n, oldPrc.typ.n, oldPrc, s)

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -10,6 +10,21 @@
 ## This module implements the instantiation of generic procs.
 ## included from sem.nim
 
+proc instantiateGenericParam(c: PContext, orig, t: PType,
+                             name: PIdent, info: TLineInfo): PSym =
+  ## Produces a new symbol representing the instantiated generic parameter.
+  ## `orig` is the original generic parameter's type, `t` the instantiated
+  ## type, `name` the name to use for symbol, and `info` is the line
+  ## information to use for the symbol.
+  let symKind =
+    case orig.kind
+    of tyStatic: skConst
+    else:        skType
+  result = newSym(symKind, name, nextSymId(c.idgen), getCurrOwner(c), info)
+  result.flags.incl {sfUsed, sfFromGeneric}
+  result.typ = t
+  if t.kind == tyStatic:
+    result.ast = t.n
 
 iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym =
   internalAssert(
@@ -25,9 +40,6 @@ iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym 
 
     var q = a.sym
     if q.typ.kind in {tyTypeDesc, tyGenericParam, tyStatic}+tyTypeClasses:
-      let symKind = if q.typ.kind == tyStatic: skConst else: skType
-      var s = newSym(symKind, q.name, nextSymId(c.idgen), getCurrOwner(c), q.info)
-      s.flags.incl {sfUsed, sfFromGeneric}
       var t = PType(idTableGet(pt, q.typ))
       if t == nil:
         if tfRetType in q.typ.flags:
@@ -35,20 +47,19 @@ iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym 
           # later by semAsgn in return type inference scenario
           t = q.typ
         else:
-          localReport(c.config, a.info, reportSym(rsemCannotInstantiate, s))
+          localReport(c.config, a.info, reportTyp(rsemCannotInstantiate, q.typ))
 
           t = errorType(c)
       elif t.kind == tyGenericParam:
-        localReport(c.config, a.info, reportSym(rsemCannotInstantiate, q))
+        localReport(c.config, a.info, reportTyp(rsemCannotInstantiate, q.typ))
 
         t = errorType(c)
       elif t.kind == tyGenericInvocation:
         #t = instGenericContainer(c, a, t)
         t = generateTypeInstance(c, pt, a, t)
         #t = ReplaceTypeVarsT(cl, t)
-      s.typ = t
-      if t.kind == tyStatic: s.ast = t.n
-      yield s
+
+      yield instantiateGenericParam(c, q.typ, t, q.name, a.info)
 
 proc sameInstantiation(a, b: TInstantiation): bool =
   if a.concreteTypes.len == b.concreteTypes.len:

--- a/tests/lang_callable/generics/tforwardgeneric.nim
+++ b/tests/lang_callable/generics/tforwardgeneric.nim
@@ -26,3 +26,12 @@ proc print[T](t: T) =
 
 echo bar()
 
+block unresolved_generic_param_in_body:
+  # instantiating a forwarded generic proc before its body is
+  # present led to the generic parameters in the instantiated body to not be
+  # properly resolved
+  proc forwarded[T]()
+  forwarded[int]()
+
+  proc forwarded[T]() = # complete the definition
+    doAssert ($T) == "int"


### PR DESCRIPTION
## Summary

Fix generic parameter symbols not being resolved in forwarded generic
routines that are instantiated before the generic routine is completed.
This led to overload resolution failures or internal compiler errors.

## Details

Instantiations created of a forwarded generic routines prior to the
body existing are incomplete and need to be fixed-up once the body is
available. This is done by `fixupInstantiatedSymbols`, but the
instantiated generic parameters weren't added to the scope, which meant
that the non-instantiated ones previously added to the scope by
`semProcAux` were used.

The symbols aren't persisted in the `TInstantiation`, only the types
are, so they need to be created again. The logic for doing so is split
out from `instantiateGenericParamList` into the standalone
`instantiateGenericParam`, which `fixupInstantiatedSymbols` then uses
to create the instantiated generic parameter symbols to add to the
scope.