### PR TITLE
niminst: use 7-Zip to create zip archives 

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -30,7 +30,7 @@ jobs:
     #               varies based on outside environment.
 
     # Skip this for PRs
-    if: github.event_name != 'pull_request'
+    #if: github.event_name != 'pull_request'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -30,7 +30,7 @@ jobs:
     #               varies based on outside environment.
 
     # Skip this for PRs
-    #if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
 
     strategy:
       fail-fast: false

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -963,8 +963,18 @@ proc createArchiveDist(c: var ConfigData) =
       let fileList = archiveBaseName & ".files.txt"
       writeFile(fileList, paths.join("\n"))
 
+      # Set timezone to UTC so that timestamp recorded in the zip file is not
+      # affected by the timezone.
+      putEnv("TZ", "UTC")
+
       manifest.name = archiveBaseName & ".zip"
-      checkedExec("7za", "a", "-tzip", manifest.name, "@" & fileList)
+      checkedExec("7za", "a",
+                  "-tzip",
+                  "-mtc=off",
+                  "-mcu=on",
+                  "-sse",
+                  manifest.name,
+                  "@" & fileList)
 
     of tarFormats:
       # Write the list into a file then supply that file to archival programs to

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -972,7 +972,6 @@ proc createArchiveDist(c: var ConfigData) =
                   "-tzip",
                   "-mtc=off",
                   "-mcu=on",
-                  "-sse",
                   manifest.name,
                   "@" & fileList)
 

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -971,6 +971,9 @@ proc createArchiveDist(c: var ConfigData) =
       checkedExec("7za", "a",
                   "-tzip",
                   "-mtc=off",
+                  "-mcl=off",
+                  "-scsUTF-8",
+                  "-sccUTF-8",
                   "-mcu=on",
                   manifest.name,
                   "@" & fileList)

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -967,14 +967,16 @@ proc createArchiveDist(c: var ConfigData) =
       # affected by the timezone.
       putEnv("TZ", "UTC")
 
+      # Force UTF-8 C locale for LC_CTYPE to prevent 7z from trying to convert
+      # the file list.
+      putEnv("LC_CTYPE", "C.utf8")
+
       manifest.name = archiveBaseName & ".zip"
       checkedExec("7za", "a",
                   "-tzip",
-                  "-mtc=off",
-                  "-mcl=off",
-                  "-scsUTF-8",
+                  "-mcu",
+                  "-mtc-",
                   "-sccUTF-8",
-                  "-mcu=on",
                   manifest.name,
                   "@" & fileList)
 

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -967,18 +967,19 @@ proc createArchiveDist(c: var ConfigData) =
       # affected by the timezone.
       putEnv("TZ", "UTC")
 
-      # Force UTF-8 C locale for LC_CTYPE to prevent 7z from trying to convert
-      # the file list.
-      putEnv("LC_CTYPE", "C.utf8")
+      # Force UTF-8 C locale to prevent 7z from trying to convert
+      # the file list on non-UTF-8 locales.
+      putEnv("LC_ALL", "C.utf8")
 
       manifest.name = archiveBaseName & ".zip"
-      checkedExec("7za", "a",
-                  "-tzip",
-                  "-mcu",
-                  "-mtc-",
-                  "-sccUTF-8",
-                  manifest.name,
-                  "@" & fileList)
+      checkedExec(
+        "7z", "a",
+        "-tzip",
+        "-mcu",      # Use UTF-8 encoding for non-ASCII
+        "-mtc-",     # Disable storing extra timestamps
+        "-sccUTF-8", # Use UTF-8 when printing to console
+        manifest.name, "@" & fileList
+      )
 
     of tarFormats:
       # Write the list into a file then supply that file to archival programs to


### PR DESCRIPTION
## Summary

This pull switches from using Info-ZIP to 7-Zip for creating Zip
archives. This makes sure that the build works correctly on Windows
regardless of locale.

## Details

While we originally moved away a while back, there are a few issues with
Info-ZIP:

- It uses "legacy" APIs on Windows, and is not Unicode aware on such
systems. This makes it unable to ingest the file list on Windows
depending on locale.
- It is not as widely available on Windows systems as 7-Zip
- Development of Info-ZIP has largely stopped, so the issues we found
are unlikely to be fixed.

The original concerns that lead to moving away from this was that
Info-ZIP has explicit support for omitting some metadata. Reexamining
7-Zip, I found that:

- 7-Zip does not support these extra metadata in the ancient version
used by most Linux distros. Later versions of 7-Zip supports these, but
have them disabled by default.
- While there are some problems with filename encoding if locale does
not support UTF-8, this problem seems to be isolated to Unix and can be
solved by forcing the locale to  `C.utf8` , which is done here.