### PR TITLE
fix(sem): crash with manual `=destroy` hook call

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -209,6 +209,8 @@ const
   UnknownLockLevel* = TLockLevel(1001'i16)
   AttachedOpToStr*: array[TTypeAttachedOp, string] = [
     "=destroy", "=copy", "=sink", "=trace", "=deepcopy"]
+  AttachedOpToMagic*: array[TTypeAttachedOp, TMagic] = [
+    mDestroy, mAsgn, mAsgn, mTrace, mDeepCopy]
 
 
 proc `$`*(x: TLockLevel): string =

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -854,9 +854,11 @@ proc produceSymDistinctType(g: ModuleGraph; c: PContext; typ: PType;
 
 proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp;
               info: TLineInfo; idgen: IdGenerator): PSym =
-
+  # a synthesized hook is treated as an instantiation of the respective generic
+  # magic procedure from the system module
   let procname = getIdent(g.cache, AttachedOpToStr[kind])
-  result = newSym(skProc, procname, nextSymId(idgen), owner, info)
+  let base = getSysMagic(g, info, AttachedOpToStr[kind], AttachedOpToMagic[kind])
+  result = newSym(skProc, procname, nextSymId(idgen), base, info)
   let dest = newSym(skParam, getIdent(g.cache, "dest"), nextSymId(idgen), result, info)
   let src = newSym(skParam, getIdent(g.cache, if kind == attachedTrace: "env" else: "src"),
                    nextSymId(idgen), result, info)
@@ -866,7 +868,7 @@ proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp
   else:
     src.typ = typ
 
-  result.typ = newProcType(info, nextTypeId(idgen), owner)
+  result.typ = newProcType(info, nextTypeId(idgen), result)
   result.typ.addParam dest
   if kind != attachedDestructor:
     result.typ.addParam src

--- a/tests/lang_callable/macros/tsynthesized_destroy_hook_roundtrip.nim
+++ b/tests/lang_callable/macros/tsynthesized_destroy_hook_roundtrip.nim
@@ -1,0 +1,43 @@
+discard """
+  description: '''
+    Regression test for a bug where manually invoking a type's `=destroy` hook
+    within a procedure defined as part of a typed macro/template argument
+    crashed the compiler
+  '''
+"""
+
+type Destroy = object
+  ## A type that has a user-defined destroy hook.
+
+proc `=destroy`(x: var Destroy) =
+  discard
+
+type
+  NoHookObject = object
+    ## Object type where no destroy hook needs to be synthesized.
+  HookObject = object
+    ## Object type that needs a compiler-synthesized destroy hook.
+    field: Destroy
+
+macro m(x: typed): untyped = x
+
+# the compiler crashed when processing the macro output
+m:
+  proc f() =
+    # the bug only surfaced when the hook call is part of a procedure. Types
+    # that need a compiler-synthesized as well as those that don't were
+    # affected.
+    var v = NoHookObject()
+    `=destroy`(v)
+    var v2 = HookObject()
+    `=destroy`(v2)
+
+# the same bug happend when using a template:
+template t(x: typed): untyped = x
+
+t:
+  proc f2() =
+    var v = NoHookObject()
+    `=destroy`(v)
+    var v2 = HookObject()
+    `=destroy`(v2)

--- a/tests/lang_callable/macros/tsynthesized_destroy_hook_roundtrip.nim
+++ b/tests/lang_callable/macros/tsynthesized_destroy_hook_roundtrip.nim
@@ -32,7 +32,7 @@ m:
     var v2 = HookObject()
     `=destroy`(v2)
 
-# the same bug happend when using a template:
+# the same bug happened when using a template:
 template t(x: typed): untyped = x
 
 t:


### PR DESCRIPTION
## Summary

Fix a bug where manually calling the `=destroy` (or `=trace`) hook for
a type where the hook is compiler-generated crashed the compiler when
the call is within a typed procedure definition that is returned by a
macro or template.

Fixes https://github.com/nim-works/nimskull/issues/1161.

## Details

All compiler-synthesized hook procedures are marked as `sfFromGeneric`.
The `owner` of such procedures is expected to be the generic procedure
the procedure is an instantiation of (`skipGenericOwner` the immediate
owner), but this wasn't the case for the synthesized hooks, where the
owner was set to the owner of the type the hook is synthesized for.

When a compiler-synthesized hook is used in overload resolution, the
search for the owning module in `initCallCandidate` skips over the
`skModule` symbol (via `skipGenericOwner`), thus resulting in an NPE.

To fix the issue, the owner of synthesized hook procedures is now set
to the hook kind's corresponding generic magic procedure from the
`system` module, making the produced symbols well-formed.