### PR TITLE
std/io, os: stop `newWideCString` buffer overflow

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1373,13 +1373,13 @@ when not defined(nimscript):
     elif defined(windows):
       var bufsize = MAX_PATH.int32
       when useWinUnicode:
-        var res = newWideCString("", bufsize)
+        var res = newWideCString(bufsize)
         while true:
           var L = getCurrentDirectoryW(bufsize, res)
           if L == 0'i32:
             raiseOSError(osLastError())
           elif L > bufsize:
-            res = newWideCString("", L)
+            res = newWideCString(L)
             bufsize = L
           else:
             result = res$L
@@ -2186,13 +2186,13 @@ proc expandFilename*(filename: string): string {.rtl, extern: "nos$1",
     var bufsize = MAX_PATH.int32
     when useWinUnicode:
       var unused: WideCString = nil
-      var res = newWideCString("", bufsize)
+      var res = newWideCString(bufsize)
       while true:
         var L = getFullPathNameW(newWideCString(filename), bufsize, res, unused)
         if L == 0'i32:
           raiseOSError(osLastError(), filename)
         elif L > bufsize:
-          res = newWideCString("", L)
+          res = newWideCString(L)
           bufsize = L
         else:
           result = res$L
@@ -3131,14 +3131,14 @@ proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noW
   when defined(windows):
     var bufsize = int32(MAX_PATH)
     when useWinUnicode:
-      var buf = newWideCString("", bufsize)
+      var buf = newWideCString(bufsize)
       while true:
         var L = getModuleFileNameW(0, buf, bufsize)
         if L == 0'i32:
           result = "" # error!
           break
         elif L > bufsize:
-          buf = newWideCString("", L)
+          buf = newWideCString(L)
           bufsize = L
         else:
           result = buf$L

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -424,7 +424,7 @@ proc readLine*(f: File, line: var string): bool {.tags: [ReadIOEffect],
     if f.isatty:
       const numberOfCharsToRead = 2048
       var numberOfCharsRead = 0'i32
-      var buffer = newWideCString("", numberOfCharsToRead)
+      var buffer = newWideCString(numberOfCharsToRead)
       if readConsole(getOsFileHandle(f), addr(buffer[0]),
         numberOfCharsToRead, addr(numberOfCharsRead), nil) == 0:
         var error = getLastError()

--- a/lib/system/widestrs.nim
+++ b/lib/system/widestrs.nim
@@ -121,9 +121,12 @@ iterator runes(s: cstring, L: int): int =
     yield result
 
 proc newWideCString*(size: int): WideCStringObj =
+  ## Create an empty `WideCStringObj` with the given buffer size in
+  ## UTF-16 code units.
   createWide(result, size + 1) # +1 for the zero terminator
 
 proc newWideCString*(source: cstring, L: int): WideCStringObj =
+  ## Take a `cstring` and its length `L` in bytes, then returns a copy in wide form.
   createWide(result, L + 1) # +1 for the zero terminator
   var d = 0
   for ch in runes(source, L):
@@ -144,11 +147,13 @@ proc newWideCString*(source: cstring, L: int): WideCStringObj =
   result[d] = Utf16Char(0)
 
 proc newWideCString*(s: cstring): WideCStringObj =
+  ## Returns a copy of the string `s` in wide form. `s` should be NUL-terminated.
   if s.isNil: return nullWide
 
   result = newWideCString(s, s.len)
 
 proc newWideCString*(s: string): WideCStringObj =
+  ## Returns a copy of the string `s` in wide form.
   result = newWideCString(cstring s, s.len)
 
 proc `$`*(w: WideCString, estimate: int, replacement: int = 0xFFFD): string =


### PR DESCRIPTION
## Summary

Fix buffer overflow in the  `std/io`  and  `std/os`  modules related to
incorrect usage of  `newWideCstring` .

## Details

`newWideCString` 's binary form, 
`proc newWideCString*(source: cstring, L: int): WideCStringObj` ,
results in buffer overflows within the  `std/io`  and  `std/os` 
modules. This change revises the erroneous usage of  `newWideCString` ,
with an empty string ( `""` ) as the  `source`  parameter in these
modules, with the single parameter version for preallocating a wide
string.

The 2-parameter form of newWideCString is meant to take a  `cstring` 
and its  `length` , then convert them to wide form. As such this length
must be the exact length of the given string.

To prevent incorrect usage in the future, this PR also documents the
various  `newWideCString`  variants.