### PR TITLE
fix unsigned `range` arithmetic causing overflow error

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -97,7 +97,7 @@ proc isPureObject*(typ: PType): bool =
   result = t.sym != nil and sfPure in t.sym.flags
 
 func isUnsigned*(t: PType): bool {.inline.} =
-  t.skipTypes(abstractInst + {tyEnum}).kind in {tyChar, tyUInt..tyUInt64}
+  t.skipTypes(abstractRange + {tyEnum}).kind in {tyChar, tyUInt..tyUInt64}
 
 proc getOrdValue*(n: PNode; onError = high(Int128)): Int128 =
   let k =

--- a/tests/lang_types/range/tuint_range_overflow_bug.nim
+++ b/tests/lang_types/range/tuint_range_overflow_bug.nim
@@ -1,0 +1,11 @@
+discard """
+  description: '''
+    Regression test for a compiler bug where incrementing an unsigned range
+    resulted in an overflow defect.
+  '''
+  targets: "c js vm"
+"""
+
+var a: range[0'u32..high(uint32)] = high(uint32)
+inc a
+doAssert a == typeof(a)(0)


### PR DESCRIPTION
## Summary

Fix incrementing or decrementing (with `inc`, `dec`, `+=`, or `-=`) to
cause an overflow error for unsigned `range` types when the value would
wrap around.

The regression was introduced by commit
db5dcbffa2b580edb040b5d7d77ec96d6dfe082e.

## Details

`isUnsigned` didn't skip `tyRange` types, meaning that range types were
not treated as unsigned if their base type is an unsigned int. The
`isUnsigned` procedure is used:
1. in `getOrdValue` for forcing the node's integer value to be treated
   as unsigned (problematic usage)
2. in `mirgen.genMagic` for `mInc` and `mDec` translation (problematic
   usage)
3. in `semfold.getConstExpr` (unproblematic usage; the type is never a
   `tyRange`)
4. in `vmgen` for deciding the opcode for narrowing (unproblematic
   usage; range types are skipped prior)

For `getOrdValue`, the result of `isUnsigned` only makes a difference
values of unsigned type where the node kind is not a `nkUIntLitX` node.
The node kind seems to match the signed-ness of the type in most cases,
so `isUnsigned` not considering `tyRange` didn't lead to problems in
practice.

For `mirgen.genMagic`, `isUnsigned` is used to decide whether or not
checked signed integer arithmetic needs to be used for `mInc` or
`mDec`. Since `tyRange` was never treated as unsigned, this meant that
values of unsigned range type were erroneously subjected to overflow
checks.

`isUnsigned` now skips `tyRange` types, fixing the issue. A regression
test for the incorrect overflow checking is added.