### PR TITLE
vm: move thread-local state into `VmThread`

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -348,7 +348,7 @@ proc execute(jit: var JitState, c: var TCtx, start: int, frame: sink TStackFrame
         "non-static stmt evaluation must produce a value, mode: " & $c.mode
       let reg =
         if r.reg.isSome:
-          c.sframes[0].slots[r.reg.get]
+          thread[0].slots[r.reg.get]
         else:
           TFullReg(kind: rkNone)
       result.initSuccess cb(c, reg)
@@ -671,8 +671,6 @@ proc execProc*(jit: var JitState, c: var TCtx; sym: PSym;
                args: openArray[PNode]): PNode =
   # XXX: `localReport` is still used here since execProc is only used by the
   # VM's compilerapi (`nimeval`) whose users don't know about nkError yet
-
-  c.loopIterations = c.config.maxLoopIterationsVM
   if sym.kind in routineKinds:
     if sym.typ.len-1 != args.len:
       localReport(c.config, sym.info, SemReport(

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -499,8 +499,9 @@ type
 
   # XXX: TCtx's contents should be separated into five parts (separate object
   #      types):
-  #      - 'execution state': stack frames, program counter, etc.; everything
-  #        that makes up a single VM invocation. Mutated during execution
+  #      - (DONE) 'execution state': stack frames, program counter, etc.;
+  #        everything that makes up a single VM invocation. Mutated during
+  #        execution
   #      - 'shared execution state': allocator, managed slots, etc.; state that
   #        is shared across VM invocations. Mutated during execution
   #      - 'execution environment': types, globals, constants, functions, etc.;
@@ -663,7 +664,6 @@ type
     code*: seq[TInstr]
     debug*: seq[TLineInfo]  # line info for every instruction; kept separate
                             # to not slow down interpretation
-    sframes*: seq[TStackFrame] ## The stack of the currently running code # XXX: rename to `stack`?
     globals*: seq[HeapSlotHandle] ## Stores each global's corresponding heap slot
     constants*: seq[VmConstant] ## constant data
     complexConsts*: seq[LocHandle] ## complex constants (i.e. everything that
@@ -685,22 +685,11 @@ type
     # XXX: ^^ should be made part of the JIT state but ``vmcompilerserdes``
     #      currently blocks that
 
-    # exception state:
-    # XXX: this is thread-local state and should thus not be part of the
-    #      global context
-    currentExceptionA*, currentExceptionB*: HeapSlotHandle
-    activeException*: HeapSlotHandle ## the exception that is currently
-      ## in-flight (i.e. being raised), or nil, if none is in-flight. Note that
-      ## `activeException` is different from `currentException`.
-    activeExceptionTrace*: VmRawStackTrace ##
-      ## the stack-trace of where the exception was raised from
-
     module*: PSym
     callsite*: PNode
     mode*: TEvalMode
     features*: TSandboxFlags
     traceActive*: bool
-    loopIterations*: int
     comesFromHeuristic*: TLineInfo # Heuristic for better macro stack traces
     callbacks*: seq[VmCallback]
     cache*: IdentCache
@@ -866,7 +855,6 @@ proc initCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
     globals: @[],
     constants: @[],
     module: module,
-    loopIterations: g.config.maxLoopIterationsVM,
     comesFromHeuristic: unknownLineInfo,
     callbacks: @[],
     cache: cache,
@@ -887,7 +875,6 @@ proc initCtx*(module: PSym; cache: IdentCache; g: ModuleGraph;
 func refresh*(c: var TCtx, module: PSym; idgen: IdGenerator) =
   addInNimDebugUtils(c.config, "refresh")
   c.module = module
-  c.loopIterations = c.config.maxLoopIterationsVM
   c.idgen = idgen
 
 const pseudoAtomKinds* = {akObject, akArray}

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -390,7 +390,7 @@ proc main*(args: seq[string]): int =
     of yrkDone:
       # on successful execution, the executable's main function returns the
       # value of ``programResult``, which we use as the runner's exit code
-      let reg = c.sframes[0].slots[r.reg.get]
+      let reg = thread[0].slots[r.reg.get]
       result = regToNode(c, reg, nil, TLineInfo()).intVal.int
     of yrkError:
       # an uncaught error occurred


### PR DESCRIPTION
## Summary

Internal-only refactoring. Move all state associate with a single
thread of execution into `VmThread`. This means that it's now possible
to create multiple threads from a single `TCtx` and run them
concurrently.

## Details

* store the stack-frame data, exception handling state, and loop
  iteration counter in `VmThread` rather than `TCtx`
* remove the `frame` field from `TCtx`; it's never read from
* remove `currentExceptionB`; it has been unused for a long time
* `currentExceptionA` is renamed to just `currentException`
* update the usage sites accordingly
* pass the executed thread to `rawExecute`

The restriction of only one `VmThread` being able exists at a time is
thus lifted, paving the way for eventual multi-threading support. In
the shorter-term, `rawExecute` having access to the `VmThread` object
means that adding new thread-local state doesn't require adding new
types to `vmdef`.