### PR TITLE
fix(js): wrong code for `discard` of address-like

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2522,8 +2522,11 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkFastAsgn: genFastAsgn(p, n)
   of cnkVoidStmt:
     genLineDir(p, n)
-    gen(p, n[0], r)
-    r.res = "var _ = " & r.res
+    var a: TCompRes
+    gen(p, n[0], a)
+    # the expression might be something not usable as an expression (e.g.,
+    # object construction), so use a var statement
+    lineF(p, "var _ = $1;$n", [rdLoc(a)])
   of cnkAsmStmt, cnkEmitStmt: genAsmOrEmitStmt(p, n)
   of cnkTryStmt: genTry(p, n)
   of cnkRaiseStmt: genRaiseStmt(p, n)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2520,9 +2520,13 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
     genLineDir(p, n)
     var a: TCompRes
     gen(p, n[0], a)
-    # the expression might be something not usable as an expression (e.g.,
-    # object construction), so use a var statement
-    lineF(p, "var _ = $1;$n", [rdLoc(a)])
+    # wrap the expressions in parentheses so that they're not ambiguous with
+    # statements
+    if a.typ == etyBaseIndex:
+      # make sure to evaluate both the address and index
+      lineF(p, "($1); ($2);$n", [a.address, a.res])
+    else:
+      lineF(p, "($1);$n", [a.res])
   of cnkAsmStmt, cnkEmitStmt: genAsmOrEmitStmt(p, n)
   of cnkTryStmt: genTry(p, n)
   of cnkRaiseStmt: genRaiseStmt(p, n)

--- a/tests/js/tdiscard.nim
+++ b/tests/js/tdiscard.nim
@@ -1,3 +1,16 @@
 import dom
 
 discard Node()
+
+block discard_pointer_returning_call:
+  # discarding a call returning a pointer-like value previously
+  # resulted in incorrect code being generated
+  var i = 0
+
+  proc get(x: pointer): pointer =
+    inc i
+    x
+
+  discard get(nil)
+  # make sure that the call was really executed
+  doAssert i == 1, "`get` was not evaluated?"


### PR DESCRIPTION
## Summary

Fix incorrect JavaScript code being generated for `discard`s of
`pointer` values, `ptr`-to-scalar values, or address-of field/array-
element expressions.

## Details

* emit both the `address` part and `res` part for address expression
  (and not only the index)
* use `lineF` directly, slightly reducing the amount of string
  allocations
* replace using `var _ = ...` with using parenthesis when turning the
  expression into JavaScript statements; it's less code to emit