### PR TITLE
cgen: refactor `genDollar`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1267,11 +1267,6 @@ proc genAccessTypeField(p: BProc; e: CgNode; d: var TLoc) =
   # use the dynamic type stored at offset 0:
   putIntoDest(p, d, e, rdMType(p, a, nilCheck))
 
-template genDollar(p: BProc, n: CgNode, d: var TLoc, frmt: string) =
-  var a: TLoc
-  initLocExpr(p, n[1], a)
-  putIntoDest(p, d, n, ropecg(p.module, frmt, [rdLoc(a)]))
-
 proc genArrayLen(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   let a = e[1]
   var typ = skipTypes(a.typ, abstractVar + tyUserTypeClasses)
@@ -1714,9 +1709,9 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   of mLeStr: binaryExpr(p, e, d, "(#cmpStrings($1, $2) <= 0)")
   of mLtStr: binaryExpr(p, e, d, "(#cmpStrings($1, $2) < 0)")
   of mIsNil: genIsNil(p, e, d)
-  of mBoolToStr: genDollar(p, e, d, "#nimBoolToStr($1)")
-  of mCharToStr: genDollar(p, e, d, "#nimCharToStr($1)")
-  of mCStrToStr: genDollar(p, e, d, "#cstrToNimstr($1)")
+  of mBoolToStr: unaryExpr(p, e, d, "#nimBoolToStr($1)")
+  of mCharToStr: unaryExpr(p, e, d, "#nimCharToStr($1)")
+  of mCStrToStr: unaryExpr(p, e, d, "#cstrToNimstr($1)")
   of mStrToStr: expr(p, e[1], d)
   of mIsolate: genCall(p, e, d)
   of mFinished: genBreakState(p, e, d)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1270,10 +1270,7 @@ proc genAccessTypeField(p: BProc; e: CgNode; d: var TLoc) =
 template genDollar(p: BProc, n: CgNode, d: var TLoc, frmt: string) =
   var a: TLoc
   initLocExpr(p, n[1], a)
-  a.r = ropecg(p.module, frmt, [rdLoc(a)])
-  a.flags.excl lfIndirect # this flag should not be propagated here (not just for HCR)
-  if d.k == locNone: getTemp(p, n.typ, d)
-  genAssignment(p, d, a)
+  putIntoDest(p, d, n, ropecg(p.module, frmt, [rdLoc(a)]))
 
 proc genArrayLen(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   let a = e[1]


### PR DESCRIPTION
## Summary

Remove `genDollar` and replace calls to it with calls to
`unaryExpr`. The workarounds implemented by `genDollar` are obsolete
now, and without them, `genDollar` does the same as `unaryExpr`.

## Details

The `d.k == locNone` condition in `genDollar` is never true, since
all magic calls reaching the code generator appear directly in the
source expression slots of assignments.