### PR TITLE
fix(sem): template/macro issues with `var`/`lent`

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -702,13 +702,13 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
         retType = generateTypeInstance(c, paramTypes,
                                        macroResult.info, retType)
 
-      result = semExpr(c, result, flags)
+      result = semExprWithType(c, result, flags)
       if resultTypeIsInferrable(retType):
         # this is a "return type inference" scenario. There's no return type
         # to infer, but the expression still needs to use the proper type
         result = inferWithMetatype(c, retType, result)
       else:
-        result = fitNode(c, retType, result, result.info)
+        result = fitNodeConsiderViewType(c, retType, result, result.info)
   dec(c.config.evalTemplateCounter)
   discard c.friendModules.pop()
 

--- a/lib/experimental/results.nim
+++ b/lib/experimental/results.nim
@@ -200,11 +200,8 @@ func `$`*[E](self: Result[void, E]): string =
   if self.isOk: "Ok()"
   else: "Err(" & $self.e & ")"
 
-# XXX: the `value` templates only use `untyped` in order to work around a
-#      compiler bug (https://github.com/nim-works/nimskull/issues/328).
-#      Once the bug is fixed, `T` should be used as the return type again
-template value*[T, E](self: Result[T, E]): untyped = get self
-template value*[T, E](self: var Result[T, E]): untyped = get self
+template value*[T, E](self: Result[T, E]): T = get self
+template value*[T, E](self: var Result[T, E]): var T = get self
 
 template value*[E](self: Result[void, E]) = get self
 template value*[E](self: var Result[void, E]) = get self

--- a/tests/lang_callable/template/tbody_is_var_lent_expression.nim
+++ b/tests/lang_callable/template/tbody_is_var_lent_expression.nim
@@ -1,0 +1,32 @@
+discard """
+  description: '''
+    Regression test for the case where the body of a template/macro with a
+    concrete return type is of `lent`/`var` tuple type resulted in wrong code
+    being generated
+  '''
+"""
+
+# the tuple type's content doesn't matter
+type Tuple = tuple[x: int]
+
+proc getVar(x: var Tuple): var Tuple = x
+proc getLent(x: Tuple): lent Tuple = x
+
+
+template templVar(x: Tuple): Tuple =
+  # using ``untyped`` as the return type would have the code work
+  # properly. The body was not properly typed, resulting in an implicit
+  # conversion from ``lent Tuple`` to ``Tuple`` being inserted by the
+  # compiler
+  getVar(x)
+
+template templLent(x: Tuple): Tuple =
+  getLent(x)
+
+var tup = (x: 1)
+
+let v = templLent(tup)
+doAssert v.x == 1
+
+let v2 = templVar(tup)
+doAssert v.x == 1

--- a/tests/lang_callable/varres/ttemplate_var_lent_res.nim
+++ b/tests/lang_callable/varres/ttemplate_var_lent_res.nim
@@ -1,0 +1,44 @@
+discard """
+  description: '''
+    Ensure that templates with `var` and `lent` return types behave the same
+    as normal procedures would
+  '''
+"""
+
+block scalar_type:
+  # test with a scalar type
+  template borrowVar(x: untyped): var int = x
+  template borrowLent(x: untyped): lent int = x
+
+  var v = 0
+  borrowVar(v) = 1 # test that an assignment works
+  doAssert borrowVar(v) == 1 # test that a read works
+  doAssert not compiles((borrowLent(v) = 2))
+  doAssert borrowLent(v) == 1
+
+block tuple_type:
+  # test with a tuple type
+  type Tuple = tuple[x: int]
+
+  template borrowVar(x: untyped): var Tuple = x
+  template borrowLent(x: untyped): lent Tuple = x
+
+  # note: `v` being an unnamed tuple is deliberate, as it is
+  # intended to ensure that the implicit conversion in the template
+  # doesn't cause problems
+  var v: (int,) = (0,)
+  # test full assignment and read access:
+  borrowVar(v) = (x: 1)
+  doAssert borrowVar(v) == (x: 1)
+  # test with field write and read:
+  borrowVar(v).x = 2
+  doAssert borrowVar(v).x == 2
+
+  # test that the lent-returning templates cannot be used for
+  # mutations:
+  doAssert not compiles((borrowLent(v) = (x: 1)))
+  doAssert not compiles((borrowLent(v).x = 1))
+
+  # test that read-only access is possible:
+  doAssert borrowLent(v) == (x: 2)
+  doAssert borrowLent(v).x == 2


### PR DESCRIPTION
## Summary

* fix the result of `lent` returning macros and templates being
  assignable when the final body of the template/macro ends in a
  mutable lvalue expression
* fix wrong code being generated for templates and macros that had a
  concrete tuple return type and where the body was of `var`/`lent`
  tuple type (all backends were affected)

In terms of how the result can be used, macros and templates with
`var`/`lent` return types now behave the same as the other routines do.

Fixes https://github.com/nim-works/nimskull/issues/328.

## Details

The problem was that the expansion of a template/macro using a concrete
type as the return type wasn't typed correctly:
* `semExpr` doesn't insert a hidden deref for `var`/`lent`-typed
  expressions, leading to a `var`/`lent`-typed expression being passed
  to `fitNode`
* `semExpr` doesn't enforce that the expression is not `void`-typed
  (i.e., a statement)
* `fitNode` alone doesn't handle `var` and `lent` target types
  correctly

This led to semantics inconsistent with `var`/`lent`-returning
procedures and code generation problems.

For fixing the issues:
* `semExpr` is replaced with `semExprWithType`
* `fitNode` is replaced with `fitNodeConsiderViewType`

Two templates in the `results` module can now use concrete types as the
return type again.