### PR TITLE
evaltempl: unwrap default static[T] parameters

### DIFF
--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -17,7 +17,8 @@ import
     idents,
     renderer,
     errorhandling,
-    errorreporting
+    errorreporting,
+    types
   ],
   compiler/front/[
     options,
@@ -56,7 +57,14 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
     of nkArgList:
       for y in items(x): result.add(y)
     else:
-      result.add copyTree(x)
+      var x = copyTree(x)
+      if x.typ != nil:
+        case x.typ.kind
+        of tyStatic:
+          x.typ = x.typ.base
+        else:
+          discard
+      result.add x
 
   case templ.kind
   of nkSym:

--- a/tests/lang_callable/template/template_issues.nim
+++ b/tests/lang_callable/template/template_issues.nim
@@ -296,3 +296,11 @@ block: # bug #12595
     discard {i: ""}
 
   test()
+
+block: # https://github.com/nim-works/nimskull/issues/1015
+  proc takeInt(i: int) = discard
+
+  template x(b: static[bool] = false): untyped =
+    takeInt b.int
+
+  x()

--- a/tests/lang_callable/template/template_issues.nim
+++ b/tests/lang_callable/template/template_issues.nim
@@ -297,10 +297,10 @@ block: # bug #12595
 
   test()
 
-block: # https://github.com/nim-works/nimskull/issues/1015
-  proc takeInt(i: int) = discard
+block static_parameter_with_default:
+  # using a `static` template parameter as the argument to a conversion
+  # crashed the compiler
+  template x(b: static[bool] = false) =
+    discard int(b)
 
-  template x(b: static[bool] = false): untyped =
-    takeInt b.int
-
-  x()
+  x() # the default value for the parameter must be used


### PR DESCRIPTION
## Summary
Fixed a case where  `static[T]`  values leaked from templates to backend
and other parts of sem causing compiler crashes.

## Details
Most sem code expects  `tyStatic`  to have been resolved by the time it
hits them. But it seems that this was not processed for template
parameters, so add some code to handle it there.

Fixes https://github.com/nim-works/nimskull/issues/1015