### PR TITLE
fix(js): internal compiler error with `default`

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1881,8 +1881,14 @@ proc genOf(p: PProc, n: CgNode, r: var TCompRes) =
   r.kind = resExpr
 
 proc genDefault(p: PProc, n: CgNode; r: var TCompRes) =
-  r.res = createVar(p, n.typ, indirect = false)
+  r.typ = mapType(n.typ)
   r.kind = resExpr
+  case r.typ
+  of etyBaseIndex:
+    r.address = "null"
+    r.res = "0"
+  else:
+    r.res = createVar(p, n.typ, indirect = false)
 
 proc genReset(p: PProc, n: CgNode) =
   var x: TCompRes

--- a/tests/js/texplicit_default_init_pointer_var.nim
+++ b/tests/js/texplicit_default_init_pointer_var.nim
@@ -6,7 +6,7 @@ discard """
 """
 
 proc test() =
-  # test that the intial assignment works
+  # test that the initial assignment works
   var x = default(pointer)
   doAssert x == nil
 

--- a/tests/js/texplicit_default_init_pointer_var.nim
+++ b/tests/js/texplicit_default_init_pointer_var.nim
@@ -1,0 +1,17 @@
+discard """
+  description: '''
+    Regression test for where assigning `default(T)` (where `T` maps to a fat
+    pointer) resulted in an internal compiler error
+  '''
+"""
+
+proc test() =
+  # test that the intial assignment works
+  var x = default(pointer)
+  doAssert x == nil
+
+  # test that a normal assignment works
+  x = default(pointer)
+  doAssert x == nil
+
+test()


### PR DESCRIPTION
## Summary

Fix the incorrect `jsgen` logic for `default(T)` calls, which resulted
in compiler errors when the call appeared in `var`/`let` statement and
`T` mapped to a fat pointer (e.g., `pointer`, `ptr int`, `ref int`,
etc.).

## Details

The `jsgen.genDefault` procedure (code generation logic for the
`mDefault` magic) didn't set the result's `typ`, incorrectly leaving it
as `etyNone` (as initialized by `jsgen.gen`).

All code generation routines relying on the `TCompRes`'s type thus
misbehaved, although the special handling of `cnkCall` nodes in
`genArg` and `genAsgn` meant that both still generated correct,
although unnecessarily complex, code. For fat pointers, `genVarInit`
requires the source's type to also be `etyBaseIndex`, and thus raised
an internal error.

`genDefault` now sets the `TCompRes`'s type to the mapped type.
Since an `etyBaseIndex` `TCompRes` needs to store the unpacked fat-
pointer expression, using `createVar` for `etyBaseIndex` types (which
would generate a boxed pointer, `[null, 0]`) is not correct, and the
address and index expression parts need to be set manually.