### PR TITLE
vm: fix spurious access violation errors

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1905,8 +1905,8 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
           # setup register that will store the result
           if not loadEmptyReg(regs[ra], retType, c.debug[pc], c.memory):
             # allocating the destination location is the responsibility of
-            # ``vmgen``
-            discard
+            # ``vmgen``, but we still have to make sure its accessible
+            checkHandle(regs[ra])
 
         # We have to assume that the callback makes use of its parameters and
         # thus need to validate them here
@@ -1943,7 +1943,6 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         var newFrame = TStackFrame(prc: prc, comesFrom: pc, savedPC: -1)
         newFrame.slots.newSeq(regCount)
         if instr.opcode == opcIndCallAsgn:
-          checkHandle(regs[ra])
           # the destination might be a temporary complex location (`ra` is an
           # ``rkLocation`` register then). While we could use
           # ``fastAsgnComplex`` like we do with the arguments, it would mean


### PR DESCRIPTION
## Summary

Fix an internal VM bug that led to seemingly random access violation
errors being reported. The error oftentimes went away when reordering
the code or inserting dummy code somewhere else.

## Details

The following bytecode triggered the error:
```
LdNull r1 ... # setup a memory location and store its handle in r1
FastAsgnComplex r2 r1 # copy the *handle* to r2
LdNullReg r1 ...      # this frees the previously allocated location.
                      # The handle in r2 is now dangling
... # set up a callee in r3
IndCallAsgn r2 r3 1   # reported
```

which could, depending on the state of the register allocator, result
from:
```nim
block:
  let a: seq[int]
  let b: openArray[int] = a
let y: int
let x: int = f()
```

This is because `IndCallAsgn` validates the handle in the destination
register, raising an error if doesn't point to a valid location.
However, the destination register is not required to hold a valid
handle (the referenced memory location is not accessed by
`IndCallAsgn`), so the access check is incorrect -- it's removed.

### Missing access check

While the access check is wrong for calls of procedures implemented in
bytecode, it is required for calls of callbacks, as those are not
guaranteed to validate that the handle referencing the result location
is valid.

If the call's result doesn't fit into a register, and the destination
register is thus required to hold a valid handle, an access check is
now performed.

The missing access check didn't compromise safety for code running at
compile-time or on the VM target, as `vmgen` currently always sets up a
full temporary for call results.