### PR TITLE
fix wrong signed-ness for floats in constants

### DIFF
--- a/tests/compiler/tdatatables.nim
+++ b/tests/compiler/tdatatables.nim
@@ -37,8 +37,7 @@ block tree_equality:
     @[node(mnkLiteral, t1, lit, newStrNode(nkStrLit, "a"))],
     @[node(mnkLiteral, t1, lit, newFloatNode(nkFloatLit, 0.0))],
     # 0.0 and -0.0 are different float values
-    # FIXME: doesn't work yet
-    #@[node(mnkLiteral, t1, lit, newFloatNode(nkFloatLit, -0.0))],
+    @[node(mnkLiteral, t1, lit, newFloatNode(nkFloatLit, -0.0))],
 
     # --- ordered aggregates
     @[node(mnkConstr, t1, len, 0), node(mnkEnd)],


### PR DESCRIPTION
## Summary

Fix the sign of `0.0` float values being inverted in implicit or
explicit constant expression. All backends were affected, but the
issue only surfaced seemingly at random.

## Details

`datatables` used `exprStructuralEquivalent`, which treats `0.0` as
being equal to `-0.0`, for comparing nodes storing literal values.
Since the hashing procedure for nodes hashed the float values' bit-
representation, the problem only surfaced in case of hash or bucket
collision.

A dedicated comparison procedure that compares the bit-representations
of float values is now used, fixing the issue.