### PR TITLE
mir: separate constants from constant data

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -20,6 +20,7 @@ import
     options
   ],
   compiler/mir/[
+    datatables,
     mirbodies,
     mirbridge,
     mirconstr,

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -818,6 +818,7 @@ iterator process*(graph: ModuleGraph, modules: var ModuleList,
       # future direction: the body of the constant (i.e., the value
       # expression) will be transformed to its MIR representation here
       discoverFromValueAst(env, env[item.cnst].ast)
+      env.setData(item.cnst, env.data.getOrPut(env[item.cnst].ast))
       # we cannot report (i.e., yield) right away, the discovered dependencies
       # have to be reported first
       queue.prepend(module, WorkItem(kind: wikReportConst, cnst: item.cnst))
@@ -879,8 +880,10 @@ iterator discover*(env: var MirEnv, progress: EnvCheckpoint
   ## processing -- don't use it in conjunction with the ``process`` iterator.
   for id, it in since(env.constants, progress.consts):
     # first discover and report the procedures referenced by the constant's
-    # data, allowing
+    # data. This ensures that the callsite can rely on all the constant's
+    # dependencies existing in the environment
     discoverFromValueAst(env, astdef(it))
+    env.setData(id, env.data.getOrPut(astdef(it)))
     yield (it, MirNode(kind: mnkConst, cnst: id))
 
   for id, it in since(env.procedures, progress.procs):

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2011,9 +2011,10 @@ proc genConstDefinition*(q: BModule; id: ConstId) =
   let name = mangleName(q.g.graph, sym)
   if exfNoDecl notin sym.extFlags:
     let p = newProc(nil, q)
+    let data = translate(q.g.env, q.g.env[q.g.env.dataFor(id)])
     q.s[cfsData].addf("N_LIB_PRIVATE NIM_CONST $1 $2 = $3;$n",
         [getTypeDesc(q, sym.typ), name,
-        genBracedInit(p, translate(q.g.env, sym.ast), sym.typ)])
+        genBracedInit(p, data, sym.typ)])
 
   # all constants need a loc:
   q.consts[id] = initLoc(locData, newSymNode(q.g.env, sym), name, OnStatic)
@@ -2034,7 +2035,7 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
     putIntoDest(p, d, n, p.module.procs[n.prc].name, OnStack)
   of cnkConst:
     if isSimpleConst(n.typ):
-      let data = translate(p.env, p.env[n.cnst].ast)
+      let data = translate(p.env, p.env[p.env.dataFor(n.cnst)])
       putIntoDest(p, d, n, genLiteral(p, data, n.typ), OnStatic)
     else:
       useConst(p.module, n.cnst)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1565,7 +1565,8 @@ proc genConstant*(g: PGlobals, m: BModule, id: ConstId) =
   if exfNoDecl notin c.extFlags:
     var p = newInitProc(g, m)
     #genLineDir(p, c.ast)
-    genVarInit(p, c.typ, name, storage, translate(g.env, c.ast))
+    genVarInit(p, c.typ, name, storage,
+               translate(g.env, g.env[g.env.dataFor(id)]))
     g.constants.add(p.body)
 
   # all constants need a name:

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -1,0 +1,152 @@
+## Implements a bi-directional table that associates constant data
+## (represented by ``PNode`` AST) with a ``DataId`` and vice versa.
+
+import
+  std/[
+    hashes
+  ],
+  compiler/ast/[
+    ast_query,
+    ast_types,
+    trees,
+    types
+  ],
+  compiler/mir/[
+    mirtrees
+  ],
+  compiler/utils/[
+    containers,
+    idioms
+  ]
+
+type
+  ConstrTree* = PNode
+  DataTable* = object
+    ## A bi-directional table that associates constant expressions with an ID.
+    vals: Store[DataId, ConstrTree]
+    keys: seq[uint32]
+      ## indexed by ``hash(ConstrTree)``, using an open-addressing scheme.
+      ## Empty slots have value '0'. Subtracting one from the value in a non-
+      ## empty slot yields a ``DataId``
+
+func hashTree(tree: ConstrTree): Hash =
+  ## Computes the `tree`. The hash is meant to be used for lookup in a hash
+  ## table. Keep this synchronized with `cmp <#cmp,ConstrTree,ConstrTree>`_.
+  proc hash(n: PNode): Hash {.nimcall.} =
+    result = hash(n.kind)
+    case n.kind
+    of nkIntKinds:
+      result = result !& hash(n.intVal)
+    of nkFloatLiterals:
+      # make sure to hash the bit representation, so that NaNs are accounted
+      # for
+      result = result !& hash(cast[BiggestUInt](n.floatVal))
+    of nkStrKinds:
+      result = result !& hash(n.strVal)
+    of nkNilLit:
+      discard
+    of nkSym:
+      result = result !& hash(n.sym.id)
+    of nkBracket, nkCurly, nkTupleConstr, nkClosure, nkExprColonExpr, nkRange:
+      for it in n.items:
+        result = result !& hash(it)
+    of nkObjConstr:
+      for i in 1..<n.len:
+        result = result !& hash(n[i])
+    else:
+      unreachable(n.kind)
+
+  result = hash(tree)
+  # only hash the kind of the type. This trades more collisions for faster
+  # hashing
+  result = result !& hash(tree.typ.kind)
+  result = !$(result)
+
+proc cmp(a, b: ConstrTree): bool =
+  # same structure and same (backend) type means that the construction
+  # expressions produce the same value
+  result = exprStructuralEquivalent(a, b) and sameBackendType(a.typ, b.typ)
+
+proc nextTry(h, maxHash: Hash): Hash {.inline.} =
+  result = (h + 1) and maxHash
+
+template maxHash(t: DataTable): untyped = high(t.keys)
+template isFilled(x: uint32): bool = x.uint32 > 0'u32
+template toId(x: uint32): DataId = DataId(x - 1)
+
+iterator pairs*(t: DataTable): (DataId, lent ConstrTree) =
+  for id, t in t.vals.pairs:
+    yield (id, t)
+
+proc mustRehash(length, counter: int): bool {.inline.} =
+  assert(length > counter)
+  result = (length * 2 < counter * 3) or (length - counter < 4)
+
+proc enlarge(t: var DataTable) =
+  # allocate a new sequence:
+  var s: seq[uint32]
+  newSeq(s, t.keys.len * 2)
+  swap(t.keys, s)
+
+  # move all elements from the old sequence into the new one:
+  for i in 0..<s.len:
+    let key = s[i]
+    if isFilled(key):
+      var j = hashTree(t.vals[toId(key)]) and maxHash(t)
+      while isFilled(t.keys[j]):
+        j = nextTry(j, maxHash(t))
+      t.keys[j] = key
+
+proc len*(t: DataTable): int {.inline.} =
+  ## The number of items in `t`.
+  t.vals.nextId().int
+
+proc getOrPut*(t: var DataTable; tree: PNode): DataId =
+  ## Adds `tree` to `t` and returns the ID the tree can be queried with later.
+  ## If the tree already exists in the table, only the ID is returned.
+  let origH = hashTree(tree)
+  var h = origH and maxHash(t)
+  if t.keys.len > 0:
+    while isFilled(t.keys[h]):
+      if cmp(t.vals[toId(t.keys[h])], tree):
+        return DataId(t.keys[h] - 1)
+      h = nextTry(h, maxHash(t))
+
+    # not found, we need to insert it:
+    if mustRehash(t.keys.len, t.len):
+      enlarge(t)
+      # recompute where to insert:
+      h = origH and maxHash(t)
+      while isFilled(t.keys[h]):
+        h = nextTry(h, maxHash(t))
+  else:
+    t.keys.setLen(16)
+    h = origH and maxHash(t)
+
+  result = t.vals.add(tree)
+  t.keys[h] = uint32(result) + 1
+
+func `[]`*(t: DataTable, id: DataId): lent ConstrTree {.inline.} =
+  ## Returns the (existing) expression associated with `id`.
+  t.vals[id]
+
+func checkpoint*(t: DataTable): Checkpoint {.inline.} =
+  checkpoint(t.vals)
+
+proc rewind*(t: var DataTable, p: Checkpoint) =
+  for id, it in since(t.vals, p):
+    var h = hashTree(it) and maxHash(t)
+    # look for the slot holding the ID and clear it:
+    while isFilled(t.keys[h]):
+      if cmp(t.vals[toId(t.keys[h])], it):
+        t.keys[h] = 0 # clear the slot
+        break
+      h = nextTry(h, maxHash(t))
+
+  # now trim the store:
+  rewind(t.vals, p)
+
+iterator since*(t: DataTable, p: Checkpoint): (DataId, lent ConstrTree) =
+  ## Returns all entries added since `p` was created.
+  for id, it in since(t.vals, p):
+    yield (id, it)

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -8,28 +8,17 @@ import
   ],
   compiler/ast/[
     ast_query,
-    ast_types,
-    trees,
-    types
+    ast_types
   ],
   compiler/mir/[
+    datatables,
     mirtrees
   ],
   compiler/utils/[
-    containers,
-    idioms
+    containers
   ]
 
 type
-  ConstrTree = PNode
-  DataTable* = object
-    ## A bi-directional table that associates constant expressions with an ID.
-    vals: Store[DataId, ConstrTree]
-    keys: seq[uint32]
-      ## indexed by ``hash(ConstrTree)``, using an open-addressing scheme.
-      ## Empty slots have value '0'. Subtracting one from the value in a non-
-      ## empty slot yields a ``DataId``
-
   SymbolTable*[I; T] = object
     ## Acts as the central store for a kind of symbol during the mid- and
     ## backend phase. Also keeps mappings for ``PSym`` to the corresponding
@@ -58,123 +47,6 @@ type
   EnvCheckpoint* = tuple
     ## A low-cost snapshot of a `MirEnv <#MirEnv>`_.
     procs, globals, consts, data: Checkpoint
-
-# ------ DataTable implementation ------
-
-func hashTree(tree: ConstrTree): Hash =
-  ## Computes the `tree`. The hash is meant to be used for lookup in a hash
-  ## table. Keep this synchronized with `cmp <#cmp,ConstrTree,ConstrTree>`_.
-  proc hash(n: PNode): Hash {.nimcall.} =
-    result = hash(n.kind)
-    case n.kind
-    of nkIntKinds:
-      result = result !& hash(n.intVal)
-    of nkFloatLiterals:
-      # make sure to hash the bit representation, so that NaNs are accounted
-      # for
-      result = result !& hash(cast[BiggestUInt](n.floatVal))
-    of nkStrKinds:
-      result = result !& hash(n.strVal)
-    of nkNilLit:
-      discard
-    of nkSym:
-      result = result !& hash(n.sym.id)
-    of nkBracket, nkCurly, nkTupleConstr, nkClosure, nkExprColonExpr, nkRange:
-      for it in n.items:
-        result = result !& hash(it)
-    of nkObjConstr:
-      for i in 1..<n.len:
-        result = result !& hash(n[i])
-    else:
-      unreachable(n.kind)
-
-  result = hash(tree)
-  # only hash the kind of the type. This trades more collisions for faster
-  # hashing
-  result = result !& hash(tree.typ.kind)
-  result = !$(result)
-
-proc cmp(a, b: ConstrTree): bool =
-  # same structure and same (backend) type means that the construction
-  # expressions produce the same value
-  result = exprStructuralEquivalent(a, b) and sameBackendType(a.typ, b.typ)
-
-proc nextTry(h, maxHash: Hash): Hash {.inline.} =
-  result = (h + 1) and maxHash
-
-template maxHash(t: DataTable): untyped = high(t.keys)
-template isFilled(x: uint32): bool = x.uint32 > 0'u32
-template toId(x: uint32): DataId = DataId(x - 1)
-
-iterator pairs*(t: DataTable): (DataId, lent ConstrTree) =
-  for id, t in t.vals.pairs:
-    yield (id, t)
-
-proc mustRehash(length, counter: int): bool {.inline.} =
-  assert(length > counter)
-  result = (length * 2 < counter * 3) or (length - counter < 4)
-
-proc enlarge(t: var DataTable) =
-  # allocate a new sequence:
-  var s: seq[uint32]
-  newSeq(s, t.keys.len * 2)
-  swap(t.keys, s)
-
-  # move all elements from the old sequence into the new one:
-  for i in 0..<s.len:
-    let key = s[i]
-    if isFilled(key):
-      var j = hashTree(t.vals[toId(key)]) and maxHash(t)
-      while isFilled(t.keys[j]):
-        j = nextTry(j, maxHash(t))
-      t.keys[j] = key
-
-proc len*(t: DataTable): int {.inline.} =
-  ## The number of items in `t`.
-  t.vals.nextId().int
-
-proc getOrPut*(t: var DataTable; tree: PNode): DataId =
-  ## Adds `tree` to `t` and returns the ID the tree can be queried with later.
-  ## If the tree already exists in the table, only the ID is returned.
-  let origH = hashTree(tree)
-  var h = origH and maxHash(t)
-  if t.keys.len > 0:
-    while isFilled(t.keys[h]):
-      if cmp(t.vals[toId(t.keys[h])], tree):
-        return DataId(t.keys[h] - 1)
-      h = nextTry(h, maxHash(t))
-
-    # not found, we need to insert it:
-    if mustRehash(t.keys.len, t.len):
-      enlarge(t)
-      # recompute where to insert:
-      h = origH and maxHash(t)
-      while isFilled(t.keys[h]):
-        h = nextTry(h, maxHash(t))
-  else:
-    t.keys.setLen(16)
-    h = origH and maxHash(t)
-
-  result = t.vals.add(tree)
-  t.keys[h] = uint32(result) + 1
-
-proc rewind(t: var DataTable, p: Checkpoint) =
-  for id, it in since(t.vals, p):
-    var h = hashTree(it) and maxHash(t)
-    # look for the slot holding the ID and clear it:
-    while isFilled(t.keys[h]):
-      if cmp(t.vals[toId(t.keys[h])], it):
-        t.keys[h] = 0 # clear the slot
-        break
-      h = nextTry(h, maxHash(t))
-
-  # now trim the store:
-  rewind(t.vals, p)
-
-iterator since*(t: DataTable, p: Checkpoint): (DataId, lent ConstrTree) =
-  ## Returns all entries added since `p` was created.
-  for id, it in since(t.vals, p):
-    yield (id, it)
 
 # -------
 
@@ -229,7 +101,7 @@ func `[]`*(env: MirEnv, id: ProcedureId): lent PSym {.inline.} =
   env.procedures.data[id]
 
 func `[]`*(env: MirEnv, id: DataId): lent ConstrTree {.inline.} =
-  env.data.vals[id]
+  env.data[id]
 
 func setData*(env: var MirEnv, id: ConstId, data: DataId) =
   ## Sets the body for the constant identified by `id`.
@@ -244,7 +116,7 @@ func checkpoint*(env: MirEnv): EnvCheckpoint =
   ## Creates a snapshot of `env`. This is a low-cost operation, where no
   ## copies are involved.
   (env.procedures.checkpoint, env.globals.checkpoint,
-   env.constants.checkpoint, env.data.vals.checkpoint)
+   env.constants.checkpoint, env.data.checkpoint)
 
 proc rewind*(env: var MirEnv, to: EnvCheckpoint) =
   ## Undoes all additions to `env` since `to` was created. Do note that all

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -3,20 +3,33 @@
 
 import
   std/[
+    hashes,
     tables
   ],
   compiler/ast/[
     ast_query,
-    ast_types
+    ast_types,
+    trees,
+    types
   ],
   compiler/mir/[
     mirtrees
   ],
   compiler/utils/[
-    containers
+    containers,
+    idioms
   ]
 
 type
+  ConstrTree = PNode
+  DataTable* = object
+    ## A bi-directional table that associates constant expressions with an ID.
+    vals: Store[DataId, ConstrTree]
+    keys: seq[uint32]
+      ## indexed by ``hash(ConstrTree)``, using an open-addressing scheme.
+      ## Empty slots have value '0'. Subtracting one from the value in a non-
+      ## empty slot yields a ``DataId``
+
   SymbolTable*[I; T] = object
     ## Acts as the central store for a kind of symbol during the mid- and
     ## backend phase. Also keeps mappings for ``PSym`` to the corresponding
@@ -31,6 +44,8 @@ type
   MirEnv* = object
     ## Stores everything MIR-related that is shared/exists across MIR bodies,
     ## such as information about global variables, global constants, etc.
+    data*: DataTable
+      ## stores all constant data referenced by constants and MIR code
     constants*:  SymbolTable[ConstId, PSym]
     globals*:    SymbolTable[GlobalId, PSym]
       ## includes both normal globals and threadvars
@@ -38,7 +53,126 @@ type
 
   EnvCheckpoint* = tuple
     ## A low-cost snapshot of a `MirEnv <#MirEnv>`_.
-    procs, globals, consts: Checkpoint
+    procs, globals, consts, data: Checkpoint
+
+# ------ DataTable implementation ------
+
+func hashTree(tree: ConstrTree): Hash =
+  ## Computes the `tree`. The hash is meant to be used for lookup in a hash
+  ## table. Keep this synchronized with `cmp <#cmp,ConstrTree,ConstrTree>`_.
+  proc hash(n: PNode): Hash {.nimcall.} =
+    result = hash(n.kind)
+    case n.kind
+    of nkIntKinds:
+      result = result !& hash(n.intVal)
+    of nkFloatLiterals:
+      # make sure to hash the bit representation, so that NaNs are accounted
+      # for
+      result = result !& hash(cast[BiggestUInt](n.floatVal))
+    of nkStrKinds:
+      result = result !& hash(n.strVal)
+    of nkNilLit:
+      discard
+    of nkSym:
+      result = result !& hash(n.sym.id)
+    of nkBracket, nkCurly, nkTupleConstr, nkClosure, nkExprColonExpr, nkRange:
+      for it in n.items:
+        result = result !& hash(it)
+    of nkObjConstr:
+      for i in 1..<n.len:
+        result = result !& hash(n[i])
+    else:
+      unreachable(n.kind)
+
+  result = hash(tree)
+  # only hash the kind of the type. This trades more collisions for faster
+  # hashing
+  result = result !& hash(tree.typ.kind)
+  result = !$(result)
+
+proc cmp(a, b: ConstrTree): bool =
+  # same structure and same (backend) type means that the construction
+  # expressions produce the same value
+  result = exprStructuralEquivalent(a, b) and sameBackendType(a.typ, b.typ)
+
+proc nextTry(h, maxHash: Hash): Hash {.inline.} =
+  result = (h + 1) and maxHash
+
+template maxHash(t: DataTable): untyped = high(t.keys)
+template isFilled(x: uint32): bool = x.uint32 > 0'u32
+template toId(x: uint32): DataId = DataId(x - 1)
+
+iterator pairs*(t: DataTable): (DataId, lent ConstrTree) =
+  for id, t in t.vals.pairs:
+    yield (id, t)
+
+proc mustRehash(length, counter: int): bool {.inline.} =
+  assert(length > counter)
+  result = (length * 2 < counter * 3) or (length - counter < 4)
+
+proc enlarge(t: var DataTable) =
+  # allocate a new sequence:
+  var s: seq[uint32]
+  newSeq(s, t.keys.len * 2)
+  swap(t.keys, s)
+
+  # move all elements from the old sequence into the new one:
+  for i in 0..<s.len:
+    let key = s[i]
+    if isFilled(key):
+      var j = hashTree(t.vals[toId(key)]) and maxHash(t)
+      while isFilled(t.keys[j]):
+        j = nextTry(j, maxHash(t))
+      t.keys[j] = key
+
+proc len*(t: DataTable): int {.inline.} =
+  ## The number of items in `t`.
+  t.vals.nextId().int
+
+proc getOrPut*(t: var DataTable; tree: PNode): DataId =
+  ## Adds `tree` to `t` and returns the ID the tree can be queried with later.
+  ## If the tree already exists in the table, only the ID is returned.
+  let origH = hashTree(tree)
+  var h = origH and maxHash(t)
+  if t.keys.len > 0:
+    while isFilled(t.keys[h]):
+      if cmp(t.vals[toId(t.keys[h])], tree):
+        return DataId(t.keys[h] - 1)
+      h = nextTry(h, maxHash(t))
+
+    # not found, we need to insert it:
+    if mustRehash(t.keys.len, t.len):
+      enlarge(t)
+      # recompute where to insert:
+      h = origH and maxHash(t)
+      while isFilled(t.keys[h]):
+        h = nextTry(h, maxHash(t))
+  else:
+    t.keys.setLen(16)
+    h = origH and maxHash(t)
+
+  result = t.vals.add(tree)
+  t.keys[h] = uint32(result) + 1
+
+proc rewind(t: var DataTable, p: Checkpoint) =
+  for id, it in since(t.vals, p):
+    var h = hashTree(it) and maxHash(t)
+    # look for the slot holding the ID and clear it:
+    while isFilled(t.keys[h]):
+      if cmp(t.vals[toId(t.keys[h])], it):
+        t.keys[h] = 0 # clear the slot
+        break
+      h = nextTry(h, maxHash(t))
+
+  # now trim the store:
+  rewind(t.vals, p)
+
+iterator since*(t: DataTable, p: Checkpoint): (DataId, lent ConstrTree) =
+  ## Returns all entries added since `p` was created.
+  for id, it in since(t.vals, p):
+    yield (id, it)
+
+# -------
 
 func toMir(s: sink PSym, t: typedesc): PSym =
   ## Translates a symbol to the MIR representation for the given entity.
@@ -90,10 +224,14 @@ func `[]`*(env: MirEnv, id: GlobalId): lent PSym {.inline.} =
 func `[]`*(env: MirEnv, id: ProcedureId): lent PSym {.inline.} =
   env.procedures.data[id]
 
+func `[]`*(env: MirEnv, id: DataId): lent ConstrTree {.inline.} =
+  env.data.vals[id]
+
 func checkpoint*(env: MirEnv): EnvCheckpoint =
   ## Creates a snapshot of `env`. This is a low-cost operation, where no
   ## copies are involved.
-  (env.procedures.checkpoint, env.globals.checkpoint, env.constants.checkpoint)
+  (env.procedures.checkpoint, env.globals.checkpoint,
+   env.constants.checkpoint, env.data.vals.checkpoint)
 
 proc rewind*(env: var MirEnv, to: EnvCheckpoint) =
   ## Undoes all additions to `env` since `to` was created. Do note that all
@@ -109,6 +247,7 @@ proc rewind*(env: var MirEnv, to: EnvCheckpoint) =
   rewind(env.procedures, to.procs)
   rewind(env.constants, to.consts)
   rewind(env.globals, to.globals)
+  rewind(env.data, to.data)
 
 iterator items*[I, T](tab: SymbolTable[I, T]): (I, lent T) =
   ## Returns all entities in `tab` together with their ID.

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -25,6 +25,8 @@ type
     ## Identifies a procedure
   LiteralId {.used.} = distinct uint32
     ## Identifies a literal
+  DataId* = distinct uint32
+    ## Identifies a complete constant expression
 
   TypeInstance {.used.} = distinct uint32
     ## Refers to an existing type instance
@@ -348,6 +350,7 @@ func `==`*(a, b: LabelId): bool {.borrow.}
 func `==`*(a, b: ConstId): bool {.borrow.}
 func `==`*(a, b: GlobalId): bool {.borrow.}
 func `==`*(a, b: ProcedureId): bool {.borrow.}
+func `==`*(a, b: DataId): bool {.borrow.}
 
 # XXX: ideally, the arithmetic operations on ``NodePosition`` should not be
 #      exported. How the nodes are stored should be an implementation detail

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -27,6 +27,7 @@ import
     modulelowering,
   ],
   compiler/mir/[
+    datatables,
     mirbodies,
     mirenv,
     mirgen,

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -307,10 +307,10 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
   env.rtti = move c.gen.rtti
 
   # produce a list with the type of each constant:
-  var consts = newSeq[(PVmType, PNode)](c.gen.env.constants.len)
-  for i, sym in c.gen.env.constants.items:
-    let typ = c.gen.typeInfoCache.lookup(conf, sym.typ)
-    consts[ord(i)] = (typ.unsafeGet, sym.ast)
+  var consts = newSeq[(PVmType, PNode)](c.gen.env.data.len)
+  for i, data in c.gen.env.data.pairs:
+    let typ = c.gen.typeInfoCache.lookup(conf, data.typ)
+    consts[ord(i)] = (get(typ), data)
 
   env.typeInfoCache = move c.gen.typeInfoCache
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2458,6 +2458,9 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
       c.gABx(n, opcLdCmplxConst, dest, pos)
 
     discard genType(c, n.typ) # make sure the type exists
+    # somewhat hack-y, but the orchestrator later queries the type of the data
+    # (which might be a different PType that maps to the same VM type)
+    discard genType(c, c.env[DataId pos].typ)
   of cnkGlobal:
     # a global location
     let pos = useGlobal(c, n)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2448,7 +2448,7 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
   of cnkConst:
     prepare(c, dest, n.typ)
 
-    let pos = int n.cnst
+    let pos = int c.env.dataFor(n.cnst)
     if load and fitsRegister(n.typ):
       let cc = c.getTemp(n.typ)
       c.gABx(n, opcLdCmplxConst, cc, pos)
@@ -2494,7 +2494,7 @@ proc genSymAddr(c: var TCtx, n: CgNode, dest: var TDest) =
   case n.kind
   of cnkConst:
     let
-      pos = int n.cnst
+      pos = int c.env.dataFor(n.cnst)
       tmp = c.getTemp(slotTempComplex)
     c.gABx(n, opcLdCmplxConst, tmp, pos)
     c.gABC(n, opcAddr, dest, tmp)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -113,14 +113,14 @@ proc updateEnvironment(c: var TCtx, env: var MirEnv, cp: EnvCheckpoint) =
     c.globals.add c.heap.heapNew(c.allocator, typ)
 
   # constants
-  for id, sym in since(env.constants, cp.consts):
+  for id, data in since(env.data, cp.data):
     let
-      typ = c.getOrCreate(sym.typ)
+      typ = c.getOrCreate(data.typ)
       handle = c.allocator.allocConstantLocation(typ)
 
     # TODO: strings, seqs and other values using allocation also need to be
     #       allocated with `allocConstantLocation` inside `serialize` here
-    c.serialize(sym.ast, handle)
+    c.serialize(data, handle)
 
     c.complexConsts.add handle
 

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -26,6 +26,7 @@ import
     cgir
   ],
   compiler/mir/[
+    datatables,
     mirbodies,
     mirbridge,
     mirconstr,


### PR DESCRIPTION
## Summary

In the mid- and backend, there's now a clear distinction being made
between *constants* and *constant data*. A *constant* (i.e., a `const`)
links a name/interface with *constant data*, while *constant data* is
just the raw data.

Storage of constant data is now also decoupled from `TSym.ast`,
preparing for the introduction of a dedicated constant data IR.

## Details

#### General architecture

* same as before, constant data is represented by a `PNode` AST
* every complete `PNode` AST representing constant data is identified
  by the new `DataId`
* all constant data the mid- and backend know about is stored in
  `MirEnv` (in a `DataTable`)
* the association between a `DataId` and the data is *bi-directional*
  (a `DataId` maps to a constant expression and a constant expression
  maps to a `DataId`)
* each user-defined constant (`ConstId`) is associated with a `DataId`
* when discovering user-defined constants, `backends.process` and
  `backends.discover` register the data with the environment and link
  it with the constant

#### Rationale

Separating constants from their data allows two constants to share the
same `PNode` AST internally (at least in the backend). It also makes it
easy for the mid-end to create new constant data (e.g., by lifting
constant expression from procedure bodies) itself -- no name nor
interface has to be associated with the data in this case.

#### Implementation

* `DataTable` is a customized version of `BiTable`
* the `PNode` ASTs representing the constant expression are compared by
  their structure
* using structural comparison means that `Obj(a: 0)` and `Obj(b: 0)`
  are treated as being different, even though they represent the same
  data. While not critical, a normalization pass is going be needed
  here, eventually
* the `DataTable` also supports the basic rewind mechanism employed by
  `MirEnv`
* as an interim solution, a separate table is used for mapping
  constants to their body (`MirEnv.bodies`)

#### Code generation

* instead of querying `TSym.ast`, `cgen` and `jsgen` lookup the body
  for constant through `MirEnv`
* constant data in the VM maps directly to the `DataTable` now (that
  is, each item in `DataTable` maps to a complex VM constant). `vmgen`,
  `vmjit`, and `vmbackend` are adjusted accordingly