### PR TITLE
backend: use MIR for representing constant expressions

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1963,7 +1963,7 @@ proc genConstDefinition*(q: BModule; id: ConstId) =
   let name = mangleName(q.g.graph, sym)
   if exfNoDecl notin sym.extFlags:
     let p = newProc(nil, q)
-    let data = translate(q.g.env, q.g.env[q.g.env.dataFor(id)])
+    let data = translate(q.g.env[q.g.env.dataFor(id)])
     q.s[cfsData].addf("N_LIB_PRIVATE NIM_CONST $1 $2 = $3;$n",
         [getTypeDesc(q, sym.typ), name,
         genBracedInit(p, data, sym.typ)])
@@ -1983,7 +1983,7 @@ proc useData(p: BProc, x: ConstId, typ: PType): string =
     inc p.module.labels
     p.module.s[cfsData].addf("static NIM_CONST $1 $2 = $3;$n",
       [getTypeDesc(p.module, typ), result,
-       genBracedInit(p, translate(p.env, p.env[id]), typ)])
+       genBracedInit(p, translate(p.env[id]), typ)])
 
 proc expr(p: BProc, n: CgNode, d: var TLoc) =
   when defined(nimCompilerStacktraceHints):
@@ -2003,7 +2003,7 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
     if isSimpleConst(p.config, n.typ):
       # simple constants are inlined at the usage site
       let da = p.env.dataFor(n.cnst)
-      let val = translate(p.env, p.env[da])
+      let val = translate(p.env[da])
       if val.kind == cnkSetConstr:
         let cs = toBitSet(p.config, val)
         putIntoDest(p, d, n, genRawSetData(cs, int(getSize(p.config, n.typ))))

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2321,7 +2321,6 @@ proc genBracedInit(p: BProc, n: CgNode; optionalType: PType): Rope =
           #      passing the expression to evaluation
           symNode = n
         of cnkClosureConstr:
-          p.config.internalAssert(n[0].kind == cnkProc, n.info)
           p.config.internalAssert(n[1].kind == cnkNilLit, n.info)
           symNode = n[0]
         else:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1566,7 +1566,7 @@ proc genConstant*(g: PGlobals, m: BModule, id: ConstId) =
     var p = newInitProc(g, m)
     #genLineDir(p, c.ast)
     genVarInit(p, c.typ, name, storage,
-               translate(g.env, g.env[g.env.dataFor(id)]))
+               translate(g.env[g.env.dataFor(id)]))
     g.constants.add(p.body)
 
   # all constants need a name:
@@ -2215,7 +2215,7 @@ proc rdData(p: PProc, data: DataId, typ: PType): TCompRes =
   ## Returns the loc for the `data` of type `typ`. Emits the definition for
   ## `data` if it hasn't been already.
   if not containsOrIncl(p.g.dataGenerated, data.int):
-    let val = gen(p, translate(p.env, p.env[data]))
+    let val = gen(p, translate(p.env[data]))
     # emit the definition into the constants section:
     p.g.constants.addf("var Data$1 = $2;$n", [$ord(data), val.res])
 

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -94,13 +94,10 @@ proc cmp(a, b: ConstrTree): bool =
     return false
 
   # both trees are known to have the same length at this point
-  var i = 0
   # traverse both trees simultaneously and look for a divergence:
-  while i < a.len:
+  for i in 0..<a.len:
     if a[i] != b[i]:
       return false # divergence -> not equal
-
-    inc i
 
   # the cursor reached the end; the trees are equal
   result = true

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -366,7 +366,7 @@ proc extractStringLiterals(tree: MirTree, env: var MirEnv,
     # note: both normal string *and* cstring literals are currently included
     if tree[i].lit.kind in nkStrLiterals:
       # create an anonymous constant from the literal:
-      let c = toConstId env.data.getOrPut(tree[i].lit)
+      let c = toConstId env.data.getOrPut(@[tree[i]])
       # replace the usage of the literal with the anonymous constant:
       changes.replaceMulti(tree, i, bu):
         bu.use toValue(c, tree[i].typ)

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -325,6 +325,10 @@ const
   SymbolLike* = {mnkParam, mnkLocal}
     ## Nodes for which the `sym` field is available
 
+  ConstrTreeNodes* = {mnkConstr, mnkObjConstr, mnkLiteral, mnkProc,
+                      mnkArg, mnkField, mnkEnd}
+    ## Nodes that can appear in the MIR subset used for constant expressions.
+
   # --- semantics-focused sets:
 
   Atoms* = {mnkNone .. mnkType} - {mnkField}

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -47,6 +47,7 @@ import
     vmlegacy,
     vmops,
     vmprofiler,
+    vmserialize,
     vmtypegen,
     vmutils,
     vm
@@ -117,86 +118,28 @@ proc logBytecode(c: TCtx, owner: PSym, start: int) =
 
 proc putIntoReg(dest: var TFullReg; jit: var JitState, c: var TCtx, n: PNode,
                 formal: PType) =
-  ## Put the value that is represented by `n` (but not the node itself) into
-  ## `dest`. Implicit conversion is also performed, if necessary.
-  # XXX: requring access to the JIT state here is all kinds of wrong and
-  #      indicates that ``putIntoReg`` is not a good idea to begin with. The
-  #      XXX comment below describes a good way to get out of this mess
-  let t = formal.skipTypes(abstractInst+{tyStatic}-{tyTypeDesc})
-
-  # XXX: instead of performing conversion here manually, sem could generate a
-  #      small thunk for macro invocations that sets up static arguments and
-  #      then invokes the macro. The thunk would be executed in the VM, making
-  #      the code here obsolete while also eliminating unnecessary
-  #      deserialize/serialize round-trips
-
-  proc registerProcs(jit: var JitState, c: var TCtx, n: PNode) =
-    # note: this kind of scanning only works for AST representing concrete
-    # values
-    case n.kind
-    of nkSym:
-      if n.sym.kind in routineKinds:
-        discard registerProcedure(jit, c, n.sym)
-    of nkWithoutSons - {nkSym}:
-      discard "not relevant"
-    of nkWithSons:
-      for it in n.items:
-        registerProcs(jit, c, it)
-
-  # create a function table entry for each procedure referenced by `n` --
-  # ``serialize`` depends on it
-  registerProcs(jit, c, n)
-
-  case t.kind
-  of tyBool, tyChar, tyEnum, tyInt..tyInt64, tyUInt..tyUInt64:
-    assert n.kind in nkCharLit..nkUInt64Lit
+  ## Treats `n` as a constant expression and loads the value it represents
+  ## into `dest`.
+  let
+    typ = c.getOrCreate(formal.skipTypes({tySink, tyStatic}))
+    data = constDataToMir(c, jit, n)
+  case typ.kind
+  of akInt:
     dest.ensureKind(rkInt, c.memory)
-    dest.intVal = n.intVal
-  of tyFloat..tyFloat64:
-    assert n.kind in nkFloatLit..nkFloat64Lit
+    dest.intVal = data[0].lit.intVal
+  of akFloat:
     dest.ensureKind(rkFloat, c.memory)
-    dest.floatVal = n.floatVal
-  of tyNil, tyPtr, tyPointer:
+    dest.floatVal = data[0].lit.floatVal
+  of akPtr:
     dest.ensureKind(rkAddress, c.memory)
-    # XXX: it's currently forbidden to pass non-nil pointer to static
-    #      parameters. `deserialize` already reports an error, so an
-    #      assert is used here to make sure that it really got reported
-    #      earlier
-    assert n.kind == nkNilLit
-  of tyOpenArray:
-    # Handle `openArray` parameters the same way they're handled elsewhere
-    # in the VM: simply pass the argument without a conversion
-    let typ = c.getOrCreate(n.typ)
-    dest.initLocReg(typ, c.memory)
-    c.serialize(n, dest.handle)
-  of tyProc:
-    let val =
-      if t.callConv == ccClosure:
-        # do what ``transf`` would do and turn the expression into a closure
-        # construction
-        case n.kind
-        of nkSym:
-          newTreeIT(nkClosure, n.info, t, [n, newNode(nkNilLit)])
-        of nkClosure, nkNilLit:
-          n
-        else:
-          unreachable()
-      else:
-        n
-
-    dest.initLocReg(c.getOrCreate(t), c.memory)
-    c.serialize(val, dest.handle)
+    # non-nil values should have already been reported as an error
+    assert data[0].lit.kind == nkNilLit
+  of akPNode:
+    dest.ensureKind(rkNimNode, c.memory)
+    dest.nimNode = data[0].lit
   else:
-    if t.kind == tyRef and t.sym != nil and t.sym.magic == mPNimrodNode:
-      # A NimNode
-      dest.ensureKind(rkNimNode, c.memory)
-      dest.nimNode = n
-    else:
-      let typ = c.getOrCreate(formal)
-      dest.initLocReg(typ, c.memory)
-      # XXX: overriding the type (passing `formal`), leads to issues (internal
-      #      compiler error) when passing an empty set to a static parameter
-      c.serialize(n, dest.handle)#, formal)
+    dest.initLocReg(typ, c.memory)
+    initFromExpr(dest.handle, data, c.config, c.memory)
 
 proc unpackResult(res: sink ExecutionResult; config: ConfigRef, node: PNode): PNode =
   ## Unpacks the execution result. If the result represents a failure, returns

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -97,7 +97,7 @@ proc getGlobalValue*(i: Interpreter; letOrVar: PSym): PNode =
 proc setGlobalValue*(i: Interpreter; letOrVar: PSym, val: PNode) =
   ## Sets a global value to a given PNode, does not do any type checking.
   let c = PEvalContext(i.graph.vm)
-  setGlobalValue(c.vm, letOrVar, val)
+  setGlobalValue(c[], letOrVar, val)
 
 proc implementRoutine*(i: Interpreter; pkg, module, name: string;
                        impl: proc (a: VmArgs) {.closure, gcsafe.}) =

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -17,10 +17,6 @@ import
     vmdef,
     vmlinker,
     vmtypegen
-  ],
-
-  std/[
-    tables
   ]
 
 func findRecCaseAux(n: PNode, d: PSym): PNode =
@@ -123,9 +119,3 @@ func fillProcEntry*(e: var FuncTableEntry, info: CodeInfo) {.inline.} =
   ## Sets the execution information of the function table entry to `info`
   e.start = info.start
   e.regCount = info.regCount.uint16
-
-proc lookupProc*(c: var TCtx, prc: PSym): FunctionIndex {.inline.} =
-  ## Returns the function-table index corresponding to the provided `prc`
-  ## symbol. Behaviour is undefined if `prc` has no corresponding function-
-  ## table entry.
-  c.linking.symToIndexTbl[prc.id].FunctionIndex

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -82,9 +82,6 @@ type
 
     gen: CodeGenCtx ## code generator state
 
-func growBy[T](x: var seq[T], n: Natural) {.inline.} =
-  x.setLen(x.len + n)
-
 proc registerCallbacks(linking: var LinkerData) =
   ## Registers callbacks for various functions, so that no code is
   ## generated for them and that they can (must) be overridden by the runner
@@ -110,10 +107,6 @@ proc registerCallbacks(linking: var LinkerData) =
   # Used by some tests
   cb "stdlib.system.getOccupiedMem"
 
-func setLinkIndex(c: var GenCtx, s: PSym, i: LinkIndex) =
-  assert s.id notin c.gen.linking.symToIndexTbl
-  c.gen.linking.symToIndexTbl[s.id] = i
-
 proc initProcEntry(c: var GenCtx, prc: PSym): FuncTableEntry {.inline.} =
   initProcEntry(c.gen.linking, c.graph.config, c.gen.typeInfoCache, prc)
 
@@ -127,7 +120,6 @@ proc registerProc(c: var GenCtx, prc: ProcedureId) =
 
   let sym = c.gen.env[prc]
   c.functions[prc] = c.initProcEntry(sym)
-  setLinkIndex(c, sym, LinkIndex idx)
 
 proc generateCodeForProc(c: var CodeGenCtx, idgen: IdGenerator, s: PSym,
                          body: sink MirBody): CodeInfo =
@@ -239,24 +231,20 @@ proc generateCodeForMain(c: var GenCtx, config: BackendConfig,
 
   result = id
 
-proc storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
-                linking: sink LinkerData, config: ConfigRef,
-                consts: seq[(PVmType, PNode)], globals: seq[PVmType]) =
-  ## Stores the previously gathered complex constants and globals into `dst`
-
+proc storeData(enc: var PackedEncoder, dst: var PackedEnv,
+               config: ConfigRef,
+               consts: seq[(PVmType, DataId)], env: MirEnv) =
+  ## Packs all constant data (`consts`) and stores it into `dst`.
   var denc = DataEncoder(config: config)
   denc.startEncoding(dst)
-  denc.routineSymLookup = move linking.symToIndexTbl
 
-  # complex constants (i.e. non-literals):
   mapList(dst.cconsts, consts, it):
-    let id = dst.nodes.len
-    dst.nodes.growBy(1)
-    denc.storeData(dst, it[1])
+    let id = denc.storeData(dst, env[it[1]])
     (enc.typeMap[it[0]], id.uint32)
 
-  # for globals, only their types are stored. All initialization is
-  # done in VM bytecode
+func storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
+                linking: LinkerData, globals: seq[PVmType]) =
+  ## Stores the globals and callback keys into `dst`.
   mapList(dst.globals, globals, it):
     enc.typeMap[it]
 
@@ -308,10 +296,10 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
   env.rtti = move c.gen.rtti
 
   # produce a list with the type of each constant:
-  var consts = newSeq[(PVmType, PNode)](c.gen.env.data.len)
+  var consts = newSeq[(PVmType, DataId)](c.gen.env.data.len)
   for i, data in c.gen.env.data.pairs:
-    let typ = c.gen.typeInfoCache.lookup(conf, data.typ)
-    consts[ord(i)] = (get(typ), data)
+    let typ = c.gen.typeInfoCache.lookup(conf, data[0].typ)
+    consts[ord(i)] = (get(typ), i)
 
   env.typeInfoCache = move c.gen.typeInfoCache
 
@@ -322,7 +310,8 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
 
   enc.init(env.types)
   storeEnv(enc, penv, env)
-  storeExtra(enc, penv, c.gen.linking, conf, consts, base(c.globals))
+  storeData(enc, penv, conf, consts, c.gen.env)
+  storeExtra(enc, penv, c.gen.linking, base(c.globals))
   penv.entryPoint = FunctionIndex(entryPoint)
 
   let err = writeToFile(penv, prepareToWriteOutput(conf))

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2474,7 +2474,7 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
     discard genType(c, n.typ) # make sure the type exists
     # somewhat hack-y, but the orchestrator later queries the type of the data
     # (which might be a different PType that maps to the same VM type)
-    discard genType(c, c.env[DataId pos].typ)
+    discard genType(c, c.env[DataId pos][0].typ)
   of cnkGlobal:
     # a global location
     let pos = useGlobal(c, n)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -43,7 +43,7 @@ import
   ],
   compiler/vm/[
     vmaux,
-    vmcompilerserdes,
+    vmserialize,
     vmdef,
     vmgen,
     vmjit_checks,
@@ -116,12 +116,10 @@ proc updateEnvironment(c: var TCtx, env: var MirEnv, cp: EnvCheckpoint) =
   # constants
   for id, data in since(env.data, cp.data):
     let
-      typ = c.getOrCreate(data.typ)
+      typ = c.getOrCreate(data[0].typ)
       handle = c.allocator.allocConstantLocation(typ)
 
-    # TODO: strings, seqs and other values using allocation also need to be
-    #       allocated with `allocConstantLocation` inside `serialize` here
-    c.serialize(data, handle)
+    initFromExpr(handle, data, c)
 
     c.complexConsts.add handle
 

--- a/compiler/vm/vmserialize.nim
+++ b/compiler/vm/vmserialize.nim
@@ -1,0 +1,151 @@
+## Implements routines for initializing VM memory locations directly from
+## expressions.
+
+import
+  compiler/ast/[
+    ast_query,
+    ast_types,
+    types
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/mir/[
+    mirtrees
+  ],
+  compiler/vm/[
+    vmaux,
+    vmdef,
+    vmobjects,
+    vmmemory,
+    vmtypegen,
+    vmtypes
+  ],
+  compiler/utils/[
+    bitsets,
+    idioms,
+    int128
+  ]
+
+proc initFromExpr(dest: LocHandle, tree: MirTree, n: var int,
+                  c: var TCtx) =
+  ## Loads the value represented by `tree` at `n` into `dest`. On exit, `n`
+  ## points to the next sub-tree.
+  template recurse(dest: LocHandle) =
+    initFromExpr(dest, tree, n, c)
+
+  template next(): lent MirNode =
+    let i = n
+    inc n
+    tree[i]
+
+  template arg(body: untyped) =
+    inc n # skip the ``mnkArg`` node
+    body
+    inc n # skip the end node
+
+  template iterTree(name, body: untyped) =
+    let len = next().len
+    for name in 0..<len:
+      body
+    inc n # skip the end node
+
+  case dest.typ.kind
+  of akInt:
+    writeUInt(dest, next().lit.intVal)
+  of akDiscriminator:
+    # handled during object processing below
+    unreachable("cannot be written directly")
+  of akFloat:
+    if dest.typ.sizeInBytes == 4:
+      writeFloat32(dest, float32(next().lit.floatVal))
+    else:
+      writeFloat64(dest, float64(next().lit.floatVal))
+  of akString:
+    deref(dest).strVal.newVmString(next().lit.strVal, c.allocator)
+  of akSeq:
+    # allocate the sequence first:
+    newVmSeq(deref(dest).seqVal, dest.typ, tree[n].len, c.memory)
+    # then initialize the elements:
+    let slice = loadFullSlice(c.allocator, deref(dest).seqVal.data,
+                              dest.typ.seqElemType)
+    iterTree(j):
+      arg recurse(slice[j])
+  of akPtr:
+    # nothing to do, only nil literals are allowed here
+    discard next()
+  of akRef:
+    if tree[n].kind == mnkLiteral:
+      discard next() # nothing to do for 'nil' literals
+    else:
+      # allocate a managed heap location and fill it:
+      let
+        t = c.getOrCreate(tree[n].typ)
+        slot = c.heap.heapNew(c.allocator, t.targetType)
+      recurse(c.heap.unsafeDeref(slot))
+      deref(dest).refVal = slot
+  of akSet:
+    proc put(dest: LocHandle, lit: PNode, first: Int128) {.inline.} =
+      proc adjusted(n: PNode, first: Int128): BiggestInt =
+        # subtract the first element's value to make all values zero-based
+        toInt(getInt(n) - first)
+
+      if lit.kind == nkRange:
+        bitSetInclRange(mbitSet(dest),
+          adjusted(lit[0], first)..adjusted(lit[1], first))
+      else:
+        bitSetIncl(mbitSet(dest), adjusted(lit, first))
+
+    let first =
+      if tree[n].len > 0: firstOrd(c.config, tree[n].typ)
+      else:               Zero
+    # XXX: ^^ ``set[empty]``-typed literals reach here, but they shouldn't. The
+    #      len guard works around the issue
+    iterTree(j):
+      arg put(dest, next().lit, first)
+  of akPNode:
+    deref(dest).nodeVal = next().lit[0]
+  of akCallable:
+    deref(dest).callableVal = toFuncPtr FunctionIndex(next().prc)
+  of akObject:
+    # the source can either be an object or tuple constructor
+    case tree[n].kind
+    of mnkLiteral:
+      # special case: nil closure literal
+      assert tree[n].lit.kind == nkNilLit
+      # only skip the node, don't initialize anything
+      discard next()
+    of mnkConstr:
+      iterTree(j):
+        arg recurse(dest.getFieldHandle(j.FieldPosition))
+    of mnkObjConstr:
+      let typ = tree[n].typ.skipTypes(abstractPtrs) ## the object's type
+      iterTree(i):
+        let
+          sym = next().field
+          field = dest.getFieldHandle(sym.position.FieldPosition)
+        # object types require special handling for tag fields
+        if sfDiscriminant in sym.flags:
+          let (owner, idx) = getFieldAndOwner(dest.typ, fpos sym.position)
+          # fetch the integer value:
+          var val: Int128
+          arg (;val = getInt(next().lit))
+          # compute the branch index:
+          let b = findMatchingBranch(findRecCase(typ, sym), val)
+          # write the tag value to the location:
+          field.writeDiscrField(owner, idx, toInt(val), b)
+        else:
+          arg recurse(field)
+    else:
+      unreachable(tree[n].kind)
+  of akArray:
+    let slice = toSlice(dest)
+    iterTree(i):
+      arg recurse(slice[i])
+
+proc initFromExpr*(dest: LocHandle, tree: MirTree, c: var TCtx) {.inline.} =
+  ## Intializes the memory location `dest` with the value represented by the
+  ## MIR contant expression `tree`. The location is expected to be in its
+  ## zero'ed state.
+  var i = 0
+  initFromExpr(dest, tree, i, c)

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -207,3 +207,26 @@ processing and faster access, the whole code for a procedure is stored in a
 single sequence of *nodes*, with the nodes forming a tree.
 
 Sub-trees are currently delimited via an explicit `End` node.
+
+Constant Expressions
+====================
+
+MIR constant expression are stored separately from MIR trees representing
+routine bodies. Constant expressions describe a value not depending on any
+dynamic/run-time information. They use a variation/sub-set of the MIR that is
+better suited for statement-less trees.
+
+The syntax is similar to that of the normal MIR, with the biggest difference
+being that the representation is flat (i.e., a single tree rather than multiple
+ones).
+
+.. code-block:: literal
+
+  VALUE = <Proc>
+        | <Literal>
+        | COMPLEX
+
+  ARG = Arg VALUE
+
+  COMPLEX = Constr ARG...
+          | ObjConstr (<Field> ARG)...


### PR DESCRIPTION
## Summary

Instead of `PNode`, use a subset of the MIR for representing constant
expression in the mid- and back-end. Apart from removing a significant
amount of `PNode` usage from the backend, using a dedicated IR for
constant expression paves the way for applying transformation and
lowering passes to them.

## Details

### Constant expression IR

* a subset of the MIR is used (refer to the `Constant Expressions`
  section in `doc/mir.rst`)
* in the subset, recursion is allowed
* using a subset of the MIR allows for re-using most of the existing
  MIR facilities (changesets, traversal routines, etc.)

### Translation

* the translation is implemented as a single-pass traversal over the
  constant expression AST
* since procedures referenced by constant expression are now registered
  with the `MirEnv` as they're encountered, the separate scanning pass
  (`scanExpr`) is obsolete
* the translation also handles `nkHiddenStdConv` and `nkHiddenSubConv`
  nodes, making the custom `mirgen.isDeepConstExpr` overload, which
  treated these nodes as non-constant, obsolete
* the constant-expression-to-`CgNode` translation (`compat.translate`)
  is updated to operate on the MIR constant expression

### VM serialization

The VM itself is not affected, but the logic for initializing memory
locations directly from constant expressions is. Initializing a VM
memory location directly from a MIR constant expression is implemented
by the new `vmserialize` module.

Apart from the loading of constant data in `vmjit.updateEnvironment`
(which must use `vmserialize`, since it now gets passed a `MirTree`),
there were two other situations where a VM memory location is
initialized from a `PNode` expression:
1. for `static` macro parameter initialization (`putIntoReg`)
2. for setting the value of a global via the compiler API
  (`setGlobalValue`)

Both are changed to first translate the `PNode` AST to a MIR constant
expression, which the register or memory location is then initialized
with. This has the benefits that:
- initializing VM locations from constant expression works the same
  everywhere
- procedures referenced from the AST are automatically registered with
  the `MirEnv` and JIT environment
- the `vmcompilerserdes` procedures for initializing a VM location from
  `PNode` AST become obsolete

Since they're now obsolete, the `vmcompilerserdes` serialization
routines are all removed. This has an important implication: a
`LinkerData` instance doesn't have to be carried around by `vmdef.TCtx`
anymore. Nothing is removed here yet -- the cleanup is left to follow-
up work.

Finally, the serialization of constant expressions in `packed_env` is
also updated to operate directly on MIR constant expressions.

### Misc

* speed up `mirconstr.pop` in the full-buffer-to-empty-buffer case
  (which happens for `constDataToMir`)