### PR TITLE
vm: simpler closure support

### DIFF
--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -440,7 +440,7 @@ proc loadSliceList*[T: SliceListType](p: PackedEnv, id: uint32): seq[Slice[T]] =
 func numFields(t: PVmType): int =
   case t.kind
   of akInt, akFloat, akPNode: 0
-  of akPtr, akRef, akSeq, akString, akSet, akDiscriminator, akCallable, akClosure: 1
+  of akPtr, akRef, akSeq, akString, akSet, akDiscriminator, akCallable: 1
   of akArray: 1
   of akObject: 1 + t.objFields.len
 
@@ -468,7 +468,7 @@ func storeVmType(enc: var PackedEncoder, dst: var PackedEnv, t: PVmType): Packed
 
     of akSet:                 (t.setLength.uint32, 0'u32)
     of akDiscriminator:       (t.numBits.uint32, 0'u32)
-    of akCallable, akClosure: (t.routineSig.uint32, 0'u32)
+    of akCallable:            (t.routineSig.uint32, 0'u32)
     of akArray:               (t.elementCount.uint32, enc.typeMap[t.elementType])
     of akObject:              (t.relFieldStart, t.branches.len.uint32)
     of akInt, akFloat, akPNode:
@@ -516,7 +516,7 @@ func loadVmType(s: PackedEnv, types: seq[PVmType],
     t.elementCount = firstField.offset.int
     t.elementType = types[firstField.typId]
     t.elementStride = alignedSize(t.elementType).int
-  of akCallable, akClosure:
+  of akCallable:
     t.routineSig = firstField.offset.RoutineSigId
   of akObject:
     t.relFieldStart = firstField.offset

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -54,13 +54,6 @@ type
 
     opcWrProc # deref(a) = functions[Bx]
 
-    # TODO: instead of the a == c hack, use the surplus 8bit of the instruction
-    #       word that are currently unused as a boolean
-    opcWrClosure # a = (b, c)
-    # If a == c, treat the env as nil
-    opcAccessEnv ## a = b.env[]; loads a handle to the cell holding the
-                 ## environment
-
     opcAddInt,
     opcAddImmInt,
     opcSubInt,

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -112,14 +112,7 @@ proc initProcEntry*(linker: LinkerData, config: ConfigRef,
       else:
         noneType
 
-  # Create the env parameter type (if an env param exists)
-  result.envParamType =
-    if (let envP = getEnvParam(prc); envP != nil):
-      tc.getOrCreate(config, envP.typ, cl)
-    else:
-      noneType
-
-  assert result.envParamType == noneType or result.envParamType.kind == akRef
+  result.isClosure = prc.typ.callConv == ccClosure
 
 proc initProcEntry*(c: var TCtx, prc: PSym): FuncTableEntry {.inline.} =
   ## Convenience wrapper around

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -108,7 +108,7 @@ proc initProcEntry*(linker: LinkerData, config: ConfigRef,
     else:
       let rTyp = prc.getReturnType()
       if not isEmptyType(rTyp):
-        tc.getOrCreate(config, rTyp, cl)
+        tc.getOrCreate(config, rTyp, false, cl)
       else:
         noneType
 

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -30,7 +30,8 @@ import
     mirgen
   ],
   compiler/modules/[
-    modulegraphs
+    modulegraphs,
+    magicsys
   ],
   compiler/utils/[
     containers
@@ -271,6 +272,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
            gen: CodeGenCtx(config: g.config, graph: g, mode: emStandalone))
 
   c.gen.typeInfoCache.init()
+  c.gen.typeInfoCache.initRootRef(g.config, g.getCompilerProc("RootObj").typ)
 
   # register the extra ops so that code generation isn't performed for the
   # corresponding procs:

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -499,6 +499,12 @@ type
     uintTypes*: array[tyUInt..tyUInt64, PVmType]
     floatTypes*: array[tyFloat..tyFloat64, PVmType]
 
+    rootRef*: PVmType
+      ## the VM type corresponding to ``ref RootObj``.
+      # XXX: this is a temporary workaround, the type cache shouldn't need to
+      #      know nor care about ``RootObj``. Can be removed once closure types
+      #      are lowered earlier
+
   FunctionIndex* = distinct int
 
   # XXX: TCtx's contents should be separated into five parts (separate object

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -112,11 +112,6 @@ type
     akSeq
     akRef
     akCallable # TODO: rename to akProcedural or akFuncHandle
-    akClosure # XXX: closures could also be represented as an akObject
-              #      with two fields. Few problems: You'd need the concept of a
-              #      dynamically typed ref (easy); the guest must be prevented
-              #      from modifying the closure's fields (possible); extra
-              #      detection logic in `opcIndCall` is required
 
     akDiscriminator
 
@@ -194,7 +189,7 @@ type
       #       `akPtr`/`akRef`
       seqElemStride*: int
       seqElemType*: PVmType
-    of akCallable, akClosure:
+    of akCallable:
       routineSig*: RoutineSigId
     of akDiscriminator:
       # A discriminator consists of two things: the value as seen by the guest
@@ -256,10 +251,6 @@ type
     of ckCallback:
       cbOffset*: int ## the index into the callback list
 
-  VmClosure* = object
-    fnc*: VmFunctionPtr
-    env*: HeapSlotHandle
-
   VmMemPointer* = distinct ptr UncheckedArray[byte]
     ## A pointer into a memory region managed by the VM (i.e. guest memory)
   VmMemoryRegion* = openArray[byte]
@@ -306,7 +297,6 @@ type
     seqVal*: VmSeq ## akSeq
     refVal*: HeapSlotHandle ## akRef
     callableVal*: VmFunctionPtr ## akCallable
-    closureVal*: VmClosure ## akClosure
 
     nodeVal*: PNode ## akPNode
 
@@ -809,7 +799,6 @@ proc init*(cache: var TypeInfoCache) =
   setInfo(akPtr, ptr Atom)
   setInfo(akRef, HeapSlotHandle)
   setInfo(akCallable, VmFunctionPtr)
-  setInfo(akClosure, VmClosure)
   setInfo(akPNode, PNode)
 
   # Add a `nil` at index '0' so that type-id '0' means none/nil/invalid

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -246,7 +246,7 @@ type
 
     sym*: PSym
     retValDesc*: PVmType ## the return value type (may be empty)
-    envParamType*: PVmType ## the type of the hidden environment parameter
+    isClosure*: bool     ## whether the closure calling convention is used
     sig*: RoutineSigId
 
     case kind*: CallableKind

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3270,6 +3270,13 @@ proc genProcBody(c: var TCtx): int =
           gABx(c, body, opcode, c.prc[resultId].reg, c.genType(rt))
 
     prepareParameters(c, body)
+    if s.routineSignature.callConv == ccClosure:
+      # convert the environment reference to the expected type, the caller
+      # may pass it as a super type
+      let env = TRegister(s.routineSignature.n.len)
+      c.gABC(body, opcObjConv, env, env)
+      c.gABx(body, opcObjConv, 0, c.genType(c.prc.body[LocalId env].typ))
+
     gen(c, body)
 
     # generate final 'return' statement:

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -122,15 +122,6 @@ proc loadConst(s: PackedEnv, idx: int, dst: LocHandle,
     else:#of pckProc:
       deref(dst).callableVal = toFuncPtr(n.pos.FunctionIndex)
 
-  of akClosure:
-    case n.kind
-    of pdkPtr:
-      # must be nil
-      assert n.pos == 0
-    else: # of pckProc:
-      let fncPtr = toFuncPtr(n.pos.FunctionIndex)
-      deref(dst).closureVal = VmClosure(fnc: fncPtr, env: 0)
-
   of akObject:
     assert n.kind == pdkObj
     let L = n.pos.int

--- a/compiler/vm/vmtypegen.nim
+++ b/compiler/vm/vmtypegen.nim
@@ -236,9 +236,13 @@ type GenResult = object
 
 func genTuple(c: var TypeInfoCache, t: PType, cl: var GenClosure): GenResult
 
-func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure): tuple[typ: PVmType, existed: bool] =
+func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure;
+             noClosure = false): tuple[typ: PVmType, existed: bool] =
   ## The heart of `PType` -> `VmType` translation. Looks up or creates types
-  ## and adds mappings to `lut` if they don't exist already
+  ## and adds mappings to `lut` if they don't exist already.
+  ##
+  ## If `noClosure` is 'true', a proc type with ``.closure`` calling
+  ## convention is treated as a procedure type instead of a closure.
   let t = t.skipTypes(skipTypeSet)
   let typ = getAtomicType(c, cl.conf, t)
   if typ.isSome():
@@ -266,12 +270,32 @@ func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure): tuple[typ: PVm
                      seqElemType: genType(c, t[0], cl).typ)
 
   of tyProc:
-    let kind =
-      if t.callConv == ccClosure: akClosure
-      else: akCallable
+    if t.callConv == ccClosure and not noClosure:
+      # a closure is represented as a ``tuple[prc: proc, env: RootRef]``.
+      # Manually create one.
+      let
+        start = cl.tmpFields.len
+        (prcTyp, _) = c.genType(t, cl, noClosure=true)
 
-    res.typ = VmType(kind: kind)
-    res.typ.routineSig = c.makeSignatureId(t)
+      cl.tmpFields.add prcTyp
+      cl.tmpFields.add c.rootRef
+
+      var hcode = hash(akObject)
+      hcode = hcode !& hash(cl.tmpFields[start + 0])
+      hcode = hcode !& hash(cl.tmpFields[start + 1])
+
+      let id = c.types.get(c.structs, cl.tmpFields.subView(start, 2), hcode)
+      if id != 0:
+        res.existing = c.types[id]
+      else:
+        res.typ = VmType(kind: akObject)
+        res.typ.objFields.newSeq(2)
+        res.typ.objFields[0].typ = cl.tmpFields[start + 0]
+        res.typ.objFields[1].typ = cl.tmpFields[start + 1]
+
+      cl.tmpFields.setLen(start)
+    else:
+      res.typ = VmType(kind: akCallable, routineSig: c.makeSignatureId(t))
 
   of tyObject:
     if true:
@@ -369,7 +393,8 @@ func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure): tuple[typ: PVm
         cl.sizeQueue.add(result.typ)
 
   # add a lookup entry from the `PType` ID to the `VmType`
-  c.lut[t.itemId] = result.typ
+  if t.kind != tyProc:
+    c.lut[t.itemId] = result.typ
 
 
 func genTuple(c: var TypeInfoCache, t: PType, cl: var GenClosure): GenResult =
@@ -691,9 +716,7 @@ func calcSizeAndAlign(t: var VmType): SizeAlignTuple =
   t.sizeInBytes = result[0]
   t.alignment = result[1]
 
-func genAllTypes(c: var TypeInfoCache, typ: PType, cl: var GenClosure): PVmType =
-  result = genType(c, typ, cl).typ
-
+func genAllTypes(c: var TypeInfoCache, cl: var GenClosure) =
   # generate all queued object types
   var i = 0
   while i < cl.queue.len:
@@ -719,17 +742,19 @@ proc getOrCreate*(
   c: var TypeInfoCache,
   conf: ConfigRef,
   typ: PType,
+  noClosure: bool,
   cl: var GenClosure): PVmType {.inline.} =
   ## Lookup or create the `VmType` corresponding to `typ`. If a new type is
   ## created, the `PType` -> `PVmType` mapping is cached
   cl.queue.setLen(0)
   cl.conf = conf
 
-  genAllTypes(c, typ, cl)
+  result = genType(c, typ, cl, noClosure).typ
+  genAllTypes(c, cl)
 
-proc getOrCreate*(c: var TCtx, typ: PType): PVmType {.inline.} =
+proc getOrCreate*(c: var TCtx, typ: PType; noClosure = false): PVmType {.inline.} =
   var cl: GenClosure
-  getOrCreate(c.typeInfoCache, c.config, typ, cl)
+  getOrCreate(c.typeInfoCache, c.config, typ, noClosure, cl)
 
 
 func lookup*(c: TypeInfoCache, conf: ConfigRef, typ: PType): Option[PVmType] =
@@ -785,3 +810,15 @@ func makeSignatureId*(c: var TypeInfoCache, typ: PType): RoutineSigId =
   if result == c.nextSigId:
     # a table entry was just created:
     inc int(c.nextSigId)
+
+proc initRootRef*(c: var TypeInfoCache, config: ConfigRef, root: PType) =
+  ## Sets up the ``rootRef`` field for `c`. `root` must be the ``PType`` for
+  ## the ``RootObj`` type.
+  var
+    cl = GenClosure()
+    typ = VmType(kind: akRef,
+                 targetType: getOrCreate(c, config, root, false, cl))
+  (typ.sizeInBytes, typ.alignment) = c.staticInfo[akRef]
+
+  let (id, _) = c.types.getOrIncl(c.structs, hash(typ), typ)
+  c.rootRef = c.types[id]

--- a/compiler/vm/vmtypegen.nim
+++ b/compiler/vm/vmtypegen.nim
@@ -54,7 +54,7 @@ func hash(t: VmType): Hash =
     of akSeq:                 hash(t.seqElemType)
     of akPtr, akRef:          hash(t.targetType)
     of akSet:                 hash(t.setLength)
-    of akCallable, akClosure: hash(t.routineSig.int)
+    of akCallable:            hash(t.routineSig.int)
     of akDiscriminator:       hash(t.numBits)
     of akArray:               hash(t.elementCount) !& hash(t.elementType)
     of akObject:
@@ -80,7 +80,7 @@ func `==`(a, b: VmType): bool =
   of akSeq:                 cmpField(seqElemType)
   of akPtr, akRef:          cmpField(targetType)
   of akSet:                 cmpField(setLength)
-  of akCallable, akClosure: cmpField(routineSig)
+  of akCallable:            cmpField(routineSig)
   of akDiscriminator:
     # XXX: just testing for `numBits` means that `a: range[0..2]` and
     #      `b: range[0..3]` are treated as the same type!

--- a/tests/compiler/tvmbackend.nim
+++ b/tests/compiler/tvmbackend.nim
@@ -70,7 +70,7 @@ block:
 
   env.globals = @[typId2]
   env.functions =
-    @[(4'u32, RoutineSigId(18), typId1, typId2, ckCallback, 3'u32, 2'u32)]
+    @[(4'u32, RoutineSigId(18), typId1, false, ckCallback, 3'u32, 2'u32)]
   env.callbacks = @["cb1", "cb2"]
 
   env.code = @[TInstr(14), TInstr(15)]


### PR DESCRIPTION
## Summary

Replace the VM's closure support with a simpler and much more generic
implementation. This makes the VM agnostic of how closures are
represented in-memory, thus giving the core language control over their
representation.

## Details

The VM previously only supported closures to be represented as a
procedure address + `ref` pair. That significantly restricts the
core language and effectively prevents support for stack-allocated
closure environments.

Closure support is now reduced to a calling convention: if the invoked
procedure is marked as using the `.closure` calling convention, the
real number of arguments is the number of arguments specified + 1.

### VM changes

* remove the `akCallable` type kind and everything related to it
* remove the `opcAccessEnv` and `opcWrClosure` opcodes and
  corresponding implementation
* `FuncTableEntry` only stores whether the procedure uses the closure
  calling convention -- the `envParamType` field is removed

### Type translation

A closure type is translated to a tuple type equivalent to
`(proc, ref RootObj)` (where `proc` is a procedure type). Since
`tyProc` with `callConv=ccClosure` can mean both "closure" and
"procedure type", all type translation routines now accept an
additional `noClosure` parameter that specifies which interpretation to
use.

The `ref RootObj` type is cached such that `vmtypegen` doesn't have to
re-generate it each time it's needed. However, the `ref RootObj` cannot
be set up in `initCtx`, as:
* the `vmtypegen` module isn't available there
* the `RootObj` type might not have been defined yet

Instead, the new `initRootRef` procedure is expected to be called prior
to translating closure types. The direction is to lower closure types
during the MIR phase, which will allow for removing the aforementioned
type translation additions and workarounds again.

### Code generator changes

For calls where the callee is a closure, `vmgen` allocates
arguments + 1 registers and unpacks the closure (i.e., the tuple): the
procedure address goes into the usual callee register while the
environment ref goes into the last register. If at run-time the callee
isn't a procedure using the `.closure` calling convention (which means
that the closure value represents a thunk), the trailing register is
ignored.

Multiple adjustments and additions are required now that the VM no
longer knows about closures:
* the `mIsNil` and `mEqProc` magics are implemented in bytecode. In the
  future, these magics should be lowered during the MIR phase
* `opcAccessEnv` is implemented in bytecode
* `opcWrClosure` is also implemented in bytecode. Because the
  type of the environment value expression is wrong (it's either
  `tyNil`) or a sub-type of `ref RootObj`, the handle has to be
  converted to a `ref RootObj` prior to being written to the
  destination
* in the context of the callee, the environment parameter has to be
  converted to the expected type first, as the caller is allowed (and
  does) pass it as a super-type `ref`

### De-/serialization

* create a thunk when putting a raw symbol into a register where a
  closure is expected (`putIntoReg`) -- this replaces the improper
  workaround
* update `serialize` and `deserialize` to treat closures as a tuple
  with two elements. `deserializeRef` is extended to support
  deserializing a full cell without having to know the cell's type at
  the callsite