### PR TITLE
fix(sem): type-less nodes crashing the compiler

### DIFF
--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1967,10 +1967,11 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
       # ``static type``
       rawAddSon(s.typ, newTypeS(tyNone, c))
       s.ast = a
-      inc c.inGenericContext
-      var body = semTypeNode(c, a[2], nil)
-      dec c.inGenericContext
-      if body != nil:
+      # magic type definitions are allowed to not have a body on the right
+      if s.magic == mNone or a[2].kind != nkEmpty:
+        inc c.inGenericContext
+        var body = semTypeNode(c, a[2], nil)
+        dec c.inGenericContext
         body.sym = s
         body.size = -1 # could not be computed properly
         s.typ[^1] = body

--- a/tests/lang_callable/macros/tempty_type_nodes.nim
+++ b/tests/lang_callable/macros/tempty_type_nodes.nim
@@ -1,0 +1,27 @@
+discard """
+  description: '''
+    Ensure that untyped `nnkEmpty` and `nnkType` nodes used in type positions
+    result in a proper error
+  '''
+  target: native
+  matrix: "--errorMax:100"
+  action: reject
+"""
+
+import std/macros
+
+macro test1(): untyped =
+  # test case #1: untyped ``nnkEmpty`` node in type position
+  nnkConv.newTree(newNimNode(nnkEmpty)): #[tt.Error
+                            ^ type expected, but expression has no type]#
+    newNimNode(nnkEmpty)
+
+test1()
+
+macro test2(): untyped =
+  # test case #2: untyped ``nnkType`` node in type position
+  nnkConv.newTree(newNimNode(nnkType)): #[tt.Error
+                            ^ type expected, but expression has no type]#
+    newNimNode(nnkEmpty)
+
+test2()


### PR DESCRIPTION
## Summary

Fix  `nkEmpty`  and  `nkType`  nodes without a type (which can be
created by a macro) appearing in some type contexts (such as the type of
a conversion) crashing the compiler. A "type expected" error is now
reported.

## Details

`semTypeNode`  assumed that both  `nkEmpty`  and  `nkType`  nodes have a
type assigned already, but this is not true for nodes created by macros.
If the caller of  `semTypeNode`  tried to access the returned type, an
NPE ensued.

It is now verified that both nodes have a type assigned, and if they do
not, a "type expected" user error is reported. An assertion is added to 
`semTypeNode`  to alert about erroneously missing types in the future.

There was one situation where an untyped  `nkEmpty`  node is legal: in
the body slot of a magic type definition such as 
`type set[T]{.magic: "Set".}` .  `typeSectionRightSidePass`  now detects
this case itself and doesn't call  `semTypeNode`  when the body slot
legally contains an  `nkEmpty`  node.