### PR TITLE
fix(vmbackend): run-time errors with non-zero-based sets

### DIFF
--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -238,12 +238,12 @@ proc generateCodeForMain(c: var GenCtx, config: BackendConfig,
 
   result = id
 
-func storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
-                linking: sink LinkerData,
+proc storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
+                linking: sink LinkerData, config: ConfigRef,
                 consts: seq[(PVmType, PNode)], globals: seq[PVmType]) =
   ## Stores the previously gathered complex constants and globals into `dst`
 
-  var denc: DataEncoder
+  var denc = DataEncoder(config: config)
   denc.startEncoding(dst)
   denc.routineSymLookup = move linking.symToIndexTbl
 
@@ -321,7 +321,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
 
   enc.init(env.types)
   storeEnv(enc, penv, env)
-  storeExtra(enc, penv, c.gen.linking, consts, base(c.globals))
+  storeExtra(enc, penv, c.gen.linking, conf, consts, base(c.globals))
   penv.entryPoint = FunctionIndex(entryPoint)
 
   let err = writeToFile(penv, prepareToWriteOutput(conf))

--- a/tests/stdlib/types/sets/tsets.nim
+++ b/tests/stdlib/types/sets/tsets.nim
@@ -72,15 +72,7 @@ type Foo = enum
 let x = { Foo1, Foo2 }
 # bug #8425
 
-template disallowVm(code: untyped) =
-  when not defined(vm):
-    block:
-      code
-
-# knownIssue: the serilization logic (``vm/packed_env``) doesn't offset the
-#             elements for sets, resulting in either crashes or wrong values
-#             if the first element of a set doesn't have the ordinal value '0'
-disallowVm:
+block:
   # bug #2880
   type
     FakeMsgKind = enum


### PR DESCRIPTION
## Summary

Fix a bug with the VM backend's constant data serialization where
having and using a constant `set` with a non-zero lower bound resulted
in:
* set operations on the set not working as expected
* runner crashes at startup

## Details

The de-serialization logic in `vmrunner` expects zero-based `set`
construction elements, but the serialization logic in `packed_env`
didn't ensure that the element values are zero-based.

`PackedEncoder` now requires access to a `ConfigRef`, which is used for
subtracting the lower bound from all element values (making them zero
based).