### PR TITLE
sem: ill-formed sym in `for` produces an error

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1434,7 +1434,7 @@ proc symForVar(c: PContext, n: PNode): PSym =
       semmedNode[0] = resultNode
       semmedNode[1] = pragma
 
-  if resultNode.kind == nkError or hasPragma and n[1].kind == nkError:
+  if resultNode.kind == nkError or hasPragma and semmedNode[1].kind == nkError:
     result = newSym(skError, result.name, nextSymId(c.idgen), result.owner,
                     n.info)
     result.typ = c.errorType

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1423,6 +1423,7 @@ proc symForVar(c: PContext, n: PNode): PSym =
   let
     hasPragma = n.kind == nkPragmaExpr
     resultNode = newSymGNode(skForVar, (if hasPragma: n[0] else: n), c)
+    semmedNode = if hasPragma: copyNodeWithKids(n) else: resultNode
 
   result = getDefNameSymOrRecover(resultNode)
   styleCheckDef(c.config, result)
@@ -1430,13 +1431,14 @@ proc symForVar(c: PContext, n: PNode): PSym =
   if hasPragma:
     let pragma = pragmaDecl(c, result, n[1], forVarPragmas)
     if pragma.kind == nkError:
-      n[1] = pragma
+      semmedNode[0] = resultNode
+      semmedNode[1] = pragma
 
   if resultNode.kind == nkError or hasPragma and n[1].kind == nkError:
     result = newSym(skError, result.name, nextSymId(c.idgen), result.owner,
                     n.info)
     result.typ = c.errorType
-    result.ast = c.config.wrapError(n)
+    result.ast = c.config.wrapError(semmedNode)
 
 proc semSingleForVar(c: PContext, formal: PType, view: ViewTypeKind, n: PNode): PNode =
   ## Semantically analyses a single definition of a variable in the context of
@@ -1445,7 +1447,7 @@ proc semSingleForVar(c: PContext, formal: PType, view: ViewTypeKind, n: PNode): 
 
   let v = symForVar(c, n)
   if v.kind == skError:
-    return c.config.wrapError(n)
+    return v.ast
 
   if getCurrOwner(c).kind == skModule:
     incl(v.flags, sfGlobal)

--- a/tests/lang_stmts/for_stmt/tfor_ill_formed_sym.nim
+++ b/tests/lang_stmts/for_stmt/tfor_ill_formed_sym.nim
@@ -1,0 +1,13 @@
+discard """
+  description: "Ensure that ill-formed AST generates a well formed error"
+  errmsg: "identifier expected, but found '123'"
+"""
+
+# This test covers a regression where an error with the symbol outside a pragma
+# expr was not correctly wrapped in an error leading to a compiler bug.
+
+template makeAFor(x: untyped) =
+  for x in [1, 2]:
+    discard
+
+makeAFor(123)


### PR DESCRIPTION
## Summary

Ill-formed  `for`  loops with an error in the sym position, in
particular produced by meta routines now correclty produce an error.

## Details

Prior to this fix the error would not be reported because it was not
added to the production that was ultimately wrapped in an  `nkError` .
This would result in a compiler crash due to assertion failure, wrapping
AST in an error without an error present therein. Finally, the new
approach no longer mutates the input AST.