### PR TITLE
cgen: fix unnecessary default initialization of locals

### DIFF
--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -16,13 +16,11 @@ const
     # above X strings a hash-switch for strings is generated
 
 proc isAssignedImmediately(conf: ConfigRef; n: CgNode): bool {.inline.} =
-  if n.kind == cnkEmpty: return false
-  if isInvalidReturnType(conf, n.typ):
-    # var v = f()
-    # is transformed into: var v;  f(addr v)
-    # where 'f' **does not** initialize the result!
-    return false
-  result = true
+  # note: the destination can be considered assigned immediately even if the
+  # source is an exception-raising RVO call. This is because the call happens
+  # *before* the definition, meaning that nothing on the exceptional control-
+  # flow path must observe (read or write) the destination
+  n.kind != cnkEmpty
 
 proc inExceptBlockLen(p: BProc): int =
   for x in p.nestedTryStmts:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -485,16 +485,10 @@ proc resetLoc(p: BProc, loc: var TLoc; doInitObj = true) =
   constructLoc(p, loc, doInitObj)
 
 proc initLocalVar(p: BProc, v: LocalId, immediateAsgn: bool) =
-  if sfNoInit notin p.body[v].flags:
-    # we know it is a local variable and thus on the stack!
+  if not immediateAsgn and sfNoInit notin p.body[v].flags:
     # If ``not immediateAsgn`` it is not initialized in a binding like
     # ``var v = X`` and thus we need to init it.
-    # If ``v`` contains a GC-ref we may pass it to ``unsureAsgnRef`` somehow
-    # which requires initialization. However this can really only happen if
-    # ``var v = X()`` gets transformed into ``X(&v)``.
-    # Nowadays the logic in ccgcalls deals with this case however.
-    if not immediateAsgn:
-      constructLoc(p, p.locals[v])
+    constructLoc(p, p.locals[v])
 
 proc getTemp(p: BProc, t: PType, result: var TLoc) =
   inc(p.labels)


### PR DESCRIPTION
## Summary

A local of certain types was unnecessarily default-initialized even if
it was assigned immediately (that is, `var x = y`). This doesn't change
observable behaviour, but it does speed up the generated code a bit.

## Details

* only emit default-initialization for definitions when there's no
  initial-value expression
* remove the `isAssignedImmediately` procedure. It's only used a
  single time, and its general name might cause (mis-)use for purposes
  it's not intended for  
* remove the outdated comment in `cgen.initLocalVar`