### PR TITLE
fix a move-analyzer bug

### DIFF
--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -394,6 +394,7 @@ iterator traverse*(tree: MirTree, c: ControlFlowGraph,
       i = c[pc].node - 1
     else:
       # no more threads left -> exit
+      i = span.b + 1 # move pc past the end
       break
 
   template push(target: JoinId) =

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -7,8 +7,9 @@ doing shady stuff...
 192.168.0.1
 192.168.0.1
 192.168.0.1
-192.168.0.1'''
-  cmd: '''nim c --gc:arc --expandArc:newTarget --expandArc:delete --expandArc:p1 --expandArc:tt --hint:Performance:off --assertions:off --expandArc:extractConfig --expandArc:mergeShadowScope --expandArc:check $file'''
+192.168.0.1
+0'''
+  cmd: '''nim c --gc:arc --expandArc:newTarget --expandArc:delete --expandArc:p1 --expandArc:tt --hint:Performance:off --assertions:off --expandArc:extractConfig --expandArc:mergeShadowScope --expandArc:check --expandArc:treturn $file'''
   nimout: '''--expandArc: newTarget
 
 var splat
@@ -130,6 +131,21 @@ try:
       inc(i, 1)
 finally:
   =destroy(shadowScope)
+-- end of expandArc ------------------------
+--expandArc: treturn
+
+var :aux_2
+try:
+  if ==(len(x), 2):
+    result = x
+    wasMoved(x)
+    return
+  echo([
+    :aux_2 = $(len(x))
+    :aux_2])
+finally:
+  =destroy(:aux_2)
+  =destroy(x)
 -- end of expandArc ------------------------
 --expandArc: check
 
@@ -368,6 +384,16 @@ proc mergeShadowScope*(c: PContext) =
     c.addInterfaceDecl(sym)
 
 mergeShadowScope(PContext(currentScope: Scope(parent: Scope())))
+
+proc treturn(x: sink string): string =
+  if x.len == 2:
+    result = x # last use of `x` -- it can be moved
+    return
+
+  # further uses don't affect whether the above can use a move
+  echo x.len
+
+discard treturn("")
 
 type
   Foo = ref object

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -1,6 +1,6 @@
 discard """
   output: ''''''
-  cmd: '''nim c --gc:arc --expandArc:main --expandArc:tfor --hint:Performance:off $file'''
+  cmd: '''nim c --gc:arc --expandArc:main --expandArc:tfor --expandArc:texit --hint:Performance:off $file'''
   nimout: '''--expandArc: main
 
 var a
@@ -52,6 +52,22 @@ finally:
   =destroy(x)
   =destroy_1(b)
   =destroy_1(a)
+-- end of expandArc ------------------------
+--expandArc: texit
+var str
+var x
+try:
+  x = $(cond)
+  if cond:
+    return
+  str = $(cond)
+  if not(cond):
+    result = str
+    wasMoved(str)
+    return
+finally:
+  =destroy(x)
+  =destroy(str)
 -- end of expandArc ------------------------'''
 """
 
@@ -87,3 +103,19 @@ proc tfor(cond: bool) =
     b.add x
 
 tfor(false)
+
+proc texit(cond: bool): string =
+  var str: string
+  let x = $cond # starts initialized and requires destruction
+
+  if cond:
+    return # make sure `x` escapes
+
+  str = $cond # start `str`'s lifetime
+
+  if not cond:
+    result = str # `str` can be moved (str's lifetime ends)
+    return # unstructured exit
+  # there are no unstructured exits of `str`'s scope where `str` is alive
+
+discard texit(false)


### PR DESCRIPTION
## Summary

Fix a bug with the move analyzer that caused some sinks to be
erroneously turned into copies rather than moves. This didn't affect
run-time correctness or cause memory leaks, but it did led to
unnecessary copies and errors for non-copyable types.

## Details

The `resume` template in `mirexec.traverse` only exits the enclosing
loop, which is a wrong when called from within the inner loop. In
effect, `return`, `break`, and other unstructured exits were treated as
fall-through.

In the abort case, `resume` now ensures that the outer loop is exited
too. This surfaced a second bug: the `wasMoved` injection didn't
consider destructors that were automatically lifted into `finally`
clauses (because some other local within the same scope escaped), thus
leading to double frees.

Marking all destructors for a scope requiring a `finally` as appearing
in a finalizer is now done in `computeDestructors`, making this
information available to `needsReset`.