### PR TITLE
sem: `discardable` routines are discarded in `try`

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -116,9 +116,10 @@ proc fixNilType(c: PContext; n: PNode) =
 
 # start `discard` check related code
 
-proc implicitlyDiscardable(n: PNode): bool =
-  var n = n
-  while n.kind in skipForDiscardable: n = n.lastSon
+func implicitlyDiscardable(n: PNode): bool =
+  ## true if a node, `n`, is implicitly discardable, meaning it's a control
+  ## flow ending statement in a block (`return`, `break`, `raise`, etc) or a
+  ## routine call to a routine type marked as `{.discardable.}`.
   result = n.kind in nkLastBlockStmts or
            (isCallExpr(n) and n[0].kind == nkSym and
            sfDiscardable in n[0].sym.flags)
@@ -130,24 +131,24 @@ proc discardCheck(c: PContext, n: PNode, flags: TExprFlags): PNode =
   if c.matchedConcept != nil or efInTypeof in flags: return
 
   if n.typ != nil and n.typ.kind notin {tyTyped, tyVoid}:
-    if implicitlyDiscardable(n):
+    var m = n
+    while m.kind in skipForDiscardable:
+      case m.kind
+      of nkTryStmt:
+        m =
+          case m[^1].kind
+          of nkFinally:
+            m[^2]
+          of nkExceptBranch:
+            m[^1]
+          of nkAllNodeKinds - {nkFinally, nkExceptBranch}:
+            unreachable()
+      else:
+        m = m.lastSon
+
+    if implicitlyDiscardable(m):
       result = newTreeI(nkDiscardStmt, n.info, n)
     elif n.typ.kind != tyError and c.config.cmd != cmdInteractive:
-      var m = n
-      while m.kind in skipForDiscardable:
-        case m.kind
-        of nkTryStmt:
-          m =
-            case m[^1].kind
-            of nkFinally:
-              m[^2]
-            of nkExceptBranch:
-              m[^1]
-            of nkAllNodeKinds - {nkFinally, nkExceptBranch}:
-              unreachable()
-        else:
-          m = m.lastSon
-
       result = newError(c.config, n,
         PAstDiag(kind: adSemUseOrDiscardExpr, undiscarded: m))
 

--- a/tests/lang_exprs/tdiscardcheck_try_discardable.nim
+++ b/tests/lang_exprs/tdiscardcheck_try_discardable.nim
@@ -1,0 +1,34 @@
+discard """
+  description: "Test to ensure discardable items are _not_ checked"
+"""
+
+block try_should_work_fine:
+  proc foo(): int {.discardable.} =
+    42
+
+  try:
+    foo()
+  finally:
+    discard
+
+block except_should_also_work:
+  proc foo(): int {.discardable.} =
+    42
+
+  try:
+    discard
+  except:
+    foo()
+  finally:
+    discard
+
+block finally_should_also_work:
+  proc foo(): int {.discardable.} =
+    42
+
+  try:
+    discard
+  except:
+    discard
+  finally:
+    foo()


### PR DESCRIPTION
## Summary

Routines marked with the  `discardable`  pragma are now correctly
discarded inside  `try` / `except` / `finally`  expressions.

## Details

Previously the  `discardCheck`  which handled this did not correctly
traverse  `nkTryStmt`  when checking for  `implicitlyDiscardable` 
expressions.

Along with fixing the traversal, such traversals in an error case are no
longer repeated. Instead the traversal is done once, and only once. The 
`implicitlyDiscardable`  procedure is now simplified to only examine the
input node and no longer attempt traversal, which is now the
responsibility of the caller.

In addition to the fix, a test case has been added to ensure that this
behaviour is preserved, see  `trydiscardcheck_try_discardable` .

Fixes https://github.com/nim-works/nimskull/issues/1178