### PR TITLE
fix(vmgen): taking the address of named constants

### DIFF
--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -201,12 +201,10 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
       if tree[i, 0].kind == mnkTemp and
          tree[i, 0].typ.skipTypes(LocSkip).kind notin Ignore and
          tree[e].kind in LvalueExprKinds and
-         tree[getRoot(tree, e)].kind notin {mnkConst, mnkTemp}:
+         tree[getRoot(tree, e)].kind != mnkTemp:
         # definition of a temporary into which an lvalue is assigned. Elision
-        # is disabled for:
-        # * projections of temporaries; the projected temporary might be
-        #   elided itself, which could lead to evaluation order issues
-        # * constants; works around code generator issues
+        # is disabled for projections of temporaries; the projected temporary
+        # might be elided itself, which could lead to evaluation order issues
         ct[tree[i, 0].temp.uint32] = 1
 
       i = NodePosition e # skip to the source expression

--- a/tests/misc/taddr_of_const_array_element.nim
+++ b/tests/misc/taddr_of_const_array_element.nim
@@ -1,0 +1,30 @@
+discard """
+  description: '''
+    Ensure that taking the address of an aggregate constant's element works
+  '''
+  targets: "c js vm"
+  knownIssue: '''
+    The element access is folded into a literal integer, later causing an
+    internal compiler error, since taking the address of a literal integer
+    is illegal.
+  '''
+"""
+
+# XXX: once the test succeeds, merge it back into ``taddr.nim``
+
+proc test[T](x: ptr T, expect: T) {.noinline.} =
+  # prevent the addr + deref from being optimized away by using a .noinline
+  # procedure
+  doAssert x[] == expect
+
+type Object = object
+  x: int
+
+const
+  obj = Object(x: 1)
+  tup = (1, 2, 3)
+  arr = [1, 2, 3]
+
+test(addr o.x, 1)
+doAssert not compiles(test(addr tup[1], 2))
+test(addr arr[1], 2)


### PR DESCRIPTION
## Summary

Support taking the address of named constants for code running in the
VM (affects both compile-time evaluation and the VM backend).

## Details

Global constants (i.e., `const`) that aren't inlined directly were
treated like non-constant globals, which is wrong, as global constants
are accessed through a different opcode.

**Changes:**
* implement proper code generator for `cnkConst` in `vmgen.genSym` and
  `vmgen.genSymAddr`
* remove the associated workaround in the MIR temporary elimination
  pass -- temporaries created from constant projections (e.g., `c.x.y`,
  where `c` is a `const`) are now also considered by the optimizer
* remove loading constants of primitive type as literals (i.e.,
  inlining constants). This already happens at an earlier stage
  (currently `sem`)

As a preparation for eventually being able to take the address of a
`const x = 1`, `vmgen` no longer throws an internal error when
encountering a constant with primitive type (integers, floats, string)
that wasn't inlined.