### PR TITLE
relax a couple (terminal) func side-effects

### DIFF
--- a/compiler/utils/idioms.nim
+++ b/compiler/utils/idioms.nim
@@ -33,7 +33,8 @@ func unreachableImpl(str: string, loc: IInfo) {.noinline, noreturn.} =
     if str.len > 0: " unreachable: "
     else:           " unreachable"
   msg.add str
-  raiseAssert(msg)
+  {.cast(noSideEffect).}:
+    raiseAssert(msg)
 
 func unreachableImpl(e: enum, loc: IInfo) {.noinline, noreturn.} =
   ## A bit more efficient than ``unreachable($e)``, due to the stringication

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2698,7 +2698,9 @@ when compileOption("rangechecks"):
     ## Helper for performing user-defined range checks.
     ## Such checks will be performed only when the `rangechecks`
     ## compile-time option is enabled.
-    if not cond: sysFatal(RangeDefect, "range check failed")
+    if not cond:
+      {.cast(noSideEffect).}:
+        sysFatal(RangeDefect, "range check failed")
 else:
   template rangeCheck*(cond) = discard
 


### PR DESCRIPTION
## Summary
I noSideEffect'd a couple raises because they don't compile as `func` otherwise and I don't want to spend the morning tracking down and un-func'ing everything.

## Notes for Reviewers
Maybe we shouldn't use `func` until we understand what it does and why it exists.