### PR TITLE
Fix wrapError crash in semobjconstr

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1209,6 +1209,7 @@ type
     # semobjconstr
     adSemFieldAssignmentInvalid
     adSemFieldNotAccessible
+    adSemObjectRequiresFieldInit
     adSemObjectRequiresFieldInitNoDefault
     adSemExpectedObjectType
     adSemExpectedObjectOfType
@@ -1482,7 +1483,8 @@ type
       wrongFldInfo*: TLineInfo
     of adSemFieldNotAccessible:
       inaccessible*: PSym
-    of adSemObjectRequiresFieldInitNoDefault:
+    of adSemObjectRequiresFieldInit,
+       adSemObjectRequiresFieldInitNoDefault:
       missing*: seq[PSym]
       objTyp*: PType
     of adSemDistinctDoesNotHaveDefaultValue:

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3754,6 +3754,14 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       kind: kind,
       ast: diag.wrongNode,
       sym: diag.inaccessible)
+  of adSemObjectRequiresFieldInit:
+    semRep = SemReport(
+      location: some diag.location,
+      reportInst: diag.instLoc.toReportLineInfo,
+      kind: rsemObjectRequiresFieldInit,
+      ast: diag.wrongNode,
+      symbols: diag.missing,
+      typ: diag.objTyp)
   of adSemObjectRequiresFieldInitNoDefault:
     semRep = SemReport(
       location: some diag.location,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -574,6 +574,7 @@ func astDiagToLegacyReportKind*(
   of adSemReturnNotAllowed: rsemReturnNotAllowed
   of adSemFieldAssignmentInvalid: rsemFieldAssignmentInvalid
   of adSemFieldNotAccessible: rsemFieldNotAccessible
+  of adSemObjectRequiresFieldInit: rsemObjectRequiresFieldInit
   of adSemObjectRequiresFieldInitNoDefault: rsemObjectRequiresFieldInitNoDefault
   of adSemExpectedObjectType: rsemExpectedObjectType
   of adSemExpectedObjectOfType: rsemExpectedObjectType

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -483,14 +483,6 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
   var hasError = constructionError or missedFields
     ## needed to split error detect/report for better msgs
 
-  # It's possible that the object was not fully initialized while
-  # specifying a .requiresInit. pragma:
-  if missedFields:
-    localReport(c.config, result.info, reportSymbols(
-      rsemObjectRequiresFieldInit,
-      constrCtx.missingFields,
-      typ = t))
-
   if not hasError:
     # we're not tracking the error nodes and thus have to look for
     # them here
@@ -500,6 +492,13 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
         hasError = true
         break
 
-  # wrap in an error see #17437
-  if hasError:
+  # It's possible that the object was not fully initialized while
+  # specifying a .requiresInit. pragma:
+  if missedFields:
+    result = newError(c.config, result):
+      PAstDiag(kind: adSemObjectRequiresFieldInit,
+               missing: constrCtx.missingFields,
+               objTyp: t)
+  elif hasError:
+    # wrap in an error see #17437
     result = wrapError(c.config, result)


### PR DESCRIPTION
## Summary
*  `wrapError`  inside  `sem/semobjconstr`  would fail an assertion
because there was no  `nkError`  node inserted when the object
constructor was missing fields, instead a  `localReport`  was used, but 
`wrapError`  was still called at the end of the procedure

## Details
* This never got caught by CI because the CI compiler is compiled with 
`-d:danger` /assertions disabled.