### PR TITLE
sem: fix infinite loop in type identifier lookup

### DIFF
--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -585,7 +585,6 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
           localReport(c.config, err)
           return errorSym(c, n, err)
       if result.kind != skType and result.magic notin {mStatic, mType, mTypeOf}:
-        # this implements the wanted ``var v: V, x: V`` feature ...
         var ov: TOverloadIter
         var amb = initOverloadIter(ov, c, n)
         while amb != nil and amb.kind != skType:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -552,7 +552,6 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
       result = qualifiedLookUp(c, n, {checkAmbiguity, checkUndeclared})
     if result.isError:
       markUsed(c, n.info, result)
-
       # XXX: move to propagating nkError, skError, and tyError
       localReport(c.config, result.ast)
     elif result != nil:
@@ -569,7 +568,6 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         if result.typ.sym == nil:
           let err = newError(c.config, n, PAstDiag(kind: adSemTypeExpected))
           localReport(c.config, err)
-
           return errorSym(c, n, err)
         result = result.typ.sym.copySym(nextSymId c.idgen)
         result.typ = exactReplica(result.typ)
@@ -585,23 +583,20 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
         else:
           let err = newError(c.config, n, PAstDiag(kind: adSemTypeExpected))
           localReport(c.config, err)
-
           return errorSym(c, n, err)
       if result.kind != skType and result.magic notin {mStatic, mType, mTypeOf}:
         # this implements the wanted ``var v: V, x: V`` feature ...
         var ov: TOverloadIter
         var amb = initOverloadIter(ov, c, n)
-        while amb != nil:
+        while amb != nil and amb.kind != skType:
           if amb.isError:
             localReport(c.config, amb.ast)
-          if amb.kind != skType:
-            amb = nextOverloadIter(ov, c, n)
+          amb = nextOverloadIter(ov, c, n)
         if amb != nil: result = amb
         else:
           let err = newError(c.config, n, PAstDiag(kind: adSemTypeExpected))
           if result.kind != skError:
             localReport(c.config, err)
-
           return errorSym(c, n, err)
       if result.typ.kind != tyGenericParam:
         # XXX get rid of this hack!

--- a/tests/lookups/ttypes_decl_are_not_ambiguous_among_themselves.nim
+++ b/tests/lookups/ttypes_decl_are_not_ambiguous_among_themselves.nim
@@ -1,8 +1,7 @@
 discard """
   description: '''
-    Ensure types are not considered ambiguous among type declarations,
-    allowing for parameter definitions that repeat the same type, such as:
-    `f(v: V, w: V) = discard`
+    Ensure types are preferred in type contexts when the name is overloaded
+    with parameter and/or generic parameter names.
   '''
 """
 
@@ -21,3 +20,10 @@ block parameter_and_return_type_repetition:
 
 block parameter_and_parameter_repetition:
   proc foo(Foo: FOO, bar: FOO) = discard
+
+block type_and_generic_parameter_collison:
+  # xxx: this is questionable, it should probably be an ambiguity error, as
+  #      `FOO` the generic parameter is more 'local' but type names on a per
+  #      module basis should be unambiguous, at least in principal.
+  proc foo[FOO](foo: FOO): FOO = discard
+  doAssert foo[int](0) is int

--- a/tests/lookups/ttypes_decl_are_not_ambiguous_among_themselves.nim
+++ b/tests/lookups/ttypes_decl_are_not_ambiguous_among_themselves.nim
@@ -1,0 +1,23 @@
+discard """
+  description: '''
+    Ensure types are not considered ambiguous among type declarations,
+    allowing for parameter definitions that repeat the same type, such as:
+    `f(v: V, w: V) = discard`
+  '''
+"""
+
+# This is a regression test for an infinite loop in `semTypeIdent`
+# see: https://github.com/nim-works/nimskull/issues/1151
+
+
+type
+  FOO = object
+
+block parameter_and_return_type_repetition:
+  # the parameter name is kept as `Foo` to force an ambiguitity between `Foo`
+  # parameter name, and `FOO` the parameter type, as that's what resulted in
+  # an infinite loop.
+  proc foo(Foo: FOO): FOO = discard
+
+block parameter_and_parameter_repetition:
+  proc foo(Foo: FOO, bar: FOO) = discard


### PR DESCRIPTION
## Summary

Fixed an infinite loop in type identifier lookup, when parameter names
collided with parameter type declarations.

Fixes https://github.com/nim-works/nimskull/issues/1151

## Details

`semtypes.semTypeIdent`  had an infinite loop when searching for
potentially ambiguous symbols. This meant code with ambiguities between,
for instance, a parameter and a type name resulted in an infinite loop.

In addition to the change a test has been added to avoid the
regression.