### PR TITLE
sem: `semFor` no longer mutates input AST

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -735,6 +735,8 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
         let err = newError(c.config, result, PAstDiag(kind: adSemExpressionHasNoType))
         localReport(c.config, err)
         result = newSymNode(errorSym(c, result, err))
+      elif typ.kind == tyError and typ.n != nil and typ.n.kind == nkError:
+        result = typ.n
       else:
         result.typ = makeTypeDesc(c, typ)
     else:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -122,6 +122,7 @@ proc fitNode(c: PContext, formal: PType, arg: PNode; info: TLineInfo): PNode
 proc changeType(c: PContext; n: PNode, newType: PType, check: bool): PNode
 
 proc semTypeNode(c: PContext, n: PNode, prev: PType): PType
+proc semTypeNode2(c: PContext, n: PNode, prev: PType): PNode
 proc semStmt(c: PContext, n: PNode; flags: TExprFlags): PNode
 proc semOpAux(c: PContext, n: PNode): bool
 proc semParamList(c: PContext, n, genericParams: PNode, kind: TSymKind): PType
@@ -730,15 +731,9 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
       result = semExprWithType(c, result, flags)
     of tyTypeDesc:
       if result.kind == nkStmtList: result.transitionSonsKind(nkStmtListType)
-      var typ = semTypeNode(c, result, nil)
-      if typ == nil:
-        let err = newError(c.config, result, PAstDiag(kind: adSemExpressionHasNoType))
-        localReport(c.config, err)
-        result = newSymNode(errorSym(c, result, err))
-      elif typ.kind == tyError and typ.n != nil and typ.n.kind == nkError:
-        result = typ.n
-      else:
-        result.typ = makeTypeDesc(c, typ)
+      result = semTypeNode2(c, result, nil)
+      if result.kind != nkError:
+        result.typ = makeTypeDesc(c, result.typ)
     else:
       if s.ast.isGenericRoutine and retType.isMetaType:
         # The return type may depend on the Macro arguments

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1628,8 +1628,10 @@ proc semFor(c: PContext, n: PNode; flags: TExprFlags): PNode =
     result = semForVars(c, result, flags)
   if hasError or result.kind == nkError:
     discard # do nothing
-  elif result[^1].typ == c.enforceVoidContext:
+  elif result.len > 0 and result[^1].typ == c.enforceVoidContext:
     # propagate any enforced VoidContext:
+    # NB: we check the result.len because we get an empty statement list in
+    #     case of doing a `semForFields` for an empty tuple or object type.
     result.typ = c.enforceVoidContext
   elif efInTypeof in flags:
     result.typ = result.lastSon.typ

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1599,17 +1599,18 @@ proc semFor(c: PContext, n: PNode; flags: TExprFlags): PNode =
   addInNimDebugUtils(c.config, "semFor", n, result, flags)
   checkMinSonsLen(n, 3, c.config)
   openScope(c)
-  result = n
-  n[^2] = semExprNoDeref(c, n[^2], {efWantIterator})
-  var hasError = n[^2].kind == nkError
-  var call = n[^2]
+  result = copyNodeWithKids(n)
+  var
+    call = semExprNoDeref(c, n[^2], {efWantIterator})
+    hasError = call.kind == nkError
+  result[^2] = call
   if call.kind == nkStmtListExpr and isTrivalStmtExpr(call):
     call = call.lastSon
-    n[^2] = call
+    result[^2] = call
   let isCallExpr = call.kind in nkCallKinds
   if isCallExpr and call[0].kind == nkSym and
       call[0].sym.magic in {mFields, mFieldPairs}:
-    result = semForFields(c, n, call[0].sym.magic)
+    result = semForFields(c, result, call[0].sym.magic)
   else:
     if isCallExpr and isClosureIterator(call[0].typ.skipTypes(abstractInst)):
       # first class iterator:
@@ -1617,16 +1618,17 @@ proc semFor(c: PContext, n: PNode; flags: TExprFlags): PNode =
     elif not isCallExpr or call[0].kind != nkSym or
         call[0].sym.kind != skIterator:
       if n.len == 3:
-        n[^2] = implicitIterator(c, "items", n[^2])
+        result[^2] = implicitIterator(c, "items", result[^2])
       elif n.len == 4:
-        n[^2] = implicitIterator(c, "pairs", n[^2])
+        result[^2] = implicitIterator(c, "pairs", result[^2])
       else:
-        n[^2] = c.config.newError(n[^2], PAstDiag(kind: adSemForExpectedIterator))
-      hasError = n[^2].isError or hasError
-    result = semForVars(c, n, flags)
+        result[^2] = c.config.newError(n[^2],
+                                PAstDiag(kind: adSemForExpectedIterator))
+      hasError = result[^2].isError or hasError
+    result = semForVars(c, result, flags)
   if hasError or result.kind == nkError:
     discard # do nothing
-  elif n[^1].typ == c.enforceVoidContext:
+  elif result[^1].typ == c.enforceVoidContext:
     # propagate any enforced VoidContext:
     result.typ = c.enforceVoidContext
   elif efInTypeof in flags:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1622,7 +1622,7 @@ proc semFor(c: PContext, n: PNode; flags: TExprFlags): PNode =
       elif n.len == 4:
         result[^2] = implicitIterator(c, "pairs", result[^2])
       else:
-        result[^2] = c.config.newError(n[^2],
+        result[^2] = c.config.newError(call,
                                 PAstDiag(kind: adSemForExpectedIterator))
       hasError = result[^2].isError or hasError
     result = semForVars(c, result, flags)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2331,7 +2331,7 @@ proc semTypeNode2(c: PContext, n: PNode, prev: PType): PNode =
   let typ = semTypeNode(c, n, prev)
   if typ.isNil:
     result = newError(c.config, n, PAstDiag(kind: adSemTypeExpected))
-  elif typ.kind == tyError and typ.n.kind == nkError:
+  elif typ.kind == tyError and typ.n != nil and typ.n.kind == nkError:
     result = typ.n
   else:
     # the type is either valid or an error type that doesn't store a

--- a/tests/lang_callable/macros/t7454_return_error_sym_if_expect_typeddesc_but_none_provided.nim
+++ b/tests/lang_callable/macros/t7454_return_error_sym_if_expect_typeddesc_but_none_provided.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: "expression has no type:"
+errormsg: "type expected, but expression has no type"
 description: '''
 Return an error symbol if the macro output has not type and a typedes was
 expected.


### PR DESCRIPTION
## Summary

Stop mutating the input AST when semantically analysing  `for`  loops in 
`semFor` .

## Details

Previously,  `semFor`  would mutate the input AST parameter  `n` ,
resulting in partial contribution to call analysis corruption during
overload resolution. Now  `semFor`  does a cursory examination of the 
`for`  loop and dispatches to either  `semForVars`  or  `semForFields` 
based on whether it's a standard  `for`  over non-type values or over a
type's fields, respectively.

As part of this change and issue was discovered in  `semAfterMacroCall`
, which was not handling errors passed via  `tyError` , this has been
updated by having it use  `semTypeNode2` . This meant a minor change in
error message for meta-routines returning a type ( `typedesc` ), from 
`expression has no type`  to 
`type expected, but expression has no type` , which is somewhat more
informative; tests have been updated accordingly.