### PR TITLE
sem: improve type class support for built-ins

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -566,6 +566,13 @@ const
   tyMetaTypes* = {tyGenericParam, tyTypeDesc, tyUntyped} + tyTypeClasses
   tyUserTypeClasses* = {tyUserTypeClass, tyUserTypeClassInst}
 
+  tyBuiltInTypeClasses* = {tyDistinct, tyEnum, tyOrdinal, tyArray, tyObject,
+                           tyTuple, tySet, tyRange, tyPtr, tyRef, tyVar,
+                           tySequence, tyProc, tyOpenArray, tyLent, tyVarargs,
+                           tyUncheckedArray}
+    ## the type kinds that may appear as the child of a
+    ## ``tyBuiltInTypeClass``
+
   # TODO: Remove tyTypeDesc from each abstractX and (where necessary)
   # replace with typedescX
   abstractInst* = {tyGenericInst, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -680,6 +680,7 @@ type
     rsemIllformedAst
     rsemInitHereNotAllowed
     rsemTypeExpected
+    rsemSinkIsNotATypeClass
     rsemGenericTypeExpected
     rsemTypeInvalid
     rsemWrongIdent

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -851,9 +851,7 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
       result = a.sym.position == b.sym.position
   of tyBuiltInTypeClass:
     assert a.len == 1
-    assert a[0].len == 0
     assert b.len == 1
-    assert b[0].len == 0
     result = a[0].kind == b[0].kind
   of tyGenericInvocation, tyGenericBody, tySequence, tyOpenArray, tySet, tyRef,
      tyPtr, tyVar, tyLent, tySink, tyUncheckedArray, tyArray, tyProc, tyVarargs,

--- a/compiler/ast/typesrenderer.nim
+++ b/compiler/ast/typesrenderer.nim
@@ -264,6 +264,7 @@ proc typeToString*(typ: PType, prefer: TPreferedDesc = preferName): string =
     of tyBuiltInTypeClass:
       result = case t.base.kind
         of tyVar: "var"
+        of tyLent: "lent"
         of tyRef: "ref"
         of tyPtr: "ptr"
         of tySequence: "seq"
@@ -271,11 +272,16 @@ proc typeToString*(typ: PType, prefer: TPreferedDesc = preferName): string =
         of tySet: "set"
         of tyRange: "range"
         of tyDistinct: "distinct"
+        of tyOrdinal: "Ordinal"
         of tyProc: "proc"
+        of tyEnum: "enum"
         of tyObject: "object"
         of tyTuple: "tuple"
         of tyOpenArray: "openArray"
-        else: typeToStr[t.base.kind]
+        of tyVarargs: "varargs"
+        of tyUncheckedArray: "UncheckedArray"
+        of {low(TTypeKind)..high(TTypeKind)} - tyBuiltInTypeClasses:
+          "<illegal type: " & $t.base.kind & ">"
     of tyInferred:
       let concrete = t.previouslyInferred
       if concrete != nil: result = typeToString(concrete)

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -761,6 +761,9 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         result = "type expected, but got symbol '$1' of kind '$2'" %
           [r.sym.name.s, r.sym.kind.toHumanStr]
 
+    of rsemSinkIsNotATypeClass:
+      result = "'sink' cannot be used as a type class"
+
     of rsemCyclicDependency:
       result = "recursive dependency: '$1'" % r.symstr
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -186,8 +186,10 @@ proc fitNodePostMatch(c: PContext, formal: PType, arg: PNode): PNode =
   var
     a = arg
     x = a.mutableSkipConv
-  if (x.kind == nkCurly and formal.kind == tySet and formal.base.kind != tyGenericParam) or
-    (x.kind in {nkPar, nkTupleConstr}) and formal.kind notin {tyUntyped, tyBuiltInTypeClass}:
+  if x.kind in {nkCurly, nkPar, nkTupleConstr} and
+     formal.kind notin {tyUntyped, tyBuiltInTypeClass}:
+    # XXX: ^^ the test for ``tyBuiltInTypeClass`` is a hack. It can be removed
+    #      once ``fitNode`` is no longer used for meta return types
     x = changeType(c, x, formal, check=true)
 
     if x.isError:

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1665,11 +1665,12 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
       n.typ = s.typ
       return n
   of skType:
-    markUsed(c, n.info, s)
     if s.typ.kind == tyStatic and s.typ.base.kind != tyNone and s.typ.n != nil:
+      markUsed(c, n.info, s)
       return s.typ.n
     result = newSymNode(s, n.info)
-    result.typ = makeTypeDesc(c, s.typ)
+    # ``semTypeNode`` will mark the symbol as used
+    result.typ = makeTypeDesc(c, semTypeNode(c, result, nil))
   of skField:
     # old code, not sure if it's live code:
     markUsed(c, n.info, s)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1983,9 +1983,9 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
       s.typ.n = semGenericParamList(c, a[1], s.typ)
       a[1] = s.typ.n
       s.typ.size = -1 # could not be computed properly
-      # we fill it out later. For magic generics like 'seq', it won't be filled
-      # so we use tyNone instead of nil to not crash for strange conversions
-      # like: mydata.seq
+      # we fill it out later. For magic generics like 'typdesc', it won't be
+      # filled so we use tyNone instead of nil to not crash for expressions like
+      # ``static type``
       rawAddSon(s.typ, newTypeS(tyNone, c))
       s.ast = a
       inc c.inGenericContext

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -56,10 +56,10 @@ proc liftTypeClass(c: PContext, typ: PType, prev: PType,
 
   let isMagic = typ.sym != nil and typ.sym.magic != mNone
 
-  case result.kind
-  of tyOrdinal, tyRange, tySequence, tySet, tyArray, tyLent, tyOpenArray,
-     tyVarargs, tyUncheckedArray:
-    if isMagic:
+  if isMagic:
+    case result.kind
+    of tyOrdinal, tyRange, tySequence, tySet, tyArray, tyLent, tyOpenArray,
+       tyVarargs, tyUncheckedArray:
       # this is the "raw", uninstantiated magic type -> it's
       # a built-in type class
       result = newOrPrevType(tyBuiltInTypeClass, prev, c)
@@ -67,12 +67,11 @@ proc liftTypeClass(c: PContext, typ: PType, prev: PType,
       # add the generic type, but don't propagate the flags
       result.sons = @[typ]
 
-  of tySink:
-    if isMagic:
+    of tySink:
       localReport(c.config, info, SemReport(kind: rsemSinkIsNotATypeClass))
       result = newOrPrevType(tyError, prev, c)
-  else:
-    discard
+    else:
+      discard
 
 proc semEnum(c: PContext, n: PNode, prev: PType): PType =
   if n.len == 0: return newConstraint(c, tyEnum)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2466,7 +2466,6 @@ proc processMagicType(c: PContext, m: PSym) =
     setMagicType(c.config, m, tyVarargs, szUncomputedSize)
   of mRange:
     setMagicIntegral(c.config, m, tyRange, szUncomputedSize)
-    rawAddSon(m.typ, newTypeS(tyNone, c))
   of mSet:
     setMagicIntegral(c.config, m, tySet, szUncomputedSize)
   of mUncheckedArray:
@@ -2482,7 +2481,6 @@ proc processMagicType(c: PContext, m: PSym) =
     c.graph.sysTypes[tySequence] = m.typ
   of mOrdinal:
     setMagicIntegral(c.config, m, tyOrdinal, szUncomputedSize)
-    rawAddSon(m.typ, newTypeS(tyNone, c))
   of mPNimrodNode:
     m.typ.flags.incl {tfTriggersCompileTime, tfCheckedForDestructor}
   of mException: discard

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2296,11 +2296,9 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     elif s.kind == skParam and s.typ.kind == tyTypeDesc:
       c.config.internalAssert s.typ.base.kind != tyNone and prev == nil
       result = s.typ.base
-    elif prev == nil:
-      result = liftTypeClass(c, s.typ, nil, n.info)
     else:
       let lifted = liftTypeClass(c, s.typ, prev, n.info)
-      if lifted != s.typ:
+      if lifted != s.typ or prev == nil:
         result = lifted
       else:
         let alias = maybeAliasType(c, s.typ, prev)
@@ -2324,10 +2322,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
           s.typ.base
 
       let lifted = liftTypeClass(c, t, prev, n.info)
-      if lifted != t:
+      if lifted != t or prev == nil:
         result = lifted
-      elif prev == nil:
-        result = t
       else:
         let alias = maybeAliasType(c, t, prev)
         if alias != nil:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -67,6 +67,10 @@ proc liftTypeClass(c: PContext, typ: PType, prev: PType,
       # add the generic type, but don't propagate the flags
       result.sons = @[typ]
 
+  of tySink:
+    if isMagic:
+      localReport(c.config, info, SemReport(kind: rsemSinkIsNotATypeClass))
+      result = newOrPrevType(tyError, prev, c)
   else:
     discard
 

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -239,6 +239,9 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
   of tyArray:
     c &= char(t.kind)
     for i in 0..<t.len: c.hashType(t[i], flags-{CoIgnoreRange})
+  of tyBuiltInTypeClass:
+    c &= char(t.kind)
+    c &= char(t[0].kind)
   else:
     c &= char(t.kind)
     for i in 0..<t.len: c.hashType(t[i], flags)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -1743,6 +1743,11 @@ typeRel can be used to establish various relationships between types:
         of tyRange:
           if a.kind == tyRange:
             result = isGeneric
+        of tyArray:
+          # XXX: empty array types match for the array type class, but this is
+          #      inconsistent with, for example, sequence types
+          if a.kind == tyArray:
+            result = isGeneric
         of tyProc, tyPointer:
           # XXX: ^^ this should also include non-nil refs and ptrs
           if effectiveArgType.kind == tyNil:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -1743,10 +1743,10 @@ typeRel can be used to establish various relationships between types:
         of tyRange:
           if a.kind == tyRange:
             result = isGeneric
-        of tyArray:
-          # XXX: empty array types match for the array type class, but this is
-          #      inconsistent with, for example, sequence types
-          if a.kind == tyArray:
+        of tyArray, tySet:
+          # XXX: ``seq`` types weren't and still aren't included here, but for
+          #      consistency, they probably should
+          if a.kind == targetKind:
             result = isGeneric
         of tyProc, tyPointer:
           # XXX: ^^ this should also include non-nil refs and ptrs

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -1736,7 +1736,7 @@ typeRel can be used to establish various relationships between types:
       else:
         case targetKind
         of tyOrdinal, tyOpenArray, tyVarargs:
-          # these type classes of these act the same as if using, for example,
+          # the type classes of these act the same as if using, for example,
           # ``openArray[T]``. The generic type is already stored as the base
           # type -- but don't bind anything
           result = typeRel(c, f.base, a, {trDontBind})

--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -24,7 +24,8 @@ import
     options
   ],
   compiler/utils/[
-    pathutils
+    pathutils,
+    idioms
   ],
   experimental/[
     results
@@ -306,7 +307,28 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
   of tyVarargs: result = mapTypeToBracket("varargs", mVarargs, t, info)
   of tyProxy: result = atomicType("error", mNone)
   of tyBuiltInTypeClass:
-    result = mapTypeToBracket("builtinTypeClass", mNone, t, info)
+    # the type stored in the type class is not necessarily
+    # valid. We need to manually map the type.
+    result = newNodeIT(nkBracketExpr, info, t)
+    result.add atomicTypeX(cache, "builtinTypeClass", mNone, t, info, idgen)
+    template elem(kind): PNode =
+      newNodeIT(kind, info, t.base)
+    result.add:
+      case t.base.kind
+      of tyDistinct: elem(nkDistinctTy)
+      of tyEnum:     elem(nkEnumTy)
+      of tyObject:   elem(nkObjectTy)
+      of tyTuple:    elem(nkTupleClassTy)
+      of tyVar:      elem(nkVarTy)
+      of tyProc:     elem(nkProcTy)
+      of tyPtr:      elem(nkPtrTy)
+      of tyRef:      elem(nkRefTy)
+      of tyOrdinal, tyArray, tySet, tyRange, tySequence, tyOpenArray, tyLent,
+         tyVarargs, tyUncheckedArray:
+        # use the symbol of the type stored in the type class
+        newSymNode(t.base.sym, info)
+      of {low(TTypeKind)..high(TTypeKind)} - tyBuiltInTypeClasses:
+        unreachable(t.base.kind)
   of tyUserTypeClass, tyUserTypeClassInst:
     if t.isResolvedUserTypeClass:
       result = mapTypeToAst(t.lastSon, info)

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5071,7 +5071,7 @@ Type classes
 
 A type class is a special pseudo-type that can be used to match against
 types in the context of overload resolution or the `is` operator.
-Nim supports the following built-in type classes:
+|NimSkull| supports the following built-in type classes:
 
 ==================   ===================================================
 type class           matches
@@ -5084,10 +5084,16 @@ type class           matches
 `ref`                any `ref` type
 `ptr`                any `ptr` type
 `var`                any `var` type
+`lent`               any `lent` type
 `distinct`           any distinct type
+`range`              any `range` type
+`Ordinal`            any ordinal type (including `distinct` ordinal types)
 `array`              any array type
 `set`                any set type
 `seq`                any seq type
+`openArray`          any type *matching* an `openArray`
+`varargs`            any type *matching* a `varargs`
+`UncheckedArray`     any `UncheckedArray` type
 `auto`               any type
 ==================   ===================================================
 

--- a/tests/lang_callable/macros/tmacrotypes.nim
+++ b/tests/lang_callable/macros/tmacrotypes.nim
@@ -34,7 +34,7 @@ listing fields for typeof(x)
 a: int
 b: float
 typeDesc[range[1 .. 5]]; ntyTypeDesc; typeDesc[range[1, 5]]; typeDesc[range[1 .. 5]]
-typeDesc[range]; ntyTypeDesc; typeDesc[range[T]]; typeDesc[range]'''
+typeDesc[builtinTypeClass[range]]; ntyTypeDesc; typeDesc[builtinTypeClass[range]]; typeDesc[builtinTypeClass[range]]'''
 """
 
 import macros, typetraits

--- a/tests/lang_types/sink/tsink_is_not_a_typeclass.nim
+++ b/tests/lang_types/sink/tsink_is_not_a_typeclass.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    Ensure that `sink` cannot be used as a type-class or constraint
+  '''
+  cmd: "nim check --filenames=canonical --hints:off $options $file"
+  action: reject
+"""
+
+var x: int
+discard x is sink #[tt.Error
+             ^ 'sink' cannot be used as a type class]#
+
+proc p[T: sink]() = #[tt.Error
+          ^ 'sink' cannot be used as a type class]#
+  discard

--- a/tests/lang_types/typeclass/tbuiltin_type_classes_aliases.nim
+++ b/tests/lang_types/typeclass/tbuiltin_type_classes_aliases.nim
@@ -1,0 +1,55 @@
+discard """
+  description: '''
+    It is possible to create aliases for type classes of built-in generic
+    types. Since they have a different name, they are lifted into separate
+    generic parameter.
+  '''
+"""
+
+type
+  Distinct1 = distinct int
+  Distinct2 = distinct int
+  Enum1 = enum a
+  Enum2 = enum b
+
+  TcDistinct = distinct
+  TcOrdinal = Ordinal
+  TcArray = array
+  TcSet = set
+  TcRange = range
+  TcPtr = ptr
+  TcRef = ref
+  TcSeq = seq
+  TcProc = proc
+  TcOpenArray = openArray
+  TcVarargs = varargs
+  TcUncheckedArray = UncheckedArray
+
+# note: no aliases of built-in tuple, enum, and object type-class can be created
+
+proc test(x: distinct, y: TcDistinct): int = 1
+proc test1(x: Ordinal, y: TcOrdinal): int = 2
+proc test(x: array, y: TcArray): int = 3
+proc test(x: set, y: TcSet): int = 4
+proc test(x: range, y: TcRange): int = 5
+proc test(x: ptr, y: TcPtr): int = 6
+proc test(x: ref, y: TcRef): int = 7
+proc test(x: seq, y: TcSeq): int = 8
+proc test(x: proc, y: TcProc): int = 9
+proc test(x: openArray, y: TcOpenArray): int = 10
+proc test1(x: varargs, y: TcVarargs): int = 11
+proc test(x: ptr UncheckedArray, y: ptr TcUncheckedArray): int = 12
+
+doAssert test(Distinct1(1), Distinct2(2)) == 1
+doAssert test1(1, a) == 2
+doAssert test([1], [""]) == 3
+doAssert test({1}, {' '}) == 4
+doAssert test(range[1..2](1), range[4..5](4)) == 5
+doAssert test((ptr int)(nil), (ptr float)(nil)) == 6
+doAssert test((ref int)(nil), (ref float)(nil)) == 7
+doAssert test(@[1], @[""]) == 8
+doAssert test((proc(): int)(nil), (proc(): float)(nil)) == 9
+doAssert test(toOpenArray([1], 0, 0), toOpenArray([""], 0, 0)) == 10
+doAssert test1(x=[1], y=[""]) == 11
+doAssert test((ptr UncheckedArray[int])(nil),
+              (ptr UncheckedArray[float])(nil)) == 12

--- a/tests/lang_types/typeclass/tbuiltin_type_classes_bind_once.nim
+++ b/tests/lang_types/typeclass/tbuiltin_type_classes_bind_once.nim
@@ -1,0 +1,55 @@
+discard """
+  description: '''
+    All built-in type classes are *named*, and they thus have bind-once
+    behaviour. ``typedesc`` is an exception.
+  '''
+  action: compile
+"""
+
+# the used syntax is a deliberate choice, as it highlights
+# that multiple uses of the type name still all use the same
+# lifted generic parameter
+
+type
+  Object1 = object
+  Object2 = object
+  Distinct1 = distinct int
+  Distinct2 = distinct int
+  Enum1 = enum a
+  Enum2 = enum b
+
+proc test(x: object, y: object) = discard
+proc test(x: distinct, y: distinct) = discard
+proc test(x: enum, y: enum) = discard
+proc test1(x: Ordinal, y: Ordinal) = discard
+proc test(x: array, y: array) = discard
+proc test(x: tuple, y: tuple) = discard
+proc test(x: set, y: set) = discard
+proc test(x: range, y: range) = discard
+proc test(x: ptr, y: ptr) = discard
+proc test(x: ref, y: ref) = discard
+proc test(x: seq, y: seq) = discard
+proc test(x: proc, y: proc) = discard
+proc test(x: openArray, y: openArray) = discard
+proc test1(x: varargs, y: varargs) = discard
+proc test(x: ptr UncheckedArray, y: ptr UncheckedArray) = discard
+
+template fail(x: untyped) =
+  doAssert not compiles(x)
+
+static:
+  fail test(Object1(), Object2())
+  fail test(Distinct1(1), Distinct2(2))
+  fail test(a, b)
+  fail test1(1, a)
+  fail test([1], [""])
+  fail test((1,), ("",))
+  fail test({1}, {' '})
+  fail test(range[1..2](1), range[4..5](4))
+  fail test((ptr int)(nil), (ptr float)(nil))
+  fail test((ref int)(nil), (ref float)(nil))
+  fail test(@[1], @[""])
+  fail test((proc(): int)(nil), (proc(): float)(nil))
+  fail test(toOpenArray([1], 0, 0), toOpenArray([""], 0, 0))
+  fail test1(x=[1], y=[""])
+  fail test((ptr UncheckedArray[int])(nil), (ptr UncheckedArray[float])(nil))

--- a/tests/lang_types/typeclass/tbuiltin_type_classes_constraints.nim
+++ b/tests/lang_types/typeclass/tbuiltin_type_classes_constraints.nim
@@ -1,0 +1,43 @@
+discard """
+  description: '''
+    Type classes of built-in generic types can be specified as constraints on
+    generic type parameters
+  '''
+"""
+
+type
+  Distinct1 = distinct int
+  Enum1 = enum a
+  Object1 = object
+
+proc test[T: object](x: T): int = 1
+proc test[T: distinct](x: T): int = 2
+proc test[T: enum](x: T): int = 3
+proc test1[T: Ordinal](x: T): int = 4
+proc test[T: array](x: T): int = 5
+proc test[T: tuple](x: T): int = 6
+proc test[T: set](x: T): int = 7
+proc test[T: range](x: T): int = 8
+proc test[T: ptr](x: T): int = 9
+proc test[T: ref](x: T): int = 10
+proc test[T: seq](x: T): int = 11
+proc test[T: proc](x: T): int = 12
+proc test[T: openArray](x: T): int = 13
+proc test1[T: varargs](x: T): int = 14
+proc test[T: UncheckedArray](x: ptr T): int = 15
+
+doAssert test(Object1()) == 1
+doAssert test(Distinct1(1)) == 2
+doAssert test(a) == 3
+doAssert test1(1) == 4
+doAssert test([1]) == 5
+doAssert test((1,)) == 6
+doAssert test({1}) == 7
+doAssert test(range[1..2](1)) == 8
+doAssert test((ptr int)(nil)) == 9
+doAssert test((ref int)(nil)) == 10
+doAssert test(@[1]) == 11
+doAssert test((proc (): int)(nil)) == 12
+doAssert test(toOpenArray([1], 0, 0)) == 13
+doAssert test1([1]) == 14
+doAssert test((ptr UncheckedArray[int])(nil)) == 15

--- a/tests/lang_types/typeclass/tbuiltin_type_classes_params.nim
+++ b/tests/lang_types/typeclass/tbuiltin_type_classes_params.nim
@@ -1,0 +1,45 @@
+discard """
+  description: '''
+    Type classes of built-in generic types can be used as the type of routine
+    parameters and return types
+  '''
+"""
+
+type
+  Distinct1 = distinct int
+  Enum1 = enum a
+  Object1 = object
+
+proc test(x: object): object = x
+proc test(x: distinct): distinct = x
+proc test(x: enum): enum = x
+proc test1(x: Ordinal): Ordinal = x
+proc test(x: array): array = x
+proc test(x: tuple): tuple = x
+proc test(x: set): set = x
+proc test(x: range): range = x
+proc test(x: ptr): ptr = x
+proc test(x: ref): ref = x
+proc test(x: seq): seq = x
+proc test(x: proc): proc = x
+proc test(x: ptr UncheckedArray): ptr UncheckedArray = x
+
+# openArray and varargs are not supported as return types
+proc test(x: openArray): int = 1
+proc test1(x: varargs): int = 2
+
+doAssert test(Object1()) == Object1()
+doAssert test(Distinct1(1)).int == 1
+doAssert test(a) == a
+doAssert test1(1) == 1
+doAssert test([1]) == [1]
+doAssert test((1,)) == (1,)
+doAssert test({1}) == {1}
+doAssert test(range[1..2](1)) == 1
+doAssert test((ptr int)(nil)) == nil
+doAssert test((ref int)(nil)) == nil
+doAssert test(@[1]) == @[1]
+doAssert test((proc (): int)(nil)) == nil
+doAssert test(toOpenArray([1], 0, 0)) == 1
+doAssert test1([1]) == 2
+doAssert test((ptr UncheckedArray[int])(nil)) == nil

--- a/tests/lang_types/typeclass/tbuiltin_type_classes_type_ast.nim
+++ b/tests/lang_types/typeclass/tbuiltin_type_classes_type_ast.nim
@@ -1,0 +1,35 @@
+discard """
+  description: '''
+    Ensure that `getType` and friends work for all type class of built-in
+    types.
+  '''
+  action: compile
+"""
+
+import std/macros
+
+macro test(x: typed) =
+  # try all ``getType`` procedures
+  discard getType(x)
+  discard getTypeImpl(x)
+  discard getTypeInst(x)
+
+var x: int
+
+#test(object)
+test(distinct)
+test(enum)
+test(Ordinal)
+test(array)
+test(tuple)
+test(set)
+test(range)
+test(ptr)
+test(ref)
+test(seq)
+test(proc)
+test(var)
+test(lent)
+test(openArray)
+test(varargs)
+test(UncheckedArray)

--- a/tests/lang_types/typeclass/ttypeclass_multi_use.nim
+++ b/tests/lang_types/typeclass/ttypeclass_multi_use.nim
@@ -37,19 +37,17 @@ proc test[A, B: proc](a: A, b: B): int = 12
 proc test1[A, B: openArray](a: A, b: B): int = 13
 proc test1[A, B: UncheckedArray](a: ptr A, b: ptr B): int = 14
 
-# XXX: not all built-in type classes work properly at the moment
-
 doAssert test(Distinct1(1), Distinct2(1)) == 1
 doAssert test(a, b) == 2
 doAssert test1(1, 'c') == 3
-doAssert not compiles(test(arr1, arr2))
+doAssert test(arr1, arr2) == 4
 doAssert test((1,), ("",)) == 5
 doAssert test(Object1(), Object2()) == 6
-doAssert not compiles(test({1}, {'2'}))
+doAssert test({1}, {'2'}) == 7
 doAssert test(range[0..1](0), range[3..4](3)) == 8
 doAssert test((ptr int)(nil), (ptr float)(nil)) == 9
 doAssert test((ref int)(nil), (ref float)(nil)) == 10
-doAssert not compiles(test(@[1], @[""])) # == 11
+doAssert test(@[1], @[""]) == 11
 doAssert test((proc(a: int))(nil), (proc(a: float))(nil)) == 12
-doAssert not compiles(test1(arr1, arr2)) # == 13
-doAssert not compiles(test1((ptr UncheckedArray[int])(nil), (ptr UncheckedArray[float])(nil)))
+doAssert test1(arr1, arr2) == 13
+doAssert test1((ptr UncheckedArray[int])(nil), (ptr UncheckedArray[float])(nil)) == 14

--- a/tests/types/tisopr.nim
+++ b/tests/types/tisopr.nim
@@ -1,7 +1,7 @@
 discard """
   output: '''true true false yes
 false
-true
+false
 false
 true
 true
@@ -70,6 +70,7 @@ type SeqOrSetOfInt = SeqOrSet[int]
 
 # This prints "true", as expected. Previously "false" was returned and that
 # seemed less correct that (1) printing "true" or (2) raising a compiler error.
+# It now prints "false" again.
 echo seq is SeqOrSet
 
 # This prints "false", as expected.


### PR DESCRIPTION
## Summary

* the `array`, `set`, `seq`, `openArray`, `varargs`, and
  `UncheckedArray` constraints can now be used on multiple generic
  parameters without restricting the parameters to all be bound the
  same type
* type-classes of the `array`, `set`, `range`, `Ordinal`, `openArray`,
  `varargs`, and `UncheckedArray` built-in types can now be used as
  return types and as routine parameter types (making the routine
  implicitly generic)
* all type-classes for built-in generic types (except `typedesc`) are
  now bind-once. The manual already stated that they were, but reality
  didn't reflect that
* `lent`, `range`, `Ordinal`, `openArray`, `varargs`, and
  `UncheckedArray` are promoted to proper type classes -- it was
  already possible to use them as such, but this wasn't documented
* errors when using built-in type-classes in the body of non-generic
  tuples and objects are reported earlier
* it is now possible to create aliases of all built-in type-classes
  except `typedesc`, `object`, `enum`, `tuple`
* `getType`, `getTypeImpl`, and `getTypeInst` now work for all
  `tyBuiltInTypeClass` types. The compiler would previously crash for
  some of them

Breaking changes:
* `sink` cannot be used as a constraint or type-class anymore
* consistent with `ptr`, `ref`, and so on, the `array`, `set`, `seq`,
  `openArray`, `varargs`, `lent`, `UncheckedArray` type classes no
  longer match against anything else besides the type class. For
  example, `seq is seq[auto]` now returns false

The goal is to make their behaviour and implementation more consistent
in order for them to more amendable to changes in the future.

## Details

### Previous implementation

* using a built-in generic type defined in the `system` module resulted
  in a type like, for example, `array[I, T]`
  (`(Array (GenericParam I) (GenericParam T))`)
* when these types were used a routine parameter type on an otherwise
  non-generic routine, they were rejected by `typeAllowed` (due to the
  generic parameter)
* these types weren't designated as being meta-types, so meta-type
  detection using `isMetaType` missed them
* when used as generic parameter constraints, their type representation
  allowed most of them to work without special handling (but this
  caused issues when the type was used as a constraint multiple times,
  as binding of generic parameters is enabled when matching against
  constraints)
* a `tyNone` marker type was added to the base instances of `tyRange`
  and `tyOrdinal`, which allowed `typeRel` to detect these instances
  and special case them
* the `seq` type was special cased in `liftParamType` and a
  `tyBuiltInTypeClass` lifted from it

### Reworked implementation

* all built-in generic types that have no parameters specified are
  treated as a type class (`tyBuiltInTypeClass`)
* lifting the `tyBuiltInTypeClass` happens immediately after analysing
  a stand-alone type identifier/symbol (in `semTypeNode`)
* `semTypeNode` performs the lifting via the new `liftTypeClass`
* `liftTypeClass` takes a type as input and, if required it's a raw
  magic generic type, produces a `tyBuiltInTypeClass`. The generic
  magic type is stored as the first children 
* for the bind-once behaviour to work, the type needs an identifier in
  `liftParamType`. For `tyBuiltInTypeClass`es of `system`-defined
  types, the identifier is taken from magic type's symbol, while for
  the other kinds an identifier is looked up using the `TSpecialWord`
  corresponding to the type
* this way of implementing the lifting prevents the creation of extra
  symbols

So that types other than `Ordinal`, `openArray`, and `varargs` continue
to match against the respective type classes, the `typeRel` logic for
`tyBuiltInTypeClass` matches the actual type against the raw generic
type stored in the type-class type (but with all type binding
disabled).

`sigmatch` is adjusted accordingly:
* the special handling of `range` type-classes is moved to the
  `tyBuiltInTypeClass` branch
* `tyNone` detection for `tyOrdinal` is removed (it's obsolete now)

There were also two problems with structure of `tyBuiltInTypeClass` not
being accounted for properly, but they remained mostly hidden due to
the seldom use of the type:
* `hashType` was missing dedicated handling, which would lead to the
  compiler crashing when attempting to hash certain
  `tyBuiltInTypeClass`
* `mapTypeToAst` was also missing special missing handling

Multiple clean-ups and improvements are applied:
* adding `tyNone` markers to the `tyRange` and `tyOrdinal` base
  instances is obsolete and thus removed
* standalone `sink` usage is now rejected by `liftTypeClass`. Since
  `sink` is a special type modifier only allowed for routine
  parameters, it makes no sense to allow it as a constraint or type-
  class. A corresponding `SemReport` kind for the new error is added 
* the workaround for in `fitNodePostMatch` is cleaned up
* the user-facing rendering of `tyBuiltInTypeClass` types is improved