### PR TITLE
front/nimconf: add exported version of readConfigFile

### DIFF
--- a/compiler/front/nimconf.nim
+++ b/compiler/front/nimconf.nim
@@ -107,7 +107,6 @@ type
   CancelConfigProcessing = object of CatchableError
     ## internal error used to halt processing
 
-
 # ---------------- configuration file parser -----------------------------
 # we use Nim's lexer here to save space and work
 
@@ -502,4 +501,10 @@ proc loadConfigs*(
                              stopOnError: stopOnError)
   parser.loadConfigs(cfg, cache)
 
-  
+proc readConfigFile*(
+  filename: AbsoluteFile, cache: IdentCache,
+  conf: ConfigRef, evtHandler: NimConfEvtWriter
+): bool {.inline.} =
+  var parser = NimConfParser(config: conf, cfgEvtWriter: evtHandler,
+                             stopOnError: true)
+  parser.readConfigFile(filename, cache)

--- a/compiler/front/nimconf.nim
+++ b/compiler/front/nimconf.nim
@@ -505,6 +505,7 @@ proc readConfigFile*(
   filename: AbsoluteFile, cache: IdentCache,
   conf: ConfigRef, evtHandler: NimConfEvtWriter
 ): bool {.inline.} =
+  # created and exported for `nimph`
   var parser = NimConfParser(config: conf, cfgEvtWriter: evtHandler,
                              stopOnError: true)
   parser.readConfigFile(filename, cache)


### PR DESCRIPTION
## Summary
This API is used by [nimph](https://github.com/disruptek/nimph) to read
configuration files for modification.

## Details
* This is a part of the effort to get nimph running with nimskull