### PR TITLE
fix a destruction bug for global-backed locals

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -348,15 +348,11 @@ proc preprocess*(conf: BackendConfig, prc: PSym, graph: ModuleGraph,
 
 proc process*(prc: var Procedure, graph: ModuleGraph, idgen: IdGenerator) =
   ## Applies all applicable MIR passes to the procedure `prc`.
-  rewriteGlobalDefs(prc.body.tree, prc.body.source, outermost = true)
+  rewriteGlobalDefs(prc.body.tree, prc.body.source)
 
   if shouldInjectDestructorCalls(prc.sym):
     injectDestructorCalls(graph, idgen, prc.sym,
                           prc.body.tree, prc.body.source)
-
-  rewriteGlobalDefs(prc.body.tree, prc.body.source, outermost = false)
-  # XXX: ^^ this is a hack. See the documentation of the routine for more
-  #      details
 
   let target =
     case graph.config.backend

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -348,11 +348,14 @@ proc preprocess*(conf: BackendConfig, prc: PSym, graph: ModuleGraph,
 
 proc process*(prc: var Procedure, graph: ModuleGraph, idgen: IdGenerator) =
   ## Applies all applicable MIR passes to the procedure `prc`.
-  rewriteGlobalDefs(prc.body.tree, prc.body.source)
+  rewriteGlobalDefs(prc.body.tree, prc.body.source, patch=false)
 
   if shouldInjectDestructorCalls(prc.sym):
     injectDestructorCalls(graph, idgen, prc.sym,
                           prc.body.tree, prc.body.source)
+
+  # restore the correct symbols for globals:
+  patchGlobals(prc.body.tree, prc.body.source)
 
   let target =
     case graph.config.backend

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -123,9 +123,9 @@ type
     inUnscoped: bool
       ## whether the currently proceesed statement/expression is part of an
       ## unscoped control-flow context
-    defs: seq[tuple[local: LocalId, info: TLineInfo]]
-      ## the stack of locals for which the ``cnkDef`` needs to be inserted
-      ## later
+    defs: seq[CgNode]
+      ## the stack of locals/globals for which the ``cnkDef``/assignemnt needs
+      ## to be inserted later
 
   TreeWithSource = object
     ## Combines a ``MirTree`` with its associated ``SourceMap`` for
@@ -366,6 +366,10 @@ proc wrapArg(stmts: sink seq[CgNode], info: TLineInfo, val: sink CgNode): CgNode
 func newTemp(cl: var TranslateCl, typ: PType): LocalId =
   ## Creates and returns a new ``skTemp`` symbol
   cl.locals.add(Local(typ: typ, isImmutable: false))
+
+proc newDefaultCall(info: TLineInfo, typ: PType): CgNode =
+  ## Produces the tree for a ``default`` magic call.
+  newExpr(cnkCall, info, typ, [newMagicNode(mDefault, info)])
 
 proc initLocal(s: PSym): Local =
   ## Inits a ``Local`` with the data from `s`.
@@ -835,11 +839,7 @@ proc tbDef(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
     # ignore 'def's for both parameters and procedures
     def = newEmpty()
   of mnkGlobal:
-    # XXX: defs for globals reaching here implies that the MIR code wasn't
-    #      sufficiently lowered. This should be a hard error, but the
-    #      ``--expandArc`` feature currently relies on this being possible, so
-    #      we allow it for now
-    def = newEmpty()
+    def = newSymNode(entity.sym, info)
   of mnkTemp:
     # MIR temporaries are like normal locals, with the difference that they
     # are created ad-hoc and don't have any extra information attached
@@ -856,20 +856,29 @@ proc tbDef(tree: TreeWithSource, cl: var TranslateCl, prev: sink Values,
   leave(tree, cr)
 
   case def.kind
-  of cnkLocal:
+  of cnkLocal, cnkSym:
     if cl.inUnscoped:
-      # add the local to the list of moved definitions and only emit an
-      # assignment
-      cl.defs.add (def.local, info)
+      # add the local/global to the list of moved definitions and only emit
+      # an assignment
+      cl.defs.add copyTree(def)
       result =
         case prev.kind
         of vkNone:   newEmpty(info)
         of vkSingle: newStmt(cnkAsgn, info, [def, prev.single])
         of vkMulti:  unreachable()
-    else:
+    elif def.kind == cnkLocal:
       result = newStmt(cnkDef, info):
         case prev.kind
         of vkNone:   [def, newEmpty()]
+        of vkSingle: [def, prev.single]
+        of vkMulti:  unreachable()
+    else:
+      # there are no defs for globals in the ``CgNode`` IR, so we
+      # emit an assignment that has the equivalent behaviour (in
+      # terms of initialization)
+      result = newStmt(cnkAsgn, info):
+        case prev.kind
+        of vkNone:   [def, newDefaultCall(info, def.typ)]
         of vkSingle: [def, prev.single]
         of vkMulti:  unreachable()
   of cnkEmpty:
@@ -1284,6 +1293,18 @@ proc tbList(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): CgNo
   tbList(tree, cl, stmts, cr)
   result = toSingleNode(stmts)
 
+proc genDefFor(sym: sink CgNode): CgNode =
+  ## Produces the statement tree of a definition for the given symbol-like
+  ## node. Globals use an assignment.
+  case sym.kind
+  of cnkLocal:
+    newStmt(cnkDef, sym.info, [sym, newEmpty()])
+  of cnkSym:
+    # emulate the default-initialization behaviour
+    newStmt(cnkAsgn, sym.info, [sym, newDefaultCall(sym.info, sym.typ)])
+  else:
+    unreachable()
+
 proc tbScope(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
              cr: var TreeCursor): CgNode =
   let
@@ -1299,10 +1320,7 @@ proc tbScope(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
   if cl.defs.len > prev:
     # insert all the lifted defs at the start
     for i in countdown(cl.defs.high, prev):
-      let (local, info) = cl.defs[i]
-      stmts.insert newStmt(cnkDef, info, [
-        newLocalRef(local, info, cl.locals[local].typ),
-        newEmpty()])
+      stmts.insert genDefFor(move cl.defs[i])
 
     # "pop" the elements that were added as part of this scope:
     cl.defs.setLen(prev)
@@ -1373,10 +1391,7 @@ proc tbMulti(tree: TreeWithSource, cl: var TranslateCl, cr: var TreeCursor): CgN
   # insert the var section for the collected defs at the start:
   if cl.defs.len > 0:
     for i in countdown(cl.defs.high, 0):
-      let (local, info) = cl.defs[i]
-      nodes.insert newStmt(cnkDef, info, [
-        newLocalRef(local, info, cl.locals[local].typ),
-        newEmpty()])
+      nodes.insert genDefFor(move cl.defs[i])
 
   case nodes.len
   of 0: newEmpty()

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -77,11 +77,7 @@ proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
     writeBody(config, "-- output AST: " & owner.name.s):
       config.writeln(treeRepr(body.code))
 
-proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap) =
-  ## Removes definitions of non-pure globals from `body`, replacing them with
-  ## as assignment if necessary. The correct symbols for globals of which
-  ## copies were introduced during ``transf`` are also restored here.
-  proc restoreGlobal(s: PSym): PSym {.nimcall.} =
+proc restoreGlobal(s: PSym): PSym =
     ## If the global `s` is a duplicate that was introduced in order to make
     ## the code temporarily semantically correct, restores the original
     ## symbol -- otherwise returns `s` as is.
@@ -92,6 +88,11 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap) =
     else:
       s
 
+proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap;
+                        patch: bool) =
+  ## Rewrites definitions of globals in the outermost scope into assignments.
+  ## If `patch` is true, also restores the correct symbol for globals that
+  ## were introduced in ``transf``.
   var
     changes = initChangeset(body)
     depth   = 0
@@ -102,15 +103,20 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap) =
     case n.kind
     of DefNodes:
       let def = i + 1
-      if body[def].kind == mnkGlobal and depth == 1:
+      if body[def].kind == mnkGlobal:
         let
           sym = restoreGlobal(body[def].sym)
           typ = sym.typ
         changes.seek(i)
+        if depth > 1:
+          # don't rewrite the def, but still patch the symbol if requested
+          if patch:
+            changes.seek(i + 1)
+            changes.replace: MirNode(kind: mnkGlobal, sym: sym, typ: typ)
         # HACK: ``vmjit`` currently passes us expressions where a 'def' can
         #       be the very first node, something that ``hasInput`` doesn't
         #       support. We thus have to guard against i == 0
-        if i.int > 0 and hasInput(body, Operation i):
+        elif i.int > 0 and hasInput(body, Operation i):
           # the global has a starting value
           changes.replaceMulti(buf):
             let tmp = changes.getTemp()
@@ -142,7 +148,7 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap) =
       inc i, 2 # skip the whole sub-tree ('def', name, and 'end' node)
     of mnkGlobal:
       # remove the temporary duplicates of nested globals again:
-      if depth > 1:
+      if patch and depth > 1:
         let s = restoreGlobal(n.sym)
         if s != n.sym:
           changes.seek(i)
@@ -161,6 +167,17 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap) =
   let prepared = prepare(changes, sourceMap)
   updateSourceMap(sourceMap, prepared)
   apply(body, prepared)
+
+proc patchGlobals*(body: var MirTree, sourceMap: var SourceMap) =
+  # Restores the correct symbol for all globals duplicated during
+  # ``transf``.
+  for i in 0..<body.len:
+    if body[i].kind == mnkGlobal:
+      let s = restoreGlobal(body[i].sym)
+      # use in-place patching; it's more efficient than going through
+      # a changeset
+      if s != body[i].sym:
+        body[i].sym = s
 
 proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
                    body: PNode, options: set[GenOption]): Body =

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -171,9 +171,7 @@ func discoverGlobalsAndRewrite(data: var DiscoveryData, tree: var MirTree,
     else:
       inc i
 
-  # at the moment, nothing depends on non-outermost defs of globals, so we
-  # can rewrite all defs in one go:
-  rewriteGlobalDefs(tree, source, outermost = false)
+  rewriteGlobalDefs(tree, source)
 
 func register(linker: var LinkerData, data: DiscoveryData) =
   ## Registers the newly discovered entities in the link table, but doesn't

--- a/tests/lang_objects/destructor/tglobals.nim
+++ b/tests/lang_objects/destructor/tglobals.nim
@@ -30,3 +30,35 @@ block consider_call_with_side_effects:
 
 doAssert numCopies == 1
 doAssert numDestroy == 2
+
+block missing_default_init_at_scope_start:
+  # regression test: globals in nested scopes were not default-initialized
+  # at the start of their scope, which lead to an old state being
+  # observable within loop cleanup
+  type Obj = object
+    isDestroyed: bool
+
+  proc `=destroy`(x: var Obj) =
+    doAssert not x.isDestroyed, "an old state is observed"
+    x.isDestroyed = true
+
+  proc cond(): bool =
+    # hide the value in order to prevent folding
+    false
+
+  var i = 0
+  # don't use a non-true loop condition so that control-flow and scopes are
+  # explicit
+  while true:
+    if i == 1:
+      break
+
+    let o = Obj(isDestroyed: false)
+    if cond(): # never actually entered
+      # the break (i.e., unstructured exit) here is necessary to force the
+      # above `break` to trigger `o`'s destructor
+      # XXX: this is the current behaviour, but it's incorrect
+      break
+
+    doAssert not o.isDestroyed
+    inc i


### PR DESCRIPTION
## Summary

Fix stale state in some cases reaching destructors for locals defined
in loops that are themselves not part of a routine.

Fixes https://github.com/nim-works/nimskull/issues/1010.

## Details

Locations defined within loops outside of routines are globals
internally. Globals so far didn't use the default-initialized-at-scope-
entry behaviour that routine-level locals use, which caused their
destructors observing them in a not-reset state in certain situations.

For ensuring proper default-initialization:
1. the pass for removing 'def's of nested globals is removed
2. patching the symbols of globals after the `injectdestructors` pass
   has run still needs to happen after the, so the patching logic is
   duplicated into a dedicated pass 
4. removing the 'def's of globals is performed during the MIR ->
   `CgNode` translation. This allows for `cgirgen` to emit a default-
   initialization for globals that need it

The facility already used for locals (i.e. moving the definition when
it's not placed immediately within a MIR scope) is also used for
globals.

This does **not** fix the fundamental issue of cleanup also being
applied to not-yet-alive globals, but it makes the behaviour between
globals and locals consistent.