### PR TITLE
fix(sem): crash on missing explicit initial value

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1222,6 +1222,7 @@ type
     adSemObjectRequiresFieldInitNoDefault
     adSemExpectedObjectType
     adSemExpectedObjectOfType
+    adSemObjectDoesNotHaveDefaultValue
     adSemDistinctDoesNotHaveDefaultValue
     # semfold
     adSemFoldRangeCheckForLiteralConversionFailed
@@ -1500,8 +1501,9 @@ type
        adSemObjectRequiresFieldInitNoDefault:
       missing*: seq[PSym]
       objTyp*: PType
-    of adSemDistinctDoesNotHaveDefaultValue:
-      distinctTyp*: PType
+    of adSemObjectDoesNotHaveDefaultValue,
+       adSemDistinctDoesNotHaveDefaultValue:
+      typWithoutDefault*: PType
     of adSemExpectedObjectOfType:
       expectedObjTyp*: PType
     of adSemFoldRangeCheckForLiteralConversionFailed:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -565,6 +565,7 @@ type
     rsemRuntimeDiscriminantRequiresElif
     rsemObjectRequiresFieldInit
     rsemObjectRequiresFieldInitNoDefault
+    rsemObjectDoesNotHaveDefaultValue
     rsemDistinctDoesNotHaveDefaultValue
     rsemExpectedModuleNameForImportExcept
     rsemCannotExport

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1155,7 +1155,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "Array length can't be negative, but was " & $r.countMismatch.got
 
     of rsemObjectDoesNotHaveDefaultValue:
-      result = "The type '$1' doesn't have a default value" % r.typ.render
+      result = "The type '$1' requires an initial value" % r.typ.render
 
     of rsemDistinctDoesNotHaveDefaultValue:
       result = "The $1 distinct type doesn't have a default value." % r.typ.render

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1154,6 +1154,9 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemArrayExpectsPositiveRange:
       result = "Array length can't be negative, but was " & $r.countMismatch.got
 
+    of rsemObjectDoesNotHaveDefaultValue:
+      result = "The type '$1' doesn't have a default value" % r.typ.render
+
     of rsemDistinctDoesNotHaveDefaultValue:
       result = "The $1 distinct type doesn't have a default value." % r.typ.render
 
@@ -3770,13 +3773,14 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       ast: diag.wrongNode,
       symbols: diag.missing,
       typ: diag.objTyp)
-  of adSemDistinctDoesNotHaveDefaultValue:
+  of adSemObjectDoesNotHaveDefaultValue,
+     adSemDistinctDoesNotHaveDefaultValue:
     semRep = SemReport(
       location: some diag.location,
       reportInst: diag.instLoc.toReportLineInfo,
       kind: kind,
       ast: diag.wrongNode,
-      typ: diag.distinctTyp)
+      typ: diag.typWithoutDefault)
   of adSemExpectedObjectOfType:
     semRep = SemReport(
       location: some diag.location,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -580,6 +580,7 @@ func astDiagToLegacyReportKind*(
   of adSemObjectRequiresFieldInitNoDefault: rsemObjectRequiresFieldInitNoDefault
   of adSemExpectedObjectType: rsemExpectedObjectType
   of adSemExpectedObjectOfType: rsemExpectedObjectType
+  of adSemObjectDoesNotHaveDefaultValue: rsemObjectDoesNotHaveDefaultValue
   of adSemDistinctDoesNotHaveDefaultValue: rsemDistinctDoesNotHaveDefaultValue
   of adSemFoldRangeCheckForLiteralConversionFailed: rsemCantConvertLiteralToRange
   of adSemIndexOutOfBoundsStatic: rsemStaticOutOfBounds

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -367,17 +367,21 @@ proc defaultConstructionError(c: PContext, t: PType, n: PNode): PNode =
     var constrCtx = initConstrContext(objType, newNodeI(nkObjConstr, n.info))
     discard checkConstructTypeAux(c, constrCtx)
     if constrCtx.missingFields.len > 0:
-      result = c.config.newError(
+      c.config.newError(
                   n,
                   PAstDiag(
                     kind: adSemObjectRequiresFieldInitNoDefault,
                     missing: constrCtx.missingFields,
                     objTyp: t))
+    else:
+      c.config.newError(n,
+                PAstDiag(kind: adSemObjectDoesNotHaveDefaultValue,
+                         typWithoutDefault: t))
 
   of tyDistinct:
-    result = c.config.newError(n,
+    c.config.newError(n,
                 PAstDiag(kind: adSemDistinctDoesNotHaveDefaultValue,
-                         distinctTyp: t))
+                         typWithoutDefault: t))
 
   else:
     unreachable "Must not enter here."

--- a/tests/errmsgs/tmissing_initializer.nim
+++ b/tests/errmsgs/tmissing_initializer.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "The type 'Obj' doesn't have a default value"
+  line: 8
+"""
+
+type Obj {.requiresInit.} = object
+
+var x: Obj

--- a/tests/errmsgs/tmissing_initializer.nim
+++ b/tests/errmsgs/tmissing_initializer.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "The type 'Obj' doesn't have a default value"
+  errormsg: "The type 'Obj' requires an initial value"
   line: 8
 """
 


### PR DESCRIPTION
## Summary

Fix the compiler crashing on `var x: Y` statements where `Y` is a
`.requiresInit`-using object that does not have any fields requiring
initialization.

Fixes https://github.com/nim-works/nimskull/issues/1016.

## Details

* add a dedicated error diagnostic and report for diagnosing
  defining a `.requiresInit` object variable without providing an
  initial value
* for consistency, a message similar to that of the error regarding
  `distinct` types is used
* handle the "`.requiresInit` object with no fields requiring
  initialization" case in `defaultConstructionError`. `nil` was
  returned previously in that case, leading to an NPE
* the procedure is changed to not use `result`, preventing similar
  errors in the future (missing `result` assignment)