### PR TITLE
mir: introduce `MirBody`

### DIFF
--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -225,7 +225,7 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
     genConstDefinition(g.modules[moduleId(s)], s)
   of bekPartial:
     # register inline dependencies:
-    let inlineId = handleInline(inl, evt.module, evt.sym, evt.body.tree)
+    let inlineId = handleInline(inl, evt.module, evt.sym, evt.body.code)
 
     var p = getOrDefault(partial, evt.sym)
     if p == nil:
@@ -238,7 +238,7 @@ proc processEvent(g: BModuleList, inl: var InliningData, discovery: var Discover
 
     processLate(bmod, discovery, inl, evt.module, inlineId)
   of bekProcedure:
-    let inlineId = handleInline(inl, evt.module, evt.sym, evt.body.tree)
+    let inlineId = handleInline(inl, evt.module, evt.sym, evt.body.code)
 
     # mark the procedure as declared, first. This gets around an unnecessary
     # emit of the prototype in the case of self-recursion

--- a/compiler/mir/mirbodies.nim
+++ b/compiler/mir/mirbodies.nim
@@ -1,0 +1,32 @@
+## Implements the ``MirBody`` type and basic routines for querying and
+## modifying it.
+
+import
+  compiler/ast/[
+    ast_types
+  ],
+  compiler/mir/[
+    mirtrees,
+    sourcemaps
+  ]
+
+type
+  MirBody* = object
+    ## A ``MirBody`` represents a self-contained piece of MIR code. This can
+    ## either be:
+    ## - the full body of a procedure
+    ## - the partial body a procedure
+    ## - a standalone statement/expression (currently supported for compile
+    ##   time code execution)
+    ##
+    ## In each case, ``MirBody`` stores all the local data referenced and
+    ## needed by the body's MIR code. It also store additional information
+    ## associated with a body, such as how far the lowering is along.
+    source*: SourceMap
+    code*: MirTree
+
+func `[]`*(body: MirBody, n: NodePosition): lent MirNode {.inline.} =
+  body.code[n]
+
+func sourceFor*(body: MirBody, n: NodePosition): PNode {.inline.} =
+  body.source[body.code[n].info]

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -16,6 +16,7 @@ import
     options
   ],
   compiler/mir/[
+    mirbodies,
     mirchangesets,
     mirconstr,
     mirtrees,
@@ -63,12 +64,12 @@ proc echoInput*(config: ConfigRef, owner: PSym, body: PNode) =
     writeBody(config, "-- input AST: " & owner.name.s):
       config.writeln(treeRepr(config, body, reprConfig))
 
-proc echoMir*(config: ConfigRef, owner: PSym, tree: MirTree) =
-  ## If requested via the define, renders the `tree` and writes the result out
+proc echoMir*(config: ConfigRef, owner: PSym, body: MirBody) =
+  ## If requested via the define, renders the `body` and writes the result out
   ## through ``config.writeln``.
   if config.getStrDefine("nimShowMir") == owner.name.s:
     writeBody(config, "-- MIR: " & owner.name.s):
-      config.writeln(treeRepr(tree))
+      config.writeln(treeRepr(body.code))
 
 proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
   ## If requested via the define, renders the output IR `body` and writes the
@@ -134,9 +135,9 @@ proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
   ## MIR code, and the MIR code to ``CgNode`` IR.
   echoInput(graph.config, owner, body)
   # step 1: generate a ``MirTree`` from the input AST
-  let (tree, sourceMap) = generateCode(graph, owner, config, body)
-  echoMir(graph.config, owner, tree)
+  let body = generateCode(graph, owner, config, body)
+  echoMir(graph.config, owner, body)
 
   # step 2: generate the ``CgNode`` tree
-  result = generateIR(graph, idgen, owner, tree, sourceMap)
+  result = generateIR(graph, idgen, owner, body)
   echoOutput(graph.config, owner, result)

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -27,6 +27,7 @@ import
     modulelowering,
   ],
   compiler/mir/[
+    mirbodies,
     mirgen
   ],
   compiler/modules/[
@@ -121,7 +122,7 @@ proc registerProc(c: var GenCtx, prc: PSym): FunctionIndex =
   result = FunctionIndex(idx)
 
 proc generateCodeForProc(c: var CodeGenCtx, idgen: IdGenerator, s: PSym,
-                         body: sink MirFragment): CodeInfo =
+                         body: sink MirBody): CodeInfo =
   ## Generates and the bytecode for the procedure `s` with body `body`. The
   ## resulting bytecode is emitted into the global bytecode section.
   let


### PR DESCRIPTION
## Summary

The `MirBody` type represents a self-contained piece of MIR code,
usually the body of a procedure. It replaces passing around loose
`MirTree` and `SourceMap` values (a `MirBody` is now used instead).

## Details

* both `MirFragment` and `TreeWithSource` are also replaced by
  `MirBody`
* for more flexibility with imports, the type is not made part of
  `mirtrees` but instead has its own module: `mirbodies`
* the `backends.append` routine was unused; it's removed

`MirBody` serves the same purpose for the MIR as `cgir.Body` does for
the `CgNode` IR.