### PR TITLE
fix(sem): return statements not being re-sem'ed

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2319,8 +2319,9 @@ proc semReturn(c: PContext, n: PNode): PNode =
     of nkAsgn:
       # the return was already analysed (and transformed)
       if e[0].kind == nkSym and e[0].sym.id == c.p.resultSym.id:
-        # it seems to be valid, we can keep it
-        n
+        # re-analyze the assignment; it might only be partially typed and
+        # coming from a macro
+        setAsgn(c, n, semAsgn(c, e))
       else:
         setAsgn(c, n):
           c.config.newError(e, PAstDiag(kind: adSemInvalidExpression))

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2297,9 +2297,9 @@ proc semReturn(c: PContext, n: PNode): PNode =
   addInNimDebugUtils(c.config, "semReturn", n, result)
   checkSonsLen(n, 1, c.config)
 
-  proc setAsgn(c: PContext, orig: PNode, asgn: PNode): PNode =
+  proc setAsgn(c: PContext, orig: PNode, asgn: PNode): PNode {.nimcall.} =
     result = shallowCopy(orig)
-    result.flags = n.flags
+    result.flags = orig.flags
     result[0] =
       if asgn.kind == nkError:
         asgn

--- a/tests/lang_callable/macros/tmodify_result_assignment.nim
+++ b/tests/lang_callable/macros/tmodify_result_assignment.nim
@@ -1,0 +1,26 @@
+discard """
+  description: '''
+    Partially typed ``nkReturnStmt`` AST is properly re-analyzed after macro
+    invocation
+  '''
+  errmsg: "got <string> but expected 'int'"
+  line: 26
+"""
+
+import std/macros
+
+macro modify(input: typed) =
+  let input = input[0]
+  input.expectKind nnkProcDef
+  input.body.expectKind nnkReturnStmt
+  input.body[0].expectKind nnkAsgn
+
+  result = copyNimTree input
+  # replace the right side of the assignment with an expression of different,
+  # incompatible type
+  result.body[0][1] = newStrLitNode("") # wrong type: int vs. string
+  result.body.copyLineInfo(input.body[0][1])
+
+modify:
+  proc p(): int =
+    return 0


### PR DESCRIPTION
## Summary

Return statements of the form
`(ReturnStmt (Asgn (Sym "result") (...)))` weren't re-analyzed and
validated again after macro expansion, allowing macros to create
potentially ill-formed AST that crashes the compiler. This is now
fixed.

## Details

* if the `result` symbol in the assignment is correct, the `nkAsgn` is
  analyzed again, instead of being passed through
* the `setVar` inner procedure unnecessarily allocated a closure. This
  is fixed and the procedure is explicitly marked as a `.nimcall`