### PR TITLE
fix compiler crash with macros and enum `$`

### DIFF
--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -22,11 +22,10 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
   let res = newSym(skResult, getIdent(g.cache, "result"), nextSymId idgen, result, info)
   res.typ = getSysType(g, info, tyString)
 
-  result.typ = newType(tyProc, nextTypeId idgen, t.owner)
-  result.typ.n = newNodeI(nkFormalParams, info)
-  rawAddSon(result.typ, res.typ)
-  result.typ.n.add newNodeI(nkEffectList, info)
-
+  # setup the procedure's type:
+  result.typ = newProcType(info, nextTypeId idgen, result)
+  result.typ[0] = res.typ
+  propagateToOwner(result.typ, res.typ, false)
   result.typ.addParam dest
 
   var caseStmt = newNodeI(nkCaseStmt, info)

--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -51,7 +51,15 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
   # treat the symbol as a magic so that further processing can easily detect
   # auto-generated enum-to-string procedures
   result.magic = mEnumToStr
-  result.flags.incl {sfFromGeneric, sfNeverRaises}
+  result.flags.incl {sfNeverRaises}
+  # XXX: the synthesized procedure could be seen as coming from a generic
+  #      routine (the generic ``mEnumToStr`` magic procedure from the system
+  #      module), but for the ``sfFromGeneric`` flag to be included, the owner
+  #      of the symbol would have to be the originating-from generic procedure,
+  #      which isn't possible at the moment, given that sem might not have
+  #      processed the declaration (meaning no symbol) of said magic procedure
+  #      when ``genEnumToString`` is called
+  #result.flags.incl {sfFromGeneric}
 
 proc searchObjCaseImpl(obj: PNode; field: PSym): PNode =
   case obj.kind

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -52,6 +52,15 @@ type
   typed* {.magic: Stmt.}         ## Meta type to denote an expression that
                                  ## is resolved (for templates).
 
+# XXX: the ``EnumToStr`` magic has to be defined here so that the ``bool``
+#      definition can compile
+proc `$`*[Enum: enum](x: Enum): string {.magic: "EnumToStr", noSideEffect.}
+  ## The stringify operator for an enumeration argument. This works for
+  ## any enumeration type thanks to compiler magic.
+  ##
+  ## If a `$` operator for a concrete enumeration is provided, this is
+  ## used instead. (In other words: *Overwriting* is possible.)
+
 include "system/basic_types"
 
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1979,6 +1979,7 @@ template newException*(exceptn: typedesc, message: string;
                        parentException: ref Exception = nil): untyped =
   ## Creates an exception object of type `exceptn`, initializes it's `name`
   ## and sets its `msg` field to `message`. Returns the new exception object.
+  mixin `$`
   (ref exceptn)(name: $exceptn, msg: message, parent: parentException)
 
 proc getTypeInfo*[T](x: T): pointer {.magic: "GetTypeInfo", benign.}

--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -51,13 +51,6 @@ proc `$`*(x: string): string {.magic: "StrToStr", noSideEffect.}
   ## as it is. This operator is useful for generic code, so
   ## that `$expr` also works if `expr` is already a string.
 
-proc `$`*[Enum: enum](x: Enum): string {.magic: "EnumToStr", noSideEffect.}
-  ## The stringify operator for an enumeration argument. This works for
-  ## any enumeration type thanks to compiler magic.
-  ##
-  ## If a `$` operator for a concrete enumeration is provided, this is
-  ## used instead. (In other words: *Overwriting* is possible.)
-
 proc `$`*(t: typedesc): string {.magic: "TypeTrait".}
   ## Returns the name of the given type.
   ##

--- a/lib/system/memalloc.nim
+++ b/lib/system/memalloc.nim
@@ -76,6 +76,7 @@ when hasAlloc and not defined(js):
     let stats1 = getAllocStats()
     code
     let stats2 = getAllocStats()
+    mixin `$`
     echo $(stats2 - stats1)
 
   when defined(nimAllocStats):

--- a/tests/lang_callable/macros/tsynthesized_enum_to_string_roundtrip.nim
+++ b/tests/lang_callable/macros/tsynthesized_enum_to_string_roundtrip.nim
@@ -1,0 +1,17 @@
+discard """
+  description: '''
+    Regression test where returning an AST containing a call to a compiler-
+    generated enum-to-string procedure crashed the compiler.
+  '''
+  action: compile
+"""
+
+macro passthrough(x: typed): untyped = x
+
+type Enum = enum
+  enumA
+
+var e = enumA
+# the compiler crashed when processing the macro output
+passthrough:
+  discard $(e)


### PR DESCRIPTION
## Summary

Fix the compiler crashing when returning AST containing a call to the
compiler-generated `$` for an enum type from a macro. The crash only
occurred if the problematic callee is a resolved symbol (not a raw
identifier).

## Details

`sigmatch.initCallCandidate` searches for the module a routine is
owned by, by traversing the owners while skipping generic routines. If
a routine is marked with the `sfFromGeneric` flag, `skipGenericOwner`
unconditionally skips one `owner`. This is because the instantiation of
a generic routine has the generic routine it was instantiated from as
its immediate owner.

The compiler-generated enum-to-string procedure is also marked with
`sfFromGeneric`, but it has the owner of the enum type as the `owner`,
and not a generic routine. If the owner of the enum type is a module
(`skModule`), this meant that `initCallCandidate` skipped over the
`skModule` symbol, eventually reaching the end of the chain and
crashing with an NPE.

Since in the case of `genEnumToStrProc`, the generic procedure
(`EnumToStr` from the `dollars` module) might not be available yet, no
generic symbol can be used as the owner. To fix the problem, the
synthesized procedure is now no longer marked with the `sfFromGeneric`
flag.