### PR TITLE
sem: make return-type inference work consistently

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -186,10 +186,7 @@ proc fitNodePostMatch(c: PContext, formal: PType, arg: PNode): PNode =
   var
     a = arg
     x = a.mutableSkipConv
-  if x.kind in {nkCurly, nkPar, nkTupleConstr} and
-     formal.kind notin {tyUntyped, tyBuiltInTypeClass}:
-    # XXX: ^^ the test for ``tyBuiltInTypeClass`` is a hack. It can be removed
-    #      once ``fitNode`` is no longer used for meta return types
+  if x.kind in {nkCurly, nkPar, nkTupleConstr} and formal.kind != tyUntyped:
     x = changeType(c, x, formal, check=true)
 
     if x.isError:

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2413,7 +2413,7 @@ proc semYieldVarResult(c: PContext, n: PNode, restype: PType): PNode =
       else:
         n[0]
 
-    result.add takeImplicitAddr(c, t, unwrappedValue)
+    result[0] = takeImplicitAddr(c, t, unwrappedValue)
     hasError = result[0].isError
   of tyTuple:
     # first, check if the tuple contains a *direct* view-type. If it does, the
@@ -2451,7 +2451,6 @@ proc semYieldVarResult(c: PContext, n: PNode, restype: PType): PNode =
           else:
             useAddr tupleConstr[i]
 
-      result.add n[0]
     elif containsView:
       # the tuple contains a view type but the expression is not a literal
       # tuple constructor
@@ -2460,14 +2459,12 @@ proc semYieldVarResult(c: PContext, n: PNode, restype: PType): PNode =
       #        with return type ``(int, (int, var int))``, but ``x`` is not
       #        for ``(int, var int)``?
       hasError = true
-      result.add newError(c.config, n[0],
+      result[0] = newError(c.config, n[0],
                           PAstDiag(kind: adSemYieldExpectedTupleConstr,
                                     tupleTyp: t))
-    else:
-      result.add n[0]
 
   else:
-    result.add n[0]
+    discard
 
   if hasError:
     result = c.config.wrapError(result)

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2157,10 +2157,6 @@ proc asgnToResultVar(c: PContext, n: PNode): PNode {.inline.} =
   else:
     discard
 
-template resultTypeIsInferrable(typ: PType): untyped =
-  typ.isMetaType and typ.kind != tyTypeDesc and
-    (typ.kind notin tyUserTypeClasses or not typ.isResolvedUserTypeClass)
-
 proc goodLineInfo(arg: PNode): TLineInfo =
   if arg.kind == nkStmtListExpr and arg.len > 0:
     goodLineInfo(arg[^1])

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2378,7 +2378,7 @@ proc semProcBody(c: PContext, n: PNode): PNode =
     result = discardCheck(c, result, {})
 
   if c.p.owner.kind notin {skMacro, skTemplate} and
-     c.p.resultSym != nil and c.p.resultSym.typ.isMetaType:
+     c.p.resultSym != nil and resultTypeIsInferrable(c.p.resultSym.typ):
     if isEmptyType(result.typ):
       # we inferred a 'void' return type:
       c.p.resultSym.typ = errorType(c)

--- a/tests/lang/s02_core/s07_type_inference/t01_return_type_inference.nim
+++ b/tests/lang/s02_core/s07_type_inference/t01_return_type_inference.nim
@@ -1,0 +1,36 @@
+discard """
+  description: '''
+    The specified return type of a non-generic routines may be generic, in
+    which case the concrete type is inferred from the body.
+  '''
+"""
+
+## Using 'auto' as the return type enables unconstrained return type
+## inference. The real return type is taken from the source expression
+## of the first analysed assignment to the `result` variable.
+
+proc p(): auto =
+  result = 1
+
+doAssert typeof(p()) is int
+
+## The return type specified on the procedure definition may also be a
+## type-class of a built-in generic type, in which case it acts as a
+## constraint.
+
+proc p2(): tuple =
+  result = (1, 2)
+
+doAssert typeof(p2()) is (int, int)
+
+## Return type inference is also available with iterators.
+
+iterator iter(): auto =
+  yield 1
+
+doAssert typeof(iter()) is int
+
+iterator iter2(): tuple =
+  yield (1, 2)
+
+doAssert typeof(iter2()) is (int, int)

--- a/tests/lang/s02_core/s07_type_inference/t01_return_type_inference.nim
+++ b/tests/lang/s02_core/s07_type_inference/t01_return_type_inference.nim
@@ -1,6 +1,6 @@
 discard """
   description: '''
-    The specified return type of a non-generic routines may be generic, in
+    The specified return type of non-generic routines may be generic, in
     which case the concrete type is inferred from the body.
   '''
 """

--- a/tests/lang/s02_core/s07_type_inference/t01_return_type_inference_issues.nim
+++ b/tests/lang/s02_core/s07_type_inference/t01_return_type_inference_issues.nim
@@ -1,0 +1,20 @@
+discard """
+  knownIssue: '''
+    Standalone composite type-classes used as return types always result in
+    an error
+  '''
+"""
+
+type Generic[T] = (T, T)
+
+# currently fails with: "cannot instantiate"
+
+proc p3(): Generic =
+  result = ("", "")
+
+doAssert typeof(p3()).T is string
+
+iterator iter3(): Generic =
+  yield ("", "")
+
+doAssert typeof(iter3()).T is string

--- a/tests/lang/s02_core/s07_type_inference/t02_return_type_inference_converters.nim
+++ b/tests/lang/s02_core/s07_type_inference/t02_return_type_inference_converters.nim
@@ -1,0 +1,21 @@
+discard """
+  description: '''
+    Generic converters are considered when inferring the return type.
+  '''
+"""
+
+converter convert[T](x: T): seq[T] =
+  @[x]
+
+proc p(): seq =
+  result = 1
+
+doAssert p() == @[1]
+
+## The same is true for return-type inference in iterators.
+
+iterator iter(): seq =
+  yield 1
+
+for it in iter():
+  doAssert it == @[1]

--- a/tests/lang/s02_core/s07_type_inference/t02_return_type_inference_converters.nim
+++ b/tests/lang/s02_core/s07_type_inference/t02_return_type_inference_converters.nim
@@ -19,3 +19,21 @@ iterator iter(): seq =
 
 for it in iter():
   doAssert it == @[1]
+
+## While there's no return type to infer for templates and macros, a meta-
+## type used as the return type still triggers the converter.
+
+template templ(): seq =
+  1
+
+# the converter is applied on the template's result already
+let v1 = templ()
+doAssert v1 is seq[int]
+doAssert v1 == @[1]
+
+macro m(x: int): seq =
+  result = x
+
+let v2 = m(1)
+doAssert v2 is seq[int]
+doAssert v2 == @[1]

--- a/tests/lang_experimental/concepts/treturn_type_inference_issue.nim
+++ b/tests/lang_experimental/concepts/treturn_type_inference_issue.nim
@@ -1,0 +1,19 @@
+discard """
+  description: '''
+    Regression test for resolved concept types used as the return type
+    being overriden with a non-concept type on `result` assignment
+  '''
+  action: compile
+"""
+
+type
+  Generic[T] = concept x
+    x is T
+
+proc test(x: Generic): typeof(x) =
+  result = x
+
+static:
+  # the below failed previously, as the result assignment changed the return
+  # type to ``int`` instead of leaving it as the ``Generic[int]``
+  doAssert typeof(test(Generic[int](1))).T is int


### PR DESCRIPTION
## Summary

Inference of a routine's return type now works the same as inference in
the case of `var x: MetaType = y`. This means that generic converters
are now considered when inferring the return type.

Three bugs are fixed:
* return-type inference via `yield` no longer ignores the specified
  generic/meta return type
* the instance of a generic `and`/`or`/`not` type-class (e.g.,
  `Constraint[int]` where `type Constraint[T] = T or float`) now works
  as a constraint on `var`/`let`/`const` definitions and for the
  return type
* a concept type used as the return type is no longer replaced with a
  non-concept type when a `result` assignment exists in the body

## Details

Both `semAsgn` and `semYield` didn't implement the inference properly.
`semAsgn` only performed a `sigmatch`-based type comparison and on
success used the type of the source expression as the return type,
while `semYield` fully ignored the specified meta-type.

For symmetry with `var`, `let`, and `const` definitions, fitting the
expression with the inferrable return type is done via
`inferWithMetatype`, which, compared to `fitNode`, ensures that the
expression uses the resolved meta type instead of the expression's
original type.

**Main changes:**

* don't treat resolved concept types as allowing for inference in
  `resultTypeIsInferrable` -- they're already resolved
* move the return-type inference logic into the new `inferReturnType`
  procedure, which is used by both `semAsgn` and `semYield`
* use `inferWithMetatype` for fitting the source expression into the 
  result when the result type is still a meta type
* the `auto` type, which at the time of inference is represented via a
  `tyUntyped`, requires special handling
* use `inferWithMetatype` for fitting the expression in a macro/
  template using a generic and/or meta return type
* extend `inferWithMetatype` to handle `tyGenericInstance`s, which
  fixes instantiation failures
* `tyBuiltInTypeClass` types no longer reach into
  `fitNodePostMatch`, so the associated workaround is removed

**Error handling changes**:
* don't disable the void context enforcement for result assignments
  when the right-hand expression is erroneous
* infer the return type as `tyError` when the first analysed result
  assignment has an error

Both changes are intended to reduce error cascading.

**Misc changes:**

* don't mutate the input AST in `semYield`
* change `semYieldVarResult` to not create another copy -- its input
  is now already a production
* remove the obsolete `skMacro` check in `semAsgn` -- since
  https://github.com/nim-works/nimskull/pull/620, the return type of
  a macro is always `NimNode`