### PR TITLE
fix(sem): restore error on too large discriminants

### DIFF
--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -908,23 +908,21 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
       rsemExpectedOrdinalOrFloat, typ))
 
   if firstOrd(c.config, typ) != 0:
-    var rep = SemReport(
+    localReport(c.config, n.info, SemReport(
       kind: rsemExpectedLow0Discriminant,
       # TODO: fix storage and actually report data, previously captured:
       #       - expected: toInt128(0),
       #       - got: firstOrd(c.config, typ)),
       typ: typ,
-      sym: a[0].sym)
-
-    localReport(c.config, n.info, rep)
+      sym: a[0].sym))
   elif lengthOrd(c.config, typ) > 0x00007FFF:
-    var rep = SemReport(
+    localReport(c.config, n.info, SemReport(
       kind: rsemExpectedHighCappedDiscriminant,
       # TODO: fix storage and actually report data, previously captured:
       #       - expected: toInt128(32768),
       #       - got: firstOrd(c.config, typ)),
       typ: typ,
-      sym: a[0].sym)
+      sym: a[0].sym))
 
   for i in 1..<n.len:
     var b = copyTree(n[i])

--- a/tests/errmsgs/thigh_capped_discriminant.nim
+++ b/tests/errmsgs/thigh_capped_discriminant.nim
@@ -1,0 +1,11 @@
+discard """
+  errormsg: "len(x) must be less than 32768"
+  line: 7
+"""
+
+type Typ = object
+  case x: range[0..100_000]
+  of 0:
+    discard
+  else:
+    discard


### PR DESCRIPTION
## Summary

Fix no error being reported for record-case discriminators that
cover a too large value range.

## Details

The problem was already detected and a report created, but the
report object wasn't reported.

Instead of assigning the `SemReport` object to a local first, it is
passed directly to `localReport`. For visual consistency, the above
`if` branch is changed too.