### PR TITLE
mir: separate destructor from `=destroy` injection

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -741,6 +741,8 @@ proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
       res.kids.addIfNotEmpty stmtToIr(tree, env, cl, cr)
   of mnkScope:
     toSingleNode scopeToIr(tree, env, cl, cr)
+  of mnkDestroy:
+    unreachable("a 'destroy' that wasn't lowered")
   of AllNodeKinds - StmtNodes:
     unreachable(n.kind)
 

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -239,6 +239,9 @@ type
 
     mnkBranch ## defines a branch of an ``mnkExcept`` or ``mnkCase``
 
+    mnkDestroy## destroys the value stored in the given location, leaving the
+              ## location in an undefined state
+
     mnkAsm    ## embeds backend-dependent code directly into the output
     mnkEmit   ## embeds backend-dependent code directly into the output
 
@@ -339,7 +342,7 @@ const
                          mnkAddr, mnkDeref, mnkView, mnkDerefView, mnkStdConv,
                          mnkConv, mnkCast, mnkRaise, mnkTag, mnkArg,
                          mnkName, mnkConsume, mnkVoid, mnkCopy, mnkMove,
-                         mnkSink}
+                         mnkSink, mnkDestroy}
     ## Nodes that start sub-trees but that always have a single sub node.
 
   ArgumentNodes* = {mnkArg, mnkName, mnkConsume}
@@ -363,7 +366,7 @@ const
 
   StmtNodes* = {mnkScope, mnkStmtList, mnkIf, mnkCase, mnkRepeat, mnkTry,
                 mnkBlock, mnkBreak, mnkReturn, mnkRaise, mnkPNode, mnkInit,
-                mnkAsgn, mnkSwitch, mnkVoid, mnkRaise, mnkEmit,
+                mnkAsgn, mnkSwitch, mnkVoid, mnkRaise, mnkDestroy, mnkEmit,
                 mnkAsm} + DefNodes
 
   UnaryOps*  = {mnkNeg}

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -492,6 +492,10 @@ proc stmtToStr(nodes: MirTree, i: var int, indent: int, result: var string,
     tree "raise ":
       valueToStr()
     result.add "\n"
+  of mnkDestroy:
+    tree "destroy ":
+      valueToStr()
+      result.add "\n"
   of mnkPNode:
     result.add repeat("  ", indent)
     result.add "PNode " & $n.node & "\n"

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -561,6 +561,8 @@ func computeDfg*(tree: MirTree): DataFlowGraph =
       emitForValue(env, tree, i, tree.operand(i, 1))
     of mnkVoid:
       emitForExpr(env, tree, i, NodePosition tree.operand(i))
+    of mnkDestroy:
+      unreachable("not implemented yet")
     of mnkEmit, mnkAsm:
       emitForArgs(env, tree, i, i)
 

--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -36,7 +36,7 @@ import
     idioms
   ]
 
-from compiler/sem/injectdestructors import getOp
+from compiler/mir/injecthooks import getOp
 
 type
   ModuleStructs* = object

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -173,6 +173,7 @@ Semantics
             | Return                    # exit the procedure, but execute all
                                         # enclosing finalizers first (from
                                         # innermost to outermost)
+            | Destroy LVALUE
             | Emit VALUE ...
             | Asm VALUE ...
 


### PR DESCRIPTION
## Summary

Introduce the new `destroy` MIR operation and use it to decouple
destructor injection from the injection of `=destroy` hooks. Injection
of lifetime hooks is now fully decoupled from the move-analyzer /
destructor-injection pass. This is an internal-only change.

## Details

* introduce the `mnkDestroy` node kind / operator
* instead of `=destroy` hook calls, the `injectdestructors` pass only
  injects `mnkDestroy` operations
* the `injecthooks` pass then replaces `mnkDestroy` operations with
  `=destroy` calls
* the `getOp` and `genDestroy` procedure are moved to `injecthooks`
  without change
* injection of `=destroy` calls for variant objects (part of the 
  `mnkSwitch` lowering) is still part of the `injectdestructors` pass
* since `mnkDestroy` operations are replaced right away, both `mirexec`
  and `cgirgen` (MIR-to-CGIR translation) don't handle them yet