### PR TITLE
std/asyncjs: value passed to `catch` is always `Error`

### DIFF
--- a/tests/js/tasyncjs.nim
+++ b/tests/js/tasyncjs.nim
@@ -91,7 +91,26 @@ proc main() {.async.} =
     await fn(7).then((a: int) => (discard)).catch((r: Error) => (reason = r))
     doAssert reason != nil
     doAssert reason.name == "Error"
-    doAssert "foobar: 7" in $reason.message
+    doAssert "foobar: 7" == $reason.message
+
+  block async_within_try:
+    # make sure the object passed to the catch callback is an ``Error`` for
+    # futures created within try scopes
+    var
+      reason: Error
+      promise: Future[int]
+    try:
+      # the try should have no effect on the exception object the ``catch``
+      # gets
+      promise = fn(7)
+    except:
+      doAssert false, "unreachable"
+
+    await promise.catch((r: Error) => (reason = r))
+    doAssert reason != nil
+    doAssert reason.name == "Error"
+    doAssert "foobar: 7" == $reason.message
+
   echo "done" # justified here to make sure we're running this, since it's inside `async`
 
 discard main()

--- a/tests/js/tasyncjs_bad.nim
+++ b/tests/js/tasyncjs_bad.nim
@@ -1,6 +1,6 @@
 discard """
   exitCode: 1
- outputsub: "Error: unhandled exception: foobar: 13"
+ outputsub: "foobar: 13"
 """
 
 # note: this needs `--unhandled-rejections=strict`, see D20210217T215950

--- a/tests/js/tasyncjs_pragma.nim
+++ b/tests/js/tasyncjs_pragma.nim
@@ -15,8 +15,7 @@ macro f*(a: untyped): untyped =
   let call = quote:
     echo 0
   result.body.add(call)
-  for child in a.body:
-    result.body.add(child)
+  result.body.add(a.body)
   #echo result.body.repr
 
 proc t* {.async, f.} =


### PR DESCRIPTION
## Summary

* NimSkull exceptions leaving `.async` procedure are automatically
  turned into JavaScript `Error`s
* errors retrieved by `catch` that were originally NimSkull exceptions
  always use only the original exception's message (no "uncaught
  exception" prefix)

## Details

* the `.async` macro wraps the body in a `try`/`except` that turns
  catchable errors into `Error`s
* depending on whether a procedure is called within a `try` (at
  run-time), `raise` either raises a NimSkull exception or JavaScript
  error
* the `tasyncjs_pragma` test is updated to not rely on the transformed
  body being a statement list