### PR TITLE
remove obsolete VM-related reports

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -947,7 +947,6 @@ type
     adVmUserError
     adVmUnhandledException
     adVmCannotCast
-    adVmCallingNonRoutine
     adVmCannotModifyTypechecked
     adVmNilAccess
     adVmAccessOutOfBounds
@@ -998,7 +997,6 @@ type
       of adVmNotAField:
         sym*: PSym
       of adVmOpcParseExpectedExpression,
-          adVmCallingNonRoutine,
           adVmCannotModifyTypechecked,
           adVmAccessOutOfBounds,
           adVmAccessTypeMismatch,

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -226,13 +226,9 @@ type
     rvmUnhandledException
     rvmCannotGenerateCode
     rvmCannotCast
-    rvmGlobalError ## Error report that was declared as 'global' in the
-    ## VM - with current 'globalError-is-a-control-flow-mechanism' approach
-    ## this report is largely meaningless, and used only to raise exception.
     rvmCannotEvaluateAtComptime
     rvmCannotImportc
     rvmCannotCallMethod
-    rvmCallingNonRoutine
     rvmCannotModifyTypechecked
     rvmNilAccess
     rvmAccessOutOfBounds

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3016,12 +3016,6 @@ proc reportBody*(conf: ConfigRef, r: VMReport): string =
   of rvmErrInternal:
     result = r.str
 
-  of rvmCallingNonRoutine:
-    result = "NimScript: attempt to call non-routine: " & r.symstr
-
-  of rvmGlobalError:
-    result = r.str
-
   of rvmOpcParseExpectedExpression:
     result = "expected expression, but got multiple statements"
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -371,7 +371,6 @@ func astDiagVmToLegacyReportKind*(
   of adVmUserError: rvmUserError
   of adVmUnhandledException: rvmUnhandledException
   of adVmCannotCast: rvmCannotCast
-  of adVmCallingNonRoutine: rvmCallingNonRoutine
   of adVmCannotModifyTypechecked: rvmCannotModifyTypechecked
   of adVmNilAccess: rvmNilAccess
   of adVmAccessOutOfBounds: rvmAccessOutOfBounds

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -717,8 +717,7 @@ proc execProc*(jit: var JitState, c: var TCtx; sym: PSym;
       if result.isError:
         result = nil
   else:
-    localReport(c.config, sym.info):
-      VMReport(kind: rvmCallingNonRoutine, sym: sym)
+    c.config.internalError(sym.info, "symbol doesn't represent a routine")
 
 # XXX: the compilerapi regarding globals (getGlobalValue/setGlobalValue)
 #      doesn't work the same as before. Previously, the returned PNode

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2961,7 +2961,6 @@ func vmEventToAstDiagVmError*(evt: VmEvent): AstDiagVmError {.inline.} =
     of vmEvtUserError: adVmUserError
     of vmEvtUnhandledException: adVmUnhandledException
     of vmEvtCannotCast: adVmCannotCast
-    of vmEvtCallingNonRoutine: adVmCallingNonRoutine
     of vmEvtCannotModifyTypechecked: adVmCannotModifyTypechecked
     of vmEvtNilAccess: adVmNilAccess
     of vmEvtAccessOutOfBounds: adVmAccessOutOfBounds
@@ -3031,7 +3030,6 @@ func vmEventToAstDiagVmError*(evt: VmEvent): AstDiagVmError {.inline.} =
           kind: kind,
           sym: evt.sym)
       of adVmOpcParseExpectedExpression,
-          adVmCallingNonRoutine,
           adVmCannotModifyTypechecked,
           adVmAccessOutOfBounds,
           adVmAccessTypeMismatch,

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -578,7 +578,6 @@ type
     vmEvtUserError
     vmEvtUnhandledException
     vmEvtCannotCast
-    vmEvtCallingNonRoutine
     vmEvtCannotModifyTypechecked
     vmEvtNilAccess
     vmEvtAccessOutOfBounds

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -251,7 +251,6 @@ func vmEventToLegacyReportKind(evt: VmEventKind): ReportKind {.inline.} =
   of vmEvtUserError: rvmUserError
   of vmEvtUnhandledException: rvmUnhandledException
   of vmEvtCannotCast: rvmCannotCast
-  of vmEvtCallingNonRoutine: rvmCallingNonRoutine
   of vmEvtCannotModifyTypechecked: rvmCannotModifyTypechecked
   of vmEvtNilAccess: rvmNilAccess
   of vmEvtAccessOutOfBounds: rvmAccessOutOfBounds


### PR DESCRIPTION
## Summary

Remove both the `rvmGlobalError` and `rvmCallingNonRoutine` report.

## Details

* `rvmGlobalError` is not used anymore
* `rvmCallingNonRoutine` was only used by `execProc` (compiler API) for
  reporting about the violation of a parameter's precondition. This
  doesn't warrant a dedicated report kind -- an internal error is used
  instead
* the `VmEventKind` and `AstDiagVmKind` values corresponding to
  `rvmCallingNonRoutine` are removed too