### PR TITLE
js: support `addr` for object conversions

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1257,6 +1257,9 @@ proc genAddr(p: PProc, n: CgNode, r: var TCompRes) =
     # underlying type is not possible, so we simply skip the conversion and
     # apply the operation to the source expression
     genAddr(p, n.operand, r)
+  of cnkObjUpConv, cnkObjDownConv:
+    # object up-/down-conversions are no-ops
+    genAddr(p, n.operand, r)
   of cnkStmtListExpr:
     for i in 0..<n.len-1:
       genStmt(p, n[i])

--- a/tests/misc/taddr_of_up_conversion.nim
+++ b/tests/misc/taddr_of_up_conversion.nim
@@ -1,8 +1,5 @@
 discard """
   targets: "c js vm"
-  knownIssue.js: '''
-    jsgen handling for taking the address of up-conversions is missing
-  '''
   description: "Ensure that taking the address of up-conversions works"
 """
 


### PR DESCRIPTION
## Summary

Add missing logic to the JavaScript code-generator for supporting
`addr x` expressions where `x` is an object up- or down-conversion.

## Details

`jsgen.genAddr` was missing handling for the `cnkObjUpConv` and
`cnkObjDownConv` node kinds. Since both don't translate to JavaScript
code, they're simply skipped.