### PR TITLE
fix wrong C code for `addr` of `ref` conversions

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1996,7 +1996,7 @@ proc downConv(p: BProc, n: CgNode, d: var TLoc) =
       linefmt(p, cpsStmts, "if ($1 && !#isObj($2, $3)){ #raiseObjectConversionError(); $4}$n",
               [nilCheck, r, genTypeInfo2Name(p.module, dest), raiseInstr(p)])
 
-  if n.operand.typ.kind != tyObject:
+  if n.operand.typ.skipTypes(abstractInst).kind != tyObject:
     if lfWantLvalue in d.flags:
       putIntoDest(p, d, n,
                 "(($1*) ($2))" % [getTypeDesc(p.module, n.typ),

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -533,7 +533,7 @@ proc genAddr(p: BProc, e: CgNode, mutate: bool, d: var TLoc) =
   else:
     var a: TLoc
     initLoc(a, locNone, e.operand, OnUnknown)
-    a.flags.incl lfPreferAddr
+    a.flags.incl lfWantLvalue
     if mutate:
       a.flags.incl lfPrepareForMutation
 
@@ -1997,7 +1997,7 @@ proc downConv(p: BProc, n: CgNode, d: var TLoc) =
               [nilCheck, r, genTypeInfo2Name(p.module, dest), raiseInstr(p)])
 
   if n.operand.typ.kind != tyObject:
-    if lfPreferAddr in d.flags:
+    if lfWantLvalue in d.flags:
       putIntoDest(p, d, n,
                 "(($1*) (&($2)))" % [getTypeDesc(p.module, n.typ), rdLoc(a)], a.storage)
       d.flags.incl lfIndirect
@@ -2018,7 +2018,7 @@ proc upConv(p: BProc, n: CgNode, d: var TLoc) =
   let src = skipTypes(arg.typ, abstractPtrs)
   discard getTypeDesc(p.module, src)
   let isRef = skipTypes(n.typ, abstractInst).kind in {tyRef, tyPtr}
-  if isRef and d.k == locNone and lfPreferAddr in d.flags:
+  if isRef and d.k == locNone and lfWantLvalue in d.flags:
     # the address of the converted reference (i.e., pointer) is requested,
     # and since ``&&x->Sup`` is not valid, we take the address of the source
     # expression and then cast the pointer:

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1682,14 +1682,14 @@ proc genWasMoved(p: BProc; n: CgNode) =
   if p.withinBlockLeaveActions > 0 and notYetAlive(p, n1):
     discard
   else:
-    initLocExpr(p, n1, a)
+    initLocExpr(p, n1, a, {lfWantLvalue})
     resetLoc(p, a)
     #linefmt(p, cpsStmts, "#nimZeroMem((void*)$1, sizeof($2));$n",
     #  [addrLoc(p.config, a), getTypeDesc(p.module, a.t)])
 
 proc genMove(p: BProc; n: CgNode; d: var TLoc) =
   var a: TLoc
-  initLocExpr(p, n[1], a)
+  initLocExpr(p, n[1], a, {lfWantLvalue})
   if true:
     if d.k == locNone: getTemp(p, n.typ, d)
     genAssignment(p, d, a)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1999,7 +1999,8 @@ proc downConv(p: BProc, n: CgNode, d: var TLoc) =
   if n.operand.typ.kind != tyObject:
     if lfWantLvalue in d.flags:
       putIntoDest(p, d, n,
-                "(($1*) (&($2)))" % [getTypeDesc(p.module, n.typ), rdLoc(a)], a.storage)
+                "(($1*) ($2))" % [getTypeDesc(p.module, n.typ),
+                                  addrLoc(p.config, a)], a.storage)
       d.flags.incl lfIndirect
     else:
       putIntoDest(p, d, n,
@@ -2023,7 +2024,9 @@ proc upConv(p: BProc, n: CgNode, d: var TLoc) =
     # and since ``&&x->Sup`` is not valid, we take the address of the source
     # expression and then cast the pointer:
     putIntoDest(p, d, n,
-              "(($1*) (&($2)))" % [getTypeDesc(p.module, n.typ), rdLoc(a)], a.storage)
+                "(($1*) ($2))" % [getTypeDesc(p.module, n.typ),
+                                  addrLoc(p.config, a)],
+                a.storage)
     # an indirection is used:
     d.flags.incl lfIndirect
   else:

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -821,9 +821,9 @@ proc genAsgn(p: BProc, e: CgNode) =
     var a: TLoc
     discard getTypeDesc(p.module, le.typ.skipTypes(skipPtrs), skVar)
     initLoc(a, locNone, le, OnUnknown)
-    a.flags.incl {lfEnforceDeref, lfPrepareForMutation}
+    a.flags.incl {lfEnforceDeref, lfPrepareForMutation, lfWantLvalue}
     expr(p, le, a)
-    a.flags.excl lfPrepareForMutation
+    a.flags.excl {lfPrepareForMutation, lfWantLvalue}
     assert(a.t != nil)
     genLineDir(p, ri)
     loadInto(p, le, ri, a)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -584,6 +584,11 @@ proc initLocExpr(p: BProc, e: CgNode, result: var TLoc) =
   initLoc(result, locNone, e, OnUnknown)
   expr(p, e, result)
 
+proc initLocExpr(p: BProc, e: CgNode, result: var TLoc, flags: set[LocFlag]) =
+  initLoc(result, locNone, e, OnUnknown)
+  result.flags = flags
+  expr(p, e, result)
+
 proc initLocExprSingleUse(p: BProc, e: CgNode, result: var TLoc) =
   initLoc(result, locNone, e, OnUnknown)
   if e.kind == cnkCall and getCalleeMagic(e[0]) == mNone:

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -77,6 +77,8 @@ type
                              ## ptr array due to C array limitations.
                              ## See #1181, #6422, #11171
     lfPrepareForMutation     ## string location is about to be mutated
+    lfPreferAddr             ## on empty locs, signals that an address instead
+                             ## of a value is preferred (but not required)
 
   TLoc* = object
     k*: TLocKind              ## kind of location

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -77,8 +77,8 @@ type
                              ## ptr array due to C array limitations.
                              ## See #1181, #6422, #11171
     lfPrepareForMutation     ## string location is about to be mutated
-    lfPreferAddr             ## on empty locs, signals that an address instead
-                             ## of a value is preferred (but not required)
+    lfWantLvalue             ## on empty locs, signals that a C lvalue is
+                             ## expected
 
   TLoc* = object
     k*: TLocKind              ## kind of location

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -118,49 +118,6 @@ proc getRoot*(n: CgNode): CgNode =
       result = getRoot(n[1])
   else: discard
 
-proc isLValue*(n: CgNode): bool =
-  ## Duplicate of `isLValue <compiler/sem/parampatters.html#isLvalue,PNode>`_,
-  ## but simplified to the needs of the C code generator.
-  # XXX: remove this as soon as possible
-  case n.kind
-  of cnkEmpty:
-    n.typ.kind == tyVar
-  of cnkSym:
-    n.sym.kind == skVar
-  of cnkLocal:
-    # treat all locals as lvalues, even parameters
-    true
-  of cnkFieldAccess:
-    let t = skipTypes(n[0].typ, abstractInst-{tyTypeDesc})
-    t.kind in {tyVar, tySink, tyPtr, tyRef} or
-      (not isDiscriminantField(n) and isLValue(n[0]))
-  of cnkArrayAccess, cnkTupleAccess:
-    let t = skipTypes(n[0].typ, abstractInst-{tyTypeDesc})
-    t.kind in {tyVar, tySink, tyPtr, tyRef} or isLValue(n[0])
-  of cnkHiddenConv, cnkConv:
-    if skipTypes(n.typ, abstractPtrs-{tyTypeDesc}).kind in
-        {tyOpenArray, tyTuple, tyObject}:
-      isLValue(n.operand)
-    elif compareTypes(n.typ, n.operand.typ, dcEqIgnoreDistinct):
-      isLValue(n.operand)
-    else:
-      false
-  of cnkDerefView:
-    let n0 = n.operand
-    n0.typ.kind != tyLent or (n0.kind == cnkLocal and n0.local == resultId)
-  of cnkDeref, cnkHiddenAddr:
-    true
-  of cnkObjUpConv, cnkObjDownConv:
-    isLValue(n.operand)
-  of cnkCheckedFieldAccess:
-    isLValue(n[0])
-  of cnkCall:
-    (getMagic(n) == mSlice and isLValue(n[1])) or n.typ.kind in {tyVar}
-  of cnkStmtListExpr:
-    isLValue(n[^1])
-  else:
-    false
-
 proc canRaiseConservative*(fn: CgNode): bool =
   ## Duplicate of `canRaiseConservative <ast_query.html#canRaiseConservative,PNode>`_.
   # ``mNone`` is also included in the set, therefore this check works even for

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1498,8 +1498,15 @@ proc genx(c: var TCtx, n: PNode, consume: bool): EValue =
 
   of nkBracketExpr:
     genBracketExpr(c, n)
-  of nkObjDownConv, nkObjUpConv:
+  of nkObjDownConv:
     eval(c): genx(c, n[0], consume) => pathConv(n.typ)
+  of nkObjUpConv:
+    # discard conversions in the same direction that are used as the operand
+    var arg = n[0]
+    while arg.kind == nkObjUpConv:
+      arg = arg[0]
+
+    eval(c): genx(c, arg, consume) => pathConv(n.typ)
   of nkAddr:
     eval(c): genx(c, n[0]) => addrOp(n.typ)
   of nkHiddenAddr:

--- a/tests/misc/taddr_of_up_conversion.nim
+++ b/tests/misc/taddr_of_up_conversion.nim
@@ -1,0 +1,32 @@
+discard """
+  targets: "c js vm"
+  knownIssue.js: '''
+    jsgen handling for taking the address of up-conversions is missing
+  '''
+  description: "Ensure that taking the address of up-conversions works"
+"""
+
+type
+  Base = object of RootObj
+    value: int
+  Sub    = object of Base
+
+block addr_of_object:
+  let v1 = Sub(value: 1) # try with let
+  # assign to a variable so that taking the address is not folded away
+  var p = addr Base(v1)
+  doAssert p[].value == 1 # make sure that reading through the pointer works
+
+  var v2 = v1 # try with var
+  p = addr Base(v2)
+  doAssert p[].value == 1
+
+block addr_of_ref:
+  # same as the above, but with ref types
+  let v1 = (ref Sub)(value: 1)
+  var p = addr (ref Base)(v1)
+  doAssert p[].value == 1
+
+  var v2 = v1
+  p = addr (ref Base)(v2)
+  doAssert p[].value == 1

--- a/tests/misc/titer_inlining_regression.nim
+++ b/tests/misc/titer_inlining_regression.nim
@@ -1,0 +1,30 @@
+discard """
+  targets: "c js vm"
+  description: '''
+    Regression test for a C code generator bug triggered indirectly by
+    iterator inlining
+  '''
+"""
+
+# it's important for `Base` to be both a generic ref type
+type
+  Base[T] = ref object of RootObj
+  Sub     = ref object of Base[int]
+
+iterator iter(x: Base[int]): int =
+  # the iterator's body doesn't matter
+  discard
+
+proc get(x: Sub): lent Sub =
+  # a procedure that returns the borrowed parameter
+  x
+
+proc test() =
+  let v = Sub()
+  # an implicit up-conversion is inserted by the compiler for the iterator
+  # call's argument, which combined with the value coming from dereferencing
+  # a `lent` view resulted in a C code generator error
+  for it in iter(get(v)):
+    discard
+
+test()

--- a/tests/misc/titer_inlining_regression.nim
+++ b/tests/misc/titer_inlining_regression.nim
@@ -6,7 +6,7 @@ discard """
   '''
 """
 
-# it's important for `Base` to be both a generic ref type
+# it's important for `Base` to be both a generic and a ref type
 type
   Base[T] = ref object of RootObj
   Sub     = ref object of Base[int]


### PR DESCRIPTION
## Summary

Fix taking the address of a conversion of a `ref` (either explicitly
through the use of `addr` or implicitly as part of iterator inlining)
resulting in illegal C code being generated in some cases.

## Details

Emitting `&x->Sup` for up-conversions of `ref` values is wrong when the
expression needs to have its address taken, so the code generator
emits a cast of the `&x` instead.

Whether to the use this form was based on the operand expression, not
on how the resulting expression is used, and since the used analysis
(`compat.isLvalue`) is itself flawed, the wrong from was sometimes
used (e.g., `let` globals and `lent` dereferences).

### Fixing the issue

What code to generated for `ref` conversion is now decided based on
whether the expression is required to be an l-value, with the callsite
communicating this information this to `upConv` and `downConv` via the
new `lfWantsLvalue` flag.

The places where the flag needs to be set is where an expression has
its address taken directly or is used as the destination of an
assignment.

### Follow-on issues

The now-proper handling surfaced two pre-existing issues:
* `cgmeth.genConv` generated `(ObjUpConv (HiddenAddr x))` AST instead
  of the correct `(HiddenAddr (ObjUpConv x))` AST
* `cgen.downConv` treated generic object instance conversions as ref-
  conversion due to missing a `skipTypes` call

Both pre-existed issues are also fixed.

### Misc

The C code generated for up/down ref conversions is slightly improved:
`addrLoc` is now used for the operand and the destination loc is marked
as indirect. This prevents a redundant deref/take-address pair in some
cases.

In addition, discarding redundant up-conversion are now already skipped
in `mirgen`.