### PR TITLE
fix(vm): multiple memory leak issues

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -990,7 +990,11 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       if regs[rb].kind in {rkLocation, rkHandle}:
         checkHandle(regs[rb])
         if regs[rb].handle.typ.kind in RegisterAtomKinds:
-          loadFromLoc(regs[ra], regs[rb].handle)
+          let h = regs[rb].handle
+          # retrieve the handle *before* cleaning up the register, since `ra`
+          # and `rb` may point to the same register
+          cleanUpReg(regs[ra], c.memory)
+          loadFromLoc(regs[ra], h)
         else:
           unreachable() # vmgen issue
       else:

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -319,7 +319,8 @@ func initLocReg*(r: var TFullReg, typ: PVmType, mm: var VmMemoryManager) =
   r = TFullReg(kind: rkLocation)
   r.handle = mm.allocator.allocSingleLocation(typ)
 
-func initIntReg(r: var TFullReg, i: BiggestInt) =
+func initIntReg(r: var TFullReg, i: BiggestInt, mm: var VmMemoryManager) =
+  cleanUpReg(r, mm)
   r = TFullReg(kind: rkInt, intVal: i)
 
 template ensureKind(k: untyped) {.dirty.} =
@@ -2518,9 +2519,9 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       of 0: # getFile
         regs[ra].strVal.newVmString(toFullPath(c.config, n.info), c.allocator)
       of 1: # getLine
-        regs[ra].initIntReg(n.info.line.int)
+        regs[ra].initIntReg(n.info.line.int, c.memory)
       of 2: # getColumn
-        regs[ra].initIntReg(n.info.col)
+        regs[ra].initIntReg(n.info.col, c.memory)
       else:
         unreachable($imm) # vmgen issue
     of opcNSetLineInfo:

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2114,6 +2114,10 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       let typ = c.types[instr.regBx - wordExcess]
       assert typ.kind == akRef
 
+      if c.heap.pending.len > 128:
+        # free the ref-counted cells pending destruction
+        cleanUpPending(c.memory)
+
       # note: typ is the ref type, not the target type
       let dest = regs[ra].handle
       # reset the destination first:


### PR DESCRIPTION
## Summary

Fix multiple severe memory leaks with the VM implementation, reducing
the memory usage and run time of complex and allocation-heavy
programs/macros/static-blocks.

## Details

In each case, the VM's allocator still knew about the cells and kept a
reference to the host memory, meaning that a `malloc`-level leak
detector wouldn't have caught them.

The problems:
1. ref-counted cells never reached a ref-count of zero, meaning that
   `ref`s were never freed in the VM
2. even if the ref-count would have reached zero, during standalone
   execution (via `vmrunner`), garbage ref-counted cells were never
   destroyed/freed
3. the `NodeToReg` implementation didn't clean up the destination
   register
4. the `NGetLineInfo` implementation didn't clean up the destination
   register

### Improper ref-counting

Ref-counted cells (allocated through `heapNew`) start with a ref-count
value of 1. Since the initial assignment to the destination location
used `asgnRef`, the ref-count was incremented again, preventing it from
ever reaching zero.

Instead of `asgnRef`, the destination location is first cleaned up with
`resetLocation` and then the `ref` value is assigned manually.

### Missing garbage cell clean-up

Ref-counted cells aren't destroyed and freed immediately but are first
added to the `pending` list. This list was never processed during VM
execution (only when disposing a `VmThread`), meaning that the garbage
cells accumulated indefinitely.

The `New` opcode now processes the `pending` list once its size exceeds
a fixed threshold (currently 128). In addition, `cleanUpPending` is
changed to process the list back-to-front (instead of front-to-back),
reducing the amount of `seq` resizing when new cells are added to the
list during cleanup.

### Missing register clean-up

Registers have to be cleaned up (via `cleanUpReg`) prior to changing
the kind, otherwise cells owned by owning handles (`rkLocation`
registers) aren't destroyed and freed.

Both `NodeToReg` and `NGetLineInfo` were missing this, resulting in,
depending on the register layout, cells never being freed.