### PR TITLE
mir: unify call syntax

### DIFF
--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -309,7 +309,8 @@ template wrapMutAlias*(bu: var MirBuilder, t: PType, body: untyped): Value =
 
 template buildMagicCall*(bu: var MirBuilder, m: TMagic, t: PType,
                          body: untyped) =
-  bu.subTree MirNode(kind: mnkMagic, magic: m, typ: t):
+  bu.subTree MirNode(kind: mnkCall, typ: t):
+    bu.add MirNode(kind: mnkMagic, magic: m)
     body
 
 template buildCall*(bu: var MirBuilder, prc: PSym, t: PType, d: untyped) =

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -175,6 +175,17 @@ proc valueToStr(nodes: MirTree, i: var int, result: var string) =
   else:
     result.add "<error: " & $n.kind & ">"
 
+proc calleeToStr(tree: MirTree, i: var int, result: var string) =
+  case tree[i].kind
+  of mnkMagic:
+    # cut off the 'm' prefix and use a lowercase first character
+    var name = substr($tree[i].magic, 1)
+    name[0] = toLowerAscii(name[0])
+    result.add name
+    inc i
+  else:
+    valueToStr(tree, i, result)
+
 proc argToStr(tree: MirTree, i: var int, result: var string) =
   var n {.cursor.} = next(tree, i)
   case n.kind
@@ -243,16 +254,7 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string) =
       result.add ")"
   of mnkCall:
     tree "":
-      valueToStr(nodes, i, result) # callee
-      result.add "("
-      commaSeparated:
-        argToStr(nodes, i, result)
-      result.add ")"
-  of mnkMagic:
-    # cut off the 'm' prefix and use a lowercase first character
-    var name = substr($nodes[i].magic, 1)
-    name[0] = toLowerAscii(name[0])
-    tree name:
+      calleeToStr(nodes, i, result)
       result.add "("
       commaSeparated:
         argToStr(nodes, i, result)

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -60,7 +60,7 @@ type
     long: seq[PathInstr]
 
 const
-  Roots = SymbolLike + {mnkTemp, mnkCall, mnkMagic, mnkDeref, mnkDerefView}
+  Roots = SymbolLike + {mnkTemp, mnkCall, mnkDeref, mnkDerefView}
   PathOps = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv,
              mnkPathVariant}
 

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -534,7 +534,7 @@ func isMoveable(tree: MirTree, v: Values, n: NodePosition): bool =
   of mnkConv, mnkStdConv, mnkCast, mnkAddr, mnkView, mnkToSlice:
     # the result of these operations is not an owned value
     false
-  of mnkCall, mnkMagic, mnkObjConstr:
+  of mnkCall, mnkObjConstr:
     true
   of mnkConstr:
     case tree[n].typ.skipTypes(abstractInst).kind
@@ -775,8 +775,7 @@ proc consumeArg(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
                 pos + 1):
     let stmt = tree.parent(expr)
 
-    if (tree[expr].kind == mnkCall and geRaises in tree[expr].effects) or
-       (tree[expr].kind == mnkMagic and tree[expr].magic in magicsThatCanRaise):
+    if tree[expr].kind == mnkCall and geRaises in tree[expr].effects:
       # the consumer raises, meaning that resetting the consumed-from location
       # cannot happen *after* the statement. The source location's value is
       # first assigned to a temporary and then the source is reset

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -64,7 +64,7 @@ Semantics
   CALL_EXPR = Call <Proc> CALL_ARG ...   # a static call of the provided
                                          # procedure with the given arguments
             | Call LVALUE CALL_ARG ...   # indirect call
-            | Magic <Magic> CALL_ARG ... # a call of a magic procedure (i.e.,
+            | Call <Magic> CALL_ARG ...  # a call of a magic procedure (i.e.,
                                          # a procedure that is either going to
                                          # be lowered into something else, or
                                          # one for which the behaviour cannot


### PR DESCRIPTION
## Summary

Make the MIR's call expression syntax more regular by not treating
`Magic` as a call-like node. Magic calls are now represented as
`(Call (<Magic>) ...)`, with the `Magic` node treated like a callee.

## Details

Saving a node per magic call doesn't outweigh the additional complexity
of accounting for the special tree shape (no callee slot) of
magic calls when analyzing call expressions.

The `Magic` node is now treated as a node allowed in the callee slot of
a `Call` tree, removing the special shape and thus simplifying
processing and analysis. More importantly, this allows for specifying
whether the *call* of a magic can raise -- this was previously a
property of the *magic*, not of the call thereof.

**Changes:**
- don't treat `mnkMagic` as a call-like node (and remove all usages of
  it as such)
- add a `[]` sub-node access operator overload that accepts an
  `OpValue`
- update `mirpasses.preventRvo` and `mirpasses.search` to account for
  the different magic call syntax
- add the `buildCheckedMagicCall` template to `mirgen`; it's used for
  emitting magic calls that are tagged as potentially raising
- add the `buildDefectMagicCall` template to `mirgen`; it's used for
  emitting magic calls that are only tagged as potentially raising if
  panics are disabled

Since in `mirgen` the `mChckRange` call is now emitted via
`buildDefectMagicCall`, compiler-injected range checks are correctly
treated as not raising an exception when panics are enabled
(`--panics:on`).