### PR TITLE
mir: don't use `mnkPNode` for `except` branches

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -338,18 +338,11 @@ proc tbExceptItem(tree: MirBody, cl: var TranslateCl, cr: var TreeCursor
                  ): CgNode =
   let n {.cursor.} = get(tree, cr)
   case n.kind
-  of mnkPNode:
-    assert n.node.kind == nkInfix
-    assert n.node[1].kind == nkType
-    assert n.node[2].kind == nkSym
-    # the infix expression (``type as x``) signals that the except-branch is
-    # a matcher for an imported exception. We translate the infix to a
-    # ``cnkBinding`` node and let the code generators take care of it
-    let id = cl.locals.add initLocal(n.node[2].sym)
-    cl.localsMap[n.node[2].sym.id] = id
-    newTree(cnkBinding, cr.info):
-      [newNode(cnkType, n.node[1].info, n.node[1].typ),
-       newLocalRef(id, n.node[2].info, n.node[2].typ)]
+  of mnkLocal:
+    # the 'except' branch acts as a definition for the local
+    let id = cl.locals.add initLocal(n.sym)
+    cl.localsMap[n.sym.id] = id
+    newLocalRef(id, cr.info, n.typ)
   of mnkType:  newTypeNode(cr.info, n.typ)
   else:        unreachable()
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -725,23 +725,18 @@ proc genTry(p: PProc, n: CgNode) =
 
       useMagic(p, "isObj")
       for j in 0..<n[i].len - 1:
-        var throwObj: CgNode
         let it = n[i][j]
+        let throwObj = it
 
-        if it.kind == cnkBinding:
-          throwObj = it[0]
-          excAlias = it[1]
+        if it.kind == cnkLocal:
+          excAlias = it
           # If this is a ``except exc as sym`` branch there must be no following
           # nodes
           doAssert orExpr == ""
-        else:
-          p.config.internalAssert(it.kind == cnkType, n.info, "genTryStmt")
-          throwObj = it
 
         if orExpr != "": orExpr.add("||")
         # Generate the correct type checking code depending on whether this is a
-        # NIM-native or a JS-native exception
-        # if isJsObject(throwObj.typ):
+        # |NimSkull|-native or a JS-native exception
         if isImportedException(throwObj.typ, p.config):
           orExpr.addf("lastJSError instanceof $1",
             [throwObj.typ.sym.extname])

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1782,10 +1782,10 @@ proc genExceptBranch(c: var TCtx, n: PNode, dest: Destination) =
       of nkType:
         c.add MirNode(kind: mnkType, typ: tn.typ)
       of nkInfix:
-        # ``x as T`` doesn't get transformed to just ``T`` if ``T`` is the
-        # type of an imported exception. We don't care about the type of
-        # exceptions at the MIR-level, so we just use carry it along as is
-        c.add MirNode(kind: mnkPNode, node: tn)
+        # ``T as a`` doesn't get transformed to just ``T`` if ``T`` is the
+        # type of an imported exception -- the local's name is used at the
+        # MIR level
+        c.add MirNode(kind: mnkLocal, typ: tn[2].typ, sym: tn[2].sym)
       else:
         unreachable()
 

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -160,9 +160,12 @@ Semantics
             | Asm VALUE ...
 
   BRANCH_LIST = (Branch <Literal> ... STATEMENT) ... # a list of branches
-  HANDLER = Except (Branch <Type> ... STATEMENT) ... # exception handler
 
-  TRY_STMT = Try STATEMENT (HANDLER)? (Finally STATEMENT)?
+  EXCEPT_BRANCH = Branch <Type> ... STATEMENT # exception handler
+                | Branch <Local>    STATEMENT # exception handler for imported
+                                              # exception
+
+  TRY_STMT = Try STATEMENT (Except EXCEPT_BRANCH ...)? (Finally STATEMENT)?
     # if a handler is present, all `raise` statements within the tried
     # statement are redirected to the handler. If a finalizer is present, all
     # control-flow exiting the tried statement or handler is first redirected


### PR DESCRIPTION
## Summary

Translate `except T as e` (where `T` is an imported exception) to
`(Except (Local "e") ...)` instead of `(Except (PNode ...) ...)`. This
removes a usage of `mnkPNode`, and it also makes the existence of the
local visible at the MIR level.

## Details

* `mnkPNode` was only intended as a transition helper
* instead of a `cnkBinding`, the code generators (only `jsgen` at the
  moment) can identify the imported exception handler by the
  `cnkLocal` node