### PR TITLE
vmgen: clean up some linking-related types

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -553,7 +553,7 @@ proc evalMacroCall*(jit: var JitState, c: var TCtx, call, args: PNode,
     c.mode = oldMode
     c.callsite = nil
 
-  let wasAvailable = isAvailable(c, sym)
+  let wasAvailable = isAvailable(jit, c, sym)
   let (start, regCount) = loadProc(jit, c, sym).returnOnErr(c.config, call)
 
   # make sure to only output the code listing once:

--- a/compiler/vm/identpatterns.nim
+++ b/compiler/vm/identpatterns.nim
@@ -1,5 +1,5 @@
-## Implements types and procedures related to mapping symbols to their in-VM
-## IDs.
+## Implements routines for matching *qualified identifier patterns* against
+## symbols.
 
 import
   std/[
@@ -13,11 +13,6 @@ from compiler/ast/ast import id
 from compiler/ast/idents import cmpIgnoreStyle
 
 type
-  LinkIndex* = uint32
-    ## Identifies a linker-relevant entity. There are three namespaces, one
-    ## for procedures, one for globals, and one for constants -- which
-    ## namespace an index is part of is stored separately.
-
   IdentPattern* = distinct string
     ## A matcher pattern for a fully qualified symbol identifier
 

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -92,7 +92,7 @@ proc callRoutine*(i: Interpreter; routine: PSym; args: openArray[PNode]): PNode 
 
 proc getGlobalValue*(i: Interpreter; letOrVar: PSym): PNode =
   let c = PEvalContext(i.graph.vm)
-  result = getGlobalValue(c.vm, letOrVar)
+  result = getGlobalValue(c[], letOrVar)
 
 proc setGlobalValue*(i: Interpreter; letOrVar: PSym, val: PNode) =
   ## Sets a global value to a given PNode, does not do any type checking.

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -81,13 +81,13 @@ func getEnvParam*(prc: PSym): PSym =
   else: nil
 
 
-proc initProcEntry*(linker: LinkerData, config: ConfigRef,
+proc initProcEntry*(keys: Patterns, config: ConfigRef,
                     tc: var TypeInfoCache, prc: PSym): FuncTableEntry =
   ## Returns an initialized function table entry. Execution information (such
   ## as the bytecode offset and register count) for procedures not overriden
   ## by callbacks is initialized to a state that indicates "missing"; it needs
   ## to be filled in separately via `fillProcEntry`.
-  let cbIndex = lookup(linker.callbackKeys, prc)
+  let cbIndex = lookup(keys, prc)
   result =
     if cbIndex >= 0:
       FuncTableEntry(kind: ckCallback, cbOffset: cbIndex)
@@ -112,8 +112,8 @@ proc initProcEntry*(linker: LinkerData, config: ConfigRef,
 
 proc initProcEntry*(c: var TCtx, prc: PSym): FuncTableEntry {.inline.} =
   ## Convenience wrapper around
-  ## `initProcEntry <#initProcEntry,LinkerData,ConfigRef,TypeInfoCache,PSym>`_.
-  initProcEntry(c.linking, c.config, c.typeInfoCache, prc)
+  ## `initProcEntry <#initProcEntry,Patterns,ConfigRef,TypeInfoCache,PSym>`_.
+  initProcEntry(c.callbackKeys, c.config, c.typeInfoCache, prc)
 
 func fillProcEntry*(e: var FuncTableEntry, info: CodeInfo) {.inline.} =
   ## Sets the execution information of the function table entry to `info`

--- a/compiler/vm/vmaux.nim
+++ b/compiler/vm/vmaux.nim
@@ -14,8 +14,8 @@ import
     options
   ],
   compiler/vm/[
+    identpatterns,
     vmdef,
-    vmlinker,
     vmtypegen
   ]
 

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -82,7 +82,7 @@ type
 
     gen: CodeGenCtx ## code generator state
 
-proc registerCallbacks(linking: var LinkerData) =
+proc registerCallbacks(callbackKeys: var Patterns) =
   ## Registers callbacks for various functions, so that no code is
   ## generated for them and that they can (must) be overridden by the runner
 
@@ -91,7 +91,7 @@ proc registerCallbacks(linking: var LinkerData) =
   # complain if there's a mismatch
 
   template cb(key: string) =
-    linking.callbackKeys.add(IdentPattern(key))
+    callbackKeys.add(IdentPattern(key))
 
   template register(iter: untyped) =
     for it in iter:
@@ -108,7 +108,7 @@ proc registerCallbacks(linking: var LinkerData) =
   cb "stdlib.system.getOccupiedMem"
 
 proc initProcEntry(c: var GenCtx, prc: PSym): FuncTableEntry {.inline.} =
-  initProcEntry(c.gen.linking, c.graph.config, c.gen.typeInfoCache, prc)
+  initProcEntry(c.gen.callbackKeys, c.graph.config, c.gen.typeInfoCache, prc)
 
 proc registerProc(c: var GenCtx, prc: ProcedureId) =
   ## Adds an empty function-table entry for `prc` and registers `prc` in the
@@ -243,7 +243,7 @@ proc storeData(enc: var PackedEncoder, dst: var PackedEnv,
     (enc.typeMap[it[0]], id.uint32)
 
 func storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
-                linking: LinkerData, globals: seq[PVmType]) =
+                callbacks: Patterns, globals: seq[PVmType]) =
   ## Stores the globals and callback keys into `dst`.
   mapList(dst.globals, globals, it):
     enc.typeMap[it]
@@ -251,7 +251,7 @@ func storeExtra(enc: var PackedEncoder, dst: var PackedEnv,
   # TODO: add support for either `distinct string` or custom `storePrim`
   #       overloads (or both) to `rodfiles`. Due to the lack of both, we
   #       have to perform a manual copy instead of a move here
-  mapList(dst.callbacks, linking.callbackKeys, c):
+  mapList(dst.callbacks, callbacks, c):
     c.string
 
 proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
@@ -273,7 +273,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
 
   # register the extra ops so that code generation isn't performed for the
   # corresponding procs:
-  registerCallbacks(c.gen.linking)
+  registerCallbacks(c.gen.callbackKeys)
 
   # generate code for all alive routines:
   var discovery: DiscoveryData
@@ -311,7 +311,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
   enc.init(env.types)
   storeEnv(enc, penv, env)
   storeData(enc, penv, conf, consts, c.gen.env)
-  storeExtra(enc, penv, c.gen.linking, base(c.globals))
+  storeExtra(enc, penv, c.gen.callbackKeys, base(c.globals))
   penv.entryPoint = FunctionIndex(entryPoint)
 
   let err = writeToFile(penv, prepareToWriteOutput(conf))

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -42,12 +42,12 @@ import
     idioms
   ],
   compiler/vm/[
+    identpatterns,
     packed_env,
     vmaux,
     vmdef,
     vmgen,
     vmlegacy,
-    vmlinker,
     vmobjects,
     vmops,
     vmtypegen

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -28,11 +28,12 @@ import
   ],
   compiler/utils/[
     debugutils,
+  ],
+  compiler/vm/[
+    identpatterns
   ]
 
 import std/options as std_options
-
-from compiler/vm/vmlinker import Patterns
 
 import vm_enums
 export vm_enums
@@ -487,6 +488,11 @@ type
       # XXX: this is a temporary workaround, the type cache shouldn't need to
       #      know nor care about ``RootObj``. Can be removed once closure types
       #      are lowered earlier
+
+  LinkIndex* = uint32
+    ## Identifies a linker-relevant entity. There are three namespaces, one
+    ## for procedures, one for globals, and one for constants -- which
+    ## namespace an index is part of is stored separately.
 
   FunctionIndex* = distinct int
 

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -32,7 +32,7 @@ import
 
 import std/options as std_options
 
-from compiler/vm/vmlinker import LinkerData
+from compiler/vm/vmlinker import Patterns
 
 import vm_enums
 export vm_enums
@@ -673,9 +673,8 @@ type
       ## generator. Initialized by the VM's callsite and queried by the JIT.
     # XXX: ^^ make this a part of the JIT state as soon as possible
 
-    linking*: LinkerData
-    # XXX: ^^ should be made part of the JIT state but ``vmcompilerserdes``
-    #      currently blocks that
+    callbackKeys*: Patterns
+    # TODO: make this a part of the JIT state; it not needed at VM run-time
 
     module*: PSym
     callsite*: PNode

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -62,9 +62,9 @@ import
     idioms
   ],
   compiler/vm/[
+    identpatterns,
     vmaux,
     vmdef,
-    vmlinker,
     vmobjects,
     vmtypegen,
     vmtypes,

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -155,7 +155,7 @@ type
     features*: TSandboxFlags
     module*: PSym
 
-    linking*: LinkerData
+    callbackKeys*: Patterns
 
     # input-output parameters:
     code*: seq[TInstr]
@@ -2850,7 +2850,7 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
   case n.kind
   of cnkProc:
     let s = c.env.procedures[n.prc]
-    if importcCond(c, s) and lookup(c.linking.callbackKeys, s) == -1:
+    if importcCond(c, s) and lookup(c.callbackKeys, s) == -1:
       fail(n.info, vmGenDiagCannotImportc, sym = s)
 
     genProcLit(c, n, dest)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -311,11 +311,10 @@ proc registerProcedure*(jit: var JitState, c: var TCtx, prc: PSym): FunctionInde
   ## required to not be in the process of generating code.
   if prc notin jit.gen.env.procedures:
     let id = jit.gen.env.procedures.add(prc)
-    c.linking.symToIndexTbl[prc.id] = LinkIndex id
     c.functions.add initProcEntry(c, prc)
     assert int(id) == c.functions.high, "tables are out of sync"
 
-  result = FunctionIndex c.linking.symToIndexTbl[prc.id]
+  result = FunctionIndex jit.gen.env.procedures[prc]
 
 proc compile*(jit: var JitState, c: var TCtx, fnc: FunctionIndex): VmGenResult =
   ## Generates code for the the given function and updates the execution

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -85,7 +85,7 @@ func swapState(c: var TCtx, gen: var CodeGenCtx) =
   swap(mode)
   swap(features)
   swap(module)
-  swap(linking)
+  swap(callbackKeys)
 
   # input-output parameters:
   swap(code)
@@ -329,8 +329,8 @@ proc registerCallback*(c: var TCtx; pattern: string; callback: VmCallback) =
   ## procedure at run-time will invoke the callback instead.
   # XXX: consider renaming this procedure to ``registerOverride``
   c.callbacks.add(callback) # some consumers rely on preserving registration order
-  c.linking.callbackKeys.add(IdentPattern(pattern))
-  assert c.callbacks.len == c.linking.callbackKeys.len
+  c.callbackKeys.add(IdentPattern(pattern))
+  assert c.callbacks.len == c.callbackKeys.len
 
 proc constDataToMir*(c: var TCtx, jit: var JitState, e: PNode): MirTree =
   ## Translates the constant expression `e` to a MIR constant expression and

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -296,6 +296,10 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
 
   updateEnvironment(c, jit.gen.env, cp)
 
+func getGlobal*(jit: JitState, g: PSym): LinkIndex =
+  ## Returns the link index for the symbol `g`. `g` must be known to `jit`.
+  LinkIndex jit.gen.env.globals[g]
+
 func isAvailable*(jit: JitState, c: TCtx, prc: PSym): bool =
   ## Returns whether the bytecode for `prc` is already available.
   prc in jit.gen.env.procedures and

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -296,10 +296,10 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
 
   updateEnvironment(c, jit.gen.env, cp)
 
-func isAvailable*(c: TCtx, prc: PSym): bool =
+func isAvailable*(jit: JitState, c: TCtx, prc: PSym): bool =
   ## Returns whether the bytecode for `prc` is already available.
-  prc.id in c.linking.symToIndexTbl and
-    c.functions[c.linking.symToIndexTbl[prc.id].int].start >= 0
+  prc in jit.gen.env.procedures and
+    c.functions[jit.gen.env.procedures[prc].int].start >= 0
 
 proc registerProcedure*(jit: var JitState, c: var TCtx, prc: PSym): FunctionIndex =
   ## If it hasn't been already, adds `prc` to the set of procedures the JIT

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -42,12 +42,12 @@ import
     transf
   ],
   compiler/vm/[
+    identpatterns,
     vmaux,
     vmserialize,
     vmdef,
     vmgen,
     vmjit_checks,
-    vmlinker,
     vmmemory,
     vmtypegen
   ],

--- a/compiler/vm/vmlinker.nim
+++ b/compiler/vm/vmlinker.nim
@@ -50,8 +50,3 @@ func lookup*(patterns: seq[IdentPattern]; s: PSym): int =
     inc i
 
   result = -1
-
-func lookup*(data: LinkerData, s: PSym): LinkIndex {.inline.} =
-  ## Returns the link-index for the symbol `s`, which must exist in the link
-  ## table.
-  data.symToIndexTbl[s.id]

--- a/compiler/vm/vmlinker.nim
+++ b/compiler/vm/vmlinker.nim
@@ -3,8 +3,7 @@
 
 import
   std/[
-    strutils,
-    tables
+    strutils
   ],
   compiler/ast/[
     ast_types
@@ -25,8 +24,6 @@ type
   LinkerData* = object
     ## All data required for mapping symbols to the entities they represent
     ## inside the VM (procedures, globals, constants).
-    symToIndexTbl*: Table[int, LinkIndex]
-      ## the link table. Keeps track of all symbols known to the linker
     callbackKeys*: seq[IdentPattern]
       ## the matcher patterns used for implementing overrides
 

--- a/compiler/vm/vmlinker.nim
+++ b/compiler/vm/vmlinker.nim
@@ -21,11 +21,8 @@ type
   IdentPattern* = distinct string
     ## A matcher pattern for a fully qualified symbol identifier
 
-  LinkerData* = object
-    ## All data required for mapping symbols to the entities they represent
-    ## inside the VM (procedures, globals, constants).
-    callbackKeys*: seq[IdentPattern]
-      ## the matcher patterns used for implementing overrides
+  Patterns* = seq[IdentPattern]
+    ## A list of identifier matcher patterns, where the order is significant.
 
 func matches(s: PSym; x: IdentPattern): bool =
   var s = s
@@ -36,7 +33,7 @@ func matches(s: PSym; x: IdentPattern): bool =
     while s != nil and s.kind == skPackage and s.owner != nil: s = s.owner
   result = true
 
-func lookup*(patterns: seq[IdentPattern]; s: PSym): int =
+func lookup*(patterns: Patterns; s: PSym): int =
   ## Tries to find and return the index of the pattern matching `s`. If none
   ## is found, -1 is returned
   var i = 0


### PR DESCRIPTION
## Summary

Remove the obsolete `symToIndexTbl` table and the `LinkerData` type,
and rename `vmlinker` to `identpatterns`.

## Details

The `symToIndexTbl` table was originally used for mapping a `PSym` to
the entity's link index, but the `MirEnv` with its `SymbolTable` fully
subsumed this -- the remaining usages of `symToIndexTbl` are replaced
with querying `MirEnv` instead.

As a consequence, some routine interfaces change:
* `vmjit.isAvailable` has an additional `JitState` parameter
* `setGlobalValue` and `getGlobalValue` require access to the whole
  `EvalContext`
* `vmjit` provides the new `getGlobal` for querying the link index for
  the symbol of a global

Furthermore, since there's no need for a separate `LinkerData` type
anymore, all `LinkerData`  usage is replaced with directly embedding/
using the identifier pattern list. `LinkIndex` is moved to `vmdef` and
the `vmlinker` module, which contains the identifier pattern matching,
is renamed to `identpatterns`.