### PR TITLE
ci: update artifact actions

### DIFF
--- a/.github/actions/download-compiler/action.yml
+++ b/.github/actions/download-compiler/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/download-artifact@v3.0.2
+    - uses: actions/download-artifact@v4
       with:
         name: compiler ${{ runner.os }}
         path: "${{ runner.temp }}"

--- a/.github/actions/upload-compiler/action.yml
+++ b/.github/actions/upload-compiler/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       working-directory: "${{ inputs.source }}"
 
-    - uses: actions/upload-artifact@v3.1.2
+    - uses: actions/upload-artifact@v4
       with:
         name: compiler ${{ runner.os }}
         path: "${{ runner.temp }}/compiler.tar"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           echo "metadata=build/source.json" >> $GITHUB_OUTPUT
 
       - name: Publish source archive to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: source archive
           path: |
@@ -270,7 +270,7 @@ jobs:
 
     steps:
       - name: Download source archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source archive
           path: source-archive
@@ -312,9 +312,9 @@ jobs:
           echo "metadata=$metadata" >> $GITHUB_OUTPUT
 
       - name: Upload release package to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries from source archive
+          name: binaries from source archive ${{ matrix.target.name }}
           path: |
             ${{ steps.package.outputs.archive }}
             ${{ steps.package.outputs.metadata }}
@@ -372,7 +372,7 @@ jobs:
 
       - name: Upload docs to artifacts
         if: matrix.target.shared_builder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # If this name is updated, tweak publisher.yml
           name: Generated docs
@@ -380,9 +380,9 @@ jobs:
           if-no-files-found: error
 
       - name: Upload release package to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: release binaries
+          name: release binaries ${{ matrix.target.name }}
           path: |
             ${{ steps.package.outputs.archive }}
             ${{ steps.package.outputs.metadata }}
@@ -406,19 +406,22 @@ jobs:
         run: echo "::add-matcher::.github/nim-problem-matcher.json"
 
       - name: Download binaries built from source archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: binaries from source archive
+          pattern: binaries from source archive*
           path: binary-from-source
+          merge-multiple: true
 
       - name: Download release package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: release binaries
+          # Download all release binaries to the same folder
+          pattern: release binaries*
           path: release-binary
+          merge-multiple: true
 
       - name: Download release source archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source archive
           path: source-archive
@@ -449,7 +452,7 @@ jobs:
 
       - name: Upload difference test result on failure
         if: failure() && steps.diff.outputs.result != ''
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: differences between binary from source archive and git
           path: ${{ steps.diff.outputs.result }}
@@ -469,7 +472,7 @@ jobs:
       # This allow the publisher to run the tool directly without having to
       # clone the compiler.
       - name: Upload release manifest tool
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release manifest tool
           path: tools/release_manifest

--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -56,7 +56,8 @@ jobs:
           workflow_conclusion: success
           commit: ${{ github.event.after }}
           # Keep up-to-date with ci.yml
-          name: release binaries
+          name: release binaries.*
+          name_is_regexp: true
           path: release-staging
 
       - name: Download release manifest tool

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload diffoscope output
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.test.name }} reproducibility test diffoscope output
           path: ${{ steps.reprotest.outputs.result }}


### PR DESCRIPTION
## Summary

Update the artifact actions:
* https://github.com/actions/download-artifact to version 4 (was 3)
* https://github.com/actions/upload-artifact to version 4 (was 3)

Both updates require changes to the CI workflow, namely that each
release binary needs to use a separate name now.

## Details

The new versions use version 2 of the
[@actions/artifact](https://github.com/actions/toolkit/tree/main/packages/artifact)
package, which doesn't support uploading to the same artifact more than
once during a single workflow run.

This is resolved by creating two "release binaries" and "binaries from
source archives" artifacts (one for each target), with the platform
name as the suffix. For retrieving them, the download action's new
`pattern` and `merge-multiple` features are used. The `publisher` job
is adjusted too.