### PR TITLE
refactor(mir): split `mirchangesets` into two modules

### DIFF
--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -19,7 +19,7 @@ import
   ],
   compiler/mir/[
     mirbodies,
-    mirchangesets,
+    newchangesets,
     mirconstr,
     mirenv,
     mirtrees
@@ -292,6 +292,6 @@ proc injectHooks*(body: var MirBody, graph: ModuleGraph, env: var MirEnv,
                   owner: PSym) =
   ## Adapter for the legacy pass-application pipeline. Once possible, the pass
   ## needs to be treated as just another MIR pass.
-  var c = initChangeset(body.code)
+  var c = initChangeset(body)
   injectHooks(body, graph, env, owner, c)
-  apply(body.code, prepare(c))
+  body.apply(c)

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -19,7 +19,7 @@ import
     datatables,
     mirbodies,
     mirenv,
-    mirchangesets,
+    newchangesets,
     mirconstr,
     mirtrees,
     sourcemaps
@@ -465,9 +465,9 @@ proc applyPasses*(body: var MirBody, prc: PSym, env: var MirEnv,
   ## certain passes. Passes may register new entities with `env`.
   template batch(b: untyped) =
     block:
-      var c {.inject.} = initChangeset(body.code)
+      var c {.inject.} = initChangeset(body)
       b
-      apply(body.code, prepare(c))
+      apply(body, c)
 
   if target == targetC:
     batch:

--- a/compiler/mir/newchangesets.nim
+++ b/compiler/mir/newchangesets.nim
@@ -1,0 +1,92 @@
+## Implements the `Changeset <#Changeset>`_ type, which is a changeset for
+## `MirBody <mirbodies.html#MirBody>`_. It builds upon/extends
+## `TreeChangeset <treechangesets.html#TreeChangeset>`_.
+
+import
+  compiler/mir/[
+    mirbodies,
+    mirconstr,
+    mirtrees,
+    sourcemaps,
+    treechangesets
+  ]
+
+type
+  Changeset* = object
+    ## Represents a set of changes to be applied to a ``MirBody``.
+    inner: TreeChangeset
+    numTemps: uint32
+      ## keeps track of the number of temporaries. Exchanged with
+      ## the created builder, where it's used for allocating new IDs
+
+# ----------------------------------------
+# proxy routines
+
+template replace*(c: var Changeset, tree: MirTree, at: NodePosition,
+                  with: MirNode) =
+  ## Same as `replace <treechangesets.html#replace,TreeChangeset,MirTree,NodePosition,sinkMirNode>`_.
+  replace(c.inner, tree, at, with)
+
+template changeTree*(c: var Changeset, tree: MirTree, at: NodePosition,
+                     with: MirNode) =
+  ## Same as `changeTree <treechangesets.html#changeTree,TreeChangeset,MirTree,NodePosition,sinkMirNode>`_.
+  changeTree(c.inner, tree, at, with)
+
+template insert*(c: var Changeset, at: NodePosition, n: MirNode) =
+  ## Same as `insert <treechangesets.html#insert,TreeChangeset,NodePosition,sinkMirNode>`_.
+  insert(c.inner, at, n)
+
+template remove*(c: var Changeset, tree: MirTree, at: NodePosition) =
+  ## Same as `remove <treechangesets.html#remove,TreeChangeset,MirTree,NodePosition>`_.
+  remove(c.inner, tree, at)
+
+# ----------------------------------------
+# `Changeset`-specific routines
+
+func initChangeset*(body: MirBody): Changeset =
+  ## Sets up a changeset for `body`. The changeset either needs to be
+  ## discarded, or applied to the same ``MirBody`` instance it was created for.
+  # compute the next ID to use for new temporaries:
+  for i, n in body.code.pairs:
+    if n.kind in DefNodes and
+       (let ent = body.code[i, 0]; ent.kind in {mnkTemp, mnkAlias}):
+      result.numTemps = max(ent.temp.uint32 + 1, result.numTemps)
+
+func initBuilder(c: var Changeset, buffer: var MirNodeSeq,
+                 info: SourceId): MirBuilder =
+  ## Internal routine for setting up a builder. Must be paired with a
+  ## ``finishBuilder`` call.
+  result = initBuilder(info, move buffer)
+  swap(c.numTemps, result.numTemps)
+
+func finishBuilder(c: var Changeset, buffer: var MirNodeSeq,
+                   bu: sink MirBuilder) =
+  # move the ID counter and buffer back into the changeset
+  swap(c.numTemps, bu.numTemps)
+  buffer = finish(bu)
+
+template insert*(c: var Changeset, tree: MirTree, at, source: NodePosition,
+                 name: untyped, body: untyped) =
+  ## Records an insertion at the `at` position. For building the new tree,
+  ## a ``MirBuilder`` instance is made available to the provided `body` via
+  ## an injected local of name `name`. `source` identifies the node to
+  ## inherit source information from.
+  insert(c.inner, at, bufferTmp):
+    var name = initBuilder(c, bufferTmp, tree[source].info)
+    body
+    finishBuilder(c, bufferTmp, name)
+
+template replaceMulti*(c: var Changeset, tree: MirTree, at: NodePosition,
+                       name, body: untyped) =
+  ## Records a replacement of the node or sub-tree at the `at` position. For
+  ## building the replacement tree, a ``MirBuilder`` instance is made
+  ## available to the provided `body` via an injected local of name `name`.
+  let pos = at
+  replaceMulti(c.inner, tree, pos, bufferTmp):
+    var name = initBuilder(c, bufferTmp, tree[pos].info)
+    body
+    finishBuilder(c, bufferTmp, name)
+
+func apply*(body: var MirBody, c: sink Changeset) =
+  ## Applies the changeset `c` to `body`.
+  apply(body.code, prepare(move c.inner))

--- a/tests/compiler/ttreechangesets.nim
+++ b/tests/compiler/ttreechangesets.nim
@@ -1,5 +1,5 @@
 discard """
-  description: "Tests for the MIR ``Changeset`` API"
+  description: "Tests for the MIR ``TreeChangeset`` API"
   targets: native
 """
 
@@ -7,8 +7,10 @@ discard """
 
 import
   compiler/ast/ast_types,
-  compiler/mir/[mirtrees, mirchangesets, mirconstr, sourcemaps],
+  compiler/mir/[mirtrees, treechangesets, mirconstr, sourcemaps],
   compiler/utils/containers
+
+type Changeset = TreeChangeset
 
 proc temp(x: int): MirNode =
   MirNode(kind: mnkTemp, temp: x.TempId)
@@ -42,7 +44,7 @@ template test(input, output: typed, body: untyped) =
       tree =
         when input is array: @input
         else:                input
-      c {.inject.} = initChangeset(tree)
+      c {.inject.}: Changeset
       sourceMap = setupSourceMap(tree)
 
     template replace(c: Changeset, i: int, n: MirNode) {.inject.} =


### PR DESCRIPTION
## Summary

Split `mirchangesets` into two modules: one for the changesets
concerning only `MirTree`s and one for `MirBody` changesets. This
breaks up unnecessary module dependencies and prepares for future
extension of the `MirBody` changesets.

## Details

* the existing `Changeset` type is renamed to `TreeChangeset`
  * it only records changes for trees, and no longer has direct
    integration with `MirBuilder`
  * `insert` and `replaceMulti` provide the raw node storage
* the `MirBody`-focused API providing `MirBuilder` instances is of part
  to the new `newchangesets` module
  * inheritance (i.e., `TreeChangeset = object of RootObj`) is decided
    against because it doesn't work with `prepare(sink TreeChangeset)`
  * instead, `Changeset` stores an instance of `TreeChangeset`, with
    the `TreeChangeset` API being made available through proxy templates
* the `tmir_changesets` test is updated and renamed to
  `ttreechangesets`

`Changeset` needs to be coupled more with `MirBody` in the future.
Splitting the `MirTree`-only part into a separate type and module
makes it possible to keep using changesets where only a `MirTree` but
no body `MirBody` exists. One such case is going to be transforming/
modifying MIR constant expressions.