### PR TITLE
koch, niminst: move csources bundle tag location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,14 +238,14 @@ jobs:
         run: |
           ./koch.py archive
 
-          archive=build/$(jq -r .name build/archive.json)
+          archive=build/archive/$(jq -r .name build/archive/archive.json)
 
           # Rename the archive manifest to avoid collision with manifest of
           # other archives
-          mv build/archive.json build/source.json
+          mv build/archive/archive.json build/archive/source.json
 
           echo "archive=$archive" >> $GITHUB_OUTPUT
-          echo "metadata=build/source.json" >> $GITHUB_OUTPUT
+          echo "metadata=build/archive/source.json" >> $GITHUB_OUTPUT
 
       - name: Publish source archive to artifacts
         uses: actions/upload-artifact@v4
@@ -300,12 +300,12 @@ jobs:
         run: |
           ./koch.py unixrelease
 
-          archive=build/$(jq -r .name build/archive.json)
+          archive=build/archive/$(jq -r .name build/archive/archive.json)
           # Rename the archive manifest to avoid collision with other artifacts
-          os=$(jq -r .os build/archive.json)
-          cpu=$(jq -r .cpu build/archive.json)
+          os=$(jq -r .os build/archive/archive.json)
+          cpu=$(jq -r .cpu build/archive/archive.json)
           metadata=build/${os}_${cpu}.json
-          mv build/archive.json "$metadata"
+          mv build/archive/archive.json "$metadata"
 
           # Let the uploader know what to upload
           echo "archive=$archive" >> $GITHUB_OUTPUT
@@ -359,12 +359,12 @@ jobs:
         run: |
           ./koch.py unixrelease
 
-          archive=build/$(jq -r .name build/archive.json)
+          archive=build/archive/$(jq -r .name build/archive/archive.json)
           # Rename the archive manifest to avoid collision with other artifacts
-          os=$(jq -r .os build/archive.json)
-          cpu=$(jq -r .cpu build/archive.json)
+          os=$(jq -r .os build/archive/archive.json)
+          cpu=$(jq -r .cpu build/archive/archive.json)
           metadata=build/${os}_${cpu}.json
-          mv build/archive.json "$metadata"
+          mv build/archive/archive.json "$metadata"
 
           # Let the uploader know what to upload
           echo "archive=$archive" >> $GITHUB_OUTPUT

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -39,18 +39,18 @@ jobs:
         test:
           - name: Source archive
             command: "./koch.py boot -d:danger && ./koch.py csource -d:danger && ./koch.py archive"
-            pattern: "build/*.tar.zst"
+            pattern: "build/archive/*.tar.zst"
 
           - name: Unix binary archive
             command: "./koch.py boot -d:danger && ./koch.py docs --docCmd:skip && ./koch.py unixrelease"
-            pattern: "build/*.tar.zst"
+            pattern: "build/archive/*.tar.zst"
 
           # Note: this tests the zip generation and not exe generation determinism.
           #
           # Testing exe generation will be done when cross-bootstrap is possible.
           - name: Windows binary archive
             command: "./koch.py boot -d:danger && ./koch.py docs --docCmd:skip && ./koch.py winrelease"
-            pattern: "build/*.zip"
+            pattern: "build/archive/*.zip"
 
     name: "${{ matrix.test.name }} reproducibility tests"
     runs-on: ubuntu-latest

--- a/koch.py
+++ b/koch.py
@@ -72,8 +72,8 @@ class Bootstrap:
     # The location of build configuration
     ConfigPath: ClassVar = NimSource / "config" / "build_config.txt"
 
-    # The location of bootstrap source release file
-    SourceReleasePath: ClassVar = Source / "csources-release"
+    # The location of bootstrap source bundle state
+    SourceReleasePath: ClassVar = NimSource / "build" / "csources-bundled-version"
 
     def __init__(self) -> None:
         """Load configuration and initialize the object"""

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -23,6 +23,7 @@ const
   csourcesReleaseFile = "csources-bundled-version"
   releaseFile = "release.json"
   archiveManifestFile = "archive.json"
+  archiveOutputFolder = "archive"
 
 type
   AppType = enum appConsole, appGUI
@@ -656,7 +657,7 @@ proc setupDist(c: var ConfigData) =
   when defined(windows):
     if c.innosetup.path.len == 0:
       c.innosetup.path = "iscc.exe"
-    let outcmd = if c.outdir.len == 0: "build" else: c.outdir
+    let outcmd = c.getOutputDir()
     let cmd = "$# $# /O$# $#" % [quoteShell(c.innosetup.path),
                                  c.innosetup.flags, outcmd, n]
     echo(cmd)
@@ -673,7 +674,7 @@ proc setupDist2(c: var ConfigData) =
   when defined(windows):
     if c.nsisSetup.path.len == 0:
       c.nsisSetup.path = "makensis.exe"
-    let outcmd = if c.outdir.len == 0: "build" else: c.outdir
+    let outcmd = c.getOutputDir()
     let cmd = "$# $# /O$# $#" % [quoteShell(c.nsisSetup.path),
                                  c.nsisSetup.flags, outcmd, n]
     echo(cmd)
@@ -818,7 +819,7 @@ type
 proc createArchiveDist(c: var ConfigData) =
   ## Create the archive distribution
   let proj = toLowerAscii(c.name) & "-" & c.version
-  let tmpDir = if c.outdir.len == 0: "build" else: c.outdir
+  let tmpDir = c.getOutputDir / archiveOutputFolder
 
   proc processFile(destFile, src: string) =
     let dest = tmpDir / destFile

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -20,7 +20,7 @@ const
   makeFile = "makefile"
   installShFile = "install.sh"
   deinstallShFile = "deinstall.sh"
-  csourcesReleaseFile = "csources-release"
+  csourcesReleaseFile = "csources-bundled-version"
   releaseFile = "release.json"
   archiveManifestFile = "archive.json"
 
@@ -845,7 +845,7 @@ proc createArchiveDist(c: var ConfigData) =
 
     # Tag the source so koch.py knows to use it instead of cloning a fresh copy
     writeFile(tmpDir / csourcesReleaseFile, c.version)
-    processFile(bootstrapDist / csourcesReleaseFile, tmpDir / csourcesReleaseFile)
+    processFile(proj / "build" / csourcesReleaseFile, tmpDir / csourcesReleaseFile)
 
     processFile(proj / installShFile, installShFile)
     processFile(proj / deinstallShFile, deinstallShFile)


### PR DESCRIPTION
## Summary

Previously, we stored the csources bundle tag using the confusing name
"csources-release" and stored within the build/csources folder.

However, this caused some undesirable issues:

- If this file become stored within the csources git repository, it
will
  disable all csources versioning logic in koch.py.
- The old name "csources-release" did not adequately describe what the
  file is for.

This commit move the bundle tag to `build/csources-bundled-version`,
which now accurately describe the intent of the file and move the
ownership of "bundled" state away from csources.

## Details
This was brought about by
https://github.com/nim-works/csources_v1/pull/3 introducing 
`csources-release`  into csources_v1 repository, disabling koch
automatic csources version management.

A few notes:

* Moving to  `build/`  means that this file is now generated during
archive generation. To prevent that from silently turning off koch
csources logic for developers working on this, I opted to move the
archive output to  `build/archive/` .