### PR TITLE
fix(mirgen): respect `--panics:on` for overflow checks

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -894,7 +894,7 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
     if optOverflowCheck in c.userOptions:
       const Map = [mAddI: mAddI, mSubI, mMulI, mDivI, mModI,
                    mSucc: mAddI, mPred: mSubI]
-      c.buildCheckedMagicCall Map[m], n.typ:
+      c.buildDefectMagicCall Map[m], n.typ:
         arg n[1]
         arg n[2]
     else:

--- a/tests/exception/truntime_check_panics.nim
+++ b/tests/exception/truntime_check_panics.nim
@@ -1,0 +1,58 @@
+discard """
+  description: '''
+    Ensure that the compiler-inserted run-time checks don't have exceptional
+    exits when panics are enabled.
+  '''
+  targets: native
+  matrix: "--panics:on --hints:off --expandArc:test"
+  action: compile
+  nimout: '''
+--expandArc: test
+scope:
+  def a: array[0..0, int]
+  chckIndex(arg a, arg i)
+  discard a[i]
+  chckBounds(arg a, arg 0, arg i)
+  def _0: openArray[int] = toOpenArray a, 0, i
+  def _1: int = addI(arg i, arg i)
+  def _2: int = unaryMinusI(arg i)
+  def _3: range 0..1(int) = chckRange(arg i, arg 0, arg 1)
+  chckField(arg <D0>, arg o.kind, arg false, arg "field \'x\' is not accessible for type \'Object\' using \'kind = ")
+  discard o.kind.x
+  def _5: bool = isNil(arg r)
+  def _4: bool = not(arg _5)
+  if _4:
+    chckObj(arg r, arg type(Sub:ObjectType))
+  discard r.(Sub)
+  def _6: float = mulF64(arg f, arg f)
+  chckNaN(arg _6)
+
+-- end of expandArc ------------------------'''
+"""
+
+# make sure all run-time checks are enabled
+{.push boundChecks: on, overflowChecks: on, rangeChecks: on, objChecks: on,
+       fieldChecks: on, infChecks: on, nanChecks: on.}
+
+type
+  Sub = ref object of RootObj
+  Object = object
+    case kind: bool
+    of true:
+      x: int
+    else:
+      discard
+
+# export the procedure so that it's not omitted
+proc test(i: int, f: float, o: Object, r: ref RootObj) {.exportc.} =
+  var a: array[1, int]
+  discard a[i]                 # index check
+  discard toOpenArray(a, 0, i) # bound check
+  discard i + i                # overflow check for binary arithmetic
+  discard -i                   # overflow check for unary arithmetic
+  discard range[0..1](i)       # range check
+  discard o.x                  # field check
+  discard Sub(r)               # object check
+  discard f * f                # infinity and nan check
+
+{.pop.}


### PR DESCRIPTION
## Summary

Fix overflow checks for binary integer arithmetic being treated as
potentially raising exceptions when panics are enabled (`--panics:on`).
This didn't affect correctness, but some optimizations were inhibited.

## Details

Use `buildDefectMagicCall` for emitting the binary arithmetic operation
in `mirgen`. If panics are enabled, this makes sure a `mnkCall` is
emitted rather than a `mnkCheckedCall`. 

Checked calls (i.e., calls that can raise an exception) introduce
unstructured control-flow, which, depending on where the call is
located, can result in the compiler having to place additional
`wasMoved` and/or destructor calls.

An `--expandArc`-based test for making sure that all run-time checks
are correctly treated as not raising an exception is added.