### PR TITLE
mir: separate type checks from object conversion

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -830,6 +830,10 @@ type
       ## chckField(valid, val, inverted, msg); raises an error when `val` is
       ## not part of `valid`. `inverted` tells whether to invert the check
       ## and `msg` is the error message
+    mChckObj
+      ## chckObj(ptr_like, type); raises a conversion error when the dynamic
+      ## type of the object pointed to by `ptr_like` is unrelated to or a
+      ## super type of `type`
     mSamePayload
       ## returns whether both seq/string operands share the same payload
     mCopyInternal

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1921,6 +1921,12 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
              rope(lastOrd(p.config, n[1].typ))])
   of mChckField:
     genFieldCheck(p, n)
+  of mChckObj:
+    let x = gen(p, n[1])
+    useMagic(p, "chckObj")
+    # the nil-check is expected to have taken place already
+    lineF(p, "chckObj($1.m_type, $2);$n",
+          [rdLoc(x), genTypeInfo(p, n[2].typ)])
   else:
     genCall(p, n, r)
     #else internalError(p.config, e.info, 'genMagic: ' + magicToStr[op]);

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -545,7 +545,7 @@ proc capture(c: var TCtx, n: PNode; sink=false): Value =
       captureInTemp(c, f, sink=false)
     else:
       # if used in a sink context, the alias must support potentially
-      # destructive moves throught it, which requires a ``BindMut``
+      # destructive moves through it, which requires a ``BindMut``
       captureName(c, f, mutable=sink)
 
 proc genOperand(c: var TCtx, n: PNode; sink = false) =

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -818,7 +818,7 @@ proc genObjConv(c: var TCtx, n: PNode, sink, dest: bool) =
                 c.emitByVal val
       # the check:
       c.subTree mnkVoid:
-        c.buildMagicCall mChckObj, typeOrVoid(c, nil):
+        c.buildDefectMagicCall mChckObj, typeOrVoid(c, nil):
           c.emitByVal val
           c.emitByVal typeLit(deepest)
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -273,7 +273,7 @@ func isPure(tree: MirTree, n: NodePosition): bool =
     # let bindings are pure, but only if they don't have a destructor (in
     # which case they're movable)
     tree[n].sym.kind in {skLet, skForVar} and not hasDestructor(tree[n].typ)
-  of mnkPathNamed, mnkPathPos, mnkPathVariant:
+  of mnkPathNamed, mnkPathPos, mnkPathConv, mnkPathVariant:
     isPure(tree, NodePosition tree.operand(n))
   of mnkPathArray:
     let arr = NodePosition tree.operand(n, 0)
@@ -285,6 +285,7 @@ func isPure(tree: MirTree, n: NodePosition): bool =
     else:
       unreachable(tree[arr].kind)
   else:
+    # TODO: make exhaustive
     false
 
 func isStable(tree: MirTree, n: NodePosition): bool =
@@ -305,11 +306,8 @@ func isStable(tree: MirTree, n: NodePosition): bool =
       isPure(tree, tree.child(n, 1)) and isPure(tree, arr)
     else:
       unreachable()
-  of mnkPathNamed, mnkPathPos, mnkPathVariant:
+  of mnkPathNamed, mnkPathPos, mnkPathConv, mnkPathVariant:
     isStable(tree, NodePosition tree.operand(n))
-  of mnkPathConv:
-    # conversions can raise
-    false
   of mnkDeref, mnkDerefView:
     # a pure target means that the pointer is always the same
     isPure(tree, NodePosition tree.operand(n))

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -154,6 +154,7 @@ type
 
     opcLdImmInt,  # dest = immediate value
     opcSetType,   # dest.typ = types[Bx]
+    opcObjChck    # raise error if a[] not of types[Bx]
     opcNSetType,  # dest.nimNode.typ = types[Bx]
     opcTypeTrait,
     opcSymOwner,

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2061,6 +2061,10 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
     c.freeTemp(arr)
   of mChckField:
     genFieldCheck(c, n)
+  of mChckObj:
+    let obj = c.genx(n[1])
+    c.gABx(n, opcObjChck, obj, c.genType(n[2].typ))
+    c.freeTemp(obj)
   else:
     # mGCref, mGCunref, mFinished, etc.
     fail(n.info, vmGenDiagCodeGenUnhandledMagic, m)

--- a/tests/lang/s02_core/s01_user_defined_data_types/t03_inheritance.nim
+++ b/tests/lang/s02_core/s01_user_defined_data_types/t03_inheritance.nim
@@ -52,10 +52,9 @@ block derive_from_ref_root_obj:
   ## To convert base type back to derived, you can use object conversion
   doAssert Derived(base).f2 == 12
 
-  when (not defined(js) and not defined(vm)) or
+  when (not defined(vm)) or
        defined(tryBrokenSpecification):
     # Issue: the VM doesn't raise a user-catchable error for this conversion
-    # Bug: js target allows this conversion to happen parent ref -> child ref
     try:
       discard Derived(Base())
       doAssert false, "Should have raised defect"

--- a/tests/lang_exprs/trequired_conversion_error.nim
+++ b/tests/lang_exprs/trequired_conversion_error.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    Ensure that ref conversions that ultimately don't result in a differently-
+    typed still result in a conversion error
+  '''
+  outputsub: "invalid object conversion"
+  exitcode: 1
+"""
+
+type
+  A = ref object of RootObj
+  B = ref object of A
+
+var a = A()
+discard A(B(a))

--- a/tests/lang_objects/destructor/tdestruction_when_checks_failed.nim
+++ b/tests/lang_objects/destructor/tdestruction_when_checks_failed.nim
@@ -67,3 +67,13 @@ block field_checks:
 
   runTest:
     test(WithVariant(kind: false)) # provoke a field-check failure
+
+block object_conversion_checks:
+  type A = ref object of RootObj
+
+  proc test(a: RootRef) =
+    var obj = Object() # obj stores a value that needs to be destroyed
+    discard A(a)
+
+  runTest:
+    test(RootRef()) # provoke a object-conversion-check failure


### PR DESCRIPTION
## Summary

* placement of object conversion checks is now the responsibility of
  the AST -> MIR translation
* destructors are now called when the only exceptional control-flow
  within a scope comes from object-conversion checks 
* exceptional control-flow from object-conversion checks is now visible
  to data-flow analysis
* object conversion checks are now available with the JS backend

## Details

An object conversion, like:
```nim
var x: ref Base
discard (ref Sub)(x)
```

is now translated to, assuming that object conversion checks are
enabled:

```
def_cursor _1: ref Base = x
def _2: bool = isNil(arg _1)
def _3: bool = not(arg _2)
if _3:
  chckObj(arg _1, arg type(Sub)) (raises)
discard x.(ref Sub)
```

As a consequence:
*  `mnkPathConv` expressions never have side-effects now
* the exceptional control-flow is visible to data-flow analysis
* placement of object checks works the same across all backends

### `mirgen` implementation

* object conversion checks are only enabled for non-pure `ref object`
  and `ptr object` types
* this matches the behaviour of `cgen`
* as an optimization, up-/down-conversion sequences (e.g.,
  `x.Base.Sub1.Base.Sub2`) are collapses into a single `mnkPathConv`
  operation, with, at most, one check emitted 
* object conversion are special projections that, compared to the other
  projections, do require using a `BindMut` for `x` in cases such as
  `A(x) = nil`. At the moment, this requires an awkward special-casing
  of `nkObjDownConv`/`nkObjUpConv` in `genLvalueOperand`

### Implementation in the code generators

* `cgen` re-uses most of its existing converion check implementation
* `jsgen` implements `mChckObj` with a call to the pre-existing
  `chckObj` run-time procedure
* for the VM, the conversion checks are moved from the `opcObjConv`
  operation into the dedicated `opcCheckObj` operation. `vmgen` uses
  the latter to implement `mChckObj`

### Future work

All MIR lvalue expressions are now free of side effects, allowing for
various MIR pass improvements. So far, passes had to assume that all
lvalue expression potentially raise exceptions.