### PR TITLE
mir: unify defects and errors in the backend

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2131,7 +2131,7 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
     putDataIntoDest(p, d, n, genLiteral(p, n))
   of cnkIntLit, cnkUIntLit, cnkFloatLit, cnkNilLit:
     putIntoDest(p, d, n, genLiteral(p, n))
-  of cnkCall:
+  of cnkCall, cnkCheckedCall:
     genLineDir(p, n) # may be redundant, it is generated in fixupCall as well
     let m = getCalleeMagic(n[0])
     if n.typ.isNil:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -600,7 +600,7 @@ proc initLocExpr(p: BProc, e: CgNode, result: var TLoc, flags: set[LocFlag]) =
 
 proc initLocExprSingleUse(p: BProc, e: CgNode, result: var TLoc) =
   initLoc(result, locNone, e, OnUnknown)
-  if e.kind == cnkCall and getCalleeMagic(e[0]) == mNone:
+  if e.kind in {cnkCall, cnkCheckedCall} and getCalleeMagic(e[0]) == mNone:
     # We cannot check for tfNoSideEffect here because of mutable parameters.
     discard "bug #8202; enforce evaluation order for nested calls"
     # We may need to consider that 'f(g())' cannot be rewritten to 'tmp = g(); f(tmp)'

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -39,10 +39,11 @@ type
     cnkGlobal        ## reference to a global location
     cnkLocal         ## reference to a local
     cnkMagic         ## name of a magic procedure. Only valid in the callee
-                     ## slot of ``cnkCall`` nodes
+                     ## slot of ``cnkCall`` and ``cnkCheckedCall`` nodes
 
     cnkCall          ## a procedure call. The first operand is the procedure,
                      ## the following operands the arguments
+    cnkCheckedCall   ## like ``cnkCall``, but the call might raise an exception
 
     # constructors:
     cnkTupleConstr   ## tuple constructor

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -621,7 +621,8 @@ proc callToIr(tree: TreeWithSource, cl: var TranslateCl, n: MirNode,
               cr: var TreeCursor): CgNode =
   ## Translate a valid call-like tree to the CG IR.
   let info = cr.info
-  result = newExpr(cnkCall, info, n.typ)
+  result = newExpr((if n.kind == mnkCall: cnkCall else: cnkCheckedCall),
+                   info, n.typ)
   result.add: # the callee
     case tree[cr].kind
     of mnkMagic: newMagicNode(tree.get(cr).magic, info)
@@ -995,7 +996,7 @@ proc exprToIr(tree: TreeWithSource, cl: var TranslateCl,
 
     treeOp kind:
       res.add argToIr(tree, cl, cr)[1]
-  of mnkCall:
+  of mnkCall, mnkCheckedCall:
     callToIr(tree, cl, n, cr)
   of AllNodeKinds - ExprKinds - {mnkNone}:
     unreachable(n.kind)

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -109,7 +109,7 @@ proc preventRvo(tree: MirTree, changes: var Changeset) =
   # anywhere in the source expression
   for i in search(tree, {mnkFastAsgn, mnkAsgn}):
     let source = tree.operand(i, 1)
-    if tree[source].kind != mnkCall or tree[source, 0].kind == mnkMagic or
+    if tree[source].kind notin CallKinds or tree[source, 0].kind == mnkMagic or
        not eligibleForRvo(tree[source].typ):
       # the return-value optimization is not used
       continue
@@ -295,7 +295,7 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
         let stmt = tree.parent(expr)
         elide = tree[stmt].kind in {mnkInit, mnkDef, mnkDefCursor} or
                 not overlaps(p, typ, tree.operand(stmt, 0))
-      of mnkCall:
+      of CallKinds:
         # the lvalue overlapping with a mutable argument disable the elision,
         # as eliding the temporary would be obersvable when the backend decides
         # to use pass-by-reference for the immutable parameter

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -37,7 +37,7 @@ func `$`(n: MirNode): string =
   of mnkPathPos:
     result.add " position: "
     result.add $n.position
-  of mnkCall:
+  of mnkCall, mnkCheckedCall:
     result.add " effects: "
     result.add $n.effects
   of mnkMagic:
@@ -259,6 +259,13 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string) =
       commaSeparated:
         argToStr(nodes, i, result)
       result.add ")"
+  of mnkCheckedCall:
+    tree "":
+      calleeToStr(nodes, i, result)
+      result.add "("
+      commaSeparated:
+        argToStr(nodes, i, result)
+      result.add ") (raises)"
   else:
     # TODO: make this branch exhaustive
     result.add "<error: " & $nodes[i].kind & ">"

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -60,7 +60,8 @@ type
     long: seq[PathInstr]
 
 const
-  Roots = SymbolLike + {mnkTemp, mnkCall, mnkDeref, mnkDerefView}
+  Roots = SymbolLike + {mnkTemp, mnkCall, mnkCheckedCall, mnkDeref,
+                        mnkDerefView}
   PathOps = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv,
              mnkPathVariant}
 

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -241,7 +241,7 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition,
     env.dfaOp(o, tree, at, v)
 
   case tree[source].kind
-  of mnkCall, mnkConstr, mnkObjConstr:
+  of mnkCall, mnkCheckedCall, mnkConstr, mnkObjConstr:
     emitForArgs(env, tree, at, source)
   of mnkConv, mnkStdConv, mnkCast:
     # a read is performed on the source operand (if it's an lvalue)
@@ -274,7 +274,7 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition,
   # For the local data-flow, this is represented as taking place after the
   # callsite arguments are used but before the exceptional exit (if any)
   case tree[source].kind
-  of mnkCall:
+  of mnkCall, mnkCheckedCall:
     # lvalue effects:
     for k, it in arguments(tree, source):
       if tree[it].kind == mnkTag:
@@ -292,7 +292,7 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition,
     # operation has to come before the fork
     if geMutateGlobal in tree[source].effects:
       env.instrs.add Instr(op: opMutateGlobal, node: at)
-    if geRaises in tree[source].effects:
+    if tree[source].kind == mnkCheckedCall:
       exit env, opFork, at, RaiseLabel
   else:
     discard

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -1005,7 +1005,7 @@ proc checkTry(n, ctx, map): Check =
   #     newMap = childMap
   let tryCheck = check(n[0], ctx, currentMap)
   newMap = ctx.union(currentMap, tryCheck.map)
-  canRaise = n[0].canRaise
+  canRaise = canRaise(optPanics in ctx.config.globalOptions, n[0])
 
   var afterTryMap = newMap
   for a, branch in n:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2210,7 +2210,7 @@ func isPtrView(n: CgNode): bool =
     false
   of cnkFieldAccess, cnkArrayAccess, cnkTupleAccess, cnkCheckedFieldAccess:
     true
-  of cnkHiddenAddr, cnkCall:
+  of cnkHiddenAddr, cnkCall, cnkCheckedCall:
     false
   else:
     unreachable(n.kind)
@@ -2922,7 +2922,7 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
     genProcLit(c, n, s, dest)
   of cnkConst, cnkGlobal, cnkLocal:
     genSym(c, n, dest)
-  of cnkCall:
+  of cnkCall, cnkCheckedCall:
     let magic = getMagic(n)
     if magic != mNone:
       genMagic(c, n, dest, magic)

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -70,6 +70,12 @@ Semantics
                                          # one for which the behaviour cannot
                                          # be represented in the MIR)
 
+  # checked calls have the same shape as normal calls. The difference is that
+  # the call has an exceptional exit (i.e., it might raise an exception)
+  CHECKED_CALL_EXPR = CheckedCall <Proc> CALL_ARG ...
+                    | CheckedCall LVALUE CALL_ARG ...
+                    | CheckedCall <Magic> CALL_ARG ...
+
   RVALUE = CALL_EXPR
          | Constr   CONSTR_ARG ...       # construct a tuple, closure, set, or
          | ObjConstr (<Field> CONSTR_ARG) ... # construct an `object` or

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -14,8 +14,8 @@ scope:
       scope:
         x =fast construct (arg "string here", arg 80)
     def_cursor _0: (string, int) = x
-    def _1: string = $(arg _0)
-    echo(arg type(array[0..0, string]), arg _1)
+    def _1: string = $(arg _0) (raises)
+    echo(arg type(array[0..0, string]), arg _1) (raises)
   finally:
     =destroy(name _1)
 -- end of expandArc ------------------------
@@ -25,7 +25,7 @@ scope:
   scope:
     def_cursor filename: string = "debug.txt"
     def_cursor _0: string = filename
-    def f: File = open(arg _0, arg fmRead, arg 8000)
+    def f: File = open(arg _0, arg fmRead, arg 8000) (raises)
     try:
       scope:
         try:
@@ -35,7 +35,7 @@ scope:
               while true:
                 scope:
                   def_cursor _1: File = f
-                  def_cursor _2: bool = readLine(arg _1, name res)
+                  def_cursor _2: bool = readLine(arg _1, name res) (raises)
                   def_cursor _3: bool = not(arg _2)
                   if _3:
                     scope:
@@ -44,13 +44,13 @@ scope:
                     scope:
                       def_cursor x: string = res
                       def_cursor _4: string = x
-                      echo(arg type(array[0..0, string]), arg _4)
+                      echo(arg type(array[0..0, string]), arg _4) (raises)
         finally:
           =destroy(name res)
     finally:
       scope:
         def_cursor _5: File = f
-        close(arg _5)
+        close(arg _5) (raises)
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -13,7 +13,7 @@ doing shady stuff...
   nimout: '''--expandArc: newTarget
 
 scope:
-  def splat: tuple[dir: string, name: string, ext: string] = splitFile(arg path)
+  def splat: tuple[dir: string, name: string, ext: string] = splitFile(arg path) (raises)
   bind_mut _3: string = splat.0
   def _0: string = _3
   wasMoved(name _3)
@@ -33,20 +33,20 @@ scope:
   def_cursor _1: Node = _0[].parent
   def sibling: Node
   def _6: Node = _1[].left
-  =copy(name sibling, arg _6)
+  =copy(name sibling, arg _6) (raises)
   def_cursor _2: Node = sibling
   def saved: Node
   def _7: Node = _2[].right
-  =copy(name saved, arg _7)
+  =copy(name saved, arg _7) (raises)
   def_cursor _3: Node = sibling
   def_cursor _4: Node = saved
   bind_mut _8: Node = _3[].right
   def _9: Node = _4[].left
-  =copy(name _8, arg _9)
+  =copy(name _8, arg _9) (raises)
   def_cursor _5: Node = sibling
   bind_mut _10: Node = _5[].parent
-  =sink(name _10, arg saved)
-  =destroy(name sibling)
+  =sink(name _10, arg saved) (raises)
+  =destroy(name sibling) (raises)
 -- end of expandArc ------------------------
 --expandArc: p1
 
@@ -81,8 +81,8 @@ scope:
     =copy(name _1, arg _5)
     def a: (seq[int], seq[int]) = construct (consume _0, consume _1)
     def_cursor _2: (seq[int], seq[int]) = a
-    def _3: string = $(arg _2)
-    echo(arg type(array[0..0, string]), arg _3)
+    def _3: string = $(arg _2) (raises)
+    echo(arg type(array[0..0, string]), arg _3) (raises)
   finally:
     =destroy(name _3)
     =destroy(name a)
@@ -113,7 +113,7 @@ scope:
                     def_cursor _4: int = i
                     def line: lent string = borrow a[_4]
                     def_cursor _5: string = line[]
-                    def splitted: seq[string] = split(arg _5, arg " ", arg -1)
+                    def splitted: seq[string] = split(arg _5, arg " ", arg -1) (raises)
                     def_cursor _6: string = splitted[0]
                     def_cursor _7: bool = ==(arg _6, arg "opt")
                     if _7:
@@ -121,9 +121,9 @@ scope:
                         def _10: string = splitted[1]
                         =copy(name lan_ip, arg _10)
                     def_cursor _8: string = lan_ip
-                    echo(arg type(array[0..0, string]), arg _8)
+                    echo(arg type(array[0..0, string]), arg _8) (raises)
                     def_cursor _9: string = splitted[1]
-                    echo(arg type(array[0..0, string]), arg _9)
+                    echo(arg type(array[0..0, string]), arg _9) (raises)
                   finally:
                     =destroy(name splitted)
                 inc(name i, arg 1)
@@ -135,8 +135,8 @@ scope:
   try:
     def shadowScope: Scope
     def _7: Scope = c[].currentScope
-    =copy(name shadowScope, arg _7)
-    rawCloseScope(arg c)
+    =copy(name shadowScope, arg _7) (raises)
+    rawCloseScope(arg c) (raises)
     scope:
       def_cursor _0: Scope = shadowScope
       def_cursor a: seq[Symbol] = _0[].symbols
@@ -160,10 +160,10 @@ scope:
                   def _6: Symbol
                   def _8: Symbol = sym[]
                   =copy(name _6, arg _8)
-                  addInterfaceDecl(arg c, consume _6)
+                  addInterfaceDecl(arg c, consume _6) (raises)
                 inc(name i, arg 1)
   finally:
-    =destroy(name shadowScope)
+    =destroy(name shadowScope) (raises)
 -- end of expandArc ------------------------
 --expandArc: treturn
 
@@ -180,8 +180,8 @@ scope:
         return
     def_cursor _3: sink string = x
     def_cursor _4: int = len(arg _3)
-    def _5: string = $(arg _4)
-    echo(arg type(array[0..0, string]), arg _5)
+    def _5: string = $(arg _4) (raises)
+    echo(arg type(array[0..0, string]), arg _5) (raises)
   finally:
     =destroy(name _5)
     =destroy(name x)
@@ -192,11 +192,11 @@ scope:
 scope:
   try:
     def_cursor _0: string = this[].value
-    this[].isValid = fileExists(arg _0)
+    this[].isValid = fileExists(arg _0) (raises)
     def _1: tuple[dir: string, front: string]
     block L0:
       def_cursor _2: string = this[].value
-      def_cursor _3: bool = dirExists(arg _2)
+      def_cursor _3: bool = dirExists(arg _2) (raises)
       if _3:
         scope:
           def _4: string
@@ -207,11 +207,11 @@ scope:
       scope:
         try:
           def_cursor _5: string = this[].value
-          def _6: string = parentDir(arg _5)
+          def _6: string = parentDir(arg _5) (raises)
           def _7: string
           def _15: string = this[].value
           =copy(name _7, arg _15)
-          def _8: tuple[head: string, tail: string] = splitPath(consume _7)
+          def _8: tuple[head: string, tail: string] = splitPath(consume _7) (raises)
           bind_mut _16: string = _8.1
           def _9: string = _16
           wasMoved(name _16)
@@ -223,12 +223,12 @@ scope:
     def par: tuple[dir: string, front: string] = _1
     block L1:
       def_cursor _10: string = par.0
-      def_cursor _11: bool = dirExists(arg _10)
+      def_cursor _11: bool = dirExists(arg _10) (raises)
       if _11:
         scope:
           def_cursor _12: string = par.0
           def_cursor _13: string = par.1
-          def _17: seq[string] = getSubDirs(arg _12, arg _13)
+          def _17: seq[string] = getSubDirs(arg _12, arg _13) (raises)
           bind_mut _18: seq[string] = this[].matchDirs
           =sink(name _18, arg _17)
           break L1

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -19,7 +19,7 @@ scope:
           scope:
             def_cursor _4: Node = it
             def_cursor _5: string = _4[].s
-            echo(arg type(array[0..0, string]), arg _5)
+            echo(arg type(array[0..0, string]), arg _5) (raises)
             def_cursor _6: Node = it
             it =fast _6[].ri
   def_cursor jt: Node = root
@@ -39,7 +39,7 @@ scope:
             def_cursor ri: Node = _11[].ri
             def_cursor _12: Node = jt
             def_cursor _13: string = _12[].s
-            echo(arg type(array[0..0, string]), arg _13)
+            echo(arg type(array[0..0, string]), arg _13) (raises)
             jt =fast ri
 -- end of expandArc ------------------------'''
 """

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -6,7 +6,7 @@ discard """
 scope:
   def a: seq[seq[int]]
   def b: seq[seq[int]]
-  def x: seq[int] = f()
+  def x: seq[int] = f() (raises)
   block L0:
     if cond:
       scope:
@@ -25,7 +25,7 @@ scope:
   try:
     def a: seq[seq[int]]
     def b: seq[seq[int]]
-    def x: seq[int] = f()
+    def x: seq[int] = f() (raises)
     scope:
       def a: int = 0
       def b: int = 4

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -10,7 +10,7 @@ scope:
     def _0: string = newString(arg 100)
     def_cursor _1: seq[byte] = cast _0
     def_cursor _2: openArray[byte] = toOpenArray _1
-    def _3: seq[byte] = encode(arg _2)
+    def _3: seq[byte] = encode(arg _2) (raises)
     def data: string
     def _4: string = cast _3
     =copy(name data, arg _4)
@@ -28,7 +28,7 @@ scope:
     def_cursor _2: int = len(arg _1)
     def_cursor _3: int = -(arg _2, arg 1)
     def_cursor _4: openArray[byte] = slice(arg _0, arg 0, arg _3)
-    def _5: seq[byte] = encode(arg _4)
+    def _5: seq[byte] = encode(arg _4) (raises)
     def data: string
     def _6: string = cast _5
     =copy(name data, arg _6)
@@ -40,9 +40,9 @@ scope:
 --expandArc: main2
 scope:
   try:
-    def s: seq[byte] = newSeq(arg 100)
+    def s: seq[byte] = newSeq(arg 100) (raises)
     def_cursor _0: openArray[byte] = toOpenArray s
-    def _1: seq[byte] = encode(arg _0)
+    def _1: seq[byte] = encode(arg _0) (raises)
     def data: string
     def _2: string = cast _1
     =copy(name data, arg _2)
@@ -54,9 +54,9 @@ scope:
 --expandArc: main3
 scope:
   try:
-    def _0: seq[byte] = newSeq(arg 100)
+    def _0: seq[byte] = newSeq(arg 100) (raises)
     def_cursor _1: openArray[byte] = toOpenArray _0
-    def _2: seq[byte] = encode(arg _1)
+    def _2: seq[byte] = encode(arg _1) (raises)
     def data: string
     def _3: string = cast _2
     =copy(name data, arg _3)


### PR DESCRIPTION
## Summary

Consider `--panics:on` during AST -> MIR translation and move all
decision making regarding whether a call potentially raises an
exception out of the code generators.

## Details

Calls within the MIR already encode whether or not they have an
exceptional exit (i.e., potentially raise an exception). However,
`--panics:on` was not considered during the AST -> MIR translation,
meaning that all non-magic were always considered as potentially
raising an exception, even if pancis were enabled and the procedure
raised no catchable errors.

This leaves considering `--panics:on` to the code generators, which is
a problem, as all behaviour-related decision-making needs to happen
prior code generation.

Therefore, `mirgen` now consider whether panics are enabled. This
also means that the `Defect` versus `CatchableError` distinction
no longer exists after the MIR phase.

### Architectural changes

* the `canRaiseDisp` procedure is renamed to `canRaise` and moved to
  the `ast_query` module (where the other `canRaise` procedure are)
* in addition, `canRaiseDisp` is adjusted to account for imported
  JavaScript procedures (identified by the `sfInfixCall` flag; compared
  to imported C functions, it's possible for them to raise exceptions)
* the pre-existing `canRaise` overload is un-exported
* `mirgen` now uses the new panics-considering `canRaise` overload for
  deciding whether a call can raise

### Dedicated node kind

The `mnkCheckedCall` node kind is introduced, replacing the `geRaises`
flag. This is progress towards:
* removing the `effects` field from `MirNode` (so that call nodes can
  store the number of sub-nodes instead)
* bringing the MIR and `CgNode` IR closer together

The `mnkCheckedCall` node kind is then translated to the
`cnkCheckedCall` node kind. For knowing whether the a call has an
exceptional exit, only the node kind needs to be inspected.

Finally, the all places that handle the `mnkCall`/`cnkCall` node kind
now also handle the `mnkCheckedCall`/`cnkCheckedCall` node kind. When
pretty-printing, a `mnkCheckedCall` is rendered like a `mnkCall`, but
with a trailing `(raises)` annotation.

### Lifetime hooks

In order to ensure that lifetime-hooks with exceptional exits work the
same as they did previously, `injectdestructors` emits potentially
raising calls according to the `canRaise` query.

This needs to be addressed eventually , either by inserting the calls
prior to AST -> MIR translation (unlikely) or by disallowing the hooks
from raising exceptions.

### Warnings

`cgen` now only consider whether the call is checked when reporting
an `ObservableStores` warning. This means that without `--panics:on`,
the warning is reported a lot more often now.

Since the direction is to remove the warning by not performing
observable stores in the first place, this regression is deemed okay.