### PR TITLE
std: `compilesettings` show CLI compile/link flags

### DIFF
--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -484,7 +484,7 @@ proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string
 
   addOpt(result, conf.cfileSpecificOptions.getOrDefault(fullNimFile))
 
-proc getCompileOptions(conf: ConfigRef): string =
+proc getCompileOptions*(conf: ConfigRef): string =
   result = cFileSpecificOptions(conf, "__dummy__", "__dummy__")
 
 proc vccplatform(conf: ConfigRef): string =
@@ -499,7 +499,7 @@ proc vccplatform(conf: ConfigRef): string =
         of cpuAmd64: " --platform:amd64"
         else: ""
 
-proc getLinkOptions(conf: ConfigRef): string =
+proc getLinkOptions*(conf: ConfigRef): string =
   result = conf.linkOptions & " " & conf.linkOptionsCmd.join(" ") & " "
   for linkedLib in items(conf.cLinkedLibs):
     result.add(CC[conf.cCompiler].linkLibCmd % linkedLib.quoteShell)

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -461,11 +461,7 @@ proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string
   ## added in the following order:
   ## `[global(--passc)][opt=speed/size/debug][file-local][<nimname>.always]`.
   ## `<nimname>.always` is a configuration variable.
-  result = conf.compileOptions
-
-  for option in conf.compileOptionsCmd:
-    if strutils.find(result, option, 0) < 0:
-      addOpt(result, option)
+  result = getCompileOptionsStr(conf)
 
   if optCDebug in conf.globalOptions:
     let key = nimname & ".debug"
@@ -484,7 +480,7 @@ proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string
 
   addOpt(result, conf.cfileSpecificOptions.getOrDefault(fullNimFile))
 
-proc getCompileOptions*(conf: ConfigRef): string =
+proc getCompileOptions(conf: ConfigRef): string =
   result = cFileSpecificOptions(conf, "__dummy__", "__dummy__")
 
 proc vccplatform(conf: ConfigRef): string =
@@ -499,8 +495,8 @@ proc vccplatform(conf: ConfigRef): string =
         of cpuAmd64: " --platform:amd64"
         else: ""
 
-proc getLinkOptions*(conf: ConfigRef): string =
-  result = conf.linkOptions & " " & conf.linkOptionsCmd.join(" ") & " "
+proc getLinkOptions(conf: ConfigRef): string =
+  result = getLinkOptionsStr(conf) & " "
   for linkedLib in items(conf.cLinkedLibs):
     result.add(CC[conf.cCompiler].linkLibCmd % linkedLib.quoteShell)
   for libDir in items(conf.cLibs):

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -394,6 +394,11 @@ passStrTableField macrosToExpand
 passStrTableField arcToExpand
 
 proc getCompileOptionsStr*(conf: ConfigRef): string =
+  ## Returns the combination of the current C compile options and the
+  ## global `--passC` options (combined in that exact order).
+  ##
+  ## Global `--passC` options already present in the current C compile
+  ## options are *not* include again.
   result = conf.compileOptions
 
   for option in conf.compileOptionsCmd:
@@ -402,6 +407,8 @@ proc getCompileOptionsStr*(conf: ConfigRef): string =
       result.add option
 
 proc getLinkOptionsStr*(conf: ConfigRef): string =
+  ## Returns the combination of the current C linker options and the global
+  ## `--passL` options (combined in that exact order).
   conf.linkOptions & " " & conf.linkOptionsCmd.join(" ")
 
 proc defineSymbol*(conf: ConfigRef, symbol: string, value: string = "true") =

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -393,6 +393,16 @@ passStrTableField symbols
 passStrTableField macrosToExpand
 passStrTableField arcToExpand
 
+proc getCompileOptionsStr*(conf: ConfigRef): string =
+  result = conf.compileOptions
+
+  for option in conf.compileOptionsCmd:
+    if strutils.find(result, option, 0) < 0:
+      if result.len == 0 or result[^1] != ' ': result.add " "
+      result.add option
+
+proc getLinkOptionsStr*(conf: ConfigRef): string =
+  conf.linkOptions & " " & conf.linkOptionsCmd.join(" ")
 
 proc defineSymbol*(conf: ConfigRef, symbol: string, value: string = "true") =
   conf.symbolsSet(symbol, value)

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -38,8 +38,6 @@ import
     results
   ]
 
-from compiler/backend/extccomp import getCompileOptions, getLinkOptions
-
 from compiler/front/msgs import localReport
 
 # xxx: reports are a code smell meaning data types are misplaced
@@ -205,8 +203,8 @@ when defined(nimHasInvariant):
     of SingleValueSetting.projectFull: result = conf.projectFull.string
     of SingleValueSetting.command: result = conf.command
     of SingleValueSetting.commandLine: result = conf.commandLine
-    of SingleValueSetting.linkOptions: result = conf.getLinkOptions()
-    of SingleValueSetting.compileOptions: result = conf.getCompileOptions()
+    of SingleValueSetting.linkOptions: result = conf.getLinkOptionsStr()
+    of SingleValueSetting.compileOptions: result = conf.getCompileOptionsStr()
     of SingleValueSetting.ccompilerPath: result = conf.cCompilerPath
     of SingleValueSetting.backend: result = $conf.backend
     of SingleValueSetting.libPath: result = conf.libpath.string

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -38,6 +38,8 @@ import
     results
   ]
 
+from compiler/backend/extccomp import getCompileOptions, getLinkOptions
+
 from compiler/front/msgs import localReport
 
 # xxx: reports are a code smell meaning data types are misplaced
@@ -203,8 +205,8 @@ when defined(nimHasInvariant):
     of SingleValueSetting.projectFull: result = conf.projectFull.string
     of SingleValueSetting.command: result = conf.command
     of SingleValueSetting.commandLine: result = conf.commandLine
-    of SingleValueSetting.linkOptions: result = conf.linkOptions
-    of SingleValueSetting.compileOptions: result = conf.compileOptions
+    of SingleValueSetting.linkOptions: result = conf.getLinkOptions()
+    of SingleValueSetting.compileOptions: result = conf.getCompileOptions()
     of SingleValueSetting.ccompilerPath: result = conf.cCompilerPath
     of SingleValueSetting.backend: result = $conf.backend
     of SingleValueSetting.libPath: result = conf.libpath.string

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -13,7 +13,8 @@ template main =
   doAssert querySetting(backend) == "c"
   doAssert fileExists(libPath.querySetting / "system.nim")
   doAssert "-fmax-errors=4" in querySetting(compileOptions)
-  doAssert "-u dummysymboldoesnotexist" in querySetting(linkOptions), querySetting(linkOptions)
+  when not defined(macos) and not defined(windows):
+    doAssert "-u dummysymboldoesnotexist" in querySetting(linkOptions)
 
 static: main()
 main()

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -1,5 +1,5 @@
 discard """
-matrix: "--nimcache:build/myNimCache --nimblePath:myNimblePath --passc:'-fmax-errors=4' --passl:'-Xlinker --defsym -Xlinker dummysymboldoesnotexist=0x0'"
+matrix: "--nimcache:build/myNimCache --nimblePath:myNimblePath --passc:'-fmax-errors=4'"
 joinable: false
 """
 
@@ -13,8 +13,6 @@ template main =
   doAssert querySetting(backend) == "c"
   doAssert fileExists(libPath.querySetting / "system.nim")
   doAssert "-fmax-errors=4" in querySetting(compileOptions)
-  doAssert "-Xlinker --defsym -Xlinker dummysymboldoesnotexist=0x0" in
-              querySetting(linkOptions)
 
 static: main()
 main()

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -1,5 +1,5 @@
 discard """
-matrix: "--nimcache:build/myNimCache --nimblePath:myNimblePath --passc:'-fmax-errors=4'"
+matrix: "--nimcache:build/myNimCache --nimblePath:myNimblePath --passc:-fmax-errors=4"
 joinable: false
 """
 

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -1,9 +1,9 @@
 discard """
-cmd: "nim c --nimcache:build/myNimCache --nimblePath:myNimblePath $file"
+matrix: "--nimcache:build/myNimCache --nimblePath:myNimblePath --passc:'-fmax-errors=4' --passl:'-u dummysymboldoesnotexist'"
 joinable: false
 """
 
-import std/[strutils,compilesettings]
+import std/[strutils, compilesettings]
 from std/os import fileExists, `/`
 
 template main =
@@ -12,6 +12,8 @@ template main =
   doAssert "myNimblePath" in nimblePaths.querySettingSeq[0]
   doAssert querySetting(backend) == "c"
   doAssert fileExists(libPath.querySetting / "system.nim")
+  doAssert "-fmax-errors=4" in querySetting(compileOptions)
+  doAssert "-u dummysymboldoesnotexist" in querySetting(linkOptions), querySetting(linkOptions)
 
 static: main()
 main()

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -1,5 +1,5 @@
 discard """
-matrix: "--nimcache:build/myNimCache --nimblePath:myNimblePath --passc:'-fmax-errors=4' --passl:'-u dummysymboldoesnotexist'"
+matrix: "--nimcache:build/myNimCache --nimblePath:myNimblePath --passc:'-fmax-errors=4' --passl:'-Xlinker --defsym -Xlinker dummysymboldoesnotexist=0x0'"
 joinable: false
 """
 
@@ -13,8 +13,8 @@ template main =
   doAssert querySetting(backend) == "c"
   doAssert fileExists(libPath.querySetting / "system.nim")
   doAssert "-fmax-errors=4" in querySetting(compileOptions)
-  when not defined(macos) and not defined(windows):
-    doAssert "-u dummysymboldoesnotexist" in querySetting(linkOptions)
+  doAssert "-Xlinker --defsym -Xlinker dummysymboldoesnotexist=0x0" in
+              querySetting(linkOptions)
 
 static: main()
 main()

--- a/tests/vm/tcompilesettings_passl.nim
+++ b/tests/vm/tcompilesettings_passl.nim
@@ -1,0 +1,20 @@
+discard """
+  description: "Test for `std/compilesettings` querying of linker options"
+  matrix: "--passl:'-Xlinker --defsym -Xlinker dummysymboldoesnotexist=0x0'"
+  joinable: false
+  disabled: windows
+  disabled: osx
+"""
+
+# finding a "no-op" like cross-platform linker option turned out to be a pain,
+# so doing some basic testing on linux at least.
+
+import std/[strutils, compilesettings]
+from std/os import fileExists, `/`
+
+template main =
+  doAssert "-Xlinker --defsym -Xlinker dummysymboldoesnotexist=0x0" in
+              querySetting(linkOptions)
+
+static: main()
+main()


### PR DESCRIPTION
## Summary

`compilersettings`  now includes compiler and linker options that are
set via the command-line  `--passc/passl`  flags.

## Details

Prior to this change only pragma based compiler and linker options were
shown, via  `{.passC: "...".}`  or  `{.passL:"...".}` . Now  `vmops` ,
which implements the compile time querying, uses compiler and linker
option construction procedures from the  `options`  module to fulfill
the query.

The compiler and linker options procedures in  `options`  are newly
introduced, taking over logic previously carried out in the  `extccomp` 
module, which orchestrates backend C compiler and linker operations. As
part of this change  `extccomp`  has been updated to also use these
procedures so there is one way and place where these options are
constructed. Additionally, the   `tcompilesetting`  test has been
updated to ensure these continue to work.

Note: the  `compilesettings`  query for compile options does _not_
include module specific compile options, set via 
`{.localPassc: "...".}`  pragma. This could be implemented, but that
would likely require further changes, such as introducing a new query to
get all file compiler options vs file specific.