### PR TITLE
vm: remove string constants

### DIFF
--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -35,7 +35,9 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
     let field = t.n[i].sym
     let val = if field.ast == nil: field.name.s else: field.ast.strVal
     caseStmt.add newTree(nkOfBranch, newIntTypeNode(field.position, t),
-      newTree(nkStmtList, newTree(nkFastAsgn, newSymNode(res), newStrNode(val, info))))
+      newTree(nkStmtList, newTree(nkFastAsgn,
+                                  newSymNode(res),
+                                  newStrNode(val, res.typ, info))))
 
   let body = newTreeI(nkStmtList, info): caseStmt
 

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -467,7 +467,7 @@ proc genLibSetup(graph: ModuleGraph, env: var MirEnv, conf: BackendConfig,
       bu.add MirNode(kind: mnkStmtList) # manual, for less visual nesting
       for candidate in candidates.items:
         var tmp = genLoadLib(bu, graph, env, val):
-          literal(newStrNode(nkStrLit, candidate))
+          literal(newStrNode(candidate, graph.getSysType(path.info, tyString)))
 
         tmp = bu.wrapTemp(graph.getSysType(path.info, tyBool)):
           bu.buildMagicCall mNot, graph.getSysType(path.info, tyBool):

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -332,7 +332,7 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
     of backendNimVm:   targetVm
     of backendInvalid: unreachable()
 
-  applyPasses(body, prc, graph.config, target)
+  applyPasses(body, prc, env, graph.config, target)
 
 proc translate*(id: ProcedureId, body: PNode, graph: ModuleGraph,
                 config: BackendConfig, idgen: IdGenerator,

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -729,7 +729,8 @@ proc caseToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl, n: MirNode,
     result.add newTree(cnkBranch, cr.info)
     if br.len > 0:
       for x in 0..<br.len:
-        result[^1].add translateLit(get(tree, cr).lit)
+        assert tree[cr].kind in {mnkConst, mnkLiteral}
+        result[^1].add atomToIr(tree, cl, cr)
 
     result[^1].add bodyToIr(tree, env, cl, cr)
     leave(tree, cr)

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -703,7 +703,7 @@ proc genFieldCheck(c: var TCtx, access: Value, call: PNode, inverted: bool,
       c.emitByVal literal(newIntTypeNode(ord(inverted), call.typ))
       # error message operand:
       c.emitByVal literal(newStrNode(genFieldDefect(conf, field, discr),
-                                     call.info))
+                                     c.graph.getSysType(call.info, tyString)))
 
 proc genVariantAccess(c: var TCtx, n: PNode) =
   ## Generates and emits the MIR code for an object variant access, but

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1786,7 +1786,7 @@ proc genCase(c: var TCtx, n: PNode, dest: Destination) =
     of nkOfBranch:
       # emit the lables:
       for (_, lit) in branchLabels(branch):
-        c.add MirNode(kind: mnkLiteral, lit: lit)
+        c.add MirNode(kind: mnkLiteral, lit: lit, typ: lit.typ)
     else:
       unreachable(branch.kind)
 

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -11,7 +11,9 @@ import
     types
   ],
   compiler/mir/[
+    datatables,
     mirbodies,
+    mirenv,
     mirchangesets,
     mirconstr,
     mirtrees,
@@ -355,11 +357,25 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
         changes.replaceMulti(tree, pos, bu):
           bu.emitFrom(tree, tree.child(def, 1))
 
-proc applyPasses*(body: var MirBody, prc: PSym, config: ConfigRef,
-                  target: TargetBackend) =
+proc extractStringLiterals(tree: MirTree, env: var MirEnv,
+                           changes: var Changeset) =
+  ## Extracts all string literals and promotes them to anonymous constants,
+  ## replacing the string literals with a usage of the constants they were
+  ## promoted to.
+  for i in search(tree, {mnkLiteral}):
+    # note: both normal string *and* cstring literals are currently included
+    if tree[i].lit.kind in nkStrLiterals:
+      # create an anonymous constant from the literal:
+      let c = toConstId env.data.getOrPut(tree[i].lit)
+      # replace the usage of the literal with the anonymous constant:
+      changes.replaceMulti(tree, i, bu):
+        bu.use toValue(c, tree[i].typ)
+
+proc applyPasses*(body: var MirBody, prc: PSym, env: var MirEnv,
+                  config: ConfigRef, target: TargetBackend) =
   ## Applies all applicable MIR passes to the body (`tree` and `source`) of
   ## `prc`. `target` is the targeted backend and is used to enable/disable
-  ## certain passes.
+  ## certain passes. Passes may register new entities with `env`.
   template batch(b: untyped) =
     block:
       var c {.inject.} = initChangeset(body.code)
@@ -374,6 +390,10 @@ proc applyPasses*(body: var MirBody, prc: PSym, config: ConfigRef,
 
   batch:
     lowerSwap(body.code, c)
+    if target == targetVm:
+      # only the C and VM targets need the extraction, and only the VM
+      # requires the extraction for cstring literals
+      extractStringLiterals(body.code, env, c)
 
   # eliminate temporaries after all other passes
   batch:

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -802,7 +802,6 @@ proc loadEnv*(dst: var TCtx, src: PackedEnv) =
     case x[0]
     of cnstInt:     co.intVal = src.numbers[id.LitId]
     of cnstFloat:   co.floatVal = cast[BiggestFloat](src.numbers[id.LitId])
-    of cnstString:  co.strVal = src.strings[id.LitId]
 
     of cnstSliceListInt:   co.intSlices = loadSliceList[BiggestInt](src, id)
     of cnstSliceListFloat: co.floatSlices = loadSliceList[BiggestFloat](src, id)
@@ -866,7 +865,6 @@ func storeEnv*(enc: var PackedEncoder, dst: var PackedEnv, c: TCtx) =
       case c.kind
       of cnstInt:     dst.getLitId(c.intVal).uint32
       of cnstFloat:   dst.getLitId(c.floatVal).uint32
-      of cnstString:  dst.getLitId(c.strVal).uint32
 
       of cnstSliceListInt:   dst.storeSliceList(c.intSlices)
       of cnstSliceListFloat: dst.storeSliceList(c.floatSlices)

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2151,13 +2151,6 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         regs[ra] = TFullReg(kind: rkInt, intVal: cnst.intVal)
       of cnstFloat:
         regs[ra] = TFullReg(kind: rkFloat, floatVal: cnst.floatVal)
-      of cnstString:
-        regs[ra] = TFullReg(kind: rkLocation)
-        regs[ra].handle =
-          c.allocator.allocSingleLocation(c.typeInfoCache.stringType)
-        # TODO: once implemented, assign the string as a literal instead of
-        #       via deep copying
-        deref(regs[ra].handle).strVal.newVmString(cnst.strVal, c.allocator)
       of cnstNode:
         # XXX: cnstNode is also used for non-NimNodes, so using `rkNimNode` is
         #      somewhat wrong. Introducing a new register kind just for the
@@ -2171,13 +2164,8 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
     of opcAsgnConst:
       # assign the constant to the destination
       decodeBx()
-      let cnst {.cursor.} = c.constants[rbx]
-      case cnst.kind
-      of cnstString:
-        # load the string literal directly into the destination
-        deref(regs[ra].handle).strVal.newVmString(cnst.strVal, c.allocator)
-      of cnstInt, cnstFloat, cnstNode, cnstSliceListInt..cnstSliceListFloat:
-        raiseVmError(VmEvent(kind: vmEvtErrInternal, msg: "illegal constant"))
+      # TODO: remove
+      raiseVmError(VmEvent(kind: vmEvtErrInternal, msg: "illegal constant"))
     of opcLdGlobal:
       let rb = instr.regBx - wordExcess
       let slot = c.globals[rb]

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2161,11 +2161,6 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         # A slice-list must not be used with `LdConst`
         assert false
 
-    of opcAsgnConst:
-      # assign the constant to the destination
-      decodeBx()
-      # TODO: remove
-      raiseVmError(VmEvent(kind: vmEvtErrInternal, msg: "illegal constant"))
     of opcLdGlobal:
       let rb = instr.regBx - wordExcess
       let slot = c.globals[rb]

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -147,7 +147,6 @@ type
     opcLdNull,    # dest = nullvalue(types[Bx])
     opcLdNullReg,
     opcLdConst,   # dest = constants[Bx]
-    opcAsgnConst, # dest = copy(constants[Bx])
     opcLdGlobal,  # dest = globals[Bx]
 
     opcLdCmplxConst, # dest = complexConsts[Bx]

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -336,7 +336,6 @@ type
   ConstantKind* = enum
     cnstInt
     cnstFloat
-    cnstString
     cnstNode ## AST, type literals
 
     # slice-lists are used for implementing `opcBranch` (branch for case stmt)
@@ -356,8 +355,6 @@ type
       intVal*: BiggestInt
     of cnstFloat:
       floatVal*: BiggestFloat
-    of cnstString:
-      strVal*: string
     of cnstNode:
       node*: PNode
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -693,8 +693,6 @@ makeCnstFunc(toIntCnst, BiggestInt, cnstInt, intVal, `==`)
 
 makeCnstFunc(toFloatCnst, BiggestFloat, cnstFloat, floatVal, cmpFloatRep)
 
-makeCnstFunc(toStringCnst, string, cnstString, strVal, `==`)
-
 proc toIntCnst(c: var TCtx, val: Int128): int =
   # integer constants are stored as their raw bit representation
   toIntCnst(c, BiggestInt(toInt64(val)))
@@ -704,7 +702,6 @@ proc genLiteral(c: var TCtx, n: CgNode): int =
   of cnkIntLit:   toIntCnst(c, n.intVal)
   of cnkUIntLit:  toIntCnst(c, n.intVal)
   of cnkFloatLit: toFloatCnst(c, n.floatVal)
-  of cnkStrLit:   toStringCnst(c, n.strVal)
   else:           unreachable(n.kind)
 
 template fillSliceList[T](sl: var seq[Slice[T]], nodes: openArray[CgNode],
@@ -932,14 +929,9 @@ proc genReturn(c: var TCtx; n: CgNode) =
 
 proc genLit(c: var TCtx; n: CgNode; lit: int; dest: var TDest) =
   ## `lit` is the index of a constant as returned by `genLiteral`
-  if dest.isUnset or c.prc.regInfo[dest].kind == slotTempUnknown or
-     fitsRegister(n.typ):
-    # load the literal into the *register*
-    prepare(c, dest, n.typ)
-    c.gABx(n, opcLdConst, dest, lit)
-  else:
-    # assign the literal to the destination *location* directly
-    c.gABx(n, opcAsgnConst, dest, lit)
+  # load the literal into the *register*
+  prepare(c, dest, n.typ)
+  c.gABx(n, opcLdConst, dest, lit)
 
 proc genLit(c: var TCtx; n: CgNode; dest: var TDest) =
   let lit = genLiteral(c, n)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -207,7 +207,7 @@ proc genStmt*(jit: var JitState, c: var TCtx; n: PNode): VmGenResult =
 
   # `n` is expected to have been put through ``transf`` already
   var mirBody = generateMirCode(c, jit.gen.env, n, isStmt = true)
-  applyPasses(mirBody, c.module, c.config, targetVm)
+  applyPasses(mirBody, c.module, jit.gen.env, c.config, targetVm)
   for s, n in discover(jit.gen.env, cp):
     register(c.linking, s, n)
 
@@ -239,7 +239,7 @@ proc genExpr*(jit: var JitState, c: var TCtx, n: PNode): VmGenResult =
   let cp = checkpoint(jit.gen.env)
 
   var mirBody = generateMirCode(c, jit.gen.env, n)
-  applyPasses(mirBody, c.module, c.config, targetVm)
+  applyPasses(mirBody, c.module, jit.gen.env, c.config, targetVm)
   for s, n in discover(jit.gen.env, cp):
     register(c.linking, s, n)
 
@@ -278,7 +278,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   echoInput(c.config, s, body)
   var mirBody = generateCode(c.graph, jit.gen.env, s, selectOptions(c), body)
   echoMir(c.config, s, mirBody)
-  applyPasses(mirBody, s, c.config, targetVm)
+  applyPasses(mirBody, s, jit.gen.env, c.config, targetVm)
   for s, n in discover(jit.gen.env, cp):
     register(c.linking, s, n)
 

--- a/compiler/vm/vmutils.nim
+++ b/compiler/vm/vmutils.nim
@@ -33,7 +33,7 @@ type
     case opc*: TOpcode:
       of opcConv, opcCast:
         types*: tuple[tfrom, tto: PType]
-      of opcLdConst, opcAsgnConst:
+      of opcLdConst:
         ast*: PNode
       else:
         discard
@@ -86,7 +86,7 @@ proc codeListing*(c: TCtx; start = 0; last = -1): seq[DebugVmCodeEntry] =
       code.types = (c.rtti[c.code[i + 0].regBx-wordExcess].nimType,
                     c.rtti[c.code[i + 1].regBx-wordExcess].nimType)
       inc i, 1
-    of opcLdConst, opcAsgnConst:
+    of opcLdConst:
       let cnst = c.constants[code.idx]
       code.ast =
         case cnst.kind
@@ -141,7 +141,7 @@ proc renderCodeListing*(config: ConfigRef, sym: PSym,
       line.addf("  $# r$# L$#", $<e.opc, $<e.ra, $<e.idx)
     elif e.opc in {opcExcept}:
       line.addf("  $# $# $#", $<e.opc, $<e.ra, $<e.idx)
-    elif e.opc in {opcLdConst, opcAsgnConst}:
+    elif e.opc in {opcLdConst}:
       line.addf("  $# r$# $# $#",
                 $<e.opc, $<e.ra, $<e.ast.renderTree(), $<e.idx)
     else:

--- a/compiler/vm/vmutils.nim
+++ b/compiler/vm/vmutils.nim
@@ -92,7 +92,6 @@ proc codeListing*(c: TCtx; start = 0; last = -1): seq[DebugVmCodeEntry] =
         case cnst.kind
         of cnstInt:    newIntNode(nkIntLit, cnst.intVal)
         of cnstFloat:  newFloatNode(nkFloatLit, cnst.floatVal)
-        of cnstString: newStrNode(nkStrLit, cnst.strVal)
         of cnstNode:   cnst.node
         of cnstSliceListInt..cnstSliceListFloat:
           # XXX: translate into an `nkOfBranch`?

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -159,7 +159,9 @@ Semantics
             | Emit VALUE ...
             | Asm VALUE ...
 
-  BRANCH_LIST = (Branch <Literal> ... STATEMENT) ... # a list of branches
+  BRANCH_LABEL = <Literal>
+               | <Const>
+  BRANCH_LIST = (Branch BRANCH_LABEL ... STATEMENT) ... # a list of branches
 
   EXCEPT_BRANCH = Branch <Type> ... STATEMENT # exception handler
                 | Branch <Local>    STATEMENT # exception handler for imported

--- a/tests/compiler/tvmbackend.nim
+++ b/tests/compiler/tvmbackend.nim
@@ -51,7 +51,7 @@ block:
   env.dbgSyms = @[(LitId(1), LitId(2)), (LitId(3), LitId(4))]
 
   env.nodes = @[PackedDataNode(kind: pdkInt), PackedDataNode(kind: pdkFloat)]
-  env.consts = @[(cnstFloat, 1'u32), (cnstString, 2'u32)]
+  env.consts = @[(cnstFloat, 1'u32), (cnstInt, 2'u32)]
   env.cconsts = @[(typId1, 6'u32)]
 
 


### PR DESCRIPTION
## Summary

Remove support for string constants from the VM -- strings have to be
treated as data and loaded as such now. This slightly simplifies the VM
and speeds up loading string literals, as no allocation + string copy
is necessary when loading a string literal for non-mutating use (e.g.,
`f("abc")`).

## Details

String constants in the VM had two problems:
- for the VM guest to work with strings, the string has to be a VM
  memory location. Since VM constants are not, this required the
  allocation of a memory location plus a string copy
- to prevent duplicate string constants, a linear search over all
  string constants was performed, which is very inefficient (especially
  if there are many large string constants)

In order to resolve both problems and simplify the VM, a MIR pass is
used to lift anonymous MIR constants from all string literals and
replace the string literals with the anonymous constant. In effect,
this means that no `cnkStrLit` node reaches `vmgen`, and that all
string literals are treated as normal data.

String VM constants (`cnstString`) and the `AsgnConst` VM opcode (which
was only used for assigning string constants) are thus obsolete and
removed.

For the lifting pass to work, the following changes are required:
- a mutable `MirEnv` has to be passed to `mirpasses.applyPasses`
- the MIR has to allow `mnkConst` nodes as branch labels
- all string literals reaching the MIR must be typed. All problematic
  `newStrNode` usages are changed to also pass a type

The VM speed up is the result of loading a string literal via
`LdCmplxConst`, which only loads a handle and doesn't perform a copy
itself.