### PR TITLE
sem: clarify `static[T](x)` semantics

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1874,7 +1874,6 @@ proc genWithDest(c: var TCtx, n: PNode; dest: Destination) =
   else:
     gen(c, n)
 
-
 proc generateCode*(graph: ModuleGraph, options: set[GenOption], n: PNode,
                    code: var MirBuffer, source: var SourceMap) =
   ## Generates MIR code that is semantically equivalent to the expression or
@@ -1894,11 +1893,12 @@ proc generateCode*(graph: ModuleGraph, options: set[GenOption], n: PNode,
     gen(c, n)
   elif n.typ.kind == tyTypeDesc:
     # FIXME: this shouldn't happen, but type expressions are sometimes
-    #        evaluated with the VM, such as the ``int`` in the type expression
-    #        ``static int``. While it makes to allow evaluating type expression
-    #        with the VM, in simple situtations like the example above, it's
-    #        simpler, faster, and more intuitive to either evaluate them directly
-    #        when analying the type expression or during ``semfold``
+    #        evaluated with the VM, such as a ``typeof(T.x)`` appearing as
+    #        a field type within a generic object definition. While it makes
+    #        sense to allow evaluating type expression with the VM, in simple
+    #        situtations like the example above, it's simpler, faster, and more
+    #        intuitive to either evaluate them directly when analying the type
+    #        expression or during ``semfold``
     discard genTypeExpr(c, n)
   else:
     discard genx(c, n)

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3791,7 +3791,10 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     n[0] = semExpr(c, n[0], flags)
   of nkCast: result = c.config.extract(semCast(c, n))
   of nkIfExpr, nkIfStmt: result = semIf(c, n, flags)
-  of nkHiddenStdConv, nkHiddenSubConv, nkConv, nkHiddenCallConv:
+  of nkConv:
+    checkSonsLen(n, 2, c.config)
+    result = semConv(c, n)
+  of nkHiddenStdConv, nkHiddenSubConv, nkHiddenCallConv:
     checkSonsLen(n, 2, c.config)
     considerGenSyms(c, n)
   of nkStringToCString, nkCStringToString, nkObjDownConv, nkObjUpConv:

--- a/tests/lang_exprs/tconversion_ast.nim
+++ b/tests/lang_exprs/tconversion_ast.nim
@@ -1,0 +1,14 @@
+discard """
+  description: '''
+    Ensure that valid conversion AST emitted by a macro is correctly
+    semantically anaylsed
+  '''
+  targets: native
+"""
+
+import std/macros
+
+macro m(): untyped =
+  result = nnkConv.newTree(ident"int", newLit(1.1))
+
+doAssert m() == 1

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -362,7 +362,7 @@ type
 #------------------------------------------------------------------------------------------
 # issue #15858
 
-proc fn(N1: static int, N2: static int, T: typedesc): array[N1 * N2, T] = 
+proc fn(N1: static int, N2: static int, T: typedesc): array[N1 * N2, T] =
   doAssert(len(result) == N1 * N2)
 
 let yy = fn(5, 10, float)
@@ -391,3 +391,24 @@ var sorted = newSeq[int](1000)
 for i in 0..<sorted.len: sorted[i] = i*2
 doAssert isSorted2(sorted, compare)
 doAssert isSorted2(sorted, proc (a, b: int): bool {.inline.} = a < b)
+
+block invalid_type_coercion:
+  # a ``typedesc[int]`` cannot be coerced into a ``static[int]``
+  doAssert not compiles(static[int](int))
+
+block coercion_to_static_type_error:
+  # the expression to a static-type coercion must be a constant expression
+  var x = 1
+  doAssert not compiles(static[int](x))
+
+block coercion_to_static_type:
+  # expressions in static-type coercions must be fully evaluated at compile-
+  # time
+  proc get(): float =
+    when nimvm:
+      result = 1.1
+    else:
+      result = 2.1
+
+  # the call must be fully evaluated at compile-time
+  doAssert static[int](get()) == 1


### PR DESCRIPTION
## Summary

Implement `static[T](x)` as being semantically equivalent to
`static(T(x))`. As a consequence:
* the `x` expression in the coercion is now always evaluated at
  compile-time, with an error being reported if it's not
* `static[T](U)` (where `U` is a type expression) is not legal anymore.
  It was previously treated as a type construction of `static[U]`

In typed expression AST, `static int` is now represented as
`(StaticTy (Sym "int"))` instead of
`(Command (Sym "static") (Ident "int))`.

## Details

* reorder the `tyStatic` handling in `semConv` such that `static[T]` is
  handled separately from `static`
* interpret and sem a `static[T](x)` conversion expression as
  `(StaticExpr (Conv (x)))`
* don't evaluate `tyTypeDesc`-typed expression with the VM in
  `semStaticExpr`
* don't treat `nkType` without a `tyTypeDesc` type as a valid type
  expression (because it's not)
* in `semConv`, emit a `nkStaticTy` tree for `static` type
  constructions, properly reflecting the meaning of the expression
* `semStaticType` cannot be used in `semConv` anymore, as `evaluated`
  is no longer an `nkType` node. Re-semming the sem'ed type expression
  leads to errors at the moment
* update the comment regarding `tyTypeDesc` expressions in `mirgen`

Besides clarifying the expression's semantics, this also removes the
costly and unnecessary VM invocation (`transf` -> MIR -> VM) for
`static` type constructions.

In addition, `semStaticExpr` now tries to fold the expression first,
further reducing unnecessary VM invocations.