### PR TITLE
omit index checks when no index error is possible

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -746,11 +746,9 @@ proc genIndexCheck(p: BProc; x: CgNode, arr, idx: TLoc) =
   of tyArray:
     var first = intLiteral(firstOrd(p.config, ty))
     if firstOrd(p.config, ty) == 0 and lastOrd(p.config, ty) >= 0:
-      if firstOrd(p.config, idx.t) < firstOrd(p.config, ty) or
-         lastOrd(p.config, idx.t) > lastOrd(p.config, ty):
-        linefmt(p, cpsStmts, "if ((NU)($1) > (NU)($2)){ #raiseIndexError2($1, $2); $3}$n",
-                [rdCharLoc(idx), intLiteral(lastOrd(p.config, ty)),
-                 raiseInstr(p)])
+      linefmt(p, cpsStmts, "if ((NU)($1) > (NU)($2)){ #raiseIndexError2($1, $2); $3}$n",
+              [rdCharLoc(idx), intLiteral(lastOrd(p.config, ty)),
+               raiseInstr(p)])
     else:
       linefmt(p, cpsStmts, "if ($1 < $2 || $1 > $3){ #raiseIndexError3($1, $2, $3); $4}$n",
               [rdCharLoc(idx), first, intLiteral(lastOrd(p.config, ty)),

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -650,7 +650,8 @@ proc genBracketExpr(c: var TCtx, n: PNode) =
       genOperand(c, n[0])
   of tyArray, tySequence, tyOpenArray, tyVarargs, tyUncheckedArray, tyString,
      tyCstring:
-    if optBoundsCheck in c.userOptions and needsIndexCheck(n[0], n[1]):
+    if optBoundsCheck in c.userOptions and
+       needsIndexCheck(c.graph.config, n[0], n[1]):
       let
         arr = capture(c, n[0])
         idx = genRd(c, n[1])


### PR DESCRIPTION
## Summary

If all possible index operand values are valid indices, no index check
is required at run-time. The C code generator already implemented
this, but only for zero-based `array`s.

The optimization is now part of `mirgen`, making it available to all
backends and with all `array` types.