### PR TITLE
streamwrapper: create an alias before using fields

### DIFF
--- a/lib/pure/streamwrapper.nim
+++ b/lib/pure/streamwrapper.nim
@@ -99,7 +99,9 @@ proc newPipeOutStream*[T](s: sink (ref T)): owned PipeOutStream[T] =
   assert s.readDataImpl != nil
 
   new(result)
-  for dest, src in fields((ref T)(result)[], s[]):
+  # XXX: feel free to suggest a better name
+  let parentAlias = (ref T) result
+  for dest, src in fields(parentAlias[], s[]):
     dest = src
   wasMoved(s[])
   if result.readLineImpl != nil:


### PR DESCRIPTION
This serves as a workaround for https://github.com/nim-works/nimskull/issues/1113 as that bug blocks software using osproc from compiling with ARC.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
