### PR TITLE
testament: don't close Process before reading exit code

### DIFF
--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -400,6 +400,7 @@ proc callNimCompiler(cmd: string): CompilerOutput =
   verboseCmd(cmd)
   var p = startProcess(command = cmd,
                        options = {poStdErrToStdOut, poUsePath, poEvalCommand})
+  defer: close(p)
   let outp = p.outputStream
   var foundSuccessMsg = false
   var foundErrorMsg = false
@@ -418,7 +419,6 @@ proc callNimCompiler(cmd: string): CompilerOutput =
         foundSuccessMsg = true
     elif not running(p):
       break
-  close(p)
   result.msg = ""
   result.file = ""
   result.output = ""

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -400,6 +400,7 @@ proc callNimCompiler(cmd: string): CompilerOutput =
   verboseCmd(cmd)
   var p = startProcess(command = cmd,
                        options = {poStdErrToStdOut, poUsePath, poEvalCommand})
+  # windows requires reading the the exit code (below) prior to closing
   defer: close(p)
   let outp = p.outputStream
   var foundSuccessMsg = false


### PR DESCRIPTION
## Summary

On Windows Testament now correctly captures the exit code from commands
(compile, test run, etc).

## Details

On platforms like Windows closing a process before reading the exit code
invalidates the exit code, returning 0, which would falsely signify a
success.

Instead, use  `defer`  to make sure that the object is kept alive until
the end of scope.