### PR TITLE
sem: preserve untyped arguments in call dispatch

### DIFF
--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1010,7 +1010,7 @@ proc semCustomPragma(c: PContext, n: PNode): PNode =
     result = invalidPragma(c, n)
     return
 
-  let r = c.semOverloadedCall(c, callNode, {skTemplate}, {efNoUndeclared})
+  let r = c.semOverloadedCall(c, callNode, callNode, {skTemplate}, {efNoUndeclared})
   if r.isError:
     return r
   elif r.isNil or sfCustomPragma notin r[0].sym.flags:

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -619,7 +619,7 @@ type
     semConstBoolExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # XXX bite the bullet
       ## read to break cyclic dependencies, init in sem during module open and
       ## read in pragmas
-    semOverloadedCall*: proc (c: PContext, n: PNode,
+    semOverloadedCall*: proc (c: PContext, n, nOrig: PNode,
                               filter: TSymKinds, flags: TExprFlags): PNode {.nimcall.}
       ## read to break cyclic dependencies, init in sem during module open and
       ## read in pragmas and semtypinst

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1144,10 +1144,10 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode,
     # to 'skIterator' anymore; skIterator is preferred in sigmatch already
     # for typeof support.
     # for ``typeof(countup(1,3))``, see ``tests/ttoseq``.
-    result = semOverloadedCall(c, n,
+    result = semOverloadedCall(c, n, copyNodeWithKids(n),
       {skProc, skFunc, skMethod, skConverter, skMacro, skTemplate, skIterator}, flags)
   else:
-    result = semOverloadedCall(c, n,
+    result = semOverloadedCall(c, n, copyNodeWithKids(n),
       {skProc, skFunc, skMethod, skConverter, skMacro, skTemplate}, flags)
 
   if result != nil and result.kind != nkError:
@@ -1175,7 +1175,7 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode
 proc resolveIndirectCall(c: PContext; n: PNode;
                          t: PType): TCandidate =
   initCandidate(c, result, t)
-  matches(c, n, result)
+  matches(c, n, copyNodeWithKids(n), result)
 
 proc afterCallActions(c: PContext; n: PNode, flags: TExprFlags): PNode =
   if n.kind == nkError:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -221,7 +221,6 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
     elif not isException(typ):
       localReport(c.config, typeNode.info, reportAst(
         rsemCannotBeRaised, typeNode, typ = typ))
-
     if containsOrIncl(check, typ.id):
       localReport(c.config, typeNode.info, reportTyp(
         rsemExceptionAlreadyHandled, typ))
@@ -553,7 +552,7 @@ proc tryMacroPragma(c: PContext, pragmas: ptr PNode, i: int,
   x.add(operand) # the definition AST the pragma appears on
 
   # recursion assures that this works for multiple macro annotations too:
-  let r = semOverloadedCall(c, x, {skMacro, skTemplate}, {efNoUndeclared})
+  let r = semOverloadedCall(c, x, copyNodeWithKids(x), {skMacro, skTemplate}, {efNoUndeclared})
   if r.isNil:
     # restore the old list of pragmas since we couldn't process this one
     pragmas[] = n

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1725,7 +1725,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   else:
     var m = newCandidate(c, t)
     m.isNoCall = true
-    matches(c, n, m)
+    matches(c, n, copyNodeWithKids(n), m)
 
     if m.state != csMatch:
       localReport(c.config, n.info):

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -288,7 +288,7 @@ proc reResolveCallsWithTypedescParams(c: PContext, n: PNode): PNode =
       if isTypeParam(n[i]): needsFixing = true
     if needsFixing:
       n[0] = newSymNode(n[0].sym.owner)
-      return c.semOverloadedCall(c, n, {skProc, skFunc}, {})
+      return c.semOverloadedCall(c, n, n, {skProc, skFunc}, {})
 
   for i in 0..<n.safeLen:
     n[i] = reResolveCallsWithTypedescParams(c, n[i])

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -298,18 +298,18 @@ proc nameFits(c: PContext, s: PSym, n: PNode): bool =
   else: return false
   result = opr.id == s.name.id
 
-proc argsFit(c: PContext, candidate: PSym, n: PNode): bool =
+proc argsFit(c: PContext, candidate: PSym, n, nOrig: PNode): bool =
   case candidate.kind
   of OverloadableSyms:
     var m = newCallCandidate(c, candidate)
-    sigmatch.partialMatch(c, n, m)
+    sigmatch.partialMatch(c, n, nOrig, m)
     result = m.state != csNoMatch
   else:
     result = false
 
-proc suggestCall(c: PContext, n: PNode, outputs: var Suggestions) =
+proc suggestCall(c: PContext, n, nOrig: PNode, outputs: var Suggestions) =
   let info = n.info
-  wholeSymTab(filterSym(it, nil, pm) and nameFits(c, it, n) and argsFit(c, it, n),
+  wholeSymTab(filterSym(it, nil, pm) and nameFits(c, it, n) and argsFit(c, it, n, nOrig),
               ideCon)
 
 proc suggestVar(c: PContext, n: PNode, outputs: var Suggestions) =
@@ -572,7 +572,7 @@ proc suggestExprNoCheck*(c: PContext, n: PNode) =
         var x = safeSemExpr(c, n[i])
         if x.kind == nkEmpty or x.typ == nil or x.isErrorLike: break
         a.add x
-      suggestCall(c, a, outputs)
+      suggestCall(c, a, n, outputs)
     elif n.kind in nkIdentKinds:
       var x = safeSemExpr(c, n)
       if x.kind == nkEmpty or x.typ == nil or x.isErrorLike: x = n

--- a/tests/lang_callable/overload/toverload_call_corruption_1.nim
+++ b/tests/lang_callable/overload/toverload_call_corruption_1.nim
@@ -1,0 +1,29 @@
+discard """
+description: '''
+  Test for call AST corruption where typing an argument which fails, and then
+  is reused in an untyped context results in losing the original untyped AST.
+'''
+
+"""
+
+# ``test`` has to be an overloaded routine, where the overload with the non-
+# untyped parameter has to be defined **first**
+
+proc test(arg: string) =
+  doAssert false, "test:string->void called"
+
+template test(arg: untyped) =
+  for it in arg:
+    doAssert it == 0
+
+# two overloads of ``test2`` have to exist, with one being an iterator while
+# the other is not. The return types don't matter as long as the non-iterator
+# doesn't return anything that matches `string` or something for which an
+# ``items`` iterator exists.
+iterator test2(): int =
+  yield 0
+
+proc test2(): bool =
+  doAssert false, "test2:void->bool called"
+
+test(test2())


### PR DESCRIPTION
## Summary

Untyped arguments are no longer overwritten by their typed variety
during overload resolution (call corruption), fixing overload resolution
where overload candidates with untyped parameters were tested after ones
with typed parameters in the same argument positions.

## Details

Previously, during overload resolution the original call ast would be
updated incrementally with semantically analysed arguments as matches
were attempted. This was problematic when a typed formal parameter was
checked before an  `untyped`  parameter. This would result in the
argument being analysed and overwriting the original untyped AST in the
call.

Now we make a shallow copy, with the same child nodes, of the call AST,
which allows us to keep a reference to the original untyped AST. This is
then used whenever an overload resolution callee candidate has an
untyped formal parameter.

A regression test has been added to avoid this happening in the future.