### PR TITLE
don't emit header includes for unused imported globals

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1243,10 +1243,10 @@ proc genLocDef(c: var TCtx, n: PNode, val: PNode) =
     s = n.sym
     hasInitializer = val.kind != nkEmpty
     sink = sfCursor notin s.flags
-    node = nameNode(c, s)
+    kind = symbolToPmir(s)
 
   c.builder.useSource(c.sp, n)
-  if node.kind == mnkGlobal and c.scopeDepth == 1:
+  if kind == pirGlobal and c.scopeDepth == 1:
     # no 'def' statement is emitted for top-level globals
     if hasInitializer:
       genAsgn(c, true, sink, n, val)
@@ -1257,7 +1257,7 @@ proc genLocDef(c: var TCtx, n: PNode, val: PNode) =
       # the location doesn't have an explicit starting value. Initialize
       # it to the type's default value.
       c.buildStmt mnkInit:
-        c.add node
+        c.add nameNode(c, s)
         c.buildMagicCall mDefault, s.typ:
           discard
     else:
@@ -1265,7 +1265,7 @@ proc genLocDef(c: var TCtx, n: PNode, val: PNode) =
       discard
   else:
     c.buildStmt (if sfCursor in s.flags: mnkDefCursor else: mnkDef):
-      c.add node
+      c.add nameNode(c, s)
       if hasInitializer:
         genAsgnSource(c, val, sink)
       else:

--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -190,8 +190,8 @@ proc registerGlobals(stmts: seq[PNode], structs: var ModuleStructs) =
   ## the module level (within the module imperative body `stmts`).
 
   proc register(structs: var ModuleStructs, s: PSym, isTopLevel: bool) {.nimcall.} =
-    if sfCompileTime in s.flags:
-      # don't register compile-time globals with the module struct
+    if {sfCompileTime, sfImportc} * s.flags != {}:
+      # don't register compile-time or imported globals with the module struct
       discard
     elif s.kind == skTemp:
       # HACK: semantic analysis sometimes produces temporaries (it does so for

--- a/tests/lang/s05_pragmas/s01_interop/t05_unused_importc.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t05_unused_importc.nim
@@ -1,0 +1,18 @@
+discard """
+  description: '''
+    Let and var bindings for imported entities are only included in the
+    build if they're assigned to, read from, or have their address taken,
+    within code part of the final build
+  '''
+"""
+
+var a {.importc, header: "<doesnt_exist.h>".}: int
+let b {.importc, header: "<doesnt_exist2.h>".}: int
+
+# an initial assignment (e.g.: `` = 0``) would count as a usage and result in
+# a compiler error, since the headers are non-existent
+
+proc f() =
+  # while this is a usage of `a`, `f` is not part of the final build, so
+  # `a` is not pulled in
+  a = 1


### PR DESCRIPTION
## Summary

Imported globals are now only included in the build if they're used
anywhere in alive code, fixing C headers being unnecessarily pulled in
for them.

Closes https://github.com/nim-works/nimskull/issues/1190.
Closes https://github.com/nim-works/nimskull/issues/1125.

## Details

An imported 'let' or 'var' was so far added to the (logical) struct of
the module the global is part of, but this is wrong! The definition of
an imported global doesn't imply the definition of a location owned by
the NimSkull program, rather it makes an external name available with
the given name and type.

**Changes:**
- don't add globals to the module struct if they're marked with
  `sfImportc`
- introduce `symbolToPmir` for querying the PMIR/MIR kind of a symbol
  without adding it to the MIR environment (`nameNode` does this)
- change `mirgen.genLocDef` to only use `nameNode` (which registers the
  symbol with the environment) if the statement constitutes an
  assignment
- add a specification test for the new behaviour

Imported globals are now only registered with the MIR environment (and
subsequently have their definition/include emitted) when they're part
of the alive program.