### PR TITLE
shellrunner: add Windows support

### DIFF
--- a/lib/experimental/shellrunner.nim
+++ b/lib/experimental/shellrunner.nim
@@ -207,7 +207,7 @@ proc exec*(
     q[i] = start(cmds[i], dir = dir, options = options)
     idxs[i] = i
     when defined(windows):
-      w[i] = q[i].fProcessHandle
+      w[i] = q[i].processHandle
     inc(i)
 
   var ecount = len(cmds)
@@ -225,8 +225,8 @@ proc exec*(
       else:
         var status: int32
         for r in 0..m-1:
-          if not isNil(q[r]) and q[r].fProcessHandle == w[ret]:
-            discard getExitCodeProcess(q[r].fProcessHandle, status)
+          if not isNil(q[r]) and q[r].processHandle == w[ret]:
+            discard getExitCodeProcess(q[r].processHandle, status)
             q[r].exitFlag = true
             q[r].exitStatus = status
             rexit = r
@@ -262,7 +262,7 @@ proc exec*(
 
     if rexit >= 0:
       when defined(windows):
-        let processHandle = q[rexit].fProcessHandle
+        let processHandle = q[rexit].processHandle
       if afterRunEvent != nil:
         afterRunEvent(idxs[rexit], q[rexit])
 
@@ -281,7 +281,7 @@ proc exec*(
         q[rexit] = start(cmds[i], options = options)
         idxs[rexit] = i
         when defined(windows):
-          w[rexit] = q[rexit].fProcessHandle
+          w[rexit] = q[rexit].processHandle
         inc(i)
       else:
         when defined(windows):

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -203,6 +203,15 @@ proc kill*(p: Process) {.rtl, extern: "nosp$1", tags: [].}
 proc running*(p: Process): bool {.rtl, extern: "nosp$1", tags: [].}
   ## Returns true if the process `p` is still running. Returns immediately.
 
+when defined(windows) or defined(nimdoc):
+  proc processHandle*(p: Process): int {.rtl, extern: "nosp$1".}
+    ## Returns `p`'s process handle, which is unique for the process
+    ## even after it has stopped execution.
+    ##
+    ## The handle is valid until `p` is closed.
+    ##
+    ## This procedure is only supported on Windows at the moment.
+
 proc processID*(p: Process): int {.rtl, extern: "nosp$1".} =
   ## Returns `p`'s process ID.
   ##
@@ -810,6 +819,9 @@ when defined(windows) and not defined(useNimRtl):
 
   proc kill(p: Process) =
     terminate(p)
+
+  proc processHandle(p: Process): int =
+    p.fProcessHandle
 
   proc waitForExit(p: Process, timeout: int = -1): int =
     if p.exitFlag:
@@ -1581,6 +1593,9 @@ elif not defined(useNimRtl):
 
     result = int(select(cint(m+1), addr(rd), nil, nil, nil)) == 1
 
+  when defined(nimdoc):
+    # Default implementations for docgen
+    proc processHandle(p: Process): int = discard
 
 proc execCmdEx*(command: string, options: set[ProcessOption] = {
                 poStdErrToStdOut, poUsePath}, env: StringTableRef = nil,


### PR DESCRIPTION
## Summary
This pull request adds support for Windows to `std/shellrunner`.

## Details
Most of the code is already there, having originated from osproc. Only a
new API has to be added to osproc to expose the process handle for
Windows.

In the future the process handle API could be expanded to POSIX systems
where pidfd is available (ie. Linux, FreeBSD).