### PR TITLE
cgen: fix undefined behaviour with object conversion 

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1943,10 +1943,15 @@ proc upConv(p: BProc, n: CgNode, d: var TLoc) =
                 a.storage)
     # an indirection is used:
     d.flags.incl lfIndirect
+  elif isRef:
+    # using ``&(x->Sup)`` is undefined behaviour when x is null, so the
+    # pointer has to be cast instead
+    putIntoDest(p, d, n,
+                "(($1) ($2))" % [getTypeDesc(p.module, n.typ), rdLoc(a)])
   else:
-    var r = rdLoc(a) & (if isRef: "->Sup" else: ".Sup")
+    var r = rdLoc(a) & ".Sup"
     for i in 2..inheritanceDiff(src, dest): r.add(".Sup")
-    putIntoDest(p, d, n, if isRef: "&" & r else: r, a.storage)
+    putIntoDest(p, d, n, r, a.storage)
 
 proc useConst*(m: BModule; id: ConstId) =
   let sym = m.g.env[id]


### PR DESCRIPTION
## Summary

Fix up-conversions of `nil` `ref object` or `ptr object` values
invoking undefined behaviour at the C level.

Fixes https://github.com/nim-works/nimskull/issues/1193.

## Details

Up conversions of pointers or `ref`s were translated into a
dereference + address-of sequence (e.g., `&a->Sup`), which invokes UB
if the pointer is null.

Instead, the pointer is now directly cast to the super type. According
to the C89 standard (6.5.2.1 "Structure and union specifiers"), "A
pointer to a structure object, suitably converted, points to its
initial member", so this cast is legal.