### PR TITLE
backends: simplify the `process` iterator

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -168,8 +168,6 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
   ## The orchestrator's event processor.
   let bmod = g.modules[evt.module.int]
 
-  prepare(g, discovery)
-
   proc handleInline(inl: var InliningData, m: ModuleId, prc: PSym,
                     body: MirTree): Option[uint32] {.nimcall.} =
     ## Registers the dependency on inline procedure that `body` has
@@ -210,6 +208,8 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
     bmod.g.hooks.setLen(0)
 
   case evt.kind
+  of bekDiscovered:
+    prepare(g, discovery)
   of bekModule:
     # the code generator emits a call for setting up the TLS, which is a
     # procedure dependency that needs to be communicated

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -63,9 +63,10 @@ proc processEvent(g: PGlobals, graph: ModuleGraph, modules: BModuleList,
                   evt: sink BackendEvent) =
   ## The orchestrator's event processor.
   let bmod = modules[evt.module]
-  prepare(g, modules, discovery)
 
   case evt.kind
+  of bekDiscovered:
+    prepare(g, modules, discovery)
   of bekModule:
     discard "nothing to do"
   of bekPartial:

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -170,12 +170,12 @@ proc prepare(c: var GenCtx, data: var DiscoveryData) =
 proc processEvent(c: var GenCtx, mlist: ModuleList, discovery: var DiscoveryData,
                   partial: var PartialTbl, evt: sink BackendEvent) =
   ## The orchestrator's event processor.
-  prepare(c, discovery)
-
   let idgen = mlist[evt.module].idgen
   c.gen.module = mlist[evt.module].sym
 
   case evt.kind
+  of bekDiscovered:
+    prepare(c, discovery)
   of bekModule:
     discard "nothing to do"
   of bekPartial:


### PR DESCRIPTION
## Summary

Introduce a dedicated event that allows for pre-processing discovered
entities, no longer conflating this with the other events.

## Details

Pre-processing newly discovered entities (e.g., modifying the symbols,
registering them with the code generators) was so far done at the start
of processing an event.

There are multiple problems with this approach:
1. the `process` iterator cannot run code that must happen *after* pre-
   processing but before code generation
2. procedures discovered through scanning of constants were treated as
   first-seen in the module the constant is discovered from, while
   they're actually first-seen in the module the constant is defined in
3. the implementation is complex and hard to understand, requiring
   additional look-aside data structures (`EventContext`)

Number 1 is going to be a problem when moving to a data-oriented design
for the backend IRs.

To resolve the listed problems, a new event (`bekDiscovered`) is
introduced, providing a dedicated customization point for entity pre-
processing. The event is fired whenever new entities become available
(but, for implementation simplicity, sometimes also when nothing
changed).

This comes at the cost of the `process` iterator itself becoming larger
(after expansion and inlining) and that it contain more `yield`
statements.