### PR TITLE
tests: avoid importing posix on non-POSIX systems

### DIFF
--- a/tests/effects/tstrict_funcs_imports.nim
+++ b/tests/effects/tstrict_funcs_imports.nim
@@ -36,7 +36,6 @@ import
   dynlib,
   encodings,
   endians,
-  epoll,
   fenv,
   hashes,
   heapqueue,
@@ -44,10 +43,8 @@ import
   htmlparser,
   httpclient,
   httpcore,
-  inotify,
   intsets,
   json,
-  kqueue,
   lenientops,
   lexbase,
   lists,
@@ -164,5 +161,8 @@ import std/private/[
 
 when defined(posix):
   import std/[
+    epoll,
+    inotify,
+    kqueue,
     posix_utils,
   ]

--- a/tests/lang_experimental/concepts/tconcepts_issues.nim
+++ b/tests/lang_experimental/concepts/tconcepts_issues.nim
@@ -31,7 +31,7 @@ Meow
 joinable: false
 """
 
-import macros, typetraits, os
+import macros, typetraits, os, posix
 
 
 block t5983:

--- a/tests/lang_experimental/concepts/tconcepts_issues.nim
+++ b/tests/lang_experimental/concepts/tconcepts_issues.nim
@@ -31,7 +31,7 @@ Meow
 joinable: false
 """
 
-import macros, typetraits, os, posix
+import macros, typetraits, os
 
 
 block t5983:

--- a/tests/stylecheck/tstyle_imports.nim
+++ b/tests/stylecheck/tstyle_imports.nim
@@ -34,7 +34,6 @@ import
   dynlib,
   encodings,
   endians,
-  epoll,
   fenv,
   hashes,
   heapqueue,
@@ -45,7 +44,6 @@ import
   #inotify,
   intsets,
   json,
-  kqueue,
   lenientops,
   lexbase,
   lists,
@@ -168,5 +166,7 @@ import std/private/[
 
 when defined(posix):
   import std/[
+    epoll,
+    kqueue,
     posix_utils,
   ]


### PR DESCRIPTION
## Summary

Importing posix or modules that are meant to work on POSIX systems will make tests unable to compile on non-POSIX platforms (ie. Windows) due to missing required C headers.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
* Cherry picked from #1123 
* I'm not sure if importing `posix` is required for `tconcepts_issues` (ie. due to unwanted interactions), but I haven't seen complaints from CI so far, nor was there any references to symbols defined in posix.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
