### PR TITLE
make `abs` behaviour consistent across backends

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1650,12 +1650,6 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   case op
   of mNot..mUnaryMinusF64: unaryArith(p, e, e[1], d, op)
   of mUnaryMinusI, mUnaryMinusI64: unaryArithOverflow(p, e, d, op)
-  of mAbsI:
-    # TODO: lower the unchecked ``abs`` variant earlier
-    if optOverflowCheck in p.options:
-      unaryArithOverflow(p, e, d, op)
-    else:
-      unaryArith(p, e, e[1], d, op)
   of mAddF64..mDivF64: binaryFloatArith(p, e, d, op)
   of mShrI..mXor: binaryArith(p, e, e[1], e[2], d, op)
   of mEqProc: genEqProc(p, e, d)
@@ -1666,7 +1660,7 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   of mAppendStrCh:
     binaryStmtAddr(p, e, d, "nimAddCharV1")
   of mAppendStrStr: genStrAppend(p, e, d)
-  of mAppendSeqElem, mNewSeq, mSetLengthSeq:
+  of mAppendSeqElem, mNewSeq, mSetLengthSeq, mAbsI:
     genCall(p, e, d)
   of mEqStr: genStrEquals(p, e, d)
   of mLeStr: binaryExpr(p, e, d, "(#cmpStrings($1, $2) <= 0)")

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -90,7 +90,7 @@ when options.hasTinyCBackend:
 
 const NonMagics* = {mNewString, mNewStringOfCap, mNewSeq, mSetLengthSeq,
                     mAppendSeqElem, mEnumToStr, mExit, mParseBiggestFloat,
-                    mDotDot, mEqCString, mIsolate}
+                    mAbsI, mDotDot, mEqCString, mIsolate}
   ## magics that are treated like normal procedures by the code generator.
 
 const

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1267,6 +1267,16 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
         else:
           # no range check is needed
           op(c, dest, n, m)
+  of mAbsI:
+    # special handling for the ``abs`` magic: if overflow checks are enabled
+    # and panics are disabled, the call must be a checked call
+    if optOverflowCheck in n[0].sym.options and
+       optPanics notin c.graph.config.globalOptions:
+      c.buildTree mnkCheckedCall, n.typ:
+        c.genCallee(n[0])
+        arg n[1]
+    else:
+      genCall(c, n)
 
   # float arithmetic operations:
   of mAddF64, mSubF64, mMulF64, mDivF64:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1819,6 +1819,22 @@ proc `<`*[T: tuple](x, y: T): bool =
     if c > 0: return false
   return false
 
+{.push stackTrace: off.}
+func abs*(x: int): int {.magic: "AbsI", inline.} =
+  if x < 0: -x else: x
+func abs*(x: int8): int8 {.magic: "AbsI", inline.} =
+  if x < 0: -x else: x
+func abs*(x: int16): int16 {.magic: "AbsI", inline.} =
+  if x < 0: -x else: x
+func abs*(x: int32): int32 {.magic: "AbsI", inline.} =
+  if x < 0: -x else: x
+func abs*(x: int64): int64 {.magic: "AbsI", inline.} =
+  ## Returns the absolute value of `x`.
+  ##
+  ## If `x` is `low(x)` (that is -MININT for its type),
+  ## an overflow exception is thrown (if overflow checking is turned on).
+  result = if x < 0: -x else: x
+{.pop.}
 
 include "system/gc_interface"
 
@@ -1961,23 +1977,6 @@ proc getTypeInfo*[T](x: T): pointer {.magic: "GetTypeInfo", benign.}
   ##
   ## Ordinary code should not use this, but the `typeinfo module
   ## <typeinfo.html>`_ instead.
-
-{.push stackTrace: off.}
-func abs*(x: int): int {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int8): int8 {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int16): int16 {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int32): int32 {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int64): int64 {.magic: "AbsI", inline.} =
-  ## Returns the absolute value of `x`.
-  ##
-  ## If `x` is `low(x)` (that is -MININT for its type),
-  ## an overflow exception is thrown (if overflow checking is turned on).
-  result = if x < 0: -x else: x
-{.pop.}
 
 when not defined(js):
 

--- a/tests/lang_objects/destructor/tdestruction_when_checks_failed.nim
+++ b/tests/lang_objects/destructor/tdestruction_when_checks_failed.nim
@@ -86,6 +86,14 @@ block signed_integer_overflow_check:
   runTest:
     test(high(int32)) # provoke an overflow-check failure
 
+block abs_overflow_check:
+  proc test(a: int32) =
+    var obj = Object() # obj stores a value that needs to be destroyed
+    discard abs(a)
+
+  runTest:
+    test(low(int32)) # provoke an overflow-check failure
+
 block float_nan_check:
   # enable nan checks first; they're disabled by default
   {.push nanChecks: on.}

--- a/tests/overflw/toverflow_abs.nim
+++ b/tests/overflw/toverflow_abs.nim
@@ -3,13 +3,9 @@ discard """
   targets: "c js vm"
   matrix: "--overflowChecks:on"
   exitcode: 1
-  outputsub: "Error: over- or underflow"
-  knownIssue.c js: "`abs` uses the local overflow check state"
+  outputsub: "over- or underflow"
+  knownIssue.js: "64-bit signed integers aren't fully supported"
 """
-
-# instantiate the magic procedure in a context where overflow checks are
-# enabled:
-discard abs(-1)
 
 {.push overflowChecks: off.}
 


### PR DESCRIPTION
## Summary

Regarding overflow-check behaviour, `abs` is now treated the same as
any other procedure, meaning that whether or not overflow checks are
enabled at the `abs` callsite is ignored. This is a change in
behaviour for the C and JavaScript backends, but not for the VM
backend.

In addition, if an `abs` call is the only raising statement in a
scope, it raising an exception now properly invokes the destructor
for the relevant locals in the scope.

## Details

* `cgen` and `jsgen` treat `mAbsI` as a normal procedure (`vmgen`
  already did)
* the `abs` definitions in `system` are moved above the
  `{.push checks: off.}` pragma affecting them. This prevents them
  from having overflow checks unconditionally disabled
* `mirgen` uses a dedicated translation path for `mAbsI`, in order to
  pick a checked or unchecked call, based on whether overflow
  checks and panics are enabled

Calls to `abs` now using checked calls (if needed) makes the
exceptional control-flow visible at the MIR level and subsequently to
the data-flow analysis / destructor injection.

### Tests

* add a test case for ensuring proper destruction when only `abs`
  can raise
* enable `toverflow_abs` for the C target. The JS target still
  doesn't work, due to the improper 64-bit integer overflow check
  implementation
* change the expected output of `toverflow_abs` such that it also
  matches that of the C test
* `abs` for integers is not a generic procedure, the unnecessary
  "instantiation" in `toverflow_abs` is removed