### PR TITLE
fix(js): no overflow check for negation

### DIFF
--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -456,7 +456,7 @@ proc modInt(a, b: int): int {.asmNoStackFrame, compilerproc.} =
     return Math.trunc(`a` % `b`);
   """
 
-proc checkOverflowInt64(a: int) {.asmNoStackFrame, compilerproc.} =
+proc checkOverflowInt64(a: int64) {.asmNoStackFrame, compilerproc.} =
   asm """
     if (`a` > 9223372036854775807 || `a` < -9223372036854775808) `raiseOverflow`();
   """
@@ -498,9 +498,11 @@ proc modInt64(a, b: int): int {.asmNoStackFrame, compilerproc.} =
 
 proc negInt(a: int): int {.compilerproc.} =
   result = a*(-1)
+  checkOverflowInt(result)
 
 proc negInt64(a: int64): int64 {.compilerproc.} =
   result = a*(-1)
+  checkOverflowInt64(result)
 
 proc absInt(a: int): int {.compilerproc.} =
   result = if a < 0: a*(-1) else: a

--- a/tests/overflw/toverflow_negation_32.nim
+++ b/tests/overflw/toverflow_negation_32.nim
@@ -1,0 +1,10 @@
+discard """
+  targets: "c js vm"
+  description: "Ensure that overflow checks work for 32-bit integer negations"
+  exitcode: 1
+  outputsub: "over- or underflow"
+  knownIssue.vm: "Error message does not match"
+"""
+
+var x = low(int32)
+discard -x

--- a/tests/overflw/toverflow_negation_64.nim
+++ b/tests/overflw/toverflow_negation_64.nim
@@ -1,0 +1,12 @@
+discard """
+  targets: "c js vm"
+  description: "Ensure that overflow checks work for 64-bit integer negations"
+  exitcode: 1
+  outputsub: "over- or underflow"
+  knownIssue.js: '''
+    The lowest 64-bit signed integer value isn't properly represented in JS
+  '''
+"""
+
+var x = low(int64)
+discard -x


### PR DESCRIPTION
## Summary

Fix overflow checks not being performed for negations of signed
integers. Overflow checks for 64-bit signed integer negations still
don't work.

## Details

* add overflow checks to `jssys.negInt` and `jssys.negInt64`
* change the type of `checkOverflowInt64` to `int64`, so that
  `negInt64` can call it
* add tests for both the 32-bit and 64-bit integer negation