### PR TITLE
ci: add M1 Macs to matrix

### DIFF
--- a/.github/actions/download-compiler/action.yml
+++ b/.github/actions/download-compiler/action.yml
@@ -23,5 +23,5 @@ runs:
         archivepath = Path(os.environ["RUNNER_TEMP"]) / "compiler.tar"
         with tarfile.open(archivepath) as archive:
           archive.extractall()
-      shell: python
+      shell: python3 {0}
       working-directory: "${{ inputs.workspace }}"

--- a/.github/actions/download-compiler/action.yml
+++ b/.github/actions/download-compiler/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - uses: actions/download-artifact@v4
       with:
-        name: compiler ${{ runner.os }}
+        name: compiler ${{ runner.os }} ${{ runner.arch }}
         path: "${{ runner.temp }}"
 
     - name: Unpack the workspace

--- a/.github/actions/upload-compiler/action.yml
+++ b/.github/actions/upload-compiler/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: compiler ${{ runner.os }}
+        name: compiler ${{ runner.os }} ${{ runner.arch }}
         path: "${{ runner.temp }}/compiler.tar"
         # This action is only used to share data between jobs, there is no need
         # to keep this artifact for long.

--- a/.github/actions/upload-compiler/action.yml
+++ b/.github/actions/upload-compiler/action.yml
@@ -23,7 +23,7 @@ runs:
         with tarfile.open(archivepath, mode="x") as archive:
           for file in diff:
             archive.add(file)
-      shell: python
+      shell: python3 {0}
       working-directory: "${{ inputs.source }}"
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
               "runner": "macos-11"
             },
             {
+              "name": "macOS (M1)",
+              "runner": "macos-14"
+            },
+            {
               "name": "Windows",
               "runner": "windows-2022"
             }

--- a/lib/pure/fenv.nim
+++ b/lib/pure/fenv.nim
@@ -12,7 +12,7 @@
 ## The types, vars and procs are bindings for the C standard library
 ## [<fenv.h>](https://en.cppreference.com/w/c/numeric/fenv) header.
 
-when defined(posix):
+when defined(posix) and not defined(macosx):
   {.passl: "-lm".}
 
 var

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -116,7 +116,7 @@ func fac*(n: int): int =
 
 {.push checks: off, line_dir: off, stack_trace: off.}
 
-when defined(posix):
+when defined(posix) and not defined(macosx):
   {.passl: "-lm".}
 
 const

--- a/tests/misc/temit.nim
+++ b/tests/misc/temit.nim
@@ -4,6 +4,7 @@ discard """
 # Test the new ``emit`` pragma:
 
 {.emit: """
+#include <stdio.h>
 static int cvariable = 420;
 
 """.}

--- a/tests/misc/tnumeric_conversions.nim
+++ b/tests/misc/tnumeric_conversions.nim
@@ -4,7 +4,7 @@ discard """
   knownIssue.js: "full-range integers aren't supported yet"
 """
 
-when defined(amd64) or defined(i386):
+when defined(amd64) or defined(i386) or defined(js) or defined(vm):
   # FIXME: This test right now depends on architecture-specific behavior on x86
   #
   # This bug is tracked at https://github.com/nim-works/nimskull/issues/1155

--- a/tests/misc/tnumeric_conversions.nim
+++ b/tests/misc/tnumeric_conversions.nim
@@ -4,23 +4,27 @@ discard """
   knownIssue.js: "full-range integers aren't supported yet"
 """
 
-block negative_float64_to_uint:
-  # has the same result as converting to a signed int of the same width first,
-  # and then to the unsigned one
-  var f = -1.5
-  doAssert uint64(f) == uint64(int64(f))
-  doAssert uint32(f) == uint32(int32(f))
-  doAssert uint16(f) == uint16(int16(f))
-  doAssert uint8(f) == uint8(int8(f))
+when defined(amd64) or defined(i386):
+  # FIXME: This test right now depends on architecture-specific behavior on x86
+  #
+  # This bug is tracked at https://github.com/nim-works/nimskull/issues/1155
+  block negative_float64_to_uint:
+    # has the same result as converting to a signed int of the same width first,
+    # and then to the unsigned one
+    var f = -1.5
+    doAssert uint64(f) == uint64(int64(f))
+    doAssert uint32(f) == uint32(int32(f))
+    doAssert uint16(f) == uint16(int16(f))
+    doAssert uint8(f) == uint8(int8(f))
 
-block negative_float32_to_uint:
-  # has the same result as converting to a signed int of the same width first,
-  # and then to the unsigned one
-  var f = -1.5'f32
-  doAssert uint64(f) == uint64(int64(f))
-  doAssert uint32(f) == uint32(int32(f))
-  doAssert uint16(f) == uint16(int16(f))
-  doAssert uint8(f) == uint8(int8(f))
+  block negative_float32_to_uint:
+    # has the same result as converting to a signed int of the same width first,
+    # and then to the unsigned one
+    var f = -1.5'f32
+    doAssert uint64(f) == uint64(int64(f))
+    doAssert uint32(f) == uint32(int32(f))
+    doAssert uint16(f) == uint16(int16(f))
+    doAssert uint8(f) == uint8(int8(f))
 
 block bool_to_float:
   var b = true


### PR DESCRIPTION
## Summary
GitHub now provides free M1 machines for CI, which means we get to have
M1 test coverage and binaries!

For more information, see
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

## Details
* Updates to download/upload compiler actions:
  * Added awareness for runner architecture
  * Added a small workaround for  `shell: python`  not being compatible
with M1 CI
* Removed  `-lm`  compiler flags for macOS, as it is not required and
was causing
  warnings that broke tests.
* `temit.nim` is modified to include `stdio.h` due to `printf` usage.
* Disabled float-to-uint tests in  `tnumeric_conversions`  for non-x86
targets due
  to reliance on undefined behavior. See
https://github.com/nim-works/nimskull/issues/1155.