### PR TITLE
fix(C): code generation issue with `finished`

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -130,22 +130,6 @@ proc blockLeaveActions(p: BProc, howManyTrys, howManyExcepts: int) =
     for i in countdown(howManyExcepts-1, 0):
       linefmt(p, cpsStmts, "#popCurrentException();$n", [])
 
-proc genBreakState(p: BProc, n: CgNode, d: var TLoc) =
-  ## Generates the code for the ``mFinished`` magic, which tests if a
-  ## closure iterator is in the "finished" state (i.e. the internal
-  ## ``state`` field has a value < 0)
-  var a: TLoc
-  initLoc(d, locExpr, n, OnUnknown)
-
-  let arg = n[1]
-  if arg.kind == cnkClosureConstr:
-    initLocExpr(p, arg[1], a)
-    d.r = "(((NI*) $1)[1] < 0)" % [rdLoc(a)]
-  else:
-    initLocExpr(p, arg, a)
-    # the environment is guaranteed to contain the 'state' field at offset 1:
-    d.r = "((((NI*) $1.ClE_0)[1]) < 0)" % [rdLoc(a)]
-
 proc genGotoVar(p: BProc; value: CgNode) =
   case value.kind
   of cnkIntLit, cnkUIntLit:

--- a/tests/magics/tmagics.nim
+++ b/tests/magics/tmagics.nim
@@ -53,3 +53,19 @@ block t9442:
 block: # bug #12229
   proc foo(T: typedesc) = discard
   foo(ref)
+
+block wrong_finished_result:
+  # assigning the result of a ``finished`` call to a local yielded wrong
+  # results
+
+  iterator iter() {.closure.} =
+    return
+
+  proc test() =
+    let x = iter
+    x() # run to completion
+    var f = finished(x)
+    # placing the ``finished`` call within the assertion made the test work
+    doAssert f
+
+  test()


### PR DESCRIPTION
## Summary

Fix assigning the result of a `finished` call to a local either being
treated as a no-op or resulting in C compiler errors. Only the C
backend was affected.

## Details

`genBreakState` didn't handle the put-into-destination case properly:
instead of emitting an assignment, the already initialized `d` was
re-initialized as an expression.

When the call was used at the right side of an assignment, this led to
no code being generated for the assignment (leaving the assignment
destination as is). When the call was used on the right side of a
`var`/`let` statement that wasn't rewritten into an assignment, the
C name of the local was overwritten with the expression, causing all
subsequent assignments to the local resulting in invalid C code.

The `genBreakState` procedure is moved to the `ccgexprs` module (where
the magic-related code generation logic resides) and changed to place
its result into the destination loc via `putIntoDest` (which, if
necessary, emits a C assignment).