### PR TITLE
internal: improve the `mirexec` API

### DIFF
--- a/compiler/mir/analysis.nim
+++ b/compiler/mir/analysis.nim
@@ -267,7 +267,7 @@ func isAlive*(tree: MirTree, cfg: DataFlowGraph, v: Values,
 
         # partially consuming the location does *not* change the alive state
 
-    else:
+    of opUse:
       discard "not relevant"
 
   # no mutation is directly connected to `start`. The location is not alive
@@ -326,9 +326,6 @@ func isLastRead*(tree: MirTree, cfg: DataFlowGraph, values: Values,
       if overlaps(tree, loc, toLvalue n) != no:
         # value is observed -> not the last read
         return false
-
-    else:
-      discard
 
   # no further read of the value is connected to `start`
   result = true

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -491,7 +491,7 @@ func find*(dfg: DataFlowGraph, n: NodePosition): InstrPos =
   lowerBound(dfg, n)
 
 iterator traverse*(c: DataFlowGraph, span: Subgraph, start: InstrPos,
-                   state: var TraverseState): (Opcode, OpValue) =
+                   state: var TraverseState): (DataFlowOpcode, OpValue) =
   ## Starts at the data-flow operation closest to `start` and traverses/yields
   ## all data-flow operations inside `span` in control-flow order. Outside of
   ## loops, this means that an operation is visited *before* operations that
@@ -636,7 +636,7 @@ func processJoin(id: JoinId, s: var ExecState, c: DataFlowGraph) {.inline.} =
     s.time = s.visited[id]
 
 iterator traverseReverse*(c: DataFlowGraph, span: Subgraph, start: InstrPos,
-                          exit: var bool): (Opcode, OpValue) =
+                          exit: var bool): (DataFlowOpcode, OpValue) =
   ## Starts at `start - 1` and visits and returns all data-flow operations
   ## inside `span` in post-order.
   ##
@@ -744,7 +744,7 @@ iterator traverseReverse*(c: DataFlowGraph, span: Subgraph, start: InstrPos,
   exit = s.active
 
 iterator traverseFromExits*(c: DataFlowGraph, span: Subgraph,
-                            exit: var bool): (Opcode, OpValue) =
+                            exit: var bool): (DataFlowOpcode, OpValue) =
   ## Similar to ``traverseReverse``, but starts traversal at each unstructured
   ## exit of `span`. Here, unstructured exit means that the control-flow leaves
   ## `span` via a 'goto' or 'fork'.

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -62,8 +62,12 @@ const
 
 type
   # TODO: make both types distinct
-  InstrPos = int32
+  InstrPos* = int32
   JoinId = uint32
+
+  Subgraph* = Slice[InstrPos]
+    ## Represents a sub-graph within the data-flow graph. Internally, this is
+    ## a span of instructions.
 
   Instr = object
     node: NodePosition
@@ -474,8 +478,19 @@ func computeDfg*(tree: MirTree): DataFlowGraph =
     if instr.op == opJoin:
       result.map[instr.id] = InstrPos(i)
 
-iterator traverse*(c: DataFlowGraph,
-                   span: Slice[NodePosition], start: NodePosition,
+func subgraphFor*(dfg: DataFlowGraph, span: Slice[NodePosition]): Subgraph =
+  ## Computes a reference to the sub-graph encompassing the `span` of MIR
+  ## instructions.
+  result.a = lowerBound(dfg, span.a)
+  result.b = upperBound(dfg, span.b) - 1
+
+func find*(dfg: DataFlowGraph, n: NodePosition): InstrPos =
+  ## Returns the first data-/control-flow operation associated with `n`.
+  ## If none are associated with `n`, the closest following (in terms of
+  ## attached-to node position) operation is returned.
+  lowerBound(dfg, n)
+
+iterator traverse*(c: DataFlowGraph, span: Subgraph, start: InstrPos,
                    state: var TraverseState): (Opcode, OpValue) =
   ## Starts at the data-flow operation closest to `start` and traverses/yields
   ## all data-flow operations inside `span` in control-flow order. Outside of
@@ -489,11 +504,10 @@ iterator traverse*(c: DataFlowGraph,
   ## `state` is used for bi-directional communication -- see the documentation
   ## of ``TraverseState`` for more information.
   var
-    last = upperBound(c, span.b) - 1
     pc =
-      if start in span: lowerBound(c, start)
-      else:             last + 1 # disable execution
-    start = pc
+      if start in span: start
+      else:             span.b + 1 # disable execution
+    last = span.b
     queue: seq[InstrPos]
     visited: PackedSet[JoinId]
 
@@ -514,7 +528,7 @@ iterator traverse*(c: DataFlowGraph,
     ## it to the execution queue, effectively starting a new thread. Records
     ## an escape otherwise
     let dst = c.map[target]
-    if c[dst].node in span:
+    if dst in span:
       queue.incl dst
     else:
       state.escapes = true
@@ -558,7 +572,7 @@ iterator traverse*(c: DataFlowGraph,
   assert queue.len <= 1
 
   # don't set `exit` to true if nothing was traversed
-  state.exit = pc > last and start <= last
+  state.exit = pc > last and start in span
 
 template active(s: ExecState): bool =
   # if a thread is selected and it's either the or derived from the main
@@ -621,8 +635,7 @@ func processJoin(id: JoinId, s: var ExecState, c: DataFlowGraph) {.inline.} =
     s.visited[id] = max(s.time, s.visited[id])
     s.time = s.visited[id]
 
-iterator traverseReverse*(c: DataFlowGraph,
-                          span: Slice[NodePosition], start: NodePosition,
+iterator traverseReverse*(c: DataFlowGraph, span: Subgraph, start: InstrPos,
                           exit: var bool): (Opcode, OpValue) =
   ## Starts at `start - 1` and visits and returns all data-flow operations
   ## inside `span` in post-order.
@@ -642,15 +655,11 @@ iterator traverseReverse*(c: DataFlowGraph,
       start..start-1 # `span` is empty
 
   let
-    start = lowerBound(c, start)
-      ## the first instruction associated with the input `start`
-    fin   = lowerBound(c, span.a)
+    fin = span.a
       ## abstract control-flow reaching this instructions means "end reached"
 
   s.visited.newSeq(c.map.len)
-  s.pc = upperBound(c, span.b) - 1
-  # start activity *after* the start position is reached so that
-  # the start node itself is not yielded
+  s.pc = span.b
   s.top = high(Time)
   s.time = s.top
   s.bottom = s.time
@@ -734,7 +743,7 @@ iterator traverseReverse*(c: DataFlowGraph,
 
   exit = s.active
 
-iterator traverseFromExits*(c: DataFlowGraph, span: Slice[NodePosition],
+iterator traverseFromExits*(c: DataFlowGraph, span: Subgraph,
                             exit: var bool): (Opcode, OpValue) =
   ## Similar to ``traverseReverse``, but starts traversal at each unstructured
   ## exit of `span`. Here, unstructured exit means that the control-flow leaves
@@ -748,10 +757,9 @@ iterator traverseFromExits*(c: DataFlowGraph, span: Slice[NodePosition],
   const EntryTime = high(Time)
   var s: ExecState
 
-  let fin = lowerBound(c, span.a)
-  s.pc = upperBound(c, span.b) - 1
+  let fin = span.a
+  s.pc = span.b
   s.visited.newSeq(c.map.len)
-
   s.time = 0 # start as disabled
   s.top = EntryTime
   s.bottom = EntryTime
@@ -759,7 +767,7 @@ iterator traverseFromExits*(c: DataFlowGraph, span: Slice[NodePosition],
   exit = false
 
   template exits(target: JoinId): bool =
-    c[c.map[target]].node notin span
+    c.map[target] notin span
 
   # for the most part similar to the loop in ``traverseReverse``, but with
   # special handling for jumps out of `span`


### PR DESCRIPTION
## Summary

Refactor the `traverse` iterators to accept instructions spans/indices
and provide translation routines for node -> instruction translation.
This slightly simplifies the implementation, allows for instruction-
level addressing, and it reduces the amount of node-position ->
instruction translation.

## Details

It's not necessary for the `traverse` iterator to perform the node
position -> instruction translation, and since multiple instructions
may be associated with a single node, this also limited the
granularity at which traversal could start/end to nodes.

The `Subgraph` type is added, representing a sub-graph (i.e.,
instruction span) within the data-flow graph. Computing the `Subgraph`
and translating a node to an instruction position are done via
`subgraphFor` and `find`. All three `traverse` iterators are changed
to accept both a `Subgraph` and `InstrPos`. 

The change in API is propagated through the routines in the `analysis`
module, allowing for performing the node span -> `Subgraph` translation
only once for each analyzed location (instead of at the start of each
traversal). Instead of the enclosing `mnkScope`'s sub-tree,
`EntityInfo` stores the pre-computed `Subgraph` -- `getAliveRange` is
renamed to `getAliveGraph` and returns the subgraph directly.

Finally, the `traverse` iterators are changed to return a
`DataFlowOpcode` rather than an `Opcode` value, eliminating unnecessary
`case` branches when matching over the value.