### PR TITLE
lib/parseopt: require explicit parameters list

### DIFF
--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -405,14 +405,12 @@ iterator getopt*(p: var OptParser): tuple[kind: CmdLineKind, key,
     if p.kind == cmdEnd: break
     yield (p.kind, p.key, p.val)
 
-iterator getopt*(cmdline: seq[string] = @[],
-                  shortNoVal: set[char] = {}, longNoVal: seq[string] = @[]):
+iterator getopt*(cmdline: seq[string],
+                 shortNoVal: set[char] = {}, longNoVal: seq[string] = @[]):
             tuple[kind: CmdLineKind, key, val: string] =
   ## Convenience iterator for iterating over command line arguments.
   ##
-  ## This creates a new `OptParser<#OptParser>`_. If no command line
-  ## arguments are provided, the real command line as provided by the
-  ## `os` module is retrieved instead.
+  ## This creates a new `OptParser<#OptParser>`_.
   ##
   ## `shortNoVal` and `longNoVal` are used to specify which options
   ## do not take values. See the `documentation about these

--- a/tests/ccgbugs/tmangle_field.nim
+++ b/tests/ccgbugs/tmangle_field.nim
@@ -12,5 +12,5 @@ import parseopt
 type foo* {.importc: "foo", nodecl.} = object
   key* {.importc: "key".}: cint
 
-for kind, key, value in parseopt.getopt():
+for kind, key, value in parseopt.getopt(@[]):
   discard

--- a/tests/misc/tparseopt.nim
+++ b/tests/misc/tparseopt.nim
@@ -48,7 +48,7 @@ else:
 
   block: # general test
     echo "t 0-0"
-    for kind, key, val in parseopt.getopt():
+    for kind, key, val in parseopt.getopt(@[]):
       echo "kind: ", kind, "\tkey:val  --  ", key, ":", val
 
     # pass custom cmdline arguments

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -1158,7 +1158,7 @@ when defined(posix):
   useWriteStyled = terminal.isatty(stdout)
   # that should be before option processing to allow override of useWriteStyled
 
-for kind, key, val in getopt():
+for kind, key, val in commandLineParams().getopt():
   case kind
   of cmdArgument:
     if options.contains(optStdin):


### PR DESCRIPTION
Now that  `getopt`  no longer automatically pulls in command line
arguments, it makes no sense to keep the default "empty" parameter.

Included is an update to documentation about the current behavior and a
fix to nimgrep to be able to read command line parameters.

Fixes 1a72373f3f2a58709a7f87c3374a107565bf1338