### PR TITLE
only allow re-raise in scope of `except`

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -498,6 +498,7 @@ type
     rsemExpectedObjectForMethod
     rsemUnexpectedPragmaInDefinitionOf
     rsemMisplacedRunnableExample
+    rsemCannotReraise
 
     # Expressions
     rsemConstantOfTypeHasNoValue

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1350,6 +1350,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemMisplacedRunnableExample:
       result = "runnableExamples must appear before the first non-comment statement"
 
+    of rsemCannotReraise:
+      result = "an exception can only be re-raised within the scope of an" &
+               " except, with no finally in-between"
+
     of rsemCannotInferTypeOfLiteral:
       result = "cannot infer the type of the $1" % r.typ.kind.toHumanStr
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4690,10 +4690,13 @@ the `raise` statement is the only way to raise an exception.
 
 .. XXX document this better!
 
-If no exception name is given, the current exception is `re-raised`:idx:. The
-`ReraiseDefect`:idx: exception is raised if there is no exception to
-re-raise. It follows that the `raise` statement *always* raises an
-exception.
+If no exception name is given, the current exception is `re-raised`:idx:.
+There are two restrictions for `raise` statements without an exception name:
+
+1. They must appear within the scope of an `except`.
+2. They must not appear within the direct scope of a `finally`. A re-raise
+   statement within an `except` that appears within a `finally` is okay, but
+   the other way around is not.
 
 
 Exception hierarchy

--- a/tests/exception/tdisallowed_reraise.nim
+++ b/tests/exception/tdisallowed_reraise.nim
@@ -1,0 +1,62 @@
+discard """
+  description: '''
+    Ensure that re-raise statements are rejected where required by the
+    language specification.
+  '''
+  cmd: "$nim check --hints:off $options $file"
+  action: reject
+  nimoutFull: true
+  nimout: '''
+tdisallowed_reraise.nim(26, 5) Error: an exception can only be re-raised within the scope of an except, with no finally in-between
+tdisallowed_reraise.nim(20, 3) Error: an exception can only be re-raised within the scope of an except, with no finally in-between
+tdisallowed_reraise.nim(39, 5) Error: an exception can only be re-raised within the scope of an except, with no finally in-between
+tdisallowed_reraise.nim(50, 7) Error: an exception can only be re-raised within the scope of an except, with no finally in-between
+'''
+"""
+
+
+block standalone_reraise:
+  # a standalone re-raise statement is disallowed
+  raise
+
+block reraise_in_procedure:
+  proc reraise() =
+    # the re-raise statement doesn't appear within an ``except`` clause's
+    # scope
+    raise
+
+  try:
+    raise CatchableError.newException("")
+  except:
+    # where the procedure is called has no effect on the rules
+    reraise()
+
+block reraise_in_finally:
+  try:
+    raise CatchableError.newException("")
+  finally:
+    # a re-raise statement within a finally clause is disallowed
+    raise
+
+block reraise_in_nested_finally:
+  try:
+    raise CatchableError.newException("")
+  except:
+    try:
+      break
+    finally:
+      # a re-raise statement within a finally clause that's within an except
+      # clause is still disallowed
+      raise
+
+block reraise_in_nested_try:
+  # no error is reported here
+  try:
+    raise CatchableError.newException("")
+  except:
+    try:
+      # a re-raise within a try's scope is allowed, if the try is within the
+      # scope of an except
+      raise
+    finally:
+      discard

--- a/tests/exception/tdisallowed_reraise.nim
+++ b/tests/exception/tdisallowed_reraise.nim
@@ -60,3 +60,15 @@ block reraise_in_nested_try:
       raise
     finally:
       discard
+
+block reraise_in_nested_finally_try:
+  # no error is reported here
+  try:
+    discard
+  finally:
+    try:
+      raise CatchableError.newException("")
+    except:
+      # a re-raise within an except within a finally, but not directly
+      # within, is allowed.
+      raise

--- a/tests/exception/tfinally6.nim
+++ b/tests/exception/tfinally6.nim
@@ -49,24 +49,6 @@ proc raiseFromFinally() =
 
 test raiseFromFinally(), [1, 2, 3]
 
-proc reraiseFromFinally() =
-  try:
-    try:
-      raise ValueError.newException("a")
-    finally:
-      steps.add 1
-      # abort the exception but immediately re-raise it
-      raise
-    doAssert false, "unreachable"
-  except ValueError as e:
-    steps.add 2
-    doAssert e.msg == "a"
-    doAssert getCurrentException() == e
-
-  steps.add 3
-
-test reraiseFromFinally(), [1, 2, 3]
-
 proc exceptionInFinally() =
   ## Raise, and fully handle, an exception within a finally clause that was
   ## entered through exceptional control-flow.

--- a/tests/lang_callable/macros/t18203_consumed_ast_is_not_unused.nim
+++ b/tests/lang_callable/macros/t18203_consumed_ast_is_not_unused.nim
@@ -11,6 +11,6 @@ action: compile
 import std/macros
 
 macro foo(x: typed) = newProc ident"bar"
-proc bar() {.foo.} = raise
+proc bar() {.foo.} = raise CatchableError.newException("")
 bar()
 


### PR DESCRIPTION
## Summary

Treat a re-raise (i.e., `raise` without operand) as a compile-time
error when used outside of the *scope* of an `except` clause -- re-
raising from within a `finally` clause that's within the scope of an 
`except` clause is disallowed too.

This brings the re-raise feature into a "safe" state, where it can be
extended from again if wanted/needed.

## Details

If a re-raise is allowed from anywhere, it is possible to handle an in-
flight exception from within a `finally` clause:

```nim
try:
  raise CatchableError.newException("")
finally:
  try:
    raise # re-raise the in-flight exception
  except:
    # handle the exception
    discard
```

Since the exception is handled, control-flow would have to "fall out"
of the `finally` clause, but this violates the expectations of control-
flow analysis in the compiler as well as those of the code generators.
There, the expectation is that if a `finally` clause was entered
through exceptional control-flow, raising continues when the end of
the `finally` is reached.

Until it's clear if, how, and under what circumstances this should
work, a `finally` clause handling the in-flight exception is prevented
by restricting re-raise statements to the scope of `except` clauses.
`sempass2` implements the detection and error reporting.

The manual is updated accordingly and tests for the new behaviour are
added.

### Usage

In the compiler's repository, re-raising from outside the scope of an
`except` clause was only done by two tests. For one of them, the re-
raise can safely be replaced with a normal `raise`.

The other test explicitly tested the "re-raise in finally" case. It is
removed for now.