### PR TITLE
bundle the `vmrunner` with releases

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -85,6 +85,7 @@ Files: "bin/nimgrep.exe"
 Files: "bin/nimpretty.exe"
 Files: "bin/nimsuggest.exe"
 Files: "bin/vccexe.exe"
+Files: "bin/vmrunner.exe"
 
 Files: "finish.exe"
 
@@ -98,6 +99,7 @@ Files: "bin/nim"
 Files: "bin/nim_dbg"
 Files: "bin/nimgrep"
 Files: "bin/nimsuggest"
+Files: "bin/vmrunner"
 
 [Unix]
 InstallScript: "yes"


### PR DESCRIPTION
## Summary

Without the `vmrunner` executable, the runner has to be built manually
in order to run `.nimbc` executables -- the `nim vm -r` command also
doesn't work.

The `vmrunner` executable is now part of the standard installation.