### PR TITLE
disable the `tfragment_alloc` test

### DIFF
--- a/tests/fragmentation/tfragment_alloc.nim
+++ b/tests/fragmentation/tfragment_alloc.nim
@@ -3,6 +3,7 @@ discard """
   output: '''occupied ok: true
 total ok: true'''
   joinable: false
+  disabled: "osx"
 """
 
 # if the tests fails in the CI, consider disabling it again. Refer to


### PR DESCRIPTION
## Summary

Disable the `tfragment_alloc` test due to it sometimes failing during
CI runs.

## Details

Investigation into the test failure showed that the test failure is not
because of memory exhaustion, but rather because of, in case of
failure, more pages than usual being requested from the OS.

In all observed CI failures, only the MacOS target was affected, so the
test is only disabled there.