### PR TITLE
fix(sem): missed `discard` in `try/finally` errors

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -307,15 +307,15 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
     if n[0].isError:
       return wrapError(c.config, n)
     for i in 1 ..< n.len:
-      n[i] = discardCheck(c, n[i], flags)
-      if n[i].isError:
+      n[i][^1] = discardCheck(c, n[i][^1], flags)
+      if n[i][^1].isError:
         return wrapError(c.config, n)
     if typ == c.enforceVoidContext:
       result.typ = c.enforceVoidContext
   else:
     if n.lastSon.kind == nkFinally:
-      n[^1] = discardCheck(c, n[^1], flags)
-      if n[^1].isError:
+      n[^1][^1] = discardCheck(c, n[^1][^1], flags)
+      if n[^1][^1].isError:
         return wrapError(c.config, n)
     n[0] = fitNode(c, typ, n[0], n[0].info)
     for i in 1..last:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -141,9 +141,9 @@ proc discardCheck(c: PContext, n: PNode, flags: TExprFlags): PNode =
             case m[^1].kind
             of nkFinally:
               m[^2]
-            of skipForDiscardable - nkFinally:
-              m.lastSon
-            of nkAllNodeKinds - skipForDiscardable:
+            of nkExceptBranch:
+              m[^1]
+            of nkAllNodeKinds - {nkFinally, nkExceptBranch}:
               unreachable()
         else:
           m = m.lastSon

--- a/tests/lang_exprs/tdiscardcheck_try_except.nim
+++ b/tests/lang_exprs/tdiscardcheck_try_except.nim
@@ -1,0 +1,14 @@
+discard """
+description: "Ensure discard checks are done for try expressions"
+errormsg: "expression '1' is of type 'int literal(1)' and has to be used (or discarded)"
+line: 14
+"""
+
+## This was originally introduced as a regression test, where a fix to
+## `semstmts.discardCheck` erroneously changed traversals in a manner where
+## the test suite passed but this was not caught, except in code review.
+
+try:
+  discard
+except:
+  1

--- a/tests/lang_exprs/tdiscardcheck_try_finally.nim
+++ b/tests/lang_exprs/tdiscardcheck_try_finally.nim
@@ -1,7 +1,7 @@
 discard """
 description: "Ensure discard checks are done for try expressions"
 errormsg: "expression '1' is of type 'int literal(1)' and has to be used (or discarded)"
-line: 11
+line: 14
 """
 
 ## This was originally introduced as a regression test, where

--- a/tests/lang_exprs/tdiscardcheck_try_finally.nim
+++ b/tests/lang_exprs/tdiscardcheck_try_finally.nim
@@ -1,0 +1,16 @@
+discard """
+description: "Ensure discard checks are done for try expressions"
+errormsg: "expression '1' is of type 'int literal(1)' and has to be used (or discarded)"
+line: 11
+"""
+
+## This was originally introduced as a regression test, where
+## `semstmts.discardCheck` erroneously checked the `finally` branch, instead
+## of the last non-`finally` branch in the `try` expression. This generated an
+## incomplete report, and resulted in an NPE within `cli_reporter` when
+## attempting to render it.
+
+try:
+  1
+finally:
+  discard 1


### PR DESCRIPTION
## Summary

A missing `discard` in a `try/finally` no longer crashes the compiler
and emits an error as it should.

## Details

The `discardCheck` used to ensure expressions are used or `void` did not
traverse `try` appropriately. Instead of looking at the last expression
in the last `except` or `try` branch, it would look at the last branch,
even if that was a `finally`. This led to incomplete data being sent for
error reporting, which ultimately led to an NPE.

Along with the fix a regression test has been added.