### PR TITLE
export `.dynlib` procs to WASM when using Emscripten

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -225,7 +225,7 @@ __EMSCRIPTEN__
 //   Emscripten uses an EMSCRIPTEN_KEEPALIVE macro to mark exports, but also
 //   requires an <emscripten.h> include. The macro expands to __attribute__((used)).
 //   With the following, we cut out the middleman and avoid that include:
-#    define N_LIB_EXPORT  __attribute__((used, visibility("default")))
+#    define N_LIB_EXPORT  NIM_EXTERNC __attribute__((used, visibility("default")))
 #    define N_LIB_EXPORT_VAR  __attribute__((used, visibility("default")))
 #  else
 #    define N_LIB_EXPORT  NIM_EXTERNC __attribute__((visibility("default")))

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -18,6 +18,7 @@ __POCC__
 __TINYC__
 __clang__
 __AVR__
+__EMSCRIPTEN__
 */
 
 
@@ -220,8 +221,16 @@ __AVR__
 #    define N_FASTCALL_PTR(rettype, name) rettype (*name)
 #    define N_SAFECALL_PTR(rettype, name) rettype (*name)
 #  endif
-#  define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default")))
-#  define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
+#  ifdef __EMSCRIPTEN__
+//   Emscripten uses an EMSCRIPTEN_KEEPALIVE macro to mark exports, but also
+//   requires an <emscripten.h> include. The macro expands to __attribute__((used)).
+//   With the following, we cut out the middleman and avoid that include:
+#    define N_LIB_EXPORT  __attribute__((used, visibility("default")))
+#    define N_LIB_EXPORT_VAR  __attribute__((used, visibility("default")))
+#  else
+#    define N_LIB_EXPORT  NIM_EXTERNC __attribute__((visibility("default")))
+#    define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
+#  endif
 #  define N_LIB_IMPORT  extern
 #endif
 


### PR DESCRIPTION
## Summary
* The  `dynlib`  pragma now ensures that the procedure is exported to
WASM when compiling with Emscripten

## Details
*  `N_LIB_EXPORT`  now expands to 
`__attribute__((used, visibility("default")))`  when  `__EMSCRIPTEN__` 
is defined.
* Compiling to wasm with emscripten won't export symbols without 
`__attribute__((used))` .

Replaces https://github.com/nim-works/nimskull/pull/1216 (where I merged
some changes that didn't belong)