### PR TITLE
internal: fix `skConst` translation in `mirgen`

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -419,14 +419,18 @@ proc genEmpty(c: var TCtx, n: PNode): EValue =
   result = EValue(typ: c.graph.getSysType(n.info, tyVoid))
 
 func nameNode(s: PSym): MirNode =
-  if sfGlobal in s.flags:
-    MirNode(kind: mnkGlobal, typ: s.typ, sym: s)
-  elif s.kind == skParam:
-    MirNode(kind: mnkParam, typ: s.typ, sym: s)
-  elif s.kind == skConst:
+  case s.kind
+  of skConst:
     MirNode(kind: mnkConst, typ: s.typ, sym: s)
-  elif s.kind in {skVar, skLet, skForVar, skResult}:
+  of skParam:
+    MirNode(kind: mnkParam, typ: s.typ, sym: s)
+  of skResult:
     MirNode(kind: mnkLocal, typ: s.typ, sym: s)
+  of skVar, skLet, skForVar:
+    if sfGlobal in s.flags:
+      MirNode(kind: mnkGlobal, typ: s.typ, sym: s)
+    else:
+      MirNode(kind: mnkLocal, typ: s.typ, sym: s)
   else:
     unreachable(s.kind)
 


### PR DESCRIPTION
## Summary

Fix top-level `skConst` symbols being translated to `mnkGlobal` MIR
nodes.

## Details

The usage-symbol translation in `mirgen` (`nameNode`) treated all
symbols marked with the `sfGlobal` flag as globals, but since `skConst`
symbols defined at the top-level are also marked with the flag, they
too were translated to globals.

This incorrect translation didn't cause any problems, as:
* `injectdestructors` ignored the globals, since no `mnkDef` exists for
  them in the analyzed body
* both `mnkConst` and `mnkGlobal` are translated to `cnkSym`, so the
  code generators weren't affected

`nameNode` is changed to use a case statement where the `sfGlobal`
flag is only considered for the relevant symbol kinds.