### PR TITLE
mirexec: rework CFG computation

### DIFF
--- a/tests/compiler/tmir_exec.nim
+++ b/tests/compiler/tmir_exec.nim
@@ -6,7 +6,7 @@ discard """
   target: native
 """
 
-import std/[strutils, strscans, macros]
+import std/[strutils, strscans, macros, tables]
 
 include compiler/sem/mirexec
 
@@ -170,10 +170,10 @@ block:
     MirNode(kind: mnkBlock, label: LabelId(0)),
     MirNode(kind: mnkRepeat),
     MirNode(kind: mnkBreak, label: LabelId(0)),
-    MirNode(kind: mnkEnd),
-    MirNode(kind: mnkEnd),
+    MirNode(kind: mnkEnd, start: mnkRepeat),
+    MirNode(kind: mnkEnd, start: mnkBlock),
     MirNode(kind: mnkReturn),
-    MirNode(kind: mnkEnd)]
+    MirNode(kind: mnkEnd, start: mnkStmtList)]
   let cfg = computeCfg(tree)
 
   doAssert cfg == parseCfg("""


### PR DESCRIPTION
## Summary

Rework how the control-flow graph for a MIR body is computed, reducing
the amount of time taken for the `injectdestructors` pass by ~14%. The
CFG stays the same, only its creation changes.

## Details

Instead of adding both the `fork`/`goto`/`loop` and `join` instruction
when processing a control-flow statement and then relying on a `sort`
call to bring the list into the correct order, a stack-based approach
is used.

Only the opening instruction (`fork`, `goto`, or, for loops, `join`) is
added when processing the start of a structured control-flow block,
with the corresponding `join` or `loop` instruction added when the
`End` node is processed.

This eliminates both the extra MIR tree traversals (which profiling
showed to be where most of the time was spent) and the `sort` call.