### PR TITLE
fix(sem): error with `var`/`lent`-returning templates

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -954,20 +954,15 @@ proc analyseIfAddressTaken(n: PNode) =
     incl(n.sym.flags, sfAddrTaken)
 
 proc passToVarParameter(c: PContext, n: PNode): PNode =
-  ## Analyses the lvalue expression `n` that is meant to be passed to a ``var``
-  ## parameter, wrapping it in an ``nkHiddenAddr`` node, if necessary
-  # only create a mutable reference (i.e. ``nkHiddenAddr``) if the source isn't
-  # one already
-  if n.typ.skipTypes(abstractInst).kind != tyVar:
+  ## Returns `n` wrapped in an ``nkHiddenAddr`` node and marks the symbol of
+  ## the underlying location, if one exists, with ``sfAddrTaken``.
+  if n.typ.kind != tyVar:
     analyseIfAddressTaken(n)
-    result = newHiddenAddrTaken(c, n)
-  elif n.kind in {nkHiddenSubConv, nkHiddenStdConv}:
-    # this happens when passing a sub-type to super-type parameter or something
-    # that is implictly convertible to an ``openArray`` to an ``openArray``
-    # parameter
-    result = newHiddenAddrTaken(c, n)
+    newHiddenAddrTaken(c, n)
   else:
-    result = n
+    # only allowed when trying a concept
+    c.config.internalAssert(c.matchedConcept != nil, n.info)
+    n
 
 proc analyseIfAddressTakenInCall(n: PNode) =
   ## Performs the "is address taken" analysis for all immediate arguments of

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -918,6 +918,30 @@ proc checkRange(c: PEffects; value: PNode; typ: PType) =
     checkLe(c, lowBound, value)
     checkLe(c, value, highBound)
 
+proc objConvCheck(config: ConfigRef, n: PNode) =
+  case n.kind
+  of nkHiddenSubConv:
+    if n.typ.skipTypes({tyGenericInst, tyAlias, tySink}).kind == tyObject:
+      # the result of an implicit, narrowing object conversion is read as
+      # a whole (e.g., passed to a non-var parameter, assigned somewhere,
+      # etc.). Information is lost in this case, so a warning is reported
+      localReport(config, n[1], SemReport(
+        kind: rsemImplicitObjConv,
+        typeMismatch: @[typeMismatch(formal = n.typ, actual = n[1].typ)]))
+    objConvCheck(config, n[^1])
+  of nkStmtListExpr, nkIfExpr, nkBlockExpr, nkElifExpr, nkElseExpr,
+     nkExceptBranch:
+    objConvCheck(config, n[^1])
+  of nkCaseStmt:
+    for i in 1..<n.len:
+      objConvCheck(config, n[i][^1])
+  of nkTryStmt, nkHiddenTryStmt:
+    for it in n.items:
+      if it.kind != nkFinally:
+        objConvCheck(config, it)
+  else:
+    discard
+
 proc trackCall(tracked: PEffects; n: PNode) =
   template gcsafeAndSideeffectCheck() =
     if notGcSafe(op) and not importedFromC(a):
@@ -994,6 +1018,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
     if a.kind != nkSym or a.sym.magic != mRunnableExamples:
       for i in 0..<n.safeLen:
         track(tracked, n[i])
+        objConvCheck(tracked.config, n[i])
 
   if a.kind == nkSym and a.sym.name.s.len > 0 and a.sym.name.s[0] == '=' and
         tracked.owner.kind != skMacro:
@@ -1169,6 +1194,7 @@ proc track(tracked: PEffects, n: PNode) =
     dec tracked.leftPartOfAsgn
     addAsgnFact(tracked.guards, n[0], n[1])
     notNilCheck(tracked, n[1], n[0].typ)
+    objConvCheck(tracked.config, n[1])
     discriminantAsgnCheck(tracked, n)
     if tracked.owner.kind != skMacro:
       createTypeBoundOps(tracked, n[0].typ, n.info)
@@ -1198,6 +1224,7 @@ proc track(tracked: PEffects, n: PNode) =
           initVar(tracked, child[i])
           addAsgnFact(tracked.guards, child[i], last)
           notNilCheck(tracked, last, child[i].typ)
+          objConvCheck(tracked.config, last)
       elif child.kind == nkVarTuple and last.kind != nkEmpty:
         for i in 0..<child.len-1:
           if child[i].kind == nkEmpty or
@@ -1207,6 +1234,7 @@ proc track(tracked: PEffects, n: PNode) =
           if last.kind in {nkPar, nkTupleConstr}:
             addAsgnFact(tracked.guards, child[i], last[i])
             notNilCheck(tracked, last[i], child[i].typ)
+            objConvCheck(tracked.config, last[i])
       # since 'var (a, b): T = ()' is not even allowed, there is always type
       # inference for (a, b) and thus no nil checking is necessary.
   of nkConstSection:
@@ -1291,6 +1319,7 @@ proc track(tracked: PEffects, n: PNode) =
       if x.kind == nkExprColonExpr:
         if x[0].kind == nkSym:
           notNilCheck(tracked, x[1], x[0].sym.typ)
+          objConvCheck(tracked.config, x[1])
         checkForSink(tracked.config, tracked.c.idgen, tracked.owner, x[1])
       else:
         checkForSink(tracked.config, tracked.c.idgen, tracked.owner, x)
@@ -1304,6 +1333,7 @@ proc track(tracked: PEffects, n: PNode) =
     for i in 0..<n.len:
       track(tracked, n[i])
       notNilCheck(tracked, n[i].skipColon, n[i].typ)
+      objConvCheck(tracked.config, n[i].skipColon)
       if tracked.owner.kind != skMacro:
         if n[i].kind == nkExprColonExpr:
           createTypeBoundOps(tracked, n[i][0].typ, n.info)
@@ -1347,14 +1377,6 @@ proc track(tracked: PEffects, n: PNode) =
         not allowCStringConv(n[1]):
       localReport(tracked.config, n.info, reportAst(
         rsemImplicitCstringConvert, n[1]))
-    elif n.kind == nkHiddenSubConv and
-         n.typ.skipTypes(abstractVar).kind == tyObject and
-         t.kind != tyVar:
-      # an implicit conversion to a base (i.e. parent) type where the result is
-      # immutable. Since information is lost in this case, a warning is reported
-      localReport(tracked.config, n[1], SemReport(
-        kind: rsemImplicitObjConv,
-        typeMismatch: @[typeMismatch(formal = n.typ, actual = n[1].typ)]))
 
     if t.kind == tyEnum:
       if tfEnumHasHoles in t.flags:
@@ -1383,6 +1405,7 @@ proc track(tracked: PEffects, n: PNode) =
   of nkBracket:
     for i in 0..<n.safeLen:
       track(tracked, n[i])
+      objConvCheck(tracked.config, n[i])
       checkForSink(tracked.config, tracked.c.idgen, tracked.owner, n[i])
     if tracked.owner.kind != skMacro:
       createTypeBoundOps(tracked, n.typ, n.info)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2014,15 +2014,20 @@ proc getInstantiatedType(c: PContext, arg: PNode, m: TCandidate,
 
 proc implicitConv(kind: TNodeKind, f: PType, arg: PNode, m: TCandidate,
                   c: PContext): PNode =
+  const SkipSet = {tySink, tyVar, tyLent}
+  # don't produce conversions to `var` or `lent` types
+  # here. An implicit address-of operation will later be
+  # inserted to ensure proper typing
+
   result = newNodeI(kind, arg.info)
   result.typ =
     if containsGenericType(f):
       if not m.hasFauxMatch:
-        getInstantiatedType(c, arg, m, f).skipTypes({tySink})
+        getInstantiatedType(c, arg, m, f).skipTypes(SkipSet)
       else:
         errorType(c)
     else:
-      f.skipTypes({tySink})
+      f.skipTypes(SkipSet)
 
   c.graph.config.internalAssert(result.typ != nil, arg.info, "implicitConv")
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1345,9 +1345,7 @@ proc genObjConv(c: var TCtx, n: CgNode, dest: var TDest) =
   prepare(c, dest, n.typ)
   let
     tmp = genx(c, n.operand)
-    desttyp = n.typ.skipTypes(IrrelevantTypes + {tyVar, tyLent})
-  # XXX: var and lent in conversions should not end up here -- fix-up
-  #      the conversions in ``mirgen``
+    desttyp = n.typ.skipTypes(IrrelevantTypes)
 
   case desttyp.kind
   of tyRef, tyObject:

--- a/tests/lang_callable/varres/ttemplate_var_lent_res.nim
+++ b/tests/lang_callable/varres/ttemplate_var_lent_res.nim
@@ -29,7 +29,7 @@ block tuple_type:
   # note: `v` being an unnamed tuple is deliberate, as it is
   # intended to ensure that the implicit conversion in the template
   # doesn't cause problems
-  var v: (int,) = (0,)
+  var v: Tuple = (0,)
   # test full assignment and read access:
   borrowVar(v) = (x: 1)
   doAssert borrowVar(v) == (x: 1)

--- a/tests/lang_callable/varres/ttemplate_var_lent_res.nim
+++ b/tests/lang_callable/varres/ttemplate_var_lent_res.nim
@@ -1,0 +1,47 @@
+discard """
+  description: '''
+    Ensure that templates with `var` and `lent` return types behave the same
+    as normal procedures would
+  '''
+"""
+
+# XXX: they currently don't. Refer to the assertion with the
+#      "now works" string
+
+block scalar_type:
+  # test with a scalar type
+  template borrowVar(x: untyped): var int = x
+  template borrowLent(x: untyped): lent int = x
+
+  var v = 0
+  borrowVar(v) = 1 # test that an assignment works
+  doAssert borrowVar(v) == 1 # test that a read works
+  doAssert compiles((borrowLent(v) = 2)), "now works"
+  doAssert borrowLent(v) == 1
+
+block tuple_type:
+  # test with a tuple type
+  type Tuple = tuple[x: int]
+
+  template borrowVar(x: untyped): var Tuple = x
+  template borrowLent(x: untyped): lent Tuple = x
+
+  # note: `v` being an unnamed tuple is deliberate, as it is
+  # intended to ensure that the implicit conversion in the template
+  # doesn't cause problems
+  var v: (int,) = (0,)
+  # test full assignment and read access:
+  borrowVar(v) = (x: 1)
+  doAssert borrowVar(v) == (x: 1)
+  # test with field write and read:
+  borrowVar(v).x = 2
+  doAssert borrowVar(v).x == 2
+
+  # test that the lent-returning templates cannot be used for
+  # mutations:
+  doAssert compiles((borrowLent(v) = (x: 1))), "now works"
+  doAssert compiles((borrowLent(v).x = 1)), "now works"
+
+  # test that read-only access is possible:
+  doAssert borrowLent(v) == (x: 2)
+  doAssert borrowLent(v).x == 2


### PR DESCRIPTION
## Summary

Fix using templates and macros with a `var T` or `lent T` return type
leading to compiler crashes or wrong code being generated. Both the C
and the VM backend were affected.

## Details

When the receiving type is a `var` or `lent` type, `sigmatch` produced
implicit conversions to said type. These are wrong at the type-level,
as a conversion cannot turn a non-view value into a view. Due a
separate issue with `semAfterMacroCall`, this led to semantically
invalid expressions being produced after expansion of the
aforementioned templates.

The `var` and `lent` modifiers are now dropped from the produced
conversions, both fixing the concrete problem with templates and
allowing for the removal of several workarounds in the compiler. 

Reporting a warning for narrowing object conversions where information
is lost relied on the `var` modifier in conversion. The test is
replaced with looking for the problematic conversion in receiver
contexts (except for `discard`, as the value isn't used there).

Finally, a general test is added for ensuring that templates returning
`var` or `lent` types behave the same as a normal procedure would. They
currently don't, but most of the test at least compiles and runs now.