### PR TITLE
fix missing hooks for closure iterators

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1599,11 +1599,7 @@ proc genLocDef(c: var TCtx, n: PNode, val: PNode) =
     c.buildStmt (if sfCursor in s.flags: mnkDefCursor else: mnkDef):
       c.add node
       if hasInitializer:
-        # XXX: some closure types are erroneously reported as having no
-        #      destructor, which would lead to memory leaks if the
-        #      expression is a closure construction. As a work around,
-        #      a missing destructor disables the sink context
-        genAsgnSource(c, val, sink and hasDestructor(s.typ))
+        genAsgnSource(c, val, sink)
       else:
         c.add MirNode(kind: mnkNone)
 

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1438,6 +1438,11 @@ proc track(tracked: PEffects, n: PNode) =
       track(tracked, n[i])
 
     inc tracked.leftPartOfAsgn
+  of nkBlockType, nkStmtListType:
+    # TODO: it's a minor breaking change (macros can observe it via
+    #       `getImpl`), but these nodes should instead be folded into
+    #        ``nkType`` nodes by ``semfold``
+    discard
   of nkBindStmt, nkMixinStmt, nkImportStmt, nkImportExceptStmt, nkExportStmt,
      nkExportExceptStmt, nkFromStmt:
     # a declarative statement that is not relevant to the analysis. Report

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1314,6 +1314,12 @@ proc track(tracked: PEffects, n: PNode) =
          iterCall[1].typ.skipTypes(abstractVar).kind notin {tyVarargs, tyOpenArray}:
         createTypeBoundOps(tracked, iterCall[1].typ, iterCall[1].info)
     
+    if tracked.owner.kind != skMacro and iterCall.kind in nkCallKinds and
+       iterCall[0].typ.skipTypes(abstractInst).callConv == ccClosure:
+      # the loop is a for-loop over a closure iterator. Lift the hooks for
+      # the iterator
+      createTypeBoundOps(tracked, iterCall[0].typ, iterCall[0].info)
+
     track(tracked, iterCall)
     track(tracked, loopBody)
     setLen(tracked.init, oldState)


### PR DESCRIPTION
## Summary

Fix closure iterator instances created when expanding `for` loops
having no lifetime hooks lifted. This fix only has compiler-
internal implications.

## Details

Closure iterators only used as `for` loop iterables, e.g.:
```nim
for _ in iter(): # <- `iter` is the iterable here
  discard
```

didn't have lifetime hooks lifted for them, since `sempass2` ignored
this kind of usage.

In `transf`, `lambdalifting.liftForLoop` transforms the iterator usage
into:
```nim
let iter = (iter, EnvRef())
```

`iter` here is an owning variable, but due to the lack of lifetime
hooks, it is never cleaned up. `mirgen` prevented the `EnvRef` value
from being moved into `iter` (which would have caused a memory leak) by
treating the initializer expression as not appearing in a sink context
(even though it does).

### The Fix

`sempass2` now lifts the hooks for closure iterator invocations
appearing in the iterable slot of `for`-loops, making the workaround in
`mirgen` obsolete.

Removing the workaround more generally means that aggregate
constructions used as the initializer expression for locations of types
that don't have lifetime hooks properly create owning values now (they
use `mnkConsume` instead of `mnkArg`). While ownership is currently
meaningless for types without lifetime hooks, the previous behaviour
was still technically incorrect.

### Follow-on problem

`nkStmtListType` reaches `sempass2`, and if the type AST contains an
`nkForStmt` (which, as consequence of being part of type AST, is
always untyped), the new analysis of the loop AST's iterator slot
would crash with an NPE.

As a temporary workaround, `track` skips over `nkStmtListType` and
`nkBlockType`. In the future, both nodes should be folded away by
`semfold`.