### PR TITLE
fix(js): wrong code for uninitialized `pointer` locals

### DIFF
--- a/tests/js/tdefault_init_pointer_var.nim
+++ b/tests/js/tdefault_init_pointer_var.nim
@@ -1,0 +1,13 @@
+discard """
+  description: '''
+    Regression test for wrong code being generated for locals of `pointer`
+    type
+  '''
+"""
+
+proc test(): pointer =
+  # the result variable was affected too
+  var x: pointer
+  doAssert x == nil # this assertion failed
+
+doAssert test() == nil # this one too


### PR DESCRIPTION
## Summary

Fix wrong code being generated for uninitialized locals of `pointer`
type, which resulted in run-time crashes or other unexpected
behaviour.

## Details

* the set used in deciding whether to use a boxed pointer missed
  `tyPointer`. Since testing the set after the inclusion of `tyPointer`
  would be redundant with the `mapType` check, testing the set is
  simply removed
* the `not isIndirect` check is replaced with testing whether a boxed
  pointer is used. While a loc using an indirection implies a boxed
  representation, the extra indirection made the logic harder to
  understand