### PR TITLE
fix(vm): access check not failing

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -739,8 +739,9 @@ func setAddress(r: var TFullReg, handle: LocHandle) =
 
 func setHandle(r: var TFullReg, handle: LocHandle) =
   assert r.kind == rkHandle # Not rkLocation
-  assert not handle.p.isNil
   assert handle.typ.isValid
+  # note: handles storing nil pointers are okay here. Only the access thereof
+  # is disallowed
   r.handle = handle
 
 func loadEmptyReg*(r: var TFullReg, typ: PVmType, info: TLineInfo, mm: var VmMemoryManager): bool =

--- a/compiler/vm/vmmemory.nim
+++ b/compiler/vm/vmmemory.nim
@@ -94,7 +94,10 @@ func allocConstantLocation*(a: var VmAllocator, typ: PVmType): LocHandle =
 
 func mapPointerToCell*(a: VmAllocator, p: CellPtr): CellId =
   ## Maps a cell pointer to the corresponding cell id, or -1 if the pointer
-  ## is not a valid cell pointer
+  ## is not a valid cell pointer.
+  if p.isNil:
+    return -1
+
   for id in 0..<a.freeTail:
     if a.cells[id].p == pointer(p):
       return id
@@ -102,6 +105,9 @@ func mapPointerToCell*(a: VmAllocator, p: CellPtr): CellId =
   result = -1
 
 func mapInteriorPointerToCell(a: VmAllocator, p: pointer): CellId =
+  if p.isNil:
+    return -1
+
   let rp = cast[int](p)
   for id in 0..<a.freeTail:
     let
@@ -152,10 +158,7 @@ func makeLocHandle*(a: VmAllocator, p: pointer, typ: PVmType): LocHandle =
   ## Attempts to create a handle to the guest memory location that to host
   ## address `p` maps to. A handle signaling "invalid" is returned if no
   ## mapping exists.
-  let id =
-    if p == nil: -1
-    else:        mapInteriorPointerToCell(a, p)
-
+  let id = mapInteriorPointerToCell(a, p)
   LocHandle(cell: id, p: cast[VmMemPointer](p), typ: typ)
 
 func makeLocHandle*(a: VmAllocator, cp: CellPtr, offset: Natural, typ: PVmType

--- a/compiler/vm/vmmemory.nim
+++ b/compiler/vm/vmmemory.nim
@@ -174,9 +174,8 @@ func loadFullSlice*(a: VmAllocator, cp: CellPtr, typ: PVmType): VmSlice =
   ## locations of the sequence cell corresponding to `cp`. Returns a slice
   ## signaling invalid if that's not possible.
   let id = mapPointerToCell(a, cp)
-  # XXX: don't use assertions for ensuring that some expectations hold. While
-  #      it would work now, it's not future proof
-  VmSlice(cell: id, start: cast[VmMemPointer](cp), len: a.cells[id].count,
+  VmSlice(cell: id, start: cast[VmMemPointer](cp),
+          len: (if id != -1: a.cells[id].count else: 0),
           typ: typ)
 
 template internalSlice(p: VmMemPointer | CellPtr, l, h: Natural): untyped =

--- a/tests/vm/tconst_seq_crash.nim
+++ b/tests/vm/tconst_seq_crash.nim
@@ -1,0 +1,20 @@
+discard """
+  description: '''
+    Ensure that a non-early-inlined const value containing an empty `seq` can
+    be code evaluated with the compile-time VM
+  '''
+  target: native
+  action: compiles
+"""
+
+type Obj = object
+  x: seq[int]
+
+const c = Obj(x: @[])
+# ^^ any type that doesn't result in semantic analysis inlining the constant
+# work here. The error only triggered for non-inlined constants
+
+static:
+  # using `c` in a compile-time context crashed the compiler
+  var v = c
+  assert v.x.len == 0

--- a/tests/vm/tempty_seq_access_bug.nim
+++ b/tests/vm/tempty_seq_access_bug.nim
@@ -1,0 +1,36 @@
+discard """
+  description: '''
+    Regression test for an internal issue with the VM's pointer-to-cell
+    mapping that allowed
+  '''
+  targets: vm
+  matrix: "--boundChecks:off"
+  outputsub: "trying to access a location outside of the VM's memory"
+  exitcode: 1
+"""
+
+# this test is written against internal implementation details of the VM as it
+# worked when this test was written. The current VM could differ.
+
+proc test() =
+  # test in a procedure so that the locations have local lifetime
+
+  # allocate six memory cells, 3 for the seqs, 3 for their payloads:
+  var
+    a = newSeq[int](1)
+    b = newSeq[int](1)
+    c = default(seq[int]) # empty seq
+
+  # free two cells (by overwriting the seqs with empty ones):
+  a.newSeq(0)
+  b.newSeq(0)
+
+  proc write(i: var int) =
+    # when actually writing to the location, a proper access violation needs
+    # to be reported
+    i = 1
+
+  # bound checks are disabled, so no index error is raised
+  write(c[0])
+
+test()

--- a/tests/vm/tempty_seq_access_bug.nim
+++ b/tests/vm/tempty_seq_access_bug.nim
@@ -1,7 +1,7 @@
 discard """
   description: '''
     Regression test for an internal issue with the VM's pointer-to-cell
-    mapping that allowed
+    mapping that allowed out-of-bound writes.
   '''
   targets: vm
   matrix: "--boundChecks:off"


### PR DESCRIPTION
## Summary

Fix a bug with the VM's pointer-to-cell mapping that allowed out-of-
bounds reads or writes of empty `seq`s to crash the VM, instead of
resulting in a proper memory access error.

## Details

The fundamental problem was with unclear responsibilities: callers of
`mapPointerToCell` and `mapInteriorPointerToCell` expected both to
handle `nil` pointers, while the procedures expected their callers to
do so.

At the moment, the `mapX` procedure consider free cells (for which
`VmCell.p == nil`), which means that trying to map `nil` pointer values
could result in a valid `CellId` being returned! A `LocHandle` having a
non-`-1` `CellId` means that only the cell's data pointer (`nil`, in
this case) and the user pointer need to match (which in this specific
case, they did) for the access checks to not reject the access.

The dangerous `LocHandle` could only be created through indexing
into a `seq`, as the `makeLocHandle` overload for arbitrary user-
pointers properly guarded against `nil` pointers. If the VM was built
with assertions enabled, merely assigning such handle to a register
(incorrectly) resulted in an assertion failure.

When the VM is built with assertions disabled, reading from or writing
to the location resulted in the VM crashing with a segmentation
fault / `nil` dereference error.

The incorrect assertion (forbidding `nil` handles in registers is
wrong) is removed, and `mapPointerToCell`/ `mapInteriorPointerToCell`
now always return a lookup failure for `nil` pointers, fixing the
two problems.

Two tests for situations where a crash would previously happen are
added.