### PR TITLE
osproc: don't allocate memory during fork-exec

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1183,10 +1183,8 @@ elif not defined(useNimRtl):
       discard fcntl(data.pErrorPipe[writeIdx], F_SETFD, FD_CLOEXEC)
 
       if (poUsePath in data.options):
-        when defined(uClibc) or defined(linux) or defined(haiku):
-          # uClibc environment (OpenWrt included) doesn't have the full execvpe
-          let exe = findExe(data.sysCommand)
-          discard execve(exe.cstring, data.sysArgs, data.sysEnv)
+        when not defined(macosx):
+          discard execvpe(data.sysCommand.cstring, data.sysArgs, data.sysEnv)
         else:
           # MacOSX doesn't have execvpe, so we need workaround.
           # On MacOSX we can arrive here only from fork, so this is safe:


### PR DESCRIPTION
## Summary

Previously,  `osproc`  would attempt to allocate memory during fork-exec
via the use of  `findExe`  to find programs in  `PATH` . This causes
memory allocation during this sensitive period.

This PR replaces the use of  `findExe` , which was employed due to 
`execvpe`  not being ubiquitous, with  `execvpe` , now that it is widely
available.

## Details

There are a couple problems with allocating memory during fork-exec:

- This is extremely unsafe as this code is also used in  `vfork()`  case
(although disabled by default, thankfully), of which the use of an
allocator would completely mess up the parent process.
- This is super slow, since  `fork()`  has to perform CoW on pages that
are touched by the allocation procedure.
- A deadlock can occur in rare cases due to interaction with the global
allocator lock. This problem was observed in disruptek/balls.

With regard to substituting `findExe` with `execvpe`:

* This API has been available in uClibc since 2013, musl libc since 2014
and Haiku since 2015, removing the need to special case against those
systems.
* We can expect behaviors closer to how other programs perform  `PATH` 
searches. It is expected that there won't be any regression from this
change.