### PR TITLE
fix(cgen): run-time crash when modifying a `seq`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2157,10 +2157,11 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
     else:
       genSetConstr(p, n, d)
   of cnkArrayConstr:
-    let kind = skipTypes(n.typ, abstractVarRange).kind
-    if isDeepConstExpr(n) and (kind == tySequence or n.len != 0):
+    # XXX: constructions of empty seqs should be lifted into C constants too,
+    #      but that currently causes collisions and thus C compiler errors  
+    if isDeepConstExpr(n) and n.len != 0:
       exprComplexConst(p, n, d)
-    elif kind == tySequence:
+    elif skipTypes(n.typ, abstractVarRange).kind == tySequence:
       genSeqConstr(p, n, d)
     else:
       genArrayConstr(p, n, d)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2157,9 +2157,10 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
     else:
       genSetConstr(p, n, d)
   of cnkArrayConstr:
-    if isDeepConstExpr(n) and n.len != 0:
+    let kind = skipTypes(n.typ, abstractVarRange).kind
+    if isDeepConstExpr(n) and (kind == tySequence or n.len != 0):
       exprComplexConst(p, n, d)
-    elif skipTypes(n.typ, abstractVarRange).kind == tySequence:
+    elif kind == tySequence:
       genSeqConstr(p, n, d)
     else:
       genArrayConstr(p, n, d)

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -301,13 +301,6 @@ proc translateLit*(val: PNode): CgNode =
     node(cnkAstLit, astLit, val[0])
   of nkRange:
     node(cnkRange, kids, @[translateLit(val[0]), translateLit(val[1])])
-  of nkBracket:
-    assert val.len == 0
-    # XXX: ``mirgen`` having to generate ``mnkLiteral``s for empty seq
-    #      construction expressions is bad design. Fully constant
-    #      construction expresssion should probably be lifted into proper
-    #      constants during ``transf``
-    newNode(cnkArrayConstr, val.info, val.typ)
   of nkSym:
     # special case for raw symbols used with emit and asm statements
     assert val.sym.kind == skField

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1676,10 +1676,7 @@ proc genx(c: var TCtx, n: PNode, consume: bool): EValue =
       else:
         consume
 
-    if n.typ.skipTypes(abstractRange).kind == tySequence and n.len == 0:
-      genLit(c, n)
-    else:
-      genArrayConstr(c, n, consume)
+    genArrayConstr(c, n, consume)
   of nkCurly:
     # a ``set``-constructor never owns
     genSetConstr(c, n)

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -178,7 +178,7 @@ try:
       break :label_0
     var :aux_11 = this[].matchDirs
     var :aux_12 = []
-    =sink(:aux_11, :aux_12)
+    =copy_1(:aux_11, :aux_12)
 finally:
   =destroy(par)
 -- end of expandArc ------------------------'''

--- a/tests/stdlib/types/collections/tconst_seq_bug.nim
+++ b/tests/stdlib/types/collections/tconst_seq_bug.nim
@@ -1,0 +1,20 @@
+discard """
+  targets: c js vm
+  description: '''
+    Regression test for a C code generator bug where adding to, setting the
+    length, or assigning to a ``seq`` would cause a memory access violation
+  '''
+"""
+
+proc main() =
+  # wrap the test in a procedure to prevent `x` being a global from
+  # interfering
+  const Data: seq[int] = @[]
+  var x = (Data,)
+  # the code generator lifted the whole tuple into the immutable data
+  # section, but since copy hook injection already took place, no
+  # copy of the constant was created and the next mutation of the seq
+  # would thus try to write into the immutable data section
+  x[0].add 1
+
+main()


### PR DESCRIPTION
## Summary

Fix a crash when trying to add to, set the length of, or assign to a
sequence part of a tuple or array location that was initialized with a
fully constant tuple or array construction expression.

## Details

Due to `seq`s not supporting copy-on-write behaviour like strings do,
fully constant seq construction, which are lifted into C constants by
the C code generator have to be copied (via their `=copy` hook). As
an optimization, empty seq construction were exempt from this, as
they're not lifted into C constants due to an unrelated `cgen` issue.

When an empty seq construction reaches the code generator as part of
a tuple/array construction (e.g., `(TupleConstr (ArrayConstr))`), the
tuple/array construction was lifted into a C constant, which then
caused an memory access violation when adding to, setting the length
of, or assigning to the `seq` stored in the variable that the tuple/
array was assigned to.

The crash happened because the seq's payload was marked with the
`strlitFlag`, which the `add` and `setLen` procedures don't account
for, treating the sequences as having enough capacity and then
trying to write into its non-writeable buffer.

### The fix

The special casing of empty `seq` constructions is removed, meaning
that they're now also treated as non-moveable values during hook
injection -- translating `nkBracket` in `cgirgen.translateLit`
becomes obsolete too.

### Alternatives

Alternatively, `add`, `grow`, and `setLen` could take the `strlitFlag`
into account, but this alone wouldn't allow for removing the
`nkBracket` workaround.