### PR TITLE
mir: don't use `mnkStdConv` for string conversions

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -816,6 +816,8 @@ type
     mSymIsInstantiationOf, mNodeId, mPrivateAccess
 
     # magics only used internally:
+    mStrToCStr
+      ## the backend-dependent string-to-cstring conversion
     mAsgnDynlibVar
     mChckRange
       ## chckRange(v, lower, upper); conversion + range check -- returns

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1567,21 +1567,6 @@ proc genConv(p: BProc, e: CgNode, d: var TLoc) =
   else:
     genSomeCast(p, e, d)
 
-proc convStrToCStr(p: BProc, n: CgNode, d: var TLoc) =
-  var a: TLoc
-  initLocExpr(p, n.operand, a)
-  putIntoDest(p, d, n,
-              ropecg(p.module, "#nimToCStringConv($1)", [rdLoc(a)]),
-#                "($1 ? $1->data : (NCSTRING)\"\")" % [a.rdLoc],
-              a.storage)
-
-proc convCStrToStr(p: BProc, n: CgNode, d: var TLoc) =
-  var a: TLoc
-  initLocExpr(p, n.operand, a)
-  putIntoDest(p, d, n,
-              ropecg(p.module, "#cstrToNimstr($1)", [rdLoc(a)]),
-              a.storage)
-
 proc genStrEquals(p: BProc, e: CgNode, d: var TLoc) =
   var x: TLoc
   var a = e[1]
@@ -1713,6 +1698,7 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   of mCharToStr: unaryExpr(p, e, d, "#nimCharToStr($1)")
   of mCStrToStr: unaryExpr(p, e, d, "#cstrToNimstr($1)")
   of mStrToStr: expr(p, e[1], d)
+  of mStrToCStr: unaryExpr(p, e, d, "#nimToCStringConv($1)")
   of mIsolate: genCall(p, e, d)
   of mFinished: genBreakState(p, e, d)
   of mEnumToStr: genCall(p, e, d)
@@ -2142,8 +2128,6 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
   of cnkIfStmt: genIf(p, n)
   of cnkObjDownConv: downConv(p, n, d)
   of cnkObjUpConv: upConv(p, n, d)
-  of cnkStringToCString: convStrToCStr(p, n, d)
-  of cnkCStringToString: convCStrToStr(p, n, d)
   of cnkClosureConstr: genClosure(p, n, d)
   of cnkEmpty: discard
   of cnkRepeatStmt: genRepeatStmt(p, n)

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -91,13 +91,6 @@ type
     cnkCast          ## reinterpret the bit-pattern of the operand as a
                      ## different type
 
-    # ---- special conversions kept for compatibility
-    cnkStringToCString ## string to cstring
-    cnkCStringToString ## cstring to string
-    # future direction: lower these coversion operations during the MIR
-    # phase and then remove the node kinds
-    # ---- end
-
     cnkStmtList
     cnkStmtListExpr
     # future direction: remove ``cnkStmtListExpr``. The code generators know
@@ -144,7 +137,7 @@ const
 
   cnkWithOperand*  = {cnkConv, cnkHiddenConv, cnkDeref, cnkAddr, cnkHiddenAddr,
                       cnkDerefView, cnkObjDownConv, cnkObjUpConv, cnkCast,
-                      cnkStringToCString, cnkCStringToString, cnkLvalueConv}
+                      cnkLvalueConv}
   cnkAtoms*        = {cnkInvalid..cnkMagic, cnkReturnStmt, cnkPragmaStmt}
     ## node kinds that denote leafs
   cnkWithItems*    = AllKinds - cnkWithOperand - cnkAtoms

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -770,32 +770,7 @@ proc exprToIr(tree: MirBody, cl: var TranslateCl,
   of mnkConv:
     op cnkConv, valueToIr(tree, cl, cr)
   of mnkStdConv:
-    let
-      opr = valueToIr(tree, cl, cr)
-      source = opr.typ.skipTypes(abstractVarRange)
-      dest = n.typ.skipTypes(abstractVarRange)
-
-    leave(tree, cr)
-
-    var adjusted: CgNode
-
-    case dest.kind
-    of tyCstring:
-      if source.kind == tyString:
-        adjusted = newOp(cnkStringToCString, info, n.typ): opr
-
-    of tyString:
-      if source.kind == tyCstring:
-        adjusted = newOp(cnkCStringToString, info, n.typ): opr
-
-    else:
-      discard
-
-    if adjusted == nil:
-      # no special conversion is used
-      adjusted = newOp(cnkHiddenConv, info, n.typ, opr)
-
-    adjusted
+    op cnkHiddenConv, valueToIr(tree, cl, cr)
   of mnkToSlice:
     treeOp cnkToSlice:
       res.add valueToIr(tree, cl, cr)

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1878,9 +1878,12 @@ proc genx(c: var TCtx, n: PNode, consume: bool) =
         c.emitOperandTree n[0], false
         c.emitOperandTree n[1], false
         c.emitOperandTree n[2], false
-  of nkStringToCString, nkCStringToString:
-    # undo the transformation done by ``transf``
-    c.genOp mnkStdConv, n.typ, n[0]
+  of nkStringToCString:
+    c.buildMagicCall mStrToCStr, n.typ:
+      c.emitOperandTree n[0], false
+  of nkCStringToString:
+    c.buildMagicCall mCStrToStr, n.typ:
+      c.emitOperandTree n[0], false
   of nkBracket:
     let consume =
       if n.typ.skipTypes(abstractVarRange).kind == tySequence:


### PR DESCRIPTION
## Summary

Instead of `mnkStdConv` in the MIR and `cnkStringToCString` and
`cnkCStringToString` in the `CgNode` IR, both `cstring`/`string`
conversions are now represented via normal magic calls -- the
operations are used too infrequently to warrant a dedicated node kind.

## Details

* `nkCStringToString` is translated to the already-existing
  `mCStrToStr` magic
* `nkStringToCString` is translated to the new internal-only
  `mStrToCStr` magic
* the code generator lower the `mStrToCStr` magic the same as they did
  with `cnkStringToCString`
* `cnkCStringToString` and `cnkStringToCString` are removed