### PR TITLE
fix(sem): AST corruption with type expressions

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3619,11 +3619,12 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
         var baseType = semExpr(c, n[0]).typ.skipTypes({tyTypeDesc})
         result.typ = c.makeTypeDesc(c.newTypeWithSons(modifier, @[baseType]))
         return
-    let typ = semTypeNode(c, n, nil).skipTypes({tyTypeDesc})
-    result.typ = makeTypeDesc(c, typ)
+    result = semTypeNode2(c, n, nil)
+    # a type expression is of type ``typeDesc[T]``
+    result.typ = makeTypeDesc(c, result.typ.skipTypes({tyTypeDesc}))
   of nkStmtListType:
-    let typ = semTypeNode(c, n, nil)
-    result.typ = makeTypeDesc(c, typ)
+    result = semTypeNode2(c, n, nil)
+    result.typ = makeTypeDesc(c, result.typ)
   of nkCall, nkInfix, nkPrefix, nkPostfix, nkCommand, nkCallStrLit:
     # check if it is an expression macro:
     checkMinSonsLen(n, 1, c.config)

--- a/tests/lang_exprs/ttype_expr_ast_corruption.nim
+++ b/tests/lang_exprs/ttype_expr_ast_corruption.nim
@@ -2,7 +2,8 @@ discard """
   description: '''
     Ensure that a type expression can be used in the type slot of an object
     construction syntax, which is itself the argument to a `[]` procedure
-    call
+    call.
+    Reduced from https://github.com/nim-works/nimskull/issues/1113
   '''
 """
 

--- a/tests/lang_exprs/ttype_expr_ast_corruption.nim
+++ b/tests/lang_exprs/ttype_expr_ast_corruption.nim
@@ -1,0 +1,20 @@
+discard """
+  description: '''
+    Ensure that a type expression can be used in the type slot of an object
+    construction syntax, which is itself the argument to a `[]` procedure
+    call
+  '''
+"""
+
+# this is a regression test for an AST corruption
+
+type O = object
+
+# minimized version of the bug:
+discard `[]`((ref O)())
+
+# currently equivalent version of the issue, where a template is used:
+template templ() =
+  discard (ref O)()[]
+
+templ()


### PR DESCRIPTION
## Summary

Fix a bug in semantic analysis where an expression like `(ref T)()`
would result in an error when used directly within a deref (`x[]`) or
subscript (`x[...]`) expression that itself appears within a template
or generic routine.

Fixes https://github.com/nim-works/nimskull/issues/1113.

## Detail

`semExpr` does not create a copy of the input AST for type expressions,
meaning that the input AST had its type set and the `nfSem` flag
included, which is both wrong, as input AST must not be mutated in any
way.

### The symptom

The `(ref T)()` AST is processed through `semIndirectOp`, which first
analyses the expression in the callee slot and then dispatches to the
correct procedure (`semObjConstr`, in this case).

When `semObjConstr`, calls `semTypeNode` on the type expression,
`semTypeNode` overrides the node's type with `tyRef[T]` (it was
`tyTypeDesc[tyRef[T]]`).

If the `(ref T)()` expression is analysed again, which happens for
the `mArrGet` magic procedure calls that `x[]` is turned into when
appearing within templates or generic routines, the node is seen as
already analysed (due to the `nfSem` flag), meaning that it was not
typed as `tyTypeDesc` again, causing `semIndirectOp` to treat the
`(ref T)()` expression as a call (which then resulted in an error).

### The fix

`semExpr` now creates a copy of the input AST when analysing type
expressions, via `semTypeNode2`, preventing the `nfSem` flag from being
included on the original AST.