### PR TITLE
vm: remove `openArray` conversion support

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -665,39 +665,7 @@ proc opConv(c: var TCtx; dest: var TFullReg, src: TFullReg, dt, st: (PType, PVmT
     else:
       unreachable(styp.kind)
   else:
-    let desttyp = skipTypes(desttyp, abstractVarRange)
-    case desttyp.kind
-    of tyOpenArray:
-      assert dt[1].kind == akSeq
-
-      let srckind = srctyp.skipTypes(abstractRange).kind
-      case srckind
-      of tySequence:
-        # XXX: `asgnComplex` is wrong and leads to `experimental:views`
-        #      more or less not working at all for VM code. Since
-        #      first-class openArray usage is probably very rare, I believe
-        #      it's okay for now.
-        asgnValue(c.memory, dest, src)
-      of tyArray, tyString:
-        let
-          t = dt[1].seqElemType
-          L = arrayLen(src.handle)
-
-        deref(dest.handle).seqVal.newVmSeq(dt[1], L, c.memory)
-
-        let sd =
-          if srckind == tyArray: src.handle.rawPointer
-          else:                  src.strVal.data.rawPointer
-        let dd = deref(dest.handle).seqVal.data
-
-        # XXX: does the same thing as `asgnComplex` above and is thus
-        #      equally wrong
-        arrayCopy(c.memory, byteView(dd, t, L), byteView(sd, t, L), L, t, false)
-      else:
-        unreachable() # vmgen issue
-
-    else:
-      unreachable(desttyp.kind)
+    unreachable(desttyp.kind)
 
 proc opNumConv(dest: var TFullReg, src: TFullReg, info: uint16) =
   ## Perform a conversion between two numeric values. The source value is

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1341,6 +1341,13 @@ proc genToStr(c: var TCtx, n, arg: CgNode, dest: var TDest) =
   c.gABx(n, opcConv, tmp, c.genTypeInfo(arg.typ.skipTypes(Skip)))
   c.freeTemp(tmp)
 
+proc genToSlice(c: var TCtx, val: TRegister, typ: PType, info: TLineInfo,
+                dest: TRegister) =
+  let L = c.getTemp(c.graph.getSysType(info, tyInt))
+  c.gABC(info, opcLenSeq, L, val) # fetch the length of the input array
+  c.gABC(info, opcSetLenSeq, dest, L) # resize the destination
+  c.gABC(info, opcArrCopy, dest, val, L) # copy the contents
+
 proc genObjConv(c: var TCtx, n: CgNode, dest: var TDest) =
   prepare(c, dest, n.typ)
   let
@@ -2915,16 +2922,13 @@ proc genObjConstr(c: var TCtx, n: CgNode, dest: var TDest) =
         opcode = opcWrObj
         let
           le = it[0].sym.typ
-          ri = it[1].typ
-        if le.kind == tyOpenArray and not sameType(le, ri):
-          # XXX: this is a hack to make `tests/vm/tconst_views` work for now.
-          #      `transf` removes `nkHiddenStdConv` for array/seq to openArray
-          #      conversions, which we could have otherwise relied on
+        if le.kind == tyOpenArray:
+          # XXX: once the to-slice operator is passed to ``vmgen``, integrate
+          #      the conversion into ``genAsgnSource``
           let tmp2 = c.getFullTemp(it[0], le)
-          c.gABx(n, opcConv, tmp2, c.genTypeInfo(le))
-          c.gABx(n, opcConv, tmp, c.genTypeInfo(ri))
+          c.genToSlice(tmp, le, it[1].info, tmp2)
           c.freeTemp(tmp)
-          tmp = tmp2
+          tmp = TRegister(tmp2)
       else:
         tmp = c.genDiscrVal(it[0], it[1], n.typ)
         opcode = opcInitDisc

--- a/tests/lang_types/openarray/topenarray_assign_2.nim
+++ b/tests/lang_types/openarray/topenarray_assign_2.nim
@@ -1,0 +1,31 @@
+discard """
+  targets: "c js vm"
+  matrix: "--experimental:views"
+  description: "Tests for assigning first-class openArrays to object fields"
+  knownIssue.c: "`cgen` produces illegal C code"
+"""
+
+type Object[T] = object
+  x: openArray[T]
+
+proc test[T, U](s: T, val: U) =
+
+  block assignment_with_implicit_conversion:
+    let o = Object[U](x: s)
+    # try reading through the field
+    doAssert o.x.len == 2
+    doAssert o.x[1] == val
+
+  var oa: openArray[U] = s # implicit conversion takes place
+  block assignmnent_without_conversions:
+    let o = Object[U](x: oa)
+    doAssert o.x.len == 2
+    doAssert o.x[1] == val
+
+  # XXX: use `s` for the borrowing to work. This is a workaround that
+  #      shouldn't be needed
+  discard s
+
+test([1, 2], 2) # test with an array
+test(@[1, 2], 2) # test with a seq
+test("12", '2') # test with a string


### PR DESCRIPTION
## Summary

Implement the conversion operation in bytecode instead, making the VM
slightly simpler. A VM crash when assigning an `openArray` parameter to
an `openArray` field is also fixed.

## Details

* implement the current to-openArray conversion (essentially a
  `seq` copy) in `vmgen` as `SetLenSeq` + `ArrCopy`, replicating
  the VM's implementation in `opConv`
* remove the built-in VM `openArray` conversion support from
  `opConv` 

Having the operation implemented in bytecode makes the VM leaner and
reduces the amount of run-time dispatching.

In addition, the operation is now also performed when the source
expression is already an `openArray`. Locals and parameters of
`openArray` type may also be stored as arrays or strings, in which
case directly assigning the value via `WrLoc` would result in a run-
time type error.