### PR TITLE
mirgen: lift constant expressions

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -58,13 +58,11 @@ proc genLiteral(p: BProc, n: CgNode, ty: PType): Rope =
   of cnkNilLit:
     let k = if ty == nil: tyPointer else: skipTypes(ty, abstractVarRange).kind
     if k == tyProc and skipTypes(ty, abstractVarRange).callConv == ccClosure:
-      let id = getOrPut(p.module.dataCache, n, p.module.labels)
-      result = p.module.tmpBase & rope(id)
-      if id == p.module.labels:
-        # not found in cache:
-        inc(p.module.labels)
-        p.module.s[cfsData].addf(
-             "static NIM_CONST $1 $2 = {NIM_NIL,NIM_NIL};$n",
+      # TODO: expand 'nil' closure literals with a MIR pass, instead of doing
+      #       it here during code generation
+      result = "CLOSURE" & $p.labels
+      inc(p.labels)
+      linefmt(p, cpsLocals, "NIM_CONST $1 $2 = {NIM_NIL,NIM_NIL};$n",
              [getTypeDesc(p.module, ty), result])
     elif k in {tyPointer, tyNil, tyProc}:
       result = rope("NIM_NIL")

--- a/compiler/backend/ccgliterals.nim
+++ b/compiler/backend/ccgliterals.nim
@@ -25,7 +25,7 @@ proc genStringLiteralDataOnlyV2(m: BModule, s: string; result: Rope; isConst: bo
        rope(if isConst: "const" else: "")])
 
 proc genStringLiteralV2(m: BModule; n: CgNode; isConst: bool): Rope =
-  let id = getOrPut(m.dataCache, n, m.labels)
+  let id = getOrPut(m.strCache, n, m.labels)
   if id == m.labels:
     let pureLit = getTempName(m)
     genStringLiteralDataOnlyV2(m, n.strVal, pureLit, isConst)
@@ -42,7 +42,7 @@ proc genStringLiteralV2(m: BModule; n: CgNode; isConst: bool): Rope =
           rope(if isConst: "const" else: "")])
 
 proc genStringLiteralV2Const(m: BModule; n: CgNode; isConst: bool): Rope =
-  let id = getOrPut(m.dataCache, n, m.labels)
+  let id = getOrPut(m.strCache, n, m.labels)
   var pureLit: Rope
   if id == m.labels:
     pureLit = getTempName(m)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -402,7 +402,7 @@ proc rdCharLoc(a: TLoc): Rope =
     result = "((NU8)($1))" % [result]
 
 proc genObjConstr(p: BProc, e: CgNode, d: var TLoc)
-proc rawConstExpr(p: BProc, n: CgNode; d: var TLoc)
+proc defaultValueExpr(p: BProc, n: CgNode; d: var TLoc)
 proc genAssignment(p: BProc, dest, src: TLoc)
 
 type
@@ -437,7 +437,7 @@ proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: TLoc,
       else:
         unreachable("cannot have embedded type fields")
 
-    rawConstExpr(p, newExpr(kind, info, t), result)
+    defaultValueExpr(p, newExpr(kind, info, t), result)
 
   case analyseObjectWithTypeField(t)
   of frNone:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1281,7 +1281,6 @@ proc rawNewModule*(g: BModuleList; module: PSym, filename: AbsoluteFile): BModul
   result.module = module
   result.typeInfoMarker = initTable[SigHash, Rope]()
   result.sigConflicts = initCountTable[SigHash]()
-  result.dataCache = initTable[ConstrTree, int]()
   result.typeStack = @[]
   result.typeNodesName = getTempName(result)
   # no line tracing for the init sections of the system module so that we

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -265,6 +265,9 @@ type
     dataCache*: Table[ConstrTree, int] ## maps a value construction
                               ## expression to the label of the C constant
                               ## created for it
+    defaultCache*: Table[SigHash, int]
+      ## maps a type hash to the name of a C constant storing the type's
+      ## default value
     strCache*: Table[StrNode, int]
       ## associates a string node with the label of a C constant generated for
       ## it

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -263,6 +263,10 @@ type
     dataCache*: Table[ConstrTree, int] ## maps a value construction
                               ## expression to the label of the C constant
                               ## created for it
+    dataNames*: Table[DataId, int]
+      ## associates each constant expression for which a C constant was
+      ## emitted with a label. The name of the C constant can be derived from
+      ## the label
     typeNodes*: int ## used for type info generation
     typeNodesName*: Rope ## used for type info generation
     labels*: Natural          ## for generating unique module-scope names

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1950,12 +1950,6 @@ proc genSetConstr(p: PProc, n: CgNode, r: var TCompRes) =
       gen(p, it, a)
       r.res.add(a.res)
   r.res.add(")")
-  # emit better code for constant sets:
-  if isDeepConstExpr(n):
-    inc(p.g.unique)
-    let tmp = rope("ConstSet") & rope(p.g.unique)
-    p.g.constants.addf("var $1 = $2;$n", [tmp, r.res])
-    r.res = tmp
 
 proc genArrayConstr(p: PProc, n: CgNode, r: var TCompRes) =
   ## Constructs array or sequence.

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -136,7 +136,7 @@ proc rewind*(env: var MirEnv, to: EnvCheckpoint) =
   rewind(env.constants, to.consts)
   rewind(env.globals, to.globals)
   rewind(env.data, to.data)
-  setLen(env.bodies, to.data.int)
+  setLen(env.bodies, to.consts.int)
 
 iterator items*[I, T](tab: SymbolTable[I, T]): (I, lent T) =
   ## Returns all entities in `tab` together with their ID.

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -110,7 +110,10 @@ func setData*(env: var MirEnv, id: ConstId, data: DataId) =
 
 func dataFor*(env: MirEnv, id: ConstId): DataId =
   ## Returns the ID of the constant expression associated with `id`.
-  env.bodies[id]
+  if isAnon(id):
+    extract(id)
+  else:
+    env.bodies[id]
 
 func checkpoint*(env: MirEnv): EnvCheckpoint =
   ## Creates a snapshot of `env`. This is a low-cost operation, where no

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1111,7 +1111,7 @@ proc genInSetOp(c: var TCtx, n: PNode) =
               c.emitByVal b
           c.subTree mnkStmtList:
             var sv: Value
-            if se.kind == nkCurly:
+            if se.kind == nkCurly and not isDeepConstExpr(se):
               sv = c.allocTemp(se.typ)
               c.subTree mnkDef:
                 c.use sv

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1893,9 +1893,13 @@ proc scanExpr*(env: var MirEnv, n: PNode) =
       discard env.procedures.add(n.sym)
   of nkWithoutSons - {nkSym}:
     discard
-  of nkWithSons:
+  of nkWithSons - {nkObjConstr}:
     for it in n.items:
       scanExpr(env, it)
+  of nkObjConstr:
+    # don't scan the type slot:
+    for i in 1..<n.len:
+      scanExpr(env, n[i])
 
 proc toConstant(c: var TCtx, n: PNode): Value =
   ## Creates an anonymous constant from the constant expression `n`

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -470,13 +470,7 @@ func detectKind(tree: MirTree, n: NodePosition, sink: bool): ExprKind =
     else:
       Rvalue
   of mnkConstr:
-    # XXX: sequence constructions (i.e., constant ``seq``s) are allowed to be
-    #      lifted into constants at a later stage, which needs to be accounted
-    #      here by treating the values as non-owning. Performing all lifting-
-    #      into-constants here in ``mirgen`` is going to render this special-
-    #      casing obsolete
-    if sink and hasDestructor(tree[n].typ) and
-       tree[n].typ.skipTypes(abstractInst).kind != tySequence:
+    if sink and hasDestructor(tree[n].typ):
       OwnedRvalue
     else:
       Rvalue

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -16,7 +16,8 @@ type
   GlobalId* = distinct uint32
     ## Identifies a global across all MIR code
   ConstId* = distinct uint32
-    ## Identifies a named constant across all MIR code
+    ## Identifies a constant across all MIR code. This includes both
+    ## user-defined constants as well as anonymous constants
   ParamId {.used.} = distinct uint32
     ## Identifies a parameter of the code fragment
   FieldId {.used.} = distinct uint32
@@ -351,6 +352,18 @@ func `==`*(a, b: ConstId): bool {.borrow.}
 func `==`*(a, b: GlobalId): bool {.borrow.}
 func `==`*(a, b: ProcedureId): bool {.borrow.}
 func `==`*(a, b: DataId): bool {.borrow.}
+
+func isAnon*(id: ConstId): bool =
+  ## Returns whether `id` represents an anonymous constant.
+  (uint32(id) and (1'u32 shl 31)) != 0
+
+func extract*(id: ConstId): DataId =
+  ## Extracts the ``DataId`` from `id`.
+  DataId(uint32(id) and not(1'u32 shl 31))
+
+func toConstId*(id: DataId): ConstId =
+  ## Creates the ID for an anonymous constant with `id` as the content.
+  ConstId((1'u32 shl 31) or uint32(id))
 
 # XXX: ideally, the arithmetic operations on ``NodePosition`` should not be
 #      exported. How the nodes are stored should be an implementation detail

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -152,7 +152,12 @@ proc singleToStr(n: MirNode, result: var string, env: EnvPtr) =
   of SymbolLike:
     result.add n.sym.name.s
   of mnkConst:
-    result.addName(n.cnst, "<C", env)
+    if isAnon(n.cnst):
+      result.add "<D" # "D" for "Data"
+      result.addInt extract(n.cnst).uint32
+      result.add ">"
+    else:
+      result.addName(n.cnst, "<C", env)
   of mnkGlobal:
     result.addName(n.global, "<G", env)
   of mnkProc:

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -558,14 +558,8 @@ func isMoveable(tree: MirTree, v: Values, n: NodePosition): bool =
   of mnkConv, mnkStdConv, mnkCast, mnkAddr, mnkView, mnkToSlice:
     # the result of these operations is not an owned value
     false
-  of mnkCall, mnkCheckedCall, mnkObjConstr:
+  of mnkCall, mnkCheckedCall, mnkObjConstr, mnkConstr:
     true
-  of mnkConstr:
-    case tree[n].typ.skipTypes(abstractInst).kind
-    of tySequence:
-      false # sequence constructors are immutable constants
-    else:
-      true
   of AllNodeKinds - ExprKinds:
     unreachable(tree[n].kind)
 

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -5,14 +5,14 @@ discard """
 
 scope:
   try:
-    def_cursor x: (string, int) = construct (arg "hi", arg 5)
+    def_cursor x: (string, int) = <D0>
     block L0:
       if cond:
         scope:
-          x =fast construct (arg "different", arg 54)
+          x =fast <D1>
           break L0
       scope:
-        x =fast construct (arg "string here", arg 80)
+        x =fast <D2>
     def_cursor _0: (string, int) = x
     def _1: string = $(arg _0) (raises)
     echo(arg type(array[0..0, string]), arg _1) (raises)

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -233,9 +233,9 @@ scope:
           =sink(name _18, arg _17)
           break L1
       scope:
-        bind_mut _19: seq[string] = this[].matchDirs
-        def _20: seq[string] = construct ()
-        =copy(name _19, arg _20)
+        def _19: seq[string] = construct ()
+        bind_mut _20: seq[string] = this[].matchDirs
+        =sink(name _20, arg _19)
   finally:
     =destroy(name par)
 -- end of expandArc ------------------------'''

--- a/tests/ccgbugs/tconst_seq_leak.nim
+++ b/tests/ccgbugs/tconst_seq_leak.nim
@@ -1,0 +1,14 @@
+discard """
+  description: '''
+    Regression test for constant-evaluated seqs of aggregate types resulting
+    in memory leaks
+  '''
+  targets: "c"
+  matrix: "-d:useMalloc"
+  valgrind: true
+"""
+
+# caused no problems:
+var s1 = static: @[1, 2]
+# caused a leak:
+var s = static: @[(1, 2)]

--- a/tests/lang_experimental/views/tsplit_into_seq.nim
+++ b/tests/lang_experimental/views/tsplit_into_seq.nim
@@ -4,10 +4,6 @@ asdf
 231
 231
 '''
-  knownIssue: '''
-    Assignments to ``openArray`` lvalues with side-effects (e.g.,
-    ``x[y] = ...``) are currently not supported by the C code generator
-  '''
 """
 
 {.experimental: "views".}


### PR DESCRIPTION
## Summary

Introduce anonymous constants to the MIR and use them to lift fully
constant expressions into separate constants during AST -> MIR
translation.

This speeds up the compiler, improves efficiency of the generated
code, and also fixes a memory leak affecting the C backend.

## Details

### Anonymous constants

Anonymous constants are constants that don't have a name/interface
attached -- they're data only. `ConstId` represents both user-defined
and anonymous constants, by using the value of the most-significant bit
to distinguish between them: if the bit is set, the lower 31 bit
represent a `DataId`, if it's not set, the `ConstId` is the ID of a
user-defined constant.

`toConstId`, `isAnon`, and `extract` are the procedure for
introspection and creation of anonymous constants. `MirEnv.dataFor`
transparently returns the `DataId` for anonymous constants.

### Constant expression lifting

* constant `set` constructions are always lifted (mirroring what both
  `cgen` and `jsgen` did)
* non-empty, constant-folded `seq` constructions (`nkBracket`) are
  always lifted (mirroring what `cgen` did)
* non-empty constant tuple, object, and array construction are lifted
  only when used in a non-sink context (e.g., as an argument to a non-
  `sink` parameter)
* due to a limitation with `DataTable`, hidden conversions being part
  of an expression make it non-constant for now (achieved with a custom
  `isDeepConstExpr` procedure)

Lifting constant construction appearing in `sink` contexts would alter
semantics, as constants have to copied from (which might result in a
`=copy` call).

Since `mirgen` now does the lifting of `seq` construction, the
workaround of treating MIR `seq` constructions (`mnkConstr` of type
`tySequence`) as constants (because `cgen` lifted them into immutable
C constants) is no longer needed and thus removed.

### Fixes

* with the C backend, using constant-evaluated constructions of
  `seq[T]` where `T` is an aggregate type - `static: @[(1, 2)]`, for
  example - led to a copy and the original `seq` never being freed
  (refer to `tconst_seq_leak`). Removal of the workaround in
  `injectdestructors` fixes this
* `MirEnv.rewind` used the wrong checkpoint for rewinding the `bodies`
  table, which could result in compiler crashes
* `tsplit_into_seq` works now, but not because the underlying issue
  is fixed. Constants `seq` construction not requiring copies only
  means that the problematic `=copy` hook is not used

### `cgen`

* lifting of constant expressions (`exprComplexConst`, `genSetNode`) is
  removed; `mirgen` does this now
* the `dataCache` table is removed. Its most prominent user was the
  expression lifting, and it largely duplicates `DataTable`. The other
  users of `dataCache` use different strategies now:
	* caching default values uses a `SigHash`-based table
	* string values use a dedicated `StrNode` table (using `string`
    directly would require copying the string)
	* `nil` closure literals are expanded to a local C `const`
* anonymous constants are *defined* (not declared) in each C file
  they're used in

### `jsgen`

* lifting of constant `set` construction is removed (it's done by
  `mirgen` now)
* a JavaScript global is emitted for every anonymous constant on use

### `vmgen`

* the code generator and backend already use `DataId` everywhere, so no
  change is necessary
* the `packed_env` packing logic for `nkNilLit` has to work around
  unexpanded `nil` closure literals, by expanding the literal into a
  tuple construction itself. Unexpanded `nil` closure literals didn't
  reach there previously, but now they do

### Performance

The changes have a significant positive impact on:
* compiler speed
* efficiency of the generated code (all backends are affected)

The main reasons for both are that:
* lifting constant expressions in `mirgen` fixes the performance
  regression with field checks introduced by
  `78082ead0e2c5d15a1928359b7dd81dc48925d7a`, where C constants were
  copied into locals, which neither GCC nor MSVC are able to optimize
  away
* constant expression are now also lifted when using the VM and
  JavaScript backends

Compiler speed also improves because of to the reduction in MIR code,
as less MIR code means:
* less nodes that MIR passes need to scan/inspect/analyze/etc.
* less nodes that the code generators need to generate code for

Benchmarking the compiler compiling the compiler at
`3eb7c736384de0b62c88c0dcedbb910fce47f190`  (with 
`hyperfine --warump 1 "nim c --compileOnly --verbosity:0 --hints:off --warnings:off compiler/nim.nim"`
)
yields:
```
before: 14.54 s ± 0.14  (100%)
now:    13.65 s ± 0.05  ( 94%)
```