### PR TITLE
cgir: split lvalue-conversion meaning from `cnkConv`

### DIFF
--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -29,7 +29,7 @@ proc reportObservableStore(p: BProc; le, ri: CgNode) =
         return inTryStmt and sfUsedInFinallyOrExcept in p.body[n.local].flags
       of cnkFieldAccess, cnkArrayAccess, cnkTupleAccess:
         n = n[0]
-      of cnkObjUpConv, cnkObjDownConv, cnkHiddenConv, cnkConv:
+      of cnkObjUpConv, cnkObjDownConv, cnkLvalueConv:
         n = n.operand
       else:
         # cannot analyse the location; assume the worst

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2118,6 +2118,7 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
   of cnkObjConstr: genObjConstr(p, n, d)
   of cnkCast: genCast(p, n, d)
   of cnkHiddenConv, cnkConv: genConv(p, n, d)
+  of cnkLvalueConv: expr(p, n.operand, d)
   of cnkToSlice:
     if n.len == 1:
       # treated as a no-op here; the conversion is handled in ``genAssignment``

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -74,8 +74,9 @@ type
     # makes sense, e.g. C). This could make ``cnkDerefView`` obsolete
 
     cnkConv          ## a type conversion
-    # future direction: introduce a dedicated operation for "l-value preserving
-    # conversions"
+    cnkLvalueConv    ## an lvalue-preserving conversion. The ones reaching
+                     ## into the code generators are usually discarded, but
+                     ## they're still required for proper typing
     cnkHiddenConv
     # future direction: the notion of "hidden" doesn't make any sense in the
     # context of code generation. Adjust the code generators so that they no
@@ -143,7 +144,7 @@ const
 
   cnkWithOperand*  = {cnkConv, cnkHiddenConv, cnkDeref, cnkAddr, cnkHiddenAddr,
                       cnkDerefView, cnkObjDownConv, cnkObjUpConv, cnkCast,
-                      cnkStringToCString, cnkCStringToString}
+                      cnkStringToCString, cnkCStringToString, cnkLvalueConv}
   cnkAtoms*        = {cnkInvalid..cnkMagic, cnkReturnStmt, cnkPragmaStmt}
     ## node kinds that denote leafs
   cnkWithItems*    = AllKinds - cnkWithOperand - cnkAtoms

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -296,7 +296,7 @@ proc convToIr(cl: TranslateCl, n: CgNode, info: TLineInfo, dest: PType): CgNode 
   result = handleSpecialConv(cl.graph.config, n, info, dest)
   if result == nil:
     # no special conversion is used
-    result = newOp(cnkConv, info, dest, n)
+    result = newOp(cnkLvalueConv, info, dest, n)
 
 proc atomToIr(n: MirNode, cl: TranslateCl, info: TLineInfo): CgNode =
   case n.kind

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -37,7 +37,7 @@ func lastSon*(n: CgNode): CgNode {.inline.} =
 
 proc skipConv*(n: CgNode): CgNode {.inline.} =
   result = n
-  while result.kind in {cnkConv, cnkHiddenConv}:
+  while result.kind in {cnkConv, cnkHiddenConv, cnkLvalueConv}:
     result = result.operand
 
 func getInt*(n: CgNode): Int128 =


### PR DESCRIPTION
## Summary

Don't overload `cnkConv` with also meaning "lvalue conversion" and
instead use a dedicated node kind (`cnkLvalueConv`) to represent this
operation. This is a step towards splitting up the `mnkConv` operation.

## Details

* `cnkLvalueConv` has the same syntax as `cnkConv`
* all usages of `cnkConv` (and `cnkHiddenConv`) where the "lvalue
  conversion" meaning was used are replaced with `cnkLvalueConv`
* the concrete node kind also makes the node kind dispatching code
  clearer for the reader

This also fixes a latent bug with `vmgen`: `cnkConv` nodes
representing lvalue conversion went into the `opcWrLoc` branch in
`vmgen.genConv`. If the destination was an argument slot, no location
handle existed in the register, which would lead to VM crashes.

Due to how mirgen` currently does its translation, lvalue conversions
never appear directly as call arguments, meaning that this bug didn't
affect any code at the moment.