### PR TITLE
cgen: small cleanup

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -138,7 +138,7 @@ proc genGotoVar(p: BProc; value: CgNode) =
   else:
     localReport(p.config, value.info, reportSem rsemExpectedLiteralForGoto)
 
-proc genBracedInit(p: BProc, n: CgNode; isConst: bool; optionalType: PType): Rope
+proc genBracedInit(p: BProc, n: CgNode; optionalType: PType): Rope
 
 proc genSingleVar(p: BProc, vn, value: CgNode) =
   ## Generates and emits the C code for the definition statement of a local.


### PR DESCRIPTION
## Summary

Remove the `isConst` parameter from `genBracedInit`, `getNullValue`,
and their subordinate procedures -- `true` is always passed as the
argument.