### PR TITLE
system: fix `sysFatal` having side effects

### DIFF
--- a/lib/system/fatal.nim
+++ b/lib/system/fatal.nim
@@ -29,7 +29,8 @@ elif defined(nimPanics) and not defined(nimscript) and not defined(vm):
       # TODO when doAssertRaises works in CT, add a test for it
       raise (ref exceptn)(msg: message & arg)
     else:
-      writeStackTrace()
+      {.cast(noSideEffect).}:
+        writeStackTrace()
       var buf = newStringOfCap(200)
       add(buf, "Error: unhandled exception: ")
       add(buf, message)
@@ -37,7 +38,8 @@ elif defined(nimPanics) and not defined(nimscript) and not defined(vm):
       add(buf, " [")
       add(buf, name exceptn)
       add(buf, "]\n")
-      cstderr.rawWrite buf
+      {.cast(noSideEffect).}:
+        cstderr.rawWrite buf
       quit 1
 
   proc sysFatal(exceptn: typedesc, message: string) {.inline, noreturn.} =

--- a/tests/misc/trange_check_with_panics.nim
+++ b/tests/misc/trange_check_with_panics.nim
@@ -1,0 +1,13 @@
+discard """
+  description: '''
+    Ensure that ``system.rangeCheck`` has no side-effects when panics are
+    enabled
+  '''
+  targets: native
+  action: compile
+  matrix: "--panics:on"
+"""
+
+proc f() {.noSideEffect.} =
+  # must compile
+  rangeCheck(true)


### PR DESCRIPTION
## Summary

Fix the internal `sysFatal` procedure having side-effects when panics
are enabled (`--panics:on`). Usage of procedures like `rangeCheck`
and `raiseInsert` within functions is no longer prevented.

This makes it possible to bootstrap the compiler with `--panics:on`.

## Details

When panics are enabled, the `sysFatal` procedure immediately
terminates the program (no exception is raised), so the access to
global state the implementation does perform shouldn't be treated
as side effects. The problematic side-effects within `sysFatal` are
now cast away.