### PR TITLE
ci: put release archive and metadata in the same prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
           # Rename the archive manifest to avoid collision with other artifacts
           os=$(jq -r .os build/archive/archive.json)
           cpu=$(jq -r .cpu build/archive/archive.json)
-          metadata=build/${os}_${cpu}.json
+          metadata=build/archive/${os}_${cpu}.json
           mv build/archive/archive.json "$metadata"
 
           # Let the uploader know what to upload
@@ -363,7 +363,7 @@ jobs:
           # Rename the archive manifest to avoid collision with other artifacts
           os=$(jq -r .os build/archive/archive.json)
           cpu=$(jq -r .cpu build/archive/archive.json)
-          metadata=build/${os}_${cpu}.json
+          metadata=build/archive/${os}_${cpu}.json
           mv build/archive/archive.json "$metadata"
 
           # Let the uploader know what to upload


### PR DESCRIPTION
## Summary
https://github.com/nim-works/nimskull/pull/1101 introduced a regression
where the archive is placed in a subfolder within the uploaded artifact.
This happened due to the metadata being one level above the archive,
which broke publisher.

## Details
This PR puts the metadata in the same subfolder as the archive so that
the artifact uploader correctly place them in the same level.