### PR TITLE
Fix invalid spec in test

### DIFF
--- a/tests/lang_defs/enum/tstored_as_unsigned.nim
+++ b/tests/lang_defs/enum/tstored_as_unsigned.nim
@@ -1,9 +1,9 @@
 discard """
   targets: "c js vm"
-  description: "
+  description: '''
     Ensure that enum values stored as usigned integers are properly read as
     such
-  "
+  '''
 """
 
 type


### PR DESCRIPTION
## Summary
* Fix invalid spec (multiline description with only single  `"`  quotes)
in  `tests/lang_defs/enum/tstored_as_unsigned.nim` 
* This was not caught by CI because the test was joined into the
megatest