### PR TITLE
codegen: unify exception preparation

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -284,6 +284,10 @@ proc newStrNode*(strVal: string; info: TLineInfo): PNode =
   result = newNodeI(nkStrLit, info)
   result.strVal = strVal
 
+proc newStrNode*(strVal: sink string, typ: PType; info=unknownLineInfo): PNode =
+  result = newNodeIT(nkStrLit, info, typ)
+  result.strVal = strVal
+
 proc newProcNode*(kind: TNodeKind, info: TLineInfo, body: PNode,
                  params,
                  name, pattern, genericParams,

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -363,8 +363,8 @@ proc genRaiseStmt(p: BProc, t: CgNode) =
     if isImportedException(typ, p.config):
       lineF(p, cpsStmts, "throw $1;$n", [e])
     else:
-      lineCg(p, cpsStmts, "#raiseExceptionEx((#Exception*)$1, $2, $3, $4, $5);$n",
-          [e, makeCString(typ.sym.name.s),
+      lineCg(p, cpsStmts, "#raiseException2((#Exception*)$1, $2, $3, $4);$n",
+          [e,
           makeCString(if p.prc != nil: p.prc.name.s else: p.module.module.name.s),
           quotedFilename(p.config, t.info), toLinenumber(t.info)])
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -772,11 +772,10 @@ proc genRaiseStmt(p: PProc, n: CgNode) =
   if n[0].kind != cnkEmpty:
     var a: TCompRes
     gen(p, n[0], a)
-    let typ = skipTypes(n[0].typ, abstractPtrs)
     genLineDir(p, n)
     useMagic(p, "raiseException")
-    lineF(p, "raiseException($1, $2);$n",
-             [a.rdLoc, makeJSString(typ.sym.name.s)])
+    lineF(p, "raiseException($1);$n",
+             [a.rdLoc])
   else:
     genLineDir(p, n)
     useMagic(p, "reraiseException")

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -902,17 +902,8 @@ proc genTry(c: var TCtx; n: CgNode) =
 
 proc genRaise(c: var TCtx; n: CgNode) =
   if n[0].kind != cnkEmpty:
-    let
-      dest = c.genx(n[0])
-      typ = skipTypes(n[0].typ, abstractPtrs)
-
-    # get the exception name
-    var name = noDest
-    c.genLit(n[0], c.toStringCnst(typ.sym.name.s), name)
-
-    # XXX: using an ABxI encoding would make sense here...
-    c.gABI(n, opcRaise, dest, name, 0)
-    c.freeTemp(name)
+    let dest = c.genx(n[0])
+    c.gABI(n, opcRaise, dest, 0, imm=0)
     c.freeTemp(dest)
   else:
     # reraise

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2336,6 +2336,9 @@ when notJSnotNims and hostOS != "standalone":
 elif isNimVmTarget:
   proc getCurrentException*(): ref Exception {.compilerRtl.} = discard
 
+  proc prepareException(e: ref Exception, ename: cstring) {.compilerproc.} =
+    discard
+
   proc closureIterSetupExc(e: ref Exception) {.compilerproc, inline.} =
     ## Used by the closure transformation pass for preparing for exception
     ## handling. Implemented as a callback.

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -147,14 +147,9 @@ proc prepareException(e: ref Exception, ename: cstring) {.
   when NimStackTrace:
     e.trace = rawWriteStackTrace()
 
-proc raiseException(e: ref Exception, ename: cstring) {.
-    compilerproc, asmNoStackFrame.} =
-  if e.name.isNil:
-    e.name = ename
+proc raiseException(e: ref Exception) {.compilerproc, asmNoStackFrame.} =
   if excHandler == 0:
     unhandledException(e)
-  when NimStackTrace:
-    e.trace = rawWriteStackTrace()
   asm "throw `e`;"
 
 proc reraiseException() {.compilerproc, asmNoStackFrame.} =

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -140,6 +140,13 @@ proc unhandledException(e: ref Exception) {.
   }
   """.}
 
+proc prepareException(e: ref Exception, ename: cstring) {.
+    compilerproc, asmNoStackFrame.} =
+  if e.name.isNil:
+    e.name = ename
+  when NimStackTrace:
+    e.trace = rawWriteStackTrace()
+
 proc raiseException(e: ref Exception, ename: cstring) {.
     compilerproc, asmNoStackFrame.} =
   if e.name.isNil:


### PR DESCRIPTION
## Summary

Introduce a common compiler runtime procedure (`prepareException`) and
expand `raise e` into `prepareException(e, ...); raise e` during
AST -> MIR translation. This moves more exception-related handling out
of the code generators.

## Details

* `prepareException` is responsible for initializing the exception's
  name (if it hasn't been already) and populating it with the stack-
  trace entries
* `mirgen.genRaise` emits the `prepareException` call
* only the C and JavaScript backends implement the stack-trace setup,
  the VM is still missing it
* for the VM, the `Raise` opcode no longer handles the name
  initialization, making the opcode agnostic to the exception's data
  structure
* the C backend's runtime has to keep the old interface around, as the
  csources compiler still needs it
* a `ast.newStrNode` overload is added that takes a `PType`

Emitting the `prepareException` call in `mirgen` moves decision making
as to what name to initialize the exception with to a central place.