### PR TITLE
transf: improve `case` statement transform

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1752,24 +1752,12 @@ proc genCase(c: var TCtx, n: PNode, dest: Destination) =
   ## straightforward
   assert isEmptyType(n.typ) == not dest.isSome
 
-  # the number of processed branches is not necessarily equal to the amount
-  # we're going to emit (in case we skip some), so we have to count them
-  # manually
-  var num = 0
-  for (_, branch) in branches(n):
-    # an 'of' branch with no labels (e.g. ``of {}:``) is dropped, no code is
-    # generated for it
-    num += ord(branch.kind != nkOfBranch or branch.len > 1)
-
   let v = genUse(c, n[0])
-  c.add MirNode(kind: mnkCase, len: num)
+  c.add MirNode(kind: mnkCase, len: n.len - 1)
   c.use v
 
   # iterate of/else branches:
   for (_, branch) in branches(n):
-    if branch.len == 1 and branch.kind == nkOfBranch:
-      continue
-
     c.add MirNode(kind: mnkBranch, len: branch.len - 1)
 
     case branch.kind
@@ -1787,7 +1775,6 @@ proc genCase(c: var TCtx, n: PNode, dest: Destination) =
       genBranch(c, branch.lastSon, dest)
 
     c.add endNode(mnkBranch)
-    inc num
 
   c.add endNode(mnkCase)
 


### PR DESCRIPTION
## Summary

Improve the `transf` logic for `case` statements. It now drops
unused `of` branches (those without labels) and replaces `case`
statements that - once the other transformations took place - only
consist of an `else` branch.

## Details

* `mirgen` previously took care of dropping unreachable `of` branches,
  but `transf` is better suited for doing so
* a `case` statement/expression like `case x else: body` is turned into
  `(discard x; block: body)`
  * the `discard` makes sure that side-effects of `x` are evaluated and
    that the usage of `x` is preserved
  * the `block` makes sure that the scope of `body` doesn't change

Since `closureiters` takes place after the main `transf` pass but
before `mirgen`, it now also benefits from the elision of unused
`of` branches (i.e., less code to process).