### PR TITLE
cgen: remove dead code

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1679,9 +1679,7 @@ proc skipAddr(n: CgNode): CgNode =
 proc genWasMoved(p: BProc; n: CgNode) =
   var a: TLoc
   let n1 = n[1].skipAddr
-  if p.withinBlockLeaveActions > 0 and notYetAlive(p, n1):
-    discard
-  else:
+  if true:
     initLocExpr(p, n1, a, {lfWantLvalue})
     resetLoc(p, a)
     #linefmt(p, cpsStmts, "#nimZeroMem((void*)$1, sizeof($2));$n",

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -98,26 +98,6 @@ proc isDeepConstExpr*(n: CgNode): bool =
   else:
     result = false
 
-proc getRoot*(n: CgNode): CgNode =
-  ## ``getRoot`` takes a *path* ``n``. A path is an lvalue expression
-  ## like ``obj.x[i].y``. The *root* of a path is the symbol that can be
-  ## determined as the owner; ``obj`` in the example.
-  case n.kind
-  of cnkSym:
-    if n.sym.kind in {skVar, skLet, skForVar}:
-      result = n
-  of cnkLocal:
-    result = n
-  of cnkFieldAccess, cnkArrayAccess, cnkTupleAccess, cnkCheckedFieldAccess:
-    result = getRoot(n[0])
-  of cnkDerefView, cnkDeref, cnkObjUpConv, cnkObjDownConv, cnkHiddenAddr,
-     cnkAddr, cnkHiddenConv, cnkConv:
-    result = getRoot(n.operand)
-  of cnkCall:
-    if getMagic(n) == mSlice:
-      result = getRoot(n[1])
-  else: discard
-
 proc canRaiseConservative*(fn: CgNode): bool =
   ## Duplicate of `canRaiseConservative <ast_query.html#canRaiseConservative,PNode>`_.
   # ``mNone`` is also included in the set, therefore this check works even for


### PR DESCRIPTION
## Summary

Remove an optimization/semantic-change from `cgen` that's not used
anymore.

## Details

The `isInactiveDestructorCall`/`notYetAlive` procedures was responsible
for detecting whether a destructor call or reset operation could be
safely omitted for a local.

This is a workaround for destructor injection being limited to wrapping
whole scopes in `try`/`finally` statements, but it finally stopped
working with the introduction of the MIR (~11 months ago), as the 'def'
statements for all locals requiring destruction are placed before the
`try` statement responsible for their destruction.

Since the proper fix will be implemented in the destructor injection
pass rather than in the code generators, `isInactiveDestructorCall`,
`notYetAlive` are removed and their usage sites are updated. The now-
unused `compat.getRoot` procedure is removed too.