### PR TITLE
cmdlinehelper: increment errorCounter on config parse error

### DIFF
--- a/tests/errmsgs/tconfig_error.nim
+++ b/tests/errmsgs/tconfig_error.nim
@@ -1,9 +1,9 @@
 discard """
   description: '''
-  Test that a config file with invalid option will yield an error with
-  non-zero exit code.
+    Test that a config file with invalid option will yield an error with
+    non-zero exit code.
 
-  Ref https://github.com/nim-works/nimskull/issues/1112
+    References https://github.com/nim-works/nimskull/issues/1112
   '''
   errormsg: "Invalid command line option - totally_valid_config_option"
   file: "tconfig_error.nim.cfg"

--- a/tests/errmsgs/tconfig_error.nim
+++ b/tests/errmsgs/tconfig_error.nim
@@ -1,0 +1,10 @@
+discard """
+  description: '''
+  Test that a config file with invalid option will yield an error with
+  non-zero exit code.
+
+  Ref https://github.com/nim-works/nimskull/issues/1112
+  '''
+  errormsg: "Invalid command line option - totally_valid_config_option"
+  file: "tconfig_error.nim.cfg"
+"""

--- a/tests/errmsgs/tconfig_error.nim.cfg
+++ b/tests/errmsgs/tconfig_error.nim.cfg
@@ -1,0 +1,1 @@
+totally_valid_config_option = ""


### PR DESCRIPTION
## Summary
Previously we did not increment this counter, making configuration
errors yield successful exit code.

## Details
* Added a new "None" diagnostic level to simplify handling code.
* Increments error counter on Error or worse.

Fixes https://github.com/nim-works/nimskull/issues/1112