### PR TITLE
internal: implement `--profiler:on` support with MIR pass

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -342,7 +342,7 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
     of backendNimVm:   targetVm
     of backendInvalid: unreachable()
 
-  applyPasses(body, prc, env, graph.config, target)
+  applyPasses(body, prc, env, graph, target)
 
 proc translate*(id: ProcedureId, body: PNode, graph: ModuleGraph,
                 config: BackendConfig, idgen: IdGenerator,

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -200,10 +200,6 @@ proc genRepeatStmt(p: BProc, t: CgNode) =
     if true:
       startBlock(p, "while (1) {$n")
       genStmts(p, loopBody)
-
-      if optProfiler in p.options:
-        # invoke at loop body exit:
-        linefmt(p, cpsStmts, "#nimProfile();$n", [])
       endBlock(p)
 
   dec(p.withinLoop)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -258,10 +258,6 @@ template appcg(m: BModule, sec: TCFileSection, frmt: FormatStr,
            args: untyped) =
   m.s[sec].add(ropecg(m, frmt, args))
 
-template appcg(p: BProc, sec: TCProcSection, frmt: FormatStr,
-           args: untyped) =
-  p.s(sec).add(ropecg(p.module, frmt, args))
-
 template line(p: BProc, sec: TCProcSection, r: Rope) =
   p.s(sec).add(indentLine(p, r))
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -824,9 +824,6 @@ proc finishProc*(p: BProc, id: ProcedureId): string =
       generatedProc.add(initFrame(p, procname, quotedFilename(p.config, prc.info)))
     else:
       generatedProc.add(p.s(cpsLocals))
-    if optProfiler in prc.options:
-      # invoke at proc entry for recursion:
-      appcg(p, cpsInit, "\t#nimProfile();$n", [])
     # this pair of {} was added because C++ is stricter with its control flow
     # integrity checks, leaving them in
     if beforeRetNeeded in p.flags: generatedProc.add("{")

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -490,11 +490,7 @@ proc applyPasses*(body: var MirBody, prc: PSym, env: var MirEnv,
 
   # instrument the body with profiler calls after all lowerings, but before
   # optimization
-  if (sfPure notin prc.flags) and (optProfiler in prc.options) and
-     (target in {targetC, targetJs}):
-    # XXX: not enabled for the VM because compile-time and run-time cannot
-    #      be distinguished at the moment (no instrumentation should happen
-    #      for compile-time code)
+  if (sfPure notin prc.flags) and (optProfiler in prc.options):
     batch:
       injectProfilerCalls(body.code, graph, env, c)
 

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -184,7 +184,7 @@ proc genStmt*(jit: var JitState, c: var TCtx; n: PNode): VmGenResult =
 
   # `n` is expected to have been put through ``transf`` already
   var mirBody = generateMirCode(c, jit.gen.env, n, isStmt = true)
-  applyPasses(mirBody, c.module, jit.gen.env, c.config, targetVm)
+  applyPasses(mirBody, c.module, jit.gen.env, c.graph, targetVm)
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"
 
@@ -216,7 +216,7 @@ proc genExpr*(jit: var JitState, c: var TCtx, n: PNode): VmGenResult =
   let cp = checkpoint(jit.gen.env)
 
   var mirBody = generateMirCode(c, jit.gen.env, n)
-  applyPasses(mirBody, c.module, jit.gen.env, c.config, targetVm)
+  applyPasses(mirBody, c.module, jit.gen.env, c.graph, targetVm)
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"
 
@@ -255,7 +255,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   echoInput(c.config, s, body)
   var mirBody = generateCode(c.graph, jit.gen.env, s, selectOptions(c), body)
   echoMir(c.config, s, mirBody)
-  applyPasses(mirBody, s, jit.gen.env, c.config, targetVm)
+  applyPasses(mirBody, s, jit.gen.env, c.graph, targetVm)
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"
 

--- a/tests/compilerfeatures/tprofiler.nim
+++ b/tests/compilerfeatures/tprofiler.nim
@@ -34,8 +34,8 @@ proc profileCallback(st: StackTrace) =
 
 # nothing will happen before the hook is set
 profilerHook = profileCallback
-# the "profiling requested" callback guards whether to invoke the profile
-# callback is invoked
+# the "profiling requested" callback guards whether to invoke the profiler
+# callback
 profilingRequestedHook = enabledCallback
 
 proc test() =

--- a/tests/compilerfeatures/tprofiler.nim
+++ b/tests/compilerfeatures/tprofiler.nim
@@ -1,0 +1,67 @@
+discard """
+  description: '''
+    Ensure that the built-in instrumentation with profiler callback calls
+    works
+  '''
+  targets: "c js vm"
+  matrix: "--profiler:on"
+  knownIssue.vm: '''
+    Due to a deficit with MIR pass application, no instrumentation with
+    `nimProfile` calls happens
+  '''
+  knownIssue.js: '''
+    The `system/profile.nim` module is not available for the JS target
+  '''
+"""
+
+var
+  traces: array[3, StackTrace]
+  enabled = true
+  numTraces = 0
+
+# instrumentation needs to be disabled for the callbacks, otherwise there'd be
+# an infinite recursion
+{.push profiler: off.}
+
+proc enabledCallback(): bool =
+  result = enabled
+  # XXX: an issue with the profiler runtime requires disabling the callback
+  #      until the `profileCallback` is done
+  enabled = false
+
+proc profileCallback(st: StackTrace) =
+  traces[numTraces] = st
+  inc numTraces
+  enabled = true # re-enable
+
+{.pop.}
+
+# nothing will happen before the hook is set
+profilerHook = profileCallback
+# the "profiling requested" callback guards whether to invoke the profile
+# callback is invoked
+profilingRequestedHook = enabledCallback
+
+proc test() =
+  # the callback is invoked when a procedure is entered
+  var i = 0
+  while i < 2:
+    inc i
+    # the callback is also invoked at the end of while loop's body
+
+test() # run once
+
+proc testPure() {.asmNoStackFrame.} =
+  # pure routines aren't instrumented
+  var i = 0
+  while i < 2:
+    inc i
+
+# disable the callback so that the traces can be inspected
+enabled = false
+
+# validate the traces:
+doAssert numTraces == 3
+# the end of the list is signaled by a nil cstring
+doAssert traces[0].lines[0..2] == [cstring"test", "tprofiler", nil]
+doAssert traces[0].files[0..2] == [cstring"tprofiler.nim", "tprofiler.nim", nil]

--- a/tests/compilerfeatures/tprofiler.nim
+++ b/tests/compilerfeatures/tprofiler.nim
@@ -5,12 +5,8 @@ discard """
   '''
   targets: "c js vm"
   matrix: "--profiler:on"
-  knownIssue.vm: '''
-    Due to a deficit with MIR pass application, no instrumentation with
-    `nimProfile` calls happens
-  '''
-  knownIssue.js: '''
-    The `system/profile.nim` module is not available for the JS target
+  knownIssue.js vm: '''
+    The `system/profile.nim` module is not available for the targets
   '''
 """
 


### PR DESCRIPTION
## Summary

Make routine instrumentation with `nimProfile` calls a MIR pass, moving
more logic out of the C code generator and working towards
`--profiler:on` support with all backends. `nimProfile` calls are also
no longer inserted into loops within `.asmNoStackFrame` routines.

## Details

* require a `ModuleGraph` instance for `mirpasses.applyPasses`, so that
  compilerprocs can be looked up
* add the `injectProfilerCalls` MIR pass. It injects `nimProfile` in
  the same way that `cgen` does
* remove injection of `nimProfile` calls from `cgen`
* don't instrument loops within `.asmNoStackFrame` procedures;
  injection of `nimProfile` at procedure entry was already skipped for
  these procedures
* temporarily remove the `optProfiler` option from symbols when in JIT
  mode, that code generated for compile-time execution is not
  instrumented
* add a test for the `--profiler:on` feature, to make sure it works and
  keeps working