### PR TITLE
sem: correctly show errors from `defer` node body

### DIFF
--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -1592,7 +1592,8 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
       put(g, tkDefer, "defer")
     putWithSpace(g, tkColon, ":")
     gcoms(g)
-    gstmts(g, n[0], c)
+    for kid in n.sons.items:
+      gstmts(g, kid, c)
   of nkExceptBranch:
     optNL(g)
     if n.len != 1:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -568,7 +568,6 @@ type
     rsemExpectedModuleNameForImportExcept
     rsemCannotExport
     rsemCannotMixTypesAndValuesInTuple
-    rsemExpectedTypelessDeferBody
     rsemInvalidBindContext
     rsemCannotCreateImplicitOpenarray
     rsemCannotAssignToDiscriminantWithCustomDestructor

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -962,7 +962,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "invalid context for 'bind' statement: " & render(r.ast)
 
     of rsemExpectedTypelessDeferBody:
-      result = "'defer' takes a 'void' expression"
+      result = "'defer' takes a 'void' expression, got: " & render(r.ast[0])
 
     of rsemUnexpectedToplevelDefer:
       result = "defer statement not supported at top level"

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -961,9 +961,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemInvalidBindContext:
       result = "invalid context for 'bind' statement: " & render(r.ast)
 
-    of rsemExpectedTypelessDeferBody:
-      result = "'defer' takes a 'void' expression, got: " & render(r.ast[0])
-
     of rsemUnexpectedToplevelDefer:
       result = "defer statement not supported at top level"
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3878,22 +3878,14 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkDefer:
     if c.currentScope == c.topLevelScope:
       localReport(c.config, n, reportSem rsemUnexpectedToplevelDefer)
-    let res = semExpr(c, n[0])
-    case res.kind
+    checkSonsLen(n, 1, c.config)
+    result = copyNodeWithKids(n)
+    result[0] = semStmt(c, n[0], {})
+    case result[0].kind
     of nkError:
-      result = copyNodeWithKids(n)
-      result[0] = res
       result = c.config.wrapError(result)
     else:
-      if res == n[0]: # no change
-        discard
-      else:
-        result = copyNodeWithKids(n)
-        result[0] = res
-
-      # TODO: convert to nkError
-      if not res.typ.isEmptyType and not implicitlyDiscardable(res):
-        localReport(c.config, n, reportSem rsemExpectedTypelessDeferBody)
+      discard
   of nkMixinStmt: discard
   of nkBindStmt:
     if c.p != nil:

--- a/tests/lang_stmts/defer/tdefer.nim
+++ b/tests/lang_stmts/defer/tdefer.nim
@@ -1,0 +1,34 @@
+discard """
+  description: "Test for defer statements"
+"""
+
+block runs_at_the_end_of_scope:
+  proc foo(): int =
+    defer:
+      inc result
+    doAssert result == 0
+
+  doAssert foo() == 1
+
+block questionably_not_at_the_end_of_proc_scope:
+  proc foo(): int =
+    if true:
+      defer:
+        inc result
+      doAssert result == 0
+    doAssert result == 1
+    inc result
+    doAssert result == 2
+
+  doAssert foo() == 2
+
+block templates_do_not_create_scopes_defer_applies_to_the_surrounding:
+  template bar() =
+    defer:
+      inc result
+
+  proc foo(): int =
+    bar()
+    doAssert result == 0
+
+  doAssert foo() == 1

--- a/tests/lang_stmts/defer/tdefer_cannot_be_top_level.nim
+++ b/tests/lang_stmts/defer/tdefer_cannot_be_top_level.nim
@@ -1,5 +1,5 @@
 discard """
-  description: "Defer cannot be decalred at the top level"
+  description: "Defer cannot be declared at the top level"
   errormsg: "defer statement not supported at top level"
   line: 7
 """

--- a/tests/lang_stmts/defer/tdefer_cannot_be_top_level.nim
+++ b/tests/lang_stmts/defer/tdefer_cannot_be_top_level.nim
@@ -1,0 +1,8 @@
+discard """
+  description: "Defer cannot be decalred at the top level"
+  errormsg: "defer statement not supported at top level"
+  line: 7
+"""
+
+defer:
+  discard

--- a/tests/lang_stmts/defer/tdefer_malformed_empty_body.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_empty_body.nim
@@ -1,7 +1,7 @@
 discard """
   description: "Empty `defer` body is not allowed (macro input)."
   errormsg: "illformed AST"
-  line: 13
+  line: 10
 """
 
 import std/macros

--- a/tests/lang_stmts/defer/tdefer_malformed_empty_body.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_empty_body.nim
@@ -1,0 +1,15 @@
+discard """
+  description: "Empty `defer` body is not allowed (macro input)."
+  errormsg: "illformed AST"
+  line: 13
+"""
+
+import std/macros
+
+macro bar(): untyped =
+  result = newNimNode(nnkDefer)
+
+proc foo() =
+  bar()
+
+foo()

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -1,0 +1,15 @@
+discard """
+  description: "Empty `defer` body is not allowed (macro input)."
+  errormsg: "illformed AST"
+  line: 13
+"""
+
+import std/macros
+
+macro bar(): untyped =
+  result = newTree(nnkDefer, newNimNode(nnkEmpty), newNimNode(nnkEmpty))
+
+proc foo() =
+  bar()
+
+foo()

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -1,5 +1,5 @@
 discard """
-  description: "Empty `defer` body is not allowed (macro input)."
+  description: "`defer` must have exactly one child node (macro input)."
   errormsg: "illformed AST"
   file: "macros.nim"
   line: 618

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -1,7 +1,8 @@
 discard """
   description: "Empty `defer` body is not allowed (macro input)."
   errormsg: "illformed AST"
-  line: 13
+  file: "macros.nim"
+  line: 618
 """
 
 import std/macros

--- a/tests/lang_stmts/defer/tdefer_requires_stmt_1.nim
+++ b/tests/lang_stmts/defer/tdefer_requires_stmt_1.nim
@@ -1,0 +1,9 @@
+discard """
+  description: "Defer body must be statement"
+  errormsg: "'defer' takes a 'void' expression"
+  line: 8
+"""
+
+block:
+  defer:
+    true # this needs to be used

--- a/tests/lang_stmts/defer/tdefer_requires_stmt_1.nim
+++ b/tests/lang_stmts/defer/tdefer_requires_stmt_1.nim
@@ -1,7 +1,7 @@
 discard """
   description: "Defer body must be statement"
-  errormsg: "'defer' takes a 'void' expression"
-  line: 8
+  errormsg: "expression 'true' is of type 'bool' and has to be used (or discarded)"
+  line: 9
 """
 
 block:

--- a/tests/lang_stmts/defer/tdefer_requires_stmt_2.nim
+++ b/tests/lang_stmts/defer/tdefer_requires_stmt_2.nim
@@ -1,7 +1,7 @@
 discard """
   description: "Defer body must be a statement, without error"
   errormsg: "type mismatch: got <bool, int literal(1)>"
-  line: 12
+  line: 13
 """
 
 ## somewhat of a regression test to see what happens when the defer body has an

--- a/tests/lang_stmts/defer/tdefer_requires_stmt_2.nim
+++ b/tests/lang_stmts/defer/tdefer_requires_stmt_2.nim
@@ -1,0 +1,13 @@
+discard """
+  description: "Defer body must be a statement, without error"
+  errormsg: "type mismatch: got <bool, int literal(1)>"
+  line: 12
+"""
+
+## somewhat of a regression test to see what happens when the defer body has an
+## error, this was an issue encountered in CPS, where an error body was treated
+## as an expression.
+
+block:
+  defer:
+    true + 1


### PR DESCRIPTION
## Summary

Errors in a defer node body are now correctly reported, no longer
producing misleading  `'defer' takes a 'void' expression`  messages.

## Details

A `defer`  with an error node body is no longer treated as an expression
and having the underlying error supressed. Instead the body error is
correctly reported. The  `defer`  AST is also correctly wrapped in an
error node.

The implementation of `defer` semantic analysis has changed a fair bit:

1. it now checks for well formedness (number of children, and reports
illegal AST when not conforming)
2. the body is now checked via  `semStmt` , which appropriately handles
discard checks
3. as a consequence of the above, the specialized  `void expression` 
message is no longer required and assocated reports have been removed

To avoid regressions in any of these areas a relatively comprehensive
test sutie for  `defer`  statements was added testing all of these
facets.