### PR TITLE
fix(cgen): C compiler error with closures

### DIFF
--- a/tests/ccgbugs/tmissing_function_cast.nim
+++ b/tests/ccgbugs/tmissing_function_cast.nim
@@ -1,0 +1,17 @@
+discard """
+  description: '''
+    Regression test for a C code generator issues where closure constructions
+    resulted in C code that some strict compilers rejected
+  '''
+  targets: "c"
+  joinable: false
+"""
+# the test uses a custom configuration file, so don't join it
+
+type
+  NimCallProc = proc () {.nimcall.}
+  Closure = proc() {.closure.}
+
+var p1: NimCallProc
+var p2: Closure = p1
+# ^^ this was missing an explicit function pointer cast

--- a/tests/ccgbugs/tmissing_function_cast.nim.cfg
+++ b/tests/ccgbugs/tmissing_function_cast.nim.cfg
@@ -1,0 +1,5 @@
+
+# this overwrites all default compiler options, but we do need to get rid of
+# the `-w` option, otherwise no warnings are produced
+clang.options.always = "-Wincompatible-pointer-types -Werror=incompatible-pointer-types"
+gcc.options.always = "-Wincompatible-pointer-types -Werror=incompatible-pointer-types"


### PR DESCRIPTION
## Summary

The C code generated when assigning a `.nimcall` procedure to a
closure relied on an implicit conversion being introduced by the C
compiler, which some C compilers complain about.

An explicit cast is added so that the code works everywhere.

## Details

An extra configuration file is needed for the test, as the default C
compiler arguments have to be destructively overridden -- the `-w`
option passed by default would disable all warnings otherwise.