### PR TITLE
mir: store `SourceId`s directly on nodes

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -180,7 +180,7 @@ func newMagicNode(magic: TMagic, info: TLineInfo): CgNode =
   CgNode(kind: cnkMagic, info: info, magic: magic)
 
 func get(t: TreeWithSource, cr: var TreeCursor): lent MirNode {.inline.} =
-  cr.origin = sourceFor(t.map, cr.pos.NodeInstance)
+  cr.origin = t.map[t.tree[cr.pos].info]
   result = t.tree[cr.pos]
 
   inc cr.pos

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -163,9 +163,7 @@ proc rewriteGlobalDefs*(body: var MirTree, sourceMap: var SourceMap;
 
     inc i
 
-  let prepared = prepare(changes, sourceMap)
-  updateSourceMap(sourceMap, prepared)
-  apply(body, prepared)
+  apply(body, prepare(changes))
 
 proc patchGlobals*(body: var MirTree, sourceMap: var SourceMap) =
   # Restores the correct symbol for all globals duplicated during

--- a/compiler/mir/mirchangesets.nim
+++ b/compiler/mir/mirchangesets.nim
@@ -12,10 +12,8 @@
 ## the internal representation of the ``Changeset`` and is required for the
 ## later application to work.
 ##
-## Applying the ``PreparedChangeset`` is done via ``apply`` -- updating the
-## ``MirTree``'s corresponding ``SourceMap`` via ``updateSourceMap``. For
-## efficiency, ``apply`` consumes the changeset, so it is advised to call
-## ``updateSourceMap`` first.
+## Applying the ``PreparedChangeset`` is done via ``apply``. This integrates
+## all recorded changes into the applied to tree,.
 ##
 ## Order of application
 ## --------------------
@@ -51,11 +49,6 @@ type
     orig: HOslice[NodeIndex] ## the slice of nodes this change affects
     src:  HOslice[NodeIndex] ## a slice in the buffer of staged nodes
 
-    source: uint32 ## the meaning depends on whether or not this row is part
-                   ## of a ``PrepareChangeset``. If it is, `source` is a
-                   ## ``SourceId``, otherwise it's a ``NodeInstance``.
-                   ## The source information is only relevant for insertions
-
   Changeset* = object
     ## Represents a set of changes to be applied to a ``MirTree``.
     nodes: seq[MirNode]
@@ -81,16 +74,20 @@ func span[T](a, b: T): HOslice[T] {.inline.} =
 func empty[T](x: typedesc[HOslice[T]]): HOslice[T] {.inline.} =
   HOslice[T](a: default(T), b: default(T))
 
-func row(start, fin: NodePosition, src: HOslice[NodeIndex];
-         source = NodePosition(0)): Row {.inline.} =
+func row(start, fin: NodePosition, src: HOslice[NodeIndex]): Row {.inline.} =
   ## Convenience constructor for ``Row``
   Row(orig: span(NodeIndex(start), NodeIndex(fin)),
-      src: src,
-      source: source.uint32)
+      src: src)
 
 func addSingle(s: var MirNodeSeq, n: sink MirNode): HOslice[NodeIndex] =
   s.add n
   result = single(s.high.NodeIndex)
+
+func updateInfo(nodes: var MirNodeSeq, start: int, id: SourceId) =
+  ## Sets the `info` field for all nodes in the ``start..^1`` slice to
+  ## `id`.
+  for i in start..<nodes.len:
+    nodes[i].info = id
 
 func initChangeset*(tree: MirTree): Changeset =
   ## Initializes a new ``Changeset`` instance. Until the resulting
@@ -111,15 +108,14 @@ func replace*(c: var Changeset, tree: MirTree, at: NodePosition,
               with: sink MirNode) =
   ## Records replacing the node or sub-tree at `at` with `with`.
   let next = sibling(tree, at)
-  c.rows.add row(at, next, c.nodes.addSingle(with), at)
+  c.rows.add row(at, next, c.nodes.addSingle(with))
 
-func insert*(c: var Changeset, at: NodePosition, n: sink MirNode,
-             source: NodeInstance) =
-  ## Records the insertion of `n` at `at`, using `source` as the
-  ## inserted node's origin.
-  c.rows.add row(at, at, c.nodes.addSingle(n), source.NodePosition)
+func insert*(c: var Changeset, at: NodePosition, n: sink MirNode) =
+  ## Records the insertion of `n` at `at`. The ``info`` field on the node
+  ## is not modified.
+  c.rows.add row(at, at, c.nodes.addSingle(n))
 
-template insert*(c: var Changeset, at: NodePosition, source: NodeInstance,
+template insert*(c: var Changeset, tree: MirTree, at, source: NodePosition,
                  name: untyped, body: untyped) =
   ## Records an insertion at the `at` position, providing direct
   ## access to the internal node buffer inside `body` via an injected variable
@@ -131,14 +127,15 @@ template insert*(c: var Changeset, at: NodePosition, source: NodeInstance,
       # evaluate `at` and `source` before `body`, as the latter might change
       # what `source` evaluates to:
       pos = at
-      i = NodePosition source
+      info = tree[source].info
 
     var name: MirNodeSeq
     swap(c.nodes, name)
     body
     swap(c.nodes, name)
 
-    c.rows.add row(pos, pos, span(start, c.nodes.len.NodeIndex), i)
+    updateInfo(c.nodes, start.int, info)
+    c.rows.add row(pos, pos, span(start, c.nodes.len.NodeIndex))
 
 template replaceMulti*(c: var Changeset, tree: MirTree, at: NodePosition,
                        name, body: untyped) =
@@ -149,13 +146,15 @@ template replaceMulti*(c: var Changeset, tree: MirTree, at: NodePosition,
     let
       start = c.nodes.len.NodeIndex
       pos = at # prevent double evaluation
+      info = tree[pos].info
       next = sibling(tree, pos)
     var name: MirTree
     swap(c.nodes, name)
     body
     swap(c.nodes, name)
 
-    c.rows.add row(pos, next, span(start, c.nodes.len.NodeIndex), pos)
+    updateInfo(c.nodes, start.int, info)
+    c.rows.add row(pos, next, span(start, c.nodes.len.NodeIndex))
 
 func remove*(c: var Changeset, tree: MirTree, at: NodePosition) =
   ## Records the removal of the node or sub-tree at `at`.
@@ -163,7 +162,7 @@ func remove*(c: var Changeset, tree: MirTree, at: NodePosition) =
   # a removal is recorded as replacing a slice with nothing
   c.rows.add row(at, next, empty(HOslice[NodeIndex]))
 
-func prepare*(c: sink Changeset, sourceMap: SourceMap): PreparedChangeset =
+func prepare*(c: sink Changeset): PreparedChangeset =
   ## Prepares `c` for being applied
 
   # applying the changes can be done much more efficiently if they are ordered
@@ -181,14 +180,6 @@ func prepare*(c: sink Changeset, sourceMap: SourceMap): PreparedChangeset =
     result.diff -= row.orig.len
     result.diff += row.src.len
     result.stagingSize = max(result.stagingSize, result.diff)
-
-  # the `source` column of each row currently refers to the node to inherit
-  # the source information from (but only if the row represents an insertion
-  # or removal). Since the source-information attachments will become stale
-  # once the source mappings are modified, `source` is translated to the
-  # ``SourceId`` here already
-  for r in c.rows.mitems:
-    r.source = sourceMap[r.source.NodeInstance].uint32
 
   result.nodes = move c.nodes
   result.rows = move c.rows
@@ -264,18 +255,6 @@ iterator apply[T](s: var seq[T], diff, stagingSize: int, rows: seq[Row]): tuple[
   if diff != stagingSize:
     # resize to the correct number of items
     s.setLen(oldLen + diff)
-
-func updateSourceMap*(m: var SourceMap, c: PreparedChangeset) =
-  ## Updates the source mappings stored by `m` according to the changes
-  ## recorded in `c`
-  if c.rows.len == 0:
-    # nothing to do
-    return
-
-  for row, writePos in apply(m.map, c.diff, c.stagingSize, c.rows):
-    # insert the new source mappings when performing insertions or replacements
-    for p in row.src.items:
-      m.map[writePos + (p - row.src.a)] = SourceId(row.source)
 
 func apply*(tree: var MirTree, c: sink PreparedChangeset) =
   ## Applies the changeset `c` to the `tree`, modifying the tree in-place. The

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -309,7 +309,7 @@ proc preventRvo(tree: MirTree, changes: var Changeset) =
       let insert = tree.sibling(NodePosition source)
       let temp = MirNode(kind: mnkTemp, typ: tree[source].typ,
                          temp: changes.getTemp())
-      changes.insert(insert, NodeInstance source, buf):
+      changes.insert(tree, insert, NodePosition source, buf):
         buf.subTree MirNode(kind: mnkDef):
           buf.add temp
         buf.add temp
@@ -468,7 +468,7 @@ proc fixupCallArguments(tree: MirTree, config: ConfigRef,
         if needsTemp:
           let temp = MirNode(kind: mnkTemp, typ: tree[arg].typ,
                              temp: changes.getTemp())
-          changes.insert(arg, NodeInstance arg, buf):
+          changes.insert(tree, arg, arg, buf):
             buf.subTree MirNode(kind: mnkDef):
               buf.add temp
             buf.add temp
@@ -521,9 +521,7 @@ proc applyPasses*(tree: var MirTree, source: var SourceMap, prc: PSym,
     block:
       var c {.inject.} = initChangeset(tree)
       body
-      let p = prepare(c, source)
-      updateSourceMap(source, p)
-      apply(tree, p)
+      apply(tree, prepare(c))
 
   if target == targetC:
     batch:

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -35,6 +35,12 @@ type
   TypeId {.used.} = distinct uint32
     ## The ID of a type instance or nil
 
+  SourceId* = distinct range[0'u32 .. high(uint32)-1]
+    ## The ID of a source-mapping that's stored separately from the MIR nodes.
+
+# make ``SourceId`` available for use with ``OptIndex``:
+template indexLike*(_: typedesc[SourceId]) = discard
+
 type
   ## Different to the ID types above, how and what the following ID types
   ## represent is dictated by the MIR
@@ -264,7 +270,9 @@ type
 
   MirNode* = object
     typ*: PType ## must be non-nil for operators, inputs, and sinks
-
+    info*: SourceId
+      ## non-critical meta-data associated with the node (e.g., origin
+      ## information)
     case kind*: MirNodeKind
     of mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal:
       sym*: PSym
@@ -371,6 +379,7 @@ const
   SymbolLike* = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal}
     ## Nodes for which the `sym` field is available
 
+func `==`*(a, b: SourceId): bool {.borrow.}
 func `==`*(a, b: TempId): bool {.borrow.}
 func `==`*(a, b: LabelId): bool {.borrow.}
 

--- a/compiler/mir/sourcemaps.nim
+++ b/compiler/mir/sourcemaps.nim
@@ -1,10 +1,10 @@
-## This module implements the structures for associating ``MirNode``s with a
-## ``PNode`` origin.
+## This module implements a simple database for mapping MIR ``SourceId``s to
+## non-critical meta-data (currently only a ``PNode``).
 ##
 ## Information about which ``PNode`` a ``MirNode`` originated from is needed
 ## for source-code position information and other reporting-related tasks.
 ##
-## Origin information doesn't affect the semantics of MIR code and is thus
+## The meta-data doesn't affect the semantics of MIR code and it's thus
 ## stored and implemented separately. This allows for using a different way
 ## of storing such information without requiring adjustments to the core MIR
 ## data structures.
@@ -24,40 +24,26 @@ import
   ]
 
 type
-  SourceId* = distinct range[0'u32 .. high(uint32)-1]
-    ## The local ID of a source-mapping. The IDs are not unique across multiple
-    ## ``SourceMap``s
-
   SourceMap* = object
-    ## Associates each ``MirNode`` with the ``PNode`` it originated from
-    source*: Store[SourceId, PNode]
+    ## Associates meta-data (currently only ``PNode``) with ``SourceId``s.
+    ## The map is meant to be used together with ``MirTree``s.
+    source: Store[SourceId, PNode]
       ## stores the ``PNode``s used as the source/origin information
-    map*: seq[SourceId]
-      ## stores the ``SourceId`` for each ``MirNode``. The connection
-      ## happens via the index, that is, indexing `map` with a ``NodeIndex``
-      ## yields the ``SourceId`` attached to the node with the given
-      ## index. For this to work, `map` is required to always have the same
-      ## size as the associated ``MirNode`` seq
 
-# make ``SourceId`` available to be used with ``OptIndex``:
-template indexLike*(_: typedesc[SourceId]) = discard
+func `[]`*(m: SourceMap, i: SourceId): PNode {.inline.} =
+  m.source[i]
 
-func `==`*(a, b: SourceId): bool {.borrow.}
+func add*(m: var SourceMap, origin: PNode): SourceId {.inline.} =
+  ## Adds `origin` to the database and returns the ID through which it can
+  ## be looked up again.
+  m.source.add(origin)
 
-# ------- ``SourceMap``-related routines:
-
-func `[]`*(m: SourceMap, i: NodeInstance): SourceId {.inline.} =
-  m.map[ord(i)]
-
-func sourceFor*(m: SourceMap, i: NodeInstance): PNode {.inline.} =
-  m.source[m.map[ord(i)]]
-
-func append*(dst: var SourceMap, src: sink SourceMap) =
-  ## Appends all source mappings from `src` to `dst`.
-  if src.map.len == 0:
-    return # nothing to do
-
-  let first = unsafeGet(merge(dst.source, src.source))
-
-  for i, it in src.map.pairs:
-    dst.map.add SourceId(ord(first) + ord(it))
+func merge*(dst: var SourceMap, tree: var MirTree, src: sink SourceMap) =
+  ## Merges all entries from `src` into `dst` and updates all references in
+  ## `tree`.
+  let off = merge(dst.source, src.source)
+  if off.isSome:
+    let val = unsafeGet(off).uint32
+    # apply the new base ID index as an offset to all existing IDs:
+    for it in tree.mitems:
+      it.info = SourceId(it.info.uint32 + val)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -202,7 +202,9 @@ proc generateMirCode(c: var TCtx, n: PNode;
     # fragment
     result = generateCode(c.graph, c.module, selectOptions(c), n)
   else:
-    generateCode(c.graph, selectOptions(c), n, result[0], result[1])
+    var buf: MirBuffer
+    generateCode(c.graph, selectOptions(c), n, buf, result[1])
+    result[0] = finish(buf)
 
 proc generateIR(c: var TCtx, tree: sink MirTree,
                 source: sink SourceMap): Body {.inline.} =

--- a/tests/compiler/tmir_changesets.nim
+++ b/tests/compiler/tmir_changesets.nim
@@ -18,7 +18,7 @@ func `==`(a: TempId, b: int): bool =
 
 func insert(c: var Changeset, i: int, n: sink MirNode) =
   # inherit the origin information from node 0
-  c.insert(NodePosition i, n, NodeInstance 0)
+  c.insert(NodePosition i, n)
 
 func `==`(a, b: MirNode): bool =
   if a.kind != b.kind:
@@ -33,8 +33,7 @@ func `==`(a, b: MirNode): bool =
 
 func setupSourceMap(tree: MirTree): SourceMap =
   ## Sets up a minimal ``SourceMap`` instance for the given tree
-  let id = result.source.add PNode()
-  result.map.setLen(tree.len)
+  discard result.add(PNode())
 
 template test(input, output: typed, body: untyped) =
   ## Helper template to simplify writing test cases
@@ -56,8 +55,7 @@ template test(input, output: typed, body: untyped) =
 
     body
 
-    let pc = prepare(c, sourceMap)
-    apply(tree, pc)
+    apply(tree, prepare(c))
     {.line.}:
       doAssert tree == output
 


### PR DESCRIPTION
## Summary

Don't use a separate storage for `SourceId` and instead store the ID
directly in `MirNode`. This is simpler, more flexible, and it prepares
for changes to the MIR's data representation.

## Details

The `SourceId` associated with a `MirNode` was previously stored in a
separate sequence, with the connection between both happening through
the index within their storing sequences (struct-of-arrays approach).

This was intended for maximum flexibility in what data representation
the source mappings use, but this potential was not realized nor is it
likely that the ID-to-struct approach is going to change.

Upcoming changes to the MIR are going to require changing/keeping meta-
data attachments on single MIR nodes when recording changesets, which
is something not easy to support ergonomically with the decoupled
storage, so the ID is stored directly in `MirNode`.

Due to the current alignment requirements of `MirNode`, this can be
done without affecting the size of the type.

**Changes:**
* change `SourceMap` to only store `SourceId` -> `PNode` mappings and
  adjust the API accordingly
* un-export `SourceMap`'s internal fields
* move `SourceId` to the `mirtrees` module
* add the `info` field to `MirNode`
* rename the `CodeFragment` type to `MirBuffer`, which better reflects
  its purpose/usage. The approach of attaching the `SourceId` in a
  deferred manner is kept, with `MirBuffer` keeping track of what nodes
  still need to be update via the `cursor` field
* export parts of the `MirBuffer` API for use in `backends` and change
  the `MirTree`-accepting `generatedCode` overload to accept a
  `MirBuffer`
* updating the attachments is still done through the `Changeset` API,
  but it now happens directly after recording a change rather than when
  applying a changeset. This is both simpler and more efficient

Documentation is updated where necessary.