### PR TITLE
vm: use contiguous register storage

### DIFF
--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -418,12 +418,9 @@ func storeDataNode(enc: var DataEncoder, e: var PackedEnv,
   else:
     unreachable(t[n].kind)
 
-import compiler/mir/utils
-
 func storeData*(enc: var DataEncoder, e: var PackedEnv, tree: MirTree): int =
   ## Packs the MIR constant expression `tree` and puts it into `e`. Returns
   ## the index of the top data node.
-  debugEcho treeRepr(tree)
   result = enc.i
   e.nodes.growBy(1)
   storeDataNode(enc, e, tree, NodePosition 0)

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2912,12 +2912,16 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
 
 proc `=copy`*(x: var VmThread, y: VmThread) {.error.}
 
-proc initVmThread*(c: var TCtx, pc: int, frame: sink TStackFrame): VmThread =
-  ## Sets up a ``VmThread`` instance that will start execution at `pc`.
-  ## `frame` provides the initial stack frame.
+proc initVmThread*(c: var TCtx, pc: PrgCtr, numRegisters: int,
+                   sym: PSym): VmThread =
+  ## Sets up a `VmThread <#VmThread>`_ instance that will start execution at
+  ## `pc` and that has `numRegisters` as the initial amount of registers.
+  ## `sym` is the symbol to associate the initial stack-frame with. It may be
+  ## nil.
   VmThread(pc: pc,
            loopIterations: c.config.maxLoopIterationsVM,
-           sframes: @[frame])
+           sframes: @[TStackFrame(prc: sym,
+                                  slots: newSeq[TFullReg](numRegisters))])
 
 proc dispose*(c: var TCtx, t: sink VmThread) =
   ## Cleans up and frees all VM data owned by `t`.

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2006,7 +2006,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
           checkHandle(regs[i])
 
         c.callbacks[entry.cbOffset](
-          VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[ptr UncheckedArray[TFullReg]](addr regs[0]),
+          VmArgs(ra: ra, rb: rb, rc: rc, slots: regs.data,
                  currentExceptionPtr: addr t.currentException,
                  currentLineInfo: c.debug[pc],
                  typeCache: addr c.typeInfoCache,

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -201,7 +201,7 @@ proc createStackTrace*(
   assert result.stacktrace.len() <= recursionLimit # post condition check
 
 func initFrom(regs: seq[TFullReg], start: int): Registers =
-  ## Creates a register list view covering `at..regs.high`.
+  ## Creates a register list view covering `start..regs.high`.
   result = Registers(len: regs.len - start)
   if regs.len > 0:
     result.data = cast[ptr UncheckedArray[TFullReg]](addr regs[start])

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -734,8 +734,9 @@ type
 
   TStackFrame* = object
     prc*: PSym                 # current prc; proc that is evaluated
-    slots*: seq[TFullReg]      # parameters passed to the proc + locals;
-                              # parameters come first
+    start*: int
+      ## position in the thread's register sequence where the registers for
+      ## the frame start
     eh*: HOslice[int]
       ## points to the active list of instruction-to-EH mappings
     baseOffset*: PrgCtr

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -375,14 +375,11 @@ proc main*(args: seq[string]): int =
   let
     entryPoint = c.functions[lr.unsafeGet.int]
 
-  # setup the starting frame:
-  var frame = TStackFrame(prc: entryPoint.sym)
-  frame.slots.newSeq(entryPoint.regCount)
-
   # the execution part. Set up a thread and run it until it either exits
   # normally or abnormally
   var
-    thread = initVmThread(c, entryPoint.start, frame)
+    thread = initVmThread(c, entryPoint.start, entryPoint.regCount.int,
+                          entryPoint.sym)
     continueExecution = true ## whether we continue to execute after yield
   while continueExecution:
     continueExecution = false # default to stop execution on any yield

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -388,7 +388,7 @@ proc main*(args: seq[string]): int =
     of yrkDone:
       # on successful execution, the executable's main function returns the
       # value of ``programResult``, which we use as the runner's exit code
-      let reg = thread[0].slots[r.reg.get]
+      let reg = thread.regs[r.reg.get]
       result = regToNode(c, reg, nil, TLineInfo()).intVal.int
     of yrkError:
       # an uncaught error occurred


### PR DESCRIPTION
## Summary

This is an internal-only change. The VM implementation now uses a
register sequence per *thread* rather than per *stack frame*, reducing
the overhead of entering and exiting a procedure for code running in
the VM.

## Details

### VM interface

* allocating the initial stack frame and registers is part of 
`initVmThread`  now
* `compilerbridge` is adjusted accordingly; `execute` now takes a
  `VmThread`, instead of a `TStackFrame`, as input so that the
  callsites can still initialize the parameter registers

### VM architecture

* `VmThread` stores the `seq[TFullReg]` with all registers
* instead of their own `seq[TFullReg]`, each stack frame
  (`TStackFrame`) remembers the index where its register slice begins
* the register sequence is a stack: invoking a procedure grows it,
  while leaving a procedure shrinks it again
* the `.cursor`-based mechanism for keeping a low-overhead reference to
  the current frame's register slice is replaced with `Registers`,
  which is a length + `ptr UncheckedArray` pair (an unsafe first-class
  `openArray`, effectively)
* instead of by an `IndexDefect` being raised, out-of-bounds register
  access is reported via the `VmEvent` facility. This means that out-
  of-bounds register access resulting from ill-formed bytecode no
  longer crashes the VM

Using a single sequence per thread means that there's no more `seq`
allocation/destruction overhead per procedure call, which also means
less pressure on the host's allocator.

### Misc

* a leftover `debugEcho` from some earlier change in `packed_env` is
  removed