### PR TITLE
fix(cgirgen): compiler crash with unreachable code

### DIFF
--- a/tests/lang_objects/destructor/tdestruction_in_unreachable.nim
+++ b/tests/lang_objects/destructor/tdestruction_in_unreachable.nim
@@ -33,3 +33,24 @@ test(true)
 # XXX: wasDestroy must be false, but it currently isn't. Testing the inverse
 #      makes sure that the test at least compiles
 doAssert wasDestroyed, "the behaviour is correct now"
+
+# ------------------------------
+# test without if/else statement
+
+proc test2(cond: bool) =
+  block:
+    # the return is within its own scope. Using a raise would have the same
+    # compile-time effect, but would result in an unhandled exception at
+    # run-time
+    return
+
+  var o = Object()
+  if cond:
+    # introduce an unstructured exit of the scope (which currently
+    # forces destruction within a finally)
+    return
+  discard o
+
+test2(true)
+# XXX: same comment as for the assertion above
+doAssert wasDestroyed, "the behaviour is correct now"


### PR DESCRIPTION
## Summary

Fix elimination of unreachable code in the MIR-to-CGIR translation
leading to the compiler crashing in some cases.

## Details

With how the current forward translation of MIR-to-CGIR works,
definitions of locals/globals in unscoped contexts need to always be
translated, otherwise they won't be moved to the start of their scope.

The previous approach was to only disable translation following
terminal statements when in scoped contexts, and always enabling
translation after join-like statements, but this doesn't catch the
following:
```
scope:
  try:
    scope:
      raise
    def _1 = ...
  finally:
    =destroy(name _1)
```

Since the `raise` terminal statement is in a scope context, translation
is disabled, but due to the lack of a join-like statement following it,
it isn't enabled again for the `def` statement. Since there's the `_1`
local is then not registered with the CGIR body, either translation or
code generation for the (reachable) `=destroy(name _1)` crashes due to
the unknown local.

### The Solution

A different approach to mitigating the current problem with unscoped
locals is used: no special handling is applied when setting the
`cl.isActive` flag. Instead, the flag is ignored when within unscoped
contexts. This is both simpler and more robust than the previous
workaround.

A regression test that produces MIR akin to the above example is added.