### PR TITLE
Replace deprecated slurp alias usage with staticRead

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2576,8 +2576,8 @@ const
   CommitMessage = "Source hash: $1\n" &
     "Source date: $2\n"
 
-  Usage = slurp"../doc/basicopt.txt".replace(" //", "   ")
-  AdvancedUsage = slurp"../doc/advopt.txt".replace(" //", "   ") %
+  Usage = staticRead"../doc/basicopt.txt".replace(" //", "   ")
+  AdvancedUsage = staticRead"../doc/advopt.txt".replace(" //", "   ") %
     genFeatureDesc(Feature)
 
 

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -371,8 +371,8 @@ const
   ]
   CommitMessageTemplate = "Source hash: $1\n" &
                   "Source date: $2\n"
-  Usage = slurp"../doc/basicopt.txt".replace(" //", "   ")
-  AdvancedUsage = slurp"../doc/advopt.txt".replace(" //", "   ") %
+  Usage = staticRead"../doc/basicopt.txt".replace(" //", "   ")
+  AdvancedUsage = staticRead"../doc/advopt.txt".replace(" //", "   ") %
     typeof(Feature).toSeq.mapIt($it).join("|") # '|' separated features
 
 proc showMsg*(conf: ConfigRef, msg: string) =


### PR DESCRIPTION
## Summary
* Replace  `slurp`  calls with  `staticRead` , since the  `slurp`  alias
for  `staticRead`  has been deprecated in
https://github.com/nim-works/nimskull/pull/947 /
https://github.com/nim-works/nimskull/commit/9087a6221f9aa5e0e6d2d7f56138090e208dea57