### PR TITLE
fix(mirgen): loop-initialized closure locals not being destroyed

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1561,7 +1561,7 @@ proc genVarTuple(c: var TCtx, n: PNode) =
       # generate the assignment:
       c.buildStmt mnkInit:
         genOperand(c, lhs)
-        c.subTree MirNode(kind: mnkPathPos, typ: lhs.sym.typ,
+        c.subTree MirNode(kind: mnkPathPos, typ: lhs.typ,
                           position: i.uint32):
           c.use val
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -144,6 +144,8 @@ type
     sp: SourceProvider
 
     numLabels: int ## provides the ID to use for the next label
+    inLoop: int
+      ## > 0 if the current statement/expression is part of a loop
 
     # input:
     context: TSymKind ## what entity the input AST is part of (e.g. procedure,
@@ -1526,6 +1528,8 @@ proc genVarTuple(c: var TCtx, n: PNode) =
   let
     numDefs = n.len - 2
     initExpr = n[^1]
+    isInit = c.inLoop == 0
+      ## for lifted locals, whether an 'init' assignment can be used
 
   # then, generate the initialization
   case initExpr.kind
@@ -1541,7 +1545,7 @@ proc genVarTuple(c: var TCtx, n: PNode) =
 
       case lhs.kind
       of nkSym:     genLocInit(c, lhs, rhs)
-      of nkDotExpr: genAsgn(c, true, true, lhs, rhs) # closure field
+      of nkDotExpr: genAsgn(c, isInit, true, lhs, rhs) # closure field
       else:         unreachable(lhs.kind)
 
   else:
@@ -1559,7 +1563,7 @@ proc genVarTuple(c: var TCtx, n: PNode) =
         genLocDef(c, lhs, c.graph.emptyNode)
 
       # generate the assignment:
-      c.buildStmt mnkInit:
+      c.buildStmt (if isInit: mnkInit else: mnkAsgn):
         genOperand(c, lhs)
         c.subTree MirNode(kind: mnkPathPos, typ: lhs.typ,
                           position: i.uint32):
@@ -1579,11 +1583,12 @@ proc genVarSection(c: var TCtx, n: PNode) =
       of nkDotExpr:
         # initialization of a variable that was lifted into a closure
         # environment
+        let isInit = c.inLoop == 0
         if a[2].kind != nkEmpty:
-          genAsgn(c, false, true, a[0], a[2])
+          genAsgn(c, isInit, true, a[0], a[2])
         else:
           # no intializer expression -> assign the default value
-          c.buildStmt mnkInit:
+          c.buildStmt (if isInit: mnkInit else: mnkAsgn):
             genOperand(c, a[0])
             c.buildMagicCall mDefault, a[0].typ:
               discard
@@ -1599,7 +1604,9 @@ proc genWhile(c: var TCtx, n: PNode) =
   assert isTrue(n[0]), "`n` wasn't properly transformed"
   c.subTree MirNode(kind: mnkRepeat):
     c.scope:
+      inc c.inLoop
       c.gen(n[1])
+      dec c.inLoop
 
 proc genBlock(c: var TCtx, n: PNode, dest: Destination) =
   ## Generates and emits the MIR code for a ``block`` expression or statement

--- a/tests/lang_objects/destructor/tlifted_local_in_loop.nim
+++ b/tests/lang_objects/destructor/tlifted_local_in_loop.nim
@@ -1,0 +1,75 @@
+discard """
+  description: '''
+    Ensure that lifted locals declared inside loops are destroyed when control-
+    flow reaches the statement again
+  '''
+  targets: "c js vm"
+"""
+
+import mhelper
+
+# all tests are wrapped into procedures, otherwise the inner procedures would
+# not use closures
+
+proc test_no_value() =
+  ## Test local definition with no initial value.
+  var i = 0
+  while i < 2:
+    let o = initValue(1) # can be moved
+    var o2: Value[int] # must destroy the previous value
+    doAssert o2.content == 0 # make sure the location was reset
+    o2 = o
+    proc inner() =
+      doAssert o2.content == 1
+    inner()
+    inc i
+
+test_no_value()
+doAssert numDestroy == 2
+numDestroy = 0
+
+proc test_with_value() =
+  ## Test local definition with initial value.
+  var i = 0
+  while i < 2:
+    let o = initValue(1) # can be moved
+    let o2 = o # must destroy the previous value
+    proc inner() =
+      doAssert o2.content == 1
+    inner()
+    inc i
+
+test_with_value()
+doAssert numDestroy == 2
+numDestroy = 0
+
+proc test_tuple_unpacking() =
+  ## Test local definition using tuple constructor destructuring syntax.
+  var i = 0
+  while i < 2:
+    let o = initValue(1) # can be moved
+    let (o2, other) = (o, 1) # must destroy the previous value
+    proc inner() =
+      doAssert o2.content == 1
+    inner()
+    inc i
+
+test_tuple_unpacking()
+doAssert numDestroy == 2
+numDestroy = 0
+
+proc get(): (Value[int], int) =
+  (initValue(1), 1)
+
+proc test_tuple_unpacking2() =
+  ## Test local definition using tuple destructuring syntax.
+  var i = 0
+  while i < 2:
+    let (o2, other) = get()
+    proc inner() =
+      doAssert o2.content == 1
+    inner()
+    inc i
+
+test_tuple_unpacking2()
+doAssert numDestroy == 2

--- a/tests/lang_objects/destructor/tlifted_local_in_loop.nim
+++ b/tests/lang_objects/destructor/tlifted_local_in_loop.nim
@@ -4,6 +4,7 @@ discard """
     flow reaches the statement again
   '''
   targets: "c js vm"
+  knownIssue.js vm: "Heap cells (the closure environment) is not destroyed"
 """
 
 import mhelper


### PR DESCRIPTION
## Summary

Fix locals defined within a loop and closed over by an inner procedure
(which lifts them into the closure environment) not properly destroyed
when control-flow reaches the `let` or `var` statement again.

The compiler crashing for `let (a, b) = x` statements where `a`
or `b` are closed over is fixed too.

## Details

Except for `let :env.a = b` statements, `mirgen` treated all `let`/
`var` statements for closure locals as *initializing* assignments (by
emitting an `mnkInit` statement).

This is correct for closure locals defined outside of loops, but not
for those defined within loops, as control-flow possibly reaches the
assignment multiple times, but location having been destroyed in
between, (the closure environment is the same through the whole
procedure invocation).

Since `mnkInit` assignments are (correctly) turned into raw
assignments, the old value wasn't destroyed on re-assignment. `mirgen`
now keeps track of whether a statement is enclosed by a loop (via the
`inLoop` counter), and if the statement is, emits a normal assignment
(`mnkAsgn`) instead of an initializing one.

### Compiler crash

For `let (a, b) = x`, `mirgen.genVarTuple` always tried to access the
identifiers nodes as if they were symbols. If they're closed over, this
results in a field defect, since then they're `nkDotExpr` nodes. The
type is now taken from the node itself.

The added test also covers this.