### PR TITLE
remove `posix` dependency from `timportedobj`

### DIFF
--- a/tests/arc/timportedobj.nim
+++ b/tests/arc/timportedobj.nim
@@ -1,15 +1,43 @@
 discard """
-  cmd: "nim c --gc:arc $file"
+  description: '''
+    Ensure that imported object types with fake fields can be used in types
+    that have lifted hooks.
+    Derived from https://github.com/nim-lang/nim/issues/13269.
+  '''
+  targets: "c"
   action: "compile"
-  disabled: "windows"
 """
 
-# bug #13269
+type
+  Destroy = object
+    ## A type with a user-defined destructor.
+    value: int
 
-import posix
-proc foo*() =
-  var last = newSeq[Stat]()
-  var next = last
-  for i in 0..3:
-    last = next
-foo()
+proc `=destroy`(x: var Destroy) =
+  discard "body doesn't matter"
+
+type Export {.exportc: "Export", pure.} = object
+  a: int
+
+var e: Export # make sure the type is part of the C translation unit
+
+type
+  # import the type again
+  Import {.importc: "Export".} = object
+    # import the field under a different name. If not directly accessed, this
+    # must not cause a compilation error
+    b: int
+
+  Combined = object
+    i: Import
+    d: Destroy
+    # since `Destroy` is used, `Combined` has automatic hooks lifted. The
+    # automatic hook must not contain an access of the (non-existent) `i.b`
+    # field
+
+proc foo*(x: Combined) =
+  var y = x # a copy is required
+  # modify in order to prevent cursorfication:
+  y.d.value = 1
+
+foo(Combined())


### PR DESCRIPTION
## Summary

The reliance on the `posix` module made test not usable on platforms
not supporting the module. The test is reduced in order to not depend
on `posix`.

## Details

The test was added as a regression test for a bug with
`liftdestructors`  (fixed by
https://github.com/nim-works/nimskull/commit/c87796180edc86cf3cc1fa0fb35f03c1461937cd),
where a hook was lifted for imported types. If the imported type
contains a field that doesn't actually exist in the imported type (this
is the case for, e.g., padding), the resulting assignment of those
fields would result in a C compiler error.

The test is changed in a way such that it's as explicit as possible (no
`seq` usage, no reliance on `Stat`).