### PR TITLE
cgen: better default initialization for `result`

### DIFF
--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -91,6 +91,9 @@ func toValue*(id: GlobalId, typ: PType): Value =
 func toValue*(id: ProcedureId, typ: PType): Value =
   Value(node: MirNode(kind: mnkProc, typ: typ, prc: id))
 
+func toValue*(kind: range[mnkParam..mnkLocal], sym: PSym): Value =
+  Value(node: MirNode(kind: kind, typ: sym.typ, sym: sym))
+
 # --------- MirBuffer interface ----------
 
 func len*(b: MirBuffer): int {.inline.} =

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -686,13 +686,16 @@ iterator traverse*(c: DataFlowGraph, span: Subgraph, start: InstrPos,
       of DataFlowOps:
         yield (DataFlowOpcode(instr.op), instr.val)
 
-      inc pc
-
-      if state.exit or pc == start:
+      if state.exit or pc + 1 == start:
         # abort the current path if we either reached the instruction we
         # started at or the path was manually killed
         state.exit = false
         abort()
+
+      # increment *after* the abort handling, otherwise it wouldn't be
+      # possible to detect that the end wasn't reached when an abort is
+      # triggered by the very last instruction
+      inc pc
 
   assert queue.len <= 1
 

--- a/tests/compiler/tmir_exec2.nim
+++ b/tests/compiler/tmir_exec2.nim
@@ -1,0 +1,40 @@
+discard """
+  description: '''
+    Tests for the behaviour of the traversal routines from ``mirexec.nim``
+  '''
+  target: native
+"""
+
+include compiler/sem/mirexec
+
+# setup a very basic graph for testing:
+var graph = DataFlowGraph(instructions:
+  @[Instr(node: NodePosition 0, op: opDef),
+    Instr(node: NodePosition 1, op: opUse)])
+
+block forward_traverse_empty_slice:
+  # ensure that the exit flag is not set to true when no instructions are
+  # traversed
+  let empty = graph.subgraphFor(NodePosition(4)..NodePosition(5))
+  var s = TraverseState()
+  for _ in traverse(graph, empty, empty.a, s):
+    discard
+  doAssert s.exit == false
+
+  # the flag is also set to false if it was set to true externally
+  s.exit = true
+  for _ in traverse(graph, empty, empty.a, s):
+    discard
+  doAssert s.exit == false
+
+block forward_traverse_abort_path_on_last:
+  # aborting the main path on the very last operation of the traversed
+  # subgraph must not lead to the exit flag being set
+  let all = graph.subgraphFor(NodePosition(0)..NodePosition(1))
+  var s = TraverseState()
+  for op, _ in traverse(graph, all, all.a, s):
+    if op == opUse:
+      # abort the path on the last operation of the traversed subgraph
+      s.exit = true
+
+  doAssert s.exit == false


### PR DESCRIPTION
## Summary

Use a MIR pass for handling the default-initialization of `result`
variables for the C backend. This allows using the MIR's more precise
data-flow analysis, allowing for broader omission of `result` variable
initialization.

## Details

* introduce the `injectResultInit` MIR pass
  * it's only used with the C backend for now
  * if a data-flow analysis deems it required, a `result := default()`
    assignment is placed at the start of the body
* remove the `CgNode`-based `result`-assignment analysis from `cgen`

### Data-flow Analysis Bug

A small bug with the `mirexec.traversal` (forward traversal) routine
was discovered and fixed: the `exit` flag was erroneously set to true
when the main path was aborted on a data-flow instruction that's the
last instruction in the subgraph. The `exit` flag must only be true
when the end of the subgraph is reached, so this is wrong.

A regression test for the `traverse` routine is added.

This bug only affected the `injectdestructors.needsReset` optimization
(unnecessary but otherwise harmless `wasMoved` calls were injected
because of it) and `injectResultInit` (unnecessary initialization was
emitted).