### PR TITLE
Remove float128

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -663,7 +663,6 @@ func toTNodeKind*(kind: ParsedNodeKind): TNodeKind {.inline.} =
   of pnkFloatLit: nkFloatLit
   of pnkFloat32Lit: nkFloat32Lit
   of pnkFloat64Lit: nkFloat64Lit
-  of pnkFloat128Lit: nkFloat128Lit
   of pnkStrLit: nkStrLit
   of pnkRStrLit: nkRStrLit
   of pnkTripleStrLit: nkTripleStrLit

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -102,7 +102,6 @@ type
     pnkFloatLit
     pnkFloat32Lit
     pnkFloat64Lit
-    pnkFloat128Lit
     pnkStrLit
     pnkRStrLit
     pnkTripleStrLit
@@ -241,7 +240,7 @@ type
       of pnkIdent:
         startToken*: ParsedToken
       of pnkCharLit..pnkUInt64Lit,
-          pnkFloatLit..pnkFloat128Lit,
+          pnkFloatLit..pnkFloat64Lit,
           pnkStrLit..pnkTripleStrLit,
           pnkNilLit,
           pnkCustomLit:
@@ -262,7 +261,7 @@ const
   pnkParsedKindsWithSons* = {pnkCall..pnkUsingStmt}
   pnkCallKinds* = {pnkCall, pnkInfix, pnkPrefix, pnkPostfix,
                   pnkCommand, pnkCallStrLit}
-  pnkFloatKinds* = {pnkFloatLit..pnkFloat128Lit}
+  pnkFloatKinds* = {pnkFloatLit..pnkFloat64Lit}
   pnkIntKinds* = {pnkCharLit..pnkUInt64Lit}
   pnkStrKinds* = {pnkStrLit..pnkTripleStrLit}
   pnkDeclarativeDefs* = {pnkProcDef, pnkFuncDef, pnkMethodDef, pnkIteratorDef, pnkConverterDef}
@@ -341,7 +340,7 @@ proc getToken*(n: ParsedNode): ParsedToken =
   of pnkIdent:
     n.startToken
   of pnkCharLit..pnkUInt64Lit,
-      pnkFloatLit..pnkFloat128Lit,
+      pnkFloatLit..pnkFloat64Lit,
       pnkStrLit..pnkTripleStrLit,
       pnkNilLit,
       pnkCustomLit:
@@ -375,7 +374,7 @@ func info*(p: ParsedNode): TLineInfo {.inline.} =
               line: p.startToken.line,
               col: p.startToken.col)
   of pnkCharLit..pnkUInt64Lit,
-      pnkFloatLit..pnkFloat128Lit,
+      pnkFloatLit..pnkFloat64Lit,
       pnkStrLit..pnkTripleStrLit,
       pnkNilLit,
       pnkCustomLit:

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -48,11 +48,11 @@ const
     tyBool, tyChar, tyEnum, tyArray, tyObject,
     tySet, tyTuple, tyRange, tyPtr, tyRef, tyVar, tyLent, tySequence, tyProc,
     tyPointer,
-    tyOpenArray, tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat128,
+    tyOpenArray, tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat64,
     tyUInt..tyUInt64}
   
   IntegralTypes* = {tyBool, tyChar, tyEnum, tyInt..tyInt64,
-    tyFloat..tyFloat128, tyUInt..tyUInt64} # weird name because it contains tyFloat
+    tyFloat..tyFloat64, tyUInt..tyUInt64} # weird name because it contains tyFloat
   
   ConstantDataTypes*: TTypeKinds = {tyArray, tySet,
                                     tyTuple, tySequence}
@@ -90,7 +90,7 @@ const
   nkPragmaCallKinds* = {nkExprColonExpr, nkCall, nkCallStrLit}
 
   nkIntLiterals*   = {nkCharLit..nkUInt64Lit}
-  nkFloatLiterals* = {nkFloatLit..nkFloat128Lit}
+  nkFloatLiterals* = {nkFloatLit..nkFloat64Lit}
   nkStrLiterals*   = {nkStrLit..nkTripleStrLit}
   # TODO: include `nkNilLit` as it's a literal, not the same as `nnkLiterals`
   nkLiterals*      = nkIntLiterals + nkFloatLiterals + nkStrLiterals

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -75,7 +75,6 @@ type
     nkFloatLit            ## a floating point literal
     nkFloat32Lit
     nkFloat64Lit
-    nkFloat128Lit
     nkStrLit              ## a string literal ""
     nkRStrLit             ## a raw string literal r""
     nkTripleStrLit        ## a triple string literal """
@@ -253,7 +252,7 @@ const
     {nkIdent, nkSym} +
     {nkType} +
     {nkCharLit..nkUInt64Lit} +
-    {nkFloatLit..nkFloat128Lit} +
+    {nkFloatLit..nkFloat64Lit} +
     {nkStrLit..nkTripleStrLit} +
     {nkNilLit} +
     {nkError} +
@@ -268,7 +267,7 @@ const
     nkCharLit,
     nkIntLit, nkInt8Lit, nkInt16Lit, nkInt32Lit, nkInt64Lit,
     nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit,
-    nkFloatLit, nkFloat32Lit, nkFloat64Lit, nkFloat128Lit,
+    nkFloatLit, nkFloat32Lit, nkFloat64Lit, nkFloat64Lit,
     nkStrLit, nkRStrLit, nkTripleStrLit,
     nkNilLit,
 
@@ -492,7 +491,7 @@ type
     tyPointer, tyOpenArray,
     tyString, tyCstring, tyForward,
     tyInt, tyInt8, tyInt16, tyInt32, tyInt64, # signed integers
-    tyFloat, tyFloat32, tyFloat64, tyFloat128,
+    tyFloat, tyFloat32, tyFloat64,
     tyUInt, tyUInt8, tyUInt16, tyUInt32, tyUInt64,
     tySink, tyLent,
     tyVarargs,
@@ -785,7 +784,7 @@ type
     mOrdinal,
     mInt, mInt8, mInt16, mInt32, mInt64,
     mUInt, mUInt8, mUInt16, mUInt32, mUInt64,
-    mFloat, mFloat32, mFloat64, mFloat128,
+    mFloat, mFloat32, mFloat64,
     mBool, mChar, mString, mCstring,
     mPointer, mNil, mExpr, mStmt, mTypeDesc,
     mVoidType, mPNimrodNode, mDeepCopy,
@@ -1540,7 +1539,7 @@ type
     of nkCharLit..nkUInt64Lit:
       intVal*: BiggestInt
       intLitBase*: NumericalBase
-    of nkFloatLit..nkFloat128Lit:
+    of nkFloatLit..nkFloat64Lit:
       floatVal*: BiggestFloat
       floatLitBase*: NumericalBase
         # Once case branches can share fields this can be unified with

--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -77,7 +77,7 @@ type
     tkUIntLit = "tkUIntLit", tkUInt8Lit = "tkUInt8Lit", tkUInt16Lit = "tkUInt16Lit",
     tkUInt32Lit = "tkUInt32Lit", tkUInt64Lit = "tkUInt64Lit",
     tkFloatLit = "tkFloatLit", tkFloat32Lit = "tkFloat32Lit",
-    tkFloat64Lit = "tkFloat64Lit", tkFloat128Lit = "tkFloat128Lit",
+    tkFloat64Lit = "tkFloat64Lit",
     tkStrLit = "tkStrLit", tkRStrLit = "tkRStrLit", tkTripleStrLit = "tkTripleStrLit",
     tkGStrLit = "tkGStrLit", tkGTripleStrLit = "tkGTripleStrLit", tkCharLit = "tkCharLit",
     tkCustomLit = "tkCustomLit",
@@ -516,7 +516,7 @@ proc getNumber(L: var Lexer, result: var Token) =
   const
     baseCodeChars = {'X', 'x', 'o', 'b', 'B'}
     literalishChars = baseCodeChars + {'A'..'F', 'a'..'f', '0'..'9', '_', '\''}
-    floatTypes = {tkFloatLit, tkFloat32Lit, tkFloat64Lit, tkFloat128Lit}
+    floatTypes = {tkFloatLit, tkFloat32Lit, tkFloat64Lit}
   result.tokType = tkIntLit   # int literal until we know better
   result.literal = ""
   result.base = base10
@@ -586,7 +586,6 @@ proc getNumber(L: var Lexer, result: var Token) =
       case suffixAsLower
       of "f", "f32": result.tokType = tkFloat32Lit
       of "d", "f64": result.tokType = tkFloat64Lit
-      of "f128": result.tokType = tkFloat128Lit
       of "i8": result.tokType = tkInt8Lit
       of "i16": result.tokType = tkInt16Lit
       of "i32": result.tokType = tkInt32Lit

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -764,7 +764,6 @@ proc identOrLiteral(p: var Parser, mode: PrimaryMode): ParsedNode =
   of tkFloatLit:     result = p.newLitNode(pnkFloatLit,     p.tok); p.getTok
   of tkFloat32Lit:   result = p.newLitNode(pnkFloat32Lit,   p.tok); p.getTok
   of tkFloat64Lit:   result = p.newLitNode(pnkFloat64Lit,   p.tok); p.getTok
-  of tkFloat128Lit:  result = p.newLitNode(pnkFloat128Lit,  p.tok); p.getTok
   of tkStrLit:       result = p.newLitNode(pnkStrLit,       p.tok); p.getTok
   of tkRStrLit:      result = p.newLitNode(pnkRStrLit,      p.tok); p.getTok
   of tkTripleStrLit: result = p.newLitNode(pnkTripleStrLit, p.tok); p.getTok

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -986,7 +986,6 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
   of nkFloatLit: put(g, tkFloatLit, atom(g, n))
   of nkFloat32Lit: put(g, tkFloat32Lit, atom(g, n))
   of nkFloat64Lit: put(g, tkFloat64Lit, atom(g, n))
-  of nkFloat128Lit: put(g, tkFloat128Lit, atom(g, n))
   of nkStrLit: put(g, tkStrLit, atom(g, n))
   of nkRStrLit: put(g, tkRStrLit, atom(g, n))
   of nkCharLit: put(g, tkCharLit, atom(g, n))

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -552,7 +552,7 @@ proc lengthOrd*(conf: ConfigRef; t: PType): Int128 =
 
 proc firstFloat*(t: PType): BiggestFloat =
   case t.kind
-  of tyFloat..tyFloat128: -Inf
+  of tyFloat..tyFloat64: -Inf
   of tyRange:
     assert(t.n != nil)        # range directly given:
     assert(t.n.kind == nkRange)
@@ -566,7 +566,7 @@ proc firstFloat*(t: PType): BiggestFloat =
 
 proc lastFloat*(t: PType): BiggestFloat =
   case t.kind
-  of tyFloat..tyFloat128: Inf
+  of tyFloat..tyFloat64: Inf
   of tyVar: lastFloat(t[0])
   of tyRange:
     assert(t.n != nil)        # range directly given:
@@ -582,7 +582,7 @@ proc floatRangeCheck*(x: BiggestFloat, t: PType): bool =
   case t.kind
   # This needs to be special cased since NaN is never
   # part of firstFloat(t)..lastFloat(t)
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     true
   of tyRange:
     x in firstFloat(t)..lastFloat(t)
@@ -1138,7 +1138,7 @@ proc classify*(t: PType): OrdinalType =
     result = NoneLike
   else:
     case skipTypes(t, abstractVarRange).kind
-    of tyFloat..tyFloat128: result = FloatLike
+    of tyFloat..tyFloat64: result = FloatLike
     of tyInt..tyInt64, tyUInt..tyUInt64, tyBool, tyChar, tyEnum:
       result = IntLike
     else: result = NoneLike

--- a/compiler/ast/typesrenderer.nim
+++ b/compiler/ast/typesrenderer.nim
@@ -145,7 +145,7 @@ proc valueToString(a: PNode): string =
   ## Returns `int`, `float`, or `string` literals from the node, otherwise returns `<invalid value>`.
   case a.kind
   of nkCharLit..nkUInt64Lit: result = $a.intVal
-  of nkFloatLit..nkFloat128Lit: result = $a.floatVal
+  of nkFloatLit..nkFloat64Lit: result = $a.floatVal
   of nkStrLit..nkTripleStrLit: result = a.strVal
   else: result = "<invalid value>"
 
@@ -165,7 +165,7 @@ const
     "set[$1]", "range[$1]", "ptr ", "ref ", "var ", "seq[$1]", "proc",
     "pointer", "OpenArray[$1]", "string", "cstring", "Forward",
     "int", "int8", "int16", "int32", "int64",
-    "float", "float32", "float64", "float128",
+    "float", "float32", "float64",
     "uint", "uint8", "uint16", "uint32", "uint64",
     "sink",
     "lent ", "varargs[$1]", "UncheckedArray[$1]", "Error Type",
@@ -200,7 +200,7 @@ proc typeToString*(typ: PType, prefer: TPreferedDesc = preferName): string =
         result = typeToString(t[0])
       elif prefer in {preferResolved, preferMixed}:
         case t.kind
-        of IntegralTypes + {tyFloat..tyFloat128} + {tyString, tyCstring}:
+        of IntegralTypes + {tyFloat..tyFloat64} + {tyString, tyCstring}:
           result = typeToStr[t.kind]
         of tyGenericBody:
           result = typeToString(t.lastSon)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -164,7 +164,7 @@ proc genAssignment(p: BProc, dest, src: TLoc) =
   # the assignment operation in C.
   case mapType(p.config, dest.t, skVar)
   of ctChar, ctBool, ctInt, ctInt8, ctInt16, ctInt32, ctInt64,
-     ctFloat, ctFloat32, ctFloat64, ctFloat128,
+     ctFloat, ctFloat32, ctFloat64,
      ctUInt, ctUInt8, ctUInt16, ctUInt32, ctUInt64,
      ctStruct, ctPtrToArray, ctPtr, ctNimStr, ctNimSeq, ctProc,
      ctCString:
@@ -1562,7 +1562,7 @@ proc genSomeCast(p: BProc, e: CgNode, d: var TLoc) =
           [getTypeDesc(p.module, e.typ), rdCharLoc(a)], a.storage)
 
 proc genCast(p: BProc, e: CgNode, d: var TLoc) =
-  const ValueTypes = {tyFloat..tyFloat128, tyTuple, tyObject, tyArray}
+  const ValueTypes = {tyFloat..tyFloat64, tyTuple, tyObject, tyArray}
   let
     src = e.operand
     destt = skipTypes(e.typ, abstractRange)
@@ -1602,7 +1602,7 @@ proc genRangeChck(p: BProc, n: CgNode, d: var TLoc) =
       let raiser =
         case skipTypes(n.typ, abstractVarRange).kind
         of tyUInt..tyUInt64, tyChar: "raiseRangeErrorU"
-        of tyFloat..tyFloat128: "raiseRangeErrorF"
+        of tyFloat..tyFloat64: "raiseRangeErrorF"
         else: "raiseRangeErrorI"
       discard cgsym(p.module, raiser)
 
@@ -2210,7 +2210,7 @@ proc getDefaultValue(p: BProc; typ: PType; info: TLineInfo): Rope =
   case t.kind
   of tyBool: result = rope"NIM_FALSE"
   of tyEnum, tyChar, tyInt..tyInt64, tyUInt..tyUInt64: result = rope"0"
-  of tyFloat..tyFloat128: result = rope"0.0"
+  of tyFloat..tyFloat64: result = rope"0.0"
   of tyCstring, tyVar, tyLent, tyPointer, tyPtr, tyUntyped,
      tyTyped, tyTypeDesc, tyStatic, tyRef, tyNil:
     result = rope"NIM_NIL"

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -571,7 +571,7 @@ proc genCase(p: BProc, t: CgNode) =
   case skipTypes(t[0].typ, abstractVarRange).kind
   of tyString:
     genStringCase(p, t)
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     genCaseGeneric(p, t, "if ($1 >= $2 && $1 <= $3) goto $4;$n",
                          "if ($1 == $2) goto $3;$n")
   else:

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -220,7 +220,7 @@ proc getSimpleTypeDesc(m: BModule, typ: PType): Rope =
   const
     NumericalTypeToStr: array[tyInt..tyUInt64, string] = [
       "NI", "NI8", "NI16", "NI32", "NI64",
-      "NF", "NF32", "NF64", "NF128",
+      "NF", "NF32", "NF64",
       "NU", "NU8", "NU16", "NU32", "NU64"]
   case typ.kind
   of tyPointer:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -439,7 +439,7 @@ proc constructLoc(p: BProc, loc: var TLoc; doInitObj = true) =
   let kind = mapTypeChooser(loc)
   case mapType(p.config, loc.t, kind)
   of ctChar, ctBool, ctInt, ctInt8, ctInt16, ctInt32, ctInt64,
-     ctFloat, ctFloat32, ctFloat64, ctFloat128,
+     ctFloat, ctFloat32, ctFloat64,
      ctUInt, ctUInt8, ctUInt16, ctUInt32, ctUInt64:
     # numeric type
     linefmt(p, cpsStmts, "$1 = 0;$n", [rdLoc(loc)])
@@ -776,7 +776,7 @@ proc allPathsAsgnResult(n: CgNode): InitResultEnum =
     if containsResult(n[0]): return InitRequired
     result = InitSkippable
     var exhaustive = skipTypes(n[0].typ,
-        abstractVarRange-{tyTypeDesc}).kind notin {tyFloat..tyFloat128, tyString}
+        abstractVarRange-{tyTypeDesc}).kind notin {tyFloat..tyFloat64, tyString}
     for i in 1..<n.len:
       let it = n[i]
       allPathsInBranch(it.lastSon)

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -124,7 +124,7 @@ type
   TCTypeKind* = enum          ## describes the type kind of a C type
     ctVoid, ctChar, ctBool,
     ctInt, ctInt8, ctInt16, ctInt32, ctInt64,
-    ctFloat, ctFloat32, ctFloat64, ctFloat128,
+    ctFloat, ctFloat32, ctFloat64,
     ctUInt, ctUInt8, ctUInt16, ctUInt32, ctUInt64,
     ctArray, ctPtrToArray, ctStruct, ctPtr, ctNimStr, ctNimSeq, ctProc,
     ctNimOpenArray,

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -285,7 +285,7 @@ proc translateLit*(val: PNode): CgNode =
       unreachable(val.typ.skipTypes(abstractRange).kind)
   of nkFloatLiterals:
     case val.typ.skipTypes(abstractRange).kind
-    of tyFloat, tyFloat64, tyFloat128:
+    of tyFloat, tyFloat64:
       node(cnkFloatLit, floatVal, val.floatVal)
     of tyFloat32:
       # all code-generators need to do this at one point, so we help them out

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -229,7 +229,7 @@ proc mapType(typ: PType; indirect = false): TJSTypeKind =
     result = mapType(t[0], indirect)
   of tyInt..tyInt64, tyUInt..tyUInt64, tyChar: result = etyInt
   of tyBool: result = etyBool
-  of tyFloat..tyFloat128: result = etyFloat
+  of tyFloat..tyFloat64: result = etyFloat
   of tySet: result = etyObject # map a set to a table
   of tyString, tySequence: result = etySeq
   of tyObject, tyArray, tyTuple, tyOpenArray, tyVarargs, tyUncheckedArray:
@@ -1548,7 +1548,7 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
       result = putToSeq("0n", indirect)
     else:
       result = putToSeq("0", indirect)
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     result = putToSeq("0.0", indirect)
   of tyRange, tyGenericInst, tyAlias, tySink, tyLent:
     result = createVar(p, lastSon(typ), indirect)
@@ -1809,7 +1809,7 @@ proc genRepr(p: PProc, n: CgNode, r: var TCompRes) =
     genReprAux(p, n, r, "reprChar")
   of tyBool:
     genReprAux(p, n, r, "reprBool")
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     genReprAux(p, n, r, "reprFloat")
   of tyString:
     genReprAux(p, n, r, "reprStr")

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -73,3 +73,4 @@ proc initDefines*(symbols: StringTableRef) =
 
   defineSymbol("nimskullReworkStaticExec")
   defineSymbol("nimskullNoMagicNewAssign")
+  defineSymbol("nimskullNoFloat128")

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -118,7 +118,7 @@ proc sexp*(node: PNode): SexpNode =
   case node.kind
   of nkNone, nkEmpty, nkType, nkCommentStmt: discard
   of nkCharLit..nkUInt64Lit:    result.add sexp(node.intVal)
-  of nkFloatLit..nkFloat128Lit: result.add sexp(node.floatVal)
+  of nkFloatLit..nkFloat64Lit:  result.add sexp(node.floatVal)
   of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)
   of nkSym:                     result.add newSSymbol(node.sym.name.s)
   of nkIdent:                   result.add newSSymbol(node.ident.s)

--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -187,7 +187,7 @@ proc rangeCheckAnalysis(c: var AliveContext; g: PackedModuleGraph; tree: PackedT
       let raiser =
         case loadTypeKind(n.typ, c, g, abstractVarRange)
         of tyUInt..tyUInt64, tyChar: "raiseRangeErrorU"
-        of tyFloat..tyFloat128: "raiseRangeErrorF"
+        of tyFloat..tyFloat64: "raiseRangeErrorF"
         else: "raiseRangeErrorI"
       c.requestCompilerProc(g, raiser)
 

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -118,7 +118,7 @@ proc toString*(tree: PackedTree; n: NodePos; m: PackedModule; nesting: int;
   of externUIntLit:
     result.add " "
     result.addInt cast[uint64](m.numbers[LitId tree.nodes[pos].operand])
-  of nkFloatLit..nkFloat128Lit:
+  of nkFloatLit..nkFloat64Lit:
     result.add " "
     result.addFloat cast[BiggestFloat](m.numbers[LitId tree.nodes[pos].operand])
   else:
@@ -475,7 +475,7 @@ proc toPackedNode*(n: PNode; ir: var PackedTree; c: var PackedEncoder; m: var Pa
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags,
                             operand: int32 getOrIncl(m.strings, n.strVal),
                             typeId: storeTypeLater(n.typ, c, m), info: info)
-  of nkFloatLit..nkFloat128Lit:
+  of nkFloatLit..nkFloat64Lit:
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags,
                             operand: int32 getOrIncl(m.numbers, cast[BiggestInt](n.floatVal)),
                             typeId: storeTypeLater(n.typ, c, m), info: info)
@@ -788,7 +788,7 @@ proc loadNodes*(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;
     result.intVal = g[thisModule].fromDisk.numbers[n.litId]
   of nkStrLit..nkTripleStrLit:
     result.strVal = g[thisModule].fromDisk.strings[n.litId]
-  of nkFloatLit..nkFloat128Lit:
+  of nkFloatLit..nkFloat64Lit:
     result.floatVal = cast[BiggestFloat](g[thisModule].fromDisk.numbers[n.litId])
   of nkModuleRef:
     let (n1, n2) = sons2(tree, n)

--- a/compiler/ic/integrity.nim
+++ b/compiler/ic/integrity.nim
@@ -79,7 +79,7 @@ proc checkNode(c: var CheckedContext; tree: PackedTree; n: NodePos) =
     checkLocalSym(c, tree.nodes[n.int].operand)
   of directIntLit:
     discard
-  of externIntLit, nkFloatLit..nkFloat128Lit:
+  of externIntLit, nkFloatLit..nkFloat64Lit:
     assert c.g.packed[c.thisModule].fromDisk.numbers.hasLitId n.litId
   of nkStrLit..nkTripleStrLit:
     assert c.g.packed[c.thisModule].fromDisk.strings.hasLitId n.litId

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -89,7 +89,6 @@ proc getSysType*(g: ModuleGraph; info: TLineInfo; kind: TTypeKind): PType =
     of tyFloat: result = sysTypeFromName("float")
     of tyFloat32: result = sysTypeFromName("float32")
     of tyFloat64: result = sysTypeFromName("float64")
-    of tyFloat128: result = sysTypeFromName("float128")
     of tyBool: result = sysTypeFromName("bool")
     of tyChar: result = sysTypeFromName("char")
     of tyString: result = sysTypeFromName("string")

--- a/compiler/sem/dfa.nim
+++ b/compiler/sem/dfa.nim
@@ -477,7 +477,7 @@ proc genCase(c: var Con; n: PNode) =
   #    elsePart
   #  Lend:
   let isExhaustive = skipTypes(n[0].typ,
-    abstractVarRange-{tyTypeDesc}).kind notin {tyFloat..tyFloat128, tyString}
+    abstractVarRange-{tyTypeDesc}).kind notin {tyFloat..tyFloat64, tyString}
 
   # we generate endings as a set of chained gotos, this is a bit awkward but it
   # ensures when recursively traversing the CFG for various analysis, we don't

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1587,7 +1587,7 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
     markUsed(c, n.info, s)
     let typ = skipTypes(s.typ, abstractInst-{tyTypeDesc})
     case typ.kind
-    of  tyNil, tyChar, tyInt..tyInt64, tyFloat..tyFloat128,
+    of  tyNil, tyChar, tyInt..tyInt64, tyFloat..tyFloat64,
         tyTuple, tySet, tyUInt..tyUInt64:
       if s.magic == mNone: result = inlineConst(c, n, s)
       else: result = newSymNode(s, n.info)
@@ -3592,8 +3592,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     # handle `nkFloatLit` here to keep raw information of the float literal;
     # not sure why though, also why not do that for int?
     if result.typ == nil: result.typ = getSysType(c.graph, n.info, tyFloat64)
-  of nkFloat128Lit:
-    if result.typ == nil: result.typ = getSysType(c.graph, n.info, tyFloat128)
   of nkStrLit..nkTripleStrLit:
     if result.typ == nil: result.typ = getSysType(c.graph, n.info, tyString)
   of nkCharLit:

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -200,7 +200,7 @@ proc ordinalValToString(a: PNode; g: ModuleGraph): string =
     unreachable("non-ordinals never make it here")
 
 proc isFloatRange(t: PType): bool {.inline.} =
-  result = t.kind == tyRange and t[0].kind in {tyFloat..tyFloat128}
+  result = t.kind == tyRange and t[0].kind in {tyFloat..tyFloat64}
 
 proc isIntRange(t: PType): bool {.inline.} =
   result = t.kind == tyRange and t[0].kind in {
@@ -420,11 +420,11 @@ proc leValueConv*(a, b: PNode): bool =
   of nkCharLit..nkUInt64Lit:
     case b.kind
     of nkCharLit..nkUInt64Lit: result = a.getInt <= b.getInt
-    of nkFloatLit..nkFloat128Lit: result = a.intVal <= round(b.floatVal).int
+    of nkFloatLit..nkFloat64Lit: result = a.intVal <= round(b.floatVal).int
     else: result = false #internalError(a.info, "leValueConv")
-  of nkFloatLit..nkFloat128Lit:
+  of nkFloatLit..nkFloat64Lit:
     case b.kind
-    of nkFloatLit..nkFloat128Lit: result = a.floatVal <= b.floatVal
+    of nkFloatLit..nkFloat64Lit: result = a.floatVal <= b.floatVal
     of nkCharLit..nkUInt64Lit: result = a.floatVal <= toFloat64(b.getInt)
     else: result = false # internalError(a.info, "leValueConv")
   else: result = false # internalError(a.info, "leValueConv")

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -814,7 +814,7 @@ proc trackCase(tracked: PEffects, n: PNode) =
   let oldState = tracked.init.len
   let oldFacts = tracked.guards.s.len
   let stringCase = n[0].typ != nil and skipTypes(n[0].typ,
-        abstractVarRange-{tyTypeDesc}).kind in {tyFloat..tyFloat128, tyString}
+        abstractVarRange-{tyTypeDesc}).kind in {tyFloat..tyFloat64, tyString}
   let interesting = not stringCase and interestingCaseExpr(n[0]) and
         tracked.config.hasWarn(rsemProveField)
   var inter: TIntersection = @[]

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -321,7 +321,7 @@ proc fitRemoveHiddenConv(c: PContext, typ: PType, n: PNode): PNode =
   of nkHiddenStdConv, nkHiddenSubConv:
     let r1 = result[1]
     if r1.kind in {nkCharLit..nkUInt64Lit} and
-       typ.skipTypes(abstractRange).kind in {tyFloat..tyFloat128}:
+       typ.skipTypes(abstractRange).kind in {tyFloat..tyFloat64}:
       result = newFloatNode(nkFloatLit, BiggestFloat r1.intVal)
       result.info = n.info
       result.typ = typ
@@ -1678,7 +1678,7 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
   of tyRange:
     if skipTypes(caseTyp[0], abstractInst).kind in shouldChckCovered:
       chckCovered = true
-  of tyFloat..tyFloat128, tyString:
+  of tyFloat..tyFloat64, tyString:
     # xxx: possible case statement macro bug, as it'll be skipped here
     discard
   else:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -379,7 +379,7 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
       if r.kind == nkError:
         localReport(c.config, r)
 
-    elif not isOrdinalType(rangeT[0]) and rangeT[0].kind notin {tyFloat..tyFloat128} or
+    elif not isOrdinalType(rangeT[0]) and rangeT[0].kind notin {tyFloat..tyFloat64} or
         rangeT[0].kind == tyBool:
       localReport(c.config, n.info, reportTyp(
         rsemExpectedOrdinalOrFloat, rangeT[0]))
@@ -896,7 +896,7 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   case typ.kind
   of shouldChckCovered:
     chckCovered = true
-  of tyFloat..tyFloat128, tyError:
+  of tyFloat..tyFloat64, tyError:
     discard
   of tyRange:
     if skipTypes(typ[0], abstractInst).kind in shouldChckCovered:
@@ -2264,7 +2264,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       else:
         assignType(prev, s.typ)
         # bugfix: keep the fresh id for aliases to integral types:
-        if s.typ.kind notin {tyBool, tyChar, tyInt..tyInt64, tyFloat..tyFloat128,
+        if s.typ.kind notin {tyBool, tyChar, tyInt..tyInt64, tyFloat..tyFloat64,
                              tyUInt..tyUInt64}:
           prev.itemId = s.typ.itemId
         result = prev
@@ -2383,7 +2383,6 @@ proc processMagicType(c: PContext, m: PSym) =
   of mFloat: setMagicIntegral(c.config, m, tyFloat, c.config.target.floatSize)
   of mFloat32: setMagicIntegral(c.config, m, tyFloat32, 4)
   of mFloat64: setMagicIntegral(c.config, m, tyFloat64, 8)
-  of mFloat128: setMagicIntegral(c.config, m, tyFloat128, 16)
   of mBool: setMagicIntegral(c.config, m, tyBool, 1)
   of mChar: setMagicIntegral(c.config, m, tyChar, 1)
   of mString:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -244,7 +244,7 @@ proc sumGeneric(t: PType): int =
     of tyGenericParam, tyUntyped, tyTyped: break
     of tyAlias, tySink: t = t.lastSon
     of tyBool, tyChar, tyEnum, tyObject, tyPointer,
-        tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat128,
+        tyString, tyCstring, tyInt..tyInt64, tyFloat..tyFloat64,
         tyUInt..tyUInt64, tyCompositeTypeClass:
       return isvar
     else:
@@ -377,10 +377,10 @@ proc isConvertibleToRange(f, a: PType): bool =
     #of tyUInt: result = isIntLit(a) or a.kind in {tyUInt8, tyUInt16, tyUInt32, tyUInt}
     #of tyUInt64: result = isIntLit(a) or a.kind in {tyUInt8, tyUInt16, tyUInt32, tyUInt, tyUInt64}
     else: result = false
-  elif f.kind in {tyFloat..tyFloat128}:
+  elif f.kind in {tyFloat..tyFloat64}:
     # `isIntLit` is correct and should be used above as well, see PR:
     # https://github.com/nim-lang/Nim/pull/11197
-    result = isIntLit(a) or a.kind in {tyFloat..tyFloat128}
+    result = isIntLit(a) or a.kind in {tyFloat..tyFloat64}
 
 proc handleFloatRange(f, a: PType): TTypeRelation =
   if a.kind == f.kind:
@@ -391,7 +391,7 @@ proc handleFloatRange(f, a: PType): TTypeRelation =
     if k == f.kind: result = isSubrange
     elif isFloatLit(ab): result = isFromIntLit
     elif isIntLit(ab): result = isConvertible
-    elif k >= tyFloat and k <= tyFloat128:
+    elif k >= tyFloat and k <= tyFloat64:
       # conversion to "float32" is not as good:
       if f.kind == tyFloat32: result = isConvertible
       else: result = isIntConv
@@ -970,8 +970,8 @@ when false:
     of tyUInt16: greater({tyUInt, tyUInt32, tyUInt64})
     of tyUInt32: greater({tyUInt64})
 
-    of tyFloat32: greater({tyFloat64, tyFloat128})
-    of tyFloat64: greater({tyFloat128})
+    of tyFloat32: greater({tyFloat64})
+    of tyFloat64: greater({})
     else: discard
 
 proc compareInvocationArguments(c: var TCandidate, f, a: PType,
@@ -1245,7 +1245,6 @@ typeRel can be used to establish various relationships between types:
   of tyFloat:    result = handleFloatRange(f, a)
   of tyFloat32:  result = handleFloatRange(f, a)
   of tyFloat64:  result = handleFloatRange(f, a)
-  of tyFloat128: result = handleFloatRange(f, a)
   of tyVar, tyLent:
     result =
       if aOrig.kind == f.kind:

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -603,7 +603,7 @@ proc transformConv(c: PTransf, n: PNode): PNode =
         [transform(c, n[1]),
          newIntTypeNode(firstOrd(c.graph.config, rangeDest), rangeDest),
          newIntTypeNode(lastOrd(c.graph.config, rangeDest), rangeDest)]
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     # XXX int64 -> float conversion?
     let rangeDest = skipTypes(n.typ, abstractVar)
     if rangeDest.kind == tyRange:

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -127,7 +127,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     result = typeAllowedAux(marker, lastSon(t), kind, c, flags)
   of tyRange:
     if skipTypes(t[0], abstractInst-{tyTypeDesc}).kind notin
-      {tyChar, tyEnum, tyInt..tyFloat128, tyInt..tyUInt64, tyRange}: result = t
+      {tyChar, tyEnum, tyInt..tyFloat64, tyInt..tyUInt64, tyRange}: result = t
   of tyOpenArray:
     # you cannot nest openArrays/sinks/etc.
     if (kind != skParam or taIsOpenArray in flags) and views notin c.features:

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -475,7 +475,7 @@ proc nodeToHighlightedHtml(d: PDoc; n: PNode; result: var string;
     of tkIntLit..tkUInt64Lit:
       dispA(d.conf, result, "<span class=\"DecNumber\">$1</span>",
             "\\spanDecNumber{$1}", [escLit])
-    of tkFloatLit..tkFloat128Lit:
+    of tkFloatLit..tkFloat64Lit:
       dispA(d.conf, result, "<span class=\"FloatNumber\">$1</span>",
             "\\spanFloatNumber{$1}", [escLit])
     of tkSymbol:

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -858,7 +858,7 @@ proc treeRepr*(
         add $n.intVal + style.number
         postLiteral()
 
-      of nkFloatLit .. nkFloat128Lit:
+      of nkFloatLit .. nkFloat64Lit:
         add " "
         add $n.floatVal + style.floatLit
         postLiteral()
@@ -1060,7 +1060,7 @@ proc treeRepr*(
       add $n.lit.iNumber + style.number
       postLiteral()
 
-    of pnkFloatLit .. pnkFloat128Lit:
+    of pnkFloatLit .. pnkFloat64Lit:
       add " "
       add $n.lit.fNumber + style.floatLit
       postLiteral()

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -155,8 +155,8 @@ proc putIntoReg(dest: var TFullReg; jit: var JitState, c: var TCtx, n: PNode,
     assert n.kind in nkCharLit..nkUInt64Lit
     dest.ensureKind(rkInt, c.memory)
     dest.intVal = n.intVal
-  of tyFloat..tyFloat128:
-    assert n.kind in nkFloatLit..nkFloat128Lit
+  of tyFloat..tyFloat64:
+    assert n.kind in nkFloatLit..nkFloat64Lit
     dest.ensureKind(rkFloat, c.memory)
     dest.floatVal = n.floatVal
   of tyNil, tyPtr, tyPointer:

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -338,7 +338,7 @@ func storeData*(enc: var DataEncoder, e: var PackedEnv, n: PNode) =
     of EmbeddedInts:  (pdkIntLit, cast[uint32](n.intVal))
     of ExternalInts:  (pdkInt,    e.getLitId(n.intVal).uint32)
 
-    of nkFloatLit..nkFloat128Lit: (pdkFloat,  e.getLitId(n.floatVal).uint32)
+    of nkFloatLit..nkFloat64Lit:  (pdkFloat,  e.getLitId(n.floatVal).uint32)
     of nkStrLit..nkTripleStrLit:  (pdkString, e.getLitId(n.strVal).uint32)
     of nkNilLit:                  (pdkPtr,    0'u32)
 
@@ -677,7 +677,7 @@ proc loadNode(dec: var TypeInfoDecoder, ps: PackedEnv, id: NodeId): (PNode, int3
     discard "do nothing"
   of nkCharLit..nkUInt64Lit:
     r.intVal = ps.numbers[n.operand.LitId]
-  of nkFloatLit..nkFloat128Lit:
+  of nkFloatLit..nkFloat64Lit:
     # use a `cast` to preserve the bit representation:
     r.floatVal = cast[BiggestFloat](ps.numbers[n.operand.LitId])
   of nkStrLit..nkTripleStrLit:

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -654,7 +654,7 @@ proc opConv(c: var TCtx; dest: var TFullReg, src: TFullReg, dt, st: (PType, PVmT
       dest.strVal = $uint64(src.intVal)
     of tyBool:
       dest.strVal = if src.intVal == 0: "false" else: "true"
-    of tyFloat..tyFloat128:
+    of tyFloat..tyFloat64:
       dest.strVal = $src.floatVal
     of tyString:
       dest.strVal = src.strVal

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -485,9 +485,9 @@ type
       ## size and alignment information for atoms where this information is
       ## the same for every instance
 
-    # XXX: if `tyBool..tyFloat128` would only include all numeric types (plus
+    # XXX: if `tyBool..tyFloat64` would only include all numeric types (plus
     #      bool and char), we could use the `numericTypes` below instead
-    #numericTypes*: array[tyBool..tyFloat128, PVmType] ## A lookup table for all numeric types (ints/float)
+    #numericTypes*: array[tyBool..tyFloat64, PVmType] ## A lookup table for all numeric types (ints/float)
     boolType*: PVmType
     charType*: PVmType
     stringType*: PVmType
@@ -495,7 +495,6 @@ type
     nodeType*: PVmType
     emptyType*: PVmType
 
-    # TODO: merge these arrays into one. Handle `tyFloat128` somehow
     intTypes*: array[tyInt..tyInt64, PVmType]
     uintTypes*: array[tyUInt..tyUInt64, PVmType]
     floatTypes*: array[tyFloat..tyFloat64, PVmType]

--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -297,7 +297,6 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
   of tyFloat: result = atomicType("float", mFloat)
   of tyFloat32: result = atomicType("float32", mFloat32)
   of tyFloat64: result = atomicType("float64", mFloat64)
-  of tyFloat128: result = atomicType("float128", mFloat128)
   of tyUInt: result = atomicType("uint", mUInt)
   of tyUInt8: result = atomicType("uint8", mUInt8)
   of tyUInt16: result = atomicType("uint16", mUInt16)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -404,7 +404,7 @@ proc getSlotKind(t: PType): TSlotKind =
     slotTempInt
   of tyString, tyCstring:
     slotTempStr
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     slotTempFloat
   else:
     slotTempComplex
@@ -800,12 +800,12 @@ proc genBranchLit(c: var TCtx, n: CgNode, t: PType): int =
       n.kids.toOpenArray(0, n.kids.high - 1) # -1 for the branch body
 
     case t.kind
-    of IntegralTypes-{tyFloat..tyFloat128}:
+    of IntegralTypes-{tyFloat..tyFloat64}:
       cnst = VmConstant(kind: cnstSliceListInt)
       cnst.intSlices.fillSliceList(values):
         it.intVal
 
-    of tyFloat..tyFloat128:
+    of tyFloat..tyFloat64:
       cnst = VmConstant(kind: cnstSliceListFloat)
       cnst.floatSlices.fillSliceList(values):
         it.floatVal
@@ -1561,7 +1561,7 @@ proc whichAsgnOpc(n: CgNode; requiresCopy = true): TOpcode =
   case n.typ.skipTypes(IrrelevantTypes + {tyRange}).kind
   of tyBool, tyChar, tyInt..tyInt64, tyUInt..tyUInt64:
     opcAsgnInt
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     opcAsgnFloat
   else:
     # XXX: always require a copy, fastAsgn is broken in the VM

--- a/compiler/vm/vmtypegen.nim
+++ b/compiler/vm/vmtypegen.nim
@@ -326,13 +326,6 @@ func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure): tuple[typ: PVm
     # XXX: maybe it's not a good idea to add all user-type class instances to
     #      the cache?
     res.existing = c.genType(t.lastSon(), cl).typ
-  of tyFloat128:
-    # XXX: introducing an error path just for float128 seems excessive, even
-    #      more so when float128 seems to be almost never used. sem should
-    #      reject this instead, but for now we just raise an internal compiler
-    #      error
-    # XXX: could also use `globalReport`, but it's not side-effect free
-    doAssert false, "float128 not supported by the VM"
   else:
     unreachable()
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -51,8 +51,9 @@ type
     nnkType, nnkCharLit, nnkIntLit, nnkInt8Lit,
     nnkInt16Lit, nnkInt32Lit, nnkInt64Lit, nnkUIntLit, nnkUInt8Lit,
     nnkUInt16Lit, nnkUInt32Lit, nnkUInt64Lit, nnkFloatLit,
-    nnkFloat32Lit, nnkFloat64Lit, nnkFloat128Lit, nnkStrLit, nnkRStrLit,
-    nnkTripleStrLit, nnkNilLit,
+    nnkFloat32Lit, nnkFloat64Lit,
+    nnkStrLit = skipEnumValue(nimskullNoFloat128, nnkFloat64Lit)
+    nnkRStrLit, nnkTripleStrLit, nnkNilLit,
     nnkDotCall = skipEnumValue(nimHasNkComesFromNodeRemoved, nnkNilLit)
     nnkCommand, nnkCall, nnkCallStrLit, nnkInfix,
     nnkPrefix, nnkPostfix, nnkHiddenCallConv,
@@ -124,8 +125,9 @@ type
     ntySequence, ntyProc, ntyPointer, ntyOpenArray,
     ntyString, ntyCString, ntyForward, ntyInt,
     ntyInt8, ntyInt16, ntyInt32, ntyInt64,
-    ntyFloat, ntyFloat32, ntyFloat64, ntyFloat128,
-    ntyUInt, ntyUInt8, ntyUInt16, ntyUInt32, ntyUInt64,
+    ntyFloat, ntyFloat32, ntyFloat64,
+    ntyUInt = skipEnumValue(nimskullNoFloat128, ntyFloat64)
+    ntyUInt8, ntyUInt16, ntyUInt32, ntyUInt64,
     ntyUnused1 = skipEnumValue(nimHasTyOwnedRemoved, ntyUInt64),
     ntyUnused2,
     ntyVarargs,
@@ -711,12 +713,6 @@ proc newLit*(f: float64): NimNode =
   ## Produces a new float literal node.
   result = newNimNode(nnkFloat64Lit)
   result.floatVal = f
-
-when declared(float128):
-  proc newLit*(f: float128): NimNode =
-    ## Produces a new float literal node.
-    result = newNimNode(nnkFloat128Lit)
-    result.floatVal = f
 
 proc newLit*(arg: enum): NimNode =
   result = newCall(

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -66,13 +66,12 @@ type
     akFloat = 36,       ## float
     akFloat32 = 37,     ## float32
     akFloat64 = 38,     ## float64
-    akFloat128 = 39,    ## float128
-    akUInt = 40,        ## uint
-    akUInt8 = 41,       ## uint8
-    akUInt16 = 42,      ## uin16
-    akUInt32 = 43,      ## uint32
-    akUInt64 = 44,      ## uint64
-#    akOpt = 44+18       ## the builtin 'opt' type.
+    akUInt = 39,        ## uint
+    akUInt8 = 40,       ## uint8
+    akUInt16 = 41,      ## uin16
+    akUInt32 = 42,      ## uint32
+    akUInt64 = 43,      ## uint64
+#    akOpt = 43+18       ## the builtin 'opt' type.
 
   Any* = object
     ## A type that can represent any nim value.

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -355,7 +355,6 @@ typedef signed char NI8;
 typedef signed short int NI16;
 typedef signed int NI32;
 typedef __int64 NI64;
-/* XXX: Float128? */
 typedef unsigned char NU8;
 typedef unsigned short int NU16;
 typedef unsigned int NU32;
@@ -406,7 +405,6 @@ typedef __INT64_TYPE__ NI64;
 #else
 typedef long long int NI64;
 #endif
-/* XXX: Float128? */
 #ifdef __UINT8_TYPE__
 typedef __UINT8_TYPE__ NU8;
 #else

--- a/lib/pure/marshal.nim
+++ b/lib/pure/marshal.nim
@@ -122,7 +122,7 @@ proc storeAny(s: Stream, a: Any, stored: var IntSet) =
         inc(i)
       s.write("]")
   of akInt..akInt64, akUInt..akUInt64: s.write($getBiggestInt(a))
-  of akFloat..akFloat128: s.write($getBiggestFloat(a))
+  of akFloat..akFloat64: s.write($getBiggestFloat(a))
 
 proc loadAny(p: var JsonParser, a: Any, t: var Table[BiggestInt, pointer]) =
   case a.kind
@@ -254,7 +254,7 @@ proc loadAny(p: var JsonParser, a: Any, t: var Table[BiggestInt, pointer]) =
       next(p)
       return
     raiseParseErr(p, "int expected")
-  of akFloat..akFloat128:
+  of akFloat..akFloat64:
     if p.kind == jsonFloat:
       setBiggestFloat(a, getFloat(p))
       next(p)

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -668,7 +668,7 @@ proc untype(arg: NimNode): NimNode =
   of nnkCharLit..nnkUInt64Lit:
     result = newNimNode(arg.kind, arg)
     result.intVal = arg.intVal
-  of nnkFloatLit..nnkFloat128Lit:
+  of nnkFloatLit..nnkFloat64Lit:
     result = newNimNode(arg.kind, arg)
     result.floatVal = arg.floatVal
   of nnkStrLit..nnkTripleStrLit:

--- a/lib/system/hti.nim
+++ b/lib/system/hti.nim
@@ -50,7 +50,6 @@ type
     tyFloat,
     tyFloat32,
     tyFloat64,
-    tyFloat128,
     tyUInt,
     tyUInt8,
     tyUInt16,

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -196,7 +196,7 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
     add(result, reprChar(cast[char](p)))
   of tyBool:
     add(result, reprBool(cast[bool](p)))
-  of tyFloat..tyFloat128:
+  of tyFloat..tyFloat64:
     add(result, reprFloat(cast[float](p)))
   of tyString:
     var fp: int


### PR DESCRIPTION
## Summary
* Remove the deprecated/undocumented and broken built-in  `float128` 
type and its associated node and type kinds  `nkFloat128Lit`  and 
`tyFloat128` 

## Details
* The define  `nimskullNoFloat128`  was added to 
`compiler/front/condsyms` , used by  `skipEnumValue`  in 
`lib/core/macros`  to allow bootstrapping with an older compiler that
still has the  `nkFloat128Lit`  and  `tyFloat128`  kinds