### PR TITLE
mirpasses: better elision of temporaries

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -19,11 +19,9 @@
 ##
 ## The values of rvalue operations, calls, and construction are first captured
 ## in temporaries (as the MIR doesn't support them being used as, e.g., call
-## arguments directly). Lvalues that have side-effects (e.g., index errors)
-## are captured (together with their side-effects) via MIR alias. In general,
-## all call arguments are first assigned to a temporary, except if the
-## expression is stable (in case of by-name arguments) or pure (in case of
-## non-sink by-value arguments).
+## arguments directly). In general, all call arguments are first assigned to a
+## temporary, except if the expression is stable (in case of by-name
+## arguments) or pure (in case of non-sink by-value arguments).
 ##
 ## Pure expression are those that don't have side-effect and always refer to
 ## the exact same value, whereas stable expression are those that don't have
@@ -267,7 +265,7 @@ func isPure(tree: MirTree, n: NodePosition): bool =
 
 func isStable(tree: MirTree, n: NodePosition): bool =
   ## Returns whether the run-time address of the lvalue expression `n` is
-  ## always the same and whether the expression is side-effect free.
+  ## always the same, regardless of when the address is computed.
   case tree[n].kind
   of mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp, mnkAlias:
     true

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -186,10 +186,15 @@ proc lowerSwap(tree: MirTree, changes: var Changeset) =
 proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
   ## Where safe (i.e., observable program behaviour does not change), elides
   ## temporaries in a backend-agnostice way. This is an optimization.
-  const Ignore = IntegralTypes + {tyPtr, tyPointer, tyRef, tyVar, tyLent,
-                                  tyOpenArray, tyProc}
-    ## ignored by the optimization pass. These are types where a copy is
-    ## faster than creating a reference
+  ##
+  ## For example:
+  ##
+  ##   def _1 = a.b.c
+  ##   call(arg _1)
+  ##
+  ## would be transformed into:
+  ##
+  ##   call(arg a.b.c)
   var ct = initCountTable[uint32]()
 
   # first pass: gather all single-use temporaries that are created from
@@ -200,7 +205,6 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
     of mnkDef, mnkDefCursor:
       let e = tree.operand(i, 1)
       if tree[i, 0].kind == mnkTemp and
-         tree[i, 0].typ.skipTypes(LocSkip).kind notin Ignore and
          tree[e].kind in LvalueExprKinds and
          tree[getRoot(tree, e)].kind != mnkTemp:
         # definition of a temporary into which an lvalue is assigned. Elision
@@ -210,9 +214,26 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
 
       i = NodePosition e # skip to the source expression
     of mnkTemp:
+      # treat as usage
+      # XXX: this is brittle. Usages should be detected through DFA, not by
+      #      looking for names
       let id = tree[i].temp
       if hasKey(ct, id.uint32):
         ct.inc(id.uint32)
+      inc i
+    of mnkDeref, mnkDerefView:
+      # a non-name lvalue expression cannot be placed into deref slots. All
+      # analysed temporaries are assumed to have been initialized with a non-
+      # name lvalue expression, so if a temporary appears in a deref slot,
+      # elision of said temporary is disabled
+      if tree[i, 0].kind == mnkTemp:
+        ct.del(tree[i, 0].temp.uint32) # treat as not eligible
+      i = tree.sibling(i) # skip the deref
+    of mnkPathArray:
+      # for array index slots, the above also applies
+      let index = tree.child(i, 1)
+      if tree[index].kind == mnkTemp:
+        ct.del(tree[index].temp.uint32)
       inc i
     else:
       inc i
@@ -313,16 +334,12 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
         unreachable(tree[expr].kind)
 
       if elide:
-        # XXX: lvalue expression can currently have side-effects, so
-        #      forwarding the expression would change behaviour. Instead, the
-        #      temporary is turned into an alias
-        let
-          alias = MirNode(kind: mnkAlias, typ: tree[n].typ, temp: tree[n].temp)
-          def = tree.parent(n)
-
-        changes.changeTree(tree, def): MirNode(kind: mnkBind)
-        changes.replace(tree, n): alias
-        changes.replace(tree, pos): alias
+        # remove the definition of the temporary:
+        changes.remove(tree, def)
+        # replace the temporary's only usage with the lvalue expression it was
+        # created from:
+        changes.replaceMulti(tree, pos, bu):
+          bu.emitFrom(tree, tree.child(def, 1))
 
 proc applyPasses*(body: var MirBody, prc: PSym, config: ConfigRef,
                   target: TargetBackend) =

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -197,6 +197,16 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
   ##   call(arg a.b.c)
   var ct = initCountTable[uint32]()
 
+  proc isDangerous(tree: MirTree, n: NodePosition): bool =
+    # HACK: this is a tremendous hack to detect whether `n` is part of a
+    #       loose expression, which are currently required by expression
+    #       support for ``vmjit``. Remove as soon as no longer needed
+    var i = int n
+    while i < tree.len and tree[i].kind notin StmtNodes:
+      inc i
+
+    result = i >= tree.len
+
   # first pass: gather all single-use temporaries that are created from
   # lvalues and are eligible for elimination.
   var i = NodePosition 0
@@ -219,7 +229,11 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
       #      looking for names
       let id = tree[i].temp
       if hasKey(ct, id.uint32):
-        ct.inc(id.uint32)
+        if isDangerous(tree, i):
+          ct.del(id.uint32)
+        else:
+          ct.inc(id.uint32)
+
       inc i
     of mnkDeref, mnkDerefView:
       # a non-name lvalue expression cannot be placed into deref slots. All

--- a/tests/js/tjsffi.nim
+++ b/tests/js/tjsffi.nim
@@ -189,7 +189,7 @@ block:
     # a ``JsObject``. This is not guaranteed to work, and in this case it
     # doesn't
     x += jsProc(10)
-    doAssert x.to(int32) == 1, "now works as expected" # expected: 12
+    doAssert x.to(int32) == 2, "now works as expected" # expected: 12
 
 block:
   {.emit:


### PR DESCRIPTION
## Summary

Adjust the temporary-elision pass such that it:
* also eliminates small-sized temporaries, such as those of `int`,
  `float`, `ref` type
* fully removes elided temporaries, instead of just turning them into
  an alias

This speeds up the code generators, since they usually have less code
and locals to process now.

## Details

With all lvalue expressions free of side effects (i.e., no exceptions
are raised), instead of optimizing
```
def_cursor _1 = x.a
call(arg _1)
```
into
```
bind _1 = x.a
call(arg _1)
```
it can be, and is, now optimized into:
```
call(arg x.a)
```

Special care has to be taken for temporaries that are used as a
dereference targets or array index operands. Those slots don't allow
for arbitrary lvalue expressions, so the elision pass conservatively
ignores temporaries used there.

In addition, small temporaries like `int`s, `float`s, etc. are
optimized away too, now. Turning them into aliases didn't warrant the
additional processing cost, but fully eliding them does.

Together, this:
* reduces the amount of locals `cgirgen` has to allocate
* reduces the amount of MIR code that the code generators have to
  process (and `cgirgen` has to translate)
* reduces the amount of code the code generators output

The VM backend benefits the most from these improvements, since
it doesn't perform any further optimization.

Due to the analysis having a significant amount of overhead at the
moment, the code generator speedups are mostly offset (but not
completely) by the optimization pass taking a lot longer.

### Misc

* update a few documentation comments in `mirgen` that still
  mentioned lvalues expressions possibly having side-effects