### PR TITLE
internal: support multiple lifetimes for entities

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -333,14 +333,11 @@ proc preprocess*(conf: BackendConfig, prc: PSym, graph: ModuleGraph,
 
 proc process*(prc: var Procedure, graph: ModuleGraph, idgen: IdGenerator) =
   ## Applies all applicable MIR passes to the procedure `prc`.
-  rewriteGlobalDefs(prc.body.tree, prc.body.source, patch=false)
+  rewriteGlobalDefs(prc.body.tree, prc.body.source)
 
   if shouldInjectDestructorCalls(prc.sym):
     injectDestructorCalls(graph, idgen, prc.sym,
                           prc.body.tree, prc.body.source)
-
-  # restore the correct symbols for globals:
-  patchGlobals(prc.body.tree, prc.body.source)
 
   let target =
     case graph.config.backend

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -157,14 +157,15 @@ type
     a: array[2, int]
 
   EntityInfo = object
-    ## Information about an entity's livetime.
+    ## Information about a lifetime of an entity. The lifetime of an entity is
+    ## the time during which it can be *live* (i.e., store a value).
     def: NodePosition ## the position of the 'def' for the entity
     scope: Subgraph   ## the data-flow subgraph during which the entity exists
 
   EntityDict = Table[EntityName, seq[EntityInfo]]
     ## Entity dictionary. Stores all entities relevant to destructor
-    ## injection and the move analyser. A location may be alive more than
-    ## once.
+    ## injection and the move analyser. A location may have more than one
+    ## lifetimes.
 
   DestroyEntry = tuple
     scope: NodePosition ## the position of the enclosing 'scope' node
@@ -225,19 +226,19 @@ func findScope(entities: EntityDict, name: EntityName, at: InstrPos,
                exists: var bool): EntityInfo =
   ## Returns the ``EntityInfo`` for `name` that encloses the data-flow
   ## instruction at `at`. If `name` is present in `entities` but `at` is not
-  ## directly part of any livetime, the ``EntityInfo`` for the livetime
+  ## directly part of any lifetime, the ``EntityInfo`` for the lifetime
   ## preceding `at` is returned.
   ##
   ## `exists` is updated to indicate whether a scope was found.
   if name in entities:
-    let livetimes {.cursor.} = entities[name]
+    let lifetimes {.cursor.} = entities[name]
     # search for the upper bound:
     var i = 0
-    while i < livetimes.len and at >= livetimes[i].scope.a:
+    while i < lifetimes.len and at >= lifetimes[i].scope.a:
       inc i
 
     if i - 1 >= 0:
-      result = livetimes[i - 1]
+      result = lifetimes[i - 1]
       exists = true
     else:
       exists = false

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -157,12 +157,14 @@ type
     a: array[2, int]
 
   EntityInfo = object
+    ## Information about an entity's livetime.
     def: NodePosition ## the position of the 'def' for the entity
     scope: Subgraph   ## the data-flow subgraph during which the entity exists
 
-  EntityDict = Table[EntityName, EntityInfo]
+  EntityDict = Table[EntityName, seq[EntityInfo]]
     ## Entity dictionary. Stores all entities relevant to destructor
-    ## injection and the move analyser
+    ## injection and the move analyser. A location may be alive more than
+    ## once.
 
   DestroyEntry = tuple
     scope: NodePosition ## the position of the enclosing 'scope' node
@@ -219,15 +221,29 @@ func toName(n: MirNode): EntityName =
     of mnkTemp:    n.temp.int
     else:          unreachable(n.kind)
 
-func getAliveGraph(entities: EntityDict, name: EntityName, exists: var bool
-                  ): Subgraph =
-  ## Returns the data-flow sub-graph during which the entity `name` exists.
-  ## `exists` is set to whether the entity is present in the dictionary.
-  let info =
-    entities.getOrDefault(name, EntityInfo(def: NodePosition(-1)))
+func findScope(entities: EntityDict, name: EntityName, at: InstrPos,
+               exists: var bool): EntityInfo =
+  ## Returns the ``EntityInfo`` for `name` that encloses the data-flow
+  ## instruction at `at`. If `name` is present in `entities` but `at` is not
+  ## directly part of any livetime, the ``EntityInfo`` for the livetime
+  ## preceding `at` is returned.
+  ##
+  ## `exists` is updated to indicate whether a scope was found.
+  if name in entities:
+    let livetimes {.cursor.} = entities[name]
+    # search for the upper bound:
+    var i = 0
+    while i < livetimes.len and at >= livetimes[i].scope.a:
+      inc i
 
-  exists = info.def != NodePosition(-1)
-  result = info.scope
+    if i - 1 >= 0:
+      result = livetimes[i - 1]
+      exists = true
+    else:
+      exists = false
+  else:
+    exists = false
+
 
 proc getVoidType(g: ModuleGraph): PType {.inline.} =
   g.getSysType(unknownLineInfo, tyVoid)
@@ -307,12 +323,9 @@ func initEntityDict(tree: MirTree, dfg: DataFlowGraph): EntityDict =
           nil # not a location (e.g. a procedure)
 
       if t != nil and hasDestructor(t):
-        let re = toName(entity)
-        # XXX: a ``doAssert`` is only used here in order to always catch
-        #      duplicate symbols incorrectly getting past ``transf``
-        doAssert re notin result, "entity appears in a 'def' multiple times"
-        # don't include the data-flow operations preceding the def
-        result[re] = EntityInfo(def: i, scope: subgraphFor(dfg, i .. scope.b))
+        result.mgetOrPut(toName(entity), @[]).add:
+          # don't include the data-flow operations preceding the def
+          EntityInfo(def: i, scope: subgraphFor(dfg, i .. scope.b))
 
     else:
       discard
@@ -341,9 +354,9 @@ func computeOwnership(tree: MirTree, cfg: DataFlowGraph, entities: EntityDict,
     #       pseudo-use at the end of the body and make all procedure exits
     #       visit it first
     var exists = false
-    let aliveRange = entities.getAliveGraph(toName(tree[lval.root]), exists)
+    let info = entities.findScope(toName(tree[lval.root]), start, exists)
     exists and not isCursor(tree, lval) and
-      isLastRead(tree, cfg, aliveRange, lval, start)
+      isLastRead(tree, cfg, info.scope, lval, start)
   else:
     unreachable()
 
@@ -405,7 +418,12 @@ func computeDestructors(tree: MirTree, cfg: DataFlowGraph, values: Values,
   ## to "escape")
   var needsFinally: PackedSet[NodePosition]
 
-  for _, info in entities.pairs:
+  iterator items(x: EntityDict): lent EntityInfo =
+    for _, infos in x.pairs:
+      for it in infos.items:
+        yield it
+
+  for info in entities.items:
     let
       def = info.def ## the position of the entity's definition
       entity = tree[getDefEntity(tree, def)]
@@ -449,8 +467,8 @@ func isAlive(tree: MirTree, cfg: DataFlowGraph, v: Values,
         cfg.subgraphFor(NodePosition(0) .. NodePosition(tree.high))
       else:
         var exists: bool
-        let s = entities.getAliveGraph(toName(tree[root]), exists)
-        if exists: s
+        let info = entities.findScope(toName(tree[root]), at, exists)
+        if exists: info.scope
         else:      return true # not something we can analyse -> assume alive
 
     # if the location is not assigned an initial value on definition, `start`
@@ -488,10 +506,10 @@ func needsReset(tree: MirTree, cfg: DataFlowGraph, ar: AnalysisResults,
   if tree[root].kind in SymbolLike and tree[root].sym.kind == skResult:
     return true
 
-  let info = getOrDefault(ar.entities[], toName(tree[root]),
-                          EntityInfo(def: NodePosition -1))
+  var exists: bool
+  let info = findScope(ar.entities[], toName(tree[root]), at, exists)
 
-  if info.def == NodePosition(-1):
+  if not exists:
     # the location is not local to the current context -> assume that it needs
     # to be reset
     return true

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -187,20 +187,7 @@ proc freshVar(c: PTransf; v: PSym): PNode =
     # don't introduce copies of symbols of globals. The processing
     # following after ``transf`` expects that the set of existing globals
     # stays unchanged
-    if v.owner.kind == skModule:
-      # HACK: a nested global. Not introducing a new global would cause the
-      #       resulting AST to be semantically invalid (and the
-      #       ``injectdestructors`` pass to rightfully complain). As a
-      #       workaround, we introduce a copy here, associate it with the
-      #       correct global via the `owner` field, and then restore the
-      #       proper global during the MIR phase...
-      let newVar = copySym(v, nextSymId(c.idgen))
-      newVar.owner = v
-      result = newSymNode(newVar)
-    else:
-      # a lifted global; don't introduce a copy
-      result = newSymNode(v)
-
+    result = newSymNode(v)
   elif owner.isIterator:
     result = freshVarForClosureIter(c.graph, v, c.idgen, owner)
   else:

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -161,22 +161,14 @@ func discoverGlobalsAndRewrite(data: var DiscoveryData, tree: var MirTree,
         # found a global definition; register it. Imported ones are
         # ignored -- ``vmgen`` will report an error when the global is
         # accessed
-        let s =
-          if g.owner.kind in {skVar, skLet, skForVar}:
-            g.owner # account for duplicated symbols (see ``transf.freshVar``)
-          else:
-            g
-        data.registerGlobal(s)
+        data.registerGlobal(g)
 
       i = sibling(tree, i)
     else:
       inc i
 
   if rewrite:
-    rewriteGlobalDefs(tree, source, patch=true)
-  else:
-    # the globals still need to be patched
-    patchGlobals(tree, source)
+    rewriteGlobalDefs(tree, source)
 
 func register(linker: var LinkerData, data: DiscoveryData) =
   ## Registers the newly discovered entities in the link table, but doesn't


### PR DESCRIPTION
## Summary

Update the `injectdestructors` pass to support an entity (global or
local) being defined multiple times within a MIR body. A workaround for
this previous shortcoming is now obsolete and thus removed.

## Details

### Background

No new global variables must be introduced after module lowering. For
this reason, `transf` doesn't introduce replicas for symbols of global
variables when inlining the same `for`-loop body multiple times
(because of more than one `yield` statement).

This, however, is a problem for the `injectdestructors` pass, as it, so
far, only supported an location existing once (i.e., there only being a
single 'def' for it). As a workaround, `transf` had to introduce
temporary replicas of the symbol, where are then replaced with the
originating-from symbol after the `injectdestructors` pass is over.

### The problem

The workaround is scattered across multiple layers and all new
processing that touches symbols of globals needs to account for the
fact that the symbol might not be the "correct" one.

### Solution

The `injectdestructors` pass is updated to support entity locations'
having multiple lifetimes within a body:
* associate an entity with a list of `EntityInfo` rather than only a
  single one (each one representing a single lifetime/scope)
* replace `getAliveGraph` with `findScope`, which looks up the entity's
  scope corresponding to the given data-flow instruction

A downside is that more allocations are performed due to the usage of
`seq`, but this is going to be resolved by injecting destructors
during AST -> MIR translation.

Creating a temporary copy of the symbol and later restoring it is
removed.