### PR TITLE
MIR: refactor the data-flow analysis

### DIFF
--- a/compiler/mir/analysis.nim
+++ b/compiler/mir/analysis.nim
@@ -43,7 +43,6 @@
 
 import
   std/[
-    hashes,
     tables
   ],
   compiler/ast/[
@@ -82,15 +81,6 @@ type
                             ## ``ValueInfo`` is invalid)
     owns: Owned             ## whether the handle owns its value
 
-  Effect = object
-    kind: EffectKind
-    loc: OpValue ## the lvalue the effect applies to
-
-  EffectMap = object
-    ## Accelerator structure that maps each operation to its lvalue effects.
-    list: seq[Effect]
-    map: Table[Operation, Slice[uint32]]
-
   Values* = object
     ## Stores information about the produced values plus the lvalue effects of
     ## operations
@@ -101,7 +91,6 @@ type
     #      A ``Table`` could be used, but that would make lookup less
     #      efficient (although less used memory could also mean better memory
     #      locality)
-    effects: EffectMap
 
   AliveState = enum
     unchanged
@@ -109,26 +98,8 @@ type
     alive
 
   ComputeAliveProc[T] =
-    proc(tree: MirTree, values: Values, loc: T, n: MirNode,
-         op: Operation): AliveState {.nimcall, noSideEffect.}
-
-const
-  ConsumeCtx* = {mnkConsume, mnkRaise, mnkDefUnpack}
-    ## if an lvalue is used as an operand to these operators, the value stored
-    ## in the named location is considered to be consumed (ownership over it
-    ## transfered to the operation)
-  UseContext* = {mnkArg, mnkDeref, mnkDerefView, mnkStdConv, mnkConv, mnkCast,
-                 mnkVoid, mnkIf, mnkCase} + ConsumeCtx
-    ## using an lvalue as the operand to one of these operators means that
-    ## the content of the location is observed (when control-flow reaches the
-    ## operator). In other words, applying the operator results in a read
-
-  OpsWithEffects = {mnkCall, mnkMagic, mnkAsgn, mnkFastAsgn, mnkSwitch,
-                    mnkInit, mnkRegion}
-    ## the set of operations that can have lvalue-parameterized or general
-    ## effects
-
-func hash(x: Operation): Hash {.borrow.}
+    proc(tree: MirTree, values: Values, loc: T, op: Opcode,
+         n: OpValue): AliveState {.nimcall, noSideEffect.}
 
 func skipConversions(tree: MirTree, val: OpValue): OpValue =
   ## Returns the producing operation after skipping handle-only
@@ -152,35 +123,17 @@ func toLvalue*(v: Values, val: OpValue): LvalueExpr {.inline.} =
   (NodePosition v.values[val].root[],
    NodePosition val)
 
-iterator effects(v: Values, op: Operation): lent Effect =
-  ## Yields all location-related effects of the given operation `op` in the
-  ## order they were registered
-  let s = v.effects.map.getOrDefault(op, 1.uint32..0.uint32)
-  for i in s:
-    yield v.effects.list[i]
-
 func decayed(x: ValueInfo): ValueInfo {.inline.} =
   ## Turns 'weak' ownership into 'no' ownership
   result = x
   if result.owns == Owned.weak:
     result.owns = Owned.no
 
-func add(m: var EffectMap, op: Operation, effects: openArray[Effect]) =
-  ## Registers `effects` with `op` in the map `m`
-  let start = m.list.len
-  m.list.add effects
-  m.map[op] = start.uint32 .. m.list.high.uint32
-
 func computeValuesAndEffects*(body: MirTree): Values =
   ## Creates a ``Values`` dictionary with all operation effects collected and
   ## (static) value roots computed. Value ownership is already computed where it
   ## is possible to do so by just taking the static operation sequences into
   ## account (i.e. no control- or data-flow analysis is performed)
-  var
-    stack: seq[Effect]
-    # more than 65K nested effects seems unlikely
-    num: seq[uint16]
-
   result.values.newSeq(body.len)
 
   template inherit(i, source: NodePosition) =
@@ -189,25 +142,13 @@ func computeValuesAndEffects*(body: MirTree): Values =
   template inheritDecay(i, source: NodePosition) =
     result.values[OpValue i] = decayed result.values[OpValue source]
 
-  template popEffects(op: Operation) =
-    let v = num.pop().int
-    if v < stack.len:
-      result.effects.add op, toOpenArray(stack, v, stack.high)
-      stack.setLen(v)
-
   # we're doing three things here:
   # 1. propagate the value root
   # 2. propagate ownership status
-  # 3. collect the lvalue effects for operations
   #
   # This is done in a single forward iteration over all nodes in the code
   # fragment -- nodes that don't represent operations are ignored.
-  # Effects are collected by looking for 'tag' operations. Each occurrence of
-  # an 'arg-block' node starts a new "frame". When a 'tag' operation is
-  # encountered, the corresponding ``Effect`` information is added to the
-  # frame. At the end of the 'arg-block', the frame is popped and the effects
-  # collected as part of it are registered to the arg-block's corresponding
-  # operation
+  # XXX: this is all going to change.
 
   for i, n in body.pairs:
     template start(owned: Owned) =
@@ -269,15 +210,7 @@ func computeValuesAndEffects*(body: MirTree): Values =
     of mnkPathConv:
       inherit(i, NodePosition body.operand(i))
 
-    of mnkArgBlock:
-      num.add stack.len.uint16 # remember the current top-of-stack
-    of mnkTag:
-      stack.add Effect(kind: n.effect, loc: body.operand(i))
-    of mnkEnd:
-      if n.start == mnkArgBlock:
-        popEffects(Operation(i+1))
-
-    of AllNodeKinds - InOutNodes - InputNodes - {mnkEnd}:
+    of AllNodeKinds - InOutNodes - InputNodes + {mnkTag, mnkArgBlock}:
       discard "leave uninitialized"
 
 func isAlive*(tree: MirTree, cfg: ControlFlowGraph, v: Values,
@@ -300,41 +233,34 @@ func isAlive*(tree: MirTree, cfg: ControlFlowGraph, v: Values,
   # somewhere else)
 
   var exit = false
-  for i, n in traverseReverse(tree, cfg, span, pos, exit):
-    case n.kind
-    of OpsWithEffects:
-      # iterate over the effects and look for the ones involving the analysed
-      # location
-      for effect in effects(v, Operation i):
-        case effect.kind
-        of ekMutate, ekReassign:
-          if overlaps(effect.loc):
-            # consider ``a.b = x`` (A) and ``a.b.c.d.e = y`` (B). If the
-            # analysed l-value expression is ``a.b.c`` then both A and B mutate
-            # it (either fully or partially). If traversal reaches what's
-            # possibly a mutation of the analysed location, it means that the
-            # location needs to be treated as being alive at `pos`, so we can
-            # return already
-            return true
+  for op, n in traverseReverse(cfg, span, pos, exit):
+    case op
+    of opDef, opMutate:
+      if overlaps(n):
+        # consider ``a.b = x`` (A) and ``a.b.c.d.e = y`` (B). If the
+        # analysed l-value expression is ``a.b.c`` then both A and B mutate
+        # it (either fully or partially). If traversal reaches what's
+        # possibly a mutation of the analysed location, it means that the
+        # location needs to be treated as being alive at `pos`, so we can
+        # return already
+        return true
 
-        of ekKill:
-          if isPartOf(tree, loc, toLvalue effect.loc) == yes:
-            exit = true
-            break
+    of opKill:
+      if isPartOf(tree, loc, toLvalue n) == yes:
+        exit = true
 
-        of ekInvalidate:
-          discard
+    of opInvalidate:
+      discard
 
-      if tree[loc.root].kind == mnkGlobal and
-         n.kind == mnkCall and geMutateGlobal in n.effects:
+    of opMutateGlobal:
+      if tree[loc.root].kind == mnkGlobal:
         # an unspecified global is mutated and we're analysing a location
         # derived from a global -> assume the analysed global is mutated
         return true
 
-    of ConsumeCtx:
-      let opr = tree.operand(i)
-      if v.owned(opr) == Owned.yes:
-        if isPartOf(tree, loc, toLvalue opr) == yes:
+    of opConsume:
+      if v.owned(n) == Owned.yes:
+        if isPartOf(tree, loc, toLvalue n) == yes:
           # the location's value is consumed and it becomes empty. No operation
           # coming before the current one can change that, so we can stop
           # traversing the current path
@@ -351,10 +277,10 @@ func isAlive*(tree: MirTree, cfg: ControlFlowGraph, v: Values,
 func isLastRead*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
                  span: Slice[NodePosition], loc: LvalueExpr, pos: NodePosition
                 ): bool =
-  ## Performs data-flow analysis to compute whether the value that `loc`
-  ## evaluates to at `pos` is *not* observed by operations that have a
-  ## control-flow dependency on the operation/statement at `pos` and
-  ## are located inside `span`.
+  ## Performs data-flow analysis to compute whether the value in `loc`
+  ## is observed on any paths starting from and including `pos`. If it is
+  ## observed, 'false' is returned, 'true' otherwise. Only operations within
+  ## `span` are considered.
   ## It's important to note that this analysis does not test whether the
   ## underlying *location* is accessed, but rather the *value* it stores. If a
   ## new value is assigned to the underlying location which is then accessed
@@ -363,52 +289,43 @@ func isLastRead*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
     toLvalue(values, val)
 
   var state: TraverseState
-  for i, n in traverse(tree, cfg, span, pos, state):
-    case n.kind
-    of OpsWithEffects:
-      for effect in effects(values, Operation i):
-        let cmp = compareLvalues(tree, loc, toLvalue effect.loc)
-        case effect.kind
-        of ekReassign:
-          if isAPartOfB(cmp) == yes:
-            # the location is reassigned -> all operations coming after will
-            # observe a different value
-            state.exit = true
-            break
-          elif isBPartOfA(cmp) != no:
-            # the location is partially written to -> the relevant values is
-            # observed
-            return false
+  for op, n in traverse(cfg, span, pos, state):
+    case op
+    of opDef:
+      let cmp = compareLvalues(tree, loc, toLvalue n)
+      if isAPartOfB(cmp) == yes:
+        # the location is reassigned -> all operations coming after will
+        # observe a different value
+        state.exit = true
+      elif isBPartOfA(cmp) != no:
+        # the location is partially written to -> the relevant values is
+        # observed
+        return false
 
-        of ekMutate:
-          if cmp.overlaps != no:
-            # the location is partially written to
-            return false
+    of opMutate:
+      if overlaps(tree, loc, toLvalue n) != no:
+        # the location is partially written to
+        return false
 
-        of ekKill:
-          if isAPartOfB(cmp) == yes:
-            # the location is definitely killed, it no longer stores the value
-            # we're interested in
-            state.exit = true
-            break
+    of opKill:
+      let cmp = compareLvalues(tree, loc, toLvalue n)
+      if isAPartOfB(cmp) == yes:
+        # the location is definitely killed, it no longer stores the value
+        # we're interested in
+        state.exit = true
 
-        of ekInvalidate:
-          discard
+    of opInvalidate:
+      discard
 
-      if tree[loc.root].kind == mnkGlobal and
-         n.kind == mnkCall and geMutateGlobal in n.effects:
+    of opMutateGlobal:
+      if tree[loc.root].kind == mnkGlobal:
         # an unspecified global is mutated and we're analysing a location
         # derived from a global -> assume that it's a read/use
         return false
 
-    of UseContext - {mnkDefUnpack}:
-      if overlaps(tree, loc, toLvalue tree.operand(Operation i)) != no:
-        return false
-
-    of DefNodes:
-      # passing a value to a 'def' is also a use
-      if hasInput(tree, Operation i) and
-         overlaps(tree, loc, toLvalue tree.operand(Operation i)) != no:
+    of opUse, opConsume:
+      if overlaps(tree, loc, toLvalue n) != no:
+        # value is observed -> not the last read
         return false
 
     else:
@@ -420,10 +337,11 @@ func isLastRead*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
 func isLastWrite*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
                   span: Slice[NodePosition], loc: LvalueExpr, pos: NodePosition
                  ): tuple[result, exits, escapes: bool] =
-  ## Computes if the location `loc` is not reassigned to or modified while it
-  ## still contains the value it contains at `pos`. In other words, computes
-  ## whether a reassignment or mutation that has a control-flow dependency on
-  ## `pos` and is located inside `span` observes the current value.
+  ## Computes whether the location `loc` is reassigned or modified on any paths
+  ## starting from and including `pos`, returning 'false' if yes and 'true' if
+  ## not. In other words, computes whether a reassignment or mutation that has
+  ## a control-flow dependency on `pos` and is located inside `span` observes
+  ## the current value.
   ##
   ## In addition, whether the `pos` is connected to a structured or
   ## unstructured exit of `span` is also returned
@@ -431,28 +349,24 @@ func isLastWrite*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
     toLvalue(values, val)
 
   var state: TraverseState
-  for i, n in traverse(tree, cfg, span, pos, state):
-    case n.kind
-    of OpsWithEffects:
-      for effect in effects(values, Operation i):
-        let cmp = compareLvalues(tree, loc, toLvalue effect.loc)
-        case effect.kind
-        of ekReassign, ekMutate, ekInvalidate:
-          # note: since we don't know what happens to the location when it is
-          # invalidated, the effect is also included here
-          if cmp.overlaps != no:
-            return (false, false, false)
+  for op, n in traverse(cfg, span, pos, state):
+    case op
+    of opDef, opMutate, opInvalidate:
+      # note: since we don't know what happens to the location when it is
+      # invalidated, the ``opInvalidate`` is also included here
+      if overlaps(tree, loc, toLvalue n) != no:
+        return (false, false, false)
 
-        of ekKill:
-          if isAPartOfB(cmp) == yes:
-            state.exit = true
-            break
+    of opKill:
+      let cmp = compareLvalues(tree, loc, toLvalue n)
+      if isAPartOfB(cmp) == yes:
+        state.exit = true
 
-          # partially killing the analysed location is not considered to be a
-          # write
+      # partially killing the analysed location is not considered to be a
+      # write
 
-      if tree[loc.root].kind == mnkGlobal and
-         n.kind == mnkCall and geMutateGlobal in n.effects:
+    of opMutateGlobal:
+      if tree[loc.root].kind == mnkGlobal:
         # an unspecified global is mutated and we're analysing a location
         # derived from a global
         return (false, false, false)
@@ -463,7 +377,7 @@ func isLastWrite*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
   result = (true, state.exit, state.escapes)
 
 func computeAliveOp*[T: PSym | TempId](
-  tree: MirTree, values: Values, loc: T, n: MirNode, op: Operation): AliveState =
+  tree: MirTree, values: Values, loc: T, op: Opcode, n: OpValue): AliveState =
   ## Computes the state of `loc` at the *end* of the given operation. The
   ## operands are expected to *not* alias with each other. The analysis
   ## result will be wrong if they do
@@ -482,39 +396,31 @@ func computeAliveOp*[T: PSym | TempId](
   template sameLocation(val: OpValue): bool =
     isAnalysedLoc(tree[skipConversions(tree, val)], loc)
 
-  case n.kind
-  of OpsWithEffects:
-    # iterate over the lvalue effects of the processed operation and check
-    # whether one of them affects the state of `loc`. If one does, further
-    # iteration is not required, as the underlying locations of the operands
-    # must not alias with each other.
-    for effect in effects(values, op):
-      case effect.kind
-      of ekMutate, ekReassign:
-        if isRootOf(effect.loc):
-          # the analysed location or one derived from it is mutated
-          return alive
+  case op
+  of opMutate, opDef:
+    if isRootOf(n):
+      # the analysed location or one derived from it is mutated
+      return alive
 
-      of ekKill:
-        if sameLocation(effect.loc):
-          # the location is killed
-          return dead
+  of opKill:
+    if sameLocation(n):
+      # the location is killed
+      return dead
 
-      of ekInvalidate:
-        discard "cannot be reasoned about here"
+  of opInvalidate:
+    discard "cannot be reasoned about here"
 
+  of opMutateGlobal:
     when T is PSym:
       # XXX: testing the symbol's flags is okay for now, but a different
       #      approach has to be used once moving away from storing ``PSym``s
       #      in ``MirNodes``
-      if sfGlobal in loc.flags and
-          n.kind == mnkCall and geMutateGlobal in n.effects:
+      if sfGlobal in loc.flags:
         # the operation mutates global state and we're analysing a global
         result = alive
 
-  of ConsumeCtx:
-    let opr = tree.operand(op)
-    if values.owned(opr) == Owned.yes and sameLocation(opr):
+  of opConsume:
+    if values.owned(n) == Owned.yes and sameLocation(n):
       # the location's value is consumed
       result = dead
 
@@ -522,7 +428,7 @@ func computeAliveOp*[T: PSym | TempId](
     discard
 
 func computeAlive*[T](tree: MirTree, cfg: ControlFlowGraph, values: Values,
-                      span: Slice[NodePosition], loc: T, hasInitialValue: bool,
+                      span: Slice[NodePosition], loc: T,
                       op: static ComputeAliveProc[T]
                      ): tuple[alive, escapes: bool] =
   ## Computes whether the location is alive when `span` is exited via either
@@ -534,8 +440,8 @@ func computeAlive*[T](tree: MirTree, cfg: ControlFlowGraph, values: Values,
   # on it "kills" it (it no longer contains a value)
 
   var exit = false
-  for i, n in traverseFromExits(tree, cfg, span, exit):
-    case op(tree, values, loc, n, Operation i)
+  for opc, n in traverseFromExits(cfg, span, exit):
+    case op(tree, values, loc, opc, n)
     of dead:
       exit = true
     of alive:
@@ -545,14 +451,9 @@ func computeAlive*[T](tree: MirTree, cfg: ControlFlowGraph, values: Values,
     of unchanged:
       discard
 
-  if exit and hasInitialValue:
-    # an unstructured exit is connected to the start of the span and the
-    # location starts initialized
-    return (true, true)
-
   # check if the location is alive at the structured exit of the span
-  for i, n in traverseReverse(tree, cfg, span, span.b + 1, exit):
-    case op(tree, values, loc, n, Operation i)
+  for opc, n in traverseReverse(cfg, span, span.b + 1, exit):
+    case op(tree, values, loc, opc, n)
     of dead:
       exit = true
     of alive:
@@ -562,7 +463,7 @@ func computeAlive*[T](tree: MirTree, cfg: ControlFlowGraph, values: Values,
     of unchanged:
       discard
 
-  result = (exit and hasInitialValue, false)
+  result = (false, false)
 
 proc doesGlobalEscape*(tree: MirTree, scope: Slice[NodePosition],
                        start: NodePosition, s: PSym): bool =

--- a/compiler/mir/analysis.nim
+++ b/compiler/mir/analysis.nim
@@ -4,9 +4,9 @@
 ## corresponding to the code fragment (i.e. ``MirTree``) that is analysed.
 ##
 ## A ``Values`` dictionary stores information about the result of operations,
-## namely, whether the value is owned and, for lvalues, the root. It also
-## stores the lvalue effects of operations. An instance of the dictionary is
-## created and initialized via the ``computeValuesAndEffects`` procedure.
+## namely, whether the value is owned and, for lvalues, the root. An instance
+## of the dictionary is created and initialized via the ``computeValues``
+## procedure.
 ##
 ## Each location that is not allocated via ``new`` or ``alloc`` is owned by a
 ## single handle (the name of a local, global, etc.), but can be aliased
@@ -26,7 +26,7 @@
 ## aliases are not detected.
 ##
 ## ..note:: implementing this is possible. A second step after
-##          ``computeValuesAndEffects`` could perform an abstract execution of
+##          ``computeValues`` could perform an abstract execution of
 ##          the MIR code to produce a conservative set of possible handles for
 ##          each pointer-like dereferencing operation. The analysis routines
 ##          would then compare the analysed handle with each set element,
@@ -129,11 +129,11 @@ func decayed(x: ValueInfo): ValueInfo {.inline.} =
   if result.owns == Owned.weak:
     result.owns = Owned.no
 
-func computeValuesAndEffects*(body: MirTree): Values =
-  ## Creates a ``Values`` dictionary with all operation effects collected and
-  ## (static) value roots computed. Value ownership is already computed where it
-  ## is possible to do so by just taking the static operation sequences into
-  ## account (i.e. no control- or data-flow analysis is performed)
+func computeValues*(body: MirTree): Values =
+  ## Creates a ``Values`` dictionary storing static information about lvalue
+  ## expressions. Value ownership is already computed where it is possible
+  ## to do so by just taking the static operation sequences into account (i.e.,
+  ## no control- or data-flow analysis is performed)
   result.values.newSeq(body.len)
 
   template inherit(i, source: NodePosition) =

--- a/compiler/mir/analysis.nim
+++ b/compiler/mir/analysis.nim
@@ -1,6 +1,6 @@
 ## This module implements various data-flow related analysis for MIR code.
 ## They're based on the ``mirexec`` traversal algorithms and require a
-## ``Values`` dictionary and a ``ControlFlowGraph`` object, both
+## ``Values`` dictionary and a ``DataFlowGraph`` object, both
 ## corresponding to the code fragment (i.e. ``MirTree``) that is analysed.
 ##
 ## A ``Values`` dictionary stores information about the result of operations,
@@ -213,7 +213,7 @@ func computeValuesAndEffects*(body: MirTree): Values =
     of AllNodeKinds - InOutNodes - InputNodes + {mnkTag, mnkArgBlock}:
       discard "leave uninitialized"
 
-func isAlive*(tree: MirTree, cfg: ControlFlowGraph, v: Values,
+func isAlive*(tree: MirTree, cfg: DataFlowGraph, v: Values,
              span: Slice[NodePosition], loc: LvalueExpr,
              pos: NodePosition): bool =
   ## Computes if the location named by `loc` does contain a value at `pos`
@@ -274,7 +274,7 @@ func isAlive*(tree: MirTree, cfg: ControlFlowGraph, v: Values,
   # no mutation is directly connected to `pos`. The location is not alive
   result = false
 
-func isLastRead*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
+func isLastRead*(tree: MirTree, cfg: DataFlowGraph, values: Values,
                  span: Slice[NodePosition], loc: LvalueExpr, pos: NodePosition
                 ): bool =
   ## Performs data-flow analysis to compute whether the value in `loc`
@@ -334,7 +334,7 @@ func isLastRead*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
   # no further read of the value is connected to `pos`
   result = true
 
-func isLastWrite*(tree: MirTree, cfg: ControlFlowGraph, values: Values,
+func isLastWrite*(tree: MirTree, cfg: DataFlowGraph, values: Values,
                   span: Slice[NodePosition], loc: LvalueExpr, pos: NodePosition
                  ): tuple[result, exits, escapes: bool] =
   ## Computes whether the location `loc` is reassigned or modified on any paths
@@ -427,7 +427,7 @@ func computeAliveOp*[T: PSym | TempId](
   else:
     discard
 
-func computeAlive*[T](tree: MirTree, cfg: ControlFlowGraph, values: Values,
+func computeAlive*[T](tree: MirTree, cfg: DataFlowGraph, values: Values,
                       span: Slice[NodePosition], loc: T,
                       op: static ComputeAliveProc[T]
                      ): tuple[alive, escapes: bool] =

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -8,7 +8,6 @@ import
     types
   ],
   compiler/mir/[
-    analysis,
     mirchangesets,
     mirconstr,
     mirtrees,

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -379,6 +379,23 @@ const
   SymbolLike* = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal}
     ## Nodes for which the `sym` field is available
 
+  # --- semantics-focused sets:
+
+  ConsumeCtx* = {mnkConsume, mnkRaise, mnkDefUnpack}
+    ## if an lvalue is used as an operand to these operators, the value stored
+    ## in the named location is considered to be consumed (ownership over it
+    ## transfered to the operation)
+  UseContext* = {mnkArg, mnkDeref, mnkDerefView, mnkStdConv, mnkConv, mnkCast,
+                 mnkVoid, mnkIf, mnkCase} + ConsumeCtx
+    ## using an lvalue as the operand to one of these operators means that
+    ## the content of the location is observed (when control-flow reaches the
+    ## operator). In other words, applying the operator results in a read
+  OpsWithEffects* = {mnkCall, mnkMagic, mnkAsgn, mnkFastAsgn, mnkSwitch,
+                     mnkInit, mnkRegion}
+    ## the set of operations that can have lvalue-parameterized or general
+    ## effects
+
+
 func `==`*(a, b: SourceId): bool {.borrow.}
 func `==`*(a, b: TempId): bool {.borrow.}
 func `==`*(a, b: LabelId): bool {.borrow.}
@@ -661,6 +678,24 @@ iterator subNodes*(tree: MirTree, n: NodePosition): NodePosition =
   for _ in 0..<L:
     yield r
     r = sibling(tree, r)
+
+iterator effects*(tree: MirTree, n: NodePosition): (EffectKind, OpValue) =
+  ## For an effectful operation, returns in an unspecified order all lvalue
+  ## effects together with their applying-to operand.
+  let prev = n - 1
+  if tree[prev].kind == mnkEnd and tree[prev].start == mnkArgBlock:
+    var pos = prev - 1
+    while tree[pos].kind != mnkArgBlock:
+      if tree[pos].kind in ArgumentNodes:
+        let arg = tree.operand(pos)
+        if tree[arg].kind == mnkTag:
+          yield (tree[arg].effect, tree.operand(arg))
+
+      pos = previous(tree, pos)
+
+  else:
+    # no argument block being used means that no effects are specified
+    discard
 
 # XXX: ``lpairs`` is not at all related to the mid-end IR. The ``pairs``
 #      iterator from the stdlib should be changed to use ``lent`` instead

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -47,7 +47,7 @@
 ## code-fragment is created and initialized. For all arguments that appear in
 ## a consume context (e.g. passed to ``sink`` argument, assignment source)
 ## and for which the ownership status could not be resolved to either 'yes' or
-## 'no' by ``analysis.computeValuesAndEffects``, a data-flow analysis is
+## 'no' by ``analysis.computeValues``, a data-flow analysis is
 ## performed to figure out the status (see ``solveOwnership``).
 ##
 ## Using the now resolved ownership status of all expressions, the next
@@ -405,7 +405,7 @@ func computeOwnership(tree: MirTree, cfg: DataFlowGraph, values: Values,
   case tree[lval.root].kind
   of mnkObjConstr, mnkConstr, mnkMagic, mnkCall:
     # all values derived from a constructor-operation that reach here are
-    # guaranteed to own (see ``analyser.computeValuesAndEffects``).
+    # guaranteed to own (see ``analyser.computeValues``).
     Owned.yes
   of mnkLocal, mnkParam, mnkGlobal, mnkTemp:
     # only entities that are relevant for destructor injection have an entry in
@@ -1234,7 +1234,7 @@ proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
       actx = AnalyseCtx(graph: g, cfg: computeDfg(tree))
       entities = initEntityDict(tree)
 
-    var values = computeValuesAndEffects(tree)
+    var values = computeValues(tree)
     solveOwnership(tree, actx.cfg, values, entities)
 
     let destructors = computeDestructors(tree, actx.cfg, values, entities)

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -57,6 +57,10 @@ type
 
   DataFlowOpcode = range[opUse..opMutateGlobal]
 
+const
+  DataFlowOps = {opUse .. opMutateGlobal}
+
+type
   # TODO: make both types distinct
   InstrPos = int32
   JoinId = uint32
@@ -68,7 +72,7 @@ type
       dest: JoinId
     of opJoin:
       id: JoinId
-    of opUse, opDef, opConsume, opInvalidate, opMutate, opKill, opMutateGlobal:
+    of DataFlowOps:
       val: OpValue
 
   DataFlowGraph* = object
@@ -127,9 +131,6 @@ type
     pc: InstrPos
       ## the program counter. Points to the CFG instruction that is executed
       ## next
-
-const
-  DataFlowOps = {opUse .. opMutateGlobal}
 
 func incl[T](s: var seq[T], v: sink T) =
   ## If not present already, adds `v` to the sorted ``seq`` `s`

--- a/tests/compiler/tmir_exec.nim
+++ b/tests/compiler/tmir_exec.nim
@@ -81,8 +81,8 @@ proc parse2(str: string): Program =
   var
     nameToId: Table[int, uint32]
 
-  func parseOp2(input: string, r: var POpcode, start: int): int =
-    for e, s in [def: "def", use: "use"]:
+  func parseOp2(input: string, r: var Opcode, start: int): int =
+    for e, s in items({opDef: "def", opUse: "use"}):
       if input.substr(start).startsWith(s):
         r = e
         result = s.len
@@ -103,7 +103,6 @@ proc parse2(str: string): Program =
     var
       name: int
       op: Opcode
-      op2: POpcode
 
     if scanf(line, "$s$i$s:$sjoin", name):
       code.add PInstr(op: cflow)
@@ -118,10 +117,18 @@ proc parse2(str: string): Program =
       code.add PInstr(op: cflow)
       cfgCode.add Instr(op: op)
       cfgCode[^1].dest = getId(name)
-    elif scanf(line, "$s${parseOp2} :$i", op2, name):
-      code.add PInstr(op: op2, id: name)
+    elif scanf(line, "$s${parseOp2} :$i", op, name):
+      case op
+      of opUse:
+        code.add PInstr(op: use, id: name)
+      of opDef:
+        code.add PInstr(op: def, id: name)
+      else:
+        doAssert false
+      # the DFG instruction points to the progam instruction
+      cfgCode.add Instr(op: DataFlowOpcode(op), val: OpValue code.high)
+
       result.map[name] = NodePosition(code.high)
-      continue
     else:
       raise ValueError.newException("syntax error in line: " & line)
 
@@ -135,6 +142,7 @@ func `==`(a, b: Instr): bool =
     case a.op
     of opFork, opGoto, opLoop: a.dest == b.dest
     of opJoin:                 a.id == b.id
+    of DataFlowOps:            a.node == b.node
 
 func `==`(a, b: ControlFlowGraph): bool =
   ## Compares two CFGs for structural equality. Differing join IDs are ignored
@@ -156,6 +164,8 @@ func `==`(a, b: ControlFlowGraph): bool =
         a.map[an.dest] == b.map[bn.dest]
       of opJoin:
         a.map[an.id] == b.map[bn.id]
+      of DataFlowOps:
+        true
 
     if not result:
       return
@@ -199,16 +209,18 @@ func isConnected(p: Program, defId, useId: int): bool =
     exit = false
 
   result = false
-  for i, _ in traverseReverse(tree, p.cfg, NodePosition(0)..NodePosition(tree.high), p.map[useId], exit):
+  for op, i in traverseReverse(p.cfg, NodePosition(0)..NodePosition(tree.high), p.map[useId], exit):
     doAssert not visited[int i]
     visited[int i] = true
 
-    case p.code[int i].op
-    of def:
+    case op
+    of opDef:
       if p.code[int i].id == defId:
         result = true
-    of use, cflow:
+    of opUse:
       discard "ignore"
+    else:
+      doAssert false, "unexpected data-flow instruction"
 
 proc useChain(p: Program, defId, start: int): seq[int] =
   ## Computes and returns the 'use's connected to the 'use' with ID `start`.
@@ -220,21 +232,21 @@ proc useChain(p: Program, defId, start: int): seq[int] =
     visited = newSeq[bool](p.code.len)
     exit = false
 
-  for i, _ in traverseReverse(tree, p.cfg, NodePosition(0)..NodePosition(tree.high), p.map[start], exit):
+  for op, i in traverseReverse(p.cfg, NodePosition(0)..NodePosition(tree.high), p.map[start], exit):
     doAssert not visited[int i],
              "instruction already visited; either the algorithm or CFG is broken"
     visited[int i] = true
 
     let instr = p.code[int i]
-    case instr.op
-    of def:
+    case op
+    of opDef:
       if instr.id == defId:
         # found the def; quit the path
         exit = true
-    of use:
+    of opUse:
       result.add instr.id
-    of cflow:
-      discard "ignore"
+    else:
+      doAssert false, "unexpected data-flow instruction"
 
 block infinite_loop:
   # while true:

--- a/tests/compiler/tmir_exec.nim
+++ b/tests/compiler/tmir_exec.nim
@@ -25,7 +25,7 @@ type
     id: int
 
   Program = object
-    cfg: ControlFlowGraph
+    cfg: DataFlowGraph
     code: seq[PInstr]
     map: Table[int, NodePosition]
       ## maps a def/use ID the position of the corresponding instruction
@@ -37,7 +37,7 @@ func parseOp(input: string, r: var Opcode, start: int): int =
       result = s.len
       break
 
-proc parseCfg(str: string): ControlFlowGraph =
+proc parseCfg(str: string): DataFlowGraph =
   ## Creat a CFG object from its text representation
   var
     list: seq[Instr]
@@ -74,7 +74,7 @@ proc parseCfg(str: string): ControlFlowGraph =
 
     list[^1].node = NodePosition(val)
 
-  result = ControlFlowGraph(instructions: list, map: map)
+  result = DataFlowGraph(instructions: list, map: map)
 
 proc parse2(str: string): Program =
   ## Parses a ``Program`` object from its text representation
@@ -144,8 +144,8 @@ func `==`(a, b: Instr): bool =
     of opJoin:                 a.id == b.id
     of DataFlowOps:            a.node == b.node
 
-func `==`(a, b: ControlFlowGraph): bool =
-  ## Compares two CFGs for structural equality. Differing join IDs are ignored
+func `==`(a, b: DataFlowGraph): bool =
+  ## Compares two DFGs for structural equality. Differing join IDs are ignored
   ## as long as they point to the same instruction
   if a.instructions.len != b.instructions.len:
     return false
@@ -184,7 +184,7 @@ block:
     MirNode(kind: mnkEnd, start: mnkBlock),
     MirNode(kind: mnkReturn),
     MirNode(kind: mnkEnd, start: mnkStmtList)]
-  let cfg = computeCfg(tree)
+  let cfg = computeDfg(tree)
 
   doAssert cfg == parseCfg("""
     0: join -> 2


### PR DESCRIPTION
## Summary

Change the data-flow analysis implementation used by the MIR phase
(`mirexec`) to rely less on the MIR's tree structure, preparing for
changes to the latter. This also speeds up the traversal and simplifies
the implementation.

## Details

The MIR data-flow analysis used a hybrid approach so far: `mirexec`
provided control-flow graph traversal routines for traversing the basic
blocks in a MIR tree, with the data-flow relevant effects directly
computed from the MIR nodes during traversal.

### Problems

This approach worked well, but it has the problem of necessitating that
MIR nodes appear in the order their data-flow effects happen, which
is what ultimately led to the current instruction-like design of the
MIR. An exception was already made for calls and assignments (refer to
`computeValuesAndEffects`), where mutation effects have to be applied
when the *call/assignment* node is visited, not when the argument's
*tag* node (which comes earlier) is visited.

### Revised implementation

In order to make evolving the MIR's layout possible without having to
change the data-flow analysis algorithms, the data-flow effects are now
encoded directly in the control-flow graph, making it a data-flow
graph.

**Data-flow operations**:
* `opDef`: corresponds to `ekReassign` effects and is also used for
  definitions (`mnkDef`)
* `opUse`: represents all lvalue usages that are not consumes
* `opConsume`: corresponds to `mnkConsume` and other consume contexts
* `opKill`, `opMutate`, `opInvalidate`: correspond to the
  `EffectKind` of the same name
* `opMutateGlobal`: represents a mutation of an unspecified global

The data-flow instruction are emitted together with the control-flow
instructions in `computeCfg`.

**Changes:**
* move the `ConsumeCtx`, `UseContext`, `OpsWithEffects` sets into
  `mirtrees`
* instead of iterating over the tree and having to map the positions to
  control-flow instructions, the `traverse`, `traverseReverse`, and
  `traverseFromExits` iterators only need to iterate the instruction
  list (which renders the `tree` parameters obsolete)
* the iterators return the data-flow operation kind plus expression
  directly

**Changes to the usage sites:**
* change the `traverse` iterator to start at `start` rather than at
  `start + 1`. This is more intuitive and easier to implement. The
  transitive callsites `isLastRead`, `isLastWrite`, `computeOwnership`,
  and `needsReset` are adjusted accordingly, by applying the offset
  themselves
* support `start` pointing outside the provided `span` in `traverse`,
  making the API easier to use (e.g., no extra guard logic is needed)
* remove the special handling for `mnkDef` statements from
  `analysis.computeAlive` -- the information is now encoded in the
  data-flow graph
* remove the now-obsolete effect tracking for `Call`, `Asgn`, etc.
  nodes
* the `tmir_exec.nim` is updated to work with the `mirexec` changes

`ControlFlowGraph` is renamed to `DataFlowGraph`, `computeCfg` to
`computeDfg`, and the associated documentation is updated to reflect
the shift in purpose.

### Additional benefits

* computing the data-flow operations in a single place (i.e., during
  data-flow graph create) means that downstream users don't have to
  duplicate the logic
* the traversal routines no longer need a `MirTree`, making it much
  easier to generalize them into something that can be used without the
  MIR