### PR TITLE
publisher: move release artifacts to the same directory

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -79,6 +79,11 @@ jobs:
       - id: release-files
         name: Create release manifest
         run: |
+          # Move the release binaries to the current folder
+          for d in "release binaries "*; do
+            mv -v "$d"/* .
+          done
+
           # Github Artifacts strip executable permissions so it has to be set again
           chmod 755 release_manifest
           # Create a new release manifest


### PR DESCRIPTION
## Summary

With release artifacts now separated, action-download-artifact downloads
and unpack them in separated directories.

This commit manually unifies the separated directories.

Fixes regression introduced by #1063

Verified to work at
https://github.com/nim-works/nimskull-merge-queue/releases/tag/0.1.0-dev.21121