### PR TITLE
fix: `nnkConv` nodes not being typed

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3774,7 +3774,10 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     n[0] = semExpr(c, n[0], flags)
   of nkCast: result = c.config.extract(semCast(c, n))
   of nkIfExpr, nkIfStmt: result = semIf(c, n, flags)
-  of nkHiddenStdConv, nkHiddenSubConv, nkConv, nkHiddenCallConv:
+  of nkConv:
+    checkSonsLen(n, 2, c.config)
+    result = semConv(c, n)
+  of nkHiddenStdConv, nkHiddenSubConv, nkHiddenCallConv:
     checkSonsLen(n, 2, c.config)
     considerGenSyms(c, n)
   of nkStringToCString, nkCStringToString, nkObjDownConv, nkObjUpConv:

--- a/tests/lang_exprs/tconversion_ast.nim
+++ b/tests/lang_exprs/tconversion_ast.nim
@@ -1,0 +1,14 @@
+discard """
+  description: '''
+    Ensure that valid conversion AST emitted by a macro is correctly
+    semantically anaylsed
+  '''
+  targets: native
+"""
+
+import std/macros
+
+macro m(): untyped =
+  result = nnkConv.newTree(ident"int", newLit(1.1))
+
+doAssert m() == 1


### PR DESCRIPTION
## Summary

Fix `nnkConv` nodes emitted by macros being skipped by semantic
analysis, which resulted in "expression has no type" errors and allowed
for invalid AST to reach into the compiler.

## Details

`semExpr` only verified that the `nkConv` node itself had the correct
amount of nodes, but didn't analyze the node further. Now, after
verifying the sub-node count, the AST is passed to `semConv`.

Besides preventing invalid AST from reaching into further compilation
stages by being part of an `nkConv` tree, this also allows sem to
create untyped `nkConv` nodes and analyze them.