### PR TITLE
Semfold type expressions into nkType nodes

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -106,6 +106,27 @@ const
 
   nkSymChoices* = {nkClosedSymChoice, nkOpenSymChoice}
 
+  nkTypeExprs* = {
+    nkTypeOfExpr,
+    nkObjectTy,
+    nkTupleTy,
+    nkTupleClassTy,
+    nkTypeClassTy,
+    nkStaticTy,
+    nkRefTy,
+    nkPtrTy,
+    nkVarTy,
+    nkConstTy,
+    nkMutableTy,
+    nkDistinctTy,
+    nkProcTy,
+    nkIteratorTy,
+    nkSharedTy,
+    nkEnumTy,
+    nkStmtListType,
+    nkBlockType
+  }
+
   # TODO: replace with `nk*Literals`, see above
   nkIntKinds*   = nkIntLiterals
   nkFloatKinds* = nkFloatLiterals

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -53,7 +53,7 @@ type
     hasError: bool
 
 const
-  ExpressionNodes = nkCallKinds + nkLiterals + {
+  ExpressionNodes = nkCallKinds + nkLiterals + nkTypeExprs + {
     nkSym, nkEmpty, nkNimNodeLit, nkNilLit,
 
     nkRange, nkBracket, nkCurly, nkObjConstr, nkTupleConstr,
@@ -62,7 +62,6 @@ const
     nkAddr, nkHiddenAddr,
 
     nkCast, nkConv, nkHiddenStdConv, nkHiddenSubConv,
-    nkTypeOfExpr,
 
     nkIfExpr, nkBlockExpr, nkStmtListExpr, nkError}
     ## apart from the call node kinds, nodes that appear exclusively in
@@ -860,15 +859,14 @@ proc foldConstExprAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Fo
     return
   of nkSym:
     discard "may be folded away"
-  of nkTypeOfExpr:
-    # XXX: could be folded into an ``nkType`` here...
-    discard
+  of nkTypeExprs - {nkStmtListType, nkBlockType}:
+    result.node = newNodeIT(nkType, n.info, n.typ)
   of nkBracket, nkCurly, nkTupleConstr, nkRange, nkAddr, nkHiddenAddr,
      nkHiddenDeref, nkDerefExpr, nkBracketExpr, nkCallKinds, nkIfExpr,
      nkElifExpr, nkElseExpr, nkElse, nkElifBranch:
     for it in n.items:
       result.add foldConstExprAux(m, it, idgen, g)
-  of nkCast, nkConv, nkHiddenStdConv, nkHiddenSubConv, nkBlockExpr:
+  of nkCast, nkConv, nkHiddenStdConv, nkHiddenSubConv, nkBlockExpr, nkBlockType:
     # the first slot only holds the type/label, which we don't need to traverse
     # into / fold
     result.add n[0]
@@ -892,7 +890,7 @@ proc foldConstExprAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Fo
     result.add n[0] # skip the type slot
     for i in 1..<n.len:
       result.add foldConstExprAux(m, n[i], idgen, g)
-  of nkStmtListExpr:
+  of nkStmtListExpr, nkStmtListType:
     for i in 0..<n.len-1:
       result.add foldInAstAux(m, n[i], idgen, g)
     # the last node is an expression


### PR DESCRIPTION
## Summary
* Fold type expressions into  `nkType`  nodes in  `semfold`  so that the
later stages don't have to deal with the unwieldy type AST

## Details
* This fixes a debug/release compiler crashing on 
`tests/vm/taccess_checks.nim`