### PR TITLE
sem: `auto`/inferred lambdas generate valid AST

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1741,15 +1741,15 @@ type
     flags*: TTypeFlags        ## flags of the type
     sons*: TTypeSeq           ## base types, etc.
     n*: PNode                 ## node for types:
-                              ## for range types a nkRange node
-                              ## for record types a nkRecord node
-                              ## for enum types a list of symbols
-                              ## if kind == tyInt: it is an 'int literal(x)' type
-                              ## for procs and tyGenericBody, it's the
-                              ## formal param list
-                              ## for concepts, the concept body
-                              ## for errors, nkError or nil if legacy
-                              ## else: unused
+                              ## - range types a nkRange node
+                              ## - record types a nkRecord node
+                              ## - enum types a list of symbols
+                              ## - if kind == tyInt: it is an 'int literal(x)' type
+                              ## - procs and tyGenericBody, it's the formal
+                              ##   param list
+                              ## - concepts, the concept body
+                              ## - errors, nkError or nil if legacy
+                              ## - else: unused
     owner*: PSym              ## the 'owner' of the type
     sym*: PSym                ## types have the sym associated with them
                               ## it is used for converting types to strings

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -175,8 +175,7 @@ proc buildErrorList(config: ConfigRef, n: PNode, errs: var seq[PNode]) =
     errs.add n
   else:
     for i in 0..<n.len:
-      if n[i] != nil:
-        buildErrorList(config, n[i], errs)
+      buildErrorList(config, n[i], errs)
 
 iterator walkErrors*(config: ConfigRef; n: PNode): PNode =
   ## traverses the ast and yields errors from innermost to outermost. this is a

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -123,6 +123,7 @@ proc evalTemplateArgs*(n: PNode, s: PSym; conf: ConfigRef; fromHlo: bool): PNode
   ## for parameters where no argument is provided.
   ##
   ## Despite the name, the procedure also applies to macro arguments.
+  addInNimDebugUtils(conf, "evalTemplateArgs", s, n, result)
   # if the template has zero arguments, it can be called without ``()``
   # `n` is then a nkSym or something similar
   let

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -881,6 +881,11 @@ proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp
   var n = newNodeI(nkProcDef, info, bodyPos+1)
   for i in 0..<n.len: n[i] = newNodeI(nkEmpty, info)
   n[namePos] = newSymNode(result)
+  # xxx: technically we shouldn't assign `result.typ.n` to `paramsPos` because
+  #      the `TType.n` AST for `tyProc` types isn't well formed. This isn't
+  #      a practical issue, because nothing inspects the results of type hooks.
+  #      At the time of writing, `semstmts.semInferredLambda` is an example of
+  #      how to build up the `paramsPos`.
   n[paramsPos] = result.typ.n
   n[bodyPos] = newNodeI(nkStmtList, info)
   result.ast = n

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2182,7 +2182,7 @@ proc semInferredLambda(c: PContext, pt: TIdTable, n: PNode): PNode {.nosinks.} =
   n[genericParamsPos] = c.graph.emptyNode
   # for LL we need to avoid wrong aliasing
   n[paramsPos] = newNodeI(nkFormalParams, n[paramsPos].info, n.typ.n.len)
-  for i, p in n.typ.n:
+  for i, p in n.typ.n.pairs:
     n[paramsPos][i] =
       case i
       of 0: # return type

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2196,7 +2196,6 @@ proc semInferredLambda(c: PContext, pt: TIdTable, n: PNode): PNode {.nosinks.} =
                               tyFromExpr}+tyTypeClasses:
       localReport(c.config, params[i].info, reportSym(
         rsemCannotInferTypeOfParameter, params[i].sym))
-
     #params[i].sym.owner = s
   openScope(c)
   pushOwner(c, s)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2180,9 +2180,16 @@ proc semInferredLambda(c: PContext, pt: TIdTable, n: PNode): PNode {.nosinks.} =
   n[namePos].sym = s
   n[genericParamsPos] = c.graph.emptyNode
   # for LL we need to avoid wrong aliasing
-  let params = copyTree n.typ.n
-  n[paramsPos] = params
+  n[paramsPos] = newNodeI(nkFormalParams, n[paramsPos].info, n.typ.n.len)
+  for i, p in n.typ.n:
+    n[paramsPos][i] =
+      case i
+      of 0: # return type
+        newNodeIT(nkType, n.info, n.typ[0])
+      else: # copy instantiated parameters
+        n.typ.n[i]
   s.typ = n.typ
+  let params = n.typ.n
   for i in 1..<params.len:
     if params[i].typ.kind in {tyTypeDesc, tyGenericParam,
                               tyFromExpr}+tyTypeClasses:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2168,6 +2168,7 @@ proc semProcAnnotation(c: PContext, prc: PNode): PNode =
 
 proc semInferredLambda(c: PContext, pt: TIdTable, n: PNode): PNode {.nosinks.} =
   ## used for resolving 'auto' in lambdas based on their callsite
+  addInNimDebugUtils(c.config, "semInferredLambda", n, result)
   var n = n
   let original = n[namePos].sym
   let s = original #copySym(original, false)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2234,7 +2234,6 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     if s.typ == nil:
       if s.kind != skError:
         localReport(c.config, n, reportSem rsemTypeExpected)
-
       result = newOrPrevType(tyError, prev, c)
     elif s.kind == skParam and s.typ.kind == tyTypeDesc:
       c.config.internalAssert s.typ.base.kind != tyNone and prev == nil

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -543,6 +543,7 @@ proc semOrdinal(c: PContext, n: PNode, prev: PType): PType =
     result = newOrPrevType(tyError, prev, c)
 
 proc semTypeIdent(c: PContext, n: PNode): PSym =
+  addInNimDebugUtils(c.config, "semTypeIdent", n, result)
   if n.kind == nkSym:
     result = getGenSym(c, n.sym)
   else:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1628,6 +1628,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       elif r.kind == tyAnything:
         # 'p(): auto' and 'p(): untyped' are equivalent, but the rest of the
         # compiler is hardly aware of 'auto':
+        # xxx: ^^^ they should _not_ be equivalent
         r = newTypeS(tyUntyped, c)
       elif r.kind == tyStatic:
         # type allowed should forbid this type


### PR DESCRIPTION
## Summary
`auto` parameter and return types resulted in inferred lambda AST being
generated with `nil`s in the parameter position. This is now no longer
the case and the AST generated is well formed.

## Details

`seminferredlambda` was incorrectly copying the AST out of the `tyProc`
type into the parameter position; that AST isn't well formed. This
resulted in `nil` nodes being inserted for the parameter and return in
the output AST. When traversing it for errors, this would generate a
NPE
during `buildErrorList`. A `nil` checking guard was put in place in
order to work around the problem.
see: https://github.com/nim-works/nimskull/pull/1124

Now the AST is well formed, and the check has been removed.
Additionally, some associated changes have been made:

- tracing coverage expansion to diagnose the issue and confirm the fix
- noting potentially the same issue in `liftdestructors`