### PR TITLE
Add EMSCRIPTEN_KEEPALIVE to N_LIB_EXPORT if emscripten

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -15,7 +15,8 @@ import
   compiler/backend/[
     cgmeth,
     cgir,
-    cgirgen
+    cgirgen,
+    cgirgen_legacy
   ],
   compiler/front/[
     msgs,
@@ -368,6 +369,13 @@ proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
   ## Translates the MIR code provided by `code` into ``CgNode`` IR and,
   ## if enabled, echoes the result.
   result = cgirgen.generateIR(graph, idgen, env, owner, body)
+  echoOutput(graph.config, owner, result)
+
+proc generateIRLegacy*(graph: ModuleGraph, idgen: IdGenerator, env: MirEnv,
+                 owner: PSym, body: sink MirBody): Body =
+  ## Translates the MIR code provided by `code` into legacy ``CgNode`` IR and,
+  ## if enabled, echoes the result.
+  result = cgirgen_legacy.generateIR(graph, idgen, env, owner, body)
   echoOutput(graph.config, owner, result)
 
 # ------- handling of lifted globals ---------

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -35,33 +35,59 @@ proc reportObservableStore(p: BProc; le, ri: CgNode) =
         # cannot analyse the location; assume the worst
         return true
 
-  if le != nil and locationEscapes(p, le, p.nestedTryStmts.len > 0):
+  # XXX: this whole procedure needs to be removed; RVO calls must only be used
+  #      if safe
+  var inTryStmt = false
+  # analyse the target to check whether a local exception handler or finally
+  # is reached
+  case ri[^1].kind
+  of cnkLabel:
+    inTryStmt = true
+  of cnkTargetList:
+    for it in ri[^1].items:
+      if it.kind == cnkLabel:
+        inTryStmt = true
+        break
+  else:
+    discard "no local exception handler or finally is reached"
+
+  if le != nil and locationEscapes(p, le, inTryStmt):
     localReport(p.config, le.info, reportSem rsemObservableStores)
 
-proc isHarmlessStore(p: BProc; canRaise: bool; d: TLoc): bool =
-  if d.k in {locTemp, locNone} or not canRaise:
+proc observableInExcept(n: CgNode): bool =
+  ## Computes whether the call expression `n` has an exceptional exit
+  ## that leads to an exception handler within the current procedure.
+  let target = n[^1]
+  case target.kind
+  of cnkLabel:      true # can only be an exception handler (of finally)
+  of cnkTargetList: target[^1].kind == cnkLabel
+  else:
+    unreachable()
+
+proc isHarmlessStore(p: BProc; ri: CgNode, d: TLoc): bool =
+  if d.k in {locTemp, locNone} or ri.kind != cnkCheckedCall:
     result = true
-  elif d.k == locLocalVar and p.withinTryWithExcept == 0:
+  elif d.k == locLocalVar and not observableInExcept(ri):
     # we cannot observe a store to a local variable if the current proc
     # has no error handler:
     result = true
   else:
     result = false
 
-proc exitCall(p: BProc, callee: CgNode, canRaise: bool) =
+proc exitCall(p: BProc, call: CgNode) =
   ## Emits the exceptional control-flow related post-call logic.
-  if p.config.exc == excGoto:
+  if call.kind == cnkCheckedCall:
     if nimErrorFlagDisabled in p.flags:
-      if callee.kind == cnkProc and sfNoReturn in p.env[callee.prc].flags and
-         canRaiseConservative(p.env, callee):
+      if call[0].kind == cnkProc and sfNoReturn in p.env[call[0].prc].flags and
+         canRaiseConservative(p.env, call[0]):
         # when using goto-exceptions, noreturn doesn't map to "doesn't return"
         # at the C-level. In order to still support dispatching to wrapper
         # procedures around ``raise`` from inside ``.compilerprocs``, we emit
         # an exit after the call
         p.flags.incl beforeRetNeeded
         lineF(p, cpsStmts, "goto BeforeRet_;$n", [])
-    elif canRaise:
-      raiseExit(p)
+    else:
+      raiseExit(p, call[^1])
 
 proc fixupCall(p: BProc, le, ri: CgNode, d: var TLoc,
                callee, params: Rope) =
@@ -86,17 +112,17 @@ proc fixupCall(p: BProc, le, ri: CgNode, d: var TLoc,
         pl.add(addrLoc(p.config, d))
         pl.add(~");$n")
         line(p, cpsStmts, pl)
-        exitCall(p, ri[0], canRaise)
+        exitCall(p, ri)
     else:
       pl.add(~")")
-      if isHarmlessStore(p, canRaise, d):
+      if isHarmlessStore(p, ri, d):
         if d.k == locNone: getTemp(p, typ[0], d)
         assert(d.t != nil)        # generate an assignment to d:
         var list: TLoc
         initLoc(list, locCall, d.lode, OnUnknown)
         list.r = pl
         genAssignment(p, d, list)
-        exitCall(p, ri[0], canRaise)
+        exitCall(p, ri)
       else:
         var tmp: TLoc
         getTemp(p, typ[0], tmp)
@@ -104,12 +130,12 @@ proc fixupCall(p: BProc, le, ri: CgNode, d: var TLoc,
         initLoc(list, locCall, d.lode, OnUnknown)
         list.r = pl
         genAssignment(p, tmp, list)
-        exitCall(p, ri[0], canRaise)
+        exitCall(p, ri)
         genAssignment(p, d, tmp)
   else:
     pl.add(~");$n")
     line(p, cpsStmts, pl)
-    exitCall(p, ri[0], canRaise)
+    exitCall(p, ri)
 
 proc reifiedOpenArray(p: BProc, n: CgNode): bool {.inline.} =
   # all non-parameter openArrays are reified
@@ -197,7 +223,7 @@ proc genArgNoParam(p: BProc, n: CgNode, needsTmp = false): Rope =
   result = rdLoc(a)
 
 proc genParams(p: BProc, ri: CgNode, typ: PType): Rope =
-  for i in 1..<ri.len:
+  for i in 1..<(1 + numArgs(ri)):
     if i < typ.len:
       assert(typ.n[i].kind == nkSym)
       let paramType = typ.n[i]
@@ -251,7 +277,7 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
   let canRaise = ri.kind == cnkCheckedCall
   if typ[0] != nil:
     if isInvalidReturnType(p.config, typ[0]):
-      if ri.len > 1: pl.add(~", ")
+      if numArgs(ri) > 0: pl.add(~", ")
       # the destination is guaranteed to be either a temporary or an lvalue
       # that can be modified in-place
       if true:
@@ -264,8 +290,8 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
           getTemp(p, typ[0], d)
         pl.add(addrLoc(p.config, d))
         genCallPattern()
-        exitCall(p, ri[0], canRaise)
-    elif isHarmlessStore(p, canRaise, d):
+        exitCall(p, ri)
+    elif isHarmlessStore(p, ri, d):
       if d.k == locNone: getTemp(p, typ[0], d)
       assert(d.t != nil)        # generate an assignment to d:
       var list: TLoc
@@ -275,7 +301,7 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
       else:
         list.r = PatProc % [rdLoc(op), pl, pl.addComma, rawProc]
       genAssignment(p, d, list)
-      exitCall(p, ri[0], canRaise)
+      exitCall(p, ri)
     else:
       var tmp: TLoc
       getTemp(p, typ[0], tmp)
@@ -287,11 +313,11 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
       else:
         list.r = PatProc % [rdLoc(op), pl, pl.addComma, rawProc]
       genAssignment(p, tmp, list)
-      exitCall(p, ri[0], canRaise)
+      exitCall(p, ri)
       genAssignment(p, d, tmp)
   else:
     genCallPattern()
-    exitCall(p, ri[0], canRaise)
+    exitCall(p, ri)
 
 proc genAsgnCall(p: BProc, le, ri: CgNode, d: var TLoc) =
   if ri[0].typ.skipTypes({tyGenericInst, tyAlias, tySink}).callConv == ccClosure:

--- a/compiler/backend/ccgflow.nim
+++ b/compiler/backend/ccgflow.nim
@@ -1,0 +1,543 @@
+## Implements the translation of CGIR to a code listing for an abstract
+## machine that focuses on control-flow and exception handling.
+##
+## This code listing is intended for consumption by the C code generator.
+
+import
+  std/[
+    options,
+    packedsets,
+    tables
+  ],
+  compiler/backend/[
+    cgir
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+type
+  COpcode* = enum
+    opJump       ## unconditional jump
+    opErrJump    ## jump if in error mode
+    opDispJump   ## jump part of a dispatcher
+    opLabel      ## jump target
+
+    opSetTarget  ## set the value of a dispatcher's discriminator
+    opDispatcher ## start of a dispatcher
+
+    opBackup     ## backup the error state in a local variable and clear it
+    opRestore    ## restore the error from a local variable
+
+    opStmts      ## slice of statements
+    opStmt       ## control-flow relevant single statement. A label
+                 ## specifier is passed along
+    # future direction: ``CStmt`` should be removed and all unstructured
+    # control-flow bits modeled with the other instructions. Checked calls
+    # used as an assignment source currently block this, as they might
+    # require an assignment-to-temporary
+
+    opAbort
+    opPopHandler
+
+  JumpOp = range[opJump..opDispJump]
+
+  CLabelId* = distinct uint32
+  CLabelSpecifier* = uint32
+    ## used for identifying the extra labels attached to finally sections
+
+  CLabel* = tuple
+    ## Name of a label.
+    id: CLabelId
+    specifier: Option[CLabelSpecifier]
+
+  CInstr* = object
+    case op*: COpcode
+    of opJump, opErrJump, opLabel, opDispJump:
+      label*: CLabel
+    of opSetTarget, opDispatcher:
+      discr*: uint32 ## ID of the discriminator variable
+      value*: int    ## either the value, or number of dispatcher branches
+    of opStmts:
+      stmts*: Slice[int]
+    of opStmt:
+      stmt*: int
+      specifier*: CLabelSpecifier
+    of opBackup, opRestore, opAbort:
+      local*: uint32 ## ID of the backup variable
+    of opPopHandler:
+      discard
+
+  FinallyInfo* = object
+    routes: seq[PathIndex]
+    numExits: int
+      ## number of exits the finally has. Pre-computed for efficiency
+    numErr: int
+      ## number of exceptional jump paths going through this finalizer
+    numNormal: int
+      ## number of non-exception jump paths going through this finalizer
+
+    discriminator: uint32
+      ## ID of the discriminator variable to use for the dispatcher
+    errBackupId: uint32
+      ## only valid if the finally is entered by exceptional control-flow
+
+  PathKind = enum
+    pkError
+    pkNormal
+  PathIndex = uint32
+    ## Index of a ``PathItem`` within the item storage.
+  PathItemTarget = object
+    label: CLabelId
+    isCleanup: bool
+  PathItem = object
+    ## Represents a step in a jump path. A jump path is a chain of finally
+    ## sections plus final target an intercepted goto visits.
+    ##
+    ## An item is part of two intrusive linked-lists: one doubly-linked-list
+    ## representing a single chain, and one singly-linked-list for the
+    ## adjacent chains. The "none" value for a pointer is represented by it
+    ## pointing to the node itself.
+    prev, next: PathIndex
+    sibling: PathIndex
+
+    target: PathItemTarget
+      ## the identifier of the jump target
+    kinds: set[PathKind]
+      ## the kinds of control-flow (exception or normal) reaching the path
+      ## item
+
+  Paths = seq[PathItem]
+    ## The data storage for multiple jump paths, with the items layed out
+    ## "tail first", meaning that the final target of a jump chain comes
+    ## *before* the others. The idea is to uniquely identify jump paths
+    ## within a body while merging common trailing paths.
+    ##
+    ## Consider the two jump paths E->D->C->B->A and G->F->C->B->A. If
+    ## both are added to the storage, the content would look like this:
+    ##
+    ##    (0: A) -> (1: B) -> (2: C) -> (3: D) -> (4: E)
+    ##                                \ (5: F) -> (6: G)
+    ##
+    ## The numbers represent the items' index in the sequence. The `sibling`
+    ## item of 3 is 5 (all other items have no siblings); the `next` pointer
+    ## of 5 points to 2. As can be seen, common trailing paths are merged into
+    ## one.
+
+  Context = object
+    ## Local state used during the translation bundled into an object for
+    ## convenience.
+    paths: Paths
+    stmtToPath: Table[int, int]
+    finallys: Table[CLabelId, FinallyInfo]
+    cleanups: Table[CLabelId, FinallyInfo]
+      ## cleanup here refers to the exception-related cleanup when
+      ## exiting a finally or except section
+
+const
+  ExitLabel* = CLabelId(0)
+    ## The label of the procedure exit.
+  ResumeLabel* = ExitLabel
+    ## The C label that a ``cnkResume`` targets.
+
+func `==`*(a, b: CLabelId): bool {.borrow.}
+
+func toCLabel*(n: CgNode): CLabelId =
+  ## Returns the ID of the C label the label-like node `n` represents.
+  case n.kind
+  of cnkResume:
+    ResumeLabel
+  of cnkLabel:
+    CLabelId(ord(n.label) + 2)
+  of cnkLeave:
+    toCLabel(n[0])
+  else:
+    unreachable(n.kind)
+
+func toCLabel*(n: CgNode, specifier: Option[CLabelSpecifier]
+              ): CLabel {.inline.} =
+  (toCLabel(n), specifier)
+
+func toBlockId*(id: CLabelId): BlockId =
+  ## If `id` was converted to from a valid CGIR label, converts it back to
+  ## the CGIR label.
+  BlockId(ord(id) - 2)
+
+func rawAdd(p: var Paths, x: openArray[PathItemTarget]): PathIndex =
+  ## Appends the chain `x` to `p` without any deduplication or
+  ## linking with the existing items. Returns the index of the
+  ## tail item.
+  result = p.len.PathIndex
+  for i in countdown(x.high, 0):
+    let pos = p.len.PathIndex
+    p.add PathItem(prev: (if i > 0: pos + 1 else: pos),
+                   next: (if i < x.high: pos - 1 else: pos),
+                   sibling: pos,
+                   target: x[i])
+
+func add(p: var Paths, path: openArray[PathItemTarget]): PathIndex =
+  ## Adds `path` to the `p`. Only the sub-path of `path` not yet present in
+  ## `p` is added. The index of the *head* item of the added (or existing)
+  ## path is returned.
+  if p.len == 0:
+    discard rawAdd(p, path)
+    p[0].next = 0'u32
+    return p.high.PathIndex
+
+  var pos = 0'u32 ## the current search position
+  for i in countdown(path.len-1, 0):
+    # search the sibling list for a matching item:
+    while p[pos].target != path[i] and pos != p[pos].sibling:
+      pos = p[pos].sibling
+
+    if p[pos].target != path[i]:
+      # no item was found, meaning that this is the end of the common paths.
+      # Add the remaining items to the storage.
+      let next = rawAdd(p, path.toOpenArray(0, i))
+      p[pos].sibling = next
+      # only set the next pointer if there was a common sub-path (otherwise
+      # there's no next item):
+      if i != path.high:
+        p[next].next = p[pos].next
+      return p.high.PathIndex
+
+    # it's a match! continue down the chain
+    if i > 0:
+      if p[pos].prev == pos:
+        # there's no next item, append the remaining new targets to the
+        # pre-existing path
+        let next = rawAdd(p, path.toOpenArray(0, i-1))
+        p[pos].prev = next
+        p[next].next = pos
+        return p.high.PathIndex
+      else:
+        pos = p[pos].prev
+
+  # the chain `path` already exists in `p`
+  result = pos
+
+func incl(p: var Paths, at: PathIndex, kind: PathKind) =
+  ## Marks all items following and including `at` with `kind`.
+  var i = at
+  while p[i].next != i:
+    p[i].kinds.incl kind
+    i = p[i].next
+  p[i].kinds.incl kind
+
+func needsDispatcher(f: FinallyInfo): bool =
+  # a dispatcher is required if re are more than one exits. An exception is
+  # the case where one exit is only taken when in error mode and the other is
+  # not. If a dispatcher is required, the finally has sub-labels.
+  f.numExits > 1 and
+    not(f.routes.len == 2 and f.numErr == 1 and f.numNormal == 1)
+
+func needsSpecifier(c: Context, target: PathItemTarget): bool =
+  # cleanup sections don't have a unique label themselves, so using a
+  # specifier is required
+  target.isCleanup or
+    ((target.label in c.finallys) and
+     needsDispatcher(c.finallys[target.label]))
+
+proc append(targets: var seq[PathItemTarget],
+            redirects: Table[BlockId, CgNode],
+            exits: PackedSet[BlockId], n: CgNode) =
+  ## Appends all jump targets `n` represents to `targets`, following
+  ## `redirects` and turning all labels part of `exits` into the
+  ## "before return" label.
+  template addTarget(t: CLabelId; cleanup = false) =
+    targets.add PathItemTarget(label: t, isCleanup: cleanup)
+
+  case n.kind
+  of cnkLabel:
+    if n.label in redirects:
+      append(targets, redirects, exits, redirects[n.label])
+    elif n.label in exits:
+      addTarget ExitLabel
+    else:
+      addTarget toCLabel(n)
+  of cnkTargetList:
+    # only the final target could possibly be redirected
+    let hasRedir = n[^1].kind == cnkLabel and n[^1].label in redirects
+    for i in 0..<n.len - ord(hasRedir):
+      case n[i].kind
+      of cnkLeave:
+        addTarget toCLabel(n[i][0]), cleanup=true
+      of cnkResume:
+        addTarget toCLabel(n[i])
+      of cnkLabel:
+        if n[i].label in exits:
+          addTarget ExitLabel
+        else:
+          addTarget toCLabel(n[i])
+      else:
+        unreachable()
+
+    if hasRedir:
+      append(targets, redirects, exits, redirects[n[^1].label])
+  else:
+    unreachable()
+
+proc gatherRedirectsAndFinallys(c: var Context, stmts: CgNode
+                               ): Table[BlockId, CgNode] =
+  #ä First pass: gather the redirects for redundant labels. Consider:
+  ##   L1:
+  ##   goto L2
+  ##
+  ## Here, all jumps to L1 can jump to L2 directly. This pattern is
+  ## especially common with compiler-generated cleanup sections.
+  ##
+  ## The table for the finally sections is also populated.
+  for i in 0..<stmts.len - 1:
+    case stmts[i].kind
+    of cnkJoinStmt:
+      var j = i + 1
+      # skip join and end statements:
+      while j < stmts.len and stmts[j].kind in {cnkJoinStmt, cnkEnd}:
+        inc j
+
+      # if the label is followed directly by a goto statement, all jumps to
+      # the label can jump to the goto's target instead
+      if j < stmts.len and stmts[j].kind == cnkGotoStmt:
+        result[stmts[i][0].label] = stmts[j][0]
+    of cnkFinally:
+      # make sure a table entry exists for the finally section:
+      c.finallys[toCLabel(stmts[i][0])] = FinallyInfo()
+    else:
+      discard
+
+proc toInstrList*(stmts: CgNode, isFull: bool): seq[CInstr] =
+  ## Turns the statements list `stmts` into an instruction list for the
+  ## abstract machine. `isFull` signals whether the end of the statement list
+  ## can be considered the end of the procedure, which allows for the merging
+  ## of some control-flow paths.
+  var c = Context()
+  let redirects = gatherRedirectsAndFinallys(c, stmts) # first pass
+
+  # mark the labels of the trailing joins as being the same as the exit
+  # label...
+  var exits: PackedSet[BlockId]
+  if isFull:
+    # ... but only of stmts constitute the whole body
+    for i in countdown(stmts.len - 1, 0):
+      if stmts[i].kind == cnkJoinStmt:
+        exits.incl stmts[i][0].label
+      else:
+        break
+
+  # second pass: collect all jump paths, using the table of redirections to
+  # eliminate unnecessary breaks in the paths
+  var targets: seq[PathItemTarget]
+  for i, it in stmts.pairs:
+    template exit(x: CgNode; isErr = false) =
+      targets.setLen(0)
+      targets.append(redirects, exits, x)
+
+      # a single jump is only of relevance if it targets a finally directly
+      if targets.len > 1 or targets[0].label in c.finallys:
+        let id = c.paths.add(targets)
+        if isErr: incl(c.paths, id, pkError)
+        else:     incl(c.paths, id, pkNormal)
+
+        # remember the path associated with the statement for later:
+        c.stmtToPath[i] = id.int
+
+    case it.kind
+    of cnkDef, cnkAsgn, cnkFastAsgn:
+      if it[1].kind == cnkCheckedCall:
+        exit(it[1][^1], true)
+    of cnkRaiseStmt, cnkCheckedCall:
+      exit(it[^1], true)
+    of cnkGotoStmt:
+      exit(it[0])
+    of cnkCaseStmt:
+      for j in 1..<it.len:
+        exit(it[j][^1])
+    of cnkExcept:
+      if it.len > 1:
+        exit(it[^1], true)
+    else:
+      discard
+
+  # register every path item with the finally section it targets, and compute
+  # some statistics that are used during the later code generation:
+  for i, it in c.paths.pairs:
+    func setup(f: var FinallyInfo, it: PathItem) =
+      f.routes.add i.PathIndex
+      f.numExits += ord(it.next.int != i)
+      f.numErr += ord(pkError in it.kinds)
+      f.numNormal += ord(pkNormal in it.kinds)
+
+    if it.target.isCleanup:
+      setup(c.cleanups.mgetOrPut(it.target.label, FinallyInfo()), it)
+    elif it.target.label in c.finallys:
+      setup(c.finallys[it.target.label], it)
+
+  # construction of the instruction list follows
+
+  proc label(code: var seq[CInstr], id: CLabelId;
+             spec = none(CLabelSpecifier)) {.nimcall.} =
+    # a label must always be preceded by some code, so no length guard is
+    # required
+    if code[^1].op in {opJump, opErrJump} and code[^1].label.id == id and
+       code[^1].label.specifier == spec:
+      # optimization: remove the preceding jump if it targets the label
+      code.setLen(code.len - 1)
+    code.add CInstr(op: opLabel, label: (id, spec))
+
+  proc jump(code: var seq[CInstr], target: CLabelId) {.nimcall.} =
+    code.add CInstr(op: opJump, label: (target, none CLabelSpecifier))
+
+  proc jump(code: var seq[CInstr], op: JumpOp, c: Context,
+            path: PathIndex) {.nimcall.} =
+    let target = c.paths[path].target
+    if needsSpecifier(c, target):
+      code.add CInstr(op: op, label: (target.label, some path))
+    else:
+      code.add CInstr(op: op, label: (target.label, none CLabelSpecifier))
+
+  proc stmt(code: var seq[CInstr], c: Context, pos: int) {.nimcall.} =
+    if (let path = c.stmtToPath.getOrDefault(pos, -1); path != -1 and
+        needsSpecifier(c, c.paths[path].target)):
+      # a label specifier, and thus a separate instruction, is needed
+      code.add CInstr(op: opStmt, stmt: pos, specifier: CLabelSpecifier path)
+    elif code.len > 0 and code[^1].op == opStmts and
+         code[^1].stmts.b == pos + 1:
+      # append to the sequence
+      inc code[^1].stmts.b
+    else:
+      # start a new sequence
+      code.add CInstr(op: opStmts, stmts: pos..pos)
+
+  var
+    code: seq[CInstr]
+    nextDispId = 0'u32
+    nextRecoverID = 0'u32
+
+  for i, it in stmts.pairs:
+    case it.kind
+    of cnkFinally:
+      stmt code, c, i
+      let
+        clabel = toCLabel(it[0])
+        f = addr c.finallys[clabel]
+
+      # allocate and set the ID for the discriminator variable:
+      f.discriminator = nextDispId
+      inc nextDispId
+
+      # emit the entry-point(s); one for each route
+      if needsDispatcher(f[]):
+        # an entry point looks like this:
+        #   L1_1_:
+        #   Target = ...
+        #   goto L1_
+        for i, entry in f.routes.pairs:
+          label code, clabel, some(entry)
+          code.add CInstr(op: opSetTarget, discr: f.discriminator, value: i)
+          # jump to the main code:
+          jump code, clabel
+
+      # the body follows:
+      label code, clabel
+      if f.numErr > 0:
+        # backing up the error state is only needed when the finally is
+        # entered by exceptional control-flow
+        f.errBackupId = nextRecoverID
+        code.add CInstr(op: opBackup, local: nextRecoverID)
+        inc nextRecoverID
+
+    of cnkContinueStmt:
+      let
+        clabel = toCLabel(it[0])
+        f {.cursor.} = c.finallys[clabel]
+
+      # no need to restore the error state if control-flow never reaches the
+      # end of the finally anyway
+      if f.numErr > 0 and f.numExits > 0:
+        code.add CInstr(op: opRestore, local: f.errBackupId)
+
+      if f.numExits == 0:
+        discard "the end is never reached; nothing to do"
+      elif not needsDispatcher(f) and f.routes.len == 2:
+        # optimization: if two paths go through a finally, with one of them
+        # an exceptional jump path and the other one not, instead of using a
+        # full dispatcher we emit:
+        #   if err: goto error_exit
+        #   goto normal_exit
+        let exit = if c.paths[f.routes[0]].kinds == {pkError}: 0 else: 1
+        jump code, opErrJump, c, c.paths[f.routes[exit]].next
+        jump code, opJump,    c, c.paths[f.routes[1 - exit]].next
+      else:
+        assert f.routes.len == f.numExits
+        # a dispatcher is only required if there is more than one exit
+        let op = if f.numExits > 1: opDispJump
+                 else:              opJump
+
+        if op == opDispJump:
+          code.add CInstr(op: opDispatcher, discr: f.discriminator,
+                          value: f.numExits)
+
+        for it in f.routes.items:
+          jump code, op, c, c.paths[it].next
+
+      # emit the exception-related cleanup after the dispatcher:
+      if clabel in c.cleanups:
+        let cleanup {.cursor.} = c.cleanups[clabel]
+        # a dispatcher is not worth the overhead, emit an abort instruction
+        # for each route
+        for entry in cleanup.routes.items:
+          label code, clabel, some(entry)
+          # TODO: omit the cleanup logic as a whole, if the finally section is
+          #       never entered via an exception
+          if f.numErr > 0:
+            code.add CInstr(op: opAbort, local: f.errBackupId)
+          jump code, opJump, c, PathIndex c.paths[entry].next
+
+      stmt code, c, i
+
+    of cnkJoinStmt:
+      # XXX: labels that were redirected cannot be eliminated yet, as case
+      #      statements (which are handled outside of ccgflow) might still
+      #      target them
+      label code, toCLabel(it[0])
+    of cnkExcept:
+      # an except section is a label followed by the filter logic
+      label code, toCLabel(it[0])
+      stmt code, c, i
+    of cnkEnd:
+      let clabel = toCLabel(it[0])
+      # emit the cleanup for except sections:
+      if clabel in c.cleanups:
+        let cleanup {.cursor.} = c.cleanups[clabel]
+        # a dispatcher is not worth the overhead, emit a pop instruction
+        # for each route
+        for entry in cleanup.routes.items:
+          label code, clabel, some(entry)
+          code.add CInstr(op: opPopHandler)
+          jump code, opJump, c, PathIndex c.paths[entry].next
+
+      stmt code, c, i
+
+    of cnkGotoStmt:
+      let target = it[0]
+      if (let path = c.stmtToPath.getOrDefault(i, -1); path != -1):
+        jump code, opJump, c, PathIndex path
+      elif target.kind == cnkLabel:
+        jump code, toCLabel(target)
+      else:
+        jump code, toCLabel(target[^1])
+    of cnkRaiseStmt:
+      stmt code, c, i # the statement handles the exception setup part
+      # the goto part is the same as for a normal goto
+      let target = it[^1]
+      if target.kind == cnkLabel:
+        jump code, toCLabel(target)
+      elif (let path = c.stmtToPath.getOrDefault(i, -1); path != -1):
+        jump code, opJump, c, PathIndex path
+      else:
+        jump code, toCLabel(target[^1])
+
+    else:
+      stmt code, c, i
+
+  result = code

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -15,29 +15,14 @@ const
   stringCaseThreshold = 8
     # above X strings a hash-switch for strings is generated
 
-proc inExceptBlockLen(p: BProc): int =
-  for x in p.nestedTryStmts:
-    if x.inExcept: result.inc
-
-proc startBlockInternal(p: BProc, blk: int) =
-  inc(p.labels)
+proc startBlockInternal(p: BProc) =
   let result = p.blocks.len
   setLen(p.blocks, result + 1)
-  p.blocks[result].id = p.labels
-  p.blocks[result].blk = blk
-  p.blocks[result].nestedTryStmts = p.nestedTryStmts.len.int16
-  p.blocks[result].nestedExceptStmts = p.inExceptBlockLen.int16
 
 template startBlock(p: BProc, start: FormatStr = "{$n",
-                args: varargs[Rope]) =
+                args: varargs[Rope]) {.used.} =
   lineCg(p, cpsStmts, start, args)
-  startBlockInternal(p, 0)
-
-template startBlock(p: BProc, id: BlockId) =
-  lineCg(p, cpsStmts, "{$n", [])
-  startBlockInternal(p, id.int + 1)
-
-proc endBlock(p: BProc)
+  startBlockInternal(p)
 
 proc loadInto(p: BProc, le, ri: CgNode, a: var TLoc) {.inline.} =
   if ri.kind in {cnkCall, cnkCheckedCall} and
@@ -53,10 +38,6 @@ proc loadInto(p: BProc, le, ri: CgNode, a: var TLoc) {.inline.} =
     # worth the effort until version 1.0 is out.
     a.flags.incl(lfEnforceDeref)
     expr(p, ri, a)
-
-proc assignLabel(b: var TBlock): Rope {.inline.} =
-  b.label = "LA" & b.id.rope
-  result = b.label
 
 proc blockBody(b: var TBlock): Rope =
   result = b.sections[cpsLocals]
@@ -80,47 +61,8 @@ proc endBlock(p: BProc) =
   var blockEnd: Rope
   if frameLen > 0:
     blockEnd.addf("FR_.len-=$1;$n", [frameLen.rope])
-  if p.blocks[topBlock].label != "":
-    blockEnd.addf("} $1: ;$n", [p.blocks[topBlock].label])
-  else:
-    blockEnd.addf("}$n", [])
+  blockEnd.addf("}$n", [])
   endBlock(p, blockEnd)
-
-proc stmtBlock(p: BProc, n: CgNode) =
-  startBlock(p)
-  genStmts(p, n)
-  endBlock(p)
-
-proc blockLeaveActions(p: BProc, howManyTrys, howManyExcepts: int) =
-  # Called by return and break stmts.
-  # Deals with issues faced when jumping out of try/except/finally stmts.
-
-  var stack = newSeq[typeof(p.nestedTryStmts[0])](0)
-
-  inc p.withinBlockLeaveActions
-  for i in 1..howManyTrys:
-    let tryStmt = p.nestedTryStmts.pop
-    # Pop this try-stmt of the list of nested trys
-    # so we don't infinite recurse on it in the next step.
-    stack.add(tryStmt)
-
-    # Find finally-stmt for this try-stmt
-    # and generate a copy of its sons
-    var finallyStmt = tryStmt.fin
-    if finallyStmt != nil:
-      genStmts(p, finallyStmt[0])
-
-  dec p.withinBlockLeaveActions
-
-  # push old elements again:
-  for i in countdown(howManyTrys-1, 0):
-    p.nestedTryStmts.add(stack[i])
-
-  # Pop exceptions that was handled by the
-  # except-blocks we are in
-  block:
-    for i in countdown(howManyExcepts-1, 0):
-      linefmt(p, cpsStmts, "#popCurrentException();$n", [])
 
 proc genGotoVar(p: BProc; value: CgNode) =
   case value.kind
@@ -166,15 +108,7 @@ proc genIf(p: BProc, n: CgNode) =
 
   initLocExprSingleUse(p, n[0], a)
   lineF(p, cpsStmts, "if ($1)$n", [rdLoc(a)])
-  stmtBlock(p, n[1])
-
-proc genReturnStmt(p: BProc, t: CgNode) =
-  p.flags.incl beforeRetNeeded
-  genLineDir(p, t)
-  blockLeaveActions(p,
-    howManyTrys    = p.nestedTryStmts.len,
-    howManyExcepts = p.inExceptBlockLen)
-  lineF(p, cpsStmts, "goto BeforeRet_;$n", [])
+  startBlock(p)
 
 proc genGotoForCase(p: BProc; caseStmt: CgNode) =
   for i in 1..<caseStmt.len:
@@ -186,71 +120,51 @@ proc genGotoForCase(p: BProc; caseStmt: CgNode) =
         return
       let val = getOrdValue(it[j])
       lineF(p, cpsStmts, "NIMSTATE_$#:$n", [val.rope])
-    genStmts(p, it.lastSon)
+
+    lineCg(p, cpsStmts, "goto $1;$n", [it[^1].label])
     endBlock(p)
 
-proc genRepeatStmt(p: BProc, t: CgNode) =
-  # we don't generate labels here as for example GCC would produce
-  # significantly worse code
-  inc(p.withinLoop)
-  genLineDir(p, t)
+proc exit(n: CgNode): CgNode =
+  # XXX: exists as a convenience for overflow check, index check, etc.
+  #      code gen. Should be removed once those are fully lowered prior
+  #      to code generation
+  case n.kind
+  of cnkCheckedCall: n[^1]
+  else:              nil
 
-  if true:
-    var loopBody = t[0]
-    if true:
-      startBlock(p, "while (1) {$n")
-      genStmts(p, loopBody)
-      endBlock(p)
+proc useLabel(p: BProc, label: CLabel) {.inline.} =
+  if label.id == ExitLabel:
+    p.flags.incl beforeRetNeeded
 
-  dec(p.withinLoop)
+proc raiseInstr(p: BProc, n: CgNode): Rope =
+  if n != nil:
+    case n.kind
+    of cnkLabel:
+      # easy case, simply goto the target:
+      result = ropecg(p.module, "goto $1;", [n.label])
+    of cnkTargetList:
+      # the first non-leave operand is the initial jump target
+      let label = toCLabel(n[0], p.specifier)
+      useLabel(p, label)
+      result = ropecg(p.module, "goto $1;", [label])
+    else:
+      unreachable(n.kind)
+  else:
+    # absence of an node storing the target means "never exits"
+    if hasAssume in CC[p.config.cCompiler].props:
+      result = "__asume(0);"
+    else:
+      # don't just fall-through; doing so would inhibit C compiler
+      # optimizations
+      p.flags.incl beforeRetNeeded
+      result = "goto BeforeRet_;"
 
-proc genBlock(p: BProc, n: CgNode) =
-  startBlock(p, n[0].label)
-  genStmts(p, n[1])
-  endBlock(p)
-
-proc genBreakStmt(p: BProc, t: CgNode) =
-  assert t[0].kind == cnkLabel
-  var idx = p.blocks.high
-  # search for the ``TBlock`` that corresponds to the label. `blk` stores the
-  # ID offset by 1, which has to be accounted for here
-  while idx >= 0 and p.blocks[idx].blk != (t[0].label.int + 1):
-    dec idx
-
-  let label = assignLabel(p.blocks[idx])
-  blockLeaveActions(p,
-    p.nestedTryStmts.len - p.blocks[idx].nestedTryStmts,
-    p.inExceptBlockLen - p.blocks[idx].nestedExceptStmts)
-  genLineDir(p, t)
-  lineF(p, cpsStmts, "goto $1;$n", [label])
-
-proc raiseExit(p: BProc) =
+proc raiseExit(p: BProc, n: CgNode) =
   assert p.config.exc == excGoto
   if nimErrorFlagDisabled notin p.flags:
     p.flags.incl nimErrorFlagAccessed
-    if p.nestedTryStmts.len == 0:
-      p.flags.incl beforeRetNeeded
-      # easy case, simply goto 'ret':
-      lineCg(p, cpsStmts, "if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;$n", [])
-    else:
-      lineCg(p, cpsStmts, "if (NIM_UNLIKELY(*nimErr_)) goto LA$1_;$n",
-        [p.nestedTryStmts[^1].label])
-
-proc raiseInstr(p: BProc): Rope =
-  if p.config.exc == excGoto:
-    let L = p.nestedTryStmts.len
-    if L == 0:
-      p.flags.incl beforeRetNeeded
-      # easy case, simply goto 'ret':
-      result = ropecg(p.module, "goto BeforeRet_;$n", [])
-    else:
-      # raise inside an 'except' must go to the finally block,
-      # raise outside an 'except' block must go to the 'except' list.
-      result = ropecg(p.module, "goto LA$1_;$n",
-        [p.nestedTryStmts[L-1].label])
-      # + ord(p.nestedTryStmts[L-1].inExcept)])
-  else:
-    result = ""
+    lineCg(p, cpsStmts, "if (NIM_UNLIKELY(*nimErr_)) $1$n",
+           [raiseInstr(p, n)])
 
 proc genRaiseStmt(p: BProc, t: CgNode) =
   if t[0].kind != cnkEmpty:
@@ -272,12 +186,11 @@ proc genRaiseStmt(p: BProc, t: CgNode) =
     genLineDir(p, t)
     # reraise the last exception:
     linefmt(p, cpsStmts, "#reraiseException();$n", [])
-  let gotoInstr = raiseInstr(p)
-  if gotoInstr != "":
-    line(p, cpsStmts, gotoInstr)
+
+  # the goto is emitted separately
 
 template genCaseGenericBranch(p: BProc, b: CgNode, e: TLoc,
-                          rangeFormat, eqFormat: FormatStr, labl: TLabel) =
+                          rangeFormat, eqFormat: FormatStr, labl: BlockId) =
   var x, y: TLoc
   for i in 0..<b.len - 1:
     if b[i].kind == cnkRange:
@@ -289,49 +202,24 @@ template genCaseGenericBranch(p: BProc, b: CgNode, e: TLoc,
       initLocExpr(p, b[i], x)
       lineCg(p, cpsStmts, eqFormat, [rdCharLoc(e), rdCharLoc(x), labl])
 
-proc genCaseSecondPass(p: BProc, t: CgNode,
-                       labId, until: int): TLabel =
-  var lend = getLabel(p)
-  for i in 1..until:
-    lineF(p, cpsStmts, "LA$1_: ;$n", [rope(labId + i)])
-    if isOfBranch(t[i]):
-      stmtBlock(p, t[i][^1])
-      lineF(p, cpsStmts, "goto $1;$n", [lend])
-    else:
-      stmtBlock(p, t[i][0])
-  result = lend
-
 template genIfForCaseUntil(p: BProc, t: CgNode,
                        rangeFormat, eqFormat: FormatStr,
-                       until: int, a: TLoc): TLabel =
+                       until: int, a: TLoc) =
   # generate a C-if statement for a Nim case statement
-  var res: TLabel
-  var labId = p.labels
   for i in 1..until:
-    inc(p.labels)
     if isOfBranch(t[i]):
       genCaseGenericBranch(p, t[i], a, rangeFormat, eqFormat,
-                           "LA" & rope(p.labels) & "_")
+                           t[i][^1].label)
     else:
-      lineF(p, cpsStmts, "goto LA$1_;$n", [rope(p.labels)])
-  if until < t.len-1:
-    inc(p.labels)
-    var gotoTarget = p.labels
-    lineF(p, cpsStmts, "goto LA$1_;$n", [rope(gotoTarget)])
-    res = genCaseSecondPass(p, t, labId, until)
-    lineF(p, cpsStmts, "LA$1_: ;$n", [rope(gotoTarget)])
-  else:
-    res = genCaseSecondPass(p, t, labId, until)
-  res
+      linefmt(p, cpsStmts, "goto $1;$n", [t[i][^1].label])
 
 template genCaseGeneric(p: BProc, t: CgNode,
                     rangeFormat, eqFormat: FormatStr) =
   var a: TLoc
   initLocExpr(p, t[0], a)
-  var lend = genIfForCaseUntil(p, t, rangeFormat, eqFormat, t.len-1, a)
-  fixLabel(p, lend)
+  genIfForCaseUntil(p, t, rangeFormat, eqFormat, t.len-1, a)
 
-proc genCaseStringBranch(p: BProc, b: CgNode, e: TLoc, labl: TLabel,
+proc genCaseStringBranch(p: BProc, b: CgNode, e: TLoc, labl: BlockId,
                          branches: var openArray[Rope]) =
   var x: TLoc
   for i in 0..<b.len - 1:
@@ -353,15 +241,11 @@ proc genStringCase(p: BProc, t: CgNode) =
     newSeq(branches, bitMask + 1)
     var a: TLoc
     initLocExpr(p, t[0], a) # fist pass: generate ifs+goto:
-    var labId = p.labels
     for i in 1..<t.len:
-      inc(p.labels)
       if isOfBranch(t[i]):
-        genCaseStringBranch(p, t[i], a, "LA" & rope(p.labels) & "_",
-                            branches)
+        genCaseStringBranch(p, t[i], a, t[i][^1].label, branches)
       else:
         # else statement: nothing to do yet
-        # but we reserved a label, which we use later
         discard
     linefmt(p, cpsStmts, "switch (#hashString($1) & $2) {$n",
             [rdLoc(a), bitMask])
@@ -371,10 +255,8 @@ proc genStringCase(p: BProc, t: CgNode) =
              [intLiteral(j), branches[j]])
     lineF(p, cpsStmts, "}$n", []) # else statement:
     if not isOfBranch(t[^1]):
-      lineF(p, cpsStmts, "goto LA$1_;$n", [rope(p.labels)])
-    # third pass: generate statements
-    var lend = genCaseSecondPass(p, t, labId, t.len-1)
-    fixLabel(p, lend)
+      lineCg(p, cpsStmts, "goto $1;$n", [t[^1][0].label])
+
   else:
     genCaseGeneric(p, t, "", "if (#eqStrings($1, $2)) goto $3;$n")
 
@@ -424,10 +306,11 @@ proc genOrdinalCase(p: BProc, n: CgNode) =
   # generate if part (might be empty):
   var a: TLoc
   initLocExpr(p, n[0], a)
-  var lend = if splitPoint > 0: genIfForCaseUntil(p, n,
+  if splitPoint > 0:
+    genIfForCaseUntil(p, n,
                     rangeFormat = "if ($1 >= $2 && $1 <= $3) goto $4;$n",
                     eqFormat = "if ($1 == $2) goto $3;$n",
-                    splitPoint, a) else: ""
+                    splitPoint, a)
 
   # generate switch part (might be empty):
   if splitPoint+1 < n.len:
@@ -441,12 +324,11 @@ proc genOrdinalCase(p: BProc, n: CgNode) =
         # else part of case statement:
         lineF(p, cpsStmts, "default:$n", [])
         hasDefault = true
-      stmtBlock(p, branch.lastSon)
-      lineF(p, cpsStmts, "break;$n", [])
+
+      linefmt(p, cpsStmts, "goto $1;$n", [branch[^1].label])
     if (hasAssume in CC[p.config.cCompiler].props) and not hasDefault:
       lineF(p, cpsStmts, "default: __assume(0);$n", [])
     lineF(p, cpsStmts, "}$n", [])
-  if lend != "": fixLabel(p, lend)
 
 proc genCase(p: BProc, t: CgNode) =
   genLineDir(p, t)
@@ -477,98 +359,38 @@ proc bodyCanRaise(p: BProc; n: CgNode): bool =
       if bodyCanRaise(p, it): return true
     result = false
 
-proc genTryGoto(p: BProc; t: CgNode) =
-  let fin = if t[^1].kind == cnkFinally: t[^1] else: nil
-  inc p.labels
-  let lab = p.labels
-  let hasExcept = t[1].kind == cnkExcept
-  if hasExcept: inc p.withinTryWithExcept
-  p.nestedTryStmts.add((fin, false, Natural lab))
+proc genExcept(p: BProc, n: CgNode) =
+  ## Generates and emits the C code for an ``Except`` join point.
 
-  p.flags.incl nimErrorFlagAccessed
+  if n.len > 1:
+    # it's a handler with a filter/matcher
+    var condExpr = ""
+    for j in 1..<n.len - 1:
+      assert n[j].kind == cnkType
+      if condExpr != "":
+        condExpr.add("||")
 
-  var errorFlagSet = false ## tracks whether the error flag is set to 'true'
-    ## on a control-flow path connected to the finally section
+      # make sure the Exception type is available in the module:
+      discard
+        getTypeDesc(p.module, p.module.g.graph.getCompilerProc("Exception").typ)
 
-  template checkSetsErrorFlag(n: CgNode) =
-    if fin != nil and not errorFlagSet:
-      errorFlagSet = bodyCanRaise(p, n)
+      appcg(p.module, condExpr, "#isObj(#nimBorrowCurrentException()->Sup.m_type, $1)",
+            [genTypeInfo2Name(p.module, n[j].typ)])
 
-  genStmts(p, t[0])
-  checkSetsErrorFlag(t[0])
-
-  if 1 < t.len and t[1].kind == cnkExcept:
-    startBlock(p, "if (NIM_UNLIKELY(*nimErr_)) {$n")
+    # jump to the next handler in the chain if the filter doesn't apply
+    linefmt(p, cpsStmts, "if (!($1)) {$2}$n",
+            [condExpr, raiseInstr(p, n[^1])])
   else:
-    startBlock(p)
-  linefmt(p, cpsStmts, "LA$1_:;$n", [lab])
+    discard "catch-all handler, nothing to check"
 
-  p.nestedTryStmts[^1].inExcept = true
-  var i = 1
-  while (i < t.len) and (t[i].kind == cnkExcept):
-
-    inc p.labels
-    let nextExcept = p.labels
-    p.nestedTryStmts[^1].label = nextExcept
-
-    if t[i].len == 1:
-      # general except section:
-      if i > 1: lineF(p, cpsStmts, "else", [])
-      startBlock(p)
-      # we handled the exception, remember this:
-      linefmt(p, cpsStmts, "*nimErr_ = NIM_FALSE;$n", [])
-      genStmts(p, t[i][0])
-      checkSetsErrorFlag(t[i][0])
-    else:
-      var orExpr = ""
-      for j in 0..<t[i].len - 1:
-        assert(t[i][j].kind == cnkType)
-        if orExpr != "": orExpr.add("||")
-        let checkFor = genTypeInfo2Name(p.module, t[i][j].typ)
-        let memberName = "Sup.m_type"
-        appcg(p.module, orExpr, "#isObj(#nimBorrowCurrentException()->$1, $2)", [memberName, checkFor])
-
-      if i > 1: line(p, cpsStmts, "else ")
-      startBlock(p, "if ($1) {$n", [orExpr])
-      # we handled the exception, remember this:
-      linefmt(p, cpsStmts, "*nimErr_ = NIM_FALSE;$n", [])
-      genStmts(p, t[i][^1])
-      checkSetsErrorFlag(t[i][^1])
-
-    linefmt(p, cpsStmts, "#popCurrentException();$n", [])
-    linefmt(p, cpsStmts, "LA$1_:;$n", [nextExcept])
-    endBlock(p)
-
-    inc(i)
-  discard pop(p.nestedTryStmts)
-  endBlock(p)
-
-  if i < t.len and t[i].kind == cnkFinally:
-    startBlock(p)
-    # future direction: the code generator should track for each procedure
-    # whether it observes the error flag. If the finally clause's body
-    # doesn't observes it itself, and also doesn't call any procedure that
-    # does, we can also omit the save/restore pair
-    if not errorFlagSet:
-      # this is an optimization; if the error flag is proven to never be
-      # 'true' when the finally section is reached, we don't need to erase
-      # nor restore it:
-      genStmts(p, t[i][0])
-    else:
-      # pretend we did handle the error for the safe execution of the 'finally' section:
-      p.procSec(cpsLocals).add(ropecg(p.module, "NIM_BOOL oldNimErrFin$1_;$n", [lab]))
-      linefmt(p, cpsStmts, "oldNimErrFin$1_ = *nimErr_; *nimErr_ = NIM_FALSE;$n", [lab])
-      genStmts(p, t[i][0])
-      # this is correct for all these cases:
-      # 1. finally is run during ordinary control flow
-      # 2. finally is run after 'except' block handling: these however set the
-      #    error back to nil.
-      # 3. finally is run for exception handling code without any 'except'
-      #    handler present or only handlers that did not match.
-      linefmt(p, cpsStmts, "*nimErr_ = oldNimErrFin$1_;$n", [lab])
-    endBlock(p)
-  raiseExit(p)
-  if hasExcept: inc p.withinTryWithExcept
+  startBlock(p)
+  p.flags.incl nimErrorFlagAccessed
+  # exit error mode:
+  lineCg(p, cpsStmts, "*nimErr_ = NIM_FALSE;$n", [])
+  # setup the handler frame:
+  var tmp: TLoc
+  getTemp(p, p.module.g.graph.getCompilerProc("ExceptionFrame").typ, tmp)
+  lineCg(p, cpsStmts, "#nimCatchException($1);$n", [addrLoc(p.config, tmp)])
 
 proc genAsmOrEmitStmt(p: BProc, t: CgNode, isAsmStmt=false): Rope =
   var res = ""
@@ -677,7 +499,7 @@ proc genAsgn(p: BProc, e: CgNode) =
     genLineDir(p, ri)
     loadInto(p, le, ri, a)
 
-proc genStmts(p: BProc, t: CgNode) =
+proc genStmt(p: BProc, t: CgNode) =
   var a: TLoc
 
   let isPush = p.config.hasHint(rsemExtendedContext)
@@ -685,3 +507,79 @@ proc genStmts(p: BProc, t: CgNode) =
   expr(p, t, a)
   if isPush: popInfoContext(p.config)
   internalAssert p.config, a.k in {locNone, locTemp, locLocalVar, locExpr}
+
+proc gen(p: BProc, code: openArray[CInstr], stmts: CgNode) =
+  ## Generates and emits the C code for `code` and `stmts`. This is the main
+  ## driver of C code generation.
+  var pos = 0
+  while pos < code.len:
+    let it = code[pos]
+    case it.op
+    of opLabel:
+      lineCg(p, cpsStmts, "$1:;$n", [it.label])
+    of opJump:
+      useLabel(p, it.label)
+      lineCg(p, cpsStmts, "goto $1;$n", [it.label])
+    of opDispJump:
+      # must only be part of a dispatcher
+      unreachable()
+    of opSetTarget:
+      lineCg(p, cpsStmts, "Target$1_ = $2;$n", [$it.discr, it.value])
+    of opDispatcher:
+      lineF(p, cpsLocals, "NU8 Target$1_;$N", [$it.discr])
+      lineF(p, cpsStmts, "switch (Target$1_) {$n", [$it.discr])
+      for i in 0..<it.value:
+        inc pos
+        useLabel(p, code[pos].label)
+        lineCg(p, cpsStmts, "case $1: goto $2;$n", [i, code[pos].label])
+
+      # help the C compiler a bit by making the case statement exhaustive
+      if hasAssume in CC[p.config.cCompiler].props:
+        lineF(p, cpsStmts, "default: __assume(0);$n", [])
+      # TODO: use ``__builtin_unreachable();`` for compiler supporting the
+      #       GCC built-ins
+      lineF(p, cpsStmts, "}$n", [])
+    of opBackup:
+      if nimErrorFlagDisabled notin p.flags:
+        p.flags.incl nimErrorFlagAccessed
+        lineCg(p, cpsStmts, "NI32 oldNimErrFin$1_ = *nimErr_; *nimErr_ = NIM_FALSE;$n",
+              [$it.local])
+    of opRestore:
+      if nimErrorFlagDisabled notin p.flags:
+        p.flags.incl nimErrorFlagAccessed
+        lineCg(p, cpsStmts, "*nimErr_ = oldNimErrFin$1_;$n", [$it.local])
+    of opErrJump:
+      if nimErrorFlagDisabled notin p.flags:
+        useLabel(p, code[pos].label)
+        p.flags.incl nimErrorFlagAccessed
+        lineCg(p, cpsStmts, "if (NIM_UNLIKELY(*nimErr_)) goto $1;$n",
+               [it.label])
+
+    of opStmts:
+      # generate the code for all statements; no label specifier is set
+      p.specifier = none CLabelSpecifier
+      for i in it.stmts.items:
+        genStmt(p, stmts[i])
+    of opStmt:
+      p.specifier = some it.specifier
+      genStmt(p, stmts[it.stmt])
+
+    of opAbort:
+      if nimErrorFlagDisabled in p.flags:
+        lineCg(p, cpsStmts, "#nimAbortException();$n", [])
+      else:
+        # there's only something to abort when the finalizer was intercepted a
+        # raise
+        lineCg(p, cpsStmts, "if (NIM_UNLIKELY(oldNimErrFin$1_)) #nimAbortException();$n",
+               [$it.local])
+    of opPopHandler:
+      lineCg(p, cpsStmts, "#nimLeaveExcept();$n", [])
+
+    inc pos
+
+proc genStmts*(p: BProc, n: CgNode) =
+  ## Generates and emits the C code for the statement list node `n`, which
+  ## makes up the full body of the procedure. This is the external entry
+  ## point into the C code generator.
+  assert n.kind == cnkStmtList
+  gen(p, toInstrList(n, true), n)

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -43,6 +43,9 @@ type
     cnkMagic         ## name of a magic procedure. Only valid in the callee
                      ## slot of ``cnkCall`` and ``cnkCheckedCall`` nodes
 
+    cnkResume        ## leave the current procedure as part of exceptional
+                     ## control-flow
+
     cnkCall          ## a procedure call. The first operand is the procedure,
                      ## the following operands the arguments
     cnkCheckedCall   ## like ``cnkCall``, but the call might raise an exception
@@ -103,9 +106,8 @@ type
 
     cnkStmtList
     cnkStmtListExpr
-    # future direction: remove ``cnkStmtListExpr``. The code generators know
-    # based on the context a statement list appears in whether its an
-    # expression or not
+    # XXX: both stmtlist and stmtlistexpr are obsolete. They're only kept for
+    #      grouping the top-level statements under a single node
 
     cnkVoidStmt   ## discard the operand value (i.e., do nothing with it)
     cnkEmitStmt   ## an ``emit`` statement
@@ -115,23 +117,29 @@ type
                   ## evaluates to 'true'
     cnkRepeatStmt ## execute the body indefinitely
     cnkCaseStmt   ## a ``case`` statement
+    cnkBranch     ## the branch of a ``case`` statement
     cnkBlockStmt  ## an (optionally) labeled block
+    cnkTryStmt
 
+    cnkGotoStmt
+    cnkLoopStmt   ## jump back to a loop join point
     cnkBreakStmt  ## break out of labeled block, or, if no label is provided,
                   ## the closest ``repeat`` loop
     cnkRaiseStmt  ## raise(x) -- set the `x` as the current exception and start
                   ## exceptional control-flow. `x` can be ``cnkEmpty`` in which
                   ## case "set current exception" part is skipped
-    # future direction: lower the high-level raise statements (which means
-    # "set the current exception" + "start exceptional control-flow") into
-    # just "start exceptional control-flow"
     cnkReturnStmt
+    cnkContinueStmt## jump to the next target in the active jump list
 
-    cnkTryStmt
-    cnkExcept
+    cnkJoinStmt   ## join point for gotos
+    cnkLoopJoinStmt## join point for loops
+    cnkEnd        ## marks the end of a structured control-flow block
+                  ## (identified by the label)
+    cnkExcept     ## special join point, representing an exception handler
     cnkFinally
 
-    cnkBranch     ## the branch of a ``case`` statement
+    cnkTargetList ## an ordered list of jump target/actions
+    cnkLeave
 
     cnkDef        ## starts the lifetime of a local and optionally assigns an
                   ## initial value
@@ -147,12 +155,19 @@ const
   cnkWithOperand*  = {cnkConv, cnkHiddenConv, cnkDeref, cnkAddr, cnkHiddenAddr,
                       cnkDerefView, cnkObjDownConv, cnkObjUpConv, cnkCast,
                       cnkLvalueConv}
-  cnkAtoms*        = {cnkInvalid..cnkMagic, cnkReturnStmt}
+  cnkAtoms*        = {cnkInvalid..cnkResume, cnkReturnStmt}
     ## node kinds that denote leafs
   cnkWithItems*    = AllKinds - cnkWithOperand - cnkAtoms
     ## node kinds for which the ``items`` iterator is available
 
   cnkLiterals* = {cnkIntLit, cnkUIntLit, cnkFloatLit, cnkStrLit}
+  cnkLegacyNodes* = {cnkBlockStmt, cnkTryStmt, cnkReturnStmt, cnkBreakStmt,
+                     cnkRepeatStmt}
+    ## node kinds that belong to the legacy control-flow representation
+  cnkNewCfNodes* = {cnkGotoStmt, cnkJoinStmt, cnkLeave, cnkResume,
+                    cnkContinueStmt, cnkLoopStmt, cnkLoopJoinStmt,
+                    cnkEnd, cnkTargetList}
+    ## node kinds that belong to the new-style control-flow representation
 
 type
   Local* = object
@@ -184,7 +199,8 @@ type
     info*: TLineInfo
     typ*: PType
     case kind*: CgNodeKind
-    of cnkInvalid, cnkEmpty, cnkType, cnkNilLit, cnkReturnStmt: discard
+    of cnkInvalid, cnkEmpty, cnkType, cnkNilLit, cnkReturnStmt, cnkResume:
+      discard
     of cnkIntLit, cnkUIntLit:
       # future direction: use a ``BiggestUint`` for uint values
       intVal*: BiggestInt
@@ -281,18 +297,34 @@ proc merge*(dest: var Body, source: Body): CgNode =
   # merge the locals:
   let offset = dest.locals.merge(source.locals)
 
-  proc update(n: CgNode, offset: uint32) {.nimcall.} =
+  proc update(n: CgNode, offset, labelOffset: uint32) {.nimcall.} =
     ## Offsets the ID of all references-to-``Local`` in `n` by `offset`.
     case n.kind
     of cnkLocal:
       n.local.uint32 += offset
-    of cnkAtoms - {cnkLocal}:
+    of cnkLabel:
+      n.label.uint32 += labelOffset
+    of cnkAtoms - {cnkLocal, cnkLabel}:
       discard "nothing to do"
     of cnkWithOperand:
-      update(n.operand, offset)
+      update(n.operand, offset, labelOffset)
     of cnkWithItems:
       for it in n.items:
-        update(it, offset)
+        update(it, offset, labelOffset)
+
+  proc computeNextLabel(n: CgNode, highest: var uint32) =
+    ## Computes the highest ID value used by labels within `n` and writes it
+    ## to `highest`.
+    case n.kind
+    of cnkLabel:
+      highest = max(n.label.uint32, highest)
+    of cnkAtoms - {cnkLabel}:
+      discard "nothing to do"
+    of cnkWithOperand:
+      computeNextLabel(n.operand, highest)
+    of cnkWithItems:
+      for it in n.items:
+        computeNextLabel(it, highest)
 
   result = source.code
 
@@ -300,8 +332,10 @@ proc merge*(dest: var Body, source: Body): CgNode =
     # make things easier by supporting `dest` being uninitialized
     dest.code = source.code
   elif source.code.kind != cnkEmpty:
-    # update references to locals in source's code:
-    update(source.code, offset.get(LocalId(0)).uint32)
+    var labelOffset = 0'u32
+    computeNextLabel(dest.code, labelOffset)
+    # update references to locals and labels in source's code:
+    update(source.code, offset.get(LocalId(0)).uint32, labelOffset + 1)
 
     # merge the code fragments:
     case dest.code.kind

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -59,7 +59,8 @@ proc treeRepr*(n: CgNode): string =
     of cnkMagic:
       result.add "magic: "
       result.add $n.magic
-    of cnkEmpty, cnkInvalid, cnkType, cnkAstLit, cnkNilLit, cnkReturnStmt:
+    of cnkEmpty, cnkInvalid, cnkType, cnkAstLit, cnkNilLit, cnkReturnStmt,
+       cnkResume:
       discard
     of cnkWithOperand:
       result.add "\n"

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -205,3 +205,8 @@ proc pick*[T](n: CgNode, forInt, forFloat: T): T =
   of tyFloat..tyFloat64:       forFloat
   else:
     unreachable("not an integer or float type")
+
+func numArgs*(n: CgNode): int {.inline.} =
+  ## Returns the number of arguments for a call-like node. The callee
+  ## is excluded.
+  n.len - 1 - ord(n.kind == cnkCheckedCall)

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -74,11 +74,11 @@ proc processEvent(g: PGlobals, graph: ModuleGraph, modules: BModuleList,
       p = startProc(g, bmod, evt.id, Body())
       partial[evt.sym.id] = p
 
-    let body = generateIR(graph, bmod.idgen, g.env, evt.sym, evt.body)
+    let body = generateIRLegacy(graph, bmod.idgen, g.env, evt.sym, evt.body)
     genPartial(p, merge(p.fullBody, body))
   of bekProcedure:
     let
-      body = generateIR(graph, bmod.idgen, g.env, evt.sym, evt.body)
+      body = generateIRLegacy(graph, bmod.idgen, g.env, evt.sym, evt.body)
       r = genProc(g, bmod, evt.id, body)
 
     if sfCompilerProc in evt.sym.flags:
@@ -115,7 +115,8 @@ proc generateCodeForMain(globals: PGlobals, graph: ModuleGraph, m: BModule,
 
   let owner = m.module
   genTopLevelStmt(globals, m):
-    canonicalize(graph, m.idgen, globals.env, owner, body, TranslationConfig())
+    canonicalize(graph, m.idgen, globals.env, owner, body, TranslationConfig(),
+                 legacy=true)
 
 proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   ## Entry point into the JS backend. Generates the code for all modules and

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2447,7 +2447,7 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkTryStmt: genTry(p, n)
   of cnkRaiseStmt: genRaiseStmt(p, n)
   of cnkInvalid, cnkMagic, cnkRange, cnkBinding, cnkExcept, cnkFinally,
-     cnkBranch, cnkAstLit, cnkLabel, cnkStmtListExpr, cnkField:
+     cnkBranch, cnkAstLit, cnkLabel, cnkStmtListExpr, cnkField, cnkNewCfNodes:
     internalError(p.config, n.info, "gen: unknown node type: " & $n.kind)
 
 proc newModule*(g: ModuleGraph; module: PSym): BModule =

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -74,3 +74,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimskullReworkStaticExec")
   defineSymbol("nimskullNoMagicNewAssign")
   defineSymbol("nimskullNoFloat128")
+  defineSymbol("nimskullNewExceptionRt")

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -19,7 +19,7 @@ import
   ],
   compiler/mir/[
     mirbodies,
-    mirchangesets,
+    newchangesets,
     mirconstr,
     mirenv,
     mirtrees
@@ -292,6 +292,6 @@ proc injectHooks*(body: var MirBody, graph: ModuleGraph, env: var MirEnv,
                   owner: PSym) =
   ## Adapter for the legacy pass-application pipeline. Once possible, the pass
   ## needs to be treated as just another MIR pass.
-  var c = initChangeset(body.code)
+  var c = initChangeset(body)
   injectHooks(body, graph, env, owner, c)
-  apply(body.code, prepare(c))
+  body.apply(c)

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -10,6 +10,7 @@ import
   compiler/backend/[
     cgir,
     cgirgen,
+    cgirgen_legacy,
     cgirutils
   ],
   compiler/front/[
@@ -76,7 +77,8 @@ proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
       config.writeln(treeRepr(body.code))
 
 proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
-                   owner: PSym, body: PNode, config: TranslationConfig): Body =
+                   owner: PSym, body: PNode, config: TranslationConfig;
+                   legacy=false): Body =
   ## Legacy routine. Translates the body `body` of the procedure `owner` to
   ## MIR code, and the MIR code to ``CgNode`` IR.
   echoInput(graph.config, owner, body)
@@ -85,5 +87,8 @@ proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
   echoMir(graph.config, owner, body)
 
   # step 2: generate the ``CgNode`` tree
-  result = generateIR(graph, idgen, env, owner, body)
+  if legacy:
+    result = cgirgen_legacy.generateIR(graph, idgen, env, owner, body)
+  else:
+    result = cgirgen.generateIR(graph, idgen, env, owner, body)
   echoOutput(graph.config, owner, result)

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -19,7 +19,7 @@ import
     datatables,
     mirbodies,
     mirenv,
-    mirchangesets,
+    newchangesets,
     mirconstr,
     mirtrees,
     sourcemaps
@@ -465,9 +465,9 @@ proc applyPasses*(body: var MirBody, prc: PSym, env: var MirEnv,
   ## certain passes. Passes may register new entities with `env`.
   template batch(b: untyped) =
     block:
-      var c {.inject.} = initChangeset(body.code)
+      var c {.inject.} = initChangeset(body)
       b
-      apply(body.code, prepare(c))
+      apply(body, c)
 
   if target == targetC:
     batch:

--- a/compiler/mir/newchangesets.nim
+++ b/compiler/mir/newchangesets.nim
@@ -1,0 +1,92 @@
+## Implements the `Changeset <#Changeset>`_ type, which is a changeset for
+## `MirBody <mirbodies.html#MirBody>`_. It builds upon/extends
+## `TreeChangeset <treechangesets.html#TreeChangeset>`_.
+
+import
+  compiler/mir/[
+    mirbodies,
+    mirconstr,
+    mirtrees,
+    sourcemaps,
+    treechangesets
+  ]
+
+type
+  Changeset* = object
+    ## Represents a set of changes to be applied to a ``MirBody``.
+    inner: TreeChangeset
+    numTemps: uint32
+      ## keeps track of the number of temporaries. Exchanged with
+      ## the created builder, where it's used for allocating new IDs
+
+# ----------------------------------------
+# proxy routines
+
+template replace*(c: var Changeset, tree: MirTree, at: NodePosition,
+                  with: MirNode) =
+  ## Same as `replace <treechangesets.html#replace,TreeChangeset,MirTree,NodePosition,sinkMirNode>`_.
+  replace(c.inner, tree, at, with)
+
+template changeTree*(c: var Changeset, tree: MirTree, at: NodePosition,
+                     with: MirNode) =
+  ## Same as `changeTree <treechangesets.html#changeTree,TreeChangeset,MirTree,NodePosition,sinkMirNode>`_.
+  changeTree(c.inner, tree, at, with)
+
+template insert*(c: var Changeset, at: NodePosition, n: MirNode) =
+  ## Same as `insert <treechangesets.html#insert,TreeChangeset,NodePosition,sinkMirNode>`_.
+  insert(c.inner, at, n)
+
+template remove*(c: var Changeset, tree: MirTree, at: NodePosition) =
+  ## Same as `remove <treechangesets.html#remove,TreeChangeset,MirTree,NodePosition>`_.
+  remove(c.inner, tree, at)
+
+# ----------------------------------------
+# `Changeset`-specific routines
+
+func initChangeset*(body: MirBody): Changeset =
+  ## Sets up a changeset for `body`. The changeset either needs to be
+  ## discarded, or applied to the same ``MirBody`` instance it was created for.
+  # compute the next ID to use for new temporaries:
+  for i, n in body.code.pairs:
+    if n.kind in DefNodes and
+       (let ent = body.code[i, 0]; ent.kind in {mnkTemp, mnkAlias}):
+      result.numTemps = max(ent.temp.uint32 + 1, result.numTemps)
+
+func initBuilder(c: var Changeset, buffer: var MirNodeSeq,
+                 info: SourceId): MirBuilder =
+  ## Internal routine for setting up a builder. Must be paired with a
+  ## ``finishBuilder`` call.
+  result = initBuilder(info, move buffer)
+  swap(c.numTemps, result.numTemps)
+
+func finishBuilder(c: var Changeset, buffer: var MirNodeSeq,
+                   bu: sink MirBuilder) =
+  # move the ID counter and buffer back into the changeset
+  swap(c.numTemps, bu.numTemps)
+  buffer = finish(bu)
+
+template insert*(c: var Changeset, tree: MirTree, at, source: NodePosition,
+                 name: untyped, body: untyped) =
+  ## Records an insertion at the `at` position. For building the new tree,
+  ## a ``MirBuilder`` instance is made available to the provided `body` via
+  ## an injected local of name `name`. `source` identifies the node to
+  ## inherit source information from.
+  insert(c.inner, at, bufferTmp):
+    var name = initBuilder(c, bufferTmp, tree[source].info)
+    body
+    finishBuilder(c, bufferTmp, name)
+
+template replaceMulti*(c: var Changeset, tree: MirTree, at: NodePosition,
+                       name, body: untyped) =
+  ## Records a replacement of the node or sub-tree at the `at` position. For
+  ## building the replacement tree, a ``MirBuilder`` instance is made
+  ## available to the provided `body` via an injected local of name `name`.
+  let pos = at
+  replaceMulti(c.inner, tree, pos, bufferTmp):
+    var name = initBuilder(c, bufferTmp, tree[pos].info)
+    body
+    finishBuilder(c, bufferTmp, name)
+
+func apply*(body: var MirBody, c: sink Changeset) =
+  ## Applies the changeset `c` to `body`.
+  apply(body.code, prepare(move c.inner))

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -126,7 +126,7 @@ proc generateCodeForProc(c: var CodeGenCtx, idgen: IdGenerator, s: PSym,
   ## Generates and the bytecode for the procedure `s` with body `body`. The
   ## resulting bytecode is emitted into the global bytecode section.
   let
-    body = generateIR(c.graph, idgen, c.env, s, body)
+    body = generateIRLegacy(c.graph, idgen, c.env, s, body)
     r    = genProc(c, s, body)
 
   if r.isOk:
@@ -181,7 +181,7 @@ proc processEvent(c: var GenCtx, mlist: ModuleList, discovery: var DiscoveryData
   of bekPartial:
     let p = addr mgetOrPut(partial, evt.id, PartialProc(sym: evt.sym))
     discard merge(p.body):
-      generateIR(c.graph, idgen, c.gen.env, evt.sym, evt.body)
+      generateIRLegacy(c.graph, idgen, c.gen.env, evt.sym, evt.body)
   of bekProcedure:
     # a complete procedure became available
     let r = generateCodeForProc(c.gen, idgen, evt.sym, evt.body)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3200,7 +3200,8 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
   of cnkAsmStmt, cnkEmitStmt:
     unused(c, n, dest)
   of cnkInvalid, cnkMagic, cnkRange, cnkExcept, cnkFinally, cnkBranch,
-     cnkBinding, cnkLabel, cnkStmtListExpr, cnkField, cnkToSlice:
+     cnkBinding, cnkLabel, cnkStmtListExpr, cnkField, cnkToSlice,
+     cnkNewCfNodes:
     unreachable(n.kind)
 
 proc initProc(c: TCtx, owner: PSym, body: sink Body): BProc =

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -154,7 +154,7 @@ proc generateMirCode(c: var TCtx, env: var MirEnv, n: PNode;
     result.code = finish(bu)
 
 proc generateIR(c: var TCtx, env: MirEnv, body: sink MirBody): Body =
-  backends.generateIR(c.graph, c.idgen, env, c.module, body)
+  backends.generateIRLegacy(c.graph, c.idgen, env, c.module, body)
 
 proc setupRootRef(c: var TCtx) =
   ## Sets up if the ``RootRef`` type for the type info cache. This
@@ -271,7 +271,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"
 
-  let outBody = generateIR(c.graph, c.idgen, jit.gen.env, s, mirBody)
+  let outBody = generateIRLegacy(c.graph, c.idgen, jit.gen.env, s, mirBody)
   echoOutput(c.config, s, outBody)
 
   try:

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -188,8 +188,6 @@ __EMSCRIPTEN__
 
 #  ifdef __cplusplus
 #    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
-#  elif __EMSCRIPTEN__
-#    define N_LIB_EXPORT  EMSCRIPTEN_KEEPALIVE __declspec(dllexport)
 #  else
 #    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
 #  endif
@@ -223,8 +221,11 @@ __EMSCRIPTEN__
 #    define N_SAFECALL_PTR(rettype, name) rettype (*name)
 #  endif
 #  ifdef __EMSCRIPTEN__
-#    define N_LIB_EXPORT  EMSCRIPTEN_KEEPALIVE __attribute__((visibility("default")))
-#    define N_LIB_EXPORT_VAR  EMSCRIPTEN_KEEPALIVE __attribute__((visibility("default")))
+//   Emscripten uses an EMSCRIPTEN_KEEPALIVE macro to mark exports, but also
+//   requires an <emscripten.h> include. The macro expands to __attribute__((used)).
+//   With the following, we cut out the middleman and avoid that include:
+#    define N_LIB_EXPORT  __attribute__((used, visibility("default")))
+#    define N_LIB_EXPORT_VAR  __attribute__((used, visibility("default")))
 #  else
 #    define N_LIB_EXPORT  NIM_EXTERNC __attribute__((visibility("default")))
 #    define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -18,6 +18,7 @@ __POCC__
 __TINYC__
 __clang__
 __AVR__
+__EMSCRIPTEN__
 */
 
 
@@ -164,7 +165,6 @@ __AVR__
 #  define NIM_CAST(type, ptr) ((type)(ptr))
 #endif
 
-
 /* ------------------------------------------------------------------- */
 #ifdef  __cplusplus
 #  define NIM_EXTERNC extern "C"
@@ -188,6 +188,8 @@ __AVR__
 
 #  ifdef __cplusplus
 #    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
+#  elif __EMSCRIPTEN__
+#    define N_LIB_EXPORT  EMSCRIPTEN_KEEPALIVE __declspec(dllexport)
 #  else
 #    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
 #  endif
@@ -220,8 +222,13 @@ __AVR__
 #    define N_FASTCALL_PTR(rettype, name) rettype (*name)
 #    define N_SAFECALL_PTR(rettype, name) rettype (*name)
 #  endif
-#  define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default")))
-#  define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
+#  ifdef __EMSCRIPTEN__
+#    define N_LIB_EXPORT  EMSCRIPTEN_KEEPALIVE __attribute__((visibility("default")))
+#    define N_LIB_EXPORT_VAR  EMSCRIPTEN_KEEPALIVE __attribute__((visibility("default")))
+#  else
+#    define N_LIB_EXPORT  NIM_EXTERNC __attribute__((visibility("default")))
+#    define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
+#  endif
 #  define N_LIB_IMPORT  extern
 #endif
 

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -67,12 +67,25 @@ type
     len: int
     prev: ptr GcFrameHeader
 
+  ExceptionFrame {.compilerproc.} = object
+    ## Represents an exception handler (i.e., an ``except`` section).
+    prev: ptr ExceptionFrame
+      ## previous frame, or nil
+    exc: ref Exception
+      ## always non-nil
+
 when NimStackTraceMsgs:
   var frameMsgBuf* {.threadvar.}: string
 var
   framePtr {.threadvar.}: PFrame
   currException {.threadvar.}: ref Exception
   gcFramePtr {.threadvar.}: GcFrame
+
+  handlers {.threadvar.}: ptr ExceptionFrame
+    ## linked list of all active handlers in the current thread
+  activeException {.threadvar.}: ref Exception
+    ## stack of in-flight exceptions. An exception stops being in-flight once
+    ## an ``except`` section "catches" it.
 
 type
   FrameState = tuple[gcFramePtr: GcFrame, framePtr: PFrame,
@@ -118,11 +131,13 @@ proc pushGcFrame*(s: GcFrame) {.compilerRtl, inl.} =
   gcFramePtr = s
 
 proc pushCurrentException(e: sink(ref Exception)) {.compilerRtl, inl.} =
+  # XXX: legacy runtime procedure only used by the csources compiler
   e.up = currException
   currException = e
   #showErrorMessage2 "A"
 
 proc popCurrentException {.compilerRtl, inl.} =
+  # XXX: legacy runtime procedure only used by the csources compiler
   currException = currException.up
   #showErrorMessage2 "B"
 
@@ -412,6 +427,13 @@ when true:
       currException = nil
       quit(1)
 
+proc pushActiveException(e: sink(ref Exception)) =
+  e.up = activeException
+  activeException = e
+  # FIXME: don't set the current exception here; it's only done this way for
+  #        backwards compatibility
+  currException = e # set the current exception already
+
 proc raiseExceptionAux(e: sink(ref Exception)) {.nodestroy.} =
   when defined(nimPanics):
     # XXX: the compiler should reject raise being used with defects. User-code
@@ -425,7 +447,10 @@ proc raiseExceptionAux(e: sink(ref Exception)) {.nodestroy.} =
   if globalRaiseHook != nil:
     if not globalRaiseHook(e): return
 
-  pushCurrentException(e)
+  when defined(nimskullNewExceptionRt):
+    pushActiveException(e)
+  else:
+    pushCurrentException(e)
   inc nimInErrorMode
 
 proc prepareException(e: ref Exception, ename: cstring) {.compilerRtl.} =
@@ -467,10 +492,16 @@ proc raiseException(e: sink(ref Exception), ename: cstring) {.compilerRtl.} =
   raiseExceptionEx(e, ename, nil, nil, 0)
 
 proc reraiseException() {.compilerRtl.} =
-  if currException == nil:
-    sysFatal(ReraiseDefect, "no exception to reraise")
-  else:
+  when defined(nimskullNewExceptionRt):
+    # the compiler makes sure that a re-raise only take place within an
+    # exception handler
+    pushActiveException(move handlers.exc)
     inc nimInErrorMode
+  else:
+    if currException == nil:
+      sysFatal(ReraiseDefect, "no exception to reraise")
+    else:
+      inc nimInErrorMode
 
 proc threadTrouble() =
   # also forward declared, it is 'raises: []' hence the try-except.
@@ -533,6 +564,71 @@ proc nimFrame(s: PFrame) {.compilerRtl, inl, raises: [].} =
   s.prev = framePtr
   framePtr = s
   if s.calldepth == nimCallDepthLimit: callDepthLimitReached()
+
+# v2 exception handling runtime
+# -----------------------------
+
+{.push stacktrace: off, checks: off.}
+
+proc nimCatchException(frame: ptr ExceptionFrame) {.compilerproc.} =
+  ## Pops the top-most in-flight exception from the stack, stores it in
+  ## `frame`, and sets it as the current exception. `frame` is pushed to the
+  ## handler stack.
+  # zero-initialize the location first
+  nimZeroMem(frame, sizeof(ExceptionFrame))
+  frame.prev = handlers
+  frame.exc = activeException
+  # push to handler stack:
+  handlers = frame
+
+  currException = activeException
+  # "pop" the exception from the active stack. Moving from the up pointer
+  # makes sure the caught exception is properly disconnected:
+  activeException = move activeException.up
+
+proc restoreCurrentEx() =
+  # FIXME: don't consider active exceptions; it's only done this way for
+  #        backwards compatibility
+  if handlers.isNil or handlers.exc.isNil:
+    currException = activeException
+  elif handlers.exc.up == activeException:
+    # the active handler is more recent than the most-recent active exception
+    currException = handlers.exc
+  else:
+    # the active exception was raised after the most-recent handler was entered
+    currException = activeException
+
+proc nimLeaveExcept() {.compilerproc, inline.} =
+  ## Called when an exception handler is exited. Pops the top-most frame from
+  ## the handler stack. Supports being called during unwinding.
+  var wasInErrorMode = nimInErrorMode
+  nimInErrorMode = false
+  handlers.exc = nil # cleanup the ref
+  handlers = handlers.prev
+  restoreCurrentEx()
+  nimInErrorMode = wasInErrorMode
+
+proc nimAbortException() {.compilerproc.} =
+  ## Abort (i.e., discard) an in-flight exception. Must only be called if an
+  ## exception is actually in-flight.
+  var wasInErrorMode = nimInErrorMode
+  # disable error mode right away
+  nimInErrorMode = false
+
+  if wasInErrorMode:
+    # if an exception is aborted by raising another exception, don't pop the
+    # active exception; drop its parent
+    if activeException.up != nil:
+      activeException.up = activeException.up.up
+  else:
+    activeException = activeException.up
+
+  restoreCurrentEx()
+  nimInErrorMode = wasInErrorMode
+
+{.pop.}
+
+# -----
 
 when not defined(noSignalHandler) and not defined(useNimRtl):
   type Sighandler = proc (a: cint) {.noconv, benign.}

--- a/tests/compiler/ttreechangesets.nim
+++ b/tests/compiler/ttreechangesets.nim
@@ -1,5 +1,5 @@
 discard """
-  description: "Tests for the MIR ``Changeset`` API"
+  description: "Tests for the MIR ``TreeChangeset`` API"
   targets: native
 """
 
@@ -7,8 +7,10 @@ discard """
 
 import
   compiler/ast/ast_types,
-  compiler/mir/[mirtrees, mirchangesets, mirconstr, sourcemaps],
+  compiler/mir/[mirtrees, treechangesets, mirconstr, sourcemaps],
   compiler/utils/containers
+
+type Changeset = TreeChangeset
 
 proc temp(x: int): MirNode =
   MirNode(kind: mnkTemp, temp: x.TempId)
@@ -42,7 +44,7 @@ template test(input, output: typed, body: untyped) =
       tree =
         when input is array: @input
         else:                input
-      c {.inject.} = initChangeset(tree)
+      c {.inject.}: Changeset
       sourceMap = setupSourceMap(tree)
 
     template replace(c: Changeset, i: int, n: MirNode) {.inject.} =

--- a/tests/exception/tfinally6.nim
+++ b/tests/exception/tfinally6.nim
@@ -3,7 +3,7 @@ discard """
     Multiple tests regarding ``finally`` interaction with exception handlers
     and raised exceptions.
   '''
-  knownIssue.c js: "The current exception is not properly cleared"
+  knownIssue.js: "The current exception is not properly cleared"
 """
 
 var steps: seq[int]

--- a/tests/exception/tleave_except2.nim
+++ b/tests/exception/tleave_except2.nim
@@ -1,0 +1,87 @@
+discard """
+  description: '''
+    Ensure that leaving an `except` section by raising an exception properly
+    updates the current exception.
+  '''
+  knownIssue.js vm: "The current exception is not reset properly"
+"""
+
+var steps: seq[string]
+
+type Ex = object of CatchableError
+
+proc `=destroy`(x: var Ex) =
+  steps.add x.msg
+
+template postcondition() =
+  # ensure that the exceptions were destroyed in the correct order
+  when defined(gcOrc) or defined(gcArc):
+    doAssert steps == ["1", "2"]
+
+# -------------
+# test case 1: local raise and local exception handler
+
+proc test1() =
+  try:
+    try:
+      raise Ex.newException("1")
+    except Ex as e:
+      doAssert getCurrentException() == e
+      doAssert e.msg == "1"
+      raise Ex.newException("2")
+  except Ex as e:
+    doAssert getCurrentException() == e
+    doAssert e.msg == "2"
+
+  doAssert getCurrentException() == nil
+
+test1()
+postcondition()
+
+# -------------
+# test case 2: indirect raise and local exception handler
+
+proc raiseEx() =
+  raise Ex.newException("2")
+
+proc test2() =
+  try:
+    try:
+      raise Ex.newException("1")
+    except Ex as e:
+      doAssert getCurrentException() == e
+      doAssert e.msg == "1"
+      raiseEx()
+  except Ex as e:
+    doAssert getCurrentException() == e
+    doAssert e.msg == "2"
+
+  doAssert getCurrentException() == nil
+
+steps = @[]
+test2()
+postcondition()
+
+# -------------
+# test case 3: indirect raise and non-local exception handler
+
+proc test3() =
+  proc inner() =
+    try:
+      raise Ex.newException("1")
+    except Ex as e:
+      doAssert getCurrentException() == e
+      doAssert e.msg == "1"
+      raiseEx()
+
+  try:
+    inner()
+  except Ex as e:
+    doAssert getCurrentException() == e
+    doAssert e.msg == "2"
+
+  doAssert getCurrentException() == nil
+
+steps = @[]
+test3()
+postcondition()

--- a/tests/exception/treraise2.nim
+++ b/tests/exception/treraise2.nim
@@ -1,0 +1,58 @@
+discard """
+  description: '''
+    Ensure that raising a caught exception from within an exception handler
+    works
+  '''
+  knownIssue.js vm: "The current exception is not properly updated"
+"""
+
+proc manualReraise() =
+  # raising an already caught exception works and doesn't interfere with how
+  # the current exception is set
+  try:
+    raise CatchableError.newException("1")
+  except CatchableError as e:
+    raise e
+
+try:
+  manualReraise()
+except CatchableError as e:
+  doAssert e.msg == "1"
+
+doAssert getCurrentException() == nil
+
+# ---------------------------------------------------------------------------
+# more complex situation: re-raise an exception not caught by the most nested
+# handler
+
+# situation 1: catch within the original handler
+try:
+  raise CatchableError.newException("1")
+except CatchableError as e:
+  try:
+    try:
+      raise CatchableError.newException("2")
+    except CatchableError as e2:
+      raise e # raise the outer exception again
+  except CatchableError as e2:
+    doAssert e2.msg == "1"
+
+  # the current exception must still be the same as `e`
+  doAssert getCurrentException().msg == "1"
+
+doAssert getCurrentException() == nil
+
+# situation 2: catch outside the original handler
+try:
+  try:
+    raise CatchableError.newException("1")
+  except CatchableError as e:
+    try:
+      raise CatchableError.newException("2")
+    except CatchableError as e2:
+      raise e # raise the outer exception again
+  # the exception propagates outside the original handler
+except CatchableError as e:
+  doAssert e.msg == "1"
+
+doAssert getCurrentException() == nil

--- a/tests/lang_objects/destructor/tdestruction_in_unreachable.nim
+++ b/tests/lang_objects/destructor/tdestruction_in_unreachable.nim
@@ -1,0 +1,35 @@
+discard """
+  description: '''
+    Ensure that no destructor is called for a local defined in an unreachable
+    part of the code, even if the scope is left via unstructured control-flow.
+  '''
+  targets: "c js vm"
+"""
+
+type Object = object
+
+var wasDestroyed = false
+
+proc `=destroy`(x: var Object) =
+  wasDestroyed = true
+
+proc test(cond: bool) =
+  block:
+    if cond:
+      return
+    else:
+      raise CatchableError.newException("")
+
+  # everything beyond this point is statically unreachable code
+  var o = Object()
+  if cond:
+    # introduce an unstructured exit of the scope
+    return
+
+  discard o
+
+test(true)
+
+# XXX: wasDestroy must be false, but it currently isn't. Testing the inverse
+#      makes sure that the test at least compiles
+doAssert wasDestroyed, "the behaviour is correct now"


### PR DESCRIPTION
## Summary
* `N_LIB_EXPORT` now expands to `__attribute__((used, visibility("default")))` when `__EMSCRIPTEN__` is defined.
* Compiling to wasm with emscripten won't export symbols without `__attribute__((used))`.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
