### PR TITLE
debug: improve compiler tracing line info

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -261,6 +261,7 @@ proc maybeLiftType(t: var PType, c: PContext, info: TLineInfo) =
   if lifted != nil: t = lifted
 
 proc semConv(c: PContext, n: PNode): PNode =
+  addInNimDebugUtils(c.config, "semConv", n, result)
   if n.len != 2:
     result = c.config.newError(n,
                 PAstDiag(kind: adSemTypeConversionArgumentMismatch,

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -25,6 +25,7 @@ proc semAddrArg(c: PContext; n: PNode): PNode =
     result = newError(c.config, n, PAstDiag(kind: adSemExprHasNoAddress))
 
 proc semTypeOf(c: PContext; n: PNode): PNode =
+  addInNimDebugUtils(c.config, "semTypeOf", n, result)
   var m = BiggestInt 1 # typeOfIter
   if n.len == 3:
     let mode = semConstExpr(c, n[2])

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -252,6 +252,7 @@ var
         trfPackedFields,
         trfSkipAuxError,
         trfShowKindTypes,
+        trfShowSymId,
         trfShowSymName,
         trfShowSymTypes,
         trfShowSymKind,

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -336,6 +336,8 @@ proc generateOutput(conf: ConfigRef, r: CompilerTrace): string =
               result.add render(s.candidate.calleeSym)
             field("call")
             result.add render(s.candidate.call)
+            field("to node")
+            result.add render(s.node)
   of compilerTraceLine:
     let ind = repeat("  ", r.ctraceData.level)
     var
@@ -493,7 +495,7 @@ template addInNimDebugUtilsAux(conf: ConfigRef; prcname: string;
         if indentLevel != 0: # print a delta stack
           # try to print only the part of the stacktrace since the last time,
           # this is done by looking for any previous calls in `debugUtilsStack`
-          {.line.}: # stops the template showing up in the StackTraceEntries
+          {.line:instantiationInfo(-2, true).}: # stops the template showing up in the StackTraceEntries
             let
               stopProc =
                 if indentLevel == 1: prcname  # we're the only ones
@@ -595,7 +597,7 @@ template traceStepImpl*(
     outputTrace(p.c, CompilerTrace(
       kind: compilerTraceStep,
       semstep: it,
-      instLoc: instLoc())
+      instLoc: params.info)
     )
 
 template traceEnterIt*(
@@ -856,6 +858,7 @@ template addInNimDebugUtils*(c: ConfigRef;
     template leaveMsg(indentLevel: int) =
       traceLeaveIt(loc, stepParams(c, stepNodeSigMatch, indentLevel, action)):
         it.candidate = toDebugCallableCandidate(res)
+        it.node = n # to track mutations
 
     addInNimDebugUtilsAux(c, action, enterMsg, leaveMsg)
 


### PR DESCRIPTION
## Summary

Improve compiler tracing line info, previously wrong line information
would be tracked uselessly pointing back to  `debugutils` . Now line
information is accurate, although there is a minor regression for some
inter-trace stacktrace printing emitting the entire stack instead of the
interval.

## Details

In addition to the above, tracing for call analysis, procs using 
`TCandidate`  now emit a  `to`  node for tracking mutations to input
AST.

Coverage for a few semantic analysis procs have been added as these
changes were the result of an attempt at overload call analysis
debugging.