### PR TITLE
js: improve cast-to-`pointer` support

### DIFF
--- a/tests/misc/tcast.nim
+++ b/tests/misc/tcast.nim
@@ -1,4 +1,7 @@
 discard """
+  targets: c js vm
+  knownIssue.vm: "Casting from pointer to proc is not yet supported"
+  knownIssue.js: "Casting the `nil` value into an `int` doesn't work"
   output: '''
 Hello World
 Hello World'''

--- a/tests/misc/tcast_int_to_pointer.nim
+++ b/tests/misc/tcast_int_to_pointer.nim
@@ -1,0 +1,41 @@
+discard """
+  targets: c js vm
+  description: '''
+    Ensure that casting an int to a pointer, storing the pointer,
+    and then casting the pointer back works.
+  '''
+"""
+
+type
+  Object = object
+    f: pointer
+
+# test with storing in a global variable
+var i = 1
+# test initial assignment
+var global = cast[pointer](i)
+doAssert cast[int](global) == 1 # cast-back works
+
+# test with normal assignment
+global = cast[pointer](i)
+doAssert cast[int](global) == 1
+
+proc test() =
+  # test with local variable
+  var local = cast[pointer](i)
+  doAssert cast[int](local) == 1 # cast-back works
+
+  local = cast[pointer](i)
+  doAssert cast[int](local) == 1
+
+test()
+
+# test with storing in a parameter
+proc test2(param: pointer) =
+  doAssert cast[int](param) == 1 # cast-back works
+
+test2(cast[pointer](i))
+
+# test with storing in an aggregate type
+var o = Object(f: cast[pointer](i))
+doAssert cast[int](o.f) == 1 # cast-back works

--- a/tests/misc/tcast_ref_object_to_pointer.nim
+++ b/tests/misc/tcast_ref_object_to_pointer.nim
@@ -1,0 +1,45 @@
+discard """
+  targets: c js vm
+  description: '''
+    Ensure that casting a ``ref object`` to a pointer, storing the pointer,
+    and then casting the pointer back works.
+  '''
+  knownIssue.vm: "Casting from ``pointer`` to ``ref`` is not yet supported"
+"""
+
+type
+  Ref = ref object
+    x: int
+
+  Object = object
+    f: pointer
+
+# test with storing in a global variable
+var r = Ref(x: 1)
+# test initial assignment
+var global = cast[pointer](r)
+doAssert cast[Ref](global).x == 1 # cast-back works
+
+# test with normal assignment
+global = cast[pointer](r)
+doAssert cast[Ref](global).x == 1
+
+proc test() =
+  # test with local variable
+  var local = cast[pointer](r)
+  doAssert cast[Ref](local).x == 1 # cast-back works
+
+  local = cast[pointer](r)
+  doAssert cast[Ref](local).x == 1
+
+test()
+
+# test with storing in a parameter
+proc test2(param: pointer) =
+  doAssert cast[Ref](param).x == 1 # cast-back works
+
+test2(cast[pointer](r))
+
+# test with storing in an aggregate type
+var o = Object(f: cast[pointer](r))
+doAssert cast[Ref](o.f).x == 1 # cast-back works

--- a/tests/misc/tcast_ref_scalar_to_pointer.nim
+++ b/tests/misc/tcast_ref_scalar_to_pointer.nim
@@ -1,0 +1,45 @@
+discard """
+  targets: c js vm
+  description: '''
+    Ensure that casting a ref-to-scalar type (``ref int`` in this case) to a
+    pointer, storing the pointer, and then casting the pointer back works.
+  '''
+  knownIssue.vm: "Casting from ``pointer`` to ``ref`` is not yet supported"
+"""
+
+type
+  Ref = ref int
+
+  Object = object
+    f: pointer
+
+# test with storing in a global variable
+var r = new Ref
+r[] = 1
+# test initial assignment
+var global = cast[pointer](r)
+doAssert cast[Ref](global)[] == 1 # cast-back works
+
+# test with normal assignment
+global = cast[pointer](r)
+doAssert cast[Ref](global)[] == 1
+
+# test with local variable
+proc test() =
+  var local = cast[pointer](r)
+  doAssert cast[Ref](local)[] == 1 # cast-back works
+
+  local = cast[pointer](r)
+  doAssert cast[Ref](local)[] == 1
+
+test()
+
+# test with storing in a parameter
+proc test2(param: pointer) =
+  doAssert cast[Ref](param)[] == 1 # cast-back works
+
+test2(cast[pointer](r))
+
+# test with storing in an aggregate type
+var o = Object(f: cast[pointer](r))
+doAssert cast[Ref](o.f)[] == 1 # cast-back works


### PR DESCRIPTION
## Summary

Support casting `ref` of aggregates, `proc`, and scalar types to
`pointer` values and the pointer back to the original type, for the JS
backend. Using the result of these casts previously either worked,
misbehaved at run-time, or caused an internal compiler error.

## Details

The `jsgen.genCast` procedure didn't account for all non-fat-pointer
types in `genCast`. If the `TCompRes` resulting from such a cast
reached `genVarInit`, the assertion for the `etyBaseIndex` handling
triggered.

As an interim solution, `genCast` now handles all to- and from-
`pointer` casts the same:
* non-`etyBaseIndex` values are cast into `pointer` by treating the
  expression as the address and `null` as the index (already happened
  for `etyObject`)
* `pointer` values are cast into non-`etyBaseIndex` values by using the
  address part as the expression (the inverse of the to-`pointer` cast)
* `pointer` to fat-pointer casts and vice versa are no-ops

This implementation means that casting `A` to `pointer` and the
`pointer` to `B` is undefined behaviour for the JS target, but that was
already the case before the change.

### Tests

Test coverage for casts is increased by:
* adding a test for casting `ref`-of-scalars to `pointer` and back
* adding a test for casting `ref`-of-aggregate to `pointer` and back
* adding a test for casting an `int` to `pointer` and back

The not-yet-working `misc/tcast.nim` is marked as a known issue for the
JS target.