### PR TITLE
internal: reduce the `CgNode` size

### DIFF
--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -173,9 +173,9 @@ type
   LocalId* = distinct uint32
     ## Identifies a local within a procedure.
 
-  CgNode* = ref object
-    ## Code-generator node
-    origin*: PNode
+  CgNode* {.acyclic.} = ref object
+    ## A node in the tree structure representing code during the code
+    ## generation stage. The "CG" prefix is short for "code generation".
     info*: TLineInfo
     typ*: PType
     case kind*: CgNodeKind


### PR DESCRIPTION
## Summary

* reduce the size of `CgNode` from 48 to 40
* mark the type as being acyclic at run-time

## Details

The `origin` field is an unused leftover that was replaced by the
`info` field. Since the nodes are not allowed to form a cycle, the type
can be marked with `.acyclic`, reducing the pressure on the cycle
collector. In addition, the type's documentation is improved.