### PR TITLE
CI: treat `XDeclaredButNotUsed` as an error

### DIFF
--- a/compiler/ast/checked_ast.nim
+++ b/compiler/ast/checked_ast.nim
@@ -110,7 +110,7 @@ func initWith*(x: var CheckedAst, n: sink PNode) =
   assert n.kind != nkError
   x.n = n
 
-func assign(x: var CheckedAst, n: sink PNode) {.inline.} =
+func assign*(x: var CheckedAst, n: sink PNode) {.inline.} =
   ## Assigns the tree `n` to `x`. The behaviour is undefined if `n` is either
   ## an error error or contains one.
   assert n != nil

--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -1171,22 +1171,6 @@ proc getPrecedence*(tok: Token): int =
   of tkOr, tkXor, tkPtr, tkRef: result = 3
   else: return -10
 
-proc newlineFollows(L: Lexer): bool =
-  var pos = L.bufpos
-  while true:
-    case L.buf[pos]
-    of ' ', '\t':
-      inc(pos)
-    of CR, LF:
-      result = true
-      break
-    of '#':
-      inc(pos)
-      if L.buf[pos] == '#': inc(pos)
-      if L.buf[pos] != '[': return true
-    else:
-      break
-
 proc skipMultiLineComment(L: var Lexer; tok: var Token; start: int;
                           isDoc: bool) =
   var pos = start
@@ -1524,21 +1508,6 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
         L.handleDiag(lexDiagInvalidToken, $c)
         inc(L.bufpos)
   atTokenEnd()
-
-proc getIndentWidth(fileIdx: FileIndex, inputstream: PLLStream;
-                     cache: IdentCache; config: ConfigRef): int =
-  var lex: Lexer
-  var tok: Token
-  initToken(tok)
-  openLexer(lex, fileIdx, inputstream, cache, config)
-  var prevToken = tkEof
-  while tok.tokType != tkEof:
-    rawGetTok(lex, tok)
-    if tok.indent > 0 and prevToken in {tkColon, tkEquals, tkType, tkConst, tkLet, tkVar, tkUsing}:
-      result = tok.indent
-      if result > 0: break
-    prevToken = tok.tokType
-  closeLexer(lex)
 
 proc getPrecedence*(ident: PIdent): int =
   ## assumes ident is binary operator already

--- a/compiler/ast/linter.nim
+++ b/compiler/ast/linter.nim
@@ -50,10 +50,6 @@ proc identLen*(line: string, start: int): int =
   while start+result < line.len and line[start+result] in Letters:
     inc result
 
-proc `=~`(s: string, a: openArray[string]): bool =
-  for x in a:
-    if s.startsWith(x): return true
-
 const 
   skContainers = {skModule, skPackage}
   skSingletonDef = {skType, skGenericParam}
@@ -227,10 +223,6 @@ proc styleCheckUse*(conf: ConfigRef; info: TLineInfo; s: PSym) =
   let newName = s.name.s
   let badName = differs(conf, info, newName)
   if badName.len > 0:
-    # special rules for historical reasons
-    let forceHint =
-      (badName == "nnkArgList" and newName == "nnkArglist") or
-      (badName == "nnkArglist" and newName == "nnkArgList")
     conf.localReport(info, SemReport(
       sym: s,
       info: info,

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -541,11 +541,8 @@ proc exprColonEqExprList(p: var Parser, kind: range[pnkPar..pnkSqrBracket],
   p.exprColonEqExprListAux(endTok, result)
 
 proc dotExpr(p: var Parser, a: ParsedNode): ParsedNode =
-  let dotTok = p.tok
   result = p.newNodeConsumingTok(pnkDotExpr, @[a])
   p.optInd(result)
-  # result.add a
-  let yTok = p.tok
   result.add p.parseSymbol(smAfterDot)
   if p.tok.tokType == tkBracketLeColon and p.tok.strongSpaceA <= 0:
     # rewrite 'x.y[:z]()' to 'y[z](x)'
@@ -1702,7 +1699,6 @@ proc parseGenericParam(p: var Parser): ParsedNode =
   while true:
     case p.tok.tokType
     of tkIn, tkOut:
-      let x = p.lex.cache.getIdent(if p.tok.tokType == tkIn: "in" else: "out")
       a = p.newNodeConsumingTok(pnkPrefix, @[p.newIdentNode(p.tok)])
       a.add parseSymbol(p)
     of tkSymbol, tkAccent:
@@ -1841,7 +1837,6 @@ proc parseEnum(p: var Parser): ParsedNode =
   # progress guaranteed
   while true:
     let
-      symTok = p.tok
       a = parseSymbol(p)
     if a.kind == pnkEmpty: return
 

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -55,9 +55,6 @@ proc reportObservableStore(p: BProc; le, ri: CgNode) =
      locationEscapes(p, le, p.nestedTryStmts.len > 0):
     localReport(p.config, le.info, reportSem rsemObservableStores)
 
-proc hasNoInit(call: CgNode): bool {.inline.} =
-  result = call[0].kind == cnkSym and sfNoInit in call[0].sym.flags
-
 proc isHarmlessStore(p: BProc; canRaise: bool; d: TLoc): bool =
   if d.k in {locTemp, locNone} or not canRaise:
     result = true

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2123,17 +2123,17 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
     putIntoDest(p, d, n, genLiteral(p, n))
   of cnkCall:
     genLineDir(p, n) # may be redundant, it is generated in fixupCall as well
-    let op = n[0]
+    let m = getCalleeMagic(n[0])
     if n.typ.isNil:
       # discard the value:
       var a: TLoc
-      if (let m = getCalleeMagic(n[0]); m != mNone):
+      if m != mNone:
         genMagicExpr(p, n, a, m)
       else:
         genCall(p, n, a)
     else:
       # load it into 'd':
-      if (let m = getCalleeMagic(n[0]); m != mNone):
+      if m != mNone:
         genMagicExpr(p, n, d, m)
       else:
         genCall(p, n, d)

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -810,10 +810,6 @@ proc linkViaResponseFile(conf: ConfigRef; cmd: string) =
   finally:
     removeFile(linkerArgs)
 
-proc getObjFilePath(conf: ConfigRef, f: Cfile): string =
-  if noAbsolutePaths(conf): f.obj.extractFilename
-  else: f.obj.string
-
 proc displayProgressCC(conf: ConfigRef, path, compileCmd: string): string =
   if conf.hasHint(rcmdCompiling):
     conf.localReport CmdReport(

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1070,7 +1070,6 @@ proc genFieldAddr(p: PProc, n: CgNode, r: var TCompRes) =
 proc genFieldAccess(p: PProc, n: CgNode, r: var TCompRes) =
   gen(p, n[0], r)
   r.typ = mapType(n.typ)
-  let otyp = skipTypes(n[0].typ, abstractVarRange)
 
   template mkTemp(i: int) =
     if r.typ == etyBaseIndex:

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2567,23 +2567,6 @@ proc presentFailedCandidates(
 
   result = (prefer, candidates)
 
-proc genFeatureDesc[T: enum](t: typedesc[T]): string {.compileTime.} =
-  result = ""
-  for f in T:
-    if result.len > 0: result.add "|"
-    result.add $f
-
-const
-  HelpMessage = "Nim Compiler Version $1 [$2: $3]\n" &
-      "Copyright (c) 2006-" & copyrightYear & " by Andreas Rumpf\n"
-  CommitMessage = "Source hash: $1\n" &
-    "Source date: $2\n"
-
-  Usage = staticRead"../doc/basicopt.txt".replace(" //", "   ")
-  AdvancedUsage = staticRead"../doc/advopt.txt".replace(" //", "   ") %
-    genFeatureDesc(Feature)
-
-
 proc reportBody*(conf: ConfigRef, r: InternalReport): string =
   assertKind r
   case InternalReportKind(r.kind):
@@ -2884,7 +2867,6 @@ proc reportShort*(conf: ConfigRef, r: BackendReport): string =
 
 proc reportBody*(conf: ConfigRef, r: VMReport): string =
   proc render(n: PNode, rf = defaultRenderFlags): string = renderTree(n, rf)
-  proc render(t: PType): string = typeToString(t)
 
   case VMReportKind(r.kind)
   of rvmUserError:

--- a/compiler/front/cmdlinehelper.nim
+++ b/compiler/front/cmdlinehelper.nim
@@ -80,17 +80,6 @@ proc writeConfigEvent(conf: ConfigRef,
 
   let
     showKindSuffix = conf.hasHint(rintErrKind)
-    pathInfo =
-      case evt.kind
-      of cekParseExpectedX, cekParseExpectedCloseX, cekParseExpectedIdent,
-           cekInvalidDirective, cekWriteConfig, cekProgressPathAdded:
-        evt.location
-      of cekInternalError, cekLexerErrorDiag, cekLexerWarningDiag:
-        evt.lexerDiag.location
-      of cekFlagError:
-        evt.flagInfo
-      of cekProgressConfStart:
-        unknownLineInfo
     useColor = if conf.cmd == cmdIdeTools: false else: conf.useColor()
     msgKindTxt =
       case evt.kind

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -87,9 +87,6 @@ proc writeln*(conf: ConfigRef, dest: static[CmdOutputKind], msg: string) =
 # temporary home for formatting output during early cli/config phase; this
 # should move to a better suited module.
 
-const
-  pathFmtStr = "$#($#, $#)" ## filename(line, column)
-
 func stylize*(str: string, color: ForegroundColor, styles: set[Style] = {}): string =
   if str.len == 0:
     result = str

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -411,9 +411,9 @@ template changed(conf: ConfigRef, s: ConfNoteSet, body: untyped) =
   # Template for debugging purposes - single place to track all changes in
   # the enabled note sets.
   when defined(debug):
-    let before = conf.active.noteSets[s]
+    let before {.used.} = conf.active.noteSets[s]
     body
-    let after = conf.active.noteSets[s]
+    let after {.used.} = conf.active.noteSets[s]
 
     # let n = rintMsgOrigin
     # if (n in before) != (n in after):
@@ -461,7 +461,7 @@ template changedOpts(conf: ConfigRef, body: untyped) =
     let before = conf.localOptions
     body
     let after = conf.localOptions
-    let removed = (optHints in before) and (optHints notin after)
+    let removed {.used.} = (optHints in before) and (optHints notin after)
 
   else:
     body

--- a/compiler/front/optionsprocessor.nim
+++ b/compiler/front/optionsprocessor.nim
@@ -590,13 +590,6 @@ proc processCompile(conf: ConfigRef; filename: string) =
 const
   gcNames = @["destructors", "arc", "orc"]
 
-  cmdNames = @[
-    "c", "cc", "compile", "compiletoc",
-    "compiletooc", "js", "compiletojs", "r", "run", "check", "e",
-    "doc2", "doc", "doc2tex", "rst2html", "rst2tex", "jsondoc2",
-    "jsondoc", "ctags", "buildindex", "gendepend", "dump", "parse", "rod",
-    "secret", "nop", "help", "jsonscript",]
-
 type
   CompileOptArgCheckResult* = enum
     compileOptArgCheckSuccessTrue

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -305,13 +305,6 @@ func applySource(frag: var CodeFragment, sp: var SourceProvider) =
   if frag.nodes.len > frag.source.len:
     apply(frag, prepareForUse(sp))
 
-func addWithSource(frag: var CodeFragment, sp: var SourceProvider,
-                   n: sink MirNode, src: PNode) =
-  ## Adds `n` to `frag` and associates the node with `src`
-  applySource(frag, sp)
-  frag.nodes.add n
-  frag.source.add sp.store.add(src)
-
 template useSource(frag: var CodeFragment, sp: var SourceProvider,
                    origin: PNode) =
   ## Pushes `origin` to be used as the source for the rest of the scope that
@@ -485,7 +478,6 @@ proc genAndOr(c: var TCtx, n: PNode, dest: Destination) =
   #       into a single one before and the logic here adjusted to handle them.
   #       With the aforementioned transformation, the previously mentioned
   #       example would become: ``or(a, b, c)``
-  let label = nextLabel(c)
   genAsgn(c, dest, n[1]) # the left-hand side
 
   # condition:

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -15,24 +15,24 @@ type
   ## interpreted. For example, a ``ParamId`` could be the index of the
   ## parameter or it could be an index into a list of symbols.
 
-  LocalId = distinct uint32
+  LocalId {.used.} = distinct uint32
     ## Identifies a local inside a code fragment
-  GlobalId = distinct uint32
+  GlobalId {.used.} = distinct uint32
     ## Identifies a global inside a code fragment
-  ConstId = distinct uint32
+  ConstId {.used.} = distinct uint32
     ## Identifies a named constant inside a code fragment
-  ParamId = distinct uint32
+  ParamId {.used.} = distinct uint32
     ## Identifies a parameter of the code fragment
-  FieldId = distinct uint32
+  FieldId {.used.} = distinct uint32
     ## Identifies the field of a record type
-  ProcedureId = distinct uint32
+  ProcedureId {.used.} = distinct uint32
     ## Identifies a procedure
-  LiteralId = distinct uint32
+  LiteralId {.used.} = distinct uint32
     ## Identifies a literal
 
-  TypeInstance = distinct uint32
+  TypeInstance {.used.} = distinct uint32
     ## Refers to an existing type instance
-  TypeId = distinct uint32
+  TypeId {.used.} = distinct uint32
     ## The ID of a type instance or nil
 
 type

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -1,7 +1,5 @@
 # Special configuration file for the Nim project
 
-hint[XDeclaredButNotUsed]:off
-
 define:booting
 define:nimcore
 define:nimPreviewFloatRoundtrip

--- a/compiler/nimfix/nimfix.nim.cfg
+++ b/compiler/nimfix/nimfix.nim.cfg
@@ -1,5 +1,4 @@
 # Special configuration file for the Nim project
-hint[XDeclaredButNotUsed]:off
 path:"$projectPath/.."
 
 path:"$lib/packages/docutils"

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -58,7 +58,6 @@ const
   someSub = {mSubI, mSubF64, mPred}
   someMul = {mMulI, mMulF64}
   someDiv = {mDivI, mDivF64}
-  someMod = {mModI}
   someMax = {mMaxI}
   someMin = {mMinI}
   someBinaryOp = someAdd+someSub+someMul+someMax+someMin

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -294,10 +294,6 @@ func getAliveRange(entities: EntityDict, name: EntityName, exists: var bool
     # ``info.def`` for the start and not ``info.scope.b``
     result = info.def .. info.scope.b
 
-func paramType(p: PSym, i: Natural): PType =
-  assert p.kind in routineKinds
-  p.typ[1 + i]
-
 proc getVoidType(g: ModuleGraph): PType {.inline.} =
   g.getSysType(unknownLineInfo, tyVoid)
 
@@ -1129,7 +1125,6 @@ proc lowerBranchSwitch(buf: var MirNodeSeq, body: MirTree, graph: ModuleGraph,
 
     let
       boolTyp = graph.getSysType(unknownLineInfo, tyBool)
-      voidTyp = graph.getSysType(unknownLineInfo, tyVoid)
 
     # XXX: comparing the discrimant values here means that the branch is
     #      destroyed even if the branch doesn't change. This differs from

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -478,12 +478,6 @@ proc newSeqCall(c: var TLiftCtx; x, y: PNode): PNode =
   lenCall.typ = getSysType(c.g, x.info, tyInt)
   result.add lenCall
 
-proc setLenStrCall(c: var TLiftCtx; x, y: PNode): PNode =
-  let lenCall = genBuiltin(c, mLengthStr, "len", y)
-  lenCall.typ = getSysType(c.g, x.info, tyInt)
-  result = genBuiltin(c, mSetLengthStr, "setLen", x) # genAddr(g, x))
-  result.add lenCall
-
 proc setLenSeqCall(c: var TLiftCtx; t: PType; x, y: PNode): PNode =
   let lenCall = genBuiltin(c, mLengthSeq, "len", y)
   lenCall.typ = getSysType(c.g, x.info, tyInt)

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -555,7 +555,6 @@ iterator traverseReverse*(tree: MirTree, c: ControlFlowGraph,
 
   exit = false
 
-  var trace = ""
   # move the program counter to the CFG instruction that marks the start of the
   # basic block `start` is located inside. While doing so, collect the loops
   # the start position is located inside:

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -286,7 +286,7 @@ proc history(map: NilMap, index: ExprIndex): seq[SemNilHistory] =
 
 
 proc symbol(n: PNode): Symbol
-func `$`(map: NilMap): string
+func `$`(map: NilMap): string {.used.}
 proc reverseDirect(map: NilMap): NilMap
 proc checkBranch(n: PNode, ctx: NilCheckerContext, map: NilMap): Check
 proc hasUnstructuredControlFlowJump(n: PNode): bool
@@ -311,6 +311,7 @@ proc symbol(n: PNode): Symbol =
   # echo "symbol ", n, " ", n.kind, " ", result.int
 
 func `$`(map: NilMap): string =
+  # intended for debugging
   var now = map
   var stack: seq[NilMap] = @[]
   while not now.isNil:
@@ -350,7 +351,8 @@ proc namedSetsDebugInfo(ctx: NilCheckerContext, map: NilMap): string =
     result.add("} ")
   result.add("\n")
 
-proc namedMapAndSetsDebugInfo(ctx: NilCheckerContext, map: NilMap): string =
+proc namedMapAndSetsDebugInfo(ctx: NilCheckerContext,
+                              map: NilMap): string {.used.} =
   result = namedMapDebugInfo(ctx, map) & namedSetsDebugInfo(ctx, map)
 
 

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -90,6 +90,8 @@ from compiler/ast/report_enums import ReportKind
 #   returns safe
 # each check returns its nilability and map
 
+{.pragma: debug, used, deprecated: "do not use in final build".}
+
 type
   SeqOfDistinct[T, U] = distinct seq[U]
 
@@ -286,7 +288,7 @@ proc history(map: NilMap, index: ExprIndex): seq[SemNilHistory] =
 
 
 proc symbol(n: PNode): Symbol
-func `$`(map: NilMap): string {.used.}
+func `$`(map: NilMap): string {.debug.}
 proc reverseDirect(map: NilMap): NilMap
 proc checkBranch(n: PNode, ctx: NilCheckerContext, map: NilMap): Check
 proc hasUnstructuredControlFlowJump(n: PNode): bool
@@ -352,7 +354,7 @@ proc namedSetsDebugInfo(ctx: NilCheckerContext, map: NilMap): string =
   result.add("\n")
 
 proc namedMapAndSetsDebugInfo(ctx: NilCheckerContext,
-                              map: NilMap): string {.used.} =
+                              map: NilMap): string {.debug.} =
   result = namedMapDebugInfo(ctx, map) & namedSetsDebugInfo(ctx, map)
 
 

--- a/compiler/sem/procfind.nim
+++ b/compiler/sem/procfind.nim
@@ -45,12 +45,10 @@ proc equalGenericParams(procA, procB: PNode): bool =
   result = true
 
 proc searchForProcAux(c: PContext, scope: PScope, fn: PSym): PSym =
-  const flags = {ExactGenericParams, ExactTypeDescValues,
-                 ExactConstraints, IgnoreCC}
   var it: TIdentIter
   result = initIdentIter(it, scope.symbols, fn.name)
   while result != nil:
-    if result.kind == fn.kind: #and sameType(result.typ, fn.typ, flags):
+    if result.kind == fn.kind:
       case equalParams(result.typ.n, fn.typ.n)
       of paramsEqual:
         if (sfExported notin result.flags) and (sfExported in fn.flags):

--- a/compiler/sem/procfind.nim
+++ b/compiler/sem/procfind.nim
@@ -29,7 +29,8 @@ import
 from compiler/ast/reports_sem import reportSym
 from compiler/ast/report_enums import ReportKind
 
-proc equalGenericParams(procA, procB: PNode): bool =
+proc equalGenericParams(procA, procB: PNode): bool {.used.} =
+  # currently unused, but might be used again
   if procA.len != procB.len: return false
   for i in 0..<procA.len:
     if procA[i].kind != nkSym:

--- a/compiler/sem/rodutils.nim
+++ b/compiler/sem/rodutils.nim
@@ -31,9 +31,6 @@ when defined(windows) and defined(bcc):
   #endif
   """.}
 
-proc c_snprintf(s: cstring; n:uint; frmt: cstring): cint {.importc: "snprintf", header: "<stdio.h>", nodecl, varargs.}
-
-
 when not declared(signbit):
   proc c_signbit(x: SomeFloat): cint {.importc: "signbit", header: "<math.h>".}
   proc signbit*(x: SomeFloat): bool {.inline.} =

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -147,23 +147,6 @@ proc wrapErrorAndUpdate(c: ConfigRef, n: PNode, s: PSym): PNode =
   result = c.wrapError(n)
   s.ast = result
 
-proc deltaTrace(stopProc, indent: string, entries: seq[StackTraceEntry])
-  {.inline.} =
-  # find the actual StackTraceEntry index based on the name
-  let endsWith = entries.len - 1
-  var startFrom = 0
-  for i in countdown(endsWith, 0):
-    let e = entries[i]
-    if i != endsWith and $e.procname == stopProc: # found the previous
-      startFrom = i + 1
-      break                                       # skip the rest
-
-  # print the trace oldest (startFrom) to newest (endsWith)
-  for i in startFrom..endsWith:
-    let e = entries[i]
-    echo:
-      "$1| $2 $3($4)" % [indent, $e.procname, $e.filename, $e.line]
-
 template semIdeForTemplateOrGenericCheck(conf, n, cursorInBody) =
   # use only for idetools support; detecting cursor in generic or template body
   # if so call `semIdeForTemplateOrGeneric` for semantic checking

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -560,10 +560,6 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   result.typ = finalCallee.typ[0]
   result = updateDefaultParams(c.config, result)
 
-proc canDeref(n: PNode): bool {.inline.} =
-  result = n.len >= 2 and (let t = n[1].typ;
-    t != nil and t.skipTypes({tyGenericInst, tyAlias, tySink}).kind in {tyPtr, tyRef})
-
 proc semOverloadedCall(c: PContext, n: PNode,
                        filter: TSymKinds, flags: TExprFlags): PNode {.nosinks.} =
   addInNimDebugUtils(c.config, "semOverloadedCall", n, result)

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -680,17 +680,6 @@ proc changeType(c: PContext, n: PNode, newType: PType, check: bool): PNode =
     result = c.config.wrapError(result)
 
 
-proc arrayConstrType(c: PContext, n: PNode): PType =
-  var typ = newTypeS(tyArray, c)
-  rawAddSon(typ, nil)     # index type
-  if n.len == 0:
-    rawAddSon(typ, newTypeS(tyEmpty, c)) # needs an empty basetype!
-  else:
-    var t = skipTypes(n[0].typ, {tyGenericInst, tyVar, tyLent, tyOrdinal, tyAlias, tySink})
-    addSonSkipIntLit(typ, t, c.idgen)
-  typ[0] = makeRangeType(c, 0, n.len - 1, n.info)
-  result = typ
-
 proc semArrayElementIndex(c: PContext, n: PNode, formalIdx: PType
                          ): tuple[n: PNode, val: Int128] =
   ## Analyses the array element expression `n`, producing either the
@@ -2744,7 +2733,7 @@ proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   let oldInGenericInst = c.inGenericInst
   let oldProcCon = c.p
   c.generics = @[]
-  var err: string
+
   try:
     result = semExpr(c, n, flags)
     if result != nil and efNoSem2Check notin flags:

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -198,21 +198,6 @@ proc ordinalValToString(a: PNode; g: ModuleGraph): string =
   else:
     unreachable("non-ordinals never make it here")
 
-proc isFloatRange(t: PType): bool {.inline.} =
-  result = t.kind == tyRange and t[0].kind in {tyFloat..tyFloat64}
-
-proc isIntRange(t: PType): bool {.inline.} =
-  result = t.kind == tyRange and t[0].kind in {
-      tyInt..tyInt64, tyUInt8..tyUInt32}
-
-proc pickIntRange(a, b: PType): PType =
-  if isIntRange(a): result = a
-  elif isIntRange(b): result = b
-  else: result = a
-
-proc isIntRangeOrLit(t: PType): bool =
-  result = isIntRange(t) or isIntLit(t)
-
 proc evalOp*(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
   # b and c may be nil
   result = nil

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -352,7 +352,7 @@ proc initConstrContext(t: PType, initExpr: PNode): ObjConstrContext =
 proc computeRequiresInit(c: PContext, t: PType): bool =
   assert t.kind == tyObject
   var constrCtx = initConstrContext(t, newNode(nkObjConstr))
-  let initResult = checkConstructTypeAux(c, constrCtx)
+  discard checkConstructTypeAux(c, constrCtx)
   constrCtx.missingFields.len > 0
 
 proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode =
@@ -365,7 +365,7 @@ proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode =
   case objType.kind
   of tyObject:
     var constrCtx = initConstrContext(objType, newNodeI(nkObjConstr, n.info))
-    let initResult = checkConstructTypeAux(c, constrCtx)
+    discard checkConstructTypeAux(c, constrCtx)
     if constrCtx.missingFields.len > 0:
       result = c.config.newError(
                   n,

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -889,7 +889,6 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       result.add newIdentNode(getIdent(c.c.cache, "[]="), n.info)
       for i in 0..<a.len: result.add(a[i])
       result.add(b)
-      let a0 = semTemplBody(c, a[0])
       result = semTemplBodySons(c, result)
     of nkCurlyExpr:
       result = newNodeI(nkCall, n.info)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1891,7 +1891,11 @@ proc applyTypeSectionPragmas(c: PContext; pragmas, operand: PNode): PNode =
       discard "builtin pragma"
     else:
       let (ident, err) = considerQuotedIdent(c, key)
-      if strTableGet(c.userPragmas, ident) != nil:
+      if err != nil:
+        # XXX: use nkError instead (or don't report an error yet and allow a
+        #      macro to recover)
+        localReport(c.config, err)
+      elif strTableGet(c.userPragmas, ident) != nil:
         discard "User-defined pragma"
       else:
         var amb = false

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -81,7 +81,6 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
   var
     counter, x: BiggestInt
     e: PSym
-    base: PType
     identToReplace: ptr PNode
   counter = 0
   result = newOrPrevType(tyEnum, prev, c)
@@ -884,15 +883,6 @@ proc toLiterals*(vals: IntSet, t: PType): seq[PNode] =
       else:
         result.add newIntNode(nkIntLit, BiggestInt(val))
 
-
-proc toEnumFields(vals: IntSet, t: PType): seq[PSym] =
-  block:
-    let t = t.skipTypes(abstractRange)
-    assert(t.kind in {tyEnum, tyBool}, $t.kind)
-
-  for node in toLiterals(vals, t):
-    result.add node.sym
-
 proc missingInts(c: PContext, n: PNode): IntSet =
   var coveredCases = initIntSet()
   for i in 1..<n.len:
@@ -904,9 +894,6 @@ proc missingInts(c: PContext, n: PNode): IntSet =
 
 proc formatMissingBranches(c: PContext, n: PNode): seq[PNode] =
   toLiterals(missingInts(c, n) , n[0].typ)
-
-proc formatMissingEnums(c: PContext, n: PNode): seq[PSym] =
-  toEnumFields(missingInts(c, n) , n[0].typ)
 
 proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
                    father: PNode, rectype: PType) =
@@ -1843,7 +1830,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
   addInNimDebugUtils(c.config, "semTypeClass", n, prev, result)
   # if n.len == 0: return newConstraint(c, tyTypeClass)
   let
-    pragmas = n[1]
+    # the first slot stores the pragmas
     inherited = n[2]
 
   result = newOrPrevType(tyUserTypeClass, prev, c)
@@ -1851,7 +1838,6 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
   let owner = getCurrOwner(c)
   var
     candidateTypeSlot = newTypeWithSons(owner, tyAlias, @[c.errorType], c.idgen)
-    cycleDetector = initIntSet()
   result.sons = @[candidateTypeSlot]
   result.n = n
 

--- a/compiler/sem/sourcemap.nim
+++ b/compiler/sem/sourcemap.nim
@@ -57,10 +57,6 @@ proc child*(node: SourceNode): Child =
   Child(kind: cSourceNode, node: node)
 
 
-proc newSourceNode(line: int, column: int, path: string, node: SourceNode, name: string = ""): SourceNode =
-  SourceNode(line: line, column: column, source: path, name: name, children: @[child(node)])
-
-
 proc newSourceNode(line: int, column: int, path: string, s: string, name: string = ""): SourceNode =
   SourceNode(line: line, column: column, source: path, name: name, children: @[child(s)])
 

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -959,7 +959,6 @@ proc transformExpandToAst(c: PTransf, n: PNode): PNode =
 
   let
     call = n[1]
-    fntyp = call[0].typ ## the signature of the macro/template
     nimNodeTyp = sysTypeFromName(c.graph, n.info, "NimNode")
 
   result = copyNode(n)

--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -70,8 +70,6 @@ proc `<`(a, b: AbstractTime): bool {.borrow.}
 proc inc(x: var AbstractTime; diff = 1) {.borrow.}
 proc dec(x: var AbstractTime; diff = 1) {.borrow.}
 
-proc `$`(x: AbstractTime): string {.borrow.}
-
 type
   SubgraphFlag = enum
     isMutated, # graph might be mutated
@@ -545,10 +543,6 @@ const
 proc isConstSym(s: PSym): bool =
   result = s.kind in {skConst, skLet} or isConstParam(s)
 
-proc toString(n: PNode): string =
-  if n.kind == nkEmpty: result = "<empty>"
-  else: result = $n
-
 proc borrowFrom(c: var Partitions; dest: PSym; src: PNode) =
   let s = pathExpr(src, c.owner)
   if s == nil:
@@ -595,9 +589,6 @@ proc borrowingCall(c: var Partitions; destType: PType; n: PNode; i: int) =
       SemReport(kind: rsemCannotDetermineBorrowTarget))
 
 proc borrowingAsgn(c: var Partitions; dest, src: PNode) =
-  proc mutableParameter(n: PNode): bool {.inline.} =
-    result = n.kind == nkSym and n.sym.kind == skParam and n.sym.typ.kind == tyVar
-
   if dest.kind == nkSym:
     if directViewType(dest.typ) != noView:
       borrowFrom(c, dest.sym, src)

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -376,12 +376,6 @@ template dispA(conf: ConfigRef; dest: var string, xml, tex: string,
   if not conf.isLatexCmd: dest.addf(xml, args)
   else: dest.addf(tex, args)
 
-proc getVarIdx(varnames: openArray[string], id: string): int =
-  for i in 0..high(varnames):
-    if cmpIgnoreStyle(varnames[i], id) == 0:
-      return i
-  result = -1
-
 proc genComment(d: PDoc, n: PNode): PRstNode =
   if n.comment.len > 0:
     result = parseRst(n.comment, toFullPath(d.conf, n.info),

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -251,7 +251,7 @@ template declareClosures =
   proc compilerMsgHandler(
       filename: string, line, col: int,
       msgKind: rst.MsgKind, arg: string
-    ) {.gcsafe.} =
+    ) {.gcsafe, used.} =
     # translate msg kind:
     {.gcsafe.}:
       globalReport(conf, newLineInfo(
@@ -275,7 +275,7 @@ template declareClosures =
             of mwRstStyle:                rbackRstRstStyle
       ))
 
-  proc docgenFindFile(s: string): string {.gcsafe.} =
+  proc docgenFindFile(s: string): string {.gcsafe, used.} =
     result = options.findFile(conf, s).string
     if result.len == 0:
       result = getCurrentDir() / s

--- a/compiler/tools/docgen2.nim
+++ b/compiler/tools/docgen2.nim
@@ -46,7 +46,7 @@ proc shouldProcess(g: PGen): bool =
 template closeImpl(body: untyped) {.dirty.} =
   var g = PGen(p)
   let useWarning = sfMainModule notin g.module.flags
-  let groupedToc = true
+  let groupedToc {.used.} = true
   if shouldProcess(g):
     finishGenerateDoc(g.doc)
     body

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -69,6 +69,9 @@ import
 
 when defined(nimsuggest):
   import compiler/sem/passes, compiler/utils/pathutils # importer
+else:
+  # prevent warnings from routines only used by nimsuggest
+  {.push hint[XDeclaredButNotUsed]: off.}
 
 proc findDocComment(n: PNode): PNode =
   if n == nil: return nil

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -499,8 +499,8 @@ proc findDefinition(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym
 
 proc suggestSym*(g: ModuleGraph; info: TLineInfo; s: PSym; usageSym: var PSym; isDecl=true) {.inline.} =
   ## misnamed: should be 'symDeclared'
-  let conf = g.config
   when defined(nimsuggest):
+    let conf = g.config
     if s.allUsages.len == 0:
       s.allUsages = @[info]
     else:

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -320,7 +320,7 @@ template genFields(res: ColText, indent: int, rconf: TReprConf): untyped =
       res.add text
 
   proc field(name: string, cond: TReprFlag, text = default ColText,
-             rc = rconf) =
+             rc = rconf) {.used.} =
     if rc.packed():
       hfield(name, cond, text, rc)
     else:

--- a/compiler/utils/int128.nim
+++ b/compiler/utils/int128.nim
@@ -60,9 +60,6 @@ template isNegative(arg: int32): bool =
 proc bitconcat(a, b: uint32): uint64 =
   (uint64(a) shl 32) or uint64(b)
 
-proc bitsplit(a: uint64): (uint32, uint32) =
-  (cast[uint32](a shr 32), cast[uint32](a))
-
 proc toInt64*(arg: Int128): int64 =
   if isNegative(arg):
     assert(arg.sdata(3) == -1, "out of range")
@@ -207,12 +204,6 @@ proc `==`*(a, b: Int128): bool =
   if a.udata[2] != b.udata[2]: return false
   if a.udata[3] != b.udata[3]: return false
   return true
-
-proc inplaceBitnot(a: var Int128) =
-  a.udata[0] = not a.udata[0]
-  a.udata[1] = not a.udata[1]
-  a.udata[2] = not a.udata[2]
-  a.udata[3] = not a.udata[3]
 
 proc bitnot*(a: Int128): Int128 =
   result.udata[0] = not a.udata[0]

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -99,9 +99,6 @@ type
 
     oldErrorCount: int
 
-# to prevent endless recursion in macro instantiation
-const evalMacroLimit = 1000
-
 # prevent a default `$` implementation from being generated
 func `$`(e: ExecErrorReport): string {.error.}
 

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -332,7 +332,7 @@ template decodeBC(k: TRegisterKind) {.dirty.} =
   let rc = instr.regC
   ensureKind(k)
 
-template decodeBC(k: AtomKind) {.dirty.} =
+template decodeBC(k: AtomKind) {.dirty, used.} =
   let rb = instr.regB
   let rc = instr.regC
   ensureAtomKind(k)
@@ -346,7 +346,7 @@ template decodeBImm(k: TRegisterKind) {.dirty.} =
   let imm = instr.regC - byteExcess
   ensureKind(k)
 
-template decodeBImm(k: AtomKind) {.dirty.} =
+template decodeBImm(k: AtomKind) {.dirty, used.} =
   let rb = instr.regB
   let imm = instr.regC - byteExcess
   ensureAtomKind(k)
@@ -360,7 +360,7 @@ template decodeBx(k: TRegisterKind) {.dirty.} =
   let rbx = instr.regBx - wordExcess
   ensureKind(k)
 
-template decodeBx(k: AtomKind) {.dirty.} =
+template decodeBx(k: AtomKind) {.dirty, used.} =
   let rbx = instr.regBx - wordExcess
   ensureAtomKind(k)
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1147,18 +1147,6 @@ proc genBinaryABC(c: var TCtx; n: CgNode; dest: var TDest; opc: TOpcode) =
   c.freeTemp(tmp)
   c.freeTemp(tmp2)
 
-proc genBinaryABCD(c: var TCtx; n: CgNode; dest: var TDest; opc: TOpcode) =
-  prepare(c, dest, n, n.typ)
-  let
-    tmp = c.genx(n[1])
-    tmp2 = c.genx(n[2])
-    tmp3 = c.genx(n[3])
-  c.gABC(n, opc, dest, tmp, tmp2)
-  c.gABC(n, opc, tmp3)
-  c.freeTemp(tmp)
-  c.freeTemp(tmp2)
-  c.freeTemp(tmp3)
-
 proc genNarrow(c: var TCtx; n: CgNode; dest: TDest) =
   let t = skipTypes(n.typ, abstractVar-{tyTypeDesc})
   # uint is uint64 in the VM, we we only need to mask the result for

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -628,9 +628,6 @@ func newVmSeq*(s: var VmSeq, typ: PVmType, numItems: Natural, mm: var VmMemoryMa
 
   s = VmSeq(data: newData, length: numItems)
 
-template fullCell(p: CellPtr, a: VmAllocator): untyped =
-  byteView(mapToCell(a, p))
-
 proc copyVmSeq*(dest: var VmSeq, src: VmSeq, typ: PVmType, mm: var VmMemoryManager) =
   if dest.length > 0:
     destroyVmSeq(dest, typ, mm)

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -373,11 +373,6 @@ proc main*(args: seq[string]): int =
 
   let
     entryPoint = c.functions[lr.unsafeGet.int]
-    cb = proc (c: TCtx, r: TFullReg): PNode =
-      c.config.internalAssert(r.kind == rkInt):
-        "expected int return value" # either the executable is malformed or
-                                    # there's an issue with the code-generator
-      newIntNode(nkIntLit, r.intVal)
 
   # setup the starting frame:
   var frame = TStackFrame(prc: entryPoint.sym)

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -15,7 +15,6 @@ cc = gcc
 --parallel_build: "0" # 0 to auto-detect number of processors
 
 hint[LineTooLong]=off
-#hint[XDeclaredButNotUsed]=off
 
 # Examples of how to setup a cross-compiler:
 # Nim can target architectures and OSes different than the local host

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -316,7 +316,7 @@ cppDefine = "NAN"
 
   @if nimHasHintAsError:
     hintAsError:ConvFromXtoItselfNotNeeded:on
-    # future work: XDeclaredButNotUsed
+    hintAsError:XDeclaredButNotUsed:on
   @end
 @end
 

--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -111,7 +111,6 @@ proc intSetPut[A](t: var PackedSet[A], key: int): Trunk =
   t.data[h] = result
 
 proc bitincl[A](s: var PackedSet[A], key: int) {.inline.} =
-  var ret: Trunk
   var t = intSetPut(s, key shr TrunkShift)
   var u = key and TrunkMask
   t.bits[u shr IntShift] = t.bits[u shr IntShift] or

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -237,17 +237,6 @@ proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
 
   executeNoHooks(cmd, file, dirtyfile, line, col, graph)
 
-proc executeEpc(cmd: IdeCmd, args: SexpNode;
-                graph: ModuleGraph) =
-  let
-    file = AbsoluteFile args[0].getStr
-    line = args[1].getNum
-    column = args[2].getNum
-  var dirtyfile = AbsoluteFile""
-  if len(args) > 3:
-    dirtyfile = AbsoluteFile args[3].getStr("")
-  execute(cmd, file, dirtyfile, int(line), int(column), graph)
-
 proc returnEpc(socket: Socket, uid: BiggestInt, s: SexpNode|string,
                returnSymbol = "return") =
   let response = $convertSexp([newSSymbol(returnSymbol), uid, s])
@@ -336,10 +325,6 @@ proc toEpc(client: Socket; uid: BiggestInt) {.gcsafe.} =
     else:
       list.add sexp(res)
   returnEpc(client, uid, list)
-
-template setVerbosity(level: typed) =
-  gVerbosity = level
-  conf.notes = NotesVerbosity[gVerbosity]
 
 proc connectToNextFreePort(server: Socket, host: string): Port =
   server.bindAddr(Port(0), host)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -390,7 +390,7 @@ proc argsToStr(x: SexpNode): string =
   let line = x[1].getNum
   let col = x[2].getNum
   let dirty = x[3].getStr
-  result = x[0].getStr.escape
+  result = file.escape
   if dirty.len > 0:
     result.add ';'
     result.add dirty.escape

--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -2,8 +2,6 @@
 
 gc:orc
 
-hint[XDeclaredButNotUsed]:off
-
 define:useStdoutAsStdmsg
 define:nimsuggest
 define:nimcore


### PR DESCRIPTION
## Summary

* fix all `XDeclaredButNotUsed` warnings in the code bases of the
  compiler and tooling
* enable the hint for the compiler and associated tooling
* promote the hint to an error when strict mode (`-d:nimStrictMode`) is
  enabled

The aim is to prevent obsolete code from being merged or being left
behind after a cleanup/refactor.

## Details

The warnings are fixed through a mixture of approaches:
* unused routines and types that were unused for a long time
  and where it's unlikely that they'll become used again are removed
* unused locals with side-effect-less initializer are removed as a
  whole
* unused locals with side-effect-ful initializer expressions are
  replaced with `discard` statements
* symbols injected by templates are marked as `.used`
* currently unused routines and locals meant for debugging are kept and
  marked as `.used`
* some unused locals are not removed but instead made use of

A few places are of special note:
* the unused `a0` local in `semTemplBody` was assigned the result of
  a redundant `semTemplBody` call. The call does have side-effects, but
  thanks to in-place AST modifications the duplicate processing didn't
  cause problems
* the `assign` procedure in the `checked_ast` module was meant from the
  start to be exported
* there are multiple routines in the `suggest` module that are unused
  when building the compiler itself. `XDeclaredButNotUsed` hints are
  now disabled for the module when not building with the `nimsuggest`
  define

Finally, disabling the `XDeclaredButNotUsed` is removed from all
configuration files and the hint is promoted to an error when
`nimStrictMode` is enabled.