### PR TITLE
cgen: don't emit unnecessary type definitions

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -803,7 +803,6 @@ proc genAsgn(p: BProc, e: CgNode) =
     let le = e[0]
     let ri = e[1]
     var a: TLoc
-    discard getTypeDesc(p.module, le.typ.skipTypes(skipPtrs), skVar)
     initLoc(a, locNone, le, OnUnknown)
     a.flags.incl {lfEnforceDeref, lfPrepareForMutation, lfWantLvalue}
     expr(p, le, a)

--- a/tests/ccgbugs/tforward_decl_only.nim
+++ b/tests/ccgbugs/tforward_decl_only.nim
@@ -14,6 +14,14 @@ type AnotherType = object
 let x = AnotherType(f: newMyRefObject("hello"))
 echo $x.f
 
+# assigning the ref (outside of a var/let statement) must not pull in the
+# type definition
+proc test() =
+  var y: MyRefObject
+  y = newMyRefObject("abc")
+  doAssert $y == "abc"
+
+test()
 
 # bug #7363
 


### PR DESCRIPTION
## Summary

Don't emit the full C type definition for a type when assigning a `ref`
or `ptr` of said type, reducing the amount of generated C code and thus
the amount of work for both the NimSkull and C compiler.

## Details

The full C type definition of the pointed-to type was requested on
assignment (`ccgstmts.genAsgn`) of the pointer-like type, but this is
unnecessary, as C doesn't require the pointed-to type to be a complete
type when assigning the pointer.

It's likely that this is a leftover from when `genDeref` didn't request
the type definition of the pointed-to type. Requesting the type
definition is removed, as translating the left and right side of the
assignment already pulls in the relevant type definitions.