### PR TITLE
mir: use IDs for more entities

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -4,7 +4,7 @@ import
   std/[
     deques,
     dynlib, # for computing possible candidate names
-    intsets
+    tables
   ],
   compiler/ast/[
     ast,
@@ -23,6 +23,7 @@ import
     mirbodies,
     mirbridge,
     mirconstr,
+    mirenv,
     mirgen,
     mirpasses,
     mirtrees,
@@ -56,31 +57,19 @@ type
       ## if ``true``, indicates that a procedure with a body should not be
       ## treated as imported, even if it's marked as such
 
-  Queue*[T] = object
-    ## Combines a sequence of items with a "read" cursor.
-    data: seq[T]
-    progress: int
-      ## remembers the position until which the items have already
-      ## been processed
-
   DiscoveryData* = object
     ## Bundles all data needed during the disovery of alive, backend-relevant
     ## entities.
-    # XXX: this type does too much. It acts as both a symbol table and
-    #      communication interface. Eventually, it should be split up.
-    seen: IntSet
-      ## remembers the symbol ID of all discovered entities
-
-    procedures*: Queue[PSym]
-    constants*: Queue[PSym]
-    globals*: Queue[PSym]
-    threadvars*: Queue[PSym]
-
+    progress: EnvCheckpoint
+      ## tracks how much of the environment was already processed (e.g.,
+      ## translated, scanned, etc.)
     libs*: seq[LibId]
       ## all dynamic libraries that the alive graph depends on
 
-    additional: seq[tuple[m: FileIndex, prc: PSym]]
-      # HACK: see documentation of the procedure that appends to this list
+    overrides: Table[ProcedureId, FileIndex]
+      ## maps a procedure to the module it needs to be queued with.
+      ## If not overriden, a procedure is queued with the module it's
+      ## discovered from.
 
   BackendEventKind* = enum
     bekDiscovered## a new entity was discovered during MIR processing. This
@@ -105,18 +94,19 @@ type
 
     case kind*: BackendEventKind
     of bekDiscovered:
-      entityId*: int
-        ## the position of the symbol within its ``DiscoveryData`` table
-      entity*: PSym
+      entity*: MirNode
         ## a reference to the discovered entity
     of bekModule:
       discard
     of bekConstant:
-      cnst*: PSym
-        ## the symbol of the constant the event is about
+      cnst*: ConstId
+        ## the ID of the constant
     of bekPartial, bekProcedure, bekImported:
+      id*: ProcedureId
+        ## the ID of the procedure
       sym*: PSym
         ## the symbol of the procedure the event is about
+        ## XXX: only here for convenience, remove it once feasible
       body*: MirBody
 
   WorkItemKind = enum
@@ -142,22 +132,22 @@ type
     ## queue. `WorkItem` describes a step.
     case kind: WorkItemKind
     of wikPreprocess:
-      raw: PSym
+      raw: ProcedureId
     of wikProcess:
-      prc: PSym
+      prc: ProcedureId
       body: PNode
     of wikProcessConst, wikReportConst:
-      cnst: PSym
+      cnst: ConstId
     of wikProcessGlobals:
       globals: seq[PNode]
         ## the unprocessed identdefs of globals lifted from a procedure's
         ## body. Due to how ``transf`` handles inlining, this list can
         ## contain duplicates
     of wikImported:
-      imported: PSym
+      imported: ProcedureId
     of wikReport:
       evt: range[bekPartial..bekImported]
-      fragSym: PSym
+      fragId: ProcedureId
       frag: MirBody
 
   WorkQueue = object
@@ -175,41 +165,6 @@ func append(queue: var WorkQueue, m: FileIndex,
             item: sink WorkItem) {.inline.} =
   ## Adds `item` to the end of the queue.
   queue.items.addLast (item, m)
-
-# ----- private and public API for ``Queue`` -----
-
-iterator visit*[T](q: var Queue[T]): (int, lent T) =
-  ## Returns all unread items from `q` together with their index, and marks
-  ## them the items as read (or processed).
-  while q.progress < q.data.len:
-    yield (q.progress, q.data[q.progress])
-    inc q.progress
-
-iterator peek*[T](q: Queue[T]): (int, lent T) =
-  ## Returns all unread items from `q` together with their index, but doesn't
-  ## mark them as read.
-  for i in q.progress..<q.data.len:
-    yield (i, q.data[i])
-
-iterator all*[T](q: Queue[T]): (int, lent T) =
-  ## Returns *all* items (regardless of whether their read or unread) from
-  ## `q` together with their index.
-  for i in 0..<q.data.len:
-    yield (i, q.data[i])
-
-func len*[T](q: Queue[T]): int =
-  q.data.len
-
-func isProcessed*[T](q: Queue[T]): bool =
-  q.progress == q.data.len
-
-func add[T](q: var Queue[T], item: sink T) =
-  q.data.add item
-
-func addProcessed[T](q: var Queue[T], item: sink T) =
-  assert q.progress == q.data.len
-  q.data.add item
-  inc q.progress
 
 func moduleId*(o: PIdObj): int32 {.inline.} =
   ## Returns the ID of the module `o` is *attached* to. Do note that in the
@@ -310,7 +265,7 @@ func isEmpty*(tree: MirTree): bool =
 func isEmpty*(f: MirBody): bool {.inline.} =
   isEmpty(f.code)
 
-iterator deps*(tree: MirTree): PSym =
+iterator deps*(tree: MirTree): lent MirNode =
   ## Returns all external entities (procedures, globals, etc.) that `tree`
   ## references *directly*, in an unspecified order.
   var i = NodePosition(0)
@@ -322,9 +277,9 @@ iterator deps*(tree: MirTree): PSym =
       i = NodePosition tree.operand(i, 1)
       continue
     of mnkProc:
-      yield n.sym
-    of mnkConst, mnkGlobal:
-      yield n.sym
+      yield tree[i]
+    of mnkGlobal:
+      yield tree[i]
     else:
       discard "nothing to do"
 
@@ -333,14 +288,15 @@ iterator deps*(tree: MirTree): PSym =
 # ----- procedure lowering and transformation -----
 
 proc preprocess*(queue: var WorkQueue, graph: ModuleGraph, idgen: IdGenerator,
-                 prc: PSym, module: FileIndex) =
+                 env: MirEnv, id: ProcedureId, module: FileIndex) =
   ## Runs the ``transf`` pass on the body of `prc` and queues the steps
   ## needed for fully processing the procedure. `module` is the module the
   ## step was queued from: it's used as the module the next processing is
   ## queued from.
+  let prc = env[id]
   if exfDynamicLib in prc.extFlags:
     # a procedure imported at runtime, it has no body
-    queue.prepend(module, WorkItem(kind: wikImported, imported: prc))
+    queue.prepend(module, WorkItem(kind: wikImported, imported: id))
     return
 
   var body = transformBodyWithCache(graph, idgen, prc)
@@ -352,7 +308,7 @@ proc preprocess*(queue: var WorkQueue, graph: ModuleGraph, idgen: IdGenerator,
   extractGlobals(body, globals,
                  isNimVm = goIsNimvm in queue.config.tconfig.options)
 
-  queue.prepend(module, WorkItem(kind: wikProcess, prc: prc, body: body))
+  queue.prepend(module, WorkItem(kind: wikProcess, prc: id, body: body))
 
   if globals.len > 0:
     # processing the lifted globals has to happen *before* processing the
@@ -362,11 +318,11 @@ proc preprocess*(queue: var WorkQueue, graph: ModuleGraph, idgen: IdGenerator,
       WorkItem(kind: wikProcessGlobals, globals: move globals)
 
 proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
-             idgen: IdGenerator) =
-  ## Applies all applicable MIR passes to the `body`. `prc` is enclosing
+             idgen: IdGenerator, env: var MirEnv) =
+  ## Applies all applicable MIR passes to the `body`. `prc` is the enclosing
   ## procedure.
   if shouldInjectDestructorCalls(prc):
-    injectDestructorCalls(graph, idgen, prc, body)
+    injectDestructorCalls(graph, idgen, env, prc, body)
 
   let target =
     case graph.config.backend
@@ -377,27 +333,30 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
 
   applyPasses(body, prc, graph.config, target)
 
-proc translate*(prc: PSym, body: PNode, graph: ModuleGraph,
-                config: BackendConfig, idgen: IdGenerator): MirBody =
+proc translate*(id: ProcedureId, body: PNode, graph: ModuleGraph,
+                config: BackendConfig, idgen: IdGenerator,
+                env: var MirEnv): MirBody =
   ## Translates `body` to MIR code, applies all applicable MIR passes, and
-  ## returns the result. `prc` is the enclosing procedure.
+  ## returns the result. `id` is the ID of the procedure the fragment belongs
+  ## to.
+  let prc = env[id]
   if optCursorInference in graph.config.options and
       shouldInjectDestructorCalls(prc):
     # TODO: turn cursor inference into a MIR pass and remove this part
     computeCursors(prc, body, graph)
 
   echoInput(graph.config, prc, body)
-  result = generateCode(graph, prc, config.tconfig, body)
+  result = generateCode(graph, env, prc, config.tconfig, body)
   echoMir(graph.config, prc, result)
 
   # now apply the passes:
-  process(result, prc, graph, idgen)
+  process(result, prc, graph, idgen, env)
 
-proc generateIR*(graph: ModuleGraph, idgen: IdGenerator,
+proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
                  owner: PSym, body: sink MirBody): Body =
   ## Translates the MIR code provided by `code` into ``CgNode`` IR and,
   ## if enabled, echoes the result.
-  result = cgirgen.generateIR(graph, idgen, owner, body)
+  result = cgirgen.generateIR(graph, idgen, env, owner, body)
   echoOutput(graph.config, owner, result)
 
 # ------- handling of lifted globals ---------
@@ -610,30 +569,9 @@ proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
 
 # ----- discovery and queueing logic -----
 
-func includeIfUnseen(q: var Queue[PSym], marker: var IntSet, sym: PSym) =
-  if not marker.containsOrIncl(sym.id):
-    q.data.add(sym)
-
-template register(data: var DiscoveryData, queue: untyped, s: PSym) =
-  data.queue.includeIfUnseen(data.seen, s)
-
-func discoverFrom*(data: var DiscoveryData, body: MirTree) =
-  ## Updates `data` with all not-yet-seen entities (except for globals) that
-  ## `body` references.
-  for dep in deps(body):
-    case dep.kind
-    of routineKinds:
-      register(data, procedures, dep)
-    of skConst:
-      register(data, constants, dep)
-    of skVar, skLet, skForVar:
-      discard "a global; ignore"
-    else:
-      unreachable()
-
-func discoverFrom*(data: var DiscoveryData, decl: PNode) =
-  ## Updates `data` with all not-yet-seen entities from the declarative
-  ## statement list `decl`.
+func discoverFrom*(env: var MirEnv, decl: PNode) =
+  ## Updates `env` with all not-yet-seen entities from the list of declarative
+  ## statements (`decl`).
   if decl.kind == nkEmpty:
     return # nothing to do
 
@@ -645,9 +583,9 @@ func discoverFrom*(data: var DiscoveryData, decl: PNode) =
       if {sfExportc, sfCompilerProc} * prc.flags == {sfExportc} or
          (sfExportc in prc.flags and exfExportLib in prc.extFlags):
         # an exported routine. It must always have code generated for it. Note
-        # that compilerprocs, while exported, are still only have code generated
+        # that compilerprocs, while exported, still only have code generated
         # for them when used
-        register(data, procedures, prc)
+        discard env.procedures.add(prc)
     of nkIteratorDef:
       discard "ignore; cannot be exported"
     of nkConstSection:
@@ -656,28 +594,28 @@ func discoverFrom*(data: var DiscoveryData, decl: PNode) =
         if it.kind == nkConstDef:
           let s = it[0].sym
           if {sfExportc, sfCompilerProc} * s.flags == {sfExportc}:
-            register(data, constants, s)
+            discard env.constants.add(s)
 
     of nkTypeSection:
       discard
     else:
       unreachable(n.kind)
 
-func discoverFromValueAst(data: var DiscoveryData, ast: PNode) =
-  ## Discover new routines from `ast`, which is an AST representing a value
+func discoverFromValueAst(env: var MirEnv, ast: PNode) =
+  ## Discovers new routines from `ast`, which is an AST representing a value
   ## construction expression.
   case ast.kind
   of nkSym:
     let s = ast.sym
     if s.kind in routineKinds:
-      register(data, procedures, s)
+      discard env.procedures.add(s)
   of nkWithSons:
     for n in ast.items:
-      discoverFromValueAst(data, n)
+      discoverFromValueAst(env, n)
   of nkWithoutSons - {nkSym}:
     discard "nothing to do"
 
-func queue(queue: var WorkQueue, prc: PSym, m: FileIndex) =
+func queue(queue: var WorkQueue, id: ProcedureId, prc: PSym, m: FileIndex) =
   ## If eligible for processing and code generation, adds `prc` to
   ## `queue`'s queue.
   assert prc.kind in routineKinds
@@ -685,77 +623,75 @@ func queue(queue: var WorkQueue, prc: PSym, m: FileIndex) =
      (sfImportc notin prc.flags or
       exfDynamicLib in prc.extFlags or (queue.config.noImported and
                                         prc.ast[bodyPos].kind != nkEmpty)):
-    queue.append(m, WorkItem(kind: wikPreprocess, raw: prc))
+    queue.append(m, WorkItem(kind: wikPreprocess, raw: id))
 
-iterator flush(queue: var WorkQueue, data: var DiscoveryData,
-               origin: FileIndex): BackendEvent =
+iterator flush(queue: var WorkQueue, env: var MirEnv,
+               data: var DiscoveryData, origin: FileIndex): BackendEvent =
   ## Commits to all unprocessed entities in `env`. This means:
   ## * for procedures to queue them for translation/code-generation
   ## * for named constants to queue them for translation/code-generation
   ##
   ## In addition, a ``bekDiscovered`` event is raised (i.e., returned) for
   ## every commited-to entity.
-  template event(i, it): untyped =
-    BackendEvent(module: origin, kind: bekDiscovered, entityId: i,
-                 entity: it)
+  let next = checkpoint(env)
 
-  for i, it in visit(data.procedures):
+  template event(e): untyped =
+    BackendEvent(module: origin, kind: bekDiscovered, entity: e)
+
+  for id, it in since(env.procedures, data.progress.procs):
     # report the procedure before queuing it
-    yield event(i, it)
-    queue(queue, it, origin)
+    yield event(MirNode(kind: mnkProc, prc: id))
+    queue(queue, id, it, origin)
 
-  for i, it in visit(data.constants):
-    yield event(i, it)
+  for id, _ in since(env.constants, data.progress.consts):
+    yield event(MirNode(kind: mnkConst, cnst: id))
     # constants are translated and reported *before* the finished procedure
     # they were reported as part of is
-    queue.prepend(origin, WorkItem(kind: wikProcessConst, cnst: it))
+    queue.prepend(origin, WorkItem(kind: wikProcessConst, cnst: id))
 
-  for i, it in visit(data.globals):
-    yield event(i, it)
+  for id, _ in since(env.globals, data.progress.globals):
+    yield event(MirNode(kind: mnkGlobal, global: id))
 
-  for i, it in visit(data.threadvars):
-    yield event(i, it)
+  assert next == checkpoint(env), "the environment was modified"
+  # move the progress cursor:
+  data.progress = next
 
 # ----- ``process`` iterator implementation -----
 
 proc isTrivialProc(graph: ModuleGraph, prc: PSym): bool {.inline.} =
   getBody(graph, prc).kind == nkEmpty
 
-proc pushProgress(queue: var WorkQueue, discovery: var DiscoveryData,
-                  graph: ModuleGraph, idgen: IdGenerator,
-                  prc: PSym, frag: sink MirBody, m: FileIndex) =
+proc pushProgress(queue: var WorkQueue, env: var MirEnv, graph: ModuleGraph,
+                  idgen: IdGenerator, prc: PSym, frag: sink MirBody,
+                  m: FileIndex) =
   ## Runs `frag` through MIR processing and, if `frag` is not empty, queues
   ## the step for reporting the progress.
   if not isEmpty(frag):
-    process(frag, prc, graph, idgen)
-    discoverFrom(discovery, frag.code)
+    let id = env.procedures.add(prc)
+    process(frag, prc, graph, idgen, env)
     # get the fragment out as soon as possible (hence ``prepend``):
     queue.prepend(m, WorkItem(kind: wikReport, evt: bekPartial,
-                              fragSym: prc, frag: frag))
+                              fragId: id, frag: frag))
 
     # mark the procedure as non-empty:
     if prc.ast[bodyPos].kind == nkEmpty:
       prc.ast[bodyPos] = newNode(nkStmtList)
 
-func processAdditional(queue: var WorkQueue, data: var DiscoveryData) =
-  ## Queues all extra dependencies registered with `data`.
-  for m, s in data.additional.items:
-    if not data.seen.containsOrIncl(s.id):
-      data.procedures.addProcessed(s)
-      queue(queue, s, m)
-
-  data.additional.setLen(0) # we've processed everything; reset
-
 func postActions(queue: var WorkQueue, discovery: var DiscoveryData,
-                 m: FileIndex) =
-  ## Queues for processing all procedures that were discovered during event
-  ## processing (i.e., by the iterator's callsite).
-  for _, it in visit(discovery.procedures):
-    queue(queue, it, m)
-  processAdditional(queue, discovery)
+                 env: var MirEnv, m: FileIndex) =
+  ## Queues the procedures registered with `env` by the event handler. These
+  ## are generaly referred to as "late dependencies".
+  for id, it in since(env.procedures, discovery.progress.procs):
+    let m = discovery.overrides.getOrDefault(id, m)
+    queue(queue, id, env.procedures[id], m)
+
+  # no need to keep the overrides around, all procedures they applied to are
+  # now queued
+  discovery.overrides.clear()
+  discovery.progress = checkpoint(env)
 
 iterator process*(graph: ModuleGraph, modules: var ModuleList,
-                  discovery: var DiscoveryData,
+                  env: var MirEnv, discovery: var DiscoveryData,
                   conf: BackendConfig): BackendEvent =
   ## Implements discovery of alive entities (procedures, globals, constants,
   ## etc.) and applying the various transformations and MIR passes to
@@ -782,47 +718,57 @@ iterator process*(graph: ModuleGraph, modules: var ModuleList,
   # dispatchers as normal procedures:
   generateMethodDispatchers(graph)
 
-  # queue the init procedures:
+  discovery.progress = checkpoint(env)
+  # remember where the globals start, it's needed for producing the dynlib
+  # loaders later:
+  let start = discovery.progress.globals
+
+  # discover and register the initial entities of each module:
   for id, m in modules.modules.pairs:
-    discoverFrom(discovery, m.decls)
+    discoverFrom(env, m.decls)
 
     if not isTrivialProc(graph, m.init):
-      register(discovery, procedures, m.init)
+      discard env.procedures.add(m.init)
 
     if not isTrivialProc(graph, m.destructor):
-      register(discovery, procedures, m.destructor)
+      discard env.procedures.add(m.destructor)
 
     # register the globals and threadvars:
     for s in m.structs.globals.items:
-      register(discovery, globals, s)
+      discard env.globals.add(s)
 
     for s in m.structs.nestedGlobals.items:
-      register(discovery, globals, s)
+      discard env.globals.add(s)
 
     for s in m.structs.threadvars.items:
-      register(discovery, threadvars, s)
+      # threadvars are part of the globals:
+      discard env.globals.add(s)
 
     # inform the caller that the initial set of alive entities became
     # available:
-    for evt in flush(queue, discovery, id):
+    for evt in flush(queue, env, discovery, id):
       yield evt
     yield BackendEvent(module: id, kind: bekModule)
-    postActions(queue, discovery, id)
+    postActions(queue, discovery, env, id)
 
-  template reportBody(prc: PSym, m: FileIndex, evt: BackendEventKind,
+  template reportBody(prc: ProcedureId, m: FileIndex, evt: BackendEventKind,
                       frag: MirBody) =
     ## Reports a procedure-related event (by yielding it).
-    yield BackendEvent(module: m, kind: evt, sym: prc, body: frag)
-    postActions(queue, discovery, m)
+    yield BackendEvent(module: m, kind: evt, id: prc, sym: env[prc],
+                       body: frag)
+    postActions(queue, discovery, env, m)
 
   template pushProgress(prc: PSym, frag: MirBody, m: FileIndex) =
-    pushProgress(queue, discovery, graph, modules[m].idgen, prc, frag, m)
+    pushProgress(queue, env, graph, modules[m].idgen, prc, frag, m)
 
   # generate the importing logic for all known dynlib globals:
-  for _, it in all(discovery.globals):
+  for _, it in since(env.globals, start):
+    # XXX: `env.globals` is mutated during the loop. While not a problem at
+    #      the moment, this should eventually be fixed
     if exfDynamicLib in it.extFlags:
       let module = moduleId(it).FileIndex
-      var frag = produceLoader(graph, modules[module], discovery, conf, it)
+      var frag = produceLoader(graph, modules[module], discovery, env, conf,
+                               it)
       pushProgress(modules[module].dynlibInit, frag, module)
 
   # let the entities discovered while producing the loaders "bleed" over
@@ -837,93 +783,73 @@ iterator process*(graph: ModuleGraph, modules: var ModuleList,
 
     case item.kind
     of wikPreprocess:
-      preprocess(queue, graph, modules[moduleId(item.raw).FileIndex].idgen,
-                 item.raw, module)
-      continue # nothing was discovered, skip the scan
+      let id = item.raw
+      preprocess(queue, graph, modules[moduleId(env[id]).FileIndex].idgen,
+                 env, id, module)
+      continue # the environment was not modified, skip the scan
     of wikProcess:
       let
-        origin = moduleId(item.prc).FileIndex # the attched-to module
+        origin = moduleId(env[item.prc]).FileIndex # the attched-to module
         frag = translate(item.prc, item.body, graph, conf,
-                         modules[origin].idgen)
+                         modules[origin].idgen, env)
 
-      discoverFrom(discovery, frag.code)
-
-      if item.prc.typ.callConv != ccInline:
+      if env[item.prc].typ.callConv != ccInline:
         # non-inline procedure are registered as coming from the module
         # they're attached to
         module = origin
 
-      queue.prepend(module, WorkItem(kind: wikReport, evt: bekProcedure,
-                                     fragSym: item.prc, frag: frag))
+      # save resources: if there are no new entities to report, report the body
+      # directly
+      if discovery.progress == checkpoint(env):
+        reportBody(item.prc, module, bekProcedure, frag)
+      else:
+        queue.prepend(module, WorkItem(kind: wikReport, evt: bekProcedure,
+                                       fragId: item.prc, frag: frag))
     of wikProcessConst:
-      module = moduleId(item.cnst).FileIndex
+      module = moduleId(env[item.cnst]).FileIndex
       # scan the constant for its dependencies
       # future direction: the body of the constant (i.e., the value
       # expression) will be transformed to its MIR representation here
-      discoverFromValueAst(discovery, item.cnst.ast)
+      discoverFromValueAst(env, env[item.cnst].ast)
       # we cannot report (i.e., yield) right away, the discovered dependencies
       # have to be reported first
       queue.prepend(module, WorkItem(kind: wikReportConst, cnst: item.cnst))
     of wikProcessGlobals:
       # produce the init/de-init code for the lifted globals:
       let (init, deinit) =
-        produceFragmentsForGlobals(discovery, item.globals, graph,
-                                   conf.tconfig)
+        produceFragmentsForGlobals(env, item.globals, graph, conf.tconfig)
 
       pushProgress(modules[module].preInit, init, module)
       pushProgress(modules[module].postDestructor, deinit, module)
     of wikImported:
-      let s = item.imported
-      # it doesn't matter where the step was queued from, the procedure is
-      module = moduleId(s).FileIndex
+      let id = item.imported
+      # the procedure is always reported from the module its attached to
+      module = moduleId(env[id]).FileIndex
       # first report that an imported procedure became available...
-      yield BackendEvent(module: module, kind: bekImported, sym: s)
-      postActions(queue, discovery, module)
+      yield BackendEvent(module: module, kind: bekImported, id: id,
+                         sym: env[id])
+      postActions(queue, discovery, env, module)
 
       # ... then produce the loader code
-      let frag = produceLoader(graph, modules[module], discovery, conf, s)
+      let frag = produceLoader(graph, modules[module], discovery, env, conf,
+                               env[id])
       pushProgress(modules[module].dynlibInit, frag, module)
     of wikReport:
-      reportBody(item.fragSym, module, item.evt, item.frag)
+      reportBody(item.fragId, module, item.evt, item.frag)
     of wikReportConst:
       yield BackendEvent(module: module, kind: bekConstant, cnst: item.cnst)
-      postActions(queue, discovery, module)
+      postActions(queue, discovery, env, module)
 
     # report and queue all discovered dependencies:
-    for evt in flush(queue, discovery, module):
+    for evt in flush(queue, env, discovery, module):
       yield evt
 
 # ----- API for interacting with ``DiscoveryData`` -----
 
-func register*(data: var DiscoveryData, prc: PSym) =
-  ## If not already know to `data`, adds the procedure `prc` to the list
-  ## of known procedures.
-  register(data, procedures, prc)
-
-func registerGlobal*(data: var DiscoveryData, sym: PSym) {.inline.} =
-  ## If not already known to `data`, adds the global `sym` to the list of
-  ## known globals.
-  register(data, globals, sym)
-
-func registerLate*(discovery: var DiscoveryData, prc: PSym, module: FileIndex) =
-  ## Registers a late late-dependency with `data`. These are dependencies
-  ## that were raised while processing some code fragment, but that are not
-  ## directly related to said fragment. They should be kept to a minimum, and
-  ## `register <#register,DiscoveryData,PSym>`_ should be preferred whenever
-  ## possible.
-  discovery.additional.add (module, prc)
-
-func rewind*(data: var DiscoveryData) =
-  ## Un-discovers all not-yet-processed procedures, globals, threadvars,
-  ## and constants. After the call to ``rewind``, it will appear as if the
-  ## dropped entities were never registered with `data`.
-  template rewindQueue(q: Queue[PSym]) =
-    for _, it in peek(q):
-      data.seen.excl(it.id)
-
-    q.data.setLen(q.progress) # remove all unprocessed items
-
-  rewindQueue(data.procedures)
-  rewindQueue(data.constants)
-  rewindQueue(data.globals)
-  rewindQueue(data.threadvars)
+func setModuleOverride*(discovery: var DiscoveryData, id: ProcedureId,
+                        module: FileIndex) =
+  ## Overrides which module the procedure identified by `id` will be reported
+  ## as having been first seen with. This only works with procedures that
+  ## haven't been queued for code generation yet. It's also fundamentally a
+  ## workaround, try to use it as little as possible.
+  discovery.overrides[id] = module

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -365,8 +365,6 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
              idgen: IdGenerator) =
   ## Applies all applicable MIR passes to the `body`. `prc` is enclosing
   ## procedure.
-  rewriteGlobalDefs(body.code, body.source)
-
   if shouldInjectDestructorCalls(prc):
     injectDestructorCalls(graph, idgen, prc, body)
 

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -873,7 +873,7 @@ iterator discover*(env: var MirEnv, progress: EnvCheckpoint
                   ): tuple[s: PSym, n: MirNode] =
   ## Returns all entities - in an unspecified order - added to `env` since the
   ## `progress` checkpoint was created. Procedures referenced from constants
-  ## also added to the environment and returnd.
+  ## also added to the environment and returned.
   ##
   ## This iterator is meant for a manual implementation of the backend
   ## processing -- don't use it in conjunction with the ``process`` iterator.

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -52,8 +52,8 @@ proc exitCall(p: BProc, callee: CgNode, canRaise: bool) =
   ## Emits the exceptional control-flow related post-call logic.
   if p.config.exc == excGoto:
     if nimErrorFlagDisabled in p.flags:
-      if callee.kind == cnkProc and sfNoReturn in callee.sym.flags and
-         canRaiseConservative(callee):
+      if callee.kind == cnkProc and sfNoReturn in p.env[callee.prc].flags and
+         canRaiseConservative(p.env, callee):
         # when using goto-exceptions, noreturn doesn't map to "doesn't return"
         # at the C-level. In order to still support dispatching to wrapper
         # procedures around ``raise`` from inside ``.compilerprocs``, we emit

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -50,7 +50,7 @@ proc endBlock(p: BProc)
 
 proc loadInto(p: BProc, le, ri: CgNode, a: var TLoc) {.inline.} =
   if ri.kind in {cnkCall, cnkCheckedCall} and
-     getCalleeMagic(ri[0]) == mNone:
+     getCalleeMagic(p.env, ri[0]) == mNone:
     genAsgnCall(p, le, ri, a)
   else:
     # this is a hacky way to fix #1181 (tmissingderef)::
@@ -677,7 +677,7 @@ proc genAsmOrEmitStmt(p: BProc, t: CgNode, isAsmStmt=false): Rope =
     of cnkStrLit:
       res.add(it.strVal)
     of cnkField:
-        let sym = it.sym
+        let sym = it.field
         # special support for raw field symbols
         discard getTypeDesc(p.module, skipTypes(sym.typ, abstractPtrs))
         p.config.internalAssert(sym.locId != 0, it.info):

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -787,8 +787,8 @@ proc genProcHeader(m: BModule, prc: PSym, locs: openArray[TLoc]): Rope =
   # careful here! don't access ``prc.ast`` as that could reload large parts of
   # the object graph!
   result.addf("$1($2, $3)$4",
-        [rope(CallingConvToStr[prc.typ.callConv]), rettype, m.procs[prc].name,
-         params])
+        [rope(CallingConvToStr[prc.typ.callConv]), rettype,
+         m.procs[m.g.env.procedures[prc]].name, params])
 
 # ------------------ type info generation -------------------------------------
 
@@ -1031,11 +1031,20 @@ proc fakeClosureType(m: BModule; owner: PSym): PType =
   r.rawAddSon(obj)
   result.rawAddSon(r)
 
+proc useHook(m: BModule, s: PSym): ProcedureId =
+  if s in m.g.env.procedures:
+    result = m.g.env.procedures[s]
+  else:
+    result = m.g.env.procedures.add(s)
+    # adding a module override is only necessary when it's a new procedure
+    m.g.hooks.add (m, result)
+
+  useProc(m, result)
+
 proc genDeepCopyProc(m: BModule; s: PSym; result: Rope) =
-  useProc(m, s)
-  m.g.hooks.add (m, s)
+  let id = useHook(m, s)
   m.s[cfsTypeInit3].addf("$1.deepcopy =(void* (N_RAW_NIMCALL*)(void*))$2;$n",
-     [result, m.procs[s].name])
+     [result, m.procs[id].name])
 
 proc declareNimType(m: BModule, name: string; str: Rope, module: int) =
   m.s[cfsData].addf("extern $2 $1;$n", [str, rope(name)])
@@ -1075,10 +1084,8 @@ proc genHook(m: BModule; t: PType; info: TLineInfo; op: TTypeAttachedOp): Rope =
       localReport(m.config, info, reportSym(
         rsemExpectedNimcallProc, theProc))
 
-    useProc(m, theProc)
-    m.g.hooks.add (m, theProc)
-
-    result = m.procs[theProc].name
+    let id = useHook(m, theProc)
+    result = m.procs[id].name
 
     when false:
       if not canFormAcycle(t) and op == attachedTrace:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -36,6 +36,10 @@ import
     magicsys,
     modulegraphs
   ],
+  compiler/mir/[
+    mirenv,
+    mirtrees
+  ],
   compiler/front/[
     options,
     msgs
@@ -301,9 +305,16 @@ proc genLineDir(p: BProc, t: CgNode) =
       linefmt(p, cpsStmts, "nimln_($1, $2);$n",
               [line, quotedFilename(p.config, t.info)])
 
-proc accessThreadLocalVar(p: BProc, s: PSym)
+proc registerLateProc(m: BModule, s: PSym): ProcedureId =
+  ## Raises a dependency on `s`, registering it with the environment if it's
+  ## not present there already.
+  result = m.g.env.procedures.add(s)
+  # inline procedure handling needs to know about the dependency...
+  m.extra.add(result)
+
+proc accessThreadLocalVar(p: BProc)
 proc emulatedThreadVars*(conf: ConfigRef): bool {.inline.}
-proc useProc(m: BModule, prc: PSym)
+proc useProc(m: BModule, id: ProcedureId)
 proc raiseInstr(p: BProc): Rope
 
 proc getTempName(m: BModule): Rope =
@@ -528,27 +539,30 @@ proc assignLocalVar(p: BProc, n: CgNode) =
 
 include ccgthreadvars
 
-proc varInDynamicLib(m: BModule, sym: PSym)
+proc varInDynamicLib(m: BModule, id: GlobalId)
 
-proc fillGlobalLoc*(m: BModule, s: PSym) =
-  let n = CgNode(kind: cnkGlobal, info: s.info, typ: s.typ, sym: s)
-  m.globals.put(s, initLoc(locGlobalVar, n, mangleName(m.g.graph, s), OnHeap))
+proc fillGlobalLoc*(m: BModule, id: GlobalId) =
+  let
+    s = m.g.env[id]
+    n = CgNode(kind: cnkGlobal, info: s.info, typ: s.typ, global: id)
+  m.globals[id] = initLoc(locGlobalVar, n, mangleName(m.g.graph, s), OnHeap)
 
-proc defineGlobalVar*(m: BModule, s: PSym) =
-  fillGlobalLoc(m, s)
+proc defineGlobalVar*(m: BModule, id: GlobalId) =
+  let s = m.g.env[id]
+  fillGlobalLoc(m, id)
 
   assert s.id notin m.declaredThings
   assert findPendingModule(m, s) == m, "not the attached-to module"
 
   if exfDynamicLib in s.extFlags:
     incl(m.declaredThings, s.id)
-    varInDynamicLib(m, s)
+    varInDynamicLib(m, id)
   else:
     useHeader(m, s)
     if exfNoDecl notin s.extFlags:
       incl(m.declaredThings, s.id)
       var decl = ""
-      var td = getTypeDesc(m, m.globals[s].t, skVar)
+      var td = getTypeDesc(m, m.globals[id].t, skVar)
       if true:
         if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
           decl.addf "NIM_ALIGN($1) ", [rope(s.alignment)]
@@ -559,13 +573,13 @@ proc defineGlobalVar*(m: BModule, s: PSym) =
         if sfRegister in s.flags: decl.add(" register")
         if sfVolatile in s.flags: decl.add(" volatile")
         if sfNoalias in s.flags: decl.add(" NIM_NOALIAS")
-        decl.addf(" $1;$n", [m.globals[s].r])
+        decl.addf(" $1;$n", [m.globals[id].r])
 
       m.s[cfsVars].add(decl)
 
-proc fillProcLoc*(m: BModule; sym: PSym) =
-  if sym.locId == 0:
-    m.procs.put(sym): ProcLoc(sym: sym, name: mangleName(m.g.graph, sym))
+proc fillProcLoc*(m: BModule; id: ProcedureId) =
+  if id notin m.procs:
+    m.procs[id] = ProcLoc(name: mangleName(m.g.graph, m.g.env[id]))
 
 proc getLabel(p: BProc): TLabel =
   inc(p.labels)
@@ -574,8 +588,8 @@ proc getLabel(p: BProc): TLabel =
 proc fixLabel(p: BProc, labl: TLabel) =
   lineF(p, cpsStmts, "$1: ;$n", [labl])
 
-proc genVarPrototype*(m: BModule, n: CgNode)
-proc genProcPrototype*(m: BModule, sym: PSym)
+proc genVarPrototype*(m: BModule, id: GlobalId)
+proc genProcPrototype*(m: BModule, id: ProcedureId)
 proc genStmts*(p: BProc, t: CgNode)
 proc expr(p: BProc, n: CgNode, d: var TLoc)
 proc putLocIntoDest(p: BProc, d: var TLoc, s: TLoc)
@@ -595,7 +609,8 @@ proc initLocExpr(p: BProc, e: CgNode, result: var TLoc, flags: set[LocFlag]) =
 
 proc initLocExprSingleUse(p: BProc, e: CgNode, result: var TLoc) =
   initLoc(result, locNone, e, OnUnknown)
-  if e.kind in {cnkCall, cnkCheckedCall} and getCalleeMagic(e[0]) == mNone:
+  if e.kind in {cnkCall, cnkCheckedCall} and
+     getCalleeMagic(p.env, e[0]) == mNone:
     # We cannot check for tfNoSideEffect here because of mutable parameters.
     discard "bug #8202; enforce evaluation order for nested calls"
     # We may need to consider that 'f(g())' cannot be rewritten to 'tmp = g(); f(tmp)'
@@ -637,22 +652,24 @@ proc mangleDynLibProc(sym: PSym): Rope =
   else:
     result = rope(strutils.`%`("Dl_$1_", $sym.id))
 
-proc fillDynlibProcLoc(m: BModule, s: PSym) =
-  if s.locId == 0:
+proc fillDynlibProcLoc(m: BModule, id: ProcedureId) =
+  if id notin m.procs:
     # XXX: a dynlib procedure is not really a ``locProc``, but rather a
     #      global variable
-    m.procs.put(s): ProcLoc(name: mangleDynLibProc(s), sym: s)
+    m.procs[id] = ProcLoc(name: mangleDynLibProc(m.g.env[id]))
 
-proc symInDynamicLib*(m: BModule, sym: PSym) =
-  fillDynlibProcLoc(m, sym)
+proc symInDynamicLib*(m: BModule, id: ProcedureId) =
+  fillDynlibProcLoc(m, id)
   m.s[cfsVars].addf("$2 $1;$n",
-                    [m.procs[sym].name, getTypeDesc(m, sym.typ, skVar)])
+                    [m.procs[id].name, getTypeDesc(m, m.g.env[id].typ, skVar)])
 
 
-proc varInDynamicLib(m: BModule, sym: PSym) =
-  let tmp = mangleDynLibProc(sym)
-  incl(m.globals[sym].flags, lfIndirect)
-  m.globals[sym].r = tmp  # from now on we only need the internal name
+proc varInDynamicLib(m: BModule, id: GlobalId) =
+  let
+    sym = m.g.env[id]
+    tmp = mangleDynLibProc(sym)
+  incl(m.globals[id].flags, lfIndirect)
+  m.globals[id].r = tmp  # from now on we only need the internal name
   m.s[cfsVars].addf("$2* $1;$n",
       [tmp, getTypeDesc(m, sym.typ, skVar)])
 
@@ -661,9 +678,9 @@ proc cgsym(m: BModule, name: string): Rope =
   if sym != nil:
     case sym.kind
     of skProc, skFunc, skMethod, skConverter, skIterator:
-      useProc(m, sym)
-      m.extra.add(sym) # notify the caller about the dependency
-    of skVar, skResult, skLet: genVarPrototype(m, newSymNode sym)
+      useProc(m, registerLateProc(m, sym))
+    of skVar, skResult, skLet:
+      genVarPrototype(m, m.g.env.globals[sym])
     of skType: discard getTypeDesc(m, sym.typ)
     else: internalError(m.config, "cgsym: " & name & ": " & $sym.kind)
   else:
@@ -826,14 +843,15 @@ proc allPathsAsgnResult(n: CgNode): InitResultEnum =
 proc isNoReturn(m: BModule; s: PSym): bool {.inline.} =
   sfNoReturn in s.flags and m.config.exc != excGoto
 
-proc startProc*(m: BModule, prc: PSym; procBody: sink Body): BProc =
+proc startProc*(m: BModule, id: ProcedureId; procBody: sink Body): BProc =
+  let prc = m.g.env[id]
   var p = newProc(prc, m)
   p.body = procBody
   assert(prc.ast != nil)
-  fillProcLoc(m, prc) # ensure that a loc exists
-  if m.procs[prc].params.len == 0:
+  fillProcLoc(m, id) # ensure that a loc exists
+  if m.procs[id].params.len == 0:
     # if a prototype was emitted, the parameter list already exists
-    m.procs[prc].params = prepareParameters(m, prc.typ)
+    m.procs[id].params = prepareParameters(m, prc.typ)
 
   synchronize(p.locals, p.body.locals)
 
@@ -866,8 +884,8 @@ proc startProc*(m: BModule, prc: PSym; procBody: sink Body): BProc =
         p.locals[res].storage = OnUnknown
 
   # setup the locs for the parameters:
-  for i in 1..<m.procs[prc].params.len:
-    p.locals[LocalId(i)] = m.procs[prc].params[i]
+  for i in 1..<m.procs[id].params.len:
+    p.locals[LocalId(i)] = m.procs[id].params[i]
 
   # for now, we treat all compilerprocs as being able to run in a boot
   # environment where the error flag is not yet accessible. This is not quite
@@ -896,12 +914,13 @@ proc startProc*(m: BModule, prc: PSym; procBody: sink Body): BProc =
 
   result = p
 
-proc finishProc*(p: BProc, prc: PSym): string =
+proc finishProc*(p: BProc, id: ProcedureId): string =
   if {nimErrorFlagAccessed, nimErrorFlagDeclared} * p.flags == {nimErrorFlagAccessed}:
     p.flags.incl nimErrorFlagDeclared
     p.blocks[0].sections[cpsLocals].add(ropecg(p.module, "NIM_BOOL* nimErr_;$n", []))
     p.blocks[0].sections[cpsInit].add(ropecg(p.module, "nimErr_ = #nimErrorFlag();$n", []))
 
+  let prc = p.env[id]
   var
     header = genProcHeader(p.module, prc, p.params)
     returnStmt = ""
@@ -947,12 +966,12 @@ proc finishProc*(p: BProc, prc: PSym): string =
 
   result = generatedProc
 
-proc genProc*(m: BModule, prc: PSym, procBody: sink Body): Rope =
-  ## Generates the code for the procedure `prc`, where `procBody` is the code
+proc genProc*(m: BModule, id: ProcedureId, procBody: sink Body): Rope =
+  ## Generates the code for the procedure `id`, where `procBody` is the code
   ## of the body with all applicable lowerings and transformation applied.
-  let p = startProc(m, prc, procBody)
+  let p = startProc(m, id, procBody)
   genStmts(p, p.body.code)
-  result = finishProc(p, prc)
+  result = finishProc(p, id)
 
 proc genPartial*(p: BProc, n: CgNode) =
   ## Generates the C code for `n` and appends the result to `p`. This
@@ -961,7 +980,8 @@ proc genPartial*(p: BProc, n: CgNode) =
   synchronize(p.locals, p.body.locals)
   genStmts(p, n)
 
-proc genProcPrototype(m: BModule, sym: PSym) =
+proc genProcPrototype(m: BModule, id: ProcedureId) =
+  let sym = m.g.env[id]
   useHeader(m, sym)
   if exfNoDecl in sym.extFlags: return
   if exfDynamicLib in sym.extFlags:
@@ -969,12 +989,12 @@ proc genProcPrototype(m: BModule, sym: PSym) =
         not containsOrIncl(m.declaredThings, sym.id):
       m.s[cfsVars].add(ropecg(m, "$1 $2 $3;$n",
                         ["extern",
-                        getTypeDesc(m, sym.typ), m.procs[sym].name]))
+                        getTypeDesc(m, sym.typ), m.procs[id].name]))
 
   elif not containsOrIncl(m.declaredProtos, sym.id):
-    if m.procs[sym].params.len == 0:
-      m.procs[sym].params = prepareParameters(m, sym.typ)
-    var header = genProcHeader(m, sym, m.procs[sym].params)
+    if m.procs[id].params.len == 0:
+      m.procs[id].params = prepareParameters(m, sym.typ)
+    var header = genProcHeader(m, sym, m.procs[id].params)
     block:
       if isNoReturn(m, sym) and hasDeclspec in extccomp.CC[m.config.cCompiler].props:
         header = "__declspec(noreturn) " & header
@@ -984,34 +1004,34 @@ proc genProcPrototype(m: BModule, sym: PSym) =
         header.add(" __attribute__((noreturn))")
     m.s[cfsProcHeaders].add(ropecg(m, "$1;$N", [header]))
 
-proc useProc(m: BModule, prc: PSym) =
+proc useProc(m: BModule, id: ProcedureId) =
+  let prc = m.g.env[id]
   if exfImportCompilerProc in prc.extFlags:
-    fillProcLoc(m, prc)
+    fillProcLoc(m, id)
     useHeader(m, prc)
     # dependency to a compilerproc:
     discard cgsym(m, prc.name.s)
   elif exfDynamicLib in prc.extFlags:
     # a special name is used for run-time imported procedures:
-    fillDynlibProcLoc(m, prc)
-    genProcPrototype(m, prc)
+    fillDynlibProcLoc(m, id)
+    genProcPrototype(m, id)
   elif exfNoDecl in prc.extFlags or sfImportc in prc.flags:
-    fillProcLoc(m, prc)
-    genProcPrototype(m, prc)
+    fillProcLoc(m, id)
+    genProcPrototype(m, id)
   else:
     # mangle based on the attached-to module
-    fillProcLoc(findPendingModule(m, prc), prc)
-    genProcPrototype(m, prc)
+    fillProcLoc(findPendingModule(m, prc), id)
+    genProcPrototype(m, id)
 
-proc genVarPrototype(m: BModule, n: CgNode) =
-  #assert(sfGlobal in sym.flags)
-  let sym = n.sym
+proc genVarPrototype(m: BModule, id: GlobalId) =
+  let sym = m.g.env[id]
   useHeader(m, sym)
   if (exfNoDecl in sym.extFlags) or contains(m.declaredThings, sym.id):
     return
   if sym.owner.id != m.module.id:
     # else we already have the symbol generated!
     if sfThread in sym.flags:
-      declareThreadVar(m, sym, true)
+      declareThreadVar(m, id, true)
     else:
       incl(m.declaredThings, sym.id)
       if sym.kind in {skLet, skVar, skField, skForVar} and sym.alignment > 0:
@@ -1022,7 +1042,7 @@ proc genVarPrototype(m: BModule, n: CgNode) =
       if sfRegister in sym.flags: m.s[cfsVars].add(" register")
       if sfVolatile in sym.flags: m.s[cfsVars].add(" volatile")
       if sfNoalias in sym.flags: m.s[cfsVars].add(" NIM_NOALIAS")
-      m.s[cfsVars].addf(" $1;$n", [m.globals[sym].r])
+      m.s[cfsVars].addf(" $1;$n", [m.globals[id].r])
 
 proc addNimDefines(result: var Rope; conf: ConfigRef) {.inline.} =
   result.addf("#define NIM_INTBITS $1\L", [

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -12,6 +12,9 @@ import
     lineinfos,
     wordrecg
   ],
+  compiler/mir/[
+    mirtrees
+  ],
   compiler/utils/[
     containers
   ]
@@ -182,13 +185,15 @@ type
     of cnkFloatLit:   floatVal*: BiggestFloat
     of cnkStrLit:     strVal*: string
     of cnkAstLit:     astLit*: PNode
+    of cnkField:      field*: PSym
+    of cnkProc:       prc*: ProcedureId
+    of cnkConst:      cnst*: ConstId
+    of cnkGlobal:     global*: GlobalId
     of cnkMagic:      magic*: TMagic
     of cnkLabel:      label*: BlockId
     of cnkLocal:      local*: LocalId
     of cnkPragmaStmt: pragma*: TSpecialWord
     of cnkWithOperand: operand*: CgNode
-    of cnkField, cnkProc, cnkConst, cnkGlobal:
-      sym*: PSym
     of cnkWithItems:
       kids*: seq[CgNode]
 

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -39,11 +39,20 @@ proc treeRepr*(n: CgNode): string =
     of cnkPragmaStmt:
       result.add "pragma: "
       result.add $n.pragma
-    of cnkField, cnkProc, cnkConst, cnkGlobal:
-      result.add "sym: "
-      result.add n.sym.name.s
+    of cnkField:
+      result.add "field: "
+      result.add n.field.name.s
       result.add " id: "
-      result.add $n.sym.itemId
+      result.add $n.field.itemId
+    of cnkProc:
+      result.add "prc: "
+      result.addInt n.prc.int
+    of cnkConst:
+      result.add "cnst: "
+      result.addInt n.cnst.int
+    of cnkGlobal:
+      result.add "global: "
+      result.addInt n.global.int
     of cnkLabel:
       result.add "label: "
       result.addInt n.label.int

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -43,6 +43,10 @@ import
     magicsys,
     modulegraphs
   ],
+  compiler/mir/[
+    mirenv,
+    mirtrees
+  ],
   compiler/front/[
     options,
     msgs
@@ -111,8 +115,13 @@ type
 
     names: Table[int, string]
       ## maps a symbol IDs to the symbol's JavaScript name
+    procs: SeqMap[ProcedureId, string]
+      ## the JavaScript name for each procedure
+    consts: SeqMap[ConstId, Loc]
+    globals: SeqMap[GlobalId, Loc]
 
-    extra*: seq[PSym]
+    env*: MirEnv
+      ## the project-wide MIR environment
 
   StorageFlag = enum
     stfIndirect ## the value is stored in a single-item array
@@ -160,6 +169,9 @@ const
     ## magics that are treated like normal procedures by the code
     ## generator
 
+template isFilled(x: string): bool =
+  x.len != 0
+
 # forward declarations:
 proc setupLocalLoc(p: PProc, id: LocalId, kind: TSymKind; name = "")
 
@@ -199,6 +211,7 @@ func analyseIfAddressTaken(n: CgNode, addrTaken: var PackedSet[LocalId]) =
       analyseIfAddressTaken(it, addrTaken)
 
 template config*(p: PProc): ConfigRef = p.module.config
+template env*(p: PProc): untyped = p.g.env
 
 proc indentLine(p: PProc, r: Rope): Rope =
   result = r
@@ -338,12 +351,6 @@ func mangleName(loc: Local, id: LocalId): string =
     result.add "_"
     result.addInt id.int
 
-proc mangledName(p: PProc, s: PSym, info: TLineInfo): lent string =
-  ## Returns the cached JavaScript name for `s`.
-  p.module.config.internalAssert(s.id in p.g.names, info):
-    "symbol has no generated name: " & s.name.s
-  result = p.g.names[s.id]
-
 proc ensureMangledName(p: PProc, s: PSym): lent string =
   ## Looks up and returns the mangled name for the non-local symbol
   ## `s`, generating and caching the mangled name if it hasn't been
@@ -354,6 +361,13 @@ proc ensureMangledName(p: PProc, s: PSym): lent string =
     n[] = mangleName(p.module, s)
 
   result = p.g.names[s.id]
+
+proc ensureMangledName(p: PProc, id: ProcedureId): lent string =
+  if id notin p.g.procs:
+    # the mangled named hasn't been generated yet
+    p.g.procs[id] = mangleName(p.module, p.env[id])
+
+  result = p.g.procs[id]
 
 proc escapeJSString(s: string): string =
   result = newStringOfCap(s.len + s.len shr 2)
@@ -392,7 +406,7 @@ proc useMagic(p: PProc, name: string) =
   if name.len == 0: return
   var s = magicsys.getCompilerProc(p.module.graph, name)
   if s != nil:
-    p.g.extra.add s
+    discard p.env.procedures.add(s)
   else:
     if p.prc != nil:
       globalReport(p.config, p.prc.info, reportStr(rsemSystemNeeds, name))
@@ -981,7 +995,7 @@ proc genFastAsgn(p: PProc, n: CgNode) =
 proc getFieldPosition(p: PProc; f: CgNode): int =
   case f.kind
   of cnkIntLit: result = int(f.intVal)
-  of cnkField:  result = f.sym.position
+  of cnkField:  result = f.field.position
   else: internalError(p.config, f.info, "genFieldPosition")
 
 proc genFieldAddr(p: PProc, n: CgNode, r: var TCompRes) =
@@ -994,7 +1008,7 @@ proc genFieldAddr(p: PProc, n: CgNode, r: var TCompRes) =
     r.res = makeJSString("Field" & $getFieldPosition(p, b[1]))
   of cnkFieldAccess:
     p.config.internalAssert(b[1].kind == cnkField, b[1].info, "genFieldAddr")
-    r.res = makeJSString(ensureMangledName(p, b[1].sym))
+    r.res = makeJSString(ensureMangledName(p, b[1].field))
   else:
     unreachable(n.kind)
   internalAssert p.config, a.typ != etyBaseIndex
@@ -1011,7 +1025,7 @@ proc genFieldAccess(p: PProc, n: CgNode, r: var TCompRes) =
         [r.res, getFieldPosition(p, n[1]).rope]
   of cnkFieldAccess:
     p.config.internalAssert(n[1].kind == cnkField, n[1].info, "genFieldAccess")
-    r.res = "$1.$2" % [r.res, ensureMangledName(p, n[1].sym)]
+    r.res = "$1.$2" % [r.res, ensureMangledName(p, n[1].field)]
   else:
     unreachable(n.kind)
 
@@ -1076,11 +1090,6 @@ proc genArrayAccess(p: PProc, n: CgNode, r: var TCompRes) =
     r.res = "$1[$2]" % [r.address, r.res]
   r.kind = resExpr
 
-func isBoxedPointer(v: PSym): bool =
-  ## Returns whether `v` stores a pointer value boxed in an array. If not,
-  ## the value is stored as two variables (base and index).
-  sfGlobal in v.flags
-
 func isBoxedPointer(v: Loc): bool =
   ## Returns whether `v` stores a pointer value boxed in an array. If not,
   ## the value is stored as two variables (base and index).
@@ -1097,7 +1106,7 @@ template isIndirect(x: PSym): bool =
 template isIndirect(x: Loc): bool =
   stfIndirect in x.storage
 
-proc addrLoc[T: Loc|PSym](name: string, s: T, r: var TCompRes) =
+proc addrLoc(s: Loc, r: var TCompRes) =
   ## Generates the code for taking the address of the location identified by
   ## symbol node `n`
   if true:
@@ -1105,23 +1114,25 @@ proc addrLoc[T: Loc|PSym](name: string, s: T, r: var TCompRes) =
     r.typ = etyBaseIndex
     r.res = "0"
     if isIndirect(s):
-      r.address = name
+      r.address = s.name
     elif mapType(s.typ) == etyBaseIndex and not isBoxedPointer(s):
       # box the separate base+index into an array first
-      r.address = "[[$1, $1_Idx]]" % name
+      r.address = "[[$1, $1_Idx]]" % s.name
     else:
       # something that doesn't directly support having its address
       # taken (e.g. imported variable, parameter, let, etc.)
-      r.address = "[$1]" % name
+      r.address = "[$1]" % s.name
 
 proc genAddr(p: PProc, n: CgNode, r: var TCompRes) =
   ## Dispatches to the appropriate procedure for generating the address-of
   ## operation based on the kind of node `n`
   case n.kind
   of cnkLocal:
-    addrLoc(p.locals[n.local].name, p.locals[n.local], r)
-  of cnkConst, cnkGlobal:
-    addrLoc(mangledName(p, n.sym, n.info), n.sym, r)
+    addrLoc(p.locals[n.local], r)
+  of cnkConst:
+    addrLoc(p.g.consts[n.cnst], r)
+  of cnkGlobal:
+    addrLoc(p.g.globals[n.global], r)
   of cnkFieldAccess, cnkTupleAccess:
     genFieldAddr(p, n, r)
   of cnkArrayAccess:
@@ -1146,24 +1157,24 @@ proc genAddr(p: PProc, n: CgNode, r: var TCompRes) =
   else:
     internalError(p.config, n.info, "genAddr: " & $n.kind)
 
-proc accessLoc[T: Loc|PSym](name: string, s: T, r: var TCompRes) =
+proc accessLoc(s: Loc, r: var TCompRes) =
     let k = mapType(s.typ)
     if k == etyBaseIndex:
       r.typ = etyBaseIndex
       if isBoxedPointer(s):
         if isIndirect(s):
-          r.address = "$1[0][0]" % [name]
-          r.res = "$1[0][1]" % [name]
+          r.address = "$1[0][0]" % [s.name]
+          r.res = "$1[0][1]" % [s.name]
         else:
-          r.address = "$1[0]" % [name]
-          r.res = "$1[1]" % [name]
+          r.address = "$1[0]" % [s.name]
+          r.res = "$1[1]" % [s.name]
       else:
-        r.address = name
-        r.res = name & "_Idx"
+        r.address = s.name
+        r.res = s.name & "_Idx"
     elif isIndirect(s):
-      r.res = "$1[0]" % [name]
+      r.res = "$1[0]" % [s.name]
     else:
-      r.res = name
+      r.res = s.name
 
 proc genDeref(p: PProc, n: CgNode, r: var TCompRes) =
   let it = n.operand
@@ -1294,7 +1305,7 @@ proc genPatternCall(p: PProc; n: CgNode; pat: string; typ: PType;
 
 proc genInfixCall(p: PProc, n: CgNode, r: var TCompRes) =
   # don't call '$' here for efficiency:
-  let f = n[0].sym
+  let f = p.g.env[n[0].prc]
   assert sfInfixCall in f.flags
   if true:
     let pat = f.extname
@@ -1488,32 +1499,18 @@ proc setupLocalLoc(p: PProc, id: LocalId, kind: TSymKind; name = "") =
 
   p.locals[id] = loc
 
-proc defineGlobal*(globals: PGlobals, m: BModule, v: PSym) =
+proc defineGlobal*(globals: PGlobals, m: BModule, id: GlobalId) =
   ## Emits the definition for the single global `v` into the top-level section,
   ## with `m` being the module the global belongs to. Also sets up the
   ## symbol's JavaScript name.
   let p = newInitProc(globals, m)
+  let v = globals.env[id]
   let name = mangleName(m, v)
   if exfNoDecl notin v.extFlags and sfImportc notin v.flags:
     lineF(p, "var $1 = $2;$n", [name, createVar(p, v.typ, isIndirect(v))])
 
-  globals.names[v.id] = name
-  # add to the top-level section:
-  globals.code.add(p.body)
-
-proc defineGlobals*(globals: PGlobals, m: BModule, vars: openArray[PSym]) =
-  ## Emits definitions for the items in `vars` into the top-level section,
-  ## with `m` being the module the globals belong to. Also sets up the
-  ## JavaScript name for the globals.
-  let p = newInitProc(globals, m)
-    ## required for emitting code
-  for v in vars.items:
-    let name = mangleName(m, v)
-    if exfNoDecl notin v.extFlags and sfImportc notin v.flags:
-      lineF(p, "var $1 = $2;$n", [name, createVar(p, v.typ, isIndirect(v))])
-
-    globals.names[v.id] = name
-
+  globals.globals[id] = Loc(name: name, typ: v.typ,
+                            storage: storage(v.flags, v.kind, false))
   # add to the top-level section:
   globals.code.add(p.body)
 
@@ -1564,17 +1561,20 @@ proc genDef(p: PProc, it: CgNode) =
   genVarInit(p, p.locals[id].typ, p.locals[id].name, p.locals[id].storage,
              it[1])
 
-proc genConstant*(g: PGlobals, m: BModule, c: PSym) =
-  let name = mangleName(m, c)
+proc genConstant*(g: PGlobals, m: BModule, id: ConstId) =
+  let
+    c = g.env[id]
+    name = mangleName(m, c)
+    storage = storage({}, skConst, false)
+
   if exfNoDecl notin c.extFlags:
     var p = newInitProc(g, m)
     #genLineDir(p, c.ast)
-    genVarInit(p, c.typ, name, storage(c.flags, skConst, false),
-               translate(c.ast))
+    genVarInit(p, c.typ, name, storage, translate(g.env, c.ast))
     g.constants.add(p.body)
 
   # all constants need a name:
-  g.names[c.id] = name
+  g.consts[id] = Loc(name: name, typ: c.typ, storage: storage)
 
 proc genNew(p: PProc, n: CgNode, r: var TCompRes) =
   ## Updates `r` with the result of a ``new`` magic invocation.
@@ -1738,7 +1738,7 @@ proc genJSArrayConstr(p: PProc, n: CgNode, r: var TCompRes) =
 proc genRangeChck(p: PProc, n: CgNode, r: var TCompRes)
 
 proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
-  let op = getCalleeMagic(n[0])
+  let op = getCalleeMagic(p.g.env, n[0])
   case op
   of mAddI..mUnaryMinusF64: arith(p, n, r, op)
   of mCharToStr:
@@ -1864,7 +1864,7 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
   of mEcho: genEcho(p, n, r)
   of mNLen..mNError:
     localReport(p.config, n.info, reportSym(
-      rsemConstExpressionExpected, n[0].sym))
+      rsemConstExpressionExpected, p.env[n[0].prc]))
 
   of mNewString: unaryExpr(p, n, r, "mnewString", "mnewString($1)")
   of mNewStringOfCap:
@@ -2012,7 +2012,7 @@ proc genObjConstr(p: PProc, n: CgNode, r: var TCompRes) =
     internalAssert p.config, it.kind == cnkBinding
     let val = it[1]
     gen(p, val, a)
-    var f = it[0].sym
+    let f = it[0].field
     let name = ensureMangledName(p, f)
     fieldIDs.incl(lookupFieldAgain(n.typ, f).id)
 
@@ -2111,7 +2111,9 @@ proc optionalLine(p: Rope): Rope =
   else:
     return p & "\L"
 
-proc startProc*(g: PGlobals, module: BModule, prc: PSym, body: sink Body): PProc =
+proc startProc*(g: PGlobals, module: BModule, id: ProcedureId,
+                body: sink Body): PProc =
+  let prc = g.env[id]
   let p = newProc(g, module, prc, prc.options)
   p.fullBody = body
 
@@ -2120,7 +2122,7 @@ proc startProc*(g: PGlobals, module: BModule, prc: PSym, body: sink Body): PProc
     analyseIfAddressTaken(p.fullBody.code, p.addrTaken)
 
   # make sure the procedure has a mangled name:
-  discard ensureMangledName(p, prc)
+  discard ensureMangledName(p, id)
 
   # setup the loc for the the result variable:
   if prc.typ[0] != nil and sfPure notin prc.flags:
@@ -2163,7 +2165,7 @@ proc finishProc*(p: PProc): string =
       let resVar = createVar(p, loc.typ, isIndirect(loc))
       resultAsgn = p.indentLine(("var $# = $#;$n") % [mname, resVar])
     var a: TCompRes
-    accessLoc(mname, loc, a)
+    accessLoc(loc, a)
     if a.typ == etyBaseIndex:
       returnStmt = "return [$#, $#];$n" % [a.address, a.res]
     else:
@@ -2173,7 +2175,7 @@ proc finishProc*(p: PProc): string =
     result = lineDir(p.config, prc.info, toLinenumber(prc.info))
 
   let
-    name   = p.g.names[prc.id]
+    name   = p.g.procs[p.env.procedures[prc]]
     header = generateHeader(toOpenArray(p.locals.base, 1, prc.typ.len-1))
 
   var def: Rope
@@ -2205,9 +2207,9 @@ proc finishProc*(p: PProc): string =
   #if gVerbosity >= 3:
   #  echo "END   generated code for: " & prc.name.s
 
-proc genProc*(g: PGlobals, module: BModule, prc: PSym,
+proc genProc*(g: PGlobals, module: BModule, id: ProcedureId,
               body: sink Body): Rope =
-  var p = startProc(g, module, prc, body)
+  var p = startProc(g, module, id, body)
   p.nested: genStmt(p, p.fullBody.code)
   result = finishProc(p)
 
@@ -2280,19 +2282,19 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
 
   case n.kind
   of cnkProc:
-    let s = n.sym
+    let s = p.env[n.prc]
     if sfCompileTime in s.flags:
       localReport(p.config, n.info, reportSym(
         rsemCannotCodegenCompiletimeProc, s))
 
-    r.res = ensureMangledName(p, s)
+    r.res = ensureMangledName(p, n.prc)
   of cnkConst:
-    r.res = mangledName(p, n.sym, n.info)
+    # XXX: properly use ``accessLoc``
+    r.res = p.g.consts[n.cnst].name
   of cnkGlobal:
-    let s = n.sym
-    accessLoc(mangledName(p, s, n.info), s, r)
+    accessLoc(p.g.globals[n.global], r)
   of cnkLocal:
-    accessLoc(p.locals[n.local].name, p.locals[n.local], r)
+    accessLoc(p.locals[n.local], r)
   of cnkIntLit, cnkUIntLit:
     r.res = intLiteral(getInt(n), n.typ)
     r.kind = resExpr
@@ -2340,9 +2342,9 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkCall, cnkCheckedCall:
     if isEmptyType(n.typ):
       genLineDir(p, n)
-    if getCalleeMagic(n[0]) != mNone:
+    if getCalleeMagic(p.g.env, n[0]) != mNone:
       genMagic(p, n, r)
-    elif n[0].kind == cnkProc and sfInfixCall in n[0].sym.flags and
+    elif n[0].kind == cnkProc and sfInfixCall in p.env[n[0].prc].flags and
         n.len >= 1:
       genInfixCall(p, n, r)
     else:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -364,7 +364,7 @@ proc ensureMangledName(p: PProc, s: PSym): lent string =
 
 proc ensureMangledName(p: PProc, id: ProcedureId): lent string =
   if id notin p.g.procs:
-    # the mangled named hasn't been generated yet
+    # the mangled name hasn't been generated yet
     p.g.procs[id] = mangleName(p.module, p.env[id])
 
   result = p.g.procs[id]

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -16,7 +16,8 @@ import
     options
   ],
   compiler/mir/[
-    mirtrees,
+    mirbodies,
+    mirenv,
     mirgen,
     utils
   ],
@@ -74,15 +75,15 @@ proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
     writeBody(config, "-- output AST: " & owner.name.s):
       config.writeln(treeRepr(body.code))
 
-proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, owner: PSym,
-                   body: PNode, config: TranslationConfig): Body =
+proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
+                   owner: PSym, body: PNode, config: TranslationConfig): Body =
   ## Legacy routine. Translates the body `body` of the procedure `owner` to
   ## MIR code, and the MIR code to ``CgNode`` IR.
   echoInput(graph.config, owner, body)
   # step 1: generate a ``MirTree`` from the input AST
-  let body = generateCode(graph, owner, config, body)
+  let body = generateCode(graph, env, owner, config, body)
   echoMir(graph.config, owner, body)
 
   # step 2: generate the ``CgNode`` tree
-  result = generateIR(graph, idgen, owner, body)
+  result = generateIR(graph, idgen, env, owner, body)
   echoOutput(graph.config, owner, result)

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -332,10 +332,13 @@ template buildMagicCall*(bu: var MirBuilder, m: TMagic, t: PType,
     bu.add MirNode(kind: mnkMagic, magic: m)
     body
 
-template buildCall*(bu: var MirBuilder, prc: PSym, t: PType, d: untyped) =
+template buildCall*(bu: var MirBuilder, prc: ProcedureId, pt, t: PType,
+                    body: untyped) =
+  ## Build and emits a call tree to the active buffer. `pt` is the type of the
+  ## procedure.
   bu.subTree MirNode(kind: mnkCall, typ: t):
-    bu.use procLit(prc)
-    d
+    bu.use toValue(prc, pt)
+    body
 
 func emitByVal*(bu: var MirBuilder, y: Value) =
   bu.subTree mnkArg:

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -63,17 +63,12 @@ func typ*(val: Value): PType =
   assert val.node.kind != mnkNone, "uninitialized"
   val.node.typ
 
-func procNode*(s: PSym): MirNode {.inline.} =
-  assert s.kind in routineKinds
-  MirNode(kind: mnkProc, sym: s)
+func procNode*(id: ProcedureId): MirNode {.inline.} =
+  MirNode(kind: mnkProc, prc: id)
 
 func endNode*(k: MirNodeKind): MirNode {.inline.} =
   assert k in SubTreeNodes
   MirNode(kind: mnkEnd, start: k)
-
-
-func procLit*(sym: PSym): Value =
-  Value(node: MirNode(kind: mnkProc, typ: sym.typ, sym: sym))
 
 func typeLit*(t: PType): Value =
   Value(node: MirNode(kind: mnkType, typ: t))
@@ -87,8 +82,14 @@ func temp*(typ: PType, id: TempId): Value =
 func alias*(typ: PType, id: TempId): Value =
   Value(node: MirNode(kind: mnkAlias, typ: typ, temp: id))
 
-func symbol*(kind: range[mnkConst..mnkLocal], sym: PSym): Value =
-  Value(node: MirNode(kind: kind, typ: sym.typ, sym: sym))
+func toValue*(id: ConstId, typ: PType): Value =
+  Value(node: MirNode(kind: mnkConst, typ: typ, cnst: id))
+
+func toValue*(id: GlobalId, typ: PType): Value =
+  Value(node: MirNode(kind: mnkGlobal, typ: typ, global: id))
+
+func toValue*(id: ProcedureId, typ: PType): Value =
+  Value(node: MirNode(kind: mnkProc, typ: typ, prc: id))
 
 # --------- MirBuffer interface ----------
 

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -1,0 +1,87 @@
+## Implements the `MirEnv <#MirEnv>`_ data type together with routines for
+## querying and manipulating it.
+
+import
+  std/[
+    tables
+  ],
+  compiler/ast/[
+    ast_query,
+    ast_types
+  ],
+  compiler/mir/[
+    mirtrees
+  ],
+  compiler/utils/[
+    containers
+  ]
+
+type
+  SymbolTable*[I; T] = object
+    ## Acts as the central store for a kind of symbol during the mid- and
+    ## backend phase. Also keeps mappings for ``PSym`` to the corresponding
+    ## backend symbol.
+    ##
+    ## In the mid- and backend, symbols are represented with IDs rather than
+    ## with ``ref`` types.
+    data: Store[I, T]
+    map: Table[int, I]
+      ## maps a symbol ID to the corresponding entity ID
+
+  MirEnv* = object
+    ## Stores everything MIR-related that is shared/exists across MIR bodies,
+    ## such as information about global variables, global constants, etc.
+    constants*:  SymbolTable[ConstId, PSym]
+    globals*:    SymbolTable[GlobalId, PSym]
+      ## includes both normal globals and threadvars
+    procedures*: SymbolTable[ProcedureId, PSym]
+
+func toMir(s: sink PSym, t: typedesc): PSym =
+  ## Translates a symbol to the MIR representation for the given entity.
+  ## Overload this procedure for customizing the translation process.
+  result = s
+
+# ------- SymbolTable API -------
+
+func `[]`*[I; T](tab: SymbolTable[I, T], s: PSym): I {.inline.} =
+  ## Looks up the ID that `s` is represented with in `tab`. `s` must have
+  ## already been registered in the table.
+  tab.map[s.id]
+
+func `[]`*[I; T](tab: SymbolTable[I, T], id: I): lent T {.inline.} =
+  tab.data[id]
+
+func contains*[I, T](tab: SymbolTable[I, T], s: PSym): bool {.inline.} =
+  ## Returns whether `s` was already registered with `tab`.
+  tab.map.contains(s.id)
+
+func add*[I; T](tab: var SymbolTable[I, T], s: PSym): I =
+  ## If `s` was not yet added to `tab`, translates `s` to the corresponding
+  ## MIR representation and returns the ID to fetch the entity from `tab`
+  ## with. If `s` was already added, returns the ID of the already-translated
+  ## entity.
+  let next = tab.data.nextId()
+  result = tab.map.mgetOrPut(s.id, next)
+  if result == next:
+    let x = tab.data.add(toMir(s, I))
+    assert x == result
+
+proc len*[I, T](tab: SymbolTable[I, T]): int =
+  ## The number of entities in `tab`.
+  tab.data.nextId().int
+
+# ------- MirEnv API --------
+
+func `[]`*(env: MirEnv, id: ConstId): lent PSym {.inline.} =
+  env.constants.data[id]
+
+func `[]`*(env: MirEnv, id: GlobalId): lent PSym {.inline.} =
+  env.globals.data[id]
+
+func `[]`*(env: MirEnv, id: ProcedureId): lent PSym {.inline.} =
+  env.procedures.data[id]
+
+iterator items*[I, T](tab: SymbolTable[I, T]): (I, lent T) =
+  ## Returns all entities in `tab` together with their ID.
+  for id, it in tab.data.pairs:
+    yield (id, it)

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1019,7 +1019,7 @@ proc genMacroCallArgs(c: var TCtx, n: PNode, kind: TSymKind, fntyp: PType) =
   of skTemplate:
     # for late template invocations, the callee template is an argument
     c.subTree mnkArg:
-      genCallee(c, n[1])
+      c.use literal(newTreeIT(nkNimNodeLit, n[1].info, n[1].typ, n[1]))
   else:
     unreachable(kind)
 

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -11,21 +11,17 @@ import
   ]
 
 type
-  ## The MIR itself doesn't not care for how each of the following ID types is
-  ## interpreted. For example, a ``ParamId`` could be the index of the
-  ## parameter or it could be an index into a list of symbols.
-
   LocalId {.used.} = distinct uint32
     ## Identifies a local inside a code fragment
-  GlobalId {.used.} = distinct uint32
-    ## Identifies a global inside a code fragment
-  ConstId {.used.} = distinct uint32
-    ## Identifies a named constant inside a code fragment
+  GlobalId* = distinct uint32
+    ## Identifies a global across all MIR code
+  ConstId* = distinct uint32
+    ## Identifies a named constant across all MIR code
   ParamId {.used.} = distinct uint32
     ## Identifies a parameter of the code fragment
   FieldId {.used.} = distinct uint32
     ## Identifies the field of a record type
-  ProcedureId {.used.} = distinct uint32
+  ProcedureId* = distinct uint32
     ## Identifies a procedure
   LiteralId {.used.} = distinct uint32
     ## Identifies a literal
@@ -252,7 +248,13 @@ type
       ## non-critical meta-data associated with the node (e.g., origin
       ## information)
     case kind*: MirNodeKind
-    of mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal:
+    of mnkProc:
+      prc*: ProcedureId
+    of mnkGlobal:
+      global*: GlobalId
+    of mnkConst:
+      cnst*: ConstId
+    of mnkParam, mnkLocal:
       sym*: PSym
     of mnkField, mnkPathNamed, mnkPathVariant:
       field*: PSym
@@ -317,7 +319,7 @@ const
   ArgumentNodes* = {mnkArg, mnkName, mnkConsume}
     ## Nodes only allowed in argument contexts.
 
-  SymbolLike* = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal}
+  SymbolLike* = {mnkParam, mnkLocal}
     ## Nodes for which the `sym` field is available
 
   # --- semantics-focused sets:
@@ -343,6 +345,9 @@ const
 func `==`*(a, b: SourceId): bool {.borrow.}
 func `==`*(a, b: TempId): bool {.borrow.}
 func `==`*(a, b: LabelId): bool {.borrow.}
+func `==`*(a, b: ConstId): bool {.borrow.}
+func `==`*(a, b: GlobalId): bool {.borrow.}
+func `==`*(a, b: ProcedureId): bool {.borrow.}
 
 # XXX: ideally, the arithmetic operations on ``NodePosition`` should not be
 #      exported. How the nodes are stored should be an implementation detail

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -154,9 +154,9 @@ proc singleToStr(n: MirNode, result: var string, env: EnvPtr) =
   of mnkConst:
     result.addName(n.cnst, "<C", env)
   of mnkGlobal:
-    result.addName(n.cnst, "<G", env)
+    result.addName(n.global, "<G", env)
   of mnkProc:
-    result.addName(n.cnst, "<P", env)
+    result.addName(n.prc, "<P", env)
   of mnkTemp, mnkAlias:
     result.add "_" & $n.temp.int
   of mnkNone:

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -60,8 +60,8 @@ type
     long: seq[PathInstr]
 
 const
-  Roots = SymbolLike + {mnkTemp, mnkCall, mnkCheckedCall, mnkDeref,
-                        mnkDerefView}
+  Roots = {mnkProc, mnkConst, mnkGlobal, mnkTemp, mnkCall, mnkDeref,
+           mnkDerefView} + SymbolLike
   PathOps = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv,
              mnkPathVariant}
 
@@ -70,13 +70,19 @@ func isSameRoot(an, bn: MirNode): bool =
     return false
 
   case an.kind
-  of SymbolLike:
+  of mnkParam, mnkLocal:
     result = an.sym.id == bn.sym.id
+  of mnkProc:
+    result = an.prc == bn.prc
+  of mnkConst:
+    result = an.cnst == bn.cnst
+  of mnkGlobal:
+    result = an.global == bn.global
   of mnkTemp:
     result = an.temp == bn.temp
-  of Roots - SymbolLike - {mnkTemp}:
+  of mnkCall, mnkDeref, mnkDerefView:
     result = false
-  else:
+  of AllNodeKinds - Roots:
     unreachable(an.kind)
 
 func sameIndex*(a, b: MirNode): Ternary =

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -116,6 +116,7 @@ import
     mirbodies,
     mirchangesets,
     mirconstr,
+    mirenv,
     mirtrees,
     sourcemaps,
     utils
@@ -570,7 +571,9 @@ func isMoveable(tree: MirTree, v: Values, n: NodePosition): bool =
 
 # ------- code generation routines --------
 
-template buildVoidCall(bu: var MirBuilder, prc: PSym, body: untyped) =
+template buildVoidCall(bu: var MirBuilder, env: var MirEnv, p: PSym,
+                       body: untyped) =
+  let prc = p # prevent multi evaluation
   bu.subTree mnkVoid:
     let kind =
       if canRaise(optPanics in graph.config.globalOptions, prc.ast[namePos]):
@@ -580,7 +583,7 @@ template buildVoidCall(bu: var MirBuilder, prc: PSym, body: untyped) =
 
     # XXX: injected procedures should not introduce new control-flow paths
     bu.subTree MirNode(kind: kind, typ: getVoidType(graph)):
-      bu.use procLit(prc)
+      bu.use toValue(env.procedures.add(prc), prc.typ)
       body
 
 proc genWasMoved(bu: var MirBuilder, graph: ModuleGraph, target: Value) =
@@ -588,44 +591,44 @@ proc genWasMoved(bu: var MirBuilder, graph: ModuleGraph, target: Value) =
     bu.buildMagicCall mWasMoved, getVoidType(graph):
       bu.emitByName(target, ekKill)
 
-proc genDestroy*(bu: var MirBuilder, graph: ModuleGraph, target: Value) =
+proc genDestroy*(bu: var MirBuilder, graph: ModuleGraph, env: var MirEnv,
+                 target: Value) =
   let destr = getOp(graph, target.typ, attachedDestructor)
 
-  bu.buildVoidCall(destr):
+  bu.buildVoidCall(env, destr):
     bu.emitByName(target, ekMutate)
 
-proc genInjectedSink(bu: var MirBuilder, graph: ModuleGraph,
+proc genInjectedSink(bu: var MirBuilder, graph: ModuleGraph, env: var MirEnv,
                      dest, source: Value) =
   ## Generates and emits either a call to the ``=sink`` hook, or (if none
   ## exists), a sink emulated via a destructor-call + bitwise-copy.
   let op = getOp(graph, dest.typ, attachedSink)
   if op != nil:
-    bu.buildVoidCall(op):
+    bu.buildVoidCall(env, op):
       bu.emitByName(dest, ekMutate)
       bu.emitByVal source
   else:
     # without a sink hook, a ``=destroy`` + blit-copy is used
-    genDestroy(bu, graph, dest)
+    genDestroy(bu, graph, env, dest)
     bu.asgn dest, source
 
 proc genSinkFromTemporary(bu: var MirBuilder, graph: ModuleGraph,
-                          dest, source: Value) =
+                          env: var MirEnv, dest, source: Value) =
   ## Similar to ``genInjectedSink`` but generates code for destructively
   ## moving the source operand into a temporary first.
   let tmp = bu.materialize(source)
   genWasMoved(bu, graph, source)
-  genInjectedSink(bu, graph, dest, tmp)
+  genInjectedSink(bu, graph, env, dest, tmp)
 
-proc genCopy(bu: var MirBuilder, graph: ModuleGraph, dst, src: Value,
-             maybeCyclic: bool) =
+proc genCopy(bu: var MirBuilder, graph: ModuleGraph, env: var MirEnv,
+             dst, src: Value, maybeCyclic: bool) =
   ## Emits a ``=copy`` hook call with `dst`, `src`, and (if necessary)
   ## `maybeCyclic` as the arguments.
   let
     t  = dst.typ
     op = getOp(graph, t, attachedAsgn)
-  assert op != nil
 
-  bu.buildVoidCall(op):
+  bu.buildVoidCall(env, op):
     bu.emitByName(dst, ekMutate)
     bu.emitByVal src
 
@@ -650,7 +653,7 @@ func destructiveMoveOperands(bu: var MirBuilder, tree: MirTree,
     (bu.bindImmutable(tree, src), bu.bindMut(tree, x))
 
 proc expandAsgn(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
-                stmt: NodePosition, pos: InstrPos,
+                env: var MirEnv, stmt: NodePosition, pos: InstrPos,
                 c: var Changeset) =
   ## Expands an assignment into either a copy, move, or destructive move.
   ## `stmt` is the assignment statement node and `pos` is the 'def' data-flow
@@ -683,17 +686,17 @@ proc expandAsgn(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
               # ``=sink`` would otherwise destroy ``x`` first, also destroying
               # ``x.y`` in the process
               let b = bu.bindImmutable(tree, source)
-              genSinkFromTemporary(bu, ctx.graph, a, b)
+              genSinkFromTemporary(bu, ctx.graph, env, a, b)
             elif needsReset(tree, ctx.cfg, ar, sourcePath, pos):
               # a sink from a location that needs to be reset after the move
               # (i.e., a destructive move)
               let (b, clear) = bu.destructiveMoveOperands(tree, source)
-              genInjectedSink(bu, ctx.graph, a, b)
+              genInjectedSink(bu, ctx.graph, env, a, b)
               genWasMoved(bu, ctx.graph, clear)
             else:
               # a sink from a location that doesn't need to be cleared after
               let b = bu.bindImmutable(tree, source)
-              genInjectedSink(bu, ctx.graph, a, b)
+              genInjectedSink(bu, ctx.graph, env, a, b)
 
         else:
           # this is a bit hack-y, but in order to support changes within the
@@ -716,7 +719,7 @@ proc expandAsgn(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
             # the value is only accessible through the source expression, a
             # destructive move is not required
             let a = bu.bindMut(tree, dest)
-            genInjectedSink(bu, ctx.graph, a, tmp)
+            genInjectedSink(bu, ctx.graph, env, a, tmp)
 
       else:
         # the destination location doesn't contain a value yet (which would
@@ -748,10 +751,11 @@ proc expandAsgn(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
         a = bu.bindMut(tree, dest)
         b = bu.inline(tree, source)
 
-      genCopy(bu, ctx.graph, a, b, maybeCyclic)
+      genCopy(bu, ctx.graph, env, a, b, maybeCyclic)
 
 proc expandDef(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
-               at: NodePosition, pos: InstrPos, c: var Changeset) =
+               env: var MirEnv, at: NodePosition, pos: InstrPos,
+               c: var Changeset) =
   ## Depending on whether the source can be moved out of, either rewrites the
   ## 'def' at `at` into a call to the ``=copy`` hook call or into a
   ## destructive move. If the source can be moved out of non-destructively,
@@ -772,7 +776,7 @@ proc expandDef(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
         b = bu.inline(tree, source)
       # the destination can only be a cell-like location (local, global,
       # etc.), no cycle can possibly be introduced
-      genCopy(bu, ctx.graph, a, b, false)
+      genCopy(bu, ctx.graph, env, a, b, false)
   of true:
     if isNamed(tree, OpValue source) and
        needsReset(tree, ctx.cfg, ar, computePath(tree, source), pos):
@@ -874,7 +878,8 @@ proc checkCopy(graph: ModuleGraph, tree: MirTree, expr: NodePosition,
                         op: attachedAsgn)
 
 proc rewriteAssignments(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
-                        diags: var seq[LocalDiag], c: var Changeset) =
+                        env: var MirEnv, diags: var seq[LocalDiag],
+                        c: var Changeset) =
   ## Rewrites assignments to locations into calls to either the ``=copy``
   ## or ``=sink`` hook (see ``expandAsgn`` for more details), using the
   ## previously computed ownership information to decide.
@@ -914,19 +919,20 @@ proc rewriteAssignments(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
             if isUsedForSink(tree, stmt):
               diags.add LocalDiag(kind: ldkPassCopyToSink,
                                   pos: src)
-          expandDef(tree, ctx, ar, stmt, i, c)
+          expandDef(tree, ctx, ar, env, stmt, i, c)
       of mnkAsgn, mnkInit:
         let src = tree.child(stmt, 1)
         if not isMoveable(tree, ar.v[], src):
           checkCopy(ctx.graph, tree, src, diags)
-        expandAsgn(tree, ctx, ar, stmt, i, c)
+        expandAsgn(tree, ctx, ar, env, stmt, i, c)
       else:
         # e.g., output arguments to procedures
         discard "ignore"
 
 # --------- destructor injection -------------
 
-proc injectDestructorsInner(bu: var MirBuilder, orig: MirTree, graph: ModuleGraph,
+proc injectDestructorsInner(bu: var MirBuilder, orig: MirTree,
+                            graph: ModuleGraph, env: var MirEnv,
                             entries: openArray[DestroyEntry]) =
   ## Generates a destructor call for each item in `entries`, using `buf` as the
   ## output.
@@ -939,11 +945,12 @@ proc injectDestructorsInner(bu: var MirBuilder, orig: MirTree, graph: ModuleGrap
       of mnkTemp:    orig[def].typ
       else:          unreachable()
 
-    bu.buildVoidCall(getOp(graph, t, attachedDestructor)):
+    bu.buildVoidCall(env, getOp(graph, t, attachedDestructor)):
       bu.emitByName(Value(node: orig[def]), ekMutate)
 
 proc injectDestructors(tree: MirTree, graph: ModuleGraph,
-                       destroy: seq[DestroyEntry], c: var Changeset) =
+                       destroy: seq[DestroyEntry], env: var MirEnv,
+                       c: var Changeset) =
   ## Injects a destructor call for each entity in the `destroy` list, in the
   ## entities reverse order they are defined. That is the entity defined last
   ## is destroyed first
@@ -1009,16 +1016,17 @@ proc injectDestructors(tree: MirTree, graph: ModuleGraph,
           # there's no need for opening a new scope -- we use a statement-list
           # instead
           buf.subTree MirNode(kind: mnkStmtList):
-            injectDestructorsInner(buf, tree, graph,
+            injectDestructorsInner(buf, tree, graph, env,
                                    toOpenArray(entries, s.a, s.b))
 
         buf.add endNode(mnkTry)
       else:
-        injectDestructorsInner(buf, tree, graph,
+        injectDestructorsInner(buf, tree, graph, env,
                                toOpenArray(entries, s.a, s.b))
 
 proc lowerBranchSwitch(bu: var MirBuilder, body: MirTree, graph: ModuleGraph,
-                       idgen: IdGenerator, stmt: NodePosition) =
+                       idgen: IdGenerator, env: var MirEnv,
+                       stmt: NodePosition) =
   ## Lowers a 'switch' operation into a simple discriminant assignment plus
   ## the logic for destroying the previous branch (if necessary)
   assert body[stmt].kind == mnkSwitch
@@ -1079,7 +1087,7 @@ proc lowerBranchSwitch(bu: var MirBuilder, body: MirTree, graph: ModuleGraph,
     bu.subTree mnkIf:
       bu.use val
       # ``=destroy`` call:
-      bu.buildVoidCall(branchDestructor):
+      bu.buildVoidCall(env, branchDestructor):
         # pass the original variant access to the destroy call
         bu.subTree mnkName:
           bu.subTree MirNode(kind: mnkTag, effect: ekInvalidate):
@@ -1121,7 +1129,8 @@ func shouldInjectDestructorCalls*(owner: PSym): bool =
      {sfInjectDestructors, sfGeneratedOp} * owner.flags == {sfInjectDestructors} and
      (owner.kind != skIterator or not isInlineIterator(owner.typ))
 
-proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
+proc injectDestructorCalls*(g: ModuleGraph, idgen: IdGenerator,
+                            env: var MirEnv, owner: PSym,
                             body: var MirBody) =
   ## The ``injectdestructors`` pass entry point. The pass is made up of
   ## multiple sub-passes, hence the mutable `body` (as opposed
@@ -1151,7 +1160,7 @@ proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
       for i, n in body.code.pairs:
         if n.kind == mnkSwitch:
           changes.replaceMulti(body.code, i, buf):
-            lowerBranchSwitch(buf, body.code, g, idgen, i)
+            lowerBranchSwitch(buf, body.code, g, idgen, env, i)
 
     apply(changes)
 
@@ -1173,12 +1182,12 @@ proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
       AnalysisResults(v: cursor(values),
                       entities: cursor(entities),
                       destroy: cursor(destructors)),
-      diags, changes)
+      env, diags, changes)
 
     # turn the collected diagnostics into reports and report them:
     reportDiagnostics(g, body, owner, diags)
 
-    injectDestructors(body.code, g, destructors, changes)
+    injectDestructors(body.code, g, destructors, env, changes)
 
     apply(changes)
 

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -1184,5 +1184,5 @@ proc injectDestructorCalls*(g: ModuleGraph; idgen: IdGenerator; owner: PSym;
 
   if g.config.arcToExpand.hasKey(owner.name.s):
     g.config.msgWrite("--expandArc: " & owner.name.s & "\n")
-    g.config.msgWrite(render(body.code))
+    g.config.msgWrite(render(body.code, addr env))
     g.config.msgWrite("\n-- end of expandArc ------------------------\n")

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1997,7 +1997,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
 
     # pass the template symbol as the first argument
     var callee = TDest(x)
-    c.genLit(call[1], c.toNodeCnst(newSymNode(call[1].sym)), callee)
+    c.genLit(call[1], c.toNodeCnst(call[1].astLit), callee)
     # XXX: don't create a new symbol node here; in ``transformExpandToAst``,
     #      emit an ``nkNimNodeLit`` for the callee instead
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -49,6 +49,10 @@ import
     magicsys,
     modulegraphs
   ],
+  compiler/mir/[
+    mirenv,
+    mirtrees
+  ],
   compiler/front/[
     msgs,
     options
@@ -140,6 +144,9 @@ type
     ## Bundles all input, output, and other contextual data needed for the
     ## code generator
     prc: BProc
+
+    # code-generator owned state:
+    env*: MirEnv
 
     # immutable input parameters:
     graph*: ModuleGraph
@@ -568,8 +575,8 @@ proc clearDest(c: var TCtx; n: CgNode; dest: var TDest) {.inline.} =
     c.freeTemp(dest)
     dest = -1
 
-func isNotOpr(n: CgNode): bool {.inline.} =
-  getMagic(n) == mNot
+func isNotOpr(env: MirEnv, n: CgNode): bool {.inline.} =
+  getMagic(env, n) == mNot
 
 proc whichAsgnOpc(t: PType): TOpcode {.used.} =
   case t.skipTypes(IrrelevantTypes + {tyRange}).kind
@@ -623,7 +630,7 @@ proc genIf(c: var TCtx, n: CgNode) =
       let it = n
       withDest(tmp):
         var elsePos: TPosition
-        if isNotOpr(it[0]):
+        if isNotOpr(c.env, it[0]):
           c.gen(it[0][1], tmp)
           elsePos = c.xjmp(it[0][1], opcTJmp, tmp) # if true
         else:
@@ -925,14 +932,14 @@ proc genLit(c: var TCtx; n: CgNode; dest: var TDest) =
   genLit(c, n, lit, dest)
 
 
-proc genProcLit(c: var TCtx, n: CgNode, s: PSym; dest: var TDest) =
-  let idx = c.linking.symToIndexTbl[s.id].int
+proc genProcLit(c: var TCtx, n: CgNode; dest: var TDest) =
   if dest.isUnset or c.prc.regInfo[dest].kind == slotTempUnknown:
     # ``prepare`` wouldn't work here, as we need to use the internal type
-    if dest.isUnset: dest = c.getTemp(s.typ)
-    c.gABx(n, opcLdNull, dest, c.genType(s.typ, noClosure=true))
+    if dest.isUnset: dest = c.getTemp(n.typ)
+    c.gABx(n, opcLdNull, dest, c.genType(n.typ, noClosure=true))
 
-  c.gABx(n, opcWrProc, dest, idx)
+  # the ID of the procedure also represents its table index
+  c.gABx(n, opcWrProc, dest, int(n.prc))
 
 proc genCall(c: var TCtx; n: CgNode; dest: var TDest) =
   var res = dest
@@ -1029,7 +1036,7 @@ proc genCall(c: var TCtx; n: CgNode; dest: var TDest) =
 proc genField(c: TCtx; n: CgNode): TRegister =
   assert n.kind == cnkField
 
-  let s = n.sym
+  let s = n.field
   if s.position > high(typeof(result)):
     fail(n.info, vmGenDiagTooLargeOffset, sym = s)
 
@@ -1467,7 +1474,7 @@ proc genCastIntFloat(c: var TCtx; n: CgNode; dest: var TDest) =
        n.operand.kind == cnkProc:
     # casting a procedure literal to another type. This is the same as just
     # loading the literal
-    genProcLit(c, n, n.operand.sym, dest)
+    genProcLit(c, n.operand, dest)
   else:
     # todo: support cast from tyInt to tyRef
     raiseVmGenError:
@@ -1923,7 +1930,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mNGetType:
     let tmp = c.genx(n[1])
     if dest.isUnset: dest = c.getTemp(n.typ)
-    let rc = case n[0].sym.name.s:
+    let rc = case c.env.procedures[n[0].prc].name.s:
       of "getType":     0
       of "typeKind":    1
       of "getTypeInst": 2
@@ -1933,7 +1940,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
     c.freeTemp(tmp)
     #genUnaryABC(c, n, dest, opcNGetType)
   of mNSizeOf:
-    let imm = case n[0].sym.name.s:
+    let imm = case c.env.procedures[n[0].prc].name.s:
       of "getSize":   0
       of "getAlign":  1
       of "getOffset": 2
@@ -1958,7 +1965,8 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mEqNimrodNode: genBinaryABC(c, n, dest, opcEqNimNode)
   of mSameNodeType: genBinaryABC(c, n, dest, opcSameNodeType)
   of mNLineInfo:
-    case n[0].sym.name.s
+    let name = c.env[n[0].prc].name
+    case name.s
     of "getFile": genUnaryABI(c, n, dest, opcNGetLineInfo, 0)
     of "getLine": genUnaryABI(c, n, dest, opcNGetLineInfo, 1)
     of "getColumn": genUnaryABI(c, n, dest, opcNGetLineInfo, 2)
@@ -1968,7 +1976,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
       genBinaryStmt(c, n, opcNSetLineInfo)
     else:
       internalAssert(
-        c.config, false, "Unexpected mNLineInfo symbol name - " & n[0].sym.name.s)
+        c.config, false, "Unexpected mNLineInfo symbol name - " & name.s)
   of mNHint, mNWarning, mNError:
     unused(c, n, dest)
     c.genCall(n, dest)
@@ -2103,8 +2111,8 @@ func cannotEval(c: TCtx; n: CgNode) {.noinline, noreturn.} =
   # XXX: move this kind of error reporting outside of vmgen instead
   {.cast(noSideEffect).}:
     let ast =
-      if n.kind in {cnkProc, cnkConst, cnkGlobal}:
-        newSymNode(n.sym, n.info)
+      if n.kind == cnkField:
+        newSymNode(n.field, n.info)
       else:
         nil # give up
 
@@ -2115,6 +2123,9 @@ proc importcCondVar*(s: PSym): bool {.inline.} =
   if sfImportc in s.flags:
     return s.kind in {skVar, skLet, skConst}
 
+# TODO: the "can eval" checks below need to happend *before* the AST -> MIR
+#       translation
+#[
 proc checkCanEval(c: TCtx; n: CgNode) =
   # we need to ensure that we don't evaluate 'x' here:
   # proc foo() = var x ...
@@ -2127,7 +2138,7 @@ proc checkCanEval(c: TCtx; n: CgNode) =
   if s.kind in {skProc, skFunc, skConverter, skMethod,
                   skIterator} and sfForward in s.flags:
     cannotEval(c, n)
-
+]#
 
 proc genDiscrVal(c: var TCtx, discr, n: CgNode, oty: PType): TRegister =
   ## Generate the code for preparing and loading the discriminator value
@@ -2140,10 +2151,10 @@ proc genDiscrVal(c: var TCtx, discr, n: CgNode, oty: PType): TRegister =
     let (o, idx) =
       getFieldAndOwner(
         c.getOrCreate(oty),
-        fpos(discr.sym.position))
+        fpos(discr.field.position))
     o.fieldAt(idx).typ
 
-  let recCase = findRecCase(oty, discr.sym)
+  let recCase = findRecCase(oty, discr.field)
   assert recCase != nil
 
   if n.kind in {cnkIntLit, cnkUIntLit}:
@@ -2206,7 +2217,7 @@ proc genFieldAsgn(c: var TCtx, obj: TRegister; le, ri: CgNode) =
   c.config.internalAssert(le.kind == cnkFieldAccess)
 
   let idx = c.genField(le[1])
-  let s = le[1].sym
+  let s = le[1].field
 
   if sfDiscriminant notin s.flags:
     putIntoLoc(c, ri, obj, idx, opcWrObj, opcLdObj)
@@ -2414,7 +2425,6 @@ proc genAsgn(c: var TCtx; le, ri: CgNode; requiresCopy: bool) =
     # they're skipped
     genAsgn(c, le.operand, ri, requiresCopy)
   of cnkGlobal:
-    checkCanEval(c, le)
     var dest = noDest
     c.genSym(le, dest, load=false)
     putIntoLoc(c, ri, dest, 0, opcWrLoc, opcWrLoc)
@@ -2439,29 +2449,23 @@ proc useGlobal(c: var TCtx, n: CgNode): int =
     ## Resolves the global identified by symbol node `n` to the ID that
     ## identifies it at run-time. If using the global is illegal (because
     ## it's an importc'ed variable, for example), an error is raised.
-    let s = n.sym
+    let s = c.env[n.global]
 
     if importcCondVar(s) or c.importcCond(s):
       # Using importc'ed symbols on the left or right side of an expression is
       # not allowed
       fail(n.info, vmGenDiagCannotImportc, sym = s)
 
-    if s.id in c.linking.symToIndexTbl:
-      # XXX: double table lookup
-      result = c.linking.symToIndexTbl[s.id].int
-    else:
-      # a global that is not accessible in the current context
-      cannotEval(c, n)
+    int n.global
 
 proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
   ## Generates and emits the code for loading either the value or handle of
   ## the location named by symbol or local node `n` into the `dest` register.
   case n.kind
   of cnkConst:
-    let s = n.sym
     prepare(c, dest, n.typ)
 
-    let pos = int c.linking.lookup(s)
+    let pos = int n.cnst
     if load and fitsRegister(n.typ):
       let cc = c.getTemp(n.typ)
       c.gABx(n, opcLdCmplxConst, cc, pos)
@@ -2473,12 +2477,11 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
     discard genType(c, n.typ) # make sure the type exists
   of cnkGlobal:
     # a global location
-    let s = n.sym
     let pos = useGlobal(c, n)
     if dest.isUnset:
-      dest = c.getTemp(s.typ)
+      dest = c.getTemp(n.typ)
 
-    if load and (isLocView(s.typ) or fitsRegister(s.typ)):
+    if load and (isLocView(n.typ) or fitsRegister(n.typ)):
       let cc = c.getTemp(n.typ)
       c.gABx(n, opcLdGlobal, cc, pos)
       c.genRegLoad(n, dest, cc)
@@ -2508,7 +2511,7 @@ proc genSymAddr(c: var TCtx, n: CgNode, dest: var TDest) =
   case n.kind
   of cnkConst:
     let
-      pos = int c.linking.lookup(n.sym)
+      pos = int n.cnst
       tmp = c.getTemp(slotTempComplex)
     c.gABx(n, opcLdCmplxConst, tmp, pos)
     c.gABC(n, opcAddr, dest, tmp)
@@ -2810,7 +2813,7 @@ proc genObjConstr(c: var TCtx, n: CgNode, dest: TRegister) =
   for it in n.items:
     assert it.kind == cnkBinding and it[0].kind == cnkField
     let idx = genField(c, it[0])
-    if sfDiscriminant notin it[0].sym.flags:
+    if sfDiscriminant notin it[0].field.flags:
       putIntoLoc(c, it[1], obj, idx, opcWrObj, opcLdObj)
     else:
       let tmp = c.genDiscrVal(it[0], it[1], n.typ)
@@ -2854,16 +2857,15 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
 
   case n.kind
   of cnkProc:
-    let s = n.sym
-    checkCanEval(c, n)
+    let s = c.env.procedures[n.prc]
     if importcCond(c, s) and lookup(c.linking.callbackKeys, s) == -1:
       fail(n.info, vmGenDiagCannotImportc, sym = s)
 
-    genProcLit(c, n, s, dest)
+    genProcLit(c, n, dest)
   of cnkConst, cnkGlobal, cnkLocal:
     genSym(c, n, dest)
   of cnkCall, cnkCheckedCall:
-    let magic = getMagic(n)
+    let magic = getMagic(c.env, n)
     if magic != mNone:
       genMagic(c, n, dest, magic)
     elif n[0].kind == cnkProc and n[0].sym.kind == skMethod and

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -29,6 +29,7 @@ import
     mirbodies,
     mirbridge,
     mirconstr,
+    mirenv,
     mirgen,
     mirpasses,
     mirtrees,
@@ -48,6 +49,9 @@ import
     vmmemory,
     vmtypegen
   ],
+  compiler/utils/[
+    idioms
+  ],
   experimental/[
     results
   ]
@@ -57,10 +61,6 @@ export VmGenResult
 type
   JitState* = object
     ## State of the VM's just-in-time compiler that is kept across invocations.
-    discovery: DiscoveryData
-      ## acts as the source-of-truth regarding what entities exists. All
-      ## entities not registered with `discovery` also don't exist in
-      ## ``TCtx``
     gen: CodeGenCtx
       ## code generator state
 
@@ -95,38 +95,24 @@ func swapState(c: var TCtx, gen: var CodeGenCtx) =
   swap(typeInfoCache)
   swap(rtti)
 
-proc updateEnvironment(c: var TCtx, data: var DiscoveryData) =
+proc updateEnvironment(c: var TCtx, env: var MirEnv, cp: EnvCheckpoint) =
   ## Needs to be called after a `vmgen` invocation and prior to resuming
   ## execution. Allocates and sets up the execution resources required for the
-  ## newly gathered dependencies.
+  ## newly gathered dependencies (those added since `cp` was created).
   ##
   ## This "commits" to the new dependencies.
 
   # procedures
-  c.functions.setLen(data.procedures.len)
-  for i, sym in visit(data.procedures):
-    c.functions[i] = initProcEntry(c, sym)
+  for id, sym in since(env.procedures, cp.procs):
+    c.functions.add initProcEntry(c, sym)
 
-  block: # globals and threadvars
-    # threadvars are currently treated the same as normal globals
-    var i = c.globals.len
-    c.globals.setLen(data.globals.len + data.threadvars.len)
-
-    template alloc(q: Queue[PSym]) =
-      for _, sym in visit(q):
-        let typ = c.getOrCreate(sym.typ)
-        c.globals[i] = c.heap.heapNew(c.allocator, typ)
-        inc i
-
-    # order is important here!
-    alloc(data.globals)
-    alloc(data.threadvars)
+  # globals (which includes threadvars)
+  for id, sym in since(env.globals, cp.globals):
+    let typ = c.getOrCreate(sym.typ)
+    c.globals.add c.heap.heapNew(c.allocator, typ)
 
   # constants
-  c.complexConsts.setLen(data.constants.len)
-  for i, sym in visit(data.constants):
-    assert sym.ast.kind notin nkLiterals
-
+  for id, sym in since(env.constants, cp.consts):
     let
       typ = c.getOrCreate(sym.typ)
       handle = c.allocator.allocConstantLocation(typ)
@@ -135,8 +121,7 @@ proc updateEnvironment(c: var TCtx, data: var DiscoveryData) =
     #       allocated with `allocConstantLocation` inside `serialize` here
     c.serialize(sym.ast, handle)
 
-    c.complexConsts[i] = handle
-
+    c.complexConsts.add handle
 
 func removeLastEof(c: var TCtx) =
   let last = c.code.len-1
@@ -146,60 +131,40 @@ func removeLastEof(c: var TCtx) =
     c.code.setLen(last)
     c.debug.setLen(last)
 
-func discoverGlobalsAndRewrite(data: var DiscoveryData, body: var MirBody,
-                               rewrite: bool) =
-  ## Scans `tree` for definitions of globals, registers them with the `data`,
-  ## and rewrites their definitions into assignments (if `rewrite` is true).
-  template tree(): MirTree =
-    body.code
+func register(linker: var LinkerData, s: PSym, it: MirNode) =
+  ## Registers a newly discovered entity in the link table.
+  case it.kind
+  of mnkConst:
+    discard "nothing to do"
+  of mnkGlobal:
+    # XXX: only required for the compiler API
+    #      (``compilerbridge.setGlobalValue``). The MirEnv should be queried
+    #      directly (through ``vmjit``), instead of the link table being used
+    #      for this
+    linker.symToIndexTbl[s.id] = LinkIndex(it.global)
+  of mnkProc:
+    # XXX: the additional table is only required so that constructing values
+    #      directly from AST works (symbols need to be translated to procedure
+    #      IDs). Once constant data is represented with the MIR, this becomes
+    #      obsolete
+    linker.symToIndexTbl[s.id] = LinkIndex(it.prc)
+  else:
+    unreachable()
 
-  # scan the body for definitions of globals:
-  var i = NodePosition 0
-  while i.int < tree.len:
-    case tree[i].kind
-    of DefNodes:
-      if tree[i + 1].kind == mnkGlobal and
-         (let g = tree[i+1].sym; sfImportc notin g.flags):
-        # found a global definition; register it. Imported ones are
-        # ignored -- ``vmgen`` will report an error when the global is
-        # accessed
-        data.registerGlobal(g)
-
-      i = sibling(tree, i)
-    else:
-      inc i
-
-func register(linker: var LinkerData, data: DiscoveryData) =
-  ## Registers the newly discovered entities in the link table, but doesn't
-  ## commit to them yet.
-  for i, it in peek(data.procedures):
-    linker.symToIndexTbl[it.id] = LinkIndex(i)
-
-  for i, it in peek(data.constants):
-    linker.symToIndexTbl[it.id] = LinkIndex(i)
-
-  # first register globals, then threadvars. This order must be the same as
-  # the one they're later committed to in
-  for i, it in peek(data.globals):
-    linker.symToIndexTbl[it.id] = LinkIndex(i)
-
-  for i, it in peek(data.threadvars):
-    linker.symToIndexTbl[it.id] = LinkIndex(i)
-
-proc generateMirCode(c: var TCtx, n: PNode;
+proc generateMirCode(c: var TCtx, env: var MirEnv, n: PNode;
                      isStmt = false): MirBody =
   ## Generates the initial MIR code for a standalone statement/expression.
   if isStmt:
     # we want statements wrapped in a scope, hence generating a proper
     # fragment
-    result = generateCode(c.graph, c.module, selectOptions(c), n)
+    result = generateCode(c.graph, env, c.module, selectOptions(c), n)
   else:
     var bu: MirBuilder
-    generateCode(c.graph, selectOptions(c), n, bu, result.source)
+    generateCode(c.graph, env, selectOptions(c), n, bu, result.source)
     result.code = finish(bu)
 
-proc generateIR(c: var TCtx, body: sink MirBody): Body =
-  backends.generateIR(c.graph, c.idgen, c.module, body)
+proc generateIR(c: var TCtx, env: MirEnv, body: sink MirBody): Body =
+  backends.generateIR(c.graph, c.idgen, env, c.module, body)
 
 proc setupRootRef(c: var TCtx) =
   ## Sets up if the ``RootRef`` type for the type info cache. This
@@ -227,25 +192,26 @@ proc genStmt*(jit: var JitState, c: var TCtx; n: PNode): VmGenResult =
   ## Generates and emits code for the standalone top-level statement `n`.
   c.removeLastEof()
 
+  let cp = checkpoint(jit.gen.env)
+
   # `n` is expected to have been put through ``transf`` already
-  var mirBody = generateMirCode(c, n, isStmt = true)
-  discoverGlobalsAndRewrite(jit.discovery, mirBody, true)
+  var mirBody = generateMirCode(c, jit.gen.env, n, isStmt = true)
   applyPasses(mirBody, c.module, c.config, targetVm)
-  discoverFrom(jit.discovery, mirBody.code)
-  register(c.linking, jit.discovery)
+  for s, n in discover(jit.gen.env, cp):
+    register(c.linking, s, n)
 
   let
-    body = generateIR(c, mirBody)
+    body = generateIR(c, jit.gen.env, mirBody)
     start = c.code.len
 
   # generate the bytecode:
   let r = runCodeGen(c, jit.gen, body): genStmt(jit.gen, body)
 
   if unlikely(r.isErr):
-    rewind(jit.discovery)
+    rewind(jit.gen.env, cp)
     return VmGenResult.err(r.takeErr)
 
-  updateEnvironment(c, jit.discovery)
+  updateEnvironment(c, jit.gen.env, cp)
 
   result = VmGenResult.ok: (start: start, regCount: r.get)
 
@@ -258,31 +224,25 @@ proc genExpr*(jit: var JitState, c: var TCtx, n: PNode): VmGenResult =
   #      all expect statements). Ideally, dedicated support for
   #      expressions would be removed from the JIT.
 
-  var mirBody = generateMirCode(c, n)
-  # constant expression outside of routines can currently also contain
-  # definitions of globals...
-  # XXX: they really should not, but that's up to sem. Example:
-  #
-  #        const c = block: (var x = 0; x)
-  #
-  #     If `c` is defined at the top-level, then `x` is a "global" variable
-  discoverGlobalsAndRewrite(jit.discovery, mirBody, false)
+  let cp = checkpoint(jit.gen.env)
+
+  var mirBody = generateMirCode(c, jit.gen.env, n)
   applyPasses(mirBody, c.module, c.config, targetVm)
-  discoverFrom(jit.discovery, mirBody.code)
-  register(c.linking, jit.discovery)
+  for s, n in discover(jit.gen.env, cp):
+    register(c.linking, s, n)
 
   let
-    body = generateIR(c, mirBody)
+    body = generateIR(c, jit.gen.env, mirBody)
     start = c.code.len
 
   # generate the bytecode:
   let r = runCodeGen(c, jit.gen, body): genExpr(jit.gen, body)
 
   if unlikely(r.isErr):
-    rewind(jit.discovery)
+    rewind(jit.gen.env, cp)
     return VmGenResult.err(r.takeErr)
 
-  updateEnvironment(c, jit.discovery)
+  updateEnvironment(c, jit.gen.env, cp)
 
   result = VmGenResult.ok: (start: start, regCount: r.get)
 
@@ -300,21 +260,16 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
       # when in suggest mode
       transformBody(c.graph, c.idgen, s, cache = true)
 
-  echoInput(c.config, s, body)
-  var mirBody = generateCode(c.graph, s, selectOptions(c), body)
-  echoMir(c.config, s, mirBody)
-  # XXX: lifted globals are currently not extracted from the procedure and,
-  #      for the most part, behave like normal locals. The call to
-  #      ``discoverGlobalsAndRewrite`` plus the MIR -> ``CgNode`` translation
-  #      make sure that at least ``vmgen`` doesn't have to be concerned with
-  #      that, but eventually it needs to be decided how lifted globals should
-  #      work in compile-time and interpreted contexts
-  discoverGlobalsAndRewrite(jit.discovery, mirBody, false)
-  applyPasses(mirBody, s, c.config, targetVm)
-  discoverFrom(jit.discovery, mirBody.code)
-  register(c.linking, jit.discovery)
+  let cp = checkpoint(jit.gen.env)
 
-  let outBody = generateIR(c.graph, c.idgen, s, mirBody)
+  echoInput(c.config, s, body)
+  var mirBody = generateCode(c.graph, jit.gen.env, s, selectOptions(c), body)
+  echoMir(c.config, s, mirBody)
+  applyPasses(mirBody, s, c.config, targetVm)
+  for s, n in discover(jit.gen.env, cp):
+    register(c.linking, s, n)
+
+  let outBody = generateIR(c.graph, c.idgen, jit.gen.env, s, mirBody)
   echoOutput(c.config, s, outBody)
 
   try:
@@ -325,10 +280,10 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
     raise
 
   if unlikely(result.isErr):
-    rewind(jit.discovery)
+    rewind(jit.gen.env, cp)
     return
 
-  updateEnvironment(c, jit.discovery)
+  updateEnvironment(c, jit.gen.env, cp)
 
 func isAvailable*(c: TCtx, prc: PSym): bool =
   ## Returns whether the bytecode for `prc` is already available.
@@ -339,24 +294,13 @@ proc registerProcedure*(jit: var JitState, c: var TCtx, prc: PSym): FunctionInde
   ## If it hasn't been already, adds `prc` to the set of procedures the JIT
   ## code-generator knowns about and sets up a function-table entry. `jit` is
   ## required to not be in the process of generating code.
-  assert jit.discovery.procedures.isProcessed, "code generation in progress?"
-  var index = -1
+  if prc notin jit.gen.env.procedures:
+    let id = jit.gen.env.procedures.add(prc)
+    c.linking.symToIndexTbl[prc.id] = LinkIndex id
+    c.functions.add initProcEntry(c, prc)
+    assert int(id) == c.functions.high, "tables are out of sync"
 
-  register(jit.discovery, prc)
-  # if one was added, commit to the new entry now and create a function-table
-  # entry it
-  c.functions.setLen(jit.discovery.procedures.len)
-  for i, it in visit(jit.discovery.procedures):
-    assert it == prc
-    c.linking.symToIndexTbl[it.id] = LinkIndex(i)
-    c.functions[i] = initProcEntry(c, it)
-    index = i
-
-  if index == -1:
-    # no entry was added -> one must exist already
-    result = FunctionIndex(c.linking.symToIndexTbl[prc.id])
-  else:
-    result = FunctionIndex(index)
+  result = FunctionIndex c.linking.symToIndexTbl[prc.id]
 
 proc compile*(jit: var JitState, c: var TCtx, fnc: FunctionIndex): VmGenResult =
   ## Generates code for the the given function and updates the execution

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -169,9 +169,6 @@ func discoverGlobalsAndRewrite(data: var DiscoveryData, body: var MirBody,
     else:
       inc i
 
-  if rewrite:
-    rewriteGlobalDefs(tree, body.source)
-
 func register(linker: var LinkerData, data: DiscoveryData) =
   ## Registers the newly discovered entities in the link table, but doesn't
   ## commit to them yet.

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -125,7 +125,7 @@ proc updateEnvironment(c: var TCtx, env: var MirEnv, cp: EnvCheckpoint) =
     c.complexConsts.add handle
 
 template preCheck(env: MirEnv, n: PNode) =
-  ## Verifies that `n` can be build and run in JIT mode. If not, aborts the
+  ## Verifies that `n` can be built and run in JIT mode. If not, aborts the
   ## surrounding routine by returning a ``VmGenResult``.
   block:
     let r = validate(env, n)

--- a/compiler/vm/vmjit_checks.nim
+++ b/compiler/vm/vmjit_checks.nim
@@ -1,0 +1,92 @@
+## Implements a validation pass for code running at compile-time or in
+## NimScript/REPL contexts.
+##
+## Future direction: this validation needs to be decoupled from the JIT and
+## moved into the semantical analyisis layer.
+
+import
+  std/[
+    intsets
+  ],
+  compiler/ast/[
+    ast_query,
+    ast_types,
+    lineinfos
+  ],
+  compiler/mir/[
+    mirenv
+  ],
+  compiler/vm/[
+    vmdef
+  ],
+  experimental/[
+    results
+  ]
+
+type
+  CheckError = object of CatchableError
+    diag: VmGenDiag
+
+proc fail(info: TLineInfo, diag: sink VmGenDiag;
+          loc: InstantiationInfo = instLoc()) {.noreturn.} =
+  diag.location = info
+  diag.instLoc = loc
+  raise (ref CheckError)(diag: diag)
+
+proc check(defs: var IntSet, env: MirEnv, n: PNode) =
+  template recurse(n: PNode) =
+    check(defs, env, n)
+
+  case n.kind
+  of nkSym:
+    let s = n.sym
+    case s.kind
+    of skVar, skLet, skForVar:
+      if sfGlobal in s.flags and s.id notin defs and s notin env.globals:
+        fail n.info, VmGenDiag(kind: vmGenDiagCannotEvaluateAtComptime, ast: n)
+    of skProcKinds - {skMethod}:
+      # XXX: instead of erroring when referencing forwarded procedures,
+      #      it might be better to error only when actually *entering* a
+      #      forwarded procedure
+      if sfForward in s.flags:
+        fail n.info, VmGenDiag(kind: vmGenDiagCannotEvaluateAtComptime, ast: n)
+    of skMethod:
+      # report an error for all method usages, including its usage as a
+      # value
+      fail n.info, VmGenDiag(kind: vmGenDiagCannotCallMethod, sym: s)
+    else:
+      discard "nothing to do"
+
+  of nkIdentDefs, nkVarTuple:
+    for it in names(n):
+      # guard against ``nkDotExpr`` (local lifted into environment)
+      if it.kind == nkSym and sfGlobal in it.sym.flags:
+        defs.incl it.sym.id
+
+    recurse(n[^1])
+  of nkWhenStmt:
+    # a 'when nimvm' statement; choose the first branch
+    recurse(n[0][1])
+  of nkCast, nkConv, nkHiddenStdConv, nkHiddenSubConv:
+    recurse(n[1])
+  of callableDefs, nkNimNodeLit, nkTypeSection, nkConstSection, nkTypeOfExpr,
+     nkMixinStmt, nkBindStmt, nkImportStmt, nkImportExceptStmt, nkFromStmt,
+     nkExportStmt:
+    discard "ignore declarative nodes"
+  else:
+    for it in n.items:
+      recurse(it)
+
+proc validate*(env: MirEnv, n: PNode): Result[void, VmGenDiag] =
+  ## Checks that the transformed AST `n`:
+  ## * doesn't use inaccessible globals
+  ## * doesn't use methods (either calling them or using them as value)
+  ## * doesn't use forwarded procedures
+  ## If the AST violates these, the ``VmGenDiag`` for the first error is
+  ## returned.
+  try:
+    var defs = initIntSet()
+    check(defs, env, n)
+    result.initSuccess()
+  except CheckError as e:
+    result.initFailure(move e.diag)

--- a/compiler/vm/vmjit_checks.nim
+++ b/compiler/vm/vmjit_checks.nim
@@ -2,7 +2,7 @@
 ## NimScript/REPL contexts.
 ##
 ## Future direction: this validation needs to be decoupled from the JIT and
-## moved into the semantical analyisis layer.
+## moved into the semantic analyisis layer.
 
 import
   std/[


### PR DESCRIPTION
## Summary

Use ID types for representing procedures, globals, and constants during
the mid- and backend phase, replacing `PSym`. This is significant
progress towards:
- a more data-oriented design
- decoupling `sem` and the backend

Together with the introduction of `MirEnv`, this also paves the way for
further MIR and backend improvements.

## Details

#### General architecture

- procedures, named constants (i.e., `const`), and globals (both normal
  ones and `.threadvar`s) are all identified with a dedicated ID type
  in the mid- and back-end

- `MirEnv` stores the all non-local, non-ephemeral MIR-related data
  - at the moment, these are the `SymbolTable`s, which map the
    aforementioned IDs to the data associated with the entities (name,
    type, flags, etc.)
  - the data is still represented with `PSym`

- `MirEnv` supports a simple snapshot/checkpoint mechanism for
  iterating over the newest additions or rewinding the environment
- the `MirEnv` is a non-`ref` type; it needs to be passed to all
  routines that wish to modify it or lookup entity-related information
- all non-local entities that the MIR wants to reference must be added
  to the `SymbolTable`s
  - a `PSym` can be added directly to a `SymbolTable`, which returns
    the ID
  - the ID is used to lookup the entity-related data later

#### MIR data types

- `MirNode` uses `ProcedureId`,  `ConstId`, and `GlobalId`, for
  referring to the respective entities, replacing `PSym`
- local entities still use `PSym`, but this is going to change in the
  future

#### AST -> MIR translation

- `mirgen` adds symbols to the environment as it needs their IDs
  - this renders separately scanning the `MirTree`s obsolete,
    `backends` only needs to look for additions to the `MirEnv`
- `mirgen` correctly translates top-level globals itself. `vmjit`
  previously had to scan the `def`s of them for the purpose of
  discovery, necessitating a separate pass
  (`mirbridge.rewriteGlobalDefs`)
- the callee of a VM-evaluated template call (i.e., `getAst(templ())`)
  is translated to an `mnkLiteral` instead of an `mnkProc`

#### Common backend logic (`backends`)

- `backends` uses the checkpoint facility of `MirEnv` to keep track of
  environmental changes; the `Queue` facility is no longer needed and
  thus removed

- `BackendEvent` uses the ID types for identifying procedures and
  constants
- `registerLate` is replaced with the `setModuleOverride` facility
- for backend-like processing that doesn't use the `process` iterator
  (e.g., `vmjit`), the `discover` iterator is provided
- procedures that need incremental code generation are marked with the
  `sfForward` flag by the `process` iterator. This prevents them from
  being queued for normal code generation
- apart from passing around IDs instead of `PSym`s, `backends` stays
  mostly the same

#### General code generation

- same as `MirNode`, `CgNode` also uses ID types instead of `PSym`
- a `MirEnv` instance is owned by the backends' respective context
  type (`cgendata.BModuleList`, `jsgen.PGlobals`, `vmgen.CodeGenCtx`)
- in general, the ID types are passed around instead of `PSym`

#### `cgen`

- code-generator information for procedures, constants, and globals now
  use a `SeqMap` instead of the legacy `PSym`-based `SymbolMap`
- `registerLateProc` replaces the manual access to the `extra` list
- `useHook` replace the manual access to the `hooks` list

#### `jsgen`

- constants and globals also use `Loc` now, making the `PSym` overloads
  for `addrLoc` and `accessLoc` obsolete
- procedures use a dedicated `SeqMap` for associating the mangled name
- only field symbols still use the `PGlobals.names` table
- the `definedGlobals` overload accepting an `openArray` was never
  used; it's removed

#### `vmgen` and `vmjit`

- the entities' ID directly corresponds to their VM table index
  - the `symToIndexTbl` still has to be kept for now, as some non-code-
    generation facilities still depend on it

- basic evaluatibility tests for the code (such as rejecting access to
  non-compile-time globals, use of forwarded procedures, etc.) now
  happens in a dedicated pass (`vmjit_checks`) prior to the MIR phase
  - it's a better architecture, decoupling more JIT-mode related checks
    from the code generator
  - it's also necessary now that globals are eagerly added to the
    environment, regardless of whether they're accessible according to
    the language rules

- the `discoverGlobalsAndRewrite` pass is removed; it's obsolete now
  that `mirgen` performs both actions

#### Code-gen orchestration

- all orchestrators are adapted to the `BackendEvent` changes, as well
  as the changes to their respective code generators
- `cbackend` uses `ProcedureId` instead of `int` (a `PSym.id` value)
  for the `.inline` procedure handling
- `vmbackend` uses `ProcedureId` and `GlobalId` instead of `LinkIndex`
  as the key for its list of procedures and globals 

#### Debug rendering

- both `treeRepr` and the pretty-printer for `MirTree`/`MirNode` are
  updated
- if no `MirEnv` is provided to the pretty-printer, it renders the raw
  ID values instead of looking up their user-provided names
  - this allows using the pretty-printer in situations where no
    `MirEnv` is available