### PR TITLE
compiler, ci: remove acyclic and run leak tests

### DIFF
--- a/.github/workflows/leak.yml
+++ b/.github/workflows/leak.yml
@@ -8,9 +8,7 @@ on:
 jobs:
   leaktest:
     # Skip this for PRs
-    #
-    # FIXME: uncomment this before merge
-    # if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
 
     name: Compiler and tools leak test
     runs-on: ubuntu-latest

--- a/.github/workflows/leak.yml
+++ b/.github/workflows/leak.yml
@@ -1,0 +1,42 @@
+name: Test compiler and tools for memory leaks
+
+on:
+  # This is for passing required checks
+  pull_request:
+  merge_group:
+
+jobs:
+  leaktest:
+    # Skip this for PRs
+    #
+    # FIXME: uncomment this before merge
+    # if: github.event_name != 'pull_request'
+
+    name: Compiler and tools leak test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Enable annotations
+        run: echo "::add-matcher::.github/nim-problem-matcher.json"
+
+      - name: Build release binaries with LeakSanitizer
+        run: |
+          ./koch.py all-strict \
+            -d:useMalloc \
+            --passC:-fsanitize=leak \
+            --passC:"-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" \
+            --passL:-fsanitize=leak \
+            --debuginfo \
+            --linedir
+
+      - name: Run tools tests
+        run: ./koch.py testTools
+
+      # NOTE: We don't run the full test suite here as self-bootstrap
+      # and tools testsuite can be considered enough to rat out memory leaks
+      # within the compiler itself.

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -226,7 +226,7 @@ type
     base*: NumericalBase
     literal*: string
 
-  ParsedNodeData*{.final, acyclic.} = object
+  ParsedNodeData*{.final.} = object
     # TODO: replace token fields with indexing into a token sequence, this
     #       should also address line info tracking.
     comment*: string       # TODO: replace with an index into a token stream

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -226,6 +226,7 @@ type
     base*: NumericalBase
     literal*: string
 
+  # TODO: This type should be marked acyclic
   ParsedNodeData*{.final.} = object
     # TODO: replace token fields with indexing into a token sequence, this
     #       should also address line info tracking.

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -901,7 +901,7 @@ type
 
 
 type
-  TIdObj* {.acyclic.} = object of RootObj
+  TIdObj* = object of RootObj
     itemId*: ItemId
   PIdObj* = ref TIdObj
 
@@ -1256,7 +1256,7 @@ type
     adSemDeprecatedCompilerOptArg   # warning promoted to error
 
   PAstDiag* = ref TAstDiag
-  TAstDiag* {.acyclic.} = object
+  TAstDiag* = object
     # xxx: consider splitting storage type vs message
     # xxx: consider breaking up diag into smaller types
     # xxx: try to shrink the int/int128 etc types for counts/ordinals
@@ -1561,7 +1561,7 @@ type
           adSemDefNameSymIllformedAst:
         discard
 
-  TNode*{.final, acyclic.} = object # on a 32bit machine, this takes 32 bytes
+  TNode*{.final.} = object # on a 32bit machine, this takes 32 bytes
                                     # on a 64bit machine, this takes 40 bytes
     typ*: PType
     id*: NodeId  # placed after `typ` field to save space due to field alignment
@@ -1642,7 +1642,7 @@ type
 
   PInstantiation* = ref TInstantiation
 
-  TScope* {.acyclic.} = object
+  TScope* = object
     depthLevel*: int
     symbols*: TStrTable
     parent*: PScope
@@ -1650,7 +1650,7 @@ type
 
   PScope* = ref TScope
 
-  TSym* {.acyclic.} = object of TIdObj # Keep in sync with PackedSym
+  TSym* = object of TIdObj # Keep in sync with PackedSym
     ## proc and type instantiations are cached in the generic symbol
     case kind*: TSymKind
     of routineKinds - {skMacro}:
@@ -1728,7 +1728,7 @@ type
     attachedTrace,
     attachedDeepCopy
 
-  TType* {.acyclic.} = object of TIdObj
+  TType*  = object of TIdObj
     ## types are identical only if they have the same id; there may be multiple
     ## copies of a type in memory! Keep in sync with PackedType
     kind*: TTypeKind          ## kind of type

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1642,6 +1642,7 @@ type
 
   PInstantiation* = ref TInstantiation
 
+  # TODO: This type should be marked acyclic
   TScope* = object
     depthLevel*: int
     symbols*: TStrTable

--- a/compiler/ast/idents.nim
+++ b/compiler/ast/idents.nim
@@ -22,6 +22,7 @@ import
 
 type
   PIdent* = ref TIdent
+  # TODO: This type should be marked acyclic
   TIdent* = object
     id*: int ## unique id; use this for comparisons and not the pointers
     s*: string

--- a/compiler/ast/idents.nim
+++ b/compiler/ast/idents.nim
@@ -22,7 +22,7 @@ import
 
 type
   PIdent* = ref TIdent
-  TIdent*{.acyclic.} = object
+  TIdent* = object
     id*: int ## unique id; use this for comparisons and not the pointers
     s*: string
     next*: PIdent ## for hash-table chaining

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -169,7 +169,7 @@ type
   LocalId* = distinct uint32
     ## Identifies a local within a procedure.
 
-  CgNode* = ref object
+  CgNode* {.acyclic.} = ref object
     ## A node in the tree structure representing code during the code
     ## generation stage. The "CG" prefix is short for "code generation".
     info*: TLineInfo

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -169,7 +169,7 @@ type
   LocalId* = distinct uint32
     ## Identifies a local within a procedure.
 
-  CgNode* {.acyclic.} = ref object
+  CgNode* = ref object
     ## A node in the tree structure representing code during the code
     ## generation stage. The "CG" prefix is short for "code generation".
     info*: TLineInfo

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -519,6 +519,17 @@ proc mainCommand*(graph: ModuleGraph) =
   when defined(nimDebugUnreportedErrors):
     addExitProc proc = echoAndResetUnreportedErrors(conf)
 
+  when defined(gcOrc):
+    # Compilation is currently very taxing on ORC due to frequent
+    # creations and destructions of ref objects with potential cycles.
+    #
+    # Disable ORC to reduce overhead from the cycle collector at the
+    # cost of memory usage.
+    #
+    # We don't collect cycles afterwards as the command is one-shot and
+    # memory should be freed once the program stops.
+    GC_disableOrc()
+
   ## process all commands
   case conf.cmd
   of cmdBackends: compileToBackend()

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -206,7 +206,7 @@ type
     ## This is useful for environments such as nimsuggest, which discard
     ## the output.
 
-  ConfigRef* {.acyclic.} = ref object
+  ConfigRef* = ref object
     ## every global configuration fields marked with '*' are subject to the
     ## incremental compilation mechanisms (+) means "part of the dependency"
 

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -87,7 +87,7 @@ type
     concreteTypes*: seq[FullId]
     inst*: PInstantiation
 
-  ModuleGraph* {.acyclic.} = ref object
+  ModuleGraph* = ref object
     ifaces*: seq[Iface]  ## indexed by int32 fileIdx
     packed*: PackedModuleGraph
     encoders*: seq[PackedEncoder]

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -59,6 +59,7 @@ type
 
   POptionEntry* = ref TOptionEntry
   PProcCon* = ref TProcCon
+  # TODO: This type should be marked acyclic
   TProcCon* = object ## procedure context; also used for top-level
                                  ## statements
     owner*: PSym              ## the symbol this context belongs to

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -59,7 +59,7 @@ type
 
   POptionEntry* = ref TOptionEntry
   PProcCon* = ref TProcCon
-  TProcCon* {.acyclic.} = object ## procedure context; also used for top-level
+  TProcCon* = object ## procedure context; also used for top-level
                                  ## statements
     owner*: PSym              ## the symbol this context belongs to
     resultSym*: PSym          ## the result symbol (if we are in a proc)

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -121,6 +121,7 @@ proc cacheTypeInst(c: PContext; inst: PType) =
   addToGenericCache(c, gt.sym, inst)
 
 type
+  # TODO: This type should be marked acyclic
   LayeredIdTable* = ref object
     topLayer*: TIdTable
     nextLayer*: LayeredIdTable

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -121,7 +121,7 @@ proc cacheTypeInst(c: PContext; inst: PType) =
   addToGenericCache(c, gt.sym, inst)
 
 type
-  LayeredIdTable* {.acyclic.} = ref object
+  LayeredIdTable* = ref object
     topLayer*: TIdTable
     nextLayer*: LayeredIdTable
 

--- a/compiler/utils/btrees.nim
+++ b/compiler/utils/btrees.nim
@@ -16,6 +16,7 @@ const
   Mhalf = M div 2
 
 type
+  # TODO: This type should be marked acyclic
   Node[Key, Val]  = ref object
     entries: int
     keys: array[M, Key]

--- a/compiler/utils/btrees.nim
+++ b/compiler/utils/btrees.nim
@@ -16,7 +16,7 @@ const
   Mhalf = M div 2
 
 type
-  Node[Key, Val] {.acyclic.} = ref object
+  Node[Key, Val]  = ref object
     entries: int
     keys: array[M, Key]
     case isInternal: bool

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -211,8 +211,6 @@ proc runGc() =
   ## Runs a GC collection pass. This procedure will also collect any cycles assuming ORC is in use.
   ##
   ## When nimsuggest is being used as a library, no GC mode change will be performed.
-  when isMainModule and defined(gcOrc):
-    GC_enableOrc()
   GC_fullCollect()
   when isMainModule and defined(gcOrc):
     GC_disableOrc()

--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -536,10 +536,10 @@ when isMainModule:
       else: showHelp(success = false)
     of cmdArgument:
       case normalize(op.key)
-      of "all": buildReleaseBinaries()
+      of "all": buildReleaseBinaries(op.cmdLineRest)
       of "all-strict":
         # when using strict mode, don't abort after the first error
-        buildReleaseBinaries("-d:nimStrictMode --errorMax:3")
+        buildReleaseBinaries("-d:nimStrictMode --errorMax:3 " & op.cmdLineRest)
       of "boot": boot(op.cmdLineRest)
       of "clean": clean(op.cmdLineRest)
       of "doc", "docs": buildDocs(op.cmdLineRest)


### PR DESCRIPTION
## Summary
Local tests have shown that the compiler does create cycles and leak
memory during compilation. As such we are dropping all acyclic
annotations and prepare the stage to either live without them or have
them reintroduced over time.


## Details
Aside from dropping acyclic annotations, this commit prepares the
compiler for future work on memory optimizations with these changes:

- Cycle collection is disabled for the compiler itself. This is because
the compilation command is not a long-running task and we value speed
over memory usage here.

- nimsuggest is set to collect cycles only after running a command. This
should keep memory usage low during extended usage while allowing the
compilation phases to stay at top speed.

- A CI pipeline has been setup to test the compiler using LeakSanitizer,
making sure that leaks are caught before they are introduced.


Some performance numbers due to these changes:

Benchmarked via: 
`hyperfine -- "bin/nim c --forceBuild --compileOnly --verbosity:0 --hints:off --warnings:off compiler/nim.nim"`


            Time             Ratio
    Before  9.155s ± 0.044s  1.00
    After   9.599s ± 0.039s  1.05