### PR TITLE
Link to `style_guide.html` in `intern.rst`

### DIFF
--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -250,7 +250,7 @@ The new runtime is active `when defined(nimV2)`.
 Coding Guidelines
 =================
 
-* We follow |NimSkull|'s official style guide, see `<nep1.html>`_.
+* We follow |NimSkull|'s official style guide, see `<style_guide.html>`_.
 * Max line length is 100 characters.
 * Provide spaces around binary operators if that enhances readability.
 * Use a space after a colon, but not before it.

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ git clone https://github.com/nim-works/nimskull.git
 cd nimskull
 ./koch.py boot -d:release
 ./koch.py tools -d:release
-**Optional** Build all nimSkull documentation
+ Build all nimSkull documentation
 ./koch.py docs -d: release
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,8 @@ git clone https://github.com/nim-works/nimskull.git
 cd nimskull
 ./koch.py boot -d:release
 ./koch.py tools -d:release
+**Optional** Build all nimSkull documentation
+./koch.py docs -d: release
 ```
 
 Finally, once you have finished the build steps (on Windows, Mac, or Linux) you

--- a/readme.md
+++ b/readme.md
@@ -143,8 +143,6 @@ git clone https://github.com/nim-works/nimskull.git
 cd nimskull
 ./koch.py boot -d:release
 ./koch.py tools -d:release
- Build all nimSkull documentation
-./koch.py docs -d: release
 ```
 
 Finally, once you have finished the build steps (on Windows, Mac, or Linux) you


### PR DESCRIPTION
## Summary

`nep1.html` was renamed to `style_guide.html`, but the reference
to it in `intern.rst` wasn't updated, resulting in a broken link.
This is fixed now.