### PR TITLE
fix: MIR passes not being applied

### DIFF
--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -173,6 +173,8 @@ proc createModuleOp(graph: ModuleGraph, idgen: IdGenerator, postfix: string,
                   nextSymId idgen, module, module.info, options)
   # the procedure doesn't return anything and doesn't have parameters:
   result.typ = newProcType(module.info, nextTypeId idgen, module)
+  # conservatively enable destructor injection:
+  result.flags = {sfInjectDestructors}
 
   # also set up a proper definition AST:
   result.ast = newProcNode(nkProcDef, module.info, body,

--- a/tests/misc/tmissing_lowering_passes.nim
+++ b/tests/misc/tmissing_lowering_passes.nim
@@ -1,0 +1,17 @@
+discard """
+  description: '''
+    Regression test for a compiler bug where some lowering passes were not
+    applied to initializer expressions of ``.global`` variables
+  '''
+  target: native
+"""
+
+proc p() =
+  var x {.global.} = block:
+    var a, b: int
+    swap(a, b)
+    # no lowering pass took place for initializer expression, causing an
+    # internal compiler error due to the unlowered ``swap`` magic
+    a
+
+p()


### PR DESCRIPTION
## Summary

Fix some MIR passes not being applied to `.global` variable initializer
expressions and `.dynlib` expressions.

Without the passes, various optimizations, fix-ups, and lowerings
weren't applied, resulting in, for example, an ICE when using the
`swap` magic within the aforementioned expressions.

## Details

Only the destructor-injection/move-analyser pass was applied to partial
procedure bodies, the passes implemented in `mirpasses` were not.

MIR pass application handling is moved into a single place
(`backends.process`), making it the same for both full procedure bodies
and partial ones.

Since the owner of a procedure is now always subjected to the
`shouldInjectDestructorCalls` test, module-bound operations (e.g., pre-
init, post-deinit, etc.) are now marked with the `sfInjectDestructors`
flag.