### PR TITLE
cgir: use dedicated node kind per symbol kind

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -679,29 +679,13 @@ proc genAsmOrEmitStmt(p: BProc, t: CgNode, isAsmStmt=false): Rope =
     case it.kind
     of cnkStrLit:
       res.add(it.strVal)
-    of cnkSym:
-      var sym = it.sym
-      case sym.kind
-      of skProc, skFunc, skIterator, skMethod:
-        var a: TLoc
-        initLocExpr(p, it, a)
-        res.add(rdLoc(a))
-      of skVar, skLet, skForVar:
-        # make sure the C type description is available:
-        discard getTypeDesc(p.module, skipTypes(sym.typ, abstractPtrs))
-        var a: TLoc
-        initLocExpr(p, it, a)
-        res.add(rdLoc(a))
-      of skType:
-        res.add(getTypeDesc(p.module, sym.typ))
-      of skField:
+    of cnkField:
+        let sym = it.sym
         # special support for raw field symbols
         discard getTypeDesc(p.module, skipTypes(sym.typ, abstractPtrs))
         p.config.internalAssert(sym.locId != 0, it.info):
           "field's surrounding type not setup"
         res.add(p.fieldName(sym))
-      else:
-        unreachable(sym.kind)
     of cnkLocal:
       # make sure the C type description is available:
       discard getTypeDesc(p.module, skipTypes(it.typ, abstractPtrs))

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -122,10 +122,7 @@ proc fillLoc(a: var TLoc, k: TLocKind, lode: CgNode, r: Rope, s: TStorageLoc) =
     if a.r == "": a.r = r
 
 proc t(a: TLoc): PType {.inline.} =
-  if a.lode.kind == cnkSym:
-    result = a.lode.sym.typ
-  else:
-    result = a.lode.typ
+  a.lode.typ
 
 proc lodeTyp(t: PType): CgNode =
   result = newNode(cnkEmpty, typ = t)
@@ -336,8 +333,14 @@ include ccgtypes
 
 func mapTypeChooser(p: BProc, n: CgNode): TSymKind =
   case n.kind
-  of cnkSym:
-    n.sym.kind
+  of cnkField:
+    skField
+  of cnkProc:
+    skProc
+  of cnkConst:
+    skConst
+  of cnkGlobal:
+    skVar
   of cnkLocal:
     if n.local == resultId:
       skResult
@@ -351,8 +354,14 @@ func mapTypeChooser(p: BProc, n: CgNode): TSymKind =
 func mapTypeChooser(a: TLoc): TSymKind =
   let n = a.lode
   case n.kind
-  of cnkSym:
-    n.sym.kind
+  of cnkField:
+    skField
+  of cnkProc:
+    skProc
+  of cnkConst:
+    skConst
+  of cnkGlobal:
+    skVar
   of cnkLocal:
     if n.local == resultId:
       skResult
@@ -527,7 +536,7 @@ include ccgthreadvars
 proc varInDynamicLib(m: BModule, sym: PSym)
 
 proc fillGlobalLoc*(m: BModule, s: PSym) =
-  let n = CgNode(kind: cnkSym, info: s.info, typ: s.typ, sym: s)
+  let n = CgNode(kind: cnkGlobal, info: s.info, typ: s.typ, sym: s)
   m.globals.put(s, initLoc(locGlobalVar, n, mangleName(m.g.graph, s), OnHeap))
 
 proc defineGlobalVar*(m: BModule, s: PSym) =

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -361,7 +361,7 @@ proc hash(n: ConstrTree): Hash =
     case n.kind
     of cnkEmpty, cnkNilLit, cnkType:
       discard
-    of cnkSym:
+    of cnkProc:
       result = result !& n.sym.id
     of cnkIntLit, cnkUIntLit:
       result = result !& hash(n.intVal)
@@ -375,7 +375,7 @@ proc hash(n: ConstrTree): Hash =
       for it in n.items:
         result = result !& hashTree(it)
     of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic,
-       cnkWithOperand, cnkLocal, cnkLabel:
+       cnkWithOperand, cnkLocal, cnkLabel, cnkField, cnkConst, cnkGlobal:
       unreachable()
     result = !$result
 
@@ -391,7 +391,7 @@ proc `==`(a, b: ConstrTree): bool =
       case a.kind
       of cnkEmpty, cnkNilLit, cnkType:
         result = true
-      of cnkSym:
+      of cnkProc:
         result = a.sym.id == b.sym.id
       of cnkIntLit, cnkUIntLit:
         result = a.intVal == b.intVal
@@ -405,7 +405,7 @@ proc `==`(a, b: ConstrTree): bool =
             if not treesEquivalent(a[i], b[i]): return
           result = true
       of cnkInvalid, cnkAstLit, cnkPragmaStmt, cnkReturnStmt, cnkMagic,
-         cnkWithOperand, cnkLocal, cnkLabel:
+         cnkWithOperand, cnkLocal, cnkLabel, cnkField, cnkConst, cnkGlobal:
         # nodes that cannot appear in construction trees
         unreachable()
 

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -32,10 +32,12 @@ type
     cnkNilLit        ## the nil literal
     cnkAstLit        ## a ``NimNode`` literal
 
-    cnkSym
+    cnkField         ## reference to an object field's symbol
     cnkLabel         ## name of a block
+    cnkProc          ## name of a procedure
+    cnkConst         ## reference to a named, global constant
+    cnkGlobal        ## reference to a global location
     cnkLocal         ## reference to a local
-    # future direction: split up ``cnkSym`` in the way the MIR does it
     cnkMagic         ## name of a magic procedure. Only valid in the callee
                      ## slot of ``cnkCall`` nodes
 
@@ -186,12 +188,13 @@ type
     of cnkFloatLit:   floatVal*: BiggestFloat
     of cnkStrLit:     strVal*: string
     of cnkAstLit:     astLit*: PNode
-    of cnkSym:        sym*: PSym
     of cnkMagic:      magic*: TMagic
     of cnkLabel:      label*: BlockId
     of cnkLocal:      local*: LocalId
     of cnkPragmaStmt: pragma*: TSpecialWord
     of cnkWithOperand: operand*: CgNode
+    of cnkField, cnkProc, cnkConst, cnkGlobal:
+      sym*: PSym
     of cnkWithItems:
       kids*: seq[CgNode]
 

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -39,7 +39,7 @@ proc treeRepr*(n: CgNode): string =
     of cnkPragmaStmt:
       result.add "pragma: "
       result.add $n.pragma
-    of cnkSym:
+    of cnkField, cnkProc, cnkConst, cnkGlobal:
       result.add "sym: "
       result.add n.sym.name.s
       result.add " id: "


### PR DESCRIPTION
## Summary

Remove the `cnkSym` node kind and replace it with a dedicated kind for
each entity `cnkSym` previously represented. This brings the `CgNode`
IR closer to the MIR.

## Details

The `CgNode` IR groups symbols of constants, globals, fields, and
procedures under a single node kind, requiring dispatching based
on the `TSym.kind`. Which entity some logic expects is also not
expressible without a separate assertion.

In order to:
* reduce the amount of dispatching in the code generators
* bring the `CgNode` IR closer to the MIR
* prevent bugs caused by symbol kinds not being considered

the `CgNode` IR is changed to also use a dedicated node kind per
symbol.

Each usage of `cnkSym` is replaced with usage of the node kind(s)
that the respective code generator logic expects, which is context
dependent. A positive effect of this is that it is now clear which
entities are processed where.

Finally, a small cleanup is performed in `ccgstmts.genAsmOrEmitStmt`:
only the field symbol handling of the `cnkSym` branch is kept, for
all other symbol kinds, the else statement suffices.