### PR TITLE
fix: setup emulated TLS before anything else

### DIFF
--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1204,13 +1204,6 @@ proc genDatInitCode*(m: BModule): bool =
       moduleDatInitRequired = true
       prc.add(m.s[i])
 
-  # setting up the TLS must happen before initializing the ``system`` module,
-  # so we emit the call at the end of the data-init procedure:
-  if sfSystemModule in m.module.flags and
-     emulatedThreadVars(m.config) and m.config.target.targetOS != osStandalone:
-    moduleDatInitRequired = true
-    prc.addf("\tinitThreadVarsEmulation();$N", [])
-
   prc.addf("}$N$N", [])
 
   if moduleDatInitRequired:


### PR DESCRIPTION
## Summary

Move setup of emulated thread-local storage (=TLS) before anything
else. For platforms that require loading `io` procedure from a dynamic
library (via `.dynlib`), this fixes programs immediately crashing at
start-up when using `--tlsEmulation:on`. Windows is one such platform.

## Details

The `initThreadVarsEmulation` call is now emitted at the very start of
the program entry point (`NimMain`), instead of at the end of the
`systemDatInit` procedure.

Modules `import`ed - instead of `include`d - by `system` (such as `io`)
run their module operations before `systemDatInit`. If a thread-local
variable (such as the stack-trace frame pointer or `nimInErrorMode`
global) is accessed by them to thread-local variables, the program
would crash with a nil access.