### PR TITLE
fix(sem): don't execute static calls too early

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1121,7 +1121,7 @@ proc evalAtCompileTime(c: PContext, n: PNode): PNode =
 
     # only attempt to fold the expression if doing so doesn't affect
     # compile-time state
-    if ecfStatic notin c.execCon.flags or sfNoSideEffect in callee.flags:
+    if not inCompileTimeOnlyContext(c) or sfNoSideEffect in callee.flags:
       if sfCompileTime in callee.flags:
         result = evalStaticExpr(c.module, c.idgen, c.graph, call, c.p.owner)
       else:

--- a/tests/vm/tcompiletimesideeffects.nim
+++ b/tests/vm/tcompiletimesideeffects.nim
@@ -1,42 +1,50 @@
 discard """
-  output:
-'''
-@[0, 1, 2]
-@[3, 4, 5]
-@[0, 1, 2]
-3
-4
-'''
+  targets: "c js vm"
+  description: '''
+    Ensure that calls to compile-time-only procedures with side-effects are
+    not folded when appearing within other compile-time-only contexts
+  '''
 """
 
-template runNTimes(n: int, f : untyped) : untyped =
-  var accum: seq[type(f)]
-  for i in 0..n-1:
-    accum.add(f)
-  accum
+# XXX: the test is unrelated to the VM, it needs to be moved into a different
+#      category
 
 var state {.compileTime.} : int = 0
-proc fill(): int {.compileTime.} =
+
+proc get(): int {.compileTime.} =
+  # `get` accesses global state and is thus not pure
   result = state
+
+# try with a static expression
+doAssert static((inc state; get())) == 1
+
+# try with a static statement
+static:
   inc state
+  doAssert get() == 2
 
-# invoke fill() at compile time as a compile time expression
-const C1 = runNTimes(3, fill())
-echo C1
+# try with the intializer of a constant
+const C0 = (inc state; get())
+doAssert C0 == 3
 
-# invoke fill() at compile time as a set of compile time statements
-const C2 =
-  block:
-    runNTimes(3, fill())
-echo C2
+# try with another compile-time-only proc
+proc other(): int {.compileTime.} =
+  inc state
+  result = get()
 
-# invoke fill() at compile time after a compile time reset of state
-const C3 =
-  block:
-    state = 0
-    runNTimes(3, fill())
-echo C3
+# for this test, don't rely on `other` being automatically folded when used in
+# a non-compile-time-only context
+const C1 = other()
+doAssert C1 == 4
 
-# evaluate fill() at compile time and use the results at runtime
-echo fill()
-echo fill()
+# try with a macro:
+macro m() =
+  inc state
+  doAssert get() == 5
+
+m()
+
+# verify that the compile-time-only procedure can be used in run-time
+# contexts
+doAssert other() == 6
+doAssert other() == 7


### PR DESCRIPTION
## Summary

Fix early execution/folding of calls to compile-time-only procedures
with side-effects not being disabled within macros and `.compileTime`
procedures. It was already disabled for `static` and `const`
contexts.

Fixes https://github.com/nim-works/nimskull/issues/1022.

## Details

* use `inCompileTimeOnlyContext` for detecting whether within a
  compile-time-only context. This also considers wether the current
  routine is compile-time-only
* refactor the existing test (`tcompiletimesideeffects.nim`). The
  `echo`-based testing is replaced with `doAssert` and all compile-
  time-only contexts are tried, instead of only `const`