### PR TITLE
compiler: restore `.acyclic` annotation where possible

### DIFF
--- a/.github/workflows/leak.yml
+++ b/.github/workflows/leak.yml
@@ -2,12 +2,14 @@ name: Test compiler and tools for memory leaks
 
 on:
   # This is for passing required checks
-  push:
   pull_request:
   merge_group:
 
 jobs:
   leaktest:
+    # Skip this for PRs
+    if: github.event_name != 'pull_request'
+
     name: Compiler and tools leak test
     runs-on: ubuntu-latest
 

--- a/.github/workflows/leak.yml
+++ b/.github/workflows/leak.yml
@@ -2,14 +2,12 @@ name: Test compiler and tools for memory leaks
 
 on:
   # This is for passing required checks
+  push:
   pull_request:
   merge_group:
 
 jobs:
   leaktest:
-    # Skip this for PRs
-    if: github.event_name != 'pull_request'
-
     name: Compiler and tools leak test
     runs-on: ubuntu-latest
 

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -226,8 +226,8 @@ type
     base*: NumericalBase
     literal*: string
 
-  # TODO: This type should be marked acyclic
-  ParsedNodeData*{.final.} = object
+  ParsedNodeData*{.final, acyclic.} = object
+    ## The AST is a tree, the nodes can never form a cycle.
     # TODO: replace token fields with indexing into a token sequence, this
     #       should also address line info tracking.
     comment*: string       # TODO: replace with an index into a token stream

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1562,7 +1562,9 @@ type
         discard
 
   TNode*{.final.} = object # on a 32bit machine, this takes 32 bytes
-                                    # on a 64bit machine, this takes 40 bytes
+                           # on a 64bit machine, this takes 40 bytes
+    # NOTE: don't mark as `.acyclic`. User-created AST might form cycles, and
+    # nodes can also form reference cycles with ``PSym`` and ``PType``
     typ*: PType
     id*: NodeId  # placed after `typ` field to save space due to field alignment
     info*: TLineInfo

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1256,7 +1256,7 @@ type
     adSemDeprecatedCompilerOptArg   # warning promoted to error
 
   PAstDiag* = ref TAstDiag
-  TAstDiag* = object
+  TAstDiag* {.acyclic.} = object
     # xxx: consider splitting storage type vs message
     # xxx: consider breaking up diag into smaller types
     # xxx: try to shrink the int/int128 etc types for counts/ordinals
@@ -1642,8 +1642,8 @@ type
 
   PInstantiation* = ref TInstantiation
 
-  # TODO: This type should be marked acyclic
-  TScope* = object
+  TScope* {.acyclic.} = object
+    ## Scopes form a stack; cycles are not allowed.
     depthLevel*: int
     symbols*: TStrTable
     parent*: PScope

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1257,6 +1257,8 @@ type
 
   PAstDiag* = ref TAstDiag
   TAstDiag* {.acyclic.} = object
+    ## A diagnostic must never store a tree that references the diagnostic
+    ## itself.
     # xxx: consider splitting storage type vs message
     # xxx: consider breaking up diag into smaller types
     # xxx: try to shrink the int/int128 etc types for counts/ordinals

--- a/compiler/ast/idents.nim
+++ b/compiler/ast/idents.nim
@@ -22,8 +22,8 @@ import
 
 type
   PIdent* = ref TIdent
-  # TODO: This type should be marked acyclic
-  TIdent* = object
+  TIdent* {.acyclic.} = object
+    ## Identifiers only form a chain, cycles are disallowed.
     id*: int ## unique id; use this for comparisons and not the pointers
     s*: string
     next*: PIdent ## for hash-table chaining

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -59,9 +59,8 @@ type
 
   POptionEntry* = ref TOptionEntry
   PProcCon* = ref TProcCon
-  # TODO: This type should be marked acyclic
-  TProcCon* = object ## procedure context; also used for top-level
-                                 ## statements
+  TProcCon* {.acyclic.} = object
+    ## procedure context; also used for top-level statements
     owner*: PSym              ## the symbol this context belongs to
     resultSym*: PSym          ## the result symbol (if we are in a proc)
     next*: PProcCon           ## used for stacking procedure contexts

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -121,8 +121,7 @@ proc cacheTypeInst(c: PContext; inst: PType) =
   addToGenericCache(c, gt.sym, inst)
 
 type
-  # TODO: This type should be marked acyclic
-  LayeredIdTable* = ref object
+  LayeredIdTable* {.acyclic.} = ref object
     topLayer*: TIdTable
     nextLayer*: LayeredIdTable
 

--- a/compiler/utils/btrees.nim
+++ b/compiler/utils/btrees.nim
@@ -16,8 +16,7 @@ const
   Mhalf = M div 2
 
 type
-  # TODO: This type should be marked acyclic
-  Node[Key, Val]  = ref object
+  Node[Key, Val] {.acyclic.} = ref object
     entries: int
     keys: array[M, Key]
     case isInternal: bool


### PR DESCRIPTION
## Summary

Mark cyclic types that cannot form reference cycles at run-time with
`.acyclic`. This reduces both the pressure on the cycle collector as
well as reference counting overhead for the types in question.

## Details

* a comment is added to types for which it's not obvious why they
  cannot form reference cycles
* `ModulfGraph` and `ConfigRef` aren't marked with `.acyclic`, since
  they both store non-final `ref` types or closures, which can
  introduce valid reference cycles