### PR TITLE
pragmas: unknown hint/warning name is not an error

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -772,6 +772,8 @@ type
     rsemUntypedParamsFollwedByMoreSpecificType
     rsemBindDeprecated
     rsemObservableStores       = "ObservableStores"
+    rsemUnknownHint            = "UnknownHint"
+    rsemUnknownWarning         = "UnknownWarning"
     rsemUseOfGc                = "GcMem" # last !
     # END !! add reports BEFORE the last enum !!
 

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1891,6 +1891,12 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemHintLibDependency:
       result = r.str
 
+    of rsemUnknownHint:
+      result = "unknown hint: '$1'" % [r.str]
+
+    of rsemUnknownWarning:
+      result = "unknown warning: '$1'" % [r.str]
+
     of rsemObservableStores:
       result = "observable stores to '$1'" % r.ast.render
 

--- a/tests/errmsgs/tinvalidpragma.nim
+++ b/tests/errmsgs/tinvalidpragma.nim
@@ -2,13 +2,14 @@ discard """
   cmd: "nim check $options $file"
   action: reject
   nimout: '''
-tinvalidpragma.nim(11, 20) Error: invalid pragma: warning[XYZ]: off
-tinvalidpragma.nim(12, 15) Error: invalid pragma: warning[XYZ]: off
-tinvalidpragma.nim(14, 22) Error: invalid pragma: "expression" {.invalid.}
+tinvalidpragma.nim(12, 23) Error: invalid pragma: warning[XYZ, 1]: off
+tinvalidpragma.nim(13, 30) Warning: unknown warning: 'XYZ' [UnknownWarning]
+tinvalidpragma.nim(13, 10) Error: invalid pragma: warning[XYZ]
+tinvalidpragma.nim(15, 22) Error: invalid pragma: "expression" {.invalid.}
 '''
 """
 
-{.push warning[XYZ]: off.}
-{.warning[XYZ]: off, push warning[XYZ]: off.}
+{.push warning[XYZ, 1]: off.}
+{.warning[XYZ], push warning[XYZ]: off.}
 
 discard "expression" {.invalid.}

--- a/tests/errmsgs/tunknown_hint.nim
+++ b/tests/errmsgs/tunknown_hint.nim
@@ -1,0 +1,8 @@
+discard """
+  matrix: "--warningAsError:UnknownHint"
+  errormsg: "unknown hint: 'Something' [UnknownHint]"
+  line: 7
+"""
+
+{.push hint[Something]: on.}
+{.pop.}

--- a/tests/errmsgs/tunknown_warning.nim
+++ b/tests/errmsgs/tunknown_warning.nim
@@ -1,0 +1,8 @@
+discard """
+  matrix: "--warningAsError:UnknownWarning"
+  errormsg: "unknown warning: 'Something' [UnknownWarning]"
+  line: 7
+"""
+
+{.push warning[Something]: on.}
+{.pop.}


### PR DESCRIPTION
## Summary

By default, providing the name of an unknown hint or warning to the 
`hint` ,  `warning` ,  `hintAsError` , or  `warningAsError`  pragmas is
now a warning rather than error. This makes it easier to write forward-
and backward-compatible code.

Two new warnings are introduced for this:  `UnknownHint`  and 
`UnknownWarning` .

## Details

Apart from reporting a warning rather than an error, the  `processNote` 
procedure, which is responsible for processing, for example, 
`hint[A]: on`  pragmas is improved:

* the procedure's documentation is improved, now describing what it does
and expects
* the boolean expression is always evaluated, even when the name of the
hint/warning is not valid
* an input AST modification is removed and proper error wrapping is
used
*  `handleNote`  doesn't capture  `n` , removing the unnecessary
allocation of a closure environment

### Tests

Two tests for the new warnings are added, and the existing 
`tinvalidpragma`  test is updated to also test the malformed pragma
expression situations, increasing test coverage of  `processNote`  's
error handling.