### PR TITLE
fix(vm): assigning string literals to `openArray`

### DIFF
--- a/tests/lang_types/openarray/topenarray_from_literal.nim
+++ b/tests/lang_types/openarray/topenarray_from_literal.nim
@@ -1,0 +1,18 @@
+discard """
+  targets: c js vm
+  description: '''
+    Ensure that creating a local, immutable openArray from a string literal
+    works and that reading from the openArray does too
+  '''
+"""
+
+{.experimental: "views".}
+
+proc test() =
+  let x: openArray[char] = "abc"
+  var y = "def"
+  # regression test for the VM: the statement above led to the assertion below
+  # failing
+  doAssert x[1] == 'b'
+
+test()


### PR DESCRIPTION
## Summary

Fix accessing the element of a first-class `openArray` resulting in a
access violation run-time errors or wrong results, if the `openArray`
was initialized from a string literal. Only the VM backend was
affected.

## Details

Initial assignments to local `openArray` bindings used a handle copy
(`FastAsgnComplex`), which works if the source is a non-temporary
location. If it isn't, the handle stored for the `openArray` local
points to a freed or reused memory cell after the temporary source
register is reclaimed.

Loading a string literal allocates a temporary string location, and
thus they were affected by this issue.

For fixing the issue, a handle copy is only created when the source
register is the register backing a local -- per the language rules, the
source lvalue has to outlive the `openArray` binding, so this is safe.
If the source is some temporary register, it is promoted to the
register backing the local.