### PR TITLE
ci: minimum x86 macOS is now version 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             },
             {
               "name": "macOS",
-              "runner": "macos-11"
+              "runner": "macos-12"
             },
             {
               "name": "macOS (M1)",


### PR DESCRIPTION
## Summary

Going forward all macOS builds of NimSkull will target macOS 12 and
above, as this change upgrades to macOS 12 based runners in CI, prompted
by GitHub's deprecation of macOS 11 runners.

## Details

Following macOS 14 support announcement, GitHub has officially
deprecated version 11 runners. As such, migrate to the next version to
prevent disruptions when GitHub decides to retire these runners.

This means that our binaries will target macOS 12 by default, which is
around 3 years old. I expect the binaries to still work on older
versions, but we cannot guarantee that into the future.

Refs
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/