### PR TITLE
Include nkCommentStmt in nkWithoutSons

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -476,7 +476,7 @@ template copyNodeImpl(dst, src, processSonsStmt) =
   of nkSym: dst.sym = src.sym
   of nkIdent: dst.ident = src.ident
   of nkStrLit..nkTripleStrLit: dst.strVal = src.strVal
-  of nkEmpty, nkNone, nkNilLit, nkType: discard "no children"
+  of nkEmpty, nkNone, nkNilLit, nkType, nkCommentStmt: discard "no children"
   of nkError: dst.diag = src.diag # do cheap copies
   of nkWithSons: processSonsStmt
 

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -345,7 +345,7 @@ proc containsNode*(n: PNode, kinds: TNodeKinds): bool =
 
 proc hasSubnodeWith*(n: PNode, kind: TNodeKind): bool =
   case n.kind
-  of nkEmpty..nkNilLit, nkFormalParams:
+  of nkEmpty..nkNilLit, nkFormalParams, nkCommentStmt:
     result = n.kind == kind
   of nkError:
     result = hasSubnodeWith(n.diag.wrongNode, kind)

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -543,7 +543,7 @@ iterator pairs*(n: PNode): tuple[i: int, n: PNode] =
   for i in 0..<n.safeLen: yield (i, n[i])
 
 proc isAtom*(n: PNode): bool {.inline.} =
-  result = n.kind >= nkNone and n.kind <= nkNilLit
+  n.kind in nkNone..nkNilLit or n.kind == nkCommentStmt
 
 proc isEmptyType*(t: PType): bool {.inline.} =
   ## 'void' and 'typed' types are often equivalent to 'nil' these days:

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -256,7 +256,8 @@ const
     {nkFloatLit..nkFloat128Lit} +
     {nkStrLit..nkTripleStrLit} +
     {nkNilLit} +
-    {nkError}
+    {nkError} +
+    {nkCommentStmt}
 
   nkWithSons* = {low(TNodeKind) .. high(TNodeKind)} - nkWithoutSons
 
@@ -1549,7 +1550,7 @@ type
       sym*: PSym
     of nkIdent:
       ident*: PIdent
-    of nkEmpty, nkNone, nkType, nkNilLit:
+    of nkEmpty, nkNone, nkType, nkNilLit, nkCommentStmt:
       discard
     of nkError:
       diag*: PAstDiag

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -165,7 +165,7 @@ proc buildErrorList(config: ConfigRef, n: PNode, errs: var seq[PNode]) =
   ## creates a list (`errs` seq) from most specific to least specific
   ## by traversing the the error tree in a depth-first-search.
   case n.kind
-  of nkEmpty .. nkNilLit:
+  of nkEmpty .. nkNilLit, nkCommentStmt:
     discard
   of nkError:
     buildErrorList(config, n.diag.wrongNode, errs)

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -77,6 +77,7 @@ proc sameTree*(a, b: PNode): bool =
     of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
     of nkFloatLit..nkFloat64Lit: result = sameFloatIgnoreNan(a.floatVal, b.floatVal)
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
+    of nkCommentStmt: result = a.comment == b.comment
     of nkEmpty, nkNilLit, nkType: result = true
     else:
       if a.len == b.len:

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -17,7 +17,7 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode]): bool =
   for v in visited:
     if v == n: return true
   case n.kind
-  of nkEmpty..nkNilLit:
+  of nkEmpty..nkNilLit, nkCommentStmt:
     discard
   of nkError:
     visited.add(n)

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -116,7 +116,7 @@ proc sexp*(node: PNode): SexpNode =
   result = newSList()
   result.add newSSymbol(($node.kind)[2 ..^ 1])
   case node.kind
-  of nkNone, nkEmpty, nkType:   discard
+  of nkNone, nkEmpty, nkType, nkCommentStmt: discard
   of nkCharLit..nkUInt64Lit:    result.add sexp(node.intVal)
   of nkFloatLit..nkFloat128Lit: result.add sexp(node.floatVal)
   of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -446,7 +446,7 @@ proc toPackedNode*(n: PNode; ir: var PackedTree; c: var PackedEncoder; m: var Pa
     return
   let info = toPackedInfo(n.info, c, m)
   case n.kind
-  of nkNone, nkEmpty, nkNilLit, nkType:
+  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt:
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags, operand: 0,
                             typeId: storeTypeLater(n.typ, c, m), info: info)
   of nkIdent:

--- a/compiler/ic/integrity.nim
+++ b/compiler/ic/integrity.nim
@@ -71,7 +71,7 @@ proc checkNode(c: var CheckedContext; tree: PackedTree; n: NodePos) =
   if tree[n.int].typeId != nilItemId:
     checkType(c, tree[n.int].typeId)
   case n.kind
-  of nkEmpty, nkNilLit, nkType, nkNilRodNode:
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkNilRodNode:
     discard
   of nkIdent:
     assert c.g.packed[c.thisModule].fromDisk.strings.hasLitId n.litId

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -91,10 +91,7 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
     # in the AST that would confuse it (bug #9432), but only if we are not in a
     # "declarative" context (bug #9235).
     if c.isDeclarative:
-      var res = copyNode(c, templ, actual)
-      for i in 0..<templ.len:
-        evalTemplateAux(templ[i], actual, c, res)
-      result.add res
+      result.add copyNode(c, templ, actual)
     else:
       result.add newNodeI(nkEmpty, templ.info)
   of nkError:

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -427,8 +427,8 @@ proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
 
       c.usedInner.add s
 
-  of nkWithoutSons - nkSym, nkTypeSection, nkCommentStmt,
-     nkTypeOfExpr, nkMixinStmt, nkBindStmt, routineDefs - nkIteratorDef:
+  of nkWithoutSons - nkSym, nkTypeSection, nkTypeOfExpr,
+     nkMixinStmt, nkBindStmt, routineDefs - nkIteratorDef:
     discard
   of nkLambdaKinds, nkIteratorDef:
     if n.typ != nil:

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -347,7 +347,7 @@ proc hashBodyTree(graph: ModuleGraph, c: var MD5Context, n: PNode) =
     return
   c &= char(n.kind)
   case n.kind
-  of nkEmpty, nkNilLit, nkType: discard
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt: discard
   of nkIdent:
     c &= n.ident.s
   of nkSym:

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -308,7 +308,7 @@ proc transformConstSection(c: PTransf, v: PNode): PNode =
 
 proc hasContinue(n: PNode): bool =
   case n.kind
-  of nkEmpty..nkNilLit, nkForStmt, nkWhileStmt: discard
+  of nkEmpty..nkNilLit, nkCommentStmt, nkForStmt, nkWhileStmt: discard
   of nkContinueStmt: result = true
   else:
     for i in 0..<n.len:
@@ -433,7 +433,7 @@ proc introduceNewLocalVars(c: PTransf, n: PNode): PNode =
   case n.kind
   of nkSym:
     result = transformSym(c, n)
-  of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit:
+  of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit, nkCommentStmt:
     # nothing to be done for leaves:
     result = n
   of callableDefs:

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -600,7 +600,7 @@ func storeNode(enc: var TypeInfoEncoder, ps: var PackedEnv, n: PNode): NodeId =
   var hasSons = false
   let item =
     case n.kind
-    of nkEmpty, nkType, nkNilLit: 0'i32 # zero children
+    of nkEmpty, nkType, nkNilLit, nkCommentStmt: 0'i32 # zero children
     of nkIdent: ps.getLitId(n.ident.s).int32
     of nkSym:   enc.storeSymLater(ps, n.sym).int32
     of nkIntKinds:   ps.getLitId(n.intVal).int32
@@ -673,7 +673,7 @@ proc loadNode(dec: var TypeInfoDecoder, ps: PackedEnv, id: NodeId): (PNode, int3
                 typ: loadType(dec, ps, n.typeId))
 
   case n.kind
-  of nkEmpty, nkType, nkNilLit:
+  of nkEmpty, nkType, nkNilLit, nkCommentStmt:
     discard "do nothing"
   of nkCharLit..nkUInt64Lit:
     r.intVal = ps.numbers[n.operand.LitId]


### PR DESCRIPTION
## Summary
*  `nkCommentStmt`  never had sons, so it should be included in 
`nkWithoutSons` 

## Details
*  `compiler/ast/trees.sameTree`  now checks the comments of 
`nkCommentStmt` s for equality, although this doesn't actually have an
effect on anything as that proc is unused.