### PR TITLE
rework the MIR (part 2)

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -401,21 +401,7 @@ proc produceFragmentsForGlobals(
       let global = env.globals.add(s)
       # generate the MIR code for an initializing assignment:
       prepare(init, result.init.source, graph.emptyNode)
-      init.setSource(result.init.source.add(it))
-      init.buildStmt mnkInit:
-        init.setSource(result.init.source.add(it[0]))
-        init.use toValue(global, s.typ)
-        init.setSource(result.init.source.add(it[2]))
-        if it[2].kind == nkEmpty:
-          # no explicit initializer expression means that the default value
-          # should be used
-          # XXX: ^^ it'd make sense to instead let semantic analysis ensure
-          #      this (i.e. by placing a ``default(T)`` in the initializer
-          #      slot)
-          init.buildMagicCall mDefault, s.typ:
-            discard
-        else:
-          generateCode(graph, env, config, it[2], init, result.init.source)
+      generateAssignment(graph, env, config, it, init, result.init.source)
 
       # if the global requires one, emit a destructor call into the deinit
       # fragment:

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -561,6 +561,7 @@ proc defToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
     arg = newOp(cnkHiddenAddr, info, def.typ, arg)
 
   let isLet = (entity.kind == mnkTemp and n.kind == mnkDefCursor) or
+              (entity.kind == mnkTemp and not hasDestructor(def.typ)) or
               (entity.kind == mnkAlias)
   # to reduce the pressure on the code generator, locals that never cross
   # structured control-flow boundaries are not lifted. As a temporary

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1215,7 +1215,7 @@ proc genAsgn(c: var TCtx, isFirst, sink: bool, lhs, rhs: PNode) =
     sink = sink and not isCursor(lhs)
 
   case rhs.kind
-  of ComplexExprs, nkStmtListExpr:
+  of ComplexExprs:
     # optimization: forward the destination. For example:
     #   x = if cond: a else: b
     # becomes:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -833,7 +833,7 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
   of mAnd, mOr:
     let tmp = getTemp(c, n.typ)
     withFront c.builder:
-      genAndOr(c, n, Destination(isSome: true, val: tmp))
+      genAndOr(c, n, Destination(isSome: true, val: tmp, flags: {dfOwns}))
     c.use tmp
   of mDefault:
     # use the canonical form:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1134,8 +1134,11 @@ proc genObjConstr(c: var TCtx, n: PNode, isConsume: bool) =
 proc genRaise(c: var TCtx, n: PNode) =
   assert n.kind == nkRaiseStmt
   if n[0].kind != nkEmpty:
-    let tmp = c.wrapTemp n[0].typ:
-      genx(c, n[0], consume=true)
+    # the raise operand slot is a sink context, and it behaves much like a
+    # ``sink`` parameter
+    var e = exprToPmir(c, n[0], true, false)
+    wantConsumeable(e)
+    let tmp = toValue(c, e, e.high)
 
     # emit the preparation code:
     let

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1349,9 +1349,13 @@ proc genVarTuple(c: var TCtx, n: PNode) =
       # generate the assignment:
       c.buildStmt (if isInit: mnkInit else: mnkAsgn):
         genOperand(c, lhs)
-        c.subTree MirNode(kind: mnkPathPos, typ: lhs.typ,
-                          position: i.uint32):
-          c.use val
+        # the temporary tuple is only used for unpacking; it can always be
+        # moved out of. The temporary tuple is not destroyed, so no
+        # destructive move is required
+        c.buildTree mnkMove, lhs.typ:
+          c.subTree MirNode(kind: mnkPathPos, typ: lhs.typ,
+                            position: i.uint32):
+            c.use val
 
 proc genVarSection(c: var TCtx, n: PNode) =
   for a in n:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1337,6 +1337,7 @@ proc genVarTuple(c: var TCtx, n: PNode) =
     let val = c.allocTemp(initExpr.typ)
     c.buildStmt mnkDefUnpack:
       c.use val
+      # ensure that the temporary owns the tuple value:
       genAsgnSource(c, initExpr, {dfEmpty, dfOwns})
 
     # generate the unpack logic:
@@ -1349,7 +1350,8 @@ proc genVarTuple(c: var TCtx, n: PNode) =
       # generate the assignment:
       c.buildStmt (if isInit: mnkInit else: mnkAsgn):
         genOperand(c, lhs)
-        # the temporary tuple is only used for unpacking; it can always be
+        # the temporary tuple is ensured to own (see the emission of the
+        # definition above), and it's only used for unpacking; it can always be
         # moved out of. The temporary tuple is not destroyed, so no
         # destructive move is required
         c.buildTree mnkMove, lhs.typ:

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -110,7 +110,7 @@ proc preventRvo(tree: MirTree, changes: var Changeset) =
   # we don't need to consider defs or initializing assignments (``mnkInit``)
   # here, because there it is guaranteed that the destination does not appear
   # anywhere in the source expression
-  for i in search(tree, {mnkFastAsgn, mnkAsgn}):
+  for i in search(tree, {mnkAsgn}):
     let source = tree.operand(i, 1)
     if tree[source].kind notin CallKinds or tree[source, 0].kind == mnkMagic or
        not eligibleForRvo(tree[source].typ):
@@ -159,9 +159,9 @@ proc preventRvo(tree: MirTree, changes: var Changeset) =
         tmp = bu.allocTemp(tree[source].typ)
         bu.use tmp
       changes.insert(tree, tree.sibling(i), i, bu):
-        bu.subTree tree[i].kind:
+        bu.subTree mnkAsgn:
           bu.emitFrom(tree, pos)
-          bu.use tmp
+          bu.move tmp
 
 proc lowerSwap(tree: MirTree, changes: var Changeset) =
   ## Lowers a ``swap(a, b)`` call into:

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -180,10 +180,10 @@ proc lowerSwap(tree: MirTree, changes: var Changeset) =
       let
         a = bu.bindMut(tree, NodePosition tree.argument(i, 0))
         b = bu.bindMut(tree, NodePosition tree.argument(i, 1))
-        temp = bu.materialize(a)
+        temp = bu.materializeMove(a)
       # we're just swapping the values, no full copy is needed
-      bu.asgn a, b
-      bu.asgn b, temp
+      bu.asgnMove a, b
+      bu.asgnMove b, temp
 
 proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
   ## Where safe (i.e., observable program behaviour does not change), elides

--- a/compiler/mir/proto_mir.nim
+++ b/compiler/mir/proto_mir.nim
@@ -345,7 +345,7 @@ func ownershipOp(e: seq[ProtoItem], i: int): ProtoItemKind =
 
 func wantOwning*(e: var seq[ProtoItem], forceTemp: bool) =
   ## Makes sure `e` produces an owning value. If `forceTemp` is true, a
-  ## temporary is materialized even if the expression would already produces
+  ## temporary is materialized even if the expression would already produce
   ## an owning value.
   case classify(e, e.high)
   of Rvalue:
@@ -362,7 +362,7 @@ func wantOwning*(e: var seq[ProtoItem], forceTemp: bool) =
       e.add pirMove
     of pirComplex:
       # watch out! try-finally expressions can have exceptional control-flow
-      # that forces the destination temporary to have be destroyed in a
+      # that forces the destination temporary to have to be destroyed in a
       # finalizer. A destructive move is required
       e.add pirMat
       e.add pirDestructiveMove

--- a/compiler/mir/proto_mir.nim
+++ b/compiler/mir/proto_mir.nim
@@ -294,7 +294,7 @@ func isStable(e: seq[ProtoItem], n: int): bool =
 func ownershipOp(e: seq[ProtoItem], i: int): ProtoItemKind =
   ## Infers and returns the best fitting operation to retrieve an owning
   ## value from the given *lvalue*.
-  proc decayMove(kind: ProtoItemKind): ProtoItemKind {.inline.} =
+  func decayMove(kind: ProtoItemKind): ProtoItemKind {.inline.} =
     # moving from a projection requires a destructive move, since the source
     # location needs to be destroyed after (in order to free the non-moved
     # parts)

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -332,6 +332,15 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, env: EnvPtr) =
                    mnkMul: " * ", mnkDiv: " div ", mnkModI: " mod "]
       result.add Map[kind]
       valueToStr() # second operand
+  of mnkCopy:
+    tree "copy ":
+      valueToStr()
+  of mnkMove:
+    tree "move ":
+      valueToStr()
+  of mnkSink:
+    tree "sink ":
+      valueToStr()
   else:
     # TODO: make this branch exhaustive
     result.add "<error: " & $nodes[i].kind & ">"
@@ -411,12 +420,6 @@ proc stmtToStr(nodes: MirTree, i: var int, indent: int, result: var string,
     tree "":
       valueToStr()
       result.add " := "
-      exprToStr()
-    result.add "\n"
-  of mnkFastAsgn:
-    tree "":
-      valueToStr()
-      result.add " =fast "
       exprToStr()
     result.add "\n"
   of mnkStmtList:

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -28,19 +28,18 @@
 ##          Except for thread-local variables, the others are destroyed at the
 ##          end of the program.
 ##
-## ``solveOwnership`` then computes for all lvalue expression appearing in
-## consume (e.g., argument to ``sink`` parameter) or sink contexts (source
-## lvalue in an assignment).
+## ``collapseSink`` then computes for all lvalue expression appearing as
+## source operands to sink assignments whether it's the last use of the
+## value currently stored in the location identified by the lvalue. All sinks
+## where this is the case are remembered, and their corresponding data-flow
+## operation is turned from a 'use' into a 'consume'.
 ##
-## Using the now resolved ownership status of all expressions, the next
-## analysis step computes which locations need to be destroyed via a destructor
-## call (see ``computeDestructors``).
+## With all sink assignments either collapsed into copy or move assignments,
+## the next analysis step computes which locations need to be destroyed via a
+## destructor call (see ``computeDestructors``).
 ##
 ## As the last step, the assignment rewriting and destructor injection is
 ## performed, using the previously gathered data.
-##
-## For the assignment rewriting, if the source operand of an assignment is
-## owned, a move is used instead of a copy.
 ##
 ## Ownership analysis
 ## ==================

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -598,6 +598,14 @@ func find*(dfg: DataFlowGraph, n: NodePosition): InstrPos =
   ## attached-to node position) operation is returned.
   lowerBound(dfg, n)
 
+func change*(dfg: var DataFlowGraph, instrs: openArray[InstrPos],
+             to: Opcode) =
+  ## Changes all data-flow instructions identified by `instrs` to use the
+  ## `to` opcode.
+  for it in instrs.items:
+    assert dfg.instructions[it].op in DataFlowOps
+    dfg.instructions[it].op = to
+
 iterator instructions*(dfg: DataFlowGraph): (InstrPos, Opcode, OpValue) =
   ## Returns all data-flow operations in order of appearance together with
   ## their position.

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -110,7 +110,14 @@ Semantics
                                          # at the upper bound (inclusive, third
                                          # parameter)
 
-  FULL_VALUE = RVALUE | VALUE
+  ASGN_SRC = RVALUE
+           | VALUE
+           | Copy VALUE
+           | Move LVALUE
+           | Sink LVALUE
+
+  SHALLOW_SRC = RVALUE
+              | VALUE
 
   STATEMENT =
             | StmtList STATEMENT ...    # a list of statements
@@ -118,10 +125,10 @@ Semantics
                                         # delimits the lifetime of all
                                         # definitions within
             | Def NAME none             # definition
-            | Def NAME FULL_VALUE       # definition + initial value assignment
+            | Def NAME ASGN_SRC         # definition + initial value assignment
             | DefCursor NAME            # definition of non-owning location
-            | DefCursor NAME FULL_VALUE # same as above, but with initial
-                                        # assignment
+            | DefCursor NAME SHALLOW_SRC# definition of non-owning location +
+                                        # initial (shallow copy) assignment
             | Bind <Alias> LVALUE       # bind the lvalue to the given alias.
                                         # May be used for mutation, but must
                                         # not be used as an assignment's
@@ -136,13 +143,11 @@ Semantics
             | Void CALL_EXPR            # represents a void call. The called
                                         # procedure or magic *must* have a
                                         # `void`` return type
-            | Asgn LVALUE FULL_VALUE    # normal assignment of the right value
+            | Asgn LVALUE ASGN_SRC      # normal assignment of the right value
                                         # to the left location
-            | Init LVALUE FULL_VALUE    # initial assignment (the destination
+            | Init LVALUE ASGN_SRC      # initial assignment (the destination
                                         # is empty)
-            | FastAsgn LVALUE FULL_VALUE# fast assignment (cannot be rewritten
-                                        # into a full copy)
-            | Switch LVALUE FULL_VALUE  # changes the active branch of a
+            | Switch LVALUE ASGN_SRC    # changes the active branch of a
                                         # variant. Unclear semantics.
             | If VALUE STATEMENT        # if the value evaluates to true
                                         # execute the statement

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -9,10 +9,10 @@ scope:
     block L0:
       if cond:
         scope:
-          x =fast <D1>
+          x = <D1>
           break L0
       scope:
-        x =fast <D2>
+        x = <D2>
     def_cursor _0: (string, int) = x
     def _1: string = $(arg _0) (raises)
     echo(arg type(array[0..0, string]), arg _1) (raises)
@@ -35,8 +35,8 @@ scope:
               while true:
                 scope:
                   def_cursor _1: File = f
-                  def_cursor _2: bool = readLine(arg _1, name res) (raises)
-                  def_cursor _3: bool = not(arg _2)
+                  def _2: bool = readLine(arg _1, name res) (raises)
+                  def _3: bool = not(arg _2)
                   if _3:
                     scope:
                       break L0

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -14,16 +14,17 @@ doing shady stuff...
 
 scope:
   def splat: tuple[dir: string, name: string, ext: string] = splitFile(arg path) (raises)
-  bind_mut _3: string = splat.0
-  def _0: string = _3
-  wasMoved(name _3)
-  bind_mut _4: string = splat.1
-  def _1: string = _4
+  bind_mut _4: string = splat.0
+  def _0: string = move _4
   wasMoved(name _4)
-  bind_mut _5: string = splat.2
-  def _2: string = _5
+  bind_mut _5: string = splat.1
+  def _1: string = move _5
   wasMoved(name _5)
-  result = construct (consume _0, consume _1, consume _2)
+  bind_mut _6: string = splat.2
+  def _2: string = move _6
+  wasMoved(name _6)
+  def _3: Target = construct (consume _0, consume _1, consume _2)
+  result = move _3
   =destroy(name splat)
 -- end of expandArc ------------------------
 --expandArc: delete
@@ -55,15 +56,16 @@ scope:
   def lresult: seq[int] = arrToSeq(consume _0)
   def lvalue: seq[int]
   def lnext: string
-  def _1: seq[int] = lresult
+  def _1: seq[int] = move lresult
   def _: (seq[int], string) = construct (consume _1, consume ";")
-  bind_mut _2: seq[int] = _.0
-  lvalue = _2
-  wasMoved(name _2)
-  bind_mut _3: string = _.1
-  lnext = _3
+  bind_mut _3: seq[int] = _.0
+  lvalue = move _3
   wasMoved(name _3)
-  result.value = move(name lvalue)
+  bind_mut _4: string = _.1
+  lnext = move _4
+  wasMoved(name _4)
+  def _2: seq[int] = move(name lvalue)
+  result.value = move _2
   =destroy(name _)
   =destroy(name lnext)
   =destroy(name lvalue)
@@ -102,8 +104,8 @@ scope:
           while true:
             scope:
               def_cursor _1: int = i
-              def_cursor _2: bool = ltI(arg _1, arg L)
-              def_cursor _3: bool = not(arg _2)
+              def _2: bool = ltI(arg _1, arg L)
+              def _3: bool = not(arg _2)
               if _3:
                 scope:
                   break L0
@@ -115,7 +117,7 @@ scope:
                     def_cursor _5: string = line[]
                     def splitted: seq[string] = split(arg _5, arg " ", arg -1) (raises)
                     def_cursor _6: string = splitted[0]
-                    def_cursor _7: bool = eqStr(arg _6, arg "opt")
+                    def _7: bool = eqStr(arg _6, arg "opt")
                     if _7:
                       scope:
                         def _10: string = splitted[1]
@@ -148,8 +150,8 @@ scope:
           while true:
             scope:
               def_cursor _2: int = i
-              def_cursor _3: bool = ltI(arg _2, arg L)
-              def_cursor _4: bool = not(arg _3)
+              def _3: bool = ltI(arg _2, arg L)
+              def _4: bool = not(arg _3)
               if _4:
                 scope:
                   break L0
@@ -171,15 +173,15 @@ scope:
   try:
     def x: sink string
     def_cursor _0: sink string = x
-    def_cursor _1: int = lengthStr(arg _0)
-    def_cursor _2: bool = eqI(arg _1, arg 2)
+    def _1: int = lengthStr(arg _0)
+    def _2: bool = eqI(arg _1, arg 2)
     if _2:
       scope:
-        result = x
+        result = move x
         wasMoved(name x)
         return
     def_cursor _3: sink string = x
-    def_cursor _4: int = lengthStr(arg _3)
+    def _4: int = lengthStr(arg _3)
     def _5: string = $(arg _4) (raises)
     echo(arg type(array[0..0, string]), arg _5) (raises)
   finally:
@@ -196,12 +198,12 @@ scope:
     def _1: tuple[dir: string, front: string]
     block L0:
       def_cursor _2: string = this[].value
-      def_cursor _3: bool = dirExists(arg _2) (raises)
+      def _3: bool = dirExists(arg _2) (raises)
       if _3:
         scope:
           def _4: string
-          def _14: string = this[].value
-          =copy(name _4, arg _14)
+          def _16: string = this[].value
+          =copy(name _4, arg _16)
           _1 := construct (consume _4, consume "")
           break L0
       scope:
@@ -209,33 +211,33 @@ scope:
           def_cursor _5: string = this[].value
           def _6: string = parentDir(arg _5) (raises)
           def _7: string
-          def _15: string = this[].value
-          =copy(name _7, arg _15)
+          def _17: string = this[].value
+          =copy(name _7, arg _17)
           def _8: tuple[head: string, tail: string] = splitPath(consume _7) (raises)
-          bind_mut _16: string = _8.1
-          def _9: string = _16
-          wasMoved(name _16)
+          bind_mut _18: string = _8.1
+          def _9: string = move _18
+          wasMoved(name _18)
           _1 := construct (consume _6, consume _9)
           wasMoved(name _6)
         finally:
           =destroy(name _8)
           =destroy(name _6)
-    def par: tuple[dir: string, front: string] = _1
+    def par: tuple[dir: string, front: string] = move _1
     block L1:
       def_cursor _10: string = par.0
-      def_cursor _11: bool = dirExists(arg _10) (raises)
+      def _11: bool = dirExists(arg _10) (raises)
       if _11:
         scope:
           def_cursor _12: string = par.0
           def_cursor _13: string = par.1
-          def _17: seq[string] = getSubDirs(arg _12, arg _13) (raises)
-          bind_mut _18: seq[string] = this[].matchDirs
-          =sink(name _18, arg _17)
+          def _14: seq[string] = getSubDirs(arg _12, arg _13) (raises)
+          bind_mut _19: seq[string] = this[].matchDirs
+          =sink(name _19, arg _14)
           break L1
       scope:
-        def _19: seq[string] = construct ()
+        def _15: seq[string] = construct ()
         bind_mut _20: seq[string] = this[].matchDirs
-        =sink(name _20, arg _19)
+        =sink(name _20, arg _15)
   finally:
     =destroy(name par)
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -10,9 +10,9 @@ scope:
       while true:
         scope:
           def_cursor _0: Node = it
-          def_cursor _1: bool = eqRef(arg _0, arg nil)
-          def_cursor _2: bool = not(arg _1)
-          def_cursor _3: bool = not(arg _2)
+          def _1: bool = eqRef(arg _0, arg nil)
+          def _2: bool = not(arg _1)
+          def _3: bool = not(arg _2)
           if _3:
             scope:
               break L0
@@ -21,16 +21,16 @@ scope:
             def_cursor _5: string = _4[].s
             echo(arg type(array[0..0, string]), arg _5) (raises)
             def_cursor _6: Node = it
-            it =fast _6[].ri
+            it = _6[].ri
   def_cursor jt: Node = root
   block L1:
     scope:
       while true:
         scope:
           def_cursor _7: Node = jt
-          def_cursor _8: bool = eqRef(arg _7, arg nil)
-          def_cursor _9: bool = not(arg _8)
-          def_cursor _10: bool = not(arg _9)
+          def _8: bool = eqRef(arg _7, arg nil)
+          def _9: bool = not(arg _8)
+          def _10: bool = not(arg _9)
           if _10:
             scope:
               break L1
@@ -40,7 +40,7 @@ scope:
             def_cursor _12: Node = jt
             def_cursor _13: string = _12[].s
             echo(arg type(array[0..0, string]), arg _13) (raises)
-            jt =fast ri
+            jt = ri
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -10,11 +10,11 @@ scope:
   block L0:
     if cond:
       scope:
-        def _0: seq[int] = x
+        def _0: seq[int] = move x
         add(name a, consume _0)
         break L0
     scope:
-      def _1: seq[int] = x
+      def _1: seq[int] = move x
       add(name b, consume _1)
   =destroy(name b)
   =destroy(name a)
@@ -29,21 +29,21 @@ scope:
     scope:
       def a: int = 0
       def b: int = 4
-      def i: int = a
+      def i: int = sink a
       block L0:
         scope:
           while true:
             scope:
               def_cursor _0: int = i
-              def_cursor _1: bool = ltI(arg _0, arg b)
-              def_cursor _2: bool = not(arg _1)
+              def _1: bool = ltI(arg _0, arg b)
+              def _2: bool = not(arg _1)
               if _2:
                 scope:
                   break L0
               scope:
                 scope:
                   def_cursor i: int = i
-                  def_cursor _3: bool = eqI(arg i, arg 2)
+                  def _3: bool = eqI(arg i, arg 2)
                   if _3:
                     scope:
                       return
@@ -54,12 +54,12 @@ scope:
     block L1:
       if cond:
         scope:
-          def _5: seq[int] = x
+          def _5: seq[int] = move x
           wasMoved(name x)
           add(name a, consume _5)
           break L1
       scope:
-        def _6: seq[int] = x
+        def _6: seq[int] = move x
         wasMoved(name x)
         add(name b, consume _6)
   finally:
@@ -75,11 +75,12 @@ scope:
     if cond:
       scope:
         return
-    str = boolToStr(arg cond)
-    def_cursor _0: bool = not(arg cond)
-    if _0:
+    def _0: string = boolToStr(arg cond)
+    str = move _0
+    def _1: bool = not(arg cond)
+    if _1:
       scope:
-        result = str
+        result = move str
         wasMoved(name str)
         return
   finally:

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -9,10 +9,10 @@ scope:
   try:
     def _0: string = newString(arg 100)
     def_cursor _1: seq[byte] = cast _0
-    def_cursor _2: openArray[byte] = toOpenArray _1
+    def _2: openArray[byte] = toOpenArray _1
     def _3: seq[byte] = encode(arg _2) (raises)
+    def_cursor _4: string = cast _3
     def data: string
-    def _4: string = cast _3
     =copy(name data, arg _4)
   finally:
     =destroy(name data)
@@ -24,13 +24,13 @@ scope:
   try:
     def s: string = newString(arg 100)
     def_cursor _0: string = s
-    def_cursor _1: int = lengthStr(arg _0)
-    def_cursor _2: int = subI(arg _1, arg 1) (raises)
+    def _1: int = lengthStr(arg _0)
+    def _2: int = subI(arg _1, arg 1) (raises)
     chckBounds(arg s, arg 0, arg _2) (raises)
-    def_cursor _3: openArray[byte] = toOpenArray s, 0, _2
+    def _3: openArray[byte] = toOpenArray s, 0, _2
     def _4: seq[byte] = encode(arg _3) (raises)
+    def_cursor _5: string = cast _4
     def data: string
-    def _5: string = cast _4
     =copy(name data, arg _5)
   finally:
     =destroy(name data)
@@ -41,10 +41,10 @@ scope:
 scope:
   try:
     def s: seq[byte] = newSeq(arg 100) (raises)
-    def_cursor _0: openArray[byte] = toOpenArray s
+    def _0: openArray[byte] = toOpenArray s
     def _1: seq[byte] = encode(arg _0) (raises)
+    def_cursor _2: string = cast _1
     def data: string
-    def _2: string = cast _1
     =copy(name data, arg _2)
   finally:
     =destroy(name data)
@@ -55,10 +55,10 @@ scope:
 scope:
   try:
     def _0: seq[byte] = newSeq(arg 100) (raises)
-    def_cursor _1: openArray[byte] = toOpenArray _0
+    def _1: openArray[byte] = toOpenArray _0
     def _2: seq[byte] = encode(arg _1) (raises)
+    def_cursor _3: string = cast _2
     def data: string
-    def _3: string = cast _2
     =copy(name data, arg _3)
   finally:
     =destroy(name data)

--- a/tests/misc/tdont_fold_procedure_cast.nim
+++ b/tests/misc/tdont_fold_procedure_cast.nim
@@ -8,9 +8,10 @@ discard """
   nimout: '''
 --expandArc: test
 scope:
-  def p: proc (x: float){.nimcall.} = cast other
-  def_cursor _0: proc (x: int){.nimcall.} = cast p
-  _0(arg 1) (raises)
+  def_cursor _0: proc (x: float){.nimcall.} = cast other
+  def p: proc (x: float){.nimcall.} = copy _0
+  def_cursor _1: proc (x: int){.nimcall.} = cast p
+  _1(arg 1) (raises)
 -- end of expandArc ------------------------
   '''
   output: "1"


### PR DESCRIPTION


## Summary

This introduces the `copy`, `move`, and `sink` *assignment modifiers*,
which make it explicit where and how ownership is transferred with
assignments. An assignment with an lvalue expression as the source
operand and no modifier is a *shallow copy*, replacing the need for
`fastAsgn`. Previously, the exact semantics of an assignment where an
implicit property of every assignment.

Besides slightly simplifying the `injectdestructors` pass and data-flow
graph construction, the semantics of assignments being properly encoded
in the MIR is a pre-requisite for many MIR-based optimization passes.
More generally, it's a significant step towards decoupling value
ownership semantics from lifetime hooks.

Semantics of existing code don't (intentionally) change, this is an
internal-only rework.

## Details

### MIR

* the `mnkCopy`, `mnkMove`, and `mnkSink` nodes are added, representing
  the modifiers. Syntax-wise, they may only appear directly in
  assignment source slots
* the `mnkFastAsgn` node is obsolete and removed
* `copy` and `move` assignments are *final* . That is, a `copy`
  assignment cannot become a `move` assignment, and the inverse is also
  not possible
* only `sink` assignments are non-final. Collapsing them into either a
  `copy` or `move` assignment is the focus of the move analyzer

### AST-to-MIR Translation

`mirgen` performs the initial placement of assignment modifier, using a
proto-MIR-based analysis. The decision-making works as follows:
1. when the destination is owning (i.e., all non-`.cursor` locals/
   globals/fields):
	1. if a non-destructive move is definitely possible, `move` is used
	2. if a move is never possible (e.g., because the source is a
     cursor), `copy` is used
	3. if whether a move is possible depends on a data-flow analysis,
     `sink` is used
	4. if a destructive move is possible, `sink` is used
	5. if the source expression is an rvalue expression returning an
     owning value (e.g., a call, a construction, etc.), and the
     assignment is an initial assignment, an in-place assignment is
     used
	6. for types with custom copy/sink/destroy behaviour, and non-initial
     assignments, the rvalue is first assigned to a temporary and then
     `move`d into the destination
2. when the destination is non-owning, no modifier is used

Except for the rule 1.6, placement of the modifiers is independent on
whether lifetime hooks are involved. 

In addition, all rvalue expressions (except for `cast`) are now treated
as returning *owning* values. What this means, in effect, is that
temporaries now properly use `def` instead of `def_cursor`. As the
moment, whether `def` or `def_cursor` is used for non-lifetime-hook
using types has no practical effect, but the new behaviour is
technically correct, while the previous one was not.

### Move Analyzer

Operation of the move analyzer changes slightly: instead of looking for
all `opConsume` data-flow instructions, it only looks for those
corresponding to `sink` assignments. Since whether a move or copy is
used is only relevant for lifetime-hook-using types, the `isLastRead`
analysis continues to only be performed for assignments of those types.

Compared to before, the DFG is now updated with the move analyzer
results, removing the need to pass them to each of the following
analysis routine.

### Assignment Rewriting

Rewriting of assignment now only looks for assignments with modifiers,
all assignments without a modifier are ignored. `move`s are exclusively
turned into `=sink` calls (never destructive moves), `copy`s into
`=copy`. `sink` is either turned into a copy, move, or destructive
move. Only the implementation is different, effective program behaviour
doesn't change.

### MIR-to-CGIR Translation

* `move` assignments and *shallow copy* assignments are translated to
  `cnkFastAsgn`
* all other assignments translate to `cnkAsgn`
* the small optimization preventing definitions being moved to the
  start of their scope is expanded to also apply to `def`s of
  temporaries without lifetime hooks, now that `def` is used for
  temporaries more often