### PR TITLE
refactor(sem): indirect operation analysis

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -488,6 +488,12 @@ proc copyNode*(src: PNode): PNode =
   copyNodeImpl(result, src):
     discard
 
+proc copyNodeWithKids*(src: PNode): PNode =
+  ## Creates a shallow copy of `src`, meaning that a copy of `src` is
+  ## created without deep-copying the tree.
+  copyNodeImpl(result, src):
+    result.sons = src.sons
+
 template transitionNodeKindCommon(k: TNodeKind) =
   let obj {.inject.} = n[]
   when defined(useNodeIds):


### PR DESCRIPTION
## Summary

Refactor analysis and processing of indirect operation AST
(`semIndirectOp`). The immediate processing now no longer modifies the
input AST.

## Details

* don't modify the callee expression slot. Use a temporary variable
  instead
* move all callee node error handling into a single place
* type callee expressions without a type (i.e., a statement) as
  `tyVoid`. This removes the need to guard against nil and allows for
  using a single `case` statement for the main processing
* introduce the `copyNodeWithKids` routine for performing the common
  shallow copy operation on nodes

In addition, the call to `semOpAux` in the `tyTypeDesc` case is
removed; `semConv` and `semObjConstr` analyze all operands themselves.