### PR TITLE
Cull some node flags and remove the {.shallow.} noop

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -472,10 +472,10 @@ template copyNodeImpl(dst, src, processSonsStmt) =
   case src.kind
   of nkIntLiterals:
     dst.intVal = src.intVal
-    dst.intLitBase= src.intLitBase
+    dst.intLitBase = src.intLitBase
   of nkFloatLiterals:
     dst.floatVal = src.floatVal
-    dst.floatLitBase= src.floatLitBase
+    dst.floatLitBase = src.floatLitBase
   of nkSym: dst.sym = src.sym
   of nkIdent: dst.ident = src.ident
   of nkStrLit..nkTripleStrLit: dst.strVal = src.strVal

--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -470,8 +470,12 @@ template copyNodeImpl(dst, src, processSonsStmt) =
       echo "GOES TO ", dst.id
       writeStackTrace()
   case src.kind
-  of nkCharLit..nkUInt64Lit: dst.intVal = src.intVal
-  of nkFloatLiterals: dst.floatVal = src.floatVal
+  of nkIntLiterals:
+    dst.intVal = src.intVal
+    dst.intLitBase= src.intLitBase
+  of nkFloatLiterals:
+    dst.floatVal = src.floatVal
+    dst.floatLitBase= src.floatLitBase
   of nkSym: dst.sym = src.sym
   of nkIdent: dst.ident = src.ident
   of nkStrLit..nkTripleStrLit: dst.strVal = src.strVal

--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -641,13 +641,6 @@ proc toHumanStr*(kind: TTypeKind): string =
   ## strips leading `tk`
   result = toHumanStrImpl(kind, 2)
 
-proc setBaseFlags*(n: PNode, base: NumericalBase) =
-  case base
-  of base10: discard
-  of base2: incl(n.flags, nfBase2)
-  of base8: incl(n.flags, nfBase8)
-  of base16: incl(n.flags, nfBase16)
-
 func toTNodeKind*(kind: ParsedNodeKind): TNodeKind {.inline.} =
   case kind
   of pnkError: nkError
@@ -808,11 +801,11 @@ proc toPNode*(parsed: ParsedNode): PNode =
 
   of pnkFloatKinds:
     result.floatVal = parsed.lit.fNumber
-    result.setBaseFlags(parsed.lit.base)
+    result.floatLitBase = parsed.lit.base
 
   of pnkIntKinds - { pnkCharLit }:
     result.intVal = parsed.lit.iNumber
-    result.setBaseFlags(parsed.lit.base)
+    result.intLitBase = parsed.lit.base
 
   of pnkCharLit:
     result.intVal = ord(parsed.lit.literal[0])

--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -17,7 +17,6 @@ import
     ast_idgen,        # Per module Id generation
     ast_query,        # querying/reading the ast
     ast_parsed_types, # Data types for the parsed node
-    numericbase       # NumericalBase
   ],
   compiler/front/[
     in_options

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -62,8 +62,7 @@ const
   
   PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
   
-  PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
-                                      nfDotSetter, nfDotField, nfLL,
+  PersistentNodeFlags*: TNodeFlags = {nfDotSetter, nfDotField, nfLL,
                                       nfFromTemplate, nfDefaultRefsParam}
   
   namePos*          = 0 ## Name of the type/proc-like node
@@ -82,8 +81,6 @@ const
                         ## on info
   firstArgPos*      = 3 ## Error first 0..n additional nodes depends on
                         ## error kind
-
-  nfAllFieldsSet* = nfBase2
 
   nkCallKinds* = {nkCall, nkInfix, nkPrefix, nkPostfix,
                   nkCommand, nkCallStrLit, nkHiddenCallConv}

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1541,7 +1541,7 @@ type
       floatVal*: BiggestFloat
       floatLitBase*: NumericalBase
         # Once case branches can share fields this can be unified with
-        # intLitKind above
+        # intLitBase above
     of nkStrLit..nkTripleStrLit:
       strVal*: string
     of nkSym:

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -614,7 +614,6 @@ type
     tfFinal,          ## is the object final?
     tfInheritable,    ## is the object inheritable?
     tfEnumHasHoles,   ## enum cannot be mapped into a range
-    tfShallow,        ## type can be shallow copied on assignment
     tfThread,         ## proc type is marked as ``thread``; alias for ``gcsafe``
     tfFromGeneric,    ## type is an instantiation of a generic; this is needed
                       ## because for instantiations of objects, structural

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1,4 +1,4 @@
-import compiler/ast/lineinfos
+import compiler/ast/[lineinfos, numericbase]
 import std/[hashes]
 
 from compiler/ast/idents import PIdent, TIdent
@@ -590,10 +590,6 @@ type
   TTypeKinds* = set[TTypeKind]
 
   TNodeFlag* = enum
-    nfNone,
-    nfBase2,    ## nfBase10 is default, so not needed
-    nfBase8,
-    nfBase16,
     nfAllConst, ## used to mark complex expressions constant; easy to get rid of
                 ## but unfortunately it has measurable impact for compilation
                 ## efficiency
@@ -605,7 +601,7 @@ type
     nfDotSetter ## the call can use a setter dot operarator
     nfExplicitCall ## `x.y()` was used instead of x.y
     nfFromTemplate ## a top-level node returned from a template
-    nfDefaultParam ## an automatically inserter default parameter
+    nfDefaultParam ## an automatically inserted default parameter
     nfDefaultRefsParam ## a default param value references another parameter
                        ## the flag is applied to proc default values and to calls
     nfHasComment ## node has a comment
@@ -1541,8 +1537,12 @@ type
     case kind*: TNodeKind
     of nkCharLit..nkUInt64Lit:
       intVal*: BiggestInt
+      intLitBase*: NumericalBase
     of nkFloatLit..nkFloat128Lit:
       floatVal*: BiggestFloat
+      floatLitBase*: NumericalBase
+        # Once case branches can share fields this can be unified with
+        # intLitKind above
     of nkStrLit..nkTripleStrLit:
       strVal*: string
     of nkSym:

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -20,6 +20,7 @@ import
     idents,
     ast,
     lineinfos,
+    numericbase
   ],
   std/[
     strutils,
@@ -308,19 +309,27 @@ proc litAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =
         result &= e.sym.name.s
         return
 
-  if nfBase2 in n.flags: result = "0b" & toBin(x, size * 8)
-  elif nfBase8 in n.flags:
-    var y = if size < sizeof(BiggestInt): x and ((1.BiggestInt shl (size*8)) - 1)
-            else: x
-    result = "0o" & toOct(y, size * 3)
-  elif nfBase16 in n.flags: result = "0x" & toHex(x, size * 2)
-  else: result = $x
+  else:
+    let base =
+      case n.kind
+      of nkIntLiterals: n.intLitBase
+      of nkFloatLiterals: n.floatLitBase
+      else: base10 # unreachable
+    case base
+    of base10: result = $x
+    of base2: result = "0b" & toBin(x, size * 8)
+    of base8:
+      var y = if size < sizeof(BiggestInt): x and ((1.BiggestInt shl (size*8)) - 1)
+              else: x
+      result = "0o" & toOct(y, size * 3)
+    of base16: result = "0x" & toHex(x, size * 2)
 
-proc ulitAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =
-  if nfBase2 in n.flags: result = "0b" & toBin(x, size * 8)
-  elif nfBase8 in n.flags: result = "0o" & toOct(x, size * 3)
-  elif nfBase16 in n.flags: result = "0x" & toHex(x, size * 2)
-  else: result = $cast[BiggestUInt](x)
+proc ulitAux(g: TSrcGen, n: PNode, x: BiggestInt, size: int): string =
+  case n.intLitBase
+  of base10: result = $cast[BiggestUInt](x)
+  of base2: result = "0b" & toBin(x, size * 8)
+  of base8: result = "0o" & toOct(x, size * 3)
+  of base16: result = "0x" & toHex(x, size * 2)
 
 proc atom(g: TSrcGen; n: PNode): string =
   var f: float32
@@ -346,16 +355,16 @@ proc atom(g: TSrcGen; n: PNode): string =
   of nkUInt32Lit: result = ulitAux(g, n, n.intVal, 4) & "\'u32"
   of nkUInt64Lit: result = ulitAux(g, n, n.intVal, 8) & "\'u64"
   of nkFloatLit:
-    if n.flags * {nfBase2, nfBase8, nfBase16} == {}: result = $(n.floatVal)
+    if n.floatLitBase == base10: result = $(n.floatVal)
     else: result = litAux(g, n, (cast[PInt64](addr(n.floatVal)))[] , 8)
   of nkFloat32Lit:
-    if n.flags * {nfBase2, nfBase8, nfBase16} == {}:
+    if n.floatLitBase == base10:
       result = $n.floatVal & "\'f32"
     else:
       f = n.floatVal.float32
       result = litAux(g, n, (cast[PInt32](addr(f)))[], 4) & "\'f32"
   of nkFloat64Lit:
-    if n.flags * {nfBase2, nfBase8, nfBase16} == {}:
+    if n.floatLitBase == base10:
       result = $n.floatVal & "\'f64"
     else:
       result = litAux(g, n, (cast[PInt64](addr(n.floatVal)))[], 8) & "\'f64"

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -74,8 +74,12 @@ proc sameTree*(a, b: PNode): bool =
       # don't go nuts here: same symbol as string is enough:
       result = a.sym.name.id == b.sym.name.id
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = sameFloatIgnoreNan(a.floatVal, b.floatVal)
+    of nkCharLit..nkUInt64Lit:
+      result = a.intVal == b.intVal and
+               a.intLitBase == b.intLitBase
+    of nkFloatLit..nkFloat64Lit:
+      result = sameFloatIgnoreNan(a.floatVal, b.floatVal) and
+               a.floatLitBase == b.floatLitBase
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkEmpty, nkNilLit, nkType: result = true
     else:

--- a/compiler/ast/wordrecg.nim
+++ b/compiler/ast/wordrecg.nim
@@ -72,7 +72,7 @@ type
     wCompileTime = "compileTime", wNoInit = "noinit", wPassc = "passc", wPassl = "passl",
     wLocalPassc = "localPassC", wBorrow = "borrow", wDiscardable = "discardable",
     wFieldChecks = "fieldChecks", wSubsChar = "subschar", wAcyclic = "acyclic",
-    wShallow = "shallow", wLinearScanEnd = "linearScanEnd",
+    wLinearScanEnd = "linearScanEnd",
     wComputedGoto = "computedGoto", wExperimental = "experimental",
     wWrite = "write", wGensym = "gensym", wInject = "inject", wDirty = "dirty",
     wInheritable = "inheritable", wThreadVar = "threadvar", wEmit = "emit",

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -109,7 +109,7 @@ const
     wRaises, wLocks, wTags, wEffectsOf,
     wGcSafe, wCodegenDecl, wNoInit, wCompileTime}
   typePragmas* = declPragmas + {wMagic, wAcyclic,
-    wPure, wHeader, wCompilerProc, wCore, wFinal, wSize, wShallow,
+    wPure, wHeader, wCompilerProc, wCore, wFinal, wSize,
     wIncompleteStruct, wCompleteStruct, wByCopy, wByRef,
     wInheritable, wGensym, wInject, wRequiresInit, wUnion, wPacked,
     wBorrow, wGcSafe, wExplain, wPackage}
@@ -1309,10 +1309,6 @@ proc applySymbolPragma(c: PContext, sym: PSym, it: PNode): PNode =
         result = noVal(c, it)
         assert sym.typ != nil
         incl(sym.typ.flags, tfAcyclic)
-      of wShallow:
-        result = noVal(c, it)
-        assert sym.typ != nil
-        incl(sym.typ.flags, tfShallow)
       of wThread:
         result = noVal(c, it)
         sym.flags.incl {sfThread, sfProcvar}

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -521,15 +521,6 @@ proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
 proc semMacroExpr(c: PContext, n: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode
 
-proc hasCycle(n: PNode): bool =
-  # xxx: this isn't used, we should consider reinstating this?
-  incl n.flags, nfNone
-  for i in 0..<n.safeLen:
-    if nfNone in n[i].flags or hasCycle(n[i]):
-      result = true
-      break
-  excl n.flags, nfNone
-
 proc tryConstExpr(c: PContext, n: PNode): PNode =
   addInNimDebugUtils(c.config, "tryConstExpr", n, result)
   pushExecCon(c, {})

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -500,9 +500,6 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
         hasError = true
         break
 
-  if initResult == initFull:
-    incl result.flags, nfAllFieldsSet
-
   # wrap in an error see #17437
   if hasError:
     result = wrapError(c.config, result)

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6509,26 +6509,6 @@ objects that inherit from an existing object (via the `object of SuperType`
 syntax) or that have been marked as `inheritable`.
 
 
-shallow pragma
---------------
-The `shallow` pragma affects the semantics of a type: The compiler is
-allowed to make a shallow copy. This can cause serious semantic issues and
-break memory safety! However, it can speed up assignments considerably,
-because the semantics of Nim require deep copying of sequences and strings.
-This can be expensive, especially if sequences are used to build a tree
-structure:
-
-.. code-block:: nim
-  type
-    NodeKind = enum nkLeaf, nkInner
-    Node {.shallow.} = object
-      case kind: NodeKind
-      of nkLeaf:
-        strVal: string
-      of nkInner:
-        children: seq[Node]
-
-
 pure pragma
 -----------
 An object type can be marked with the `pure` pragma so that its type field

--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -76,7 +76,7 @@ type
     col: int                    ## column the symbol has been declared/used in
     flags: set[NonTerminalFlag] ## the nonterminal's flags
     rule: Peg                   ## the rule that the symbol refers to
-  Peg* {.shallow.} = object ## type that represents a PEG
+  Peg* = object ## type that represents a PEG
     case kind: PegKind
     of pkEmpty..pkWhitespace: nil
     of pkTerminal, pkTerminalIgnoreCase, pkTerminalIgnoreStyle: term: string

--- a/tests/compiler/tvmbackend.nim
+++ b/tests/compiler/tvmbackend.nim
@@ -84,7 +84,7 @@ block:
   let sym = PSym(kind: skProc, magic: mSlice, name: PIdent(s: "slice"),
                  typ: typ,  offset: 1, position: 2)
   let typ2 = PType(kind: tyString, flags: {tfVarargs}, sons: @[typ],
-                   n: PNode(kind: nkStrLit, flags: {nfBase2}, typ: typ),
+                   n: PNode(kind: nkStrLit, flags: {nfAllConst}, typ: typ),
                    sym: sym)
 
   let typeInfo = VmTypeInfo(nimType: typ2, internal: vmTyp2)

--- a/tests/lang_callable/generics/tgeneric3.nim
+++ b/tests/lang_callable/generics/tgeneric3.nim
@@ -15,7 +15,7 @@ import std/strutils
 
 type
   PNode[T,D] = ref TNode[T,D]
-  TItem[T,D] {.acyclic, pure, final, shallow.} = object
+  TItem[T,D] {.acyclic, pure, final.} = object
         key: T
         value: D
         node: PNode[T,D]
@@ -23,7 +23,7 @@ type
           val_set: bool
 
   TItems[T,D] = seq[ref TItem[T,D]]
-  TNode[T,D] {.acyclic, pure, final, shallow.} = object
+  TNode[T,D] {.acyclic, pure, final.} = object
         slots: TItems[T,D]
         left: PNode[T,D]
         count: int32

--- a/tests/lang_objects/metatype/ttypetraits.nim
+++ b/tests/lang_objects/metatype/ttypetraits.nim
@@ -252,7 +252,7 @@ block genericParams:
 # bug 13095
 
 type
-  CpuStorage[T] {.shallow.} = ref object
+  CpuStorage[T] = ref object
     when supportsCopyMem(T):
       raw_buffer*: ptr UncheckedArray[T] # 8 bytes
       memalloc*: pointer                 # 8 bytes

--- a/tests/vm/tcompiletimerange.nim
+++ b/tests/vm/tcompiletimerange.nim
@@ -7,7 +7,7 @@ const rangesGCHoldEnabled = true # not defined(rangesDisableGCHold)
 
 type
   # A view into immutable array
-  Range*[T] {.shallow.} = object
+  Range*[T] = object
     when rangesGCHoldEnabled:
       gcHold: seq[T] # 0
     start: ptr T # 1


### PR DESCRIPTION
## Summary
* Removed  `nfNone`  as it was unused outside of the unused  `hasCyclic` 
proc
* Removed  `nfBase2|8|16`  and instead use an enum field in the
respective PNode variant ( `nkIntLiterals`  and  `nkFloatLiterals` )
* Removed the no-op pragma  `{.shallow.}`  and its associated typeflag 
`tfShallow` 

## Details
* Because  `sons*: TNodeSeq`  in  `TNode`  is 16 bytes big anyways, this
leaves us 8 bytes of unused space in the  `nkIntLiterals`  and 
`nkFloatLiterals`  variants, which can thus be used for an enum field of
type  `NumericalBase`  without increasing the size of  `TNode` .
* Separate fields for the  `nkIntLiterals`  and  `nkFloatLiterals` 
variants are used because variants can't share fields yet
* Because  `ast/trees.sameTree`  checks the node flags for equality and
those determined the base of a literal, checks for the introduced base
fields have been added to it in order to not change the behaviour 
* Should the removed  `hasCyclic`  proc be needed in the future it
should be easy to re-implement without using a node flag for storing
whether a node has already been visited, instead using a Set or 
`IntSet` .
* The  `nfAllFieldsSet`  constant/alias of  `nfBase2`  is unused as
there is no code that checks for it
* I considered adding  `{.pragma: shallow.}`  to  `system`  but I think
its usage is not that common, considering it was underspecified and not
memory safe.