### PR TITLE
compiler: enable ORC when running the leak test

### DIFF
--- a/.github/workflows/leak.yml
+++ b/.github/workflows/leak.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           ./koch.py all-strict \
             -d:useMalloc \
+            -d:leakTest \
             --passC:-fsanitize=leak \
             --passC:"-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" \
             --passL:-fsanitize=leak \

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -519,7 +519,7 @@ proc mainCommand*(graph: ModuleGraph) =
   when defined(nimDebugUnreportedErrors):
     addExitProc proc = echoAndResetUnreportedErrors(conf)
 
-  when defined(gcOrc):
+  when defined(gcOrc) and not defined(leakTest):
     # Compilation is currently very taxing on ORC due to frequent
     # creations and destructions of ref objects with potential cycles.
     #
@@ -528,6 +528,10 @@ proc mainCommand*(graph: ModuleGraph) =
     #
     # We don't collect cycles afterwards as the command is one-shot and
     # memory should be freed once the program stops.
+    #
+    # An exception is made for when running the leak test, as not running the
+    # cycle collector would mean that all reference cycles stay reachable
+    # (through the potential cycle root list).
     GC_disableOrc()
 
   ## process all commands


### PR DESCRIPTION
## Summary

Even when ORC is disabled at run-time, cells potentially part of
reference cycles are added to potential-cycle-root list, preventing
the leak sanitizer from detecting cycles not being free.

The `leakTest` define is now passed to the compiler when leak-
testing, with ORC enabled when the define is present.