### PR TITLE
make the CGIR goto-based and fix exception-handling bugs

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -15,7 +15,8 @@ import
   compiler/backend/[
     cgmeth,
     cgir,
-    cgirgen
+    cgirgen,
+    cgirgen_legacy
   ],
   compiler/front/[
     msgs,
@@ -368,6 +369,13 @@ proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
   ## Translates the MIR code provided by `code` into ``CgNode`` IR and,
   ## if enabled, echoes the result.
   result = cgirgen.generateIR(graph, idgen, env, owner, body)
+  echoOutput(graph.config, owner, result)
+
+proc generateIRLegacy*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
+                 owner: PSym, body: sink MirBody): Body =
+  ## Translates the MIR code provided by `code` into legacy ``CgNode`` IR and,
+  ## if enabled, echoes the result.
+  result = cgirgen_legacy.generateIR(graph, idgen, env, owner, body)
   echoOutput(graph.config, owner, result)
 
 # ------- handling of lifted globals ---------

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -197,7 +197,7 @@ proc genArgNoParam(p: BProc, n: CgNode, needsTmp = false): Rope =
   result = rdLoc(a)
 
 proc genParams(p: BProc, ri: CgNode, typ: PType): Rope =
-  for i in 1..<ri.len:
+  for i in 1..<(1 + numArgs(ri)):
     if i < typ.len:
       assert(typ.n[i].kind == nkSym)
       let paramType = typ.n[i]
@@ -251,7 +251,7 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
   let canRaise = ri.kind == cnkCheckedCall
   if typ[0] != nil:
     if isInvalidReturnType(p.config, typ[0]):
-      if ri.len > 1: pl.add(~", ")
+      if numArgs(ri) > 0: pl.add(~", ")
       # the destination is guaranteed to be either a temporary or an lvalue
       # that can be modified in-place
       if true:

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2107,11 +2107,11 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
   of cnkObjUpConv: upConv(p, n, d)
   of cnkClosureConstr: genClosure(p, n, d)
   of cnkEmpty: discard
-  of cnkRepeatStmt:
+  of cnkLoopJoinStmt:
     startBlock(p, "while (1) {$n")
   of cnkFinally:
     startBlock(p)
-  of cnkEnd, cnkContinueStmt:
+  of cnkEnd, cnkContinueStmt, cnkLoopStmt:
     endBlock(p)
   of cnkDef: genSingleVar(p, n[0], n[1])
   of cnkCaseStmt: genCase(p, n)

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -766,18 +766,19 @@ proc genArrayLikeElem(p: BProc; n: CgNode; d: var TLoc) =
 
 proc genEcho(p: BProc, n: CgNode) =
   ## Generates and emits the code for the magic echo call.
-  if n.len == 1:
+  let argCount = numArgs(n)
+  if argCount == 0:
     linefmt(p, cpsStmts, "#echoBinSafe(NIM_NIL, 0);$n", [])
   else:
     # allocate a temporary array and fill it with the arguments:
     var tmp: TLoc
     getTemp(p, n[1].typ, tmp) # the first argument stores the type to use
-    for i in 2..<n.len:
+    for i in 2..<(1 + argCount):
       var a: TLoc
       initLocExpr(p, n[i], a)
       linefmt(p, cpsStmts, "$1[$2] = $3;$n", [rdLoc(tmp), i-2, rdLoc(a)])
 
-    linefmt(p, cpsStmts, "#echoBinSafe($1, $2);$n", [rdLoc(tmp), n.len-2])
+    linefmt(p, cpsStmts, "#echoBinSafe($1, $2);$n", [rdLoc(tmp), argCount-1])
 
 proc strLoc(p: BProc; d: TLoc): Rope =
   result = byRefLoc(p, d)
@@ -1531,7 +1532,7 @@ proc genRangeChck(p: BProc, n: CgNode, d: var TLoc) =
           ""
       linefmt(p, cpsStmts, "if ($6($1) < $2 || $6($1) > $3){ $4($1, $2, $3); $5}$n",
         [rdCharLoc(a), genLiteral(p, n[2], dest), genLiteral(p, n[3], dest),
-        raiser, raiseInstr(p), boundaryCast])
+        raiser, raiseInstr(p, n.exit), boundaryCast])
   putIntoDest(p, d, n, "(($1) ($2))" %
       [getTypeDesc(p.module, dest), rdCharLoc(a)], a.storage)
 

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -2109,7 +2109,9 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
   of cnkEmpty: discard
   of cnkRepeatStmt:
     startBlock(p, "while (1) {$n")
-  of cnkEnd:
+  of cnkFinally:
+    startBlock(p)
+  of cnkEnd, cnkContinueStmt:
     endBlock(p)
   of cnkDef: genSingleVar(p, n[0], n[1])
   of cnkCaseStmt: genCase(p, n)
@@ -2125,7 +2127,7 @@ proc expr(p: BProc, n: CgNode, d: var TLoc) =
   of cnkExcept:
     genExcept(p, n)
   of cnkRaiseStmt: genRaiseStmt(p, n)
-  of cnkJoinStmt, cnkFinally, cnkContinueStmt, cnkGotoStmt:
+  of cnkJoinStmt, cnkGotoStmt:
     unreachable("handled separately")
   of cnkInvalid, cnkType, cnkAstLit, cnkMagic, cnkRange, cnkBinding, cnkBranch,
      cnkLabel, cnkTargetList, cnkStmtListExpr, cnkField, cnkStmtList,

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -294,11 +294,11 @@ template binaryArithOverflowRaw(p: BProc, t: PType, a, b: TLoc;
   var result = getTempName(p.module)
   linefmt(p, cpsLocals, "$1 $2;$n", [storage, result])
   lineCg(p, cpsStmts, "if (#$2($3, $4, &$1)) { #raiseOverflow(); $5};$n",
-      [result, cpname, rdCharLoc(a), rdCharLoc(b), raiseInstr(p)])
+      [result, cpname, rdCharLoc(a), rdCharLoc(b), raiseInstr(p, e.exit)])
   if size < p.config.target.intSize or t.kind in {tyRange, tyEnum}:
     linefmt(p, cpsStmts, "if ($1 < $2 || $1 > $3){ #raiseOverflow(); $4}$n",
             [result, intLiteral(firstOrd(p.config, t)), intLiteral(lastOrd(p.config, t)),
-            raiseInstr(p)])
+            raiseInstr(p, e.exit)])
   result
 
 proc binaryArithOverflow(p: BProc, e: CgNode, d: var TLoc, m: TMagic) =
@@ -324,7 +324,7 @@ proc binaryArithOverflow(p: BProc, e: CgNode, d: var TLoc, m: TMagic) =
     # result is only for overflows.
     if m in {mDivI, mModI}:
       linefmt(p, cpsStmts, "if ($1 == 0){ #raiseDivByZero(); $2}$n",
-              [rdLoc(b), raiseInstr(p)])
+              [rdLoc(b), raiseInstr(p, e.exit)])
 
     let res = binaryArithOverflowRaw(p, t, a, b,
       if t.kind == tyInt64: prc64[m] else: prc[m])
@@ -338,7 +338,7 @@ proc unaryArithOverflow(p: BProc, e: CgNode, d: var TLoc, m: TMagic) =
   initLocExpr(p, e[1], a)
   t = skipTypes(e.typ, abstractRange)
   linefmt(p, cpsStmts, "if ($1 == $2){ #raiseOverflow(); $3}$n",
-          [rdLoc(a), intLiteral(firstOrd(p.config, t)), raiseInstr(p)])
+          [rdLoc(a), intLiteral(firstOrd(p.config, t)), raiseInstr(p, e.exit)])
   case m
   of mUnaryMinusI:
     putIntoDest(p, d, e, "((NI$2)-($1))" % [rdLoc(a), rope(getSize(p.config, t) * 8)])
@@ -631,7 +631,7 @@ proc genFieldCheck(p: BProc, e: CgNode) =
 
     discard cgsym(p.module, raiseProc) # make sure the compilerproc is generated
     linefmt(p, cpsStmts, "{ $1($3, $4); $2} $n",
-            [raiseProc, raiseInstr(p), strLit, toStr])
+            [raiseProc, raiseInstr(p, e.exit), strLit, toStr])
 
 proc genUncheckedArrayElem(p: BProc, n, x, y: CgNode, d: var TLoc) =
   var a, b: TLoc
@@ -660,7 +660,7 @@ proc genCStringElem(p: BProc, n, x, y: CgNode, d: var TLoc) =
   putIntoDest(p, d, n,
               ropecg(p.module, "$1[$2]", [rdLoc(a), rdCharLoc(b)]), a.storage)
 
-proc genBoundsCheck(p: BProc; arr, a, b: TLoc) =
+proc genBoundsCheck(p: BProc; arr, a, b: TLoc, exit: CgNode) =
   # types that map to C pointers need to be skipped here too, since no
   # dereference is generated for ``ptr array`` and the like
   let ty = skipTypes(arr.t, abstractVarRange + {tyPtr, tyRef, tyLent})
@@ -670,29 +670,29 @@ proc genBoundsCheck(p: BProc; arr, a, b: TLoc) =
       linefmt(p, cpsStmts,
         "if ($2-$1 != -1 && " &
         "((NU)($1) >= (NU)($3.Field1) || (NU)($2) >= (NU)($3.Field1))){ #raiseIndexError(); $4}$n",
-        [rdLoc(a), rdLoc(b), rdLoc(arr), raiseInstr(p)])
+        [rdLoc(a), rdLoc(b), rdLoc(arr), raiseInstr(p, exit)])
     else:
       linefmt(p, cpsStmts,
         "if ($2-$1 != -1 && " &
         "((NU)($1) >= (NU)($3Len_0) || (NU)($2) >= (NU)($3Len_0))){ #raiseIndexError(); $4}$n",
-        [rdLoc(a), rdLoc(b), rdLoc(arr), raiseInstr(p)])
+        [rdLoc(a), rdLoc(b), rdLoc(arr), raiseInstr(p, exit)])
   of tyArray:
     let first = intLiteral(firstOrd(p.config, ty))
     linefmt(p, cpsStmts,
       "if ($2-$1 != -1 && " &
       "($2-$1 < -1 || $1 < $3 || $1 > $4 || $2 < $3 || $2 > $4)){ #raiseIndexError(); $5}$n",
-      [rdCharLoc(a), rdCharLoc(b), first, intLiteral(lastOrd(p.config, ty)), raiseInstr(p)])
+      [rdCharLoc(a), rdCharLoc(b), first, intLiteral(lastOrd(p.config, ty)), raiseInstr(p, exit)])
   of tySequence, tyString:
     linefmt(p, cpsStmts,
       "if ($2-$1 != -1 && " &
       "((NU)($1) >= (NU)$3 || (NU)($2) >= (NU)$3)){ #raiseIndexError(); $4}$n",
-      [rdLoc(a), rdLoc(b), lenExpr(p, arr), raiseInstr(p)])
+      [rdLoc(a), rdLoc(b), lenExpr(p, arr), raiseInstr(p, exit)])
   of tyUncheckedArray, tyCstring:
     discard "no checks are used"
   else:
     unreachable(ty.kind)
 
-proc genIndexCheck(p: BProc; x: CgNode, arr, idx: TLoc) =
+proc genIndexCheck(p: BProc; x: CgNode, arr, idx: TLoc, exit: CgNode) =
   ## Emits the index check logic + subsequent raise operation. `x` is
   ## the array expression the `arr` loc resulted from from.
   let ty = arr.t.skipTypes(abstractVar + tyUserTypeClasses +
@@ -703,22 +703,22 @@ proc genIndexCheck(p: BProc; x: CgNode, arr, idx: TLoc) =
     if firstOrd(p.config, ty) == 0 and lastOrd(p.config, ty) >= 0:
       linefmt(p, cpsStmts, "if ((NU)($1) > (NU)($2)){ #raiseIndexError2($1, $2); $3}$n",
               [rdCharLoc(idx), intLiteral(lastOrd(p.config, ty)),
-               raiseInstr(p)])
+               raiseInstr(p, exit)])
     else:
       linefmt(p, cpsStmts, "if ($1 < $2 || $1 > $3){ #raiseIndexError3($1, $2, $3); $4}$n",
               [rdCharLoc(idx), first, intLiteral(lastOrd(p.config, ty)),
-               raiseInstr(p)])
+               raiseInstr(p, exit)])
   of tySequence, tyString:
     linefmt(p, cpsStmts,
             "if ((NU)($1) >= (NU)$2){ #raiseIndexError2($1,$2-1); $3}$n",
-            [rdCharLoc(idx), lenExpr(p, arr), raiseInstr(p)])
+            [rdCharLoc(idx), lenExpr(p, arr), raiseInstr(p, exit)])
   of tyOpenArray, tyVarargs:
     if reifiedOpenArray(p, x):
       linefmt(p, cpsStmts, "if ((NU)($1) >= (NU)($2.Field1)){ #raiseIndexError2($1,$2.Field1-1); $3}$n",
-              [rdCharLoc(idx), rdLoc(arr), raiseInstr(p)])
+              [rdCharLoc(idx), rdLoc(arr), raiseInstr(p, exit)])
     else:
       linefmt(p, cpsStmts, "if ((NU)($1) >= (NU)($2Len_0)){ #raiseIndexError2($1,$2Len_0-1); $3}$n",
-              [rdCharLoc(idx), rdLoc(arr), raiseInstr(p)])
+              [rdCharLoc(idx), rdLoc(arr), raiseInstr(p, exit)])
   of tyCstring:
     discard "no bound checks"
   else:
@@ -1514,7 +1514,7 @@ proc genRangeChck(p: BProc, n: CgNode, d: var TLoc) =
     if n0t.kind in {tyUInt, tyUInt64}:
       linefmt(p, cpsStmts, "if ($1 > ($6)($3)){ #raiseRangeErrorNoArgs(); $5}$n",
         [rdCharLoc(a), genLiteral(p, n[2], dest), genLiteral(p, n[3], dest),
-        raiser, raiseInstr(p), getTypeDesc(p.module, n0t)])
+        raiser, raiseInstr(p, n.exit), getTypeDesc(p.module, n0t)])
     else:
       let raiser =
         case skipTypes(n.typ, abstractVarRange).kind
@@ -1568,7 +1568,8 @@ proc binaryFloatArith(p: BProc, e: CgNode, d: var TLoc, m: TMagic) =
     putIntoDest(p, d, e, ropecg(p.module, "(($4)($2) $1 ($4)($3))",
                               [opr[m], rdLoc(a), rdLoc(b),
                               getSimpleTypeDesc(p.module, e[1].typ)]))
-    linefmt(p, cpsStmts, "if ($1 != 0.0 && $1*0.5 == $1) { #raiseFloatOverflow($1); $2}$n", [rdLoc(d), raiseInstr(p)])
+    linefmt(p, cpsStmts, "if ($1 != 0.0 && $1*0.5 == $1) { #raiseFloatOverflow($1); $2}$n",
+            [rdLoc(d), raiseInstr(p, e.exit)])
 
 proc skipAddr(n: CgNode): CgNode =
   if n.kind == cnkHiddenAddr: n.operand
@@ -1758,18 +1759,18 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
     # NOTE: if the value is a signaling NaN, the comparison itself results in
     #       a float-point exception (which might result in a trap)
     linefmt(p, cpsStmts, "if ($1 != $1){ #raiseFloatInvalidOp(); $2}$n",
-            [rdLoc(a), raiseInstr(p)])
+            [rdLoc(a), raiseInstr(p, e.exit)])
   of mChckIndex:
     var arr, a: TLoc
     initLocExpr(p, e[1], arr)
     initLocExpr(p, e[2], a)
-    genIndexCheck(p, e[1], arr, a)
+    genIndexCheck(p, e[1], arr, a, e.exit)
   of mChckBounds:
     var arr, a, b: TLoc
     initLocExpr(p, e[1], arr)
     initLocExpr(p, e[2], a)
     initLocExpr(p, e[3], b)
-    genBoundsCheck(p, arr, a, b)
+    genBoundsCheck(p, arr, a, b, e.exit)
   of mChckField:
     genFieldCheck(p, e)
   of mChckObj:
@@ -1781,7 +1782,7 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
     # the nil-check is expected to have taken place already
     linefmt(p, cpsStmts, "if (!#isObj($2, $3)){ #raiseObjectConversionError(); $4}$n",
             [nilCheck, r, genTypeInfo2Name(p.module, e[2].typ),
-             raiseInstr(p)])
+             raiseInstr(p, e.exit)])
   of mSamePayload:
     var a, b: TLoc
     initLocExpr(p, e[1], a)

--- a/compiler/backend/ccgflow.nim
+++ b/compiler/backend/ccgflow.nim
@@ -421,6 +421,7 @@ proc toInstrList*(stmts: CgNode, isFull: bool): seq[CInstr] =
   for i, it in stmts.pairs:
     case it.kind
     of cnkFinally:
+      stmt code, c, i
       let
         clabel = toCLabel(it[0])
         f = addr c.finallys[clabel]
@@ -496,6 +497,8 @@ proc toInstrList*(stmts: CgNode, isFull: bool): seq[CInstr] =
           if f.numErr > 0:
             code.add CInstr(op: opAbort, local: f.errBackupId)
           jump code, opJump, c, PathIndex c.paths[entry].next
+
+      stmt code, c, i
 
     of cnkJoinStmt:
       # XXX: labels that were redirected cannot be eliminated yet, as case

--- a/compiler/backend/ccgflow.nim
+++ b/compiler/backend/ccgflow.nim
@@ -1,0 +1,486 @@
+## Implements the translation of CGIR to a code listing for an abstract
+## machine that focuses on control-flow and exception handling.
+##
+## This code listing is intended for consumption by the C code generator.
+
+import
+  std/[
+    options,
+    packedsets,
+    tables
+  ],
+  compiler/backend/[
+    cgir
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+type
+  COpcode* = enum
+    opJump       ## unconditional jump
+    opErrJump    ## jump if in error mode
+    opDispJump   ## jump part of a dispatcher
+    opLabel      ## jump target
+
+    opSetTarget  ## set the value of a dispatcher's discriminator
+    opDispatcher ## start of a dispatcher
+
+    opBackup     ## backup the error state in a local variable and clear it
+    opRestore    ## restore the error from a local variable
+
+    opStmts      ## slice of statements
+    opStmt       ## control-flow relevant single statement. A label
+                 ## specifier is passed along
+    # future direction: ``CStmt`` should be removed and all unstructured
+    # control-flow bits modeled with the other instructions. Checked calls
+    # used as an assignment source currently block this, as they might
+    # require an assignment-to-temporary
+
+  JumpOp = range[opJump..opDispJump]
+
+  CLabelId* = distinct uint32
+  CLabelSpecifier* = uint32
+    ## used for identifying the extra labels attached to finally sections
+
+  CLabel* = tuple
+    ## Name of a label.
+    id: CLabelId
+    specifier: Option[CLabelSpecifier]
+
+  CInstr* = object
+    case op*: COpcode
+    of opJump, opErrJump, opLabel, opDispJump:
+      label*: CLabel
+    of opSetTarget, opDispatcher:
+      discr*: uint32 ## ID of the discriminator variable
+      value*: int    ## either the value, or number of dispatcher branches
+    of opStmts:
+      stmts*: Slice[int]
+    of opStmt:
+      stmt*: int
+      specifier*: CLabelSpecifier
+    of opBackup, opRestore:
+      local*: uint32 ## ID of the backup variable
+
+  FinallyInfo* = object
+    routes: seq[PathIndex]
+    numExits: int
+      ## number of exits the finally has. Pre-computed for efficiency
+    numErr: int
+      ## number of exceptional jump paths going through this finalizer
+    numNormal: int
+      ## number of non-exception jump paths going through this finalizer
+
+    discriminator: uint32
+      ## ID of the discriminator variable to use for the dispatcher
+    errBackupId: uint32
+      ## only valid if the finally is entered by exceptional control-flow
+
+  PathKind = enum
+    pkError
+    pkNormal
+  PathIndex = uint32
+    ## Index of a ``PathItem`` within the item storage.
+  PathItem = object
+    ## Represents a step in a jump path. A jump path is a chain of finally
+    ## sections plus final target an intercepted goto visits.
+    ##
+    ## An item is part of two intrusive linked-lists: one doubly-linked-list
+    ## representing a single chain, and one singly-linked-list for the
+    ## adjacent chains. The "none" value for a pointer is represented by it
+    ## pointing to the node itself.
+    prev, next: PathIndex
+    sibling: PathIndex
+
+    target: CLabelId
+      ## the label identifying the jump target
+    kinds: set[PathKind]
+      ## the kinds of control-flow (exception or normal) reaching the path
+      ## item
+
+  Paths = seq[PathItem]
+    ## The data storage for multiple jump paths, with the items layed out
+    ## "tail first", meaning that the final target of a jump chain comes
+    ## *before* the others. The idea is to uniquely identify jump paths
+    ## within a body while merging common trailing paths.
+    ##
+    ## Consider the two jump paths E->D->C->B->A and G->F->C->B->A. If
+    ## both are added to the storage, the content would look like this:
+    ##
+    ##    (0: A) -> (1: B) -> (2: C) -> (3: D) -> (4: E)
+    ##                                \ (5: F) -> (6: G)
+    ##
+    ## The numbers represent the items' index in the sequence. The `sibling`
+    ## item of 3 is 5 (all other items have no siblings); the `next` pointer
+    ## of 5 points to 2. As can be seen, common trailing paths are merged into
+    ## one.
+
+  Context = object
+    ## Local state used during the translation bundled into an object for
+    ## convenience.
+    paths: Paths
+    stmtToPath: Table[int, int]
+    finallys: Table[CLabelId, FinallyInfo]
+
+const
+  ExitLabel* = CLabelId(0)
+    ## The label of the procedure exit.
+  ResumeLabel* = ExitLabel
+    ## The C label that a ``cnkResume`` targets.
+
+func `==`*(a, b: CLabelId): bool {.borrow.}
+
+func toCLabel*(n: CgNode): CLabelId =
+  ## Returns the ID of the C label the label-like node `n` represents.
+  case n.kind
+  of cnkResume:
+    ResumeLabel
+  of cnkLabel:
+    CLabelId(ord(n.label) + 2)
+  else:
+    unreachable(n.kind)
+
+func toCLabel*(n: CgNode, specifier: Option[CLabelSpecifier]
+              ): CLabel {.inline.} =
+  (toCLabel(n), specifier)
+
+func toBlockId*(id: CLabelId): BlockId =
+  ## If `id` was converted to from a valid CGIR label, converts it back to
+  ## the CGIR label.
+  BlockId(ord(id) - 2)
+
+func rawAdd(p: var Paths, x: openArray[CLabelId]): PathIndex =
+  ## Appends the chain `x` to `p` without any deduplication or
+  ## linking with the existing items. Returns the index of the
+  ## tail item.
+  result = p.len.PathIndex
+  for i in countdown(x.high, 0):
+    let pos = p.len.PathIndex
+    p.add PathItem(prev: (if i > 0: pos + 1 else: pos),
+                   next: (if i < x.high: pos - 1 else: pos),
+                   sibling: pos,
+                   target: x[i])
+
+func add(p: var Paths, path: openArray[CLabelId]): PathIndex =
+  ## Adds `path` to the `p`. Only the sub-path of `path` not yet present in
+  ## `p` is added. The index of the *head* item of the added (or existing)
+  ## path is returned.
+  if p.len == 0:
+    discard rawAdd(p, path)
+    p[0].next = 0'u32
+    return p.high.PathIndex
+
+  var pos = 0'u32 ## the current search position
+  for i in countdown(path.len-1, 0):
+    # search the sibling list for a matching item:
+    while p[pos].target != path[i] and pos != p[pos].sibling:
+      pos = p[pos].sibling
+
+    if p[pos].target != path[i]:
+      # no item was found, meaning that this is the end of the common paths.
+      # Add the remaining items to the storage.
+      let next = rawAdd(p, path.toOpenArray(0, i))
+      p[pos].sibling = next
+      # only set the next pointer if there was a common sub-path (otherwise
+      # there's no next item):
+      if i != path.high:
+        p[next].next = p[pos].next
+      return p.high.PathIndex
+
+    # it's a match! continue down the chain
+    if i > 0:
+      if p[pos].prev == pos:
+        # there's no next item, append the remaining new targets to the
+        # pre-existing path
+        let next = rawAdd(p, path.toOpenArray(0, i-1))
+        p[pos].prev = next
+        p[next].next = pos
+        return p.high.PathIndex
+      else:
+        pos = p[pos].prev
+
+  # the chain `path` already exists in `p`
+  result = pos
+
+func incl(p: var Paths, at: PathIndex, kind: PathKind) =
+  ## Marks all items following and including `at` with `kind`.
+  var i = at
+  while p[i].next != i:
+    p[i].kinds.incl kind
+    i = p[i].next
+  p[i].kinds.incl kind
+
+func needsDispatcher(f: FinallyInfo): bool =
+  # a dispatcher is required if re are more than one exits. An exception is
+  # the case where one exit is only taken when in error mode and the other is
+  # not. If a dispatcher is required, the finally has sub-labels.
+  f.numExits > 1 and
+    not(f.routes.len == 2 and f.numErr == 1 and f.numNormal == 1)
+
+func needsDispatcher(f: Table[CLabelId, FinallyInfo], b: CLabelId): bool =
+  (b in f) and needsDispatcher(f[b])
+
+proc append(targets: var seq[CLabelId], redirects: Table[BlockId, CgNode],
+            exits: PackedSet[BlockId], n: CgNode) =
+  ## Appends all jump targets `n` represents to `targets`, following
+  ## `redirects` and turning all labels part of `exits` into the
+  ## "before return" label.
+  case n.kind
+  of cnkLabel:
+    if n.label in redirects:
+      append(targets, redirects, exits, redirects[n.label])
+    elif n.label in exits:
+      targets.add ExitLabel
+    else:
+      targets.add toCLabel(n)
+  of cnkTargetList:
+    # only the final target could possibly be redirected
+    let hasRedir = n[^1].kind == cnkLabel and n[^1].label in redirects
+    for i in 0..<n.len - ord(hasRedir):
+      case n[i].kind
+      of cnkLeave:
+        discard
+      of cnkResume:
+        targets.add toCLabel(n[i])
+      of cnkLabel:
+        if n[i].label in exits:
+          targets.add ExitLabel
+        else:
+          targets.add toCLabel(n[i])
+      else:
+        unreachable()
+
+    if hasRedir:
+      append(targets, redirects, exits, redirects[n[^1].label])
+  else:
+    unreachable()
+
+proc gatherRedirectsAndFinallys(c: var Context, stmts: CgNode
+                               ): Table[BlockId, CgNode] =
+  #ä First pass: gather the redirects for redundant labels. Consider:
+  ##   L1:
+  ##   goto L2
+  ##
+  ## Here, all jumps to L1 can jump to L2 directly. This pattern is
+  ## especially common with compiler-generated cleanup sections.
+  ##
+  ## The table for the finally sections is also populated.
+  var ifs: PackedSet[BlockId]
+    ## keeps track of which labels refer to if statements
+  for i in 0..<stmts.len - 1:
+    case stmts[i].kind
+    of cnkJoinStmt:
+      var j = i + 1
+      # skip join and (safe) end statements:
+      while j < stmts.len and (stmts[j].kind == cnkJoinStmt or
+            (stmts[j].kind == cnkEnd and stmts[j][0].label in ifs)):
+        inc j
+
+      # if the label is followed directly by a goto statement, all jumps to
+      # the label can jump to the goto's target instead
+      if j < stmts.len and stmts[j].kind == cnkGotoStmt:
+        result[stmts[i][0].label] = stmts[j][0]
+    of cnkIfStmt:
+      ifs.incl stmts[i][^1].label
+    of cnkFinally:
+      # make sure a table entry exists for the finally section:
+      c.finallys[toCLabel(stmts[i][0])] = FinallyInfo()
+    else:
+      discard
+
+proc toInstrList*(stmts: CgNode, isFull: bool): seq[CInstr] =
+  ## Turns the statements list `stmts` into an instruction list for the
+  ## abstract machine. `isFull` signals whether the end of the statement list
+  ## can be considered the end of the procedure, which allows for the merging
+  ## of some control-flow paths.
+  var c = Context()
+  let redirects = gatherRedirectsAndFinallys(c, stmts) # first pass
+
+  # mark the labels of the trailing joins as being the same as the exit label:
+  var exits: PackedSet[BlockId]
+  for i in countdown(stmts.len - 1, 0):
+    if stmts[i].kind == cnkJoinStmt:
+      exits.incl stmts[i][0].label
+    else:
+      break
+
+  # second pass: collect all jump paths, using the table of redirections to
+  # eliminate unnecessary breaks in the paths
+  var targets: seq[CLabelId]
+  for i, it in stmts.pairs:
+    template exit(x: CgNode; isErr = false) =
+      targets.setLen(0)
+      targets.append(redirects, exits, x)
+
+      # a single jump is only of relevance if it targets a finally directly
+      if targets.len > 1 or targets[0] in c.finallys:
+        let id = c.paths.add(targets)
+        if isErr: incl(c.paths, id, pkError)
+        else:     incl(c.paths, id, pkNormal)
+
+        # remember the path associated with the statement for later:
+        c.stmtToPath[i] = id.int
+
+    case it.kind
+    of cnkDef, cnkAsgn, cnkFastAsgn:
+      if it[1].kind == cnkCheckedCall:
+        exit(it[1][^1], true)
+    of cnkRaiseStmt, cnkCheckedCall:
+      exit(it[^1], true)
+    of cnkGotoStmt:
+      exit(it[0])
+    of cnkCaseStmt:
+      for j in 1..<it.len:
+        exit(it[j][^1])
+    of cnkExcept:
+      if it.len > 1:
+        exit(it[^1], true)
+    else:
+      discard
+
+  # register every path item with the finally section it targets, and compute
+  # some statistics that are used during the later code generation:
+  for i, it in c.paths.pairs:
+    if it.target in c.finallys:
+      let f = addr c.finallys[it.target]
+      f.routes.add i.PathIndex
+      f.numExits += ord(it.next.int != i)
+      f.numErr += ord(pkError in it.kinds)
+      f.numNormal += ord(pkNormal in it.kinds)
+
+  # construction of the instruction list follows
+
+  proc label(code: var seq[CInstr], id: CLabelId;
+             spec = none(CLabelSpecifier)) {.nimcall.} =
+    # a label must always be preceded by some code, so no length guard is
+    # required
+    if code[^1].op in {opJump, opErrJump} and code[^1].label.id == id and
+       code[^1].label.specifier == spec:
+      # optimization: remove the preceding jump if it targets the label
+      code.setLen(code.len - 1)
+    code.add CInstr(op: opLabel, label: (id, spec))
+
+  proc jump(code: var seq[CInstr], target: CLabelId) {.nimcall.} =
+    code.add CInstr(op: opJump, label: (target, none CLabelSpecifier))
+
+  proc jump(code: var seq[CInstr], op: JumpOp, c: Context,
+            path: PathIndex) {.nimcall.} =
+    let target = c.paths[path].target
+    if needsDispatcher(c.finallys, target):
+      code.add CInstr(op: op, label: (target, some path))
+    else:
+      code.add CInstr(op: op, label: (target, none CLabelSpecifier))
+
+  proc stmt(code: var seq[CInstr], c: Context, pos: int) {.nimcall.} =
+    if (let path = c.stmtToPath.getOrDefault(pos, -1); path != -1 and
+       needsDispatcher(c.finallys, c.paths[path].target)):
+      # a label specifier, and thus a separate instruction, is needed
+      code.add CInstr(op: opStmt, stmt: pos, specifier: CLabelSpecifier path)
+    elif code.len > 0 and code[^1].op == opStmts and
+         code[^1].stmts.b == pos + 1:
+      # append to the sequence
+      inc code[^1].stmts.b
+    else:
+      # start a new sequence
+      code.add CInstr(op: opStmts, stmts: pos..pos)
+
+  var
+    code: seq[CInstr]
+    nextDispId = 0'u32
+    nextRecoverID = 0'u32
+
+  for i, it in stmts.pairs:
+    case it.kind
+    of cnkFinally:
+      let
+        clabel = toCLabel(it[0])
+        f = addr c.finallys[clabel]
+
+      # allocate and set the ID for the discriminator variable:
+      f.discriminator = nextDispId
+      inc nextDispId
+
+      # emit the entry-point(s); one for each route
+      if needsDispatcher(f[]):
+        # an entry point looks like this:
+        #   L1_1_:
+        #   Target = ...
+        #   goto L1_
+        for i, entry in f.routes.pairs:
+          label code, clabel, some(entry)
+          code.add CInstr(op: opSetTarget, discr: f.discriminator, value: i)
+          # jump to the main code:
+          jump code, clabel
+
+      # the body follows:
+      label code, clabel
+      if f.numErr > 0:
+        # backing up the error state is only needed when the finally is
+        # entered by exceptional control-flow
+        f.errBackupId = nextRecoverID
+        code.add CInstr(op: opBackup, local: nextRecoverID)
+        inc nextRecoverID
+
+    of cnkContinueStmt:
+      let f {.cursor.} = c.finallys[toCLabel(it[0])]
+
+      # no need to restore the error state if control-flow never reaches the
+      # end of the finally anyway
+      if f.numErr > 0 and f.numExits > 0:
+        code.add CInstr(op: opRestore, local: f.errBackupId)
+
+      if f.numExits == 0:
+        discard "the end is never reached; nothing to do"
+      elif not needsDispatcher(f) and f.routes.len == 2:
+        # optimization: if two paths go through a finally, with one of them
+        # an exceptional jump path and the other one not, instead of using a
+        # full dispatcher we emit:
+        #   if err: goto error_exit
+        #   goto normal_exit
+        let exit = if c.paths[f.routes[0]].kinds == {pkError}: 0 else: 1
+        jump code, opErrJump, c, c.paths[f.routes[exit]].next
+        jump code, opJump,    c, c.paths[f.routes[1 - exit]].next
+      else:
+        assert f.routes.len == f.numExits
+        # a dispatcher is only required if there is more than one exit
+        let op = if f.numExits > 1: opDispJump
+                 else:              opJump
+
+        if op == opDispJump:
+          code.add CInstr(op: opDispatcher, discr: f.discriminator,
+                          value: f.numExits)
+
+        for it in f.routes.items:
+          jump code, op, c, c.paths[it].next
+
+    of cnkJoinStmt:
+      label code, toCLabel(it[0])
+    of cnkExcept:
+      # an except section is a label followed by the filter logic
+      label code, toCLabel(it[0])
+      stmt code, c, i
+
+    of cnkGotoStmt:
+      let target = it[0]
+      if target.kind == cnkLabel:
+        jump code, toCLabel(target)
+      elif (let path = c.stmtToPath.getOrDefault(i, -1); path != -1):
+        jump code, opJump, c, PathIndex path
+      else:
+        jump code, toCLabel(target[^1])
+    of cnkRaiseStmt:
+      stmt code, c, i # the statement handles the exception setup part
+      # the goto part is the same as for a normal goto
+      let target = it[^1]
+      if target.kind == cnkLabel:
+        jump code, toCLabel(target)
+      elif (let path = c.stmtToPath.getOrDefault(i, -1); path != -1):
+        jump code, opJump, c, PathIndex path
+      else:
+        jump code, toCLabel(target[^1])
+
+    else:
+      stmt code, c, i
+
+  result = code

--- a/compiler/backend/ccgflow.nim
+++ b/compiler/backend/ccgflow.nim
@@ -313,13 +313,16 @@ proc toInstrList*(stmts: CgNode, isFull: bool): seq[CInstr] =
   var c = Context()
   let redirects = gatherRedirectsAndFinallys(c, stmts) # first pass
 
-  # mark the labels of the trailing joins as being the same as the exit label:
+  # mark the labels of the trailing joins as being the same as the exit
+  # label...
   var exits: PackedSet[BlockId]
-  for i in countdown(stmts.len - 1, 0):
-    if stmts[i].kind == cnkJoinStmt:
-      exits.incl stmts[i][0].label
-    else:
-      break
+  if isFull:
+    # ... but only of stmts constitute the whole body
+    for i in countdown(stmts.len - 1, 0):
+      if stmts[i].kind == cnkJoinStmt:
+        exits.incl stmts[i][0].label
+      else:
+        break
 
   # second pass: collect all jump paths, using the table of redirections to
   # eliminate unnecessary breaks in the paths

--- a/compiler/backend/ccgflow.nim
+++ b/compiler/backend/ccgflow.nim
@@ -498,6 +498,9 @@ proc toInstrList*(stmts: CgNode, isFull: bool): seq[CInstr] =
           jump code, opJump, c, PathIndex c.paths[entry].next
 
     of cnkJoinStmt:
+      # XXX: labels that were redirected cannot be eliminated yet, as case
+      #      statements (which are handled outside of ccgflow) might still
+      #      target them
       label code, toCLabel(it[0])
     of cnkExcept:
       # an except section is a label followed by the filter logic

--- a/compiler/backend/ccgflow.nim
+++ b/compiler/backend/ccgflow.nim
@@ -519,10 +519,10 @@ proc toInstrList*(stmts: CgNode, isFull: bool): seq[CInstr] =
 
     of cnkGotoStmt:
       let target = it[0]
-      if target.kind == cnkLabel:
-        jump code, toCLabel(target)
-      elif (let path = c.stmtToPath.getOrDefault(i, -1); path != -1):
+      if (let path = c.stmtToPath.getOrDefault(i, -1); path != -1):
         jump code, opJump, c, PathIndex path
+      elif target.kind == cnkLabel:
+        jump code, toCLabel(target)
       else:
         jump code, toCLabel(target[^1])
     of cnkRaiseStmt:

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -150,7 +150,14 @@ proc raiseInstr(p: BProc, n: CgNode): Rope =
     else:
       unreachable(n.kind)
   else:
-    result = ""
+    # absence of an node storing the target means "never exits"
+    if hasAssume in CC[p.config.cCompiler].props:
+      result = "__asume(0);"
+    else:
+      # don't just fall-through; doing so would inhibit C compiler
+      # optimizations
+      p.flags.incl beforeRetNeeded
+      result = "goto BeforeRet_;"
 
 proc raiseExit(p: BProc, n: CgNode) =
   assert p.config.exc == excGoto

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -373,6 +373,7 @@ proc genExcept(p: BProc, n: CgNode) =
   else:
     discard "catch-all handler, nothing to check"
 
+  startBlock(p)
   p.flags.incl nimErrorFlagAccessed
   lineCg(p, cpsStmts, "*nimErr_ = NIM_FALSE;$n", []) # exit error mode
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -598,13 +598,6 @@ proc fillProcLoc*(m: BModule; id: ProcedureId) =
   if id notin m.procs:
     m.procs[id] = ProcLoc(name: mangleName(m.g.graph, m.g.env[id]))
 
-proc getLabel(p: BProc): TLabel =
-  inc(p.labels)
-  result = "LA" & rope(p.labels) & "_"
-
-proc fixLabel(p: BProc, labl: TLabel) =
-  lineF(p, cpsStmts, "$1: ;$n", [labl])
-
 proc genVarPrototype*(m: BModule, id: GlobalId)
 proc genProcPrototype*(m: BModule, id: ProcedureId)
 proc genStmt(p: BProc, t: CgNode)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -613,7 +613,7 @@ proc putLocIntoDest(p: BProc, d: var TLoc, s: TLoc)
 proc intLiteral(i: BiggestInt): Rope
 proc intLiteral(p: BProc, i: Int128, ty: PType): Rope
 proc genLiteral(p: BProc, n: CgNode): Rope
-proc raiseExit(p: BProc)
+proc raiseExit(p: BProc, n: CgNode)
 
 proc initLocExpr(p: BProc, e: CgNode, result: var TLoc) =
   initLoc(result, locNone, e, OnUnknown)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -338,7 +338,7 @@ proc registerLateProc(m: BModule, s: PSym): ProcedureId =
 proc accessThreadLocalVar(p: BProc)
 proc emulatedThreadVars*(conf: ConfigRef): bool {.inline.}
 proc useProc(m: BModule, id: ProcedureId)
-proc raiseInstr(p: BProc): Rope
+proc raiseInstr(p: BProc, n: CgNode): Rope
 
 proc getTempName(m: BModule): Rope =
   result = m.tmpBase & rope(m.labels)

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -41,6 +41,7 @@ import
     pathutils
   ]
 
+import std/options as std_options
 
 type
   SymbolMap*[T] = object
@@ -174,6 +175,10 @@ type
     withinTryWithExcept*: int ## required for goto based exception handling
     withinBlockLeaveActions*: int ## complex to explain
     sigConflicts*: CountTable[string]
+
+    specifier*: Option[uint32]
+    # XXX: `specifier` is a hack. Some parts of the code generator manually
+    #      emit gotos, and thus need a label specifier, but they shouldn't
 
     body*: Body               ## the procedure's full body
     locals*: OrdinalSeq[LocalId, TLoc]

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -137,15 +137,7 @@ type
   BModule* = ref TCGen
   BProc* = ref TCProc
   TBlock* = object
-    id*: int                  ## the ID of the label; positive means that it
-    blk*: int                 ## the ``BlockId`` + 1 of the block.
-                              ## '0' if the ``TBlock`` doesn't correspond to a
-                              ## ``cnkBlockStmt``
-    label*: Rope              ## generated text for the label
-                              ## nil if label is not used
     sections*: TCProcSections ## the code belonging
-    nestedTryStmts*: int16    ## how many try statements is it nested into
-    nestedExceptStmts*: int16 ## how many except statements is it nested into
     frameLen*: int16
 
   TCProcFlag* = enum

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -161,18 +161,12 @@ type
     flags*: set[TCProcFlag]
     lastLineInfo*: TLineInfo  ## to avoid generating excessive 'nimln' statements
     currLineInfo*: TLineInfo  ## AST codegen will make this superfluous
-    nestedTryStmts*: seq[tuple[fin: CgNode, inExcept: bool, label: Natural]]
-                              ## in how many nested try statements we are
-                              ## (the vars must be volatile then)
-                              ## bool is true when are in the except part of a try block
     labels*: Natural          ## for generating unique labels in the C proc
     blocks*: seq[TBlock]      ## nested blocks
     options*: TOptions        ## options that should be used for code
                               ## generation; this is the same as prc.options
                               ## unless prc == nil
     module*: BModule          ## used to prevent excessive parameter passing
-    withinTryWithExcept*: int ## required for goto based exception handling
-    withinBlockLeaveActions*: int ## complex to explain
     sigConflicts*: CountTable[string]
 
     specifier*: Option[uint32]
@@ -323,7 +317,6 @@ proc newProc*(prc: PSym, module: BModule): BProc =
   result.options = if prc != nil: prc.options
                    else: module.config.options
   newSeq(result.blocks, 1)
-  result.nestedTryStmts = @[]
   result.sigConflicts = initCountTable[string]()
 
 proc newModuleList*(g: ModuleGraph): BModuleList =

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -171,7 +171,6 @@ type
                               ## generation; this is the same as prc.options
                               ## unless prc == nil
     module*: BModule          ## used to prevent excessive parameter passing
-    withinLoop*: int          ## > 0 if we are within a loop
     withinTryWithExcept*: int ## required for goto based exception handling
     withinBlockLeaveActions*: int ## complex to explain
     sigConflicts*: CountTable[string]

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -122,6 +122,7 @@ type
     cnkTryStmt
 
     cnkGotoStmt
+    cnkLoopStmt   ## jump back to a loop join point
     cnkBreakStmt  ## break out of labeled block, or, if no label is provided,
                   ## the closest ``repeat`` loop
     cnkRaiseStmt  ## raise(x) -- set the `x` as the current exception and start
@@ -131,6 +132,7 @@ type
     cnkContinueStmt## jump to the next target in the active jump list
 
     cnkJoinStmt   ## join point for gotos
+    cnkLoopJoinStmt## join point for loops
     cnkEnd        ## marks the end of a structured control-flow block
                   ## (identified by the label)
     cnkExcept     ## special join point, representing an exception handler
@@ -159,10 +161,12 @@ const
     ## node kinds for which the ``items`` iterator is available
 
   cnkLiterals* = {cnkIntLit, cnkUIntLit, cnkFloatLit, cnkStrLit}
-  cnkLegacyNodes* = {cnkBlockStmt, cnkTryStmt, cnkReturnStmt, cnkBreakStmt}
+  cnkLegacyNodes* = {cnkBlockStmt, cnkTryStmt, cnkReturnStmt, cnkBreakStmt,
+                     cnkRepeatStmt}
     ## node kinds that belong to the legacy control-flow representation
   cnkNewCfNodes* = {cnkGotoStmt, cnkJoinStmt, cnkLeave, cnkResume,
-                    cnkContinueStmt, cnkEnd, cnkTargetList}
+                    cnkContinueStmt, cnkLoopStmt, cnkLoopJoinStmt,
+                    cnkEnd, cnkTargetList}
     ## node kinds that belong to the new-style control-flow representation
 
 type

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -41,10 +41,17 @@ import
     int128
   ]
 
+import std/options as std_options
+from std/sequtils import delete
+
 from compiler/ast/ast import newSym, newType, rawAddSon
 from compiler/sem/semdata import makeVarType
 
 type
+  NodeLabelPair = tuple
+    node: CgNode
+    target: LabelId
+
   TranslateCl = object
     graph: ModuleGraph
     idgen: IdGenerator
@@ -56,8 +63,24 @@ type
     localsMap: Table[int, LocalId]
       ## maps a sybmol ID to the corresponding local. Needed because normal
       ## local variables reach here as ``PSym``s
-    blocks: seq[LabelId]
+    blocks: seq[tuple[input, actual: LabelId]]
       ## the stack of enclosing blocks for the currently processed node
+
+    numLabels: int
+      ## incremented when a new label ID is allocated
+    exits: seq[NodeLabelPair]
+      ## non-exception goto-like statements that need patching when crossing
+      ## ``try``, ``finally``, or ``except`` boundaries
+    raiseExits: seq[NodeLabelPair]
+      ## similar to `exits`, but for exceptional control-flow statements/
+      ## nodes. The label doesn't matter, it's only there so that `raiseExits`
+      ## can be passed to the same procedures as `exits`
+    returnLabel: Option[LabelId]
+      ## the label to be placed after all other statements. A label is only
+      ## allocated if an ``mnkReturn`` appears somewhere in the MIR code
+    isActive: bool
+      ## whether translation of statements is enabled. Used to eliminate
+      ## unreachable code
 
     locals: Store[LocalId, Local]
       ## the in-progress list of all locals in the translated body
@@ -85,6 +108,12 @@ template isFilled(x: LocalId): bool =
   # temporaries, which can never map to the result variable
   x.int != 0
 
+func delete[T](s: var seq[T], a, b: int) =
+  # XXX: this procedure is a workaround for ``sequtils.delete`` not handling
+  #      empty slices properly (an IndexDefect is erroneously raised)
+  if b > a:
+    sequtils.delete(s, a..(b-1))
+
 func newMagicNode(magic: TMagic, info: TLineInfo): CgNode =
   CgNode(kind: cnkMagic, info: info, magic: magic)
 
@@ -93,6 +122,12 @@ func get(t: MirBody, cr: var TreeCursor): lent MirNode {.inline.} =
   result = t.code[cr.pos]
 
   inc cr.pos
+
+func skip(body: MirBody, cr: var TreeCursor) =
+  ## Skips over the node or sub-tree at the cursor.
+  let next = uint32 body.code.sibling(NodePosition cr.pos)
+  assert next > cr.pos
+  cr.pos = next
 
 func enter(t: MirBody, cr: var TreeCursor): lent MirNode {.inline.} =
   assert t.code[cr.pos].kind in SubTreeNodes, "not a sub-tree"
@@ -212,17 +247,6 @@ func addIfNotEmpty(stmts: var seq[CgNode], n: sink CgNode) =
   if n.kind != cnkEmpty:
     stmts.add n
 
-func toSingleNode(stmts: sink seq[CgNode]): CgNode =
-  ## Creates a single ``CgNode`` from a list of *statements*
-  case stmts.len
-  of 0:
-    result = newEmpty()
-  of 1:
-    result = move stmts[0]
-  else:
-    result = newNode(cnkStmtList)
-    result.kids = stmts
-
 proc newDefaultCall(info: TLineInfo, typ: PType): CgNode =
   ## Produces the tree for a ``default`` magic call.
   newExpr(cnkCall, info, typ, [newMagicNode(mDefault, info)])
@@ -261,9 +285,9 @@ proc genObjConv(n: CgNode, a, b, t: PType): CgNode =
 
 # forward declarations:
 proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
-              cr: var TreeCursor): CgNode
+              cr: var TreeCursor, stmts: var seq[CgNode])
 proc scopeToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
-               cr: var TreeCursor, allowExpr=false): seq[CgNode]
+               cr: var TreeCursor, stmts: var seq[CgNode], allowExpr=false)
 
 proc handleSpecialConv(c: ConfigRef, n: CgNode, info: TLineInfo,
                        dest: PType): CgNode =
@@ -608,93 +632,274 @@ proc defToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
     unreachable()
 
 proc bodyToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
-              cr: var TreeCursor): CgNode =
+              cr: var TreeCursor, stmts: var seq[CgNode]) =
   ## Generates the ``CgNode`` tree for the body of a construct that implies
   ## some form of control-flow.
   let prev = cl.inUnscoped
   # assume the body is unscoped until stated otherwise
   cl.inUnscoped = true
-  result = stmtToIr(tree, env, cl, cr)
+  stmtToIr(tree, env, cl, cr, stmts)
   cl.inUnscoped = prev
 
 proc caseToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl, n: MirNode,
-              cr: var TreeCursor): CgNode
+              cr: var TreeCursor, stmts: var seq[CgNode])
+
+func newLabel(cl: var TranslateCl): LabelId =
+  ## Allocates a new label ID and returns it.
+  result = LabelId(cl.numLabels)
+  inc cl.numLabels
+
+func getReturnLabel(cl: var TranslateCl): LabelId =
+  ## Returns the label that points to the end of the current procedure.
+  if cl.returnLabel.isSome:
+    result = cl.returnLabel.unsafeGet()
+  else:
+    # allocate a new label first
+    result = newLabel(cl)
+    cl.returnLabel = some result
+
+func node(lbl: LabelId): CgNode =
+  newLabelNode(BlockId(lbl))
+
+proc patch(stmt: CgNode, target: sink CgNode) =
+  ## Appends `target` to the goto-like statement `stmt`, always wrapping
+  ## `target` in a ``cnkTargetList`` if there's none yet.
+  if stmt[^1] == nil:
+    stmt[^1] = newTree(cnkTargetList, unknownLineInfo, target)
+  else:
+    # a target list already exists
+    stmt[^1].kids.add target
+
+proc patchSingle(stmt: CgNode, target: sink CgNode) =
+  ## Appends `target` to the goto-like statement `stmt`.
+  if stmt[^1] == nil:
+    stmt[^1] = target
+  else:
+    stmt[^1].kids.add target
+
+proc patch(x: seq[NodeLabelPair], start: int, exit: LabelId) =
+  for i in start..<x.len:
+    patch(x[i].node, node(exit))
+
+proc patchLeave(x: seq[NodeLabelPair], start: int, exit: LabelId) =
+  for i in start..<x.len:
+    patch(x[i].node, newTree(cnkLeave, x[i].node.info, node(exit)))
+
+proc patchResume(x: seq[NodeLabelPair], start: int) =
+  for i in start..<x.len:
+    patch(x[i].node, newNode(cnkResume, x[i].node.info))
+
+proc join(stmts: var seq[CgNode], cl: var TranslateCl, info: TLineInfo,
+          target: LabelId, required: bool) =
+  ## Emits a join statement with label `target`, enabling translation
+  ## again if it's disabled and an exit targetting `target` exists.
+  ## If `required` is false and a join statement was immediately emitted
+  ## prior, no new join statement is emitted.
+  var label = target
+
+  # if allowed and possible, coalesce a join with the previous one:
+  if not required and stmts.len > 0 and stmts[^1].kind == cnkJoinStmt:
+    label = stmts[^1][0].label.LabelId
+
+  var
+    i = 0
+    found = false
+  # search for exits targetting `target`, update them with the correct label,
+  # and then remove them from the list
+  while i < cl.exits.len:
+    if cl.exits[i][1] == target:
+      patchSingle(cl.exits[i][0], node(label))
+      cl.exits.del(i)
+      # remember that at least one exit was found:
+      found = true
+    else:
+      inc i
+
+  # emit the join, but only if no coalescing took place and the label is
+  # actually targeted:
+  if label == target and (found or required):
+    stmts.add newTree(cnkJoinStmt, info, node(label))
+
+  if found:
+    # code is alive if following a join that is targeted by an alive goto
+    cl.isActive = true
+
+template join(info: TLineInfo, lbl: LabelId; required = false) =
+  join(stmts, cl, info, lbl, required)
+
+template goto(kind: CgNodeKind, info: TLineInfo, target: LabelId) =
+  ## Emits a fixed goto-like statement targeting `target`.
+  stmts.add newStmt(kind, info, node(target))
+
+template exit(lbl: LabelId) =
+  ## Emits a goto statement and registers it with `lbl` as the target.
+  if cl.isActive:
+    let n = newStmt(cnkGotoStmt, unknownLineInfo, nil)
+    stmts.add n
+    cl.exits.add((n, lbl))
+    cl.isActive = false
+
+template guarded(lbl: LabelId, body: untyped) =
+  ## Updates all exits emitted as part of `body` with a leave instruction
+  ## targetting `lbl`.
+  let
+    raiseStart = cl.raiseExits.len
+    exitStart = cl.exits.len
+  body
+  patchLeave(cl.raiseExits, raiseStart, lbl)
+  patchLeave(cl.exits, exitStart, lbl)
 
 proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
-              cr: var TreeCursor): CgNode =
+              cr: var TreeCursor, stmts: var seq[CgNode]) =
+
+  # skip the statement if translation is disabled
+  if not cl.isActive:
+    tree.skip(cr)
+    return
+
   let n {.cursor.} = tree.get(cr)
   let info = cr.info ## the source information of `n`
 
-  template body(): CgNode =
-    bodyToIr(tree, env, cl, cr)
+  template body() =
+    bodyToIr(tree, env, cl, cr, stmts)
 
-  template to(kind: CgNodeKind, args: varargs[untyped]): CgNode =
+  template to(kind: CgNodeKind, args: varargs[untyped]) =
     let r = newStmt(kind, info, args)
     leave(tree, cr)
-    r
+    stmts.add r
 
-  template toList(k: CgNodeKind, body: untyped): CgNode =
+  template toList(k: CgNodeKind, body: untyped) =
     let res {.inject.} = newStmt(k, info)
     while tree[cr].kind != mnkEnd:
       body
     leave(tree, cr)
-    res
+    stmts.add res
 
   case n.kind
   of DefNodes:
-    defToIr(tree, env, cl, n, cr)
+    stmts.addIfNotEmpty defToIr(tree, env, cl, n, cr)
   of mnkAsgn, mnkInit, mnkSwitch:
     let
       dst = lvalueToIr(tree, cl, cr)
       (src, useFast) = sourceExprToIr(tree, cl, cr)
     to (if useFast: cnkFastAsgn else: cnkAsgn), dst, src
   of mnkRepeat:
-    to cnkRepeatStmt, body()
+    let label = newLabel(cl)
+    stmts.add newTree(cnkRepeatStmt, info, node(label))
+    body()
+    stmts.add newStmt(cnkEnd, info, node(label))
+    leave(tree, cr)
   of mnkBlock:
-    cl.blocks.add n.label # push the label to the stack
-    let body = body()
-    cl.blocks.setLen(cl.blocks.len - 1) # pop block from the stack
-    to cnkBlockStmt, newLabelNode(cl.blocks.len.BlockId, info), body
+    cl.blocks.add (n.label, newLabel(cl))
+    body()
+    join info, cl.blocks.pop().actual
+    leave(tree, cr)
   of mnkTry:
-    let res = newStmt(cnkTryStmt, info, [body()])
     assert n.len <= 2
+    let
+      raiseExitStart = cl.raiseExits.len
+      exitStart      = cl.exits.len
+
+    body() # body of the try block
+    let target = newLabel(cl)
+    exit target # jump past the except and/or finally sections
 
     for _ in 0..<n.len:
       let it {.cursor.} = enter(tree, cr)
 
       case it.kind
       of mnkExcept:
-        for _ in 0..<it.len:
-          let br {.cursor.} = enter(tree, cr)
-          assert br.kind == mnkBranch
+        # only translate the except section if it's actually entered
+        if raiseExitStart < cl.raiseExits.len:
+          var next = newLabel(cl)
+            ## the label of the next except branch
+          for i in raiseExitStart..<cl.raiseExits.len:
+            patchSingle(cl.raiseExits[i][0], node(next))
 
-          let excpt = newNode(cnkExcept, cr.info)
-          for j in 0..<br.len:
-            excpt.add tbExceptItem(tree, cl, cr)
+          # translating the handler could add new exceptional exits, so pop
+          # the raise exits first
+          cl.raiseExits.setLen(raiseExitStart)
 
-          excpt.add body()
-          res.add excpt
+          for bIdx in 0..<it.len:
+            let br {.cursor.} = enter(tree, cr)
+            assert br.kind == mnkBranch
 
-          leave(tree, cr)
+            let
+              this = next ## label of the current except branch
+              excpt = newTree(cnkExcept, cr.info, node(this))
+            for j in 0..<br.len:
+              excpt.add tbExceptItem(tree, cl, cr)
 
+            # no filters mean that this is a catch-all branch
+            if br.len > 0:
+              if bIdx == it.len-1:
+                # last branch in the handler block
+                excpt.add nil
+                cl.raiseExits.add (excpt, LabelId(0))
+              else:
+                # setup the label for the follow-up handler
+                next = newLabel(cl)
+                excpt.add node(next)
+
+            stmts.add excpt
+            guarded this:
+              cl.isActive = true # each branch starts as active
+              body() # body of the handler
+              exit target # jump to the after the try statement
+
+            leave(tree, cr)
+
+        else:
+          # skip all branches
+          for _ in 0..<it.len:
+            tree.skip(cr)
       of mnkFinally:
-        res.add newTree(cnkFinally, cr.info, body())
+        # only translate the finally if it's actually entered
+        if raiseExitStart < cl.raiseExits.len or exitStart < cl.exits.len:
+          let label = newLabel(cl)
+          # add the finalizer as an intermediate target
+          patch(cl.raiseExits, raiseExitStart, label)
+          patch(cl.exits, exitStart, label)
+
+          # remember the states prior to translating the body:
+          let
+            raiseExitStart2 = cl.raiseExits.len
+            exitStart2 = cl.exits.len
+
+          stmts.add newStmt(cnkFinally, info, node(label))
+          guarded label:
+            cl.isActive = true
+            body()
+
+          if not cl.isActive:
+            # the finally section has no structured exit. Discard all
+            # intercepted exits; their final target is the finally
+            cl.raiseExits.delete(raiseExitStart, raiseExitStart2)
+            cl.exits.delete(exitStart, exitStart2)
+
+          stmts.add newStmt(cnkContinueStmt, info, node(label))
+        else:
+          tree.skip(cr) # skip the body
+
       else:
         unreachable(it.kind)
 
       leave(tree, cr)
 
+    cl.isActive = false
+    # if structured control-flow exits the try statement, the join will enable
+    # translation again
+    join info, target
     leave(tree, cr)
-    res
   of mnkBreak:
     # find the stack index of the enclosing 'block' identified by the break's
-    # label; we use the index as the ID
+    # label
     var idx = cl.blocks.high
-    while idx >= 0 and cl.blocks[idx] != n.label:
+    while idx >= 0 and cl.blocks[idx].input != n.label:
       dec idx
-    newStmt(cnkBreakStmt, info, [newLabelNode(BlockId idx, info)])
+    exit cl.blocks[idx].actual
   of mnkReturn:
-    newNode(cnkReturnStmt, info)
+    exit getReturnLabel(cl)
   of mnkVoid:
     var res = exprToIr(tree, cl, cr)
     if res.typ.isEmptyType():
@@ -703,17 +908,32 @@ proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
     else:
       res = newStmt(cnkVoidStmt, info, [res])
     leave(tree, cr)
-    res
+    stmts.add res
   of mnkIf:
-    to cnkIfStmt, valueToIr(tree, cl, cr), body()
+    let label = newLabel(cl)
+    stmts.add newStmt(cnkIfStmt, info, [valueToIr(tree, cl, cr), node(label)])
+    body()
+    stmts.add newStmt(cnkEnd, info, [node(label)])
+    # if control-flow reaches the ``if`` itself, it also reaches the code
+    # following the ``if``
+    cl.isActive = true
+    leave(tree, cr)
   of mnkRaise:
     # the operand can either be empty or an lvalue expression
-    to cnkRaiseStmt:
-      case tree[cr].kind
-      of mnkNone: atomToIr(tree, cl, cr)
-      else:       lvalueToIr(tree, cl, cr)
+    let
+      arg {.cursor.} = tree.get(cr)
+      res = newStmt(cnkRaiseStmt, info):
+        case arg.kind
+        of mnkNone: newEmpty()
+        else:       lvalueToIr(tree, cl, arg, cr)
+
+    res.add nil # reserve a slot for the label
+    cl.raiseExits.add (res, LabelId(0))
+    stmts.add res
+    cl.isActive = false
+    leave(tree, cr)
   of mnkCase:
-    caseToIr(tree, env, cl, n, cr)
+    caseToIr(tree, env, cl, n, cr, stmts)
   of mnkAsm:
     toList cnkAsmStmt:
       res.add valueToIr(tree, cl, cr)
@@ -721,30 +941,51 @@ proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
     toList cnkEmitStmt:
       res.add valueToIr(tree, cl, cr)
   of mnkStmtList:
-    toList cnkStmtList:
-      res.kids.addIfNotEmpty stmtToIr(tree, env, cl, cr)
+    while tree[cr].kind != mnkEnd:
+      stmtToIr(tree, env, cl, cr, stmts)
+    leave(tree, cr)
   of mnkScope:
-    toSingleNode scopeToIr(tree, env, cl, cr)
+    scopeToIr(tree, env, cl, cr, stmts)
   of mnkDestroy:
     unreachable("a 'destroy' that wasn't lowered")
   of AllNodeKinds - StmtNodes:
     unreachable(n.kind)
 
 proc caseToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl, n: MirNode,
-              cr: var TreeCursor): CgNode =
+              cr: var TreeCursor, stmts: var seq[CgNode]) =
   assert n.kind == mnkCase
-  result = newStmt(cnkCaseStmt, cr.info, [valueToIr(tree, cl, cr)])
+  let
+    exit = newLabel(cl)
+    result = newStmt(cnkCaseStmt, cr.info, [valueToIr(tree, cl, cr)])
+  # whether the statement has a structured exit is computed manually
+  var doesExit = false
+
+  stmts.add result # add the case statement already
   for j in 0..<n.len:
     let br {.cursor.} = enter(tree, cr)
 
     result.add newTree(cnkBranch, cr.info)
-    if br.len > 0:
-      for x in 0..<br.len:
-        assert tree[cr].kind in {mnkConst, mnkLiteral}
-        result[^1].add atomToIr(tree, cl, cr)
+    for x in 0..<br.len:
+      assert tree[cr].kind in {mnkConst, mnkLiteral}
+      result[^1].add atomToIr(tree, cl, cr)
 
-    result[^1].add bodyToIr(tree, env, cl, cr)
+    let label = newLabel(cl)
+    result[^1].add node(label)
+
+    # start each branch as active again:
+    cl.isActive = true
+
+    join cr.info, label, required=true
+    bodyToIr(tree, env, cl, cr, stmts)
+    if cl.isActive:
+      doesExit = true
+      goto cnkGotoStmt, result.info, exit
+
     leave(tree, cr)
+
+  # we used manual gotos, so emission of a join statement has to be forced
+  join result.info, exit, required=true
+  cl.isActive = doesExit
 
   leave(tree, cr)
 
@@ -810,8 +1051,13 @@ proc exprToIr(tree: MirBody, cl: var TranslateCl,
 
     treeOp kind:
       res.add argToIr(tree, cl, cr)[1]
-  of mnkCall, mnkCheckedCall:
+  of mnkCall:
     callToIr(tree, cl, n, cr)
+  of mnkCheckedCall:
+    let res = callToIr(tree, cl, n, cr)
+    res.kids.add nil # reserve the slot for the target
+    cl.raiseExits.add (res, LabelId(0))
+    res
   of UnaryOps:
     const Map = [mnkNeg: cnkNeg]
     treeOp Map[n.kind]:
@@ -840,53 +1086,59 @@ proc genDefFor(sym: sink CgNode): CgNode =
     unreachable()
 
 proc scopeToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
-               cr: var TreeCursor, allowExpr = false): seq[CgNode] =
+               cr: var TreeCursor, stmts: var seq[CgNode],
+               allowExpr = false) =
   let
     ends =
       if allowExpr: {mnkEnd} + Atoms
       else:         {mnkEnd}
     prev = cl.defs.len
     prevInUnscoped = cl.inUnscoped
+    start = stmts.len
 
   # a scope is entered, meaning that we're no longer in an unscoped context
   cl.inUnscoped = false
 
-  var stmts: seq[CgNode]
   # translate all statements:
   while cr.hasNext(tree) and tree[cr].kind notin ends:
-    stmts.addIfNotEmpty stmtToIr(tree, env, cl, cr)
+    stmtToIr(tree, env, cl, cr, stmts)
 
   if cr.hasNext(tree) and tree[cr].kind == mnkEnd:
     leave(tree, cr) # close the sub-tree
 
   if cl.defs.len > prev:
-    # insert all the lifted defs at the start
+    # insert all the lifted defs at the start of the scope
     for i in countdown(cl.defs.high, prev):
-      stmts.insert genDefFor(move cl.defs[i])
+      stmts.insert genDefFor(move cl.defs[i]), start
 
     # "pop" the elements that were added as part of this scope:
     cl.defs.setLen(prev)
 
   cl.inUnscoped = prevInUnscoped
 
-  result = stmts
-
 proc tb(tree: MirBody, env: MirEnv, cl: var TranslateCl,
         start: NodePosition): CgNode =
   ## Translate `tree` to the corresponding ``CgNode`` representation.
   var cr = TreeCursor(pos: start.uint32)
-  var nodes = scopeToIr(tree, env, cl, cr, allowExpr=true)
+  var stmts: seq[CgNode]
+  scopeToIr(tree, env, cl, cr, stmts, allowExpr=true)
+  if cl.raiseExits.len > 0:
+    # there's unhandled exceptional control-flow
+    patchResume(cl.raiseExits, 0)
+
+  # emit the join for the return label, if used
+  if cl.returnLabel.isSome:
+    join unknownLineInfo, cl.returnLabel.get()
+
   if cr.hasNext(tree):
     # the tree must be an expression; the last node is required to be an atom
     let x = atomToIr(tree, cl, cr)
-    if nodes.len == 0:
-      x
-    else:
-      nodes.add x
-      newExpr(cnkStmtListExpr, unknownLineInfo, nodes[^1].typ, nodes)
-  else:
-    # it's a statement list
-    toSingleNode nodes
+    stmts.add x
+
+  # XXX: the list of statements is still wrapped in a node for now, but
+  #      this needs to change once all code generators use the new CGIR
+  result = newStmt(cnkStmtList, unknownLineInfo)
+  result.kids = move stmts
 
 proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
                  owner: PSym,
@@ -919,6 +1171,9 @@ proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
     if sig.callConv == ccClosure:
       # environment parameter
       add(owner.ast[paramsPos][^1].sym)
+
+  # enable translation:
+  cl.isActive = true
 
   result = Body()
   result.code = tb(body, env, cl, NodePosition 0)

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -785,9 +785,9 @@ proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
     to (if useFast: cnkFastAsgn else: cnkAsgn), dst, src
   of mnkRepeat:
     let label = newLabel(cl)
-    stmts.add newTree(cnkRepeatStmt, info, node(label))
+    stmts.add newTree(cnkLoopJoinStmt, info, node(label))
     body()
-    stmts.add newStmt(cnkEnd, info, node(label))
+    stmts.add newStmt(cnkLoopStmt, info, node(label))
     leave(tree, cr)
   of mnkBlock:
     cl.blocks.add (n.label, newLabel(cl))

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -737,8 +737,12 @@ proc join(stmts: var seq[CgNode], cl: var TranslateCl, info: TLineInfo,
   if label == target and (found or required):
     stmts.add newTree(cnkJoinStmt, info, node(label))
 
-  if found:
+  if found or true:
     # code is alive if following a join that is targeted by an alive goto
+    # XXX: translation has to be forcefully enabled at a join, even if not
+    #      within a scoped context: the surrounding scope might itself be
+    #      part of an unscoped context. This is a temporary workaround, see
+    #      `disable <#disable,TranslateCl>`_
     cl.isActive = true
 
 template join(info: TLineInfo, lbl: LabelId; required = false) =

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -846,6 +846,7 @@ proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
               cl.isActive = true # each branch starts as active
               body() # body of the handler
               exit target # jump to the after the try statement
+              stmts.add newStmt(cnkEnd, excpt.info, [node(this)])
 
             leave(tree, cr)
 

--- a/compiler/backend/cgirgen_legacy.nim
+++ b/compiler/backend/cgirgen_legacy.nim
@@ -1,0 +1,925 @@
+## Implements the translation from the MIR to the ``CgNode`` IR. All code
+## reaching the code generation phase passes through here.
+##
+## .. note::
+##   The `tb` prefix that's still used in some places is an abbreviation of
+##   "translate back"
+##
+## .. note::
+##   The ``CgNode`` IR is slated for removal, with the MIR intended to take
+##   its place as the code-generator input.
+
+import
+  std/[
+    tables
+  ],
+  compiler/ast/[
+    ast_types,
+    ast_idgen,
+    ast_query,
+    lineinfos,
+    types
+  ],
+  compiler/backend/[
+    cgir
+  ],
+  compiler/front/[
+    options
+  ],
+  compiler/mir/[
+    mirbodies,
+    mirenv,
+    mirtrees,
+    sourcemaps
+  ],
+  compiler/modules/[
+    modulegraphs
+  ],
+  compiler/utils/[
+    containers,
+    idioms,
+    int128
+  ]
+
+from compiler/ast/ast import newSym, newType, rawAddSon
+from compiler/sem/semdata import makeVarType
+
+type
+  TranslateCl = object
+    graph: ModuleGraph
+    idgen: IdGenerator
+
+    owner: PSym
+
+    tempMap: SeqMap[TempId, LocalId]
+      ## maps a ``TempId`` to the ID of the local created for it
+    localsMap: Table[int, LocalId]
+      ## maps a sybmol ID to the corresponding local. Needed because normal
+      ## local variables reach here as ``PSym``s
+    blocks: seq[LabelId]
+      ## the stack of enclosing blocks for the currently processed node
+
+    locals: Store[LocalId, Local]
+      ## the in-progress list of all locals in the translated body
+
+    # a 'def' in the MIR means that the the local starts to exists and that it
+    # is accessible in all connected basic blocks part of the enclosing
+    # ``mnkScope``. The ``CgNode`` IR doesn't use same notion of scope,
+    # so for now, all 'def's (without the initial values) within nested
+    # control-flow-related trees are moved to the start of the enclosing
+    # ``mnkScope``.
+    inUnscoped: bool
+      ## whether the currently proceesed statement/expression is part of an
+      ## unscoped control-flow context
+    defs: seq[CgNode]
+      ## the stack of locals/globals for which the ``cnkDef``/assignemnt needs
+      ## to be inserted later
+
+  TreeCursor = object
+    ## A cursor into a ``MirBody``.
+    pos: uint32 ## the index of the currently pointed to node
+    origin {.cursor.}: PNode ## the source node
+
+template isFilled(x: LocalId): bool =
+  # '0' is a valid ID, but this procedure is only used for
+  # temporaries, which can never map to the result variable
+  x.int != 0
+
+func newMagicNode(magic: TMagic, info: TLineInfo): CgNode =
+  CgNode(kind: cnkMagic, info: info, magic: magic)
+
+func get(t: MirBody, cr: var TreeCursor): lent MirNode {.inline.} =
+  cr.origin = t.sourceFor(cr.pos.NodePosition)
+  result = t.code[cr.pos]
+
+  inc cr.pos
+
+func enter(t: MirBody, cr: var TreeCursor): lent MirNode {.inline.} =
+  assert t.code[cr.pos].kind in SubTreeNodes, "not a sub-tree"
+  result = get(t, cr)
+
+func leave(t: MirBody, cr: var TreeCursor) =
+  assert t.code[cr.pos].kind == mnkEnd, "not at the end of sub-tree"
+  inc cr.pos
+
+template info(cr: TreeCursor): TLineInfo =
+  cr.origin.info
+
+template `[]`(t: MirBody, cr: TreeCursor): untyped =
+  t.code[cr.pos]
+
+template hasNext(cr: TreeCursor, t: MirBody): bool =
+  cr.pos.int < t.code.len
+
+template `[]=`(x: CgNode, i: Natural, n: CgNode) =
+  x.kids[i] = n
+
+template `[]=`(x: CgNode, i: BackwardsIndex, n: CgNode) =
+  x.kids[i] = n
+
+template add(x: CgNode, y: CgNode) =
+  x.kids.add y
+
+proc copyTree(n: CgNode): CgNode =
+  case n.kind
+  of cnkAtoms:
+    new(result)
+    result[] = n[]
+  of cnkWithOperand:
+    result = CgNode(kind: n.kind, info: n.info, typ: n.typ)
+    result.operand = copyTree(n.operand)
+  of cnkWithItems:
+    result = CgNode(kind: n.kind, info: n.info, typ: n.typ)
+    result.kids.setLen(n.kids.len)
+    for i, it in n.pairs:
+      result[i] = copyTree(it)
+
+proc newEmpty(info = unknownLineInfo): CgNode =
+  CgNode(kind: cnkEmpty, info: info)
+
+proc newTree(kind: CgNodeKind, info: TLineInfo, kids: varargs[CgNode]): CgNode =
+  ## For node kinds that don't represent standalone statements.
+  result = CgNode(kind: kind, info: info)
+  result.kids = @kids
+
+func newTypeNode(info: TLineInfo, typ: PType): CgNode =
+  CgNode(kind: cnkType, info: info, typ: typ)
+
+func newFieldNode(s: PSym; info = unknownLineInfo): CgNode =
+  CgNode(kind: cnkField, info: info, typ: s.typ, field: s)
+
+func newLabelNode(blk: BlockId; info = unknownLineInfo): CgNode =
+  CgNode(kind: cnkLabel, info: info, label: blk)
+
+proc newExpr(kind: CgNodeKind, info: TLineInfo, typ: PType,
+             kids: sink seq[CgNode]): CgNode =
+  ## Variant of ``newExpr`` optimized for passing a pre-existing child
+  ## node sequence.
+  result = CgNode(kind: kind, info: info, typ: typ)
+  result.kids = kids
+
+proc translateLit*(val: PNode): CgNode =
+  ## Translates an ``mnkLiteral`` node to a ``CgNode``.
+  ## Note that the MIR not only uses ``mnkLiteral`` for "real" literals, but
+  ## also for pushing other raw ``PNode``s through the MIR phase.
+  template node(k: CgNodeKind, field, value: untyped): CgNode =
+    CgNode(kind: k, info: val.info, typ: val.typ, field: value)
+
+  case val.kind
+  of nkIntLiterals:
+    # use the type for deciding what whether it's a signed or unsigned value
+    case val.typ.skipTypes(abstractRange + {tyEnum}).kind
+    of tyInt..tyInt64, tyBool:
+      node(cnkIntLit, intVal, val.intVal)
+    of tyUInt..tyUInt64, tyChar:
+      node(cnkUIntLit, intVal, val.intVal)
+    of tyPtr, tyPointer, tyProc:
+      # XXX: consider adding a dedicated node for pointer-like-literals
+      #      to both ``PNode`` and ``CgNode``
+      node(cnkUIntLit, intVal, val.intVal)
+    else:
+      unreachable(val.typ.skipTypes(abstractRange).kind)
+  of nkFloatLiterals:
+    case val.typ.skipTypes(abstractRange).kind
+    of tyFloat, tyFloat64:
+      node(cnkFloatLit, floatVal, val.floatVal)
+    of tyFloat32:
+      # all code-generators need to do this at one point, so we help them out
+      # by narrowing the value to a float32 value
+      node(cnkFloatLit, floatVal, val.floatVal.float32.float64)
+    else:
+      unreachable()
+  of nkStrKinds:
+    node(cnkStrLit, strVal, val.strVal)
+  of nkNilLit:
+    newNode(cnkNilLit, val.info, val.typ)
+  of nkNimNodeLit:
+    node(cnkAstLit, astLit, val[0])
+  of nkRange:
+    node(cnkRange, kids, @[translateLit(val[0]), translateLit(val[1])])
+  of nkSym:
+    # special case for raw symbols used with emit and asm statements
+    assert val.sym.kind == skField
+    node(cnkField, field, val.sym)
+  else:
+    unreachable("implement: " & $val.kind)
+
+func addIfNotEmpty(stmts: var seq[CgNode], n: sink CgNode) =
+  ## Only adds the node to the list if it's not an empty node. Used to prevent
+  ## the creation of statement-list expression that only consist of empty
+  ## nodes + the result-expression (a statement-list expression is unnecessary
+  ## in that case)
+  if n.kind != cnkEmpty:
+    stmts.add n
+
+func toSingleNode(stmts: sink seq[CgNode]): CgNode =
+  ## Creates a single ``CgNode`` from a list of *statements*
+  case stmts.len
+  of 0:
+    result = newEmpty()
+  of 1:
+    result = move stmts[0]
+  else:
+    result = newNode(cnkStmtList)
+    result.kids = stmts
+
+proc newDefaultCall(info: TLineInfo, typ: PType): CgNode =
+  ## Produces the tree for a ``default`` magic call.
+  newExpr(cnkCall, info, typ, [newMagicNode(mDefault, info)])
+
+proc initLocal(s: PSym): Local =
+  ## Inits a ``Local`` with the data from `s`.
+  result = Local(typ: s.typ, flags: s.flags, isImmutable: (s.kind == skLet),
+                 name: s.name)
+  if s.kind in {skVar, skLet, skForVar}:
+    result.alignment = s.alignment.uint32
+
+proc wrapInHiddenAddr(cl: TranslateCl, n: CgNode): CgNode =
+  ## Restores the ``cnkHiddenAddr`` around lvalue expressions passed to ``var``
+  ## parameters. The code-generators operating on ``CgNode``-IR depend on the
+  ## hidden addr to be present
+  if n.typ.skipTypes(abstractInst).kind != tyVar:
+    newOp(cnkHiddenAddr, n.info, makeVarType(cl.owner, n.typ, cl.idgen), n)
+  else:
+    # XXX: is this case ever reached? It should not be. Raw ``var`` values
+    #      must never be passed directly to ``var`` parameters at the MIR
+    #      level
+    n
+
+proc genObjConv(n: CgNode, a, b, t: PType): CgNode =
+  ## Depending on the relationship between `a` and `b`, wraps `n` in either an
+  ## up- or down-conversion. `t` is the type to use for the resulting
+  ## expression
+  let diff = inheritanceDiff(b, a)
+  #echo "a: ", a.sym.name.s, "; b: ", b.sym.name.s
+  #assert diff != 0 and diff != high(int), "redundant or illegal conversion"
+  if diff == 0:
+    return nil
+  result = newOp(
+    if diff < 0: cnkObjUpConv else: cnkObjDownConv,
+    n.info, t): n
+
+# forward declarations:
+proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
+              cr: var TreeCursor): CgNode
+proc scopeToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
+               cr: var TreeCursor, allowExpr=false): seq[CgNode]
+
+proc handleSpecialConv(c: ConfigRef, n: CgNode, info: TLineInfo,
+                       dest: PType): CgNode =
+  ## Checks if a special conversion operator is required for a conversion
+  ## between the source type (i.e. that of `n`) and the destination type.
+  ## If it is, generates the conversion operation IR and returns it -- nil
+  ## otherwise
+  let
+    orig = dest
+    source = n.typ.skipTypes(abstractVarRange)
+    dest = dest.skipTypes(abstractVarRange)
+
+  case dest.kind
+  of tyObject:
+    assert source.kind == tyObject
+    genObjConv(n, source, dest, orig)
+  of tyRef, tyPtr, tyVar, tyLent:
+    assert source.kind == dest.kind
+    if source.base.kind == tyObject:
+      genObjConv(n, source.base, dest.base, orig)
+    else:
+      nil
+  else:
+    nil
+
+proc convToIr(cl: TranslateCl, n: CgNode, info: TLineInfo, dest: PType): CgNode =
+  ## Generates the ``CgNode`` IR for an ``mnkPathConv`` operation (handle
+  ## conversion).
+  result = handleSpecialConv(cl.graph.config, n, info, dest)
+  if result == nil:
+    # no special conversion is used
+    result = newOp(cnkLvalueConv, info, dest, n)
+
+proc atomToIr(n: MirNode, cl: TranslateCl, info: TLineInfo): CgNode =
+  case n.kind
+  of mnkProc:
+    CgNode(kind: cnkProc, info: info, typ: n.typ, prc: n.prc)
+  of mnkGlobal:
+    CgNode(kind: cnkGlobal, info: info, typ: n.typ, global: n.global)
+  of mnkConst:
+    CgNode(kind: cnkConst, info: info, typ: n.typ, cnst: n.cnst)
+  of mnkLocal, mnkParam:
+    # paramaters are treated like locals in the code generators
+    assert n.sym.id in cl.localsMap
+    newLocalRef(cl.localsMap[n.sym.id], info, n.sym.typ)
+  of mnkTemp:
+    newLocalRef(cl.tempMap[n.temp], info, n.typ)
+  of mnkAlias:
+    # the type of the node doesn't match the real one
+    let
+      id = cl.tempMap[n.temp]
+      typ = cl.locals[id].typ
+    # the view is auto-dereferenced here for convenience
+    newOp(cnkDerefView, info, typ.base, newLocalRef(id, info, typ))
+  of mnkLiteral:
+    translateLit(n.lit)
+  of mnkType:
+    newTypeNode(info, n.typ)
+  of mnkNone:
+    # type arguments do use `mnkNone` in some situtations, so keep
+    # the type
+    CgNode(kind: cnkEmpty, info: info, typ: n.typ)
+  else:
+    unreachable("not an atom: " & $n.kind)
+
+proc atomToIr(tree: MirBody, cl: var TranslateCl,
+              cr: var TreeCursor): CgNode {.inline.} =
+  atomToIr(get(tree, cr), cl, cr.info)
+
+proc tbExceptItem(tree: MirBody, cl: var TranslateCl, cr: var TreeCursor
+                 ): CgNode =
+  let n {.cursor.} = get(tree, cr)
+  case n.kind
+  of mnkLocal:
+    # the 'except' branch acts as a definition for the local
+    let id = cl.locals.add initLocal(n.sym)
+    cl.localsMap[n.sym.id] = id
+    newLocalRef(id, cr.info, n.typ)
+  of mnkType:  newTypeNode(cr.info, n.typ)
+  else:        unreachable()
+
+
+proc lvalueToIr(tree: MirBody, cl: var TranslateCl, n: MirNode,
+                cr: var TreeCursor; preferField = true): CgNode =
+  ## Translates a MIR lvalue expression to the corresponding CG IR.
+  ## Due to tagged unions (currently) not being addressable at the type-
+  ## representation level, the exact meaning of ``mnkPathVariant`` is
+  ## context-dependent -- `preferField` disambiguates whether it should be
+  ## turned into a field access rather than a (pseudo) access of the tagged
+  ## union.
+  let info = cr.info
+
+  template recurse(): CgNode =
+    lvalueToIr(tree, cl, tree.get(cr), cr, false)
+
+  case n.kind
+  of mnkLocal, mnkGlobal, mnkParam, mnkTemp, mnkAlias, mnkConst, mnkProc:
+    return atomToIr(n, cl, info)
+  of mnkPathNamed:
+    result = newExpr(cnkFieldAccess, info, n.typ,
+                     [recurse(), newFieldNode(n.field)])
+  of mnkPathVariant:
+    if preferField:
+      result = newExpr(cnkFieldAccess, cr.info, n.field.typ,
+                      [recurse(), newFieldNode(n.field)])
+    else:
+      # variant access itself has no ``CgNode`` counterpart at the moment
+      result = recurse()
+  of mnkPathPos:
+    result = newExpr(cnkTupleAccess, info, n.typ,
+                     [recurse(),
+                      CgNode(kind: cnkIntLit, intVal: n.position.BiggestInt)])
+  of mnkPathArray:
+    # special case in order to support string literal access
+    # XXX: this needs to be removed once there is a dedicated run-time-
+    #      sequence access operator
+    let arg =
+      if tree[cr].kind == mnkLiteral:
+        atomToIr(tree, cl, cr)
+      else:
+        recurse()
+
+    result = newExpr(cnkArrayAccess, info, n.typ, [arg, atomToIr(tree, cl, cr)])
+  of mnkPathConv:
+    result = convToIr(cl, recurse(), info, n.typ)
+  # dereferences are allowed at the end of a path tree
+  of mnkDeref:
+    result = newOp(cnkDeref, info, n.typ, atomToIr(tree, cl, cr))
+  of mnkDerefView:
+    result = newOp(cnkDerefView, info, n.typ, atomToIr(tree, cl, cr))
+  of AllNodeKinds - LvalueExprKinds - {mnkProc}:
+    unreachable(n.kind)
+
+  leave(tree, cr)
+
+proc lvalueToIr(tree: MirBody, cl: var TranslateCl,
+                cr: var TreeCursor; preferField=true): CgNode {.inline.} =
+  lvalueToIr(tree, cl, tree.get(cr), cr, preferField)
+
+proc valueToIr(tree: MirBody, cl: var TranslateCl,
+               cr: var TreeCursor): CgNode =
+  case tree[cr].kind
+  of mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp, mnkAlias,
+     mnkLiteral, mnkType:
+    atomToIr(tree, cl, cr)
+  of mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv, mnkPathVariant,
+     mnkDeref, mnkDerefView:
+    lvalueToIr(tree, cl, cr)
+  else:
+    unreachable("not a value: " & $tree[cr].kind)
+
+proc argToIr(tree: MirBody, cl: var TranslateCl,
+             cr: var TreeCursor): (bool, CgNode) =
+  ## Translates a MIR argument tree to the corresponding CG IR tree.
+  ## Returns both the tree and whether the argumnet was wrapped in a tag
+  ## operator (which indicates that the parameter is a ``var`` parameter).
+  var n {.cursor.} = tree.get(cr)
+  assert n.kind in ArgumentNodes, "argument node expected: " & $n.kind
+  # the inner node may be a tag node
+  n = tree.get(cr)
+  case n.kind
+  of mnkTag:
+    # it is one, the expression must be an lvalue
+    result = (true, lvalueToIr(tree, cl, cr))
+    leave(tree, cr)
+  of mnkLiteral, mnkType, mnkProc, mnkNone:
+    # not a tag but an atom
+    result = (false, atomToIr(n, cl, cr.info))
+  of LvalueExprKinds:
+    result = (false, lvalueToIr(tree, cl, n, cr))
+  else:
+    unreachable("not a valid argument expression")
+
+  leave(tree, cr)
+
+proc callToIr(tree: MirBody, cl: var TranslateCl, n: MirNode,
+              cr: var TreeCursor): CgNode =
+  ## Translate a valid call-like tree to the CG IR.
+  let info = cr.info
+  result = newExpr((if n.kind == mnkCall: cnkCall else: cnkCheckedCall),
+                   info, n.typ)
+  result.add: # the callee
+    case tree[cr].kind
+    of mnkMagic: newMagicNode(tree.get(cr).magic, info)
+    else:        valueToIr(tree, cl, cr)
+
+  # the code generators currently require some magics to not have any
+  # arguments wrapped in ``cnkHiddenAddr`` nodes
+  let noAddr = result[0].kind == cnkMagic and
+               result[0].magic in FakeVarParams
+
+  # translate the arguments:
+  while tree[cr].kind != mnkEnd:
+    var (mutable, arg) = argToIr(tree, cl, cr)
+    if noAddr:
+      if arg.typ.kind == tyVar:
+        # auto-dereference the view
+        # XXX: prevent this case from happening
+        arg = newOp(cnkDerefView, arg.info, arg.typ.base, arg)
+    elif mutable:
+      arg = wrapInHiddenAddr(cl, arg)
+
+    result.add arg
+
+  leave(tree, cr)
+
+proc exprToIr(tree: MirBody, cl: var TranslateCl, cr: var TreeCursor): CgNode
+
+proc sourceExprToIr(tree: MirBody, cl: var TranslateCl,
+                    cr: var TreeCursor): tuple[n: CgNode, useFast: bool] =
+  ## Translates the MIR expression appearing in an assignment's source
+  ## slot. Assignment modifiers are dropped, and whether a fast assignment or
+  ## normal assignment should be used is computed and returned.
+  case tree[cr].kind
+  of mnkCopy, mnkSink:
+    # requires a full assignment
+    discard enter(tree, cr)
+    result = (valueToIr(tree, cl, cr), false)
+    leave(tree, cr)
+  of mnkMove:
+    # an ``x = move y`` assignment can be turned into a fast assignment
+    discard enter(tree, cr)
+    result = (valueToIr(tree, cl, cr), true)
+    leave(tree, cr)
+  of LvalueExprKinds:
+    # a fast assignment is correct for all raw lvalues
+    result = (lvalueToIr(tree, cl, cr), true)
+  else:
+    # rvalue expressions require a full assignment
+    result = (exprToIr(tree, cl, cr), false)
+
+proc defToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
+           n: MirNode, cr: var TreeCursor): CgNode =
+  ## Translates a 'def'-like construct
+  assert n.kind in DefNodes
+  let
+    entity {.cursor.} = get(tree, cr) # the name of the defined entity
+    info = cr.info
+
+  var def: CgNode
+
+  case entity.kind
+  of mnkLocal:
+    # translate the ``PSym`` to a ``Local`` and establish a mapping
+    let
+      sym = entity.sym
+      id = cl.locals.add initLocal(sym)
+
+    assert sym.id notin cl.localsMap, "re-definition of local"
+    cl.localsMap[sym.id] = id
+
+    def = newLocalRef(id, info, entity.typ)
+  of mnkParam:
+    # ignore 'def's for parameters
+    def = newEmpty()
+  of mnkGlobal:
+    def = CgNode(kind: cnkGlobal, info: info, typ: entity.typ,
+                 global: entity.global)
+  of mnkTemp:
+    # MIR temporaries are like normal locals, with the difference that they
+    # are created ad-hoc and don't have any extra information attached
+    assert entity.typ != nil
+    let tmp = cl.locals.add Local(typ: entity.typ)
+
+    assert entity.temp notin cl.tempMap, "re-definition of temporary"
+    cl.tempMap[entity.temp] = tmp
+
+    def = newLocalRef(tmp, info, entity.typ)
+  of mnkAlias:
+    # MIR aliases are translated to var/lent views
+    assert n.kind in {mnkBind, mnkBindMut}, "alias can only be defined by binds"
+    assert entity.typ != nil
+    let
+      typ = makeVarType(cl.owner, entity.typ, cl.idgen,
+                        if n.kind == mnkBind: tyLent else: tyVar)
+      tmp = cl.locals.add Local(typ: typ)
+
+    assert entity.temp notin cl.tempMap, "re-definition of temporary"
+    cl.tempMap[entity.temp] = tmp
+
+    def = newLocalRef(tmp, info, typ)
+  else:
+    unreachable()
+
+  var arg =
+    if n.kind in {mnkBind, mnkBindMut} and tree[cr].kind in LvalueExprKinds:
+      # don't use the field interperation for variant access
+      lvalueToIr(tree, cl, cr, preferField=false)
+    else:
+      sourceExprToIr(tree, cl, cr)[0]
+  leave(tree, cr)
+  if n.kind in {mnkBind, mnkBindMut} and arg.typ.kind notin {tyVar, tyLent}:
+    # wrap the operand in an address-of operation
+    arg = newOp(cnkHiddenAddr, info, def.typ, arg)
+
+  let isLet = (entity.kind == mnkTemp and n.kind == mnkDefCursor) or
+              (entity.kind == mnkTemp and not hasDestructor(def.typ)) or
+              (entity.kind == mnkAlias)
+  # to reduce the pressure on the code generator, locals that never cross
+  # structured control-flow boundaries are not lifted. As a temporary
+  # measure, cursor temporaries and aliases are treated as such, but
+  # do note that this is not guaranteed and relies on how `mirgen`
+  # produces MIR code
+
+  case def.kind
+  of cnkLocal:
+    if cl.inUnscoped and not isLet:
+      # add the local to the list of moved definitions and only emit
+      # an assignment
+      cl.defs.add copyTree(def)
+      result =
+        case arg.kind
+        of cnkEmpty: arg
+        else:        newStmt(cnkAsgn, info, [def, arg])
+    else:
+      result = newStmt(cnkDef, info, [def, arg])
+  of cnkGlobal:
+    # there are no defs for globals in the ``CgNode`` IR, so we
+    # emit an assignment that has the equivalent behaviour (in
+    # terms of initialization)
+    case arg.kind
+    of cnkEmpty:
+      if sfImportc in env.globals[def.global].flags:
+        # for imported globals, the 'def' only means that the symbol becomes
+        # known to us, not that it starts its lifetime here -> don't
+        # initialize or move it
+        result = arg
+      elif cl.inUnscoped:
+        # move the default initialization to the start of the scope
+        cl.defs.add def
+        result = arg
+      else:
+        result = newStmt(cnkAsgn, info, [def, newDefaultCall(info, def.typ)])
+    else:
+      if sfImportc notin env.globals[def.global].flags and cl.inUnscoped:
+        # default intialization is required at the start of the scope
+        cl.defs.add def
+      result = newStmt(cnkAsgn, info, [def, arg])
+  of cnkEmpty:
+    result = def
+  else:
+    unreachable()
+
+proc bodyToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
+              cr: var TreeCursor): CgNode =
+  ## Generates the ``CgNode`` tree for the body of a construct that implies
+  ## some form of control-flow.
+  let prev = cl.inUnscoped
+  # assume the body is unscoped until stated otherwise
+  cl.inUnscoped = true
+  result = stmtToIr(tree, env, cl, cr)
+  cl.inUnscoped = prev
+
+proc caseToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl, n: MirNode,
+              cr: var TreeCursor): CgNode
+
+proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
+              cr: var TreeCursor): CgNode =
+  let n {.cursor.} = tree.get(cr)
+  let info = cr.info ## the source information of `n`
+
+  template body(): CgNode =
+    bodyToIr(tree, env, cl, cr)
+
+  template to(kind: CgNodeKind, args: varargs[untyped]): CgNode =
+    let r = newStmt(kind, info, args)
+    leave(tree, cr)
+    r
+
+  template toList(k: CgNodeKind, body: untyped): CgNode =
+    let res {.inject.} = newStmt(k, info)
+    while tree[cr].kind != mnkEnd:
+      body
+    leave(tree, cr)
+    res
+
+  case n.kind
+  of DefNodes:
+    defToIr(tree, env, cl, n, cr)
+  of mnkAsgn, mnkInit, mnkSwitch:
+    let
+      dst = lvalueToIr(tree, cl, cr)
+      (src, useFast) = sourceExprToIr(tree, cl, cr)
+    to (if useFast: cnkFastAsgn else: cnkAsgn), dst, src
+  of mnkRepeat:
+    to cnkRepeatStmt, body()
+  of mnkBlock:
+    cl.blocks.add n.label # push the label to the stack
+    let body = body()
+    cl.blocks.setLen(cl.blocks.len - 1) # pop block from the stack
+    to cnkBlockStmt, newLabelNode(cl.blocks.len.BlockId, info), body
+  of mnkTry:
+    let res = newStmt(cnkTryStmt, info, [body()])
+    assert n.len <= 2
+
+    for _ in 0..<n.len:
+      let it {.cursor.} = enter(tree, cr)
+
+      case it.kind
+      of mnkExcept:
+        for _ in 0..<it.len:
+          let br {.cursor.} = enter(tree, cr)
+          assert br.kind == mnkBranch
+
+          let excpt = newNode(cnkExcept, cr.info)
+          for j in 0..<br.len:
+            excpt.add tbExceptItem(tree, cl, cr)
+
+          excpt.add body()
+          res.add excpt
+
+          leave(tree, cr)
+
+      of mnkFinally:
+        res.add newTree(cnkFinally, cr.info, body())
+      else:
+        unreachable(it.kind)
+
+      leave(tree, cr)
+
+    leave(tree, cr)
+    res
+  of mnkBreak:
+    # find the stack index of the enclosing 'block' identified by the break's
+    # label; we use the index as the ID
+    var idx = cl.blocks.high
+    while idx >= 0 and cl.blocks[idx] != n.label:
+      dec idx
+    newStmt(cnkBreakStmt, info, [newLabelNode(BlockId idx, info)])
+  of mnkReturn:
+    newNode(cnkReturnStmt, info)
+  of mnkVoid:
+    var res = exprToIr(tree, cl, cr)
+    if res.typ.isEmptyType():
+      # a void expression doesn't need to be discarded
+      discard
+    else:
+      res = newStmt(cnkVoidStmt, info, [res])
+    leave(tree, cr)
+    res
+  of mnkIf:
+    to cnkIfStmt, valueToIr(tree, cl, cr), body()
+  of mnkRaise:
+    # the operand can either be empty or an lvalue expression
+    to cnkRaiseStmt:
+      case tree[cr].kind
+      of mnkNone: atomToIr(tree, cl, cr)
+      else:       lvalueToIr(tree, cl, cr)
+  of mnkCase:
+    caseToIr(tree, env, cl, n, cr)
+  of mnkAsm:
+    toList cnkAsmStmt:
+      res.add valueToIr(tree, cl, cr)
+  of mnkEmit:
+    toList cnkEmitStmt:
+      res.add valueToIr(tree, cl, cr)
+  of mnkStmtList:
+    toList cnkStmtList:
+      res.kids.addIfNotEmpty stmtToIr(tree, env, cl, cr)
+  of mnkScope:
+    toSingleNode scopeToIr(tree, env, cl, cr)
+  of mnkDestroy:
+    unreachable("a 'destroy' that wasn't lowered")
+  of AllNodeKinds - StmtNodes:
+    unreachable(n.kind)
+
+proc caseToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl, n: MirNode,
+              cr: var TreeCursor): CgNode =
+  assert n.kind == mnkCase
+  result = newStmt(cnkCaseStmt, cr.info, [valueToIr(tree, cl, cr)])
+  for j in 0..<n.len:
+    let br {.cursor.} = enter(tree, cr)
+
+    result.add newTree(cnkBranch, cr.info)
+    if br.len > 0:
+      for x in 0..<br.len:
+        assert tree[cr].kind in {mnkConst, mnkLiteral}
+        result[^1].add atomToIr(tree, cl, cr)
+
+    result[^1].add bodyToIr(tree, env, cl, cr)
+    leave(tree, cr)
+
+  leave(tree, cr)
+
+proc exprToIr(tree: MirBody, cl: var TranslateCl,
+              cr: var TreeCursor): CgNode =
+  ## Translates a MIR expression to the corresponding CG IR representation.
+  ## Moves the cursor to the next tree item.
+  let n {.cursor.} = get(tree, cr)
+  let info = cr.info
+
+  template op(kind: CgNodeKind, e: CgNode): CgNode =
+    let r = newOp(kind, info, n.typ, e)
+    leave(tree, cr)
+    r
+
+  template treeOp(k: CgNodeKind, body: untyped): CgNode =
+    let res {.inject.} = newExpr(k, info, n.typ)
+    while tree[cr].kind != mnkEnd:
+      body
+    leave(tree, cr)
+    res
+
+  case n.kind
+  of Atoms:
+    atomToIr(n, cl, info)
+  of mnkPathVariant, mnkPathArray, mnkPathConv, mnkPathNamed, mnkPathPos:
+    lvalueToIr(tree, cl, n, cr)
+  of mnkCast:
+    op cnkCast, valueToIr(tree, cl, cr)
+  of mnkConv:
+    op cnkConv, valueToIr(tree, cl, cr)
+  of mnkStdConv:
+    op cnkHiddenConv, valueToIr(tree, cl, cr)
+  of mnkToSlice:
+    treeOp cnkToSlice:
+      res.add valueToIr(tree, cl, cr)
+  of mnkAddr:
+    op cnkAddr, lvalueToIr(tree, cl, cr)
+  of mnkDeref:
+    op cnkDeref, atomToIr(tree, cl, cr)
+  of mnkView:
+    op cnkHiddenAddr, lvalueToIr(tree, cl, cr)
+  of mnkDerefView:
+    op cnkDerefView, atomToIr(tree, cl, cr)
+  of mnkObjConstr:
+    assert n.typ.skipTypes(abstractVarRange).kind in {tyObject, tyRef}
+    treeOp cnkObjConstr:
+      let f = newFieldNode(get(tree, cr).field)
+      res.add newTree(cnkBinding, cr.info, [f, argToIr(tree, cl, cr)[1]])
+  of mnkConstr:
+    let typ = n.typ.skipTypes(abstractVarRange)
+
+    let kind =
+      case typ.kind
+      of tySet:               cnkSetConstr
+      of tyArray, tySequence: cnkArrayConstr
+      of tyTuple:             cnkTupleConstr
+      of tyProc:
+        assert typ.callConv == ccClosure
+        cnkClosureConstr
+      else:
+        unreachable(typ.kind)
+
+    treeOp kind:
+      res.add argToIr(tree, cl, cr)[1]
+  of mnkCall, mnkCheckedCall:
+    callToIr(tree, cl, n, cr)
+  of UnaryOps:
+    const Map = [mnkNeg: cnkNeg]
+    treeOp Map[n.kind]:
+      res.add valueToIr(tree, cl, cr)
+  of BinaryOps:
+    const Map = [mnkAdd: cnkAdd, mnkSub: cnkSub,
+                 mnkMul: cnkMul, mnkDiv: cnkDiv, mnkModI: cnkModI]
+    treeOp Map[n.kind]:
+      res.kids = @[valueToIr(tree, cl, cr), valueToIr(tree, cl, cr)]
+  of mnkCopy, mnkMove, mnkSink:
+    # translation of assignments needs to handle all modifiers
+    unreachable("loose assignment modifier")
+  of AllNodeKinds - ExprKinds - {mnkNone}:
+    unreachable(n.kind)
+
+proc genDefFor(sym: sink CgNode): CgNode =
+  ## Produces the statement tree of a definition for the given symbol-like
+  ## node. Globals use an assignment.
+  case sym.kind
+  of cnkLocal:
+    newStmt(cnkDef, sym.info, [sym, newEmpty()])
+  of cnkGlobal:
+    # emulate the default-initialization behaviour
+    newStmt(cnkAsgn, sym.info, [sym, newDefaultCall(sym.info, sym.typ)])
+  else:
+    unreachable()
+
+proc scopeToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
+               cr: var TreeCursor, allowExpr = false): seq[CgNode] =
+  let
+    ends =
+      if allowExpr: {mnkEnd} + Atoms
+      else:         {mnkEnd}
+    prev = cl.defs.len
+    prevInUnscoped = cl.inUnscoped
+
+  # a scope is entered, meaning that we're no longer in an unscoped context
+  cl.inUnscoped = false
+
+  var stmts: seq[CgNode]
+  # translate all statements:
+  while cr.hasNext(tree) and tree[cr].kind notin ends:
+    stmts.addIfNotEmpty stmtToIr(tree, env, cl, cr)
+
+  if cr.hasNext(tree) and tree[cr].kind == mnkEnd:
+    leave(tree, cr) # close the sub-tree
+
+  if cl.defs.len > prev:
+    # insert all the lifted defs at the start
+    for i in countdown(cl.defs.high, prev):
+      stmts.insert genDefFor(move cl.defs[i])
+
+    # "pop" the elements that were added as part of this scope:
+    cl.defs.setLen(prev)
+
+  cl.inUnscoped = prevInUnscoped
+
+  result = stmts
+
+proc tb(tree: MirBody, env: MirEnv, cl: var TranslateCl,
+        start: NodePosition): CgNode =
+  ## Translate `tree` to the corresponding ``CgNode`` representation.
+  var cr = TreeCursor(pos: start.uint32)
+  var nodes = scopeToIr(tree, env, cl, cr, allowExpr=true)
+  if cr.hasNext(tree):
+    # the tree must be an expression; the last node is required to be an atom
+    let x = atomToIr(tree, cl, cr)
+    if nodes.len == 0:
+      x
+    else:
+      nodes.add x
+      newExpr(cnkStmtListExpr, unknownLineInfo, nodes[^1].typ, nodes)
+  else:
+    # it's a statement list
+    toSingleNode nodes
+
+proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
+                 owner: PSym,
+                 body: sink MirBody): Body =
+  ## Generates the ``CgNode`` IR corresponding to the input MIR `body`,
+  ## using `idgen` to provide new IDs when creating symbols.
+  var cl = TranslateCl(graph: graph, idgen: idgen, owner: owner)
+  if owner.kind in routineKinds:
+    # setup the locals and associated mappings for the parameters
+    template add(v: PSym) =
+      let s = v
+      cl.localsMap[s.id] = cl.locals.add initLocal(s)
+
+    let sig =
+      if owner.kind == skMacro: owner.internal
+      else:                     owner.typ
+
+    # result variable:
+    if sig[0].isEmptyType():
+      # always reserve a slot for the result variable, even if the latter is
+      # not present
+      discard cl.locals.add(Local())
+    else:
+      add(owner.ast[resultPos].sym)
+
+    # normal parameters:
+    for i in 1..<sig.len:
+      add(sig.n[i].sym)
+
+    if sig.callConv == ccClosure:
+      # environment parameter
+      add(owner.ast[paramsPos][^1].sym)
+
+  result = Body()
+  result.code = tb(body, env, cl, NodePosition 0)
+  result.locals = cl.locals

--- a/compiler/backend/cgirgen_legacy.nim
+++ b/compiler/backend/cgirgen_legacy.nim
@@ -80,11 +80,6 @@ type
     pos: uint32 ## the index of the currently pointed to node
     origin {.cursor.}: PNode ## the source node
 
-template isFilled(x: LocalId): bool =
-  # '0' is a valid ID, but this procedure is only used for
-  # temporaries, which can never map to the result variable
-  x.int != 0
-
 func newMagicNode(magic: TMagic, info: TLineInfo): CgNode =
   CgNode(kind: cnkMagic, info: info, magic: magic)
 

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -59,7 +59,8 @@ proc treeRepr*(n: CgNode): string =
     of cnkMagic:
       result.add "magic: "
       result.add $n.magic
-    of cnkEmpty, cnkInvalid, cnkType, cnkAstLit, cnkNilLit, cnkReturnStmt:
+    of cnkEmpty, cnkInvalid, cnkType, cnkAstLit, cnkNilLit, cnkReturnStmt,
+       cnkResume:
       discard
     of cnkWithOperand:
       result.add "\n"

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -205,3 +205,8 @@ proc pick*[T](n: CgNode, forInt, forFloat: T): T =
   of tyFloat..tyFloat64:       forFloat
   else:
     unreachable("not an integer or float type")
+
+func numArgs*(n: CgNode): int {.inline.} =
+  ## Returns the number of arguments for a call-like node. The callee
+  ## is excluded.
+  n.len - 1 - ord(n.kind == cnkCheckedCall)

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -74,11 +74,11 @@ proc processEvent(g: PGlobals, graph: ModuleGraph, modules: BModuleList,
       p = startProc(g, bmod, evt.id, Body())
       partial[evt.sym.id] = p
 
-    let body = generateIR(graph, bmod.idgen, g.env, evt.sym, evt.body)
+    let body = generateIRLegacy(graph, bmod.idgen, g.env, evt.sym, evt.body)
     genPartial(p, merge(p.fullBody, body))
   of bekProcedure:
     let
-      body = generateIR(graph, bmod.idgen, g.env, evt.sym, evt.body)
+      body = generateIRLegacy(graph, bmod.idgen, g.env, evt.sym, evt.body)
       r = genProc(g, bmod, evt.id, body)
 
     if sfCompilerProc in evt.sym.flags:
@@ -115,7 +115,8 @@ proc generateCodeForMain(globals: PGlobals, graph: ModuleGraph, m: BModule,
 
   let owner = m.module
   genTopLevelStmt(globals, m):
-    canonicalize(graph, m.idgen, globals.env, owner, body, TranslationConfig())
+    canonicalize(graph, m.idgen, globals.env, owner, body, TranslationConfig(),
+                 legacy=true)
 
 proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   ## Entry point into the JS backend. Generates the code for all modules and

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2447,7 +2447,7 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkTryStmt: genTry(p, n)
   of cnkRaiseStmt: genRaiseStmt(p, n)
   of cnkInvalid, cnkMagic, cnkRange, cnkBinding, cnkExcept, cnkFinally,
-     cnkBranch, cnkAstLit, cnkLabel, cnkStmtListExpr, cnkField:
+     cnkBranch, cnkAstLit, cnkLabel, cnkStmtListExpr, cnkField, cnkNewCfNodes:
     internalError(p.config, n.info, "gen: unknown node type: " & $n.kind)
 
 proc newModule*(g: ModuleGraph; module: PSym): BModule =

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -74,3 +74,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimskullReworkStaticExec")
   defineSymbol("nimskullNoMagicNewAssign")
   defineSymbol("nimskullNoFloat128")
+  defineSymbol("nimskullNewExceptionRt")

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -10,6 +10,7 @@ import
   compiler/backend/[
     cgir,
     cgirgen,
+    cgirgen_legacy,
     cgirutils
   ],
   compiler/front/[
@@ -76,7 +77,8 @@ proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
       config.writeln(treeRepr(body.code))
 
 proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
-                   owner: PSym, body: PNode, config: TranslationConfig): Body =
+                   owner: PSym, body: PNode, config: TranslationConfig;
+                   legacy=false): Body =
   ## Legacy routine. Translates the body `body` of the procedure `owner` to
   ## MIR code, and the MIR code to ``CgNode`` IR.
   echoInput(graph.config, owner, body)
@@ -85,5 +87,8 @@ proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
   echoMir(graph.config, owner, body)
 
   # step 2: generate the ``CgNode`` tree
-  result = generateIR(graph, idgen, env, owner, body)
+  if legacy:
+    result = cgirgen_legacy.generateIR(graph, idgen, env, owner, body)
+  else:
+    result = cgirgen.generateIR(graph, idgen, env, owner, body)
   echoOutput(graph.config, owner, result)

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -126,7 +126,7 @@ proc generateCodeForProc(c: var CodeGenCtx, idgen: IdGenerator, s: PSym,
   ## Generates and the bytecode for the procedure `s` with body `body`. The
   ## resulting bytecode is emitted into the global bytecode section.
   let
-    body = generateIR(c.graph, idgen, c.env, s, body)
+    body = generateIRLegacy(c.graph, idgen, c.env, s, body)
     r    = genProc(c, s, body)
 
   if r.isOk:
@@ -181,7 +181,7 @@ proc processEvent(c: var GenCtx, mlist: ModuleList, discovery: var DiscoveryData
   of bekPartial:
     let p = addr mgetOrPut(partial, evt.id, PartialProc(sym: evt.sym))
     discard merge(p.body):
-      generateIR(c.graph, idgen, c.gen.env, evt.sym, evt.body)
+      generateIRLegacy(c.graph, idgen, c.gen.env, evt.sym, evt.body)
   of bekProcedure:
     # a complete procedure became available
     let r = generateCodeForProc(c.gen, idgen, evt.sym, evt.body)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3200,7 +3200,8 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
   of cnkAsmStmt, cnkEmitStmt:
     unused(c, n, dest)
   of cnkInvalid, cnkMagic, cnkRange, cnkExcept, cnkFinally, cnkBranch,
-     cnkBinding, cnkLabel, cnkStmtListExpr, cnkField, cnkToSlice:
+     cnkBinding, cnkLabel, cnkStmtListExpr, cnkField, cnkToSlice,
+     cnkNewCfNodes:
     unreachable(n.kind)
 
 proc initProc(c: TCtx, owner: PSym, body: sink Body): BProc =

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -154,7 +154,7 @@ proc generateMirCode(c: var TCtx, env: var MirEnv, n: PNode;
     result.code = finish(bu)
 
 proc generateIR(c: var TCtx, env: MirEnv, body: sink MirBody): Body =
-  backends.generateIR(c.graph, c.idgen, env, c.module, body)
+  backends.generateIRLegacy(c.graph, c.idgen, env, c.module, body)
 
 proc setupRootRef(c: var TCtx) =
   ## Sets up if the ``RootRef`` type for the type info cache. This
@@ -271,7 +271,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"
 
-  let outBody = generateIR(c.graph, c.idgen, jit.gen.env, s, mirBody)
+  let outBody = generateIRLegacy(c.graph, c.idgen, jit.gen.env, s, mirBody)
   echoOutput(c.config, s, outBody)
 
   try:

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -181,9 +181,10 @@ Semantics
             | Repeat STATEMENT          # unconditional loop. Repeat the
                                         # statement for an indefinite amount
                                         # of times (legacy)
-            | Repeat <Label>            # unconditional loop
             | TRY_STMT                  # (legacy)
             | Goto TARGET
+            | Loop <Label>              # unconditional jump back to the start
+                                        # of a loop
             | Raise LVALUE              # push the given exception to the
                                         # exception stack and start exceptional
                                         # control-flow. The `ref object` is
@@ -197,6 +198,7 @@ Semantics
             | Raise <None> EX_TARGET
             | Join <Label>              # join point for non-exceptional
                                         # control-flow (e.g., goto)
+            | LoopJoin <Label>          # join point for `Loop`
             | Except <Type> ... EX_TARGET
             | Except <Local> EX_TARGET
             | Except                    # catch-all handler
@@ -263,19 +265,21 @@ Terminology:
 * *terminator*: marks the end of a basic block
 
 A basic block is started by `Finally` and `Except`. Terminators are: `Case`,
-`Goto`, `Raise`, and `Continue`.  `If`, `Repeat`, and `Join` acts as both
-the start and end of a basic block. The nature of `End` depends on the
+`Goto`, `Raise`, `Continue`, and `Loop`. `If`, `Join`, and `LoopJoin` act as
+both the start and end of a basic block. The nature of `End` depends on the
 associated construct:
-* for `If` and `Except`, it acts as both a terminator and start of a basic
-  block
-* for `Repeat`, it acts a terminator (jump back to the start of the loop)
+* for `If`, it acts as both a terminator and start of a basic block
+* for `Except`, it only marks the end of the section
+
+Except for `Loop`, all terminators only allow forward control-flow.
 
 Structured Constructs
 ---------------------
 
-Each `If`, `Except`, and `Repeat` must be paired with exactly one `End`,
-each `Finally` with a `Continue`. They represent the *structured* constructs,
-and they must not overlap each other, meaning that:
+Each `If` and `Except` must be paired with exactly one `End`, each `LoopJoin`
+with a `Loop`, and each `Finally` with a `Continue`. These are the
+*structured* constructs, and they must not overlap each other, meaning
+that:
 
 .. code-block::
 

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -48,6 +48,15 @@ Semantics
         | <Type>
         | LVALUE
 
+  INTERMEDIATE_TARGET = <Label>
+                      | Leave <Label>
+
+  TARGET = <Label>
+         | TargetList INTERMEDIATE_TARGET ... <Label>
+
+  EX_TARGET = TARGET
+            | TargetList INTERMEDIATE_TARGET ... Resume
+
   UNARY_OP = NegI VALUE
 
   BINARY_OP = AddI VALUE, VALUE
@@ -78,11 +87,16 @@ Semantics
                                          # one for which the behaviour cannot
                                          # be represented in the MIR)
 
-  # checked calls have the same shape as normal calls. The difference is that
-  # the call has an exceptional exit (i.e., it might raise an exception)
+  # (legacy) checked calls have the same shape as normal calls. The difference
+  # is that the call has an exceptional exit (i.e., it might raise an
+  # exception)
   CHECKED_CALL_EXPR = CheckedCall <Proc> CALL_ARG ...
                     | CheckedCall LVALUE CALL_ARG ...
                     | CheckedCall <Magic> CALL_ARG ...
+
+  CHECKED_CALL_EXPR = CheckedCall <Proc> CALL_ARG ...  EX_TARGET
+                    | CheckedCall LVALUE CALL_ARG ...  EX_TARGET
+                    | CheckedCall <Magic> CALL_ARG ... EX_TARGET
 
 
   RVALUE = UNARY_OP
@@ -150,7 +164,10 @@ Semantics
             | Switch LVALUE ASGN_SRC    # changes the active branch of a
                                         # variant. Unclear semantics.
             | If VALUE STATEMENT        # if the value evaluates to true
-                                        # execute the statement
+                                        # execute the statement (legacy)
+            | If VALUE <Label>          # fall through if the value evaluates
+                                        # to true, otherwise jump to the if's
+                                        # corresponding end
             | Case VALUE BRANCH_LIST    # dispatch to one of the branches based
                                         # on the value, where value must be
                                         # either of integer, float, or string
@@ -158,13 +175,15 @@ Semantics
             | Block <Label> STATEMENT   # run the wrapped statement and provide
                                         # a named exit. The label must be
                                         # unique across all blocks in the
-                                        # procedure
+                                        # procedure (legacy)
             | Break <Label>             # exit the enclosing block that has the
-                                        # given label
+                                        # given label (legacy)
             | Repeat STATEMENT          # unconditional loop. Repeat the
                                         # statement for an indefinite amount
-                                        # of times
-            | TRY_STMT
+                                        # of times (legacy)
+            | Repeat <Label>            # unconditional loop
+            | TRY_STMT                  # (legacy)
+            | Goto TARGET
             | Raise LVALUE              # push the given exception to the
                                         # exception stack and start exceptional
                                         # control-flow. The `ref object` is
@@ -172,14 +191,26 @@ Semantics
             | Raise <None>              # re-raise the current exception
             | Return                    # exit the procedure, but execute all
                                         # enclosing finalizers first (from
-                                        # innermost to outermost)
+                                        # innermost to outermost) (legacy)
             | Destroy LVALUE
+            | Raise LVALUE EX_TARGET
+            | Raise <None> EX_TARGET
+            | Join <Label>              # join point for non-exceptional
+                                        # control-flow (e.g., goto)
+            | Except <Type> ... EX_TARGET
+            | Except <Local> EX_TARGET
+            | Except                    # catch-all handler
+            | Finally <Label>
+            | Continue <Label> (<Label> | Resume) ...
+            | End <Label>               # marks the end of an if, repeat, or
+                                        # except
             | Emit VALUE ...
             | Asm VALUE ...
 
   BRANCH_LABEL = <Literal>
                | <Const>
   BRANCH_LIST = (Branch BRANCH_LABEL ... STATEMENT) ... # a list of branches
+              | (Branch BRANCH_LABEL ... TARGET) ...
 
   EXCEPT_BRANCH = Branch <Type> ... STATEMENT # exception handler
                 | Branch <Local>    STATEMENT # exception handler for imported
@@ -218,6 +249,108 @@ be read from during execution of the procedure.
 
 This information is intended for use by data-flow analysis and code
 generators.
+
+
+Control Flow Representation
+===========================
+
+.. note:: This only covers the new control-flow primitives.
+
+Terminology:
+* *basic block*: a basic block is a region of statements that contains no
+  jumps and is not jumped into
+* *label*: identifies a control-flow-related construct
+* *terminator*: marks the end of a basic block
+
+A basic block is started by `Finally` and `Except`. Terminators are: `Case`,
+`Goto`, `Raise`, and `Continue`.  `If`, `Repeat`, and `Join` acts as both
+the start and end of a basic block. The nature of `End` depends on the
+associated construct:
+* for `If` and `Except`, it acts as both a terminator and start of a basic
+  block
+* for `Repeat`, it acts a terminator (jump back to the start of the loop)
+
+Structured Constructs
+---------------------
+
+Each `If`, `Except`, and `Repeat` must be paired with exactly one `End`,
+each `Finally` with a `Continue`. They represent the *structured* constructs,
+and they must not overlap each other, meaning that:
+
+.. code-block::
+
+  if x (L1)
+  if y (L2)
+  end L1
+  end L2
+
+is not allowed. However, much like in the high-level language, structured
+constructs can be nested.
+
+Target Lists
+------------
+
+`Goto`, `Raise`, `Except`, and `CheckedCall` support *target lists*. The
+target list specifies intermediate jump targets as well as which sections
+are exited. Take, for example:
+
+.. code-block::
+
+  goto [Leave L1, L2, Leave L3, L4]
+
+What this means is the following:
+1. leave the section (`Except` or `Finally`) identified by label L1
+2. enter the `Finally` section identified by label L2
+3. leave the section identified by label L3
+4. land at the `Finally` or `Join` identified by label L4
+
+An example of the code that would result in such `Goto`:
+
+.. code-block:: nim
+
+  block L4:
+    try:
+      ...
+    finally:
+      try:
+        try
+          ...
+        finally:
+          break L4 # this would translate to the aforementioned goto
+      finally:
+        ...
+
+In the context of exceptional control-flow, the final target must be either
+a `Finally` or an `Except`, otherwise it must be either a `Finally` or `Join`.
+
+Resume
+------
+
+`Resume` is a special jump target that may only appear as the final target of
+`Raise`, `CheckedCall`, and `Except`. It specifies that unwinding/exception-
+handling *resumes* in the caller procedure.
+
+Exception Handler
+-----------------
+
+`Except` represents an exception handler. If types or a local is specified,
+the section is only entered if the run-time type of the active exception
+matches the section's filters. If there's a match, execution continues with
+the statement following the `Except`, otherwise it continues at the target
+specified by the `Except`.
+
+Finally Sections
+----------------
+
+A `Finally` section is used as an intermediate target in a jump chain. Where
+the `Continue` statement marking the end of the section jumps to depends on
+the *target list* the entered `Finally` is part of. For example, with
+`Goto [L1, L2]`, the `Continue` of the `Finally` section identified by L1
+would jump to L2.
+
+The `Continue` must also be present if it is never actually reached. In this
+case, the `Finally` section may only appear as the final target in a target
+list.
 
 Storage
 =======

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -430,6 +430,8 @@ when true:
 proc pushActiveException(e: sink(ref Exception)) =
   e.up = activeException
   activeException = e
+  # FIXME: don't set the current exception here; it's only done this way for
+  #        backwards compatibility
   currException = e # set the current exception already
 
 proc raiseExceptionAux(e: sink(ref Exception)) {.nodestroy.} =
@@ -585,6 +587,8 @@ proc nimCatchException(frame: ptr ExceptionFrame) {.compilerproc.} =
   activeException = move activeException.up
 
 proc restoreCurrentEx() =
+  # FIXME: don't consider active exceptions; it's only done this way for
+  #        backwards compatibility
   if handlers.isNil or handlers.exc.isNil:
     currException = activeException
   elif handlers.exc.up == activeException:

--- a/tests/exception/tfinally6.nim
+++ b/tests/exception/tfinally6.nim
@@ -3,7 +3,7 @@ discard """
     Multiple tests regarding ``finally`` interaction with exception handlers
     and raised exceptions.
   '''
-  knownIssue.c js: "The current exception is not properly cleared"
+  knownIssue.js: "The current exception is not properly cleared"
 """
 
 var steps: seq[int]

--- a/tests/exception/tleave_except2.nim
+++ b/tests/exception/tleave_except2.nim
@@ -1,0 +1,87 @@
+discard """
+  description: '''
+    Ensure that leaving an `except` section by raising an exception properly
+    updates the current exception.
+  '''
+  knownIssue.js vm: "The current exception is not reset properly"
+"""
+
+var steps: seq[string]
+
+type Ex = object of CatchableError
+
+proc `=destroy`(x: var Ex) =
+  steps.add x.msg
+
+template postcondition() =
+  # ensure that the exceptions were destroyed in the correct order
+  when defined(gcOrc) or defined(gcArc):
+    doAssert steps == ["1", "2"]
+
+# -------------
+# test case 1: local raise and local exception handler
+
+proc test1() =
+  try:
+    try:
+      raise Ex.newException("1")
+    except Ex as e:
+      doAssert getCurrentException() == e
+      doAssert e.msg == "1"
+      raise Ex.newException("2")
+  except Ex as e:
+    doAssert getCurrentException() == e
+    doAssert e.msg == "2"
+
+  doAssert getCurrentException() == nil
+
+test1()
+postcondition()
+
+# -------------
+# test case 2: indirect raise and local exception handler
+
+proc raiseEx() =
+  raise Ex.newException("2")
+
+proc test2() =
+  try:
+    try:
+      raise Ex.newException("1")
+    except Ex as e:
+      doAssert getCurrentException() == e
+      doAssert e.msg == "1"
+      raiseEx()
+  except Ex as e:
+    doAssert getCurrentException() == e
+    doAssert e.msg == "2"
+
+  doAssert getCurrentException() == nil
+
+steps = @[]
+test2()
+postcondition()
+
+# -------------
+# test case 3: indirect raise and non-local exception handler
+
+proc test3() =
+  proc inner() =
+    try:
+      raise Ex.newException("1")
+    except Ex as e:
+      doAssert getCurrentException() == e
+      doAssert e.msg == "1"
+      raiseEx()
+
+  try:
+    inner()
+  except Ex as e:
+    doAssert getCurrentException() == e
+    doAssert e.msg == "2"
+
+  doAssert getCurrentException() == nil
+
+steps = @[]
+test3()
+postcondition()

--- a/tests/exception/treraise2.nim
+++ b/tests/exception/treraise2.nim
@@ -1,0 +1,58 @@
+discard """
+  description: '''
+    Ensure that raising a caught exception from within an exception handler
+    works
+  '''
+  knownIssue.js vm: "The current exception is not properly updated"
+"""
+
+proc manualReraise() =
+  # raising an already caught exception works and doesn't interfere with how
+  # the current exception is set
+  try:
+    raise CatchableError.newException("1")
+  except CatchableError as e:
+    raise e
+
+try:
+  manualReraise()
+except CatchableError as e:
+  doAssert e.msg == "1"
+
+doAssert getCurrentException() == nil
+
+# ---------------------------------------------------------------------------
+# more complex situation: re-raise an exception not caught by the most nested
+# handler
+
+# situation 1: catch within the original handler
+try:
+  raise CatchableError.newException("1")
+except CatchableError as e:
+  try:
+    try:
+      raise CatchableError.newException("2")
+    except CatchableError as e2:
+      raise e # raise the outer exception again
+  except CatchableError as e2:
+    doAssert e2.msg == "1"
+
+  # the current exception must still be the same as `e`
+  doAssert getCurrentException().msg == "1"
+
+doAssert getCurrentException() == nil
+
+# situation 2: catch outside the original handler
+try:
+  try:
+    raise CatchableError.newException("1")
+  except CatchableError as e:
+    try:
+      raise CatchableError.newException("2")
+    except CatchableError as e2:
+      raise e # raise the outer exception again
+  # the exception propagates outside the original handler
+except CatchableError as e:
+  doAssert e.msg == "1"
+
+doAssert getCurrentException() == nil

--- a/tests/lang_objects/destructor/tdestruction_in_unreachable.nim
+++ b/tests/lang_objects/destructor/tdestruction_in_unreachable.nim
@@ -1,0 +1,35 @@
+discard """
+  description: '''
+    Ensure that no destructor is called for a local defined in an unreachable
+    part of the code, even if the scope is left via unstructured control-flow.
+  '''
+  targets: "c js vm"
+"""
+
+type Object = object
+
+var wasDestroyed = false
+
+proc `=destroy`(x: var Object) =
+  wasDestroyed = true
+
+proc test(cond: bool) =
+  block:
+    if cond:
+      return
+    else:
+      raise CatchableError.newException("")
+
+  # everything beyond this point is statically unreachable code
+  var o = Object()
+  if cond:
+    # introduce an unstructured exit of the scope
+    return
+
+  discard o
+
+test(true)
+
+# XXX: wasDestroy must be false, but it currently isn't. Testing the inverse
+#      makes sure that the test at least compiles
+doAssert wasDestroyed, "the behaviour is correct now"


### PR DESCRIPTION
## Summary

* extend the MIR's design with goto-based control-flow primitives
* implement the new control-flow primitives for the CGIR
* make the C code generator use the new control-flow primitives
* (C backend) fix multiple bugs with `getCurrentException` returning
  the wrong exception
* (C backend) fix exceptions being leaked when aborting a `finally`
  section

### Details

The main goals of replacing the higher-level control-flow primitives in
the MIR with lower-level, goto-based ones are to:
* be able to express more complex control-flow
* make control-flow-related transformations easier and/or possible
* reduce the cost of computing the data-flow graph
* make evolving the language and MIR easier

A guiding principle was that the design should allow for enough freedom
to generate efficient code with all three code generators (which differ
significantly in control-flow-related capabilities).

To be able to implement this incrementally, as a first step, the new
control-flow primitives are only added to the CGIR, with only `cgen`
actually supporting them. So that `jsgen` and `vmgen` continue to work
without change, the legacy primitives are kept, with `cgirgen_legacy`
(a full copy of the original `cgirgen`) continuing to produce the
legacy CGIR.

### MIR

An in-depth description of syntax and behaviour is added to
`docs/mir.rst`. The gist of the design is that:
* terminators of basic-blocks become explicit (an exception being `If`)
* jump targets are directly specified on jump/fork-like operations
  (e.g., `Goto`, `CheckedCall`, etc.)
* intercepted control-flow (via `finally` sections) is also specified
  on jump/fork-like operations
* `finally` sections are *not* required to be duplicated for each
  unique control-flow passing through them
* jump targets and join points are identified by *labels*, which are
  integers IDs unique within a body

As a consequence of this design, there's no more statement-in-statement
nesting.

### CGIR & Translation

The CGIR implements all the new control-flow primitives from the MIR,
with the only difference being that the CGIR's `ContinueStmt` doesn't
track the possible exits of a `Finally` section (it's information
irrelevant to the code generators).

`cgirgen` handles translation of the old-style primitives still used by
the MIR to the new-style ones. While not strictly needed at the moment,
translation is disabled of intra-procedure unreachable code is
disabled, meaning that unreachable code is effectively dropped. This is
so that `Finally` sections that never exit normally (e.g.,
`finally: return`) can be ensured to work.

### C code generation

The CGIR is first translated into a small, low-level, C-specific IR
(all implemented in `ccgflow`). Here, the focus is on figuring out what
C code to produce for `Finally` sections; unnecessary gotos are also
eliminated.

#### Finally Handling

The previous strategy for `finally` was to:
* emit an error-state considering version of the `finally` at the end
  of the `try`
* duplicate the body of all enclosing `finally`s at `break`s and
  `return`s

Now, only a single version of the `finally` section is ever emitted. If
the `finally` section has more than one possible exit, a run-time
dispatcher is used, like so:
```c
{
  NI32 Target0_;
  L1_1_:
  Target0_ = 0;
  goto L1_;
  L1_2_:
  Target0_ = 1;
  L1_: // never jumped to from the outside
  NI32 oldNimErr0_ = *nimErr_; *nimErr_ = NIM_FALSE; // temporarily disable error mode
  // ... body of the finally ...
  *nimErr_ = oldNimErr0_;
  switch (Target0_) {
  case 0: goto L2_;
  case 1: goto L3_;
  }
}
```

Depending on the context and complexity of the code in-between, an
optimizing C compiler is able to eliminate the dispatcher and
`Target0_` assignment by directly inlining the body at a `goto L1_1_;`.

For the common case of a `Finally` section having two exits - one for
exceptional control-flow cases, and one for the -, a
`if (NIM_UNLIKELY(*nimErr_)) goto <error_label>; goto <non_error>` is
used instead of a full dispatcher. This mirrors how the exit of a
`finally` section previously looked like.

The idea behind not duplicating `Finally` sections is that it reduces
the amount of C code the compiler has to output. Nonetheless, the IR
from `ccgflow` is flexible enough to use the duplication strategy,
should this be needed again.

#### Exception Handling

Whether control-flow crosses the boundary of a (i.e., leaves it) is
encoded in the MIR/CGIR via the `Leave` item in target lists. `ccgflow`
uses this information to make sure that leaving a `Finally` via
unstructured control-flow properly aborts the active exception (if any)
and that leaving an `Except` properly pops the handler.   

#### Other

The IR from `ccgflow` then drives the rest of C code generation. Since
there's no more statement-in-statement nesting, recursion reduces
significantly.

A side-effect of the flatter representation is that less C scopes are
used (only `if`, loops, `finally`, and `except` use C scopes), which
seems to harm C compiler optimization.

Support for the legacy control-flow primitives is fully removed.

### Exception Handling Runtime

The runtime part of exception handling for the C target is partially
overhauled. For compatibility with the `csources` compiler, the new
version is guarded behind the `nimskullNewExceptionRt` condsym.

A distinction is now made between an *in-flight* exception and the
*current* exception. Previously, both were treated as being one and the
same.

An exception becomes *in-flight* once it is raised (`raiseException2`),
and stops being in-flight when it is caught (`nimCatchException`).
While in-flight, an exception can be aborted (`nimAbortException`), by
breaking out of an intercepting `finally`. On being caught by a
handler, the exception is associated with the handler and the handler
pushed to the handler stack. When control-flow leaves the handler
(`nimLeaveExcept`), the handler is popped from the stack.

The new runtime fixes the `currentException` not being updated when
breaking out of a `finally` or raising from within an `except` handler.
In addition, an exception caught by a handler can now be raised again
within the handler (e.g., `except CatchableError as e: raise e`)
without reference cycles being introduced.