### PR TITLE
fix(sem): some caught exceptions being leaked

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -586,14 +586,6 @@ proc toVar*(typ: PType; kind: TTypeKind; idgen: IdGenerator): PType =
     result = newType(kind, nextTypeId(idgen), typ.owner)
     rawAddSon(result, typ)
 
-proc toRef*(typ: PType; idgen: IdGenerator): PType =
-  ## If ``typ`` is a tyObject then it is converted into a `ref <typ>` and
-  ## returned. Otherwise ``typ`` is simply returned as-is.
-  result = typ
-  if typ.skipTypes({tyAlias, tyGenericInst}).kind == tyObject:
-    result = newType(tyRef, nextTypeId(idgen), typ.owner)
-    rawAddSon(result, typ)
-
 proc toObject*(typ: PType): PType =
   ## If ``typ`` is a tyRef then its immediate son is returned (which in many
   ## cases should be a ``tyObject``).

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -953,6 +953,14 @@ proc makePtrType*(owner: PSym, baseType: PType; idgen: IdGenerator): PType =
 proc makePtrType*(c: PContext, baseType: PType): PType =
   makePtrType(getCurrOwner(c), baseType, c.idgen)
 
+proc makeRefType*(conf: ConfigRef, typ: PType; idgen: IdGenerator): PType =
+  ## Creates a ``ref <typ>`` type.
+  result = newType(tyRef, nextTypeId(idgen), typ.owner)
+  rawAddSon(result, typ)
+  # refs only have custom assignment logic with arc/orc
+  if conf.selectedGC in {gcArc, gcOrc}:
+    result.flags.incl tfHasAsgn
+
 proc makeTypeWithModifier*(c: PContext,
                            modifier: TTypeKind,
                            baseType: PType): PType =

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1051,12 +1051,11 @@ proc transformCall(c: PTransf, n: PNode): PNode =
 
 proc transformExceptBranch(c: PTransf, n: PNode): PNode =
   if n[0].isInfixAs() and not isImportedException(n[0][1].typ, c.graph.config):
-    let excTypeNode = n[0][1]
     # Generating `let exc = (excType)(getCurrentException())`
     # -> getCurrentException()
     let excCall = callCodegenProc(c.graph, "getCurrentException")
     # -> (excType)
-    let convNode = newTreeIT(nkObjDownConv, n[1].info, excTypeNode.typ.toRef(c.idgen)):
+    let convNode = newTreeIT(nkObjDownConv, n[1].info, n[0][2].typ):
       [excCall]
     # -> let exc = ...
     let identDefs = newTreeI(nkIdentDefs, n[1].info):

--- a/tests/lang_objects/destructor/texception_leak.nim
+++ b/tests/lang_objects/destructor/texception_leak.nim
@@ -1,0 +1,38 @@
+discard """
+  description: '''
+    Regression test for exceptions being leaked when caught by an ``T as e``
+    exception branch within a closure iterator where `T` is an object type
+  '''
+"""
+
+type Ex = object of CatchableError
+# for this test, it's important that `Ex` is **not** a ref type
+
+var destroyed: int
+
+proc `=destroy`(x: var Ex) =
+  inc destroyed
+
+iterator iter(): int {.closure.} =
+  var i = 0
+  # catch the exception twice for the lifted `e` to be assigned twice
+  while i < 2:
+    try:
+      raise Ex.newException("")
+    except Ex as e:
+      # yield within the handler so that it's split, which (at the time of
+      # writing) forces `e` to be lifted into the environment
+      yield i
+      inc i
+
+proc test() =
+  var it = iter
+  discard it()
+  discard it()
+  discard it() # finish iterating
+  # `it` is destroyed
+
+test()
+
+doAssert destroyed >= 2, "object is leaked"
+doAssert destroyed == 2, "object is destroyed too often (double free?)"


### PR DESCRIPTION
## Summary

Fix exceptions caught by `T as e` handler branches within closure
iterators where `T` is an object type being leaked when the handler
is entered multiple times.

## Details

* add the `makeRefType` procedure to `semdata`, for creating a `ref`
  type of a given type while properly setting the `tfHasAsgn` flag
* use `makeRefType` in `semTry` for creating the ref type of the non-
  ref exception type
* also set the type of symbol *node* for the `T as e` part; this was
  previously missing, leaving the node's type as nil
* take the type for the conversion expression created during lowering
  of the handler branch from the symbol rather than creating a new and
  improper `ref` type via `toRef`
* remove the `ast.toRef` procedure; it's unused now and also not
  generally applicable (due to the missing `tfHasAsgn` handling)

### The problem

The lowering of `except T as e:` produces a
`let e = T(getCurrentException())` statement, using `T`'s type as
the the right-hand expression's type. If `T` wasn't a `ref` type
already, a new `tyRef` type was first created via `ast.toRef`.

The `tyRef` created by `toRef` doesn't have the `tfHasAsgn` flag set,
however, and since no more automatic hook lifting takes place after
`transf`, the ref type had no attached hooks and thus no sink or copy
hook calls are injected for assignments it's part of.

This is not a problem for the when `e` is not lifted into an object, as
the local is still destroyed and an initial assignment without a hook
call is correct. However, when `e` is lifted into an object and
assigned to multiple times, the missing `=sink` call means that the
`ref` already stored in the field is not freed, leaking the heap cell.