### PR TITLE
fix(vmgen): wrong `range` value being read

### DIFF
--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1362,7 +1362,7 @@ proc genNarrowUnsigned(c: var TCtx; info: TLineInfo, typ: PType,
   ## Only masks the value in `dest` (with ``opcNarrowU``) if `typ` is an
   ## unsigned integer type.
   let t = skipTypes(typ, IrrelevantTypes + {tyRange})
-  if isUnsigned(t) and (let size = getSize(c.config, typ); size < 8):
+  if isUnsigned(t) and (let size = getSize(c.config, t); size < 8):
     c.gABC(info, opcNarrowU, dest, TRegister(size * 8))
 
 proc genBinaryABCnarrow(c: var TCtx; n: CgNode; dest: var TDest; opc: TOpcode) =

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1350,12 +1350,9 @@ proc genNarrow(c: var TCtx; n: CgNode; dest: TRegister; sNarrow = opcNarrowS) =
       else:             sNarrow
     c.gABC(n, op, dest, TRegister(size*8))
 
-proc genNarrowU(c: var TCtx; n: CgNode; dest: TDest) =
-  let t = skipTypes(n.typ, IrrelevantTypes + {tyRange})
-  assert t.kind in {tyUInt..tyUInt64, tyInt..tyInt64}
-  let size = getSize(c.config, t)
-  if size < 8:
-    c.gABC(n, opcNarrowU, dest, TRegister(size * 8))
+proc genNarrowU(c: var TCtx; n: CgNode; dest: TDest) {.inline.} =
+  # always mask the value, even if of signed type
+  genNarrow(c, n, dest, opcNarrowU)
 
 proc genNarrowUnsigned(c: var TCtx; info: TLineInfo, typ: PType,
                        dest: TRegister) =

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1271,12 +1271,12 @@ proc genIndex(c: var TCtx; n: CgNode; arr: PType): TRegister =
   else:
     result = c.genx(n)
 
+proc genNarrowUnsigned(c: var TCtx; info: TLineInfo, typ: PType,
+                       dest: TRegister)
+
 proc genRegLoad(c: var TCtx, n: CgNode, typ: PType, dest, src: TRegister) =
   c.gABC(n, opcNodeToReg, dest, src)
-
-  let t = typ.skipTypes(abstractInst)
-  if t.isUnsigned() and t.size < sizeof(BiggestInt):
-    c.gABC(n, opcNarrowU, dest, TRegister(t.size * 8))
+  genNarrowUnsigned(c, n.info, typ, dest)
 
 proc genRegLoad(c: var TCtx, n: CgNode, dest, src: TRegister) {.inline.} =
   genRegLoad(c, n, n.typ, dest, src)
@@ -1337,22 +1337,33 @@ proc genBinaryABC(c: var TCtx; n: CgNode; dest: var TDest; opc: TOpcode) =
   c.freeTemp(tmp)
   c.freeTemp(tmp2)
 
-proc genNarrow(c: var TCtx; n: CgNode; dest: TDest) =
-  let t = skipTypes(n.typ, abstractVar-{tyTypeDesc})
-  # uint is uint64 in the VM, we we only need to mask the result for
-  # other unsigned types:
-  if t.kind in {tyUInt8..tyUInt32} or (t.kind == tyUInt and t.size < 8):
-    c.gABC(n, opcNarrowU, dest, TRegister(t.size*8))
-  elif t.kind in {tyInt8..tyInt32} or (t.kind == tyInt and t.size < 8):
-    c.gABC(n, opcNarrowS, dest, TRegister(t.size*8))
+proc genNarrow(c: var TCtx; n: CgNode; dest: TRegister; sNarrow = opcNarrowS) =
+  ## If required for the type of `n`, emits a narrow/masking instruction for
+  ## the value in `dest`. `sNarrow` is the opcode to use for signed integers.
+  let
+    t = skipTypes(n.typ, IrrelevantTypes + {tyRange})
+    size = getSize(c.config, t)
+  if size < 8:
+    # the value doesn't occupy the full register's range
+    let op =
+      if isUnsigned(t): opcNarrowU
+      else:             sNarrow
+    c.gABC(n, op, dest, TRegister(size*8))
 
 proc genNarrowU(c: var TCtx; n: CgNode; dest: TDest) =
-  let t = skipTypes(n.typ, abstractVar-{tyTypeDesc})
-  # uint is uint64 in the VM, we we only need to mask the result for
-  # other unsigned types:
-  if t.kind in {tyUInt8..tyUInt32, tyInt8..tyInt32} or
-    (t.kind in {tyUInt, tyInt} and t.size < 8):
-    c.gABC(n, opcNarrowU, dest, TRegister(t.size*8))
+  let t = skipTypes(n.typ, IrrelevantTypes + {tyRange})
+  assert t.kind in {tyUInt..tyUInt64, tyInt..tyInt64}
+  let size = getSize(c.config, t)
+  if size < 8:
+    c.gABC(n, opcNarrowU, dest, TRegister(size * 8))
+
+proc genNarrowUnsigned(c: var TCtx; info: TLineInfo, typ: PType,
+                       dest: TRegister) =
+  ## Only masks the value in `dest` (with ``opcNarrowU``) if `typ` is an
+  ## unsigned integer type.
+  let t = skipTypes(typ, IrrelevantTypes + {tyRange})
+  if isUnsigned(t) and (let size = getSize(c.config, typ); size < 8):
+    c.gABC(info, opcNarrowU, dest, TRegister(size * 8))
 
 proc genBinaryABCnarrow(c: var TCtx; n: CgNode; dest: var TDest; opc: TOpcode) =
   genBinaryABC(c, n, dest, opc)
@@ -1887,12 +1898,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
     c.freeTemp(tmp2)
   of mShlI:
     genBinaryABC(c, n, dest, opcShlInt)
-    # genNarrowU modified
-    let t = skipTypes(n.typ, abstractVar-{tyTypeDesc})
-    if t.kind in {tyUInt8..tyUInt32} or (t.kind == tyUInt and t.size < 8):
-      c.gABC(n, opcNarrowU, dest, TRegister(t.size*8))
-    elif t.kind in {tyInt8..tyInt32} or (t.kind == tyInt and t.size < 8):
-      c.gABC(n, opcSignExtend, dest, TRegister(t.size*8))
+    genNarrow(c, n, dest, opcSignExtend)
   of mAshrI: genBinaryABC(c, n, dest, opcAshrInt)
   of mBitandI: genBinaryABC(c, n, dest, opcBitandInt)
   of mBitorI: genBinaryABC(c, n, dest, opcBitorInt)
@@ -1955,10 +1961,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mUnaryPlusI, mUnaryPlusF64: gen(c, n[1], dest)
   of mBitnotI:
     genUnaryABC(c, n, dest, opcBitnotInt)
-    #genNarrowU modified, do not narrow signed types
-    let t = skipTypes(n.typ, abstractVar-{tyTypeDesc})
-    if t.kind in {tyUInt8..tyUInt32} or (t.kind == tyUInt and t.size < 8):
-      c.gABC(n, opcNarrowU, dest, TRegister(t.size*8))
+    genNarrowUnsigned(c, n.info, n.typ, dest)
   of mCharToStr, mBoolToStr, mIntToStr, mInt64ToStr, mFloatToStr, mStrToStr,
      mEnumToStr:
     genToStr(c, n, n[1], dest)

--- a/tests/vm/twrong_range_value.nim
+++ b/tests/vm/twrong_range_value.nim
@@ -1,0 +1,17 @@
+discard """
+  description: '''
+    Regression test for the wrong value being loaded from locations of range
+    type
+  '''
+  targets: "c js vm"
+"""
+
+# VM specific bug; tested with all targets for the sake of coverage
+
+type Object = object
+  x: range[0'u8..255'u8]
+
+var x = Object(x: 255'u8) # all bits of `x` are set
+# the value wasn't properly read from the location, resulting in the
+# temporary register storing 18446744073709551615 (all bits set)
+doAssert x.x == 255


### PR DESCRIPTION
## Summary

Fix an incorrect/invalid value being read from locations of unsigned
`range` type. Only the VM backend was affected, and only when the value
stored in the location had the most-significant bit set.

## Details

With the VM, all unsigned values require masking after being read from
a memory location.  `genRegLoad`  emits the necessary masking
instruction,
but `isUnsigned` doesn't consider range types (a separate bug), meaning
that values of type `tyRange` with an unsigned base type were not
masked.

* all code generation for narrowing/masking instructions is changed to
  skip `tyRange` types
* the custom narrowing implementation used for `mShrI` code generation
  is merged into `genNarrow`
* the duplicated unsigned integer masking is moved to a dedicated
  procedure (`genNarrowUnsigned`)

There was also the problem of the types' `size` field being accessed
directly; since a type's size is computed on demand, the value in
`size` might not be valid. `getSize` is used instead.