### PR TITLE
vm: remove the `opcLdStrIdxAddr` opcode

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1055,20 +1055,6 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         regs[ra].intVal = s[idx].ord
       else:
         raiseVmError(reportVmIdx(idx, s.len-1))
-    of opcLdStrIdxAddr:
-      # a = addr(b[c]); similar to opcLdArrAddr
-      decodeBC(rkAddress)
-      if regs[rc].intVal > high(int):
-        raiseVmError(reportVmIdx(regs[rc].intVal, high(int)))
-
-      checkHandle(regs[rb])
-
-      let idx = regs[rc].intVal.int
-      let s = regs[rb].atomVal.strVal
-      if idx <% s.len:
-        regs[ra].setAddress(s.data.applyOffset(uint idx), c.typeInfoCache.charType)
-      else:
-        raiseVmError(reportVmIdx(idx, s.len-1))
 
     of opcWrArr:
       # a[b] = c

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -46,8 +46,7 @@ type
     opcLdDeref,
     opcWrDeref,
     opcWrStrIdx,
-    opcLdStrIdx, # a = b[c]
-    opcLdStrIdxAddr,  # a = addr(b[c])
+    opcLdStrIdx, # a = b[c]; the character is loaded directly into register 'a'
 
     opcInitDisc # init discriminant (a.b = c)
     opcSetDisc # set discriminant (a.b = c)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2501,7 +2501,7 @@ proc genArrAccessOpcode(c: var TCtx; n: CgNode; dest: var TDest; opc: TOpcode; l
     b = c.genIndex(n[1], n[0].typ)
 
   prepare(c, dest, n.typ)
-  if opc in {opcLdArrAddr, opcLdStrIdx, opcLdStrIdxAddr}:
+  if opc in {opcLdArrAddr, opcLdStrIdx}:
     # the result is already stored in a register; no special handling
     # required
     c.gABC(n, opc, dest, a, b)
@@ -2640,9 +2640,7 @@ proc genArrayAddr(c: var TCtx, n: CgNode, dest: var TDest) =
   ## ``addr x[0]``)
   assert not dest.isUnset
   case n[0].typ.skipTypes(abstractInst).kind
-  of tyString, tyCstring:
-    genArrAccessOpcode(c, n, dest, opcLdStrIdxAddr)
-  of tyArray, tySequence, tyOpenArray, tyVarargs:
+  of tyString, tyCstring, tyArray, tySequence, tyOpenArray, tyVarargs:
     genArrAccessOpcode(c, n, dest, opcLdArrAddr)
   else:
     unreachable()


### PR DESCRIPTION
## Summary

The opcode is fully redundant with `LdArrAddr`, and the specialization
provides little to no benefit given that taking the address of a
string's element is an uncommon operation.

## Details

* remove the `opcLdStrIdxAddr` opcode and its implementation
* `vmgen` emits an `opcLdArrAddr` instruction instead

Note that creating a `var` or `lent` view of a string's element did not
use `LdStrIdxAddr` previously. The dedicated opcode is a leftover from
the time where strings used a special in-VM representation.