### PR TITLE
mir: separate hook injection from move analyzer

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -23,6 +23,7 @@ import
   ],
   compiler/mir/[
     datatables,
+    injecthooks,
     mirbodies,
     mirbridge,
     mirconstr,
@@ -327,6 +328,7 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
   ## procedure.
   if shouldInjectDestructorCalls(prc):
     injectDestructorCalls(graph, idgen, env, prc, body)
+    injectHooks(body, graph, env, prc)
 
     if graph.config.arcToExpand.hasKey(prc.name.s):
       graph.config.msgWrite("--expandArc: " & prc.name.s & "\n")

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -4,6 +4,7 @@ import
   std/[
     deques,
     dynlib, # for computing possible candidate names
+    strtabs,
     tables
   ],
   compiler/ast/[
@@ -17,6 +18,7 @@ import
     cgirgen
   ],
   compiler/front/[
+    msgs,
     options
   ],
   compiler/mir/[
@@ -28,7 +30,8 @@ import
     mirgen,
     mirpasses,
     mirtrees,
-    sourcemaps
+    sourcemaps,
+    utils
   ],
   compiler/modules/[
     modulegraphs,
@@ -324,6 +327,11 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
   ## procedure.
   if shouldInjectDestructorCalls(prc):
     injectDestructorCalls(graph, idgen, env, prc, body)
+
+    if graph.config.arcToExpand.hasKey(prc.name.s):
+      graph.config.msgWrite("--expandArc: " & prc.name.s & "\n")
+      graph.config.msgWrite(render(body.code, addr env))
+      graph.config.msgWrite("\n-- end of expandArc ------------------------\n")
 
   let target =
     case graph.config.backend

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -193,7 +193,7 @@ proc injectHooks*(body: MirBody, graph: ModuleGraph, env: var MirEnv,
         # with:
         #   def_cursor _1 = a.b
         #   =copy(name x, arg _1)
-        # XXX: the temporary could be emitted in more cases by using proper
+        # XXX: the temporary could be omitted in more cases by using proper
         #      alias analysis
         changes.replaceMulti(tree, stmt, bu):
           let tmp = bu.inline(tree, src)

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -1,0 +1,259 @@
+## Implements the MIR pass for replacing copy and move assignments with the
+## ``=copy`` or ``=sink`` hook (if available for the type).
+##
+## Future direction: injection of ``=destroy`` hooks also needs to happen
+## here.
+
+import
+  compiler/ast/[
+    ast_query,
+    ast_types,
+    lineinfos
+  ],
+  compiler/front/[
+    msgs,
+    options
+  ],
+  compiler/mir/[
+    mirbodies,
+    mirchangesets,
+    mirconstr,
+    mirenv,
+    mirtrees
+  ],
+  compiler/modules/[
+    modulegraphs
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+# XXX: reports are a code smell meaning data types are misplaced
+from compiler/ast/reports_sem import SemReport
+from compiler/ast/report_enums import ReportKind
+
+# XXX: temporary dependency until destroy hooks are injected here
+from compiler/sem/injectdestructors import getOp, genDestroy, buildVoidCall
+
+from compiler/sem/liftdestructors import boolLit, cyclicType
+
+type
+  LocalDiagKind = enum
+    ldkPassCopyToSink       ## a copy is introduced in a consume context
+    ldkUnavailableTypeBound ## a type-bound operator is requested but not
+                            ## available
+
+  LocalDiag = object
+    ## A temporary diagnostic representation that is later turned into a
+    ## ``SemReport``
+    pos: NodePosition ## the location of the report
+    case kind: LocalDiagKind
+    of ldkUnavailableTypeBound:
+      op: TTypeAttachedOp
+    of ldkPassCopyToSink:
+      discard
+
+const
+  skipAliases = {tyGenericInst, tyAlias, tySink}
+
+proc isUsedForSink(tree: MirTree, stmt: NodePosition): bool =
+  ## Computes whether the definition statement is something produced for
+  ## sink parameter handling.
+  assert tree[stmt].kind in {mnkDef, mnkDefUnpack}
+  let def = tree.operand(stmt, 0)
+  if tree[def].kind != mnkTemp:
+    # only temporaries are used for sink handling
+    return
+
+  # look for whether the temporary is used as a 'consume' node's operand,
+  # but do reduce the amount of work by not searching beyond the
+  # temporary's lifetime
+  # HACK: this detection relies on the code shapes ``mirgen`` currently
+  #       emits for sink parameters and is thus very brittle. The proper
+  #       solution is to mark through a side channel the statement as being
+  #       generated for a sink parameter
+  var
+    n = tree.sibling(stmt)
+    depth = 0
+  while n < NodePosition tree.len:
+    case tree[n].kind
+    of mnkConsume:
+      let x = tree.operand(n)
+      if tree[x].kind == mnkTemp and tree[x].temp == tree[def].temp:
+        # the temporary is used for sink parameter passing
+        result = true
+        break
+    of mnkScope:
+      inc depth
+    of mnkEnd:
+      if tree[n].kind == mnkScope:
+        dec depth
+        if depth < 0:
+          # the end of the temporary's surrounding scope is reached
+          break
+    else:
+      discard
+
+    inc n
+
+proc reportDiagnostics(g: ModuleGraph, body: MirBody,
+                       owner: PSym, diags: var seq[LocalDiag]) =
+  ## Reports all diagnostics in `diags` as ``SemReport``s and clear the list
+  for diag in diags.items:
+    let ast = body.sourceFor(diag.pos)
+    let rep =
+      case diag.kind
+      of ldkUnavailableTypeBound:
+        SemReport(kind: rsemUnavailableTypeBound,
+                  typ: body[diag.pos].typ,
+                  str: AttachedOpToStr[diag.op],
+                  ast: ast,
+                  sym: owner)
+      of ldkPassCopyToSink:
+        SemReport(kind: rsemCopiesToSink, ast: ast)
+
+    localReport(g.config, ast.info, rep)
+
+func couldIntroduceCycle(tree: MirTree, dest: NodePosition): bool =
+  # copies to locals or globals can't introduce cyclic structures, as
+  # both are standlone and not part of any other structure
+  tree[dest].kind notin {mnkLocal, mnkTemp, mnkParam, mnkGlobal}
+
+template genCopy(bu: var MirBuilder, graph: ModuleGraph, env: var MirEnv,
+             op: PSym, tree: MirTree, dst: NodePosition,
+             maybeCyclic: bool, src: untyped) =
+  ## Emits a ``=copy`` hook call with `dst` and `src` as the arguments. If ORC
+  ## is enabled, an additional bool value is passed to the hook, informing
+  ## whether a reference cycle might be created at run-time.
+  bu.buildVoidCall(env, op):
+    bu.emitByName ekMutate:
+      bu.emitFrom(tree, dst)
+    bu.subTree mnkArg:
+      src
+
+    if graph.config.selectedGC == gcOrc and
+       cyclicType(tree[dst].typ.skipTypes(skipAliases + {tyDistinct}), graph):
+      # pass whether the copy can potentially introduce cycles as the third
+      # parameter:
+      let c = maybeCyclic and couldIntroduceCycle(tree, dest)
+      bu.emitByVal literal(boolLit(graph, unknownLineInfo, c))
+
+proc injectHooks*(body: MirBody, graph: ModuleGraph, env: var MirEnv,
+                  owner: PSym, changes: var Changeset) =
+  ## Replaces all copy and move assignments for locations with lifetime hooks
+  ## to the types' respective hook.
+  var diags: seq[LocalDiag]
+  template tree: MirTree = body.code
+
+  for i, n in tree.pairs:
+    case n.kind
+    of mnkCopy:
+      let
+        stmt = tree.parent(i)
+        typ  = tree[stmt, 0].typ
+
+      if not hasDestructor(typ):
+        # nothing to insert
+        continue
+
+      let
+        dest = tree.child(stmt, 0)
+        src  = tree.child(i, 0)
+        op   = getOp(graph, typ, attachedAsgn)
+
+      if sfError in op.flags:
+        # emit an error if the hook is not available, but still continue
+        diags.add LocalDiag(pos: src, kind: ldkUnavailableTypeBound,
+                            op: attachedAsgn)
+
+      if tree[stmt].kind == mnkDef and isUsedForSink(tree, stmt):
+        # emit a warning for copies-to-sink:
+        diags.add LocalDiag(pos: src, kind: ldkPassCopyToSink)
+
+      case tree[stmt].kind
+      of mnkDef, mnkDefUnpack:
+        # turn a ``def x = copy a.b`` into:
+        #   def x
+        #   =copy(name x, arg a.b)
+        changes.replace(tree, i): MirNode(kind: mnkNone)
+        changes.insert(tree, tree.sibling(stmt), i, bu):
+          # the destination is a local; the assignment thus cannot introduce a
+          # cycle
+          genCopy(bu, graph, env, op, tree, dest, false):
+            bu.emitFrom(tree, src)
+      of mnkInit:
+        # we know the destination cannot overlap with the source. Replace
+        # ``x := copy a.b`` with:
+        #   =copy(name x, arg a.b)
+        changes.replaceMulti(tree, stmt, bu):
+          genCopy(bu, graph, env, op, tree, dest, true):
+            bu.emitFrom(tree, src)
+      of mnkAsgn:
+        # the source and destination could overlap. Replace ``x = copy a.b``
+        # with:
+        #   def_cursor _1 = a.b
+        #   =copy(name x, arg _1)
+        # XXX: the temporary could be emitted in more cases by using proper
+        #      alias analysis
+        changes.replaceMulti(tree, stmt, bu):
+          let tmp = bu.inline(tree, src)
+          genCopy(bu, graph, env, op, tree, dest, true):
+            bu.use(tmp)
+      else:
+        unreachable(tree[stmt].kind)
+
+    of mnkMove:
+      let
+        stmt = tree.parent(i)
+        typ  = tree[stmt, 0].typ
+
+      if not hasDestructor(typ) or
+         tree[stmt].kind in {mnkDef, mnkDefUnpack, mnkInit}:
+        # nothing to do if:
+        # * the type has no hooks
+        # * it's guaranteed that there's no value in the destination
+        continue
+
+      let
+        dest = tree.child(stmt, 0)
+        src  = tree.child(i, 0)
+        op   = getOp(graph, typ, attachedSink)
+
+      # note: the move analyzer has to make sure that the source operand
+      # doesn't overlap with the destination, so no temporary for the source is
+      # needed
+      if op != nil:
+        # replace ``x = move a.b`` with:
+        #   =sink(name x, arg a.b)
+        changes.replaceMulti(tree, stmt, bu):
+          bu.buildVoidCall(env, op):
+            bu.subTree mnkName:
+              bu.subTree MirNode(kind: mnkTag, effect: ekMutate):
+                bu.emitFrom(tree, dest)
+            bu.subTree mnkArg:
+              bu.emitFrom(tree, src)
+      else:
+        # no sink hook exists, rewrite ``x.y = move a.b`` into:
+        #   bind_mut _1 = x.y
+        #   =destroy(name _1)
+        #   _1 = move a.b
+        var loc: Value
+        changes.insert(tree, stmt, dest, bu):
+          loc = bu.bindMut(tree, dest)
+          genDestroy(bu, graph, env, loc)
+        changes.replaceMulti(tree, dest, bu):
+          bu.use loc
+
+    else:
+      discard "nothing to do"
+
+  # turn the collected diagnostics into reports and report them:
+  reportDiagnostics(graph, body, owner, diags)
+
+proc injectHooks*(body: var MirBody, graph: ModuleGraph, env: var MirEnv,
+                  owner: PSym) =
+  ## Adapter for the legacy pass-application pipeline. Once possible, the pass
+  ## needs to be treated as just another MIR pass.
+  var c = initChangeset(body.code)
+  injectHooks(body, graph, env, owner, c)
+  apply(body.code, prepare(c))

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -352,10 +352,14 @@ func emitByVal*(bu: var MirBuilder, y: Value) =
   bu.subTree mnkArg:
     bu.use y
 
-func emitByName*(bu: var MirBuilder, val: Value, e: EffectKind) =
+template emitByName*(bu: var MirBuilder, e: EffectKind, body: untyped) =
   bu.subTree mnkName:
     bu.subTree MirNode(kind: mnkTag, effect: e):
-      bu.use val
+      body
+
+func emitByName*(bu: var MirBuilder, val: Value, e: EffectKind) =
+  bu.emitByName e:
+    bu.use val
 
 func move*(bu: var MirBuilder, val: Value) =
   ## Emits ``move val``.

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -379,17 +379,19 @@ func asgnMove*(bu: var MirBuilder, a, b: Value) =
     bu.move b
 
 func inline*(bu: var MirBuilder, tree: MirTree, fr: NodePosition): Value =
-  ## Inlines the operand for non-mutating use. This is meant to be used for
-  ## materialzing immutable arguments when inlining calls / expanding
+  ## Inlines the lvalue operand for non-mutating use. This is meant to be used
+  ## for materialzing immutable arguments when inlining calls / expanding
   ## assignments.
   case tree[fr].kind
   of Atoms:
     result = Value(node: tree[fr])
-  else:
+  of LvalueExprKinds - Atoms:
     result = allocTemp(bu, tree[fr].typ)
-    bu.subTree mnkDef:
+    bu.subTree mnkDefCursor:
       bu.use result
       bu.emitFrom(tree, fr)
+  else:
+    unreachable("can only inline lvalue-expression arguments")
 
 func bindImmutable*(bu: var MirBuilder, tree: MirTree,
                     lval: NodePosition): Value =

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -824,13 +824,15 @@ proc lowerBranchSwitch(bu: var MirBuilder, body: MirTree, graph: ModuleGraph,
     typ = body[target].field.typ
 
   assert body[target].kind == mnkPathVariant
+  assert body[stmt, 1].kind in ModifierNodes
 
   let
     a = bu.wrapMutAlias(typ):
       # bind the discriminator lvalue, not the variant lvalue
       bu.subTree MirNode(kind: mnkPathNamed, typ: typ, field: body[target].field):
         bu.emitFrom(body, NodePosition body.operand(target))
-    b = bu.inline(body, body.child(stmt, 1))
+    b = bu.wrapTemp typ:
+      bu.emitFrom(body, body.child(stmt, 1))
 
   # check if the object contains fields requiring destruction:
   if hasDestructor(objType):

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -102,7 +102,6 @@ import
     algorithm,
     hashes,
     packedsets,
-    strtabs,
     tables
   ],
   compiler/ast/[
@@ -117,16 +116,14 @@ import
     mirconstr,
     mirenv,
     mirtrees,
-    sourcemaps,
-    utils
+    sourcemaps
   ],
   compiler/modules/[
     magicsys,
     modulegraphs
   ],
   compiler/front/[
-    options,
-    msgs
+    options
   ],
   compiler/sem/[
     aliasanalysis,
@@ -1179,8 +1176,3 @@ proc injectDestructorCalls*(g: ModuleGraph, idgen: IdGenerator,
     injectDestructors(body.code, g, destructors, env, changes)
 
     apply(changes)
-
-  if g.config.arcToExpand.hasKey(owner.name.s):
-    g.config.msgWrite("--expandArc: " & owner.name.s & "\n")
-    g.config.msgWrite(render(body.code, addr env))
-    g.config.msgWrite("\n-- end of expandArc ------------------------\n")

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -644,7 +644,7 @@ proc specializeAsgn(tree: MirTree, ctx: AnalyseCtx, ar: AnalysisResults,
       # the assignment initializes the location
       c.changeTree(tree, stmt): MirNode(kind: mnkInit)
   else:
-    # it's a move or move already, so nothing to change there
+    # it's a move or copy already, so nothing to change there
     if tree[stmt].kind == mnkAsgn and
        not isAlive(tree, ctx.cfg, ar.entities[], destPath, pos):
       # the assignment initializes the location

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -24,7 +24,7 @@ scope:
   def _2: string = move _6
   wasMoved(name _6)
   def _3: Target = construct (consume _0, consume _1, consume _2)
-  result = move _3
+  result := move _3
   =destroy(name splat)
 -- end of expandArc ------------------------
 --expandArc: delete
@@ -33,20 +33,16 @@ scope:
   def_cursor _0: Node = target[]
   def_cursor _1: Node = _0[].parent
   def sibling: Node
-  def _6: Node = _1[].left
-  =copy(name sibling, arg _6) (raises)
+  =copy(name sibling, arg _1[].left) (raises)
   def_cursor _2: Node = sibling
   def saved: Node
-  def _7: Node = _2[].right
-  =copy(name saved, arg _7) (raises)
+  =copy(name saved, arg _2[].right) (raises)
   def_cursor _3: Node = sibling
   def_cursor _4: Node = saved
-  bind_mut _8: Node = _3[].right
-  def _9: Node = _4[].left
-  =copy(name _8, arg _9) (raises)
+  def_cursor _6: Node = _4[].left
+  =copy(name _3[].right, arg _6) (raises)
   def_cursor _5: Node = sibling
-  bind_mut _10: Node = _5[].parent
-  =sink(name _10, arg saved) (raises)
+  =sink(name _5[].parent, arg saved) (raises)
   =destroy(name sibling) (raises)
 -- end of expandArc ------------------------
 --expandArc: p1
@@ -59,13 +55,13 @@ scope:
   def _1: seq[int] = move lresult
   def _: (seq[int], string) = construct (consume _1, consume ";")
   bind_mut _3: seq[int] = _.0
-  lvalue = move _3
+  lvalue := move _3
   wasMoved(name _3)
   bind_mut _4: string = _.1
-  lnext = move _4
+  lnext := move _4
   wasMoved(name _4)
   def _2: seq[int] = move(name lvalue)
-  result.value = move _2
+  result.value := move _2
   =destroy(name _)
   =destroy(name lnext)
   =destroy(name lvalue)
@@ -76,11 +72,9 @@ scope:
   try:
     def_cursor it: KeyValue = x
     def _0: seq[int]
-    def _4: seq[int] = it.0
-    =copy(name _0, arg _4)
+    =copy(name _0, arg it.0)
     def _1: seq[int]
-    def _5: seq[int] = it.1
-    =copy(name _1, arg _5)
+    =copy(name _1, arg it.1)
     def a: (seq[int], seq[int]) = construct (consume _0, consume _1)
     def_cursor _2: (seq[int], seq[int]) = a
     def _3: string = $(arg _2) (raises)
@@ -120,7 +114,7 @@ scope:
                     def _7: bool = eqStr(arg _6, arg "opt")
                     if _7:
                       scope:
-                        def _10: string = splitted[1]
+                        def_cursor _10: string = splitted[1]
                         =copy(name lan_ip, arg _10)
                     def_cursor _8: string = lan_ip
                     echo(arg type(array[0..0, string]), arg _8) (raises)
@@ -136,8 +130,7 @@ scope:
 scope:
   try:
     def shadowScope: Scope
-    def _7: Scope = c[].currentScope
-    =copy(name shadowScope, arg _7) (raises)
+    =copy(name shadowScope, arg c[].currentScope) (raises)
     rawCloseScope(arg c) (raises)
     scope:
       def_cursor _0: Scope = shadowScope
@@ -160,8 +153,7 @@ scope:
                   def_cursor _5: int = i
                   def sym: lent Symbol = borrow a[_5]
                   def _6: Symbol
-                  def _8: Symbol = sym[]
-                  =copy(name _6, arg _8)
+                  =copy(name _6, arg sym[])
                   addInterfaceDecl(arg c, consume _6) (raises)
                 i = addI(arg i, arg 1) (raises)
   finally:
@@ -177,7 +169,7 @@ scope:
     def _2: bool = eqI(arg _1, arg 2)
     if _2:
       scope:
-        result = move x
+        result := move x
         wasMoved(name x)
         return
     def_cursor _3: sink string = x
@@ -202,8 +194,7 @@ scope:
       if _3:
         scope:
           def _4: string
-          def _16: string = this[].value
-          =copy(name _4, arg _16)
+          =copy(name _4, arg this[].value)
           _1 := construct (consume _4, consume "")
           break L0
       scope:
@@ -211,12 +202,11 @@ scope:
           def_cursor _5: string = this[].value
           def _6: string = parentDir(arg _5) (raises)
           def _7: string
-          def _17: string = this[].value
-          =copy(name _7, arg _17)
+          =copy(name _7, arg this[].value)
           def _8: tuple[head: string, tail: string] = splitPath(consume _7) (raises)
-          bind_mut _18: string = _8.1
-          def _9: string = move _18
-          wasMoved(name _18)
+          bind_mut _16: string = _8.1
+          def _9: string = move _16
+          wasMoved(name _16)
           _1 := construct (consume _6, consume _9)
           wasMoved(name _6)
         finally:
@@ -231,13 +221,11 @@ scope:
           def_cursor _12: string = par.0
           def_cursor _13: string = par.1
           def _14: seq[string] = getSubDirs(arg _12, arg _13) (raises)
-          bind_mut _19: seq[string] = this[].matchDirs
-          =sink(name _19, arg _14)
+          =sink(name this[].matchDirs, arg _14)
           break L1
       scope:
         def _15: seq[string] = construct ()
-        bind_mut _20: seq[string] = this[].matchDirs
-        =sink(name _20, arg _15)
+        =sink(name this[].matchDirs, arg _15)
   finally:
     =destroy(name par)
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -29,7 +29,7 @@ scope:
     scope:
       def a: int = 0
       def b: int = 4
-      def i: int = sink a
+      def i: int = copy a
       block L0:
         scope:
           while true:
@@ -76,11 +76,11 @@ scope:
       scope:
         return
     def _0: string = boolToStr(arg cond)
-    str = move _0
+    str := move _0
     def _1: bool = not(arg cond)
     if _1:
       scope:
-        result = move str
+        result := move str
         wasMoved(name str)
         return
   finally:


### PR DESCRIPTION
## Summary

Make turning copy and move assignments into `=copy` and `=sink` calls a
standalone MIR pass; semantics don't change, but higher quality MIR
code is produced. This is progress towards fully decoupling lifetime
hooks from the move analyzer / destructor injection.

## Details

### General architecture

* the `injectdestructors` pass/module only collapses `sink` assignments
  and updates the MIR tree accordingly
* turning copy assignments into `=copy` and sink assignments into
  `=sink` calls is done by the new `injecthooks` pass/module
* reporting errors and warnings regarding hooks is also made part of
  the `injecthooks` pass
* the `injecthooks` is run after the `injectdestructors` pass
* handling of `--expandArc` is moved to `backends.process`, so that it
  can happen after hook injection

### `injectdestructors` Pass

* assignments are not replaced with `=copy` or `=sink` calls
* `expandAsgn` is renamed to `specializeAsgn`
* `sink` assignments are turned into either `copy`, `move`, or
  destructive `move` assignments (same as before)
* assignments to locations that don't yet store a value are turned into
  *initializing* assignments (this is necessary for the later `=sink`
  injection to work)
* compared to before, *all* assignments are processed by
  `specializeAsgn`, not only those for locations with lifetime hooks
* `=destroy` hooks are still injected

### `injecthooks` Pass

* the pass looks for `move` and `copy` assignment modifiers
  * if the involved type has lifetime hooks, the assignment is
     replaced with a call to the appropriate hook
  * the same injection rules as used previously apply
* the error detection and reporting logic is moved over - without
  change - from `injectdestructors`
* an adapter procedure to the legacy pass managements is provided
  (needed by `backends`)

With less surrounding complexity, more effort is spent on using less
temporaries for the hook call injection:
* no temporary is used for the destination operand
* no temporary is used for the source operand when it's guaranteed to
  not alias the destination. This is the case for:
  * `move` assignments
  * define with `copy` (e.g., `def x = copy y`)
  * initial assignments with `copy` (e.g., `x := copy y`)

Less temporaries means less work for the pass eliminating unnecessary
temporaries.

### Technical Correctness

* `mirconstr.inline` is only usable with lvalue expressions and always
  creates a non-owning temporary (instead of an owning temporary)
* the remaining usage of `mirconstr.inline` in
  `injectdestructors.lowerBranchSwitch`, where an owning temporary is
  required, is replaced with using `wrapTemp`