### PR TITLE
fix(sem): issues related to subscript analysis

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1193,6 +1193,8 @@ type
     adSemCallIndirectTypeMismatch
     adSemSystemNeeds
     adSemDisallowedNilDeref
+    adSemCannotDeref
+    adSemInvalidTupleSubscript
     adSemLocalEscapesStackFrame
     adSemImplicitAddrIsNotFirstParam
     adSemCannotAssignTo
@@ -1331,6 +1333,7 @@ type
         adSemExpectedObjectForOf,
         adSemCannotBeOfSubtype,
         adSemDisallowedNilDeref,
+        adSemCannotDeref,
         adSemCannotReturnTypeless,
         adSemExpectedValueForYield,
         adSemNamedExprExpected,
@@ -1472,6 +1475,9 @@ type
       ordRange*: PType
     of adSemExpectedOrdinal:
       nonOrdTyp*: PType
+    of adSemInvalidTupleSubscript:
+      tupleIndex*: int
+      tupleLen*: int
     of adSemRecursiveDependencyIterator:
       recurrCallee*: PSym
     of adSemCallIndirectTypeMismatch:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -532,6 +532,7 @@ type
     rsemRecursiveDependencyIterator
     rsemIllegalNimvmContext
     rsemDisallowedNilDeref
+    rsemCannotDeref
     rsemInvalidTupleSubscript
     rsemLocalEscapesStackFrame
     rsemImplicitAddrIsNotFirstParam

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -559,6 +559,8 @@ func astDiagToLegacyReportKind*(
   of adSemCallIndirectTypeMismatch: rsemCallIndirectTypeMismatch
   of adSemSystemNeeds: rsemSystemNeeds
   of adSemDisallowedNilDeref: rsemDisallowedNilDeref
+  of adSemCannotDeref: rsemCannotDeref
+  of adSemInvalidTupleSubscript: rsemInvalidTupleSubscript
   of adSemLocalEscapesStackFrame: rsemLocalEscapesStackFrame
   of adSemImplicitAddrIsNotFirstParam: rsemImplicitAddrIsNotFirstParam
   of adSemCannotAssignTo: rsemCannotAssignTo

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -644,14 +644,15 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   newInst.typ.flags.excl tfUnresolved
   newSymNode(newInst, info)
 
-proc explicitGenericInstantiation(c: PContext, n: PNode): PNode =
+proc explicitGenericInstantiation(c: PContext, a: PNode, n: PNode): PNode =
+  ## Resolves the instantiation expression `n` to a single symbol or symbol
+  ## choice. `a` is the symbol-like node denoting the overloads to consider.
   assert n.kind == nkBracketExpr
   # analyse the operands first
   let args = semGenericArgs(c, n)
   if args.kind == nkError:
     return args
 
-  let a = n[0]
   case a.kind
   of nkSym:
     # common case; check the only candidate has the right

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -76,7 +76,7 @@ proc semArrGet(c: PContext; n: PNode; flags: TExprFlags): PNode =
       result.add(n[i])
     result = semSubscript(c, result, flags)
 
-  if result.isNil:
+  if result.kind == nkCall:
     let x = copyTree(n)
     x[0] = newIdentNode(getIdent(c.cache, "[]"), n.info)
     result = bracketNotFoundError(c, x)

--- a/tests/errmsgs/tout_of_bounds_tuple.nim
+++ b/tests/errmsgs/tout_of_bounds_tuple.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "invalid index value (4) for tuple subscript. Tuple has 2 element(s)"
+  line: 6
+"""
+
+discard (1, 2)[4]

--- a/tests/lang_callable/generics/tnullary_generic_proc_value.nim
+++ b/tests/lang_callable/generics/tnullary_generic_proc_value.nim
@@ -1,0 +1,12 @@
+discard """
+  description: '''
+    Ensure that nullary generic procedures can be explicitly instantiated and
+    the result treated as a first-class procedural value
+  '''
+"""
+
+proc nullary[](x: int): int =
+  result = x
+
+let p = nullary[]
+doAssert p(1) == 1

--- a/tests/lang_callable/overload/toverload_pointer_to_array_bracket.nim
+++ b/tests/lang_callable/overload/toverload_pointer_to_array_bracket.nim
@@ -1,0 +1,39 @@
+discard """
+  description: '''
+    Regression test for pointer-to-array and pointer-to-tuple bracket
+    overloads being ignored
+  '''
+"""
+
+var
+  arr = [1]
+  tup = (2,)
+  arrPtr = addr arr
+  tupPtr = addr tup
+
+# test bracket assignment overload for pointer-to-array and pointer-to-tuple
+# types
+
+template `[]=`(x: ptr array[1, int], y: string, val: int) =
+  # `y`'s value is not relevant. It's only important that the parameter has a
+  # type that's incompatible with the array's index type
+  x[][0] = val
+
+arrPtr[""] = 2
+
+template `[]=`(x: ptr tuple[v: int], y: string, val: int) =
+  x[][0] = val
+
+tupPtr[""] = 3
+
+# test bracket overload for pointer-to-array and pointer-to-tuple types
+
+template `[]`(x: ptr array[1, int], y: string): int =
+  x[][0]
+
+doAssert arrPtr[""] == 2
+
+template `[]`(x: ptr tuple[v: int], y: string): int =
+  x[][0]
+
+doAssert tupPtr[""] == 3

--- a/tests/lang_exprs/tinvalid_deref_expr.nim
+++ b/tests/lang_exprs/tinvalid_deref_expr.nim
@@ -1,0 +1,16 @@
+discard """
+  description: '''
+    Regression test for invalid macro-generated dereference expression
+    crashing the compiler
+  '''
+  errormsg: "the built-in dereference operator is only available for 'ptr' and 'ref' types"
+  line: 16
+"""
+
+import std/macros
+
+macro gen(x: untyped): untyped =
+  nnkDerefExpr.newTree(x)
+
+var val = 1 # not something that has a pointer-like type
+discard gen(val)


### PR DESCRIPTION
## Summary

Refactor subscript analysis to not mutate the input AST, which, as a
side-effect, fixes two issues:
* fix the `[]` and `[]=` operator overloads for pointer-to-array-like
  or ref-to-array-like types being ignored
* fix a compiler crash on macro-generated `nnkDerefExpr` AST where the
  operand is not a `ref` or `ptr` expression

In addition:
* the error message for an out-of-bounds tuple access now includes the
  provided index and tuple length
* nullary generic routines can now be instantiated outside of callee
  expressions using the `routine[]` syntax

## Details

* make `semDerefEval` a standalone procedure that expects a sem'ed
  pointer-like expression and always returns a non-nil AST
* change `semDeref` to return an error when the expression is not a
  valid deref expression

The analysis of subscript operations (`semSubscript`) is restructured
and changed:
* explicit generic instantiations are tested for first. This render the
  `tyStatic` handling obsolete and enables support for instantiating
  nullary generic routines outside of callee positions
* don't fold the result of a type instantiation into a symbol node.
  Doing so was inconsistent with what the `tyTypeDesc` branch does
  (which was the branch previously taken in most cases)
* `semDerefEval` is dispatched to directly (without going through
  `semDeref`), but only if the dereference operator is available for
  the type
* the array-like and tuple subscript analysis is changed to only insert
  dereference operations when the subscript operator is a built-in one.
  This fixes `[]` and `[]=` operator overloads for pointer-to-array-
  like types being ignored
* analysis for the array-like and tuple `[]` operator is changed to not
  mutate the input AST
* processing of `macroOrTempl[...]` expressions is still incorrect, but
  fixing the problem is outside the scope of this commit

Instead of returning 'nil' when the subscript operator is not a built-
in one, `semSubscript` now returns a `(Call (Ident '[]') ...)` AST.
This is necessary for keeping the already-analyzed argument
expressions without having to modify the input AST. The callsites of
`semSubscript` are adjusted accordingly.

Finally, tests and regression tests are added for the fixes and
changes.