### PR TITLE
fix: compiler crash when `errorMax` != 1

### DIFF
--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -148,9 +148,10 @@ proc group(n: PNode, decl, imperative: var seq[PNode]) =
   of nkTemplateDef, nkMacroDef:
     # not relevant to the backend
     discard
-  of nkEmpty:
-    discard "drop empty node"
-  of nkNone, nkError:
+  of nkEmpty, nkError:
+    # errors were already reported earlier
+    discard "drop errors and empty nodes"
+  of nkNone:
     unreachable()
   of nkStmtList:
     # flatten statement lists
@@ -433,6 +434,10 @@ proc myProcess(b: PPassContext, n: PNode): PNode =
 
 proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
   result = myProcess(b, n)
+  if graph.config.errorCounter != 0:
+    # a user error occured somewhere earlier. Code generation is now disabled
+    # anyway, so skip the processing
+    return
 
   if graph.backend == nil:
     graph.backend = ModuleListBackend()

--- a/tests/compilerfeatures/terror_limit_error.nim
+++ b/tests/compilerfeatures/terror_limit_error.nim
@@ -1,0 +1,13 @@
+discard """
+  description: '''
+    Regression test for the compiler crashing when there's an error in a
+    module and the error limit is not 1
+  '''
+  targets: native
+  errormsg: "type mismatch: got <int literal(1)> but expected 'string"
+  matrix: "--errorMax:100"
+"""
+
+# the error itself doesn't matter, it only matter that there's an error in
+# top-level code
+var a: string = 1


### PR DESCRIPTION
## Summary

Fix the compiler crashing when compiling with an error limit beyond
one and there's an error somewhere in top-level code.

## Details

If the compiler doesn't abort on the first error (i.e., when
`errorMax` is `1`), an `nkError` node in top-level code reaches into
the `modulelowering` pass, which was so far treated as an internal
error.

An `nkError` node reaching into `modulelowering` is now ignored and the
pass is also disabled when an error occurred, as the code generation
phase is known to be disabled at that point.