### PR TITLE
fix(c): `toOpenArray` issues with `array` operand

### DIFF
--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -147,7 +147,7 @@ proc genOpenArraySlice(p: BProc; q: CgNode; formalType, destType: PType): (Rope,
   # but first produce the required index checks:
   if optBoundsCheck in p.options:
     genBoundsCheck(p, a, b, c)
-  let ty = skipTypes(a.t, abstractVar+{tyPtr})
+  let ty = skipTypes(a.t, abstractVar+{tyPtr, tyRef, tyLent})
   let dest = getTypeDesc(p.module, destType)
   let lengthExpr = "($1)-($2)+1" % [rdLoc(c), rdLoc(b)]
   case ty.kind

--- a/tests/lang_callable/overload/toverload_bracket_accessor_template.nim
+++ b/tests/lang_callable/overload/toverload_bracket_accessor_template.nim
@@ -9,7 +9,7 @@ block:
   let txt = "Hello World"
 
   template `[]`[T](p: ptr T, span: Slice[int]): untyped =
-    toOpenArray(cast[ptr array[0, T]](p)[], span.a, span.b)
+    toOpenArray(cast[ptr UncheckedArray[T]](p), span.a, span.b)
 
   doAssert $cast[ptr uint8](txt[0].addr)[0 ..< txt.len] == 
                 "[72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]"
@@ -19,7 +19,7 @@ block:
   let txt = "Hello World"
 
   template `[]`[T](p: ptr T, span: Slice[int]): untyped =
-    toOpenArray(cast[ptr array[0, T]](p)[], span.a, span.b)
+    toOpenArray(cast[ptr UncheckedArray[T]](p), span.a, span.b)
 
   doAssert $cast[ptr uint8](txt[0].addr)[0 ..< txt.len] == 
                 "[72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]"

--- a/tests/misc/ttoopenarray_array_bound_checks.nim
+++ b/tests/misc/ttoopenarray_array_bound_checks.nim
@@ -1,0 +1,36 @@
+discard """
+  targets: c js vm
+  description: '''
+    Regression test for ``toOpenArray`` calls not bound-checking dereferenced
+    pointer-to-array values
+  '''
+  knownIssue.js: "No bound checks are emitted for `toOpenArray`"
+  knownIssue.vm: "`toOpenArray` is not yet supported"
+"""
+
+template check(x: untyped) =
+  {.line.}:
+    doAssertRaises IndexDefect:
+      discard toOpenArray(x, 2, 3)
+
+var arr = [0, 1]
+
+# test with ref-of-array:
+let a = new array[2, int]
+check a[]
+
+# test with ptr-of-array:
+let p = addr arr
+check p[]
+
+# test with var-array:
+proc getVar(x: var array[2, int]): var array[2, int] =
+  result = x
+
+check getVar(arr)
+
+# test with lent-array:
+proc getLent(x: array[2, int]): lent array[2, int] =
+  result = x
+
+check getLent(arr)


### PR DESCRIPTION
## Summary

Fix two C code generator issues with `toOpenArray`:
* passing a dereferenced `ref array` or `lent array` to `toOpenArray`
  no longer results in an internal compiler error
* bound checks are now correctly performed for dereferenced `ptr array`
  and `var array` `toOpenArray` arguments

## Details

The C code generator translates pointer-to-array types (e.g.,
`ref array[T]`, `ptr array[T]`, etc.) to `ptr T` and then omits the
deference. As a consequence, the type of C expression (`TLoc`) returned
by `ccgexpres.genDeref` is still a `ptr array[T]`, etc., but
`genOpenArraySlice` didn't account for this.

Pointer-like types are now skipped by both `genOpenArraySlice` and
`genBoundsCheck` (which is only used by `genOpenArraySlice`) fixing the
issues that arose from pointer-like types being ignored.

The case statement in `genBoundsCheck` is made exhaustive too, in order
to prevent bound checks from being silently omitted.

There was also a test (`toverload_bracket_accessor_template.nim`) that
relied on the bound check to be omitted. Since the test is for
overloading and doesn't depend on `ptr array` being used, it is changed
to use `ptr UncheckedArray` instead.