### PR TITLE
vmgen: use the new-style CGIR

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2072,7 +2072,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       inc pc, rbx
       handleJmpBack()
     of opcBranch:
-      # we know the next instruction is a 'fjmp':
+      # we know the next instruction is a 'tjmp':
       let value = c.constants[instr.regBx-wordExcess]
 
       checkHandle(regs[ra])
@@ -2090,11 +2090,11 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       else:
         unreachable(value.kind)
 
-      assert c.code[pc+1].opcode == opcFJmp
+      assert c.code[pc+1].opcode == opcTJmp
       inc pc
       # we skip this instruction so that the final 'inc(pc)' skips
       # the following jump
-      if not cond:
+      if cond:
         let instr2 = c.code[pc]
         let rbx = instr2.regBx - wordExcess - 1 # -1 for the following 'inc pc'
         inc pc, rbx

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -605,10 +605,8 @@ proc runEh(t: var VmThread, c: var TCtx): Result[PrgCtr, VmException] =
         t.ehStack.setLen(t.ehStack.len - 1)
       of 1:
         # discard the parent thread if it's associated with the provided
-        # ``finally``
-        let instr = c.code[instr.b]
-        vmAssert instr.opcode == opcFinallyEnd
-        let (fromEh, b) = decodeControl(t.getReg(instr.regA).intVal)
+        # control register
+        let (fromEh, b) = decodeControl(t.getReg(instr.b.TRegister).intVal)
         if fromEh:
           vmAssert b.int == t.ehStack.high - 1
           swap(tos, t.ehStack[^2])

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -126,7 +126,7 @@ proc generateCodeForProc(c: var CodeGenCtx, idgen: IdGenerator, s: PSym,
   ## Generates and the bytecode for the procedure `s` with body `body`. The
   ## resulting bytecode is emitted into the global bytecode section.
   let
-    body = generateIRLegacy(c.graph, idgen, c.env, s, body)
+    body = generateIR(c.graph, idgen, c.env, s, body)
     r    = genProc(c, s, body)
 
   if r.isOk:
@@ -181,7 +181,7 @@ proc processEvent(c: var GenCtx, mlist: ModuleList, discovery: var DiscoveryData
   of bekPartial:
     let p = addr mgetOrPut(partial, evt.id, PartialProc(sym: evt.sym))
     discard merge(p.body):
-      generateIRLegacy(c.graph, idgen, c.gen.env, evt.sym, evt.body)
+      generateIR(c.graph, idgen, c.gen.env, evt.sym, evt.body)
   of bekProcedure:
     # a complete procedure became available
     let r = generateCodeForProc(c.gen, idgen, evt.sym, evt.body)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -3239,7 +3239,7 @@ proc genExpr*(c: var TCtx; body: sink Body): Result[int, VmGenDiag] =
   var d: TDest = -1
   try:
     let eh = genSetEh(c, n.info)
-    if n.kind == cnkStmtListExpr:
+    if n.kind == cnkStmtList:
       # special case the expression here so that ``gen`` doesn't have to
       for i in 0..<n.len-1:
         c.gen(n[i])

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -131,9 +131,9 @@ type
     bkFinally ## ``finally`` clause
 
   BlockInfo = object
-    label: BlockId
     oldRegisterCount: int
       ## upper bound of allocated registers at the beginning of the block
+    label: BlockId
     case kind: BlockKind
     of bkBlock, bkFinally:
       start: TPosition

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -500,8 +500,7 @@ proc registerEh(c: var TCtx, n: CgNode) =
       # procedure, no EH code needs to be associated with the instruction
       return
 
-    if c.prc.lastPath == nil or (let shared = comparePaths(n, c.prc.lastPath);
-       shared < n.len):
+    if c.prc.lastPath == nil or comparePaths(n, c.prc.lastPath) < n.len:
       # cannot re-use the previous instruction sequence
       genEhCode(c, n)
 

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -154,7 +154,7 @@ proc generateMirCode(c: var TCtx, env: var MirEnv, n: PNode;
     result.code = finish(bu)
 
 proc generateIR(c: var TCtx, env: MirEnv, body: sink MirBody): Body =
-  backends.generateIRLegacy(c.graph, c.idgen, env, c.module, body)
+  backends.generateIR(c.graph, c.idgen, env, c.module, body)
 
 proc setupRootRef(c: var TCtx) =
   ## Sets up if the ``RootRef`` type for the type info cache. This
@@ -271,7 +271,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"
 
-  let outBody = generateIRLegacy(c.graph, c.idgen, jit.gen.env, s, mirBody)
+  let outBody = generateIR(c.graph, c.idgen, jit.gen.env, s, mirBody)
   echoOutput(c.config, s, outBody)
 
   try:

--- a/tests/exception/tleave_except2.nim
+++ b/tests/exception/tleave_except2.nim
@@ -3,7 +3,7 @@ discard """
     Ensure that leaving an `except` section by raising an exception properly
     updates the current exception.
   '''
-  knownIssue.js vm: "The current exception is not reset properly"
+  knownIssue.js: "The current exception is not reset properly"
 """
 
 var steps: seq[string]

--- a/tests/exception/treraise2.nim
+++ b/tests/exception/treraise2.nim
@@ -3,7 +3,7 @@ discard """
     Ensure that raising a caught exception from within an exception handler
     works
   '''
-  knownIssue.js vm: "The current exception is not properly updated"
+  knownIssue.js: "The current exception is not properly updated"
 """
 
 proc manualReraise() =


### PR DESCRIPTION
## Summary

Use the goto-using version of the CGIR for VM code generation,
removing another usage of the legacy variant. This also fixes the
current exception (`getCurrentException`) being incorrect after
raising from within an `except`, on the VM backend.

## Details

### VM changes

To accomodate the code generator, two small changes are made to the
instruction interface:
* instead of the instruction position from where to extract the
  register, the register index is directly encoded in `ehoLeave` EH
  instructions
* `opcBranch` must now be followed by a `opcTJmp` (jump if true)
  instead of a `opcFJmp` (jump if false)

### Code generator changes

The CGIR's control-flow representation translates more or less directly
to the VM's control-flow instructions, so code generation for it is
straightforward.

* the new-style CGIR is enabled in both `vmbackend` and `vmjit`
* no pre-pass over the CGIR - like is used by the C code generator - is
  needed
* registers for locals are freed at the end of structured blocks
  (`cnkIf`, `cnkFinally`, `cnkExcept`, and loops)
* EH instructions are emitted as the jump actions are processed
* jump actions for exceptional exits (e.g., `cnkCheckedCall`,
  `cnkRaise`, etc.) are usually the same for regions of code, so a
  caching mechanism is used to prevent repeated EH instructions
  sequences in that case. (not required for correctness)