### PR TITLE
fix(orc): cycle collection causing heap corruption

### DIFF
--- a/tests/arc/tcollect_in_destroy.nim
+++ b/tests/arc/tcollect_in_destroy.nim
@@ -1,0 +1,48 @@
+discard """
+  description: '''
+    Ensure that calling ``GC_fullCollect`` during destruction of a cell part
+    of a reference cycle doesn't cause issues (stack overflow or heap
+    corruption).
+  '''
+  targets: "c"
+  matrix: "-d:useMalloc"
+  valgrind: true
+"""
+
+type
+  CyclicRef = ref Cyclic
+  Cyclic = object
+    self: CyclicRef
+
+var destroyCalled = true
+
+proc `=destroy`(x: var Cyclic) =
+  destroyCalled = true
+  GC_fullCollect()
+  `=destroy`(x.self)
+
+proc test1(a: sink CyclicRef, cond: bool) =
+  # try with normal destruction. The ref is passed from the outside so that
+  # the optimizer doesn't know where it came from
+  a.self = a
+  if cond: # obfuscate the reset for the optimizer
+    a.self = nil
+    # ^^ registers the cell as a potential cycle root, but effectively breaks
+    # the cycle
+
+test1(CyclicRef(), true)
+doAssert destroyCalled
+
+proc test2(a: sink CyclicRef) =
+  # now test with a real cycle, where destruction is triggered by the cycle
+  # collector
+  a.self = a
+  # XXX: work around compiler bug, by forcing a copy
+  discard a
+
+destroyCalled = false
+test2(CyclicRef())
+doAssert not destroyCalled
+# now run the cycle collector, which should destroy the cell
+GC_fullCollect()
+doAssert destroyCalled

--- a/tests/arc/tcycle_test.nim
+++ b/tests/arc/tcycle_test.nim
@@ -24,11 +24,11 @@ proc init() =
   # create two cycles and link them together via `Bridge`
   var a = Cycle1(self: Cycle1())
   a.self.self = a
-  var b = Cycle2(self: Cycle2())
-  b.self.self = b
+  var c = Cycle2(self: Cycle2())
+  c.self.self = c
 
   a.self.bridge = new Bridge
-  a.self.bridge.other = b
+  a.self.bridge.other = c
   # the following structure now exists:
   # A -> B -> Bridge -> C -> D
   # ^    |              ^    |

--- a/tests/arc/tcycle_test.nim
+++ b/tests/arc/tcycle_test.nim
@@ -1,0 +1,58 @@
+discard """
+  description: '''
+    A regression test for a bug with the cycle collector, where two reference
+    cycles linked together by a non-cyclic reference type trigger a memory
+    corruption
+  '''
+  targets: "c"
+  matrix: "-d:useMalloc"
+  valgrind: true
+"""
+
+type
+  Bridge = object
+    other: Cycle2
+  Cycle1 = ref object
+    bridge: ref Bridge
+      ## bridges the two cyclic types. This must be a `ref`, otherwise tracing
+      ## would visit the `other` field and the issue would not be triggered
+    self: Cycle1
+  Cycle2 = ref object
+    self: Cycle2
+
+proc init() =
+  # create two cycles and link them together via `Bridge`
+  var a = Cycle1(self: Cycle1())
+  a.self.self = a
+  var b = Cycle2(self: Cycle2())
+  b.self.self = b
+
+  a.self.bridge = new Bridge
+  a.self.bridge.other = b
+  # the following structure now exists:
+  # A -> B -> Bridge -> C -> D
+  # ^    |              ^    |
+  # + -- +              + -- +
+
+  b = nil # remove the stack root, which marks A as a potential cycle root
+  # 'A' is now the root of a garbage cycle
+
+GC_disableOrc() # disable the cycle collector
+
+var s: seq[Cycle1]
+# register enough potential cycle roots for the default collection
+# threshold (128) to overflow
+for i in 0..<1000:
+  var a = Cycle1()
+  s.add a
+  # force the `add` to copy by using `a` afterwards. The subsequent destroy
+  # for the ref will add it to the list of potential cycle roots
+  discard a
+
+init() # setup the dangerous cycle
+# first enable the GC again. This is important, as it sets the root list
+# threshold back to its default value
+GC_enableOrc()
+# now force a garbage collection, which results in a recursive cycle collector
+# invocation and thus memory corruption.
+GC_fullCollect()

--- a/tests/arc/tcycle_test.nim
+++ b/tests/arc/tcycle_test.nim
@@ -34,7 +34,7 @@ proc init() =
   # ^    |              ^    |
   # + -- +              + -- +
 
-  b = nil # remove the stack root, which marks A as a potential cycle root
+  a = nil # remove the stack root, which marks A as a potential cycle root
   # 'A' is now the root of a garbage cycle
 
 GC_disableOrc() # disable the cycle collector

--- a/tests/arc/tcycle_test_acyclic_annotation.nim
+++ b/tests/arc/tcycle_test_acyclic_annotation.nim
@@ -1,0 +1,49 @@
+discard """
+  description: "A variation of ``tcycle_test`` where ``.acyclic`` is used"
+  targets: "c"
+  matrix: "-d:useMalloc"
+  valgrind: true
+"""
+
+type
+  Bridge {.acyclic.} = ref object
+    other: Cycle
+  Cycle = ref object
+    bridge: Bridge
+    self: Cycle
+
+proc init() =
+  # create two cycles and link them together via `Bridge`
+  var a = Cycle(self: Cycle())
+  a.self.self = a
+  var b = Cycle(self: Cycle())
+  b.self.self = b
+
+  b.self.bridge = Bridge(other: a)
+  # the following structure now exists:
+  # A -> B -> Bridge -> C -> D
+  # ^    |              ^    |
+  # + -- +              + -- +
+
+  b = nil # remove the stack root, which marks A as a potential cycle root
+  # 'A' is now the root of a garbage cycle
+
+GC_disableOrc() # disable the cycle collector
+
+var s: seq[Cycle]
+# register enough potential cycle roots for the default collection
+# threshold (128) to overflow
+for i in 0..<1000:
+  var a = Cycle()
+  s.add a
+  # force the `add` to copy by using `a` afterwards. The subsequent destroy
+  # for the ref will add it to the list of potential cycle roots
+  discard a
+
+init() # setup the dangerous cycle
+# first enable the GC again. This is important, as it sets the root list
+# threshold back to its default value
+GC_enableOrc()
+# now force a garbage collection, which results in a recursive cycle collector
+# invocation and thus memory corruption.
+GC_fullCollect()

--- a/tests/arc/tcycle_test_acyclic_annotation.nim
+++ b/tests/arc/tcycle_test_acyclic_annotation.nim
@@ -25,7 +25,7 @@ proc init() =
   # ^    |              ^    |
   # + -- +              + -- +
 
-  b = nil # remove the stack root, which marks A as a potential cycle root
+  a = nil # remove the stack root, which marks A as a potential cycle root
   # 'A' is now the root of a garbage cycle
 
 GC_disableOrc() # disable the cycle collector

--- a/tests/arc/tcycle_test_acyclic_annotation.nim
+++ b/tests/arc/tcycle_test_acyclic_annotation.nim
@@ -16,10 +16,10 @@ proc init() =
   # create two cycles and link them together via `Bridge`
   var a = Cycle(self: Cycle())
   a.self.self = a
-  var b = Cycle(self: Cycle())
-  b.self.self = b
+  var c = Cycle(self: Cycle())
+  c.self.self = c
 
-  b.self.bridge = Bridge(other: a)
+  a.self.bridge = Bridge(other: c)
   # the following structure now exists:
   # A -> B -> Bridge -> C -> D
   # ^    |              ^    |


### PR DESCRIPTION
## Summary

In case there was a reference cycle that was kept alive by a non-
traced cell, and the non-traced cell was kept alive by a garbage
reference cycle, running the cycle collector made the collector
recurse.

A non-traced cell refers to a managed heap cell that's not scanned by
the cycle collector because its not cyclic (including due to the use
of `.acyclic`).

Depending on the circumstances, the recursion would either cause a
stack overflow or a heap corruption. The bug is now fixed.

## Details

The fundamental problem is that a call to `free` can add new roots to
the global `roots` list, either via automatic destructor or through
user-defined destructors.

Since neither the `roots` list nor root threshold are reset prior to
the cleanup phase, a call to `registerCycle` would trigger a
`collectCycles` recursion, which then ran trial deletion for all
already scanned roots again.

This would then cause a heap corruption if one of the roots was freed
already.

### The solution

Prior to the cleanup phase, all processed roots are removed from the
`roots` list. In addition, a reentrance guard (`collectorLock`) is
added that prevents recursion into `collectCycles`/`partialCollect`,
even if explicitly requested via `GC_fullCollect`.

So that a single full collection frees *all* reference cycles, even
those only discovered during a run of the cleanup phase,
`collectCycles` runs the core cycle collection in a loop until no more
new roots were discovered during cleanup.