### PR TITLE
vm: implement `case string` in bytecode

### DIFF
--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -806,7 +806,6 @@ proc loadEnv*(dst: var TCtx, src: PackedEnv) =
 
     of cnstSliceListInt:   co.intSlices = loadSliceList[BiggestInt](src, id)
     of cnstSliceListFloat: co.floatSlices = loadSliceList[BiggestFloat](src, id)
-    of cnstSliceListStr:   co.strSlices = loadSliceList[ConstantId](src, id)
     of cnstNode: unreachable()
 
     co
@@ -871,7 +870,6 @@ func storeEnv*(enc: var PackedEncoder, dst: var PackedEnv, c: TCtx) =
 
       of cnstSliceListInt:   dst.storeSliceList(c.intSlices)
       of cnstSliceListFloat: dst.storeSliceList(c.floatSlices)
-      of cnstSliceListStr:   dst.storeSliceList(c.strSlices)
       of cnstNode:
         # node constants are not created in a non-compiletime context
         unreachable()

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2173,7 +2173,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         #      cases where non-NimNode PNodes need to be stored in registers
         #      seems unnecessary however.
         regs[ra] = TFullReg(kind: rkNimNode, nimNode: cnst.node)
-      of cnstSliceListInt..cnstSliceListStr:
+      of cnstSliceListInt..cnstSliceListFloat:
         # A slice-list must not be used with `LdConst`
         assert false
 
@@ -2185,7 +2185,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       of cnstString:
         # load the string literal directly into the destination
         deref(regs[ra].handle).strVal.newVmString(cnst.strVal, c.allocator)
-      of cnstInt, cnstFloat, cnstNode, cnstSliceListInt..cnstSliceListStr:
+      of cnstInt, cnstFloat, cnstNode, cnstSliceListInt..cnstSliceListFloat:
         raiseVmError(VmEvent(kind: vmEvtErrInternal, msg: "illegal constant"))
     of opcLdGlobal:
       let rb = instr.regBx - wordExcess

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2013,39 +2013,12 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         for s in list.items:
           if v in s: return true
 
-      func cmp(a: string, b: VmString): int =
-        let minLen = min(a.len, b.len)
-        if minLen > 0:
-          result = cmpMem(unsafeAddr a[0], b.data.rawPointer, minLen)
-        if result == 0:
-          result = a.len - b.len
-
       var cond = false
       case value.kind
       of cnstInt:      cond = regs[ra].intVal == value.intVal
-      of cnstString:   cond = regs[ra].strVal == value.strVal
       of cnstFloat:    cond = regs[ra].floatVal == value.floatVal
       of cnstSliceListInt:   cond = regs[ra].intVal in value.intSlices
       of cnstSliceListFloat: cond = regs[ra].floatVal in value.floatSlices
-      of cnstSliceListStr:
-        # string slice-lists don't store the strings directly, but the ID of
-        # a constant instead
-        let str = regs[ra].strVal
-        for s in value.strSlices.items:
-          let a = c.constants[s.a].strVal
-          let r = cmp(a, str)
-          if s.a == s.b:
-            # no need to compare the string with both slice elements if
-            # they're the same
-            if r == 0:
-              cond = true
-              break
-          else:
-            let b = c.constants[s.b].strVal
-            if r <= 0 and cmp(b, str) >= 0:
-              cond = true
-              break
-
       else:
         unreachable(value.kind)
 

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -342,7 +342,6 @@ type
     # slice-lists are used for implementing `opcBranch` (branch for case stmt)
     cnstSliceListInt
     cnstSliceListFloat
-    cnstSliceListStr
 
   ConstantId* = int ## The ID of a `VmConstant`. Currently just an index into
                     ## `TCtx.constants`
@@ -368,9 +367,6 @@ type
       intSlices*: seq[Slice[BiggestInt]]
     of cnstSliceListFloat:
       floatSlices*: seq[Slice[BiggestFloat]]
-    of cnstSliceListStr:
-      strSlices*: seq[Slice[ConstantId]] ## Stores the ids of string constants
-                                         ## as a storage optimization
 
   VmArgs* = object
     ra*, rb*, rc*: Natural

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -757,11 +757,6 @@ proc genBranchLit(c: var TCtx, n: CgNode, t: PType): int =
       cnst.floatSlices.fillSliceList(values):
         it.floatVal
 
-    of tyString:
-      cnst = VmConstant(kind: cnstSliceListStr)
-      cnst.strSlices.fillSliceList(values):
-        c.toStringCnst(it.strVal)
-
     else:
       unreachable(t.kind)
 

--- a/compiler/vm/vmutils.nim
+++ b/compiler/vm/vmutils.nim
@@ -94,7 +94,7 @@ proc codeListing*(c: TCtx; start = 0; last = -1): seq[DebugVmCodeEntry] =
         of cnstFloat:  newFloatNode(nkFloatLit, cnst.floatVal)
         of cnstString: newStrNode(nkStrLit, cnst.strVal)
         of cnstNode:   cnst.node
-        of cnstSliceListInt..cnstSliceListStr:
+        of cnstSliceListInt..cnstSliceListFloat:
           # XXX: translate into an `nkOfBranch`?
           newNode(nkEmpty)
     else:


### PR DESCRIPTION
## Summary

Remove the dedicated  `string`  slice-list matching support from the VM
and replace it with an in-bytecode implementation. This gives more
control to the code generator and removes the last internal usage of 
`cnstString` , preparing for the latter's removal.

## Details

An  `of`  branch of a  `case`  matching over a string is now translated
into a sequence of  `LdConst` + `EqStr` + `TJmp`  (one per label),
replicating the behaviour previously implemented by the  `Branch` 
opcode.

While the bytecode implementation is a bit slower and also results in
slightly larger VM executables, having less high-level string operations
in the VM makes it easier to evolve.

The string slice-list matching is removed from the  `Branch`  opcode
implementation, and  `cnstSliceListStr`  together with all its usages is
removed.