### PR TITLE
fix(sem): don't fold away `proc` casts

### DIFF
--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -905,7 +905,7 @@ proc foldConstExprAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Fo
   # are not folded if they have a comment in the first position
   let exprIsPointerCast = n.kind in {nkCast, nkConv, nkHiddenStdConv} and
                           n.typ != nil and
-                          n.typ.kind == tyPointer
+                          n.typ.kind in {tyPointer, tyProc}
   if not exprIsPointerCast and
      not (n.kind == nkStmtListExpr and n[0].kind == nkCommentStmt):
     var cnst = getConstExpr(m, result.node, idgen, g)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1463,6 +1463,11 @@ proc genCastIntFloat(c: var TCtx; n: CgNode; dest: var TDest) =
     if dest.isUnset: dest = c.getTemp(n.typ)
     let opcode = if fitsRegister(dst): opcLdNullReg else: opcReset
     c.gABx(n, opcode, dest, c.genType(dst))
+  elif dst.kind == tyProc and dst.callConv != ccClosure and
+       n.operand.kind == cnkProc:
+    # casting a procedure literal to another type. This is the same as just
+    # loading the literal
+    genProcLit(c, n, n.operand.sym, dest)
   else:
     # todo: support cast from tyInt to tyRef
     raiseVmGenError:

--- a/tests/misc/tdont_fold_procedure_cast.nim
+++ b/tests/misc/tdont_fold_procedure_cast.nim
@@ -1,0 +1,29 @@
+discard """
+  description: '''
+    Regression test for an issue where a cast to procedural type was folded
+    away when the operand was a constant expression
+  '''
+  targets: c
+  matrix: "--expandArc:test"
+  nimout: '''
+--expandArc: test
+scope:
+  def p: proc (x: float){.nimcall.} = cast other
+  def_cursor _0: proc (x: int){.nimcall.} = cast p
+  _0(arg 1) (raises)
+-- end of expandArc ------------------------
+  '''
+  output: "1"
+"""
+
+proc other(x: int) {.nimcall.} =
+  echo x
+
+proc test() =
+  # cast to an incompatible procedure type. This must not result in an
+  # error
+  var p = cast[proc(x: float) {.nimcall.}](other)
+  # now cast to the back to the correct type and invoke
+  (cast[proc(x: int){.nimcall.}](p))(1)
+
+test()


### PR DESCRIPTION
## Summary

Don't fold away `cast`s to `proc` type where the operand is a
constant expression -- the backend might need to generate code for
the cast operation.

This fixes C compiler errors when casting `proc` types and using a C
compiler that disallows incompatible function pointer types.

## Details

Folding the `nkCast` allowed casting procedure literals to different
procedural types with the VM backend, even though `cast` is not
implemented for `tyProc` there.

`vmgen` now implements to-`tyProc` casts for literals, by loading the
procedure literal without modifications. This is equivalent to what
happened previously.