### PR TITLE
testament: don't error on directories without tests

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -573,8 +573,4 @@ proc processCategory(r: var TResults, cat: Category, targets: set[TTarget],
       runs.setLen(0) # prepare for the next test
       inc testsRun
     if testsRun == 0:
-      const allowedDirs = ["deps", "htmldocs", "pkgs"]
-        # `pkgs` because bug #16556 creates `pkgs` dirs and this can affect some users
-        # that try an old version of choosenim.
-      doAssert cat.string in allowedDirs,
-        "Invalid category specified: '$#' not in allow list: $#" % [cat.string, $allowedDirs]
+      echo "No tests found in ",cat.string


### PR DESCRIPTION
## Summary
This makes  `testament`  not crash on directories that don't contain
tests to run as there's no good reason to consider that an error

## Details
These can linger around after checking out an old branch that has
different test categories and running the tests there, because git will
not delete the directories when switching the branch as they will
contain binaries from the tests.