### PR TITLE
mir: remove support the `def <proc>` syntax

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -507,8 +507,8 @@ proc defToIr(tree: TreeWithSource, cl: var TranslateCl,
     cl.localsMap[sym.id] = id
 
     def = newLocalRef(id, info, entity.typ)
-  of mnkParam, mnkProc:
-    # ignore 'def's for both parameters and procedures
+  of mnkParam:
+    # ignore 'def's for parameters
     def = newEmpty()
   of mnkGlobal:
     def = newSymNode(cnkGlobal, entity.sym, info)

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2004,11 +2004,6 @@ proc gen(c: var TCtx, n: PNode) =
     # statements
     c.buildStmt mnkVoid:
       genCallOrMagic(c, n)
-  of nkProcDef, nkFuncDef, nkIteratorDef, nkMethodDef, nkConverterDef:
-    c.subTree mnkDef:
-      c.add procNode(n[namePos].sym)
-      c.add MirNode(kind: mnkNone)
-
   of nkDiscardStmt:
     if n[0].kind != nkEmpty:
       let f = c.builder.push: genx(c, n[0])
@@ -2030,7 +2025,7 @@ proc gen(c: var TCtx, n: PNode) =
     # a 'nil' literals can be used as a statement, in which case it is treated
     # as a ``discard``
     assert n.typ.isEmptyType()
-  of nkCommentStmt, nkTemplateDef, nkMacroDef, nkImportStmt,
+  of routineDefs, nkCommentStmt, nkImportStmt,
      nkImportExceptStmt, nkFromStmt, nkIncludeStmt, nkStaticStmt,
      nkExportStmt, nkExportExceptStmt, nkTypeSection, nkMixinStmt,
      nkBindStmt, nkConstSection, nkEmpty:

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -321,9 +321,9 @@ func initEntityDict(tree: MirTree, dfg: DataFlowGraph): EntityDict =
         of mnkTemp:
           entity.typ
         else:
-          nil # not a location (e.g. a procedure)
+          unreachable()
 
-      if t != nil and hasDestructor(t):
+      if hasDestructor(t):
         result.mgetOrPut(toName(entity), @[]).add:
           # don't include the data-flow operations preceding the def
           EntityInfo(def: i, scope: subgraphFor(dfg, i .. scope.b))


### PR DESCRIPTION
## Summary

Declaring inner procedure within the MIR was intended for implementing
lambda-lifting at the MIR level, but this idea has since been
discarded.

The syntax is removed, meaning that `def` are only used for locations
now, simplifying some processing.