### PR TITLE
Use more node kind sets

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -482,7 +482,7 @@ template copyNodeImpl(dst, src, processSonsStmt) =
     dst.floatLitBase = src.floatLitBase
   of nkSym: dst.sym = src.sym
   of nkIdent: dst.ident = src.ident
-  of nkStrLit..nkTripleStrLit: dst.strVal = src.strVal
+  of nkStrLiterals: dst.strVal = src.strVal
   of nkEmpty, nkNone, nkNilLit, nkType, nkCommentStmt: discard "no children"
   of nkError: dst.diag = src.diag # do cheap copies
   of nkWithSons: processSonsStmt

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -357,17 +357,17 @@ proc containsNode*(n: PNode, kinds: TNodeKinds): bool =
   if n == nil: return
   case n.kind
   of nkWithoutSons: result = n.kind in kinds
-  else:
+  of nkWithSons:
     for i in 0..<n.len:
       if n.kind in kinds or containsNode(n[i], kinds): return true
 
 proc hasSubnodeWith*(n: PNode, kind: TNodeKind): bool =
   case n.kind
-  of nkEmpty..nkNilLit, nkFormalParams, nkCommentStmt:
+  of nkNone, nkEmpty..nkNilLit, nkFormalParams, nkCommentStmt:
     result = n.kind == kind
   of nkError:
     result = hasSubnodeWith(n.diag.wrongNode, kind)
-  else:
+  of nkWithSons - nkFormalParams:
     for i in 0..<n.len:
       if (n[i].kind == kind) or hasSubnodeWith(n[i], kind):
         return true

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -249,15 +249,14 @@ const
   nkIntLiterals*   = nkUIntLiterals + nkSIntLiterals
   nkFloatLiterals* = {nkFloatLit..nkFloat64Lit}
   nkStrLiterals*   = {nkStrLit..nkTripleStrLit}
-  # TODO: include `nkNilLit` as it's a literal, not the same as `nnkLiterals`
-  nkLiterals*      = nkIntLiterals + nkFloatLiterals + nkStrLiterals
+  nkLiterals*      = nkIntLiterals + nkFloatLiterals + nkStrLiterals + nkNilLit
+  # TODO: `nnkLiterals` doesn't include `nkNilLit`
 
   nkWithoutSons* =
     {nkEmpty, nkNone} +
     {nkIdent, nkSym} +
     {nkType} +
     nkLiterals +
-    {nkNilLit} +
     {nkError} +
     {nkCommentStmt}
 

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -244,13 +244,19 @@ type
   TNodeKinds* = set[TNodeKind]
 
 const
+  nkUIntLiterals*  = {nkCharLit, nkUIntLit..nkUInt64Lit}
+  nkSIntLiterals*  = {nkIntLit..nkInt64Lit}
+  nkIntLiterals*   = nkUIntLiterals + nkSIntLiterals
+  nkFloatLiterals* = {nkFloatLit..nkFloat64Lit}
+  nkStrLiterals*   = {nkStrLit..nkTripleStrLit}
+  # TODO: include `nkNilLit` as it's a literal, not the same as `nnkLiterals`
+  nkLiterals*      = nkIntLiterals + nkFloatLiterals + nkStrLiterals
+
   nkWithoutSons* =
     {nkEmpty, nkNone} +
     {nkIdent, nkSym} +
     {nkType} +
-    {nkCharLit..nkUInt64Lit} +
-    {nkFloatLit..nkFloat64Lit} +
-    {nkStrLit..nkTripleStrLit} +
+    nkLiterals +
     {nkNilLit} +
     {nkError} +
     {nkCommentStmt}
@@ -1572,15 +1578,15 @@ type
     info*: TLineInfo
     flags*: TNodeFlags
     case kind*: TNodeKind
-    of nkCharLit..nkUInt64Lit:
+    of nkIntLiterals:
       intVal*: BiggestInt
       intLitBase*: NumericalBase
-    of nkFloatLit..nkFloat64Lit:
+    of nkFloatLiterals:
       floatVal*: BiggestFloat
       floatLitBase*: NumericalBase
         # Once case branches can share fields this can be unified with
         # intLitBase above
-    of nkStrLit..nkTripleStrLit:
+    of nkStrLiterals:
       strVal*: string
     of nkSym:
       sym*: PSym

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -245,7 +245,9 @@ type
 
 const
   nkUIntLiterals*  = {nkCharLit, nkUIntLit..nkUInt64Lit}
+    ## Unsigned int literals
   nkSIntLiterals*  = {nkIntLit..nkInt64Lit}
+    ## Signed int literals
   nkIntLiterals*   = nkUIntLiterals + nkSIntLiterals
   nkFloatLiterals* = {nkFloatLit..nkFloat64Lit}
   nkStrLiterals*   = {nkStrLit..nkTripleStrLit}

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -250,7 +250,6 @@ const
   nkFloatLiterals* = {nkFloatLit..nkFloat64Lit}
   nkStrLiterals*   = {nkStrLit..nkTripleStrLit}
   nkLiterals*      = nkIntLiterals + nkFloatLiterals + nkStrLiterals + nkNilLit
-  # TODO: `nnkLiterals` doesn't include `nkNilLit`
 
   nkWithoutSons* =
     {nkEmpty, nkNone} +

--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -75,12 +75,12 @@ proc skipConvCastAndClosure*(n: PNode): PNode =
 proc sameValue*(a, b: PNode): bool =
   result = false
   case a.kind
-  of nkCharLit..nkUInt64Lit:
-    if b.kind in {nkCharLit..nkUInt64Lit}: result = getInt(a) == getInt(b)
-  of nkFloatLit..nkFloat64Lit:
-    if b.kind in {nkFloatLit..nkFloat64Lit}: result = a.floatVal == b.floatVal
-  of nkStrLit..nkTripleStrLit:
-    if b.kind in {nkStrLit..nkTripleStrLit}: result = a.strVal == b.strVal
+  of nkIntLiterals:
+    if b.kind in nkIntLiterals: result = getInt(a) == getInt(b)
+  of nkFloatLiterals:
+    if b.kind in nkFloatLiterals: result = a.floatVal == b.floatVal
+  of nkStrLiterals:
+    if b.kind in nkStrLiterals: result = a.strVal == b.strVal
   else:
     # don't raise an internal error for 'nim check':
     #InternalError(a.info, "SameValue")
@@ -90,12 +90,12 @@ proc leValue*(a, b: PNode): bool =
   # a <= b?
   result = false
   case a.kind
-  of nkCharLit..nkUInt64Lit:
-    if b.kind in {nkCharLit..nkUInt64Lit}: result = getInt(a) <= getInt(b)
-  of nkFloatLit..nkFloat64Lit:
-    if b.kind in {nkFloatLit..nkFloat64Lit}: result = a.floatVal <= b.floatVal
-  of nkStrLit..nkTripleStrLit:
-    if b.kind in {nkStrLit..nkTripleStrLit}: result = a.strVal <= b.strVal
+  of nkIntLiterals:
+    if b.kind in nkIntLiterals: result = getInt(a) <= getInt(b)
+  of nkFloatLiterals:
+    if b.kind in nkFloatLiterals: result = a.floatVal <= b.floatVal
+  of nkStrLiterals:
+    if b.kind in nkStrLiterals: result = a.strVal <= b.strVal
   else:
     # don't raise an internal error for 'nim check':
     #InternalError(a.info, "leValue")

--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -102,7 +102,7 @@ proc leValue*(a, b: PNode): bool =
     discard
 
 proc weakLeValue*(a, b: PNode): TImplication =
-  if a.kind notin nkLiterals or b.kind notin nkLiterals:
+  if a.kind notin nkLiterals - nkNilLit or b.kind notin nkLiterals - nkNilLit:
     result = impUnknown
   else:
     result = if leValue(a, b): impYes else: impNo

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -50,10 +50,10 @@ when defined(nimDebugUnreportedErrors):
 proc errorSubNode*(n: PNode): PNode =
   ## find the first error node, or nil, under `n` using a depth first traversal
   case n.kind
-  of nkNone, nkEmpty..nkNilLit, nkCommentStmt:
-    result = nil
   of nkError:
     result = n
+  of nkWithoutSons - nkError:
+    result = nil
   of nkWithSons:
     result = nil
     for s in n.items:
@@ -165,7 +165,7 @@ proc buildErrorList(config: ConfigRef, n: PNode, errs: var seq[PNode]) =
   ## creates a list (`errs` seq) from most specific to least specific
   ## by traversing the the error tree in a depth-first-search.
   case n.kind
-  of nkNone, nkEmpty .. nkNilLit, nkCommentStmt:
+  of nkWithoutSons - nkError:
     discard
   of nkError:
     buildErrorList(config, n.diag.wrongNode, errs)

--- a/compiler/ast/filters.nim
+++ b/compiler/ast/filters.nim
@@ -38,7 +38,7 @@ proc invalidPragma(conf: ConfigRef; n: PNode) =
 proc getArg(conf: ConfigRef; n: PNode, name: string, pos: int): PNode =
   result = nil
   case n.kind
-  of nkWithoutSons: return
+  of nkWithoutSons: discard # these can't have args
   of nkWithSons:
     for i in 1..<n.len:
       if n[i].kind == nkExprEqExpr:

--- a/compiler/ast/filters.nim
+++ b/compiler/ast/filters.nim
@@ -37,14 +37,16 @@ proc invalidPragma(conf: ConfigRef; n: PNode) =
 
 proc getArg(conf: ConfigRef; n: PNode, name: string, pos: int): PNode =
   result = nil
-  if n.kind in {nkEmpty..nkNilLit}: return
-  for i in 1..<n.len:
-    if n[i].kind == nkExprEqExpr:
-      if n[i][0].kind != nkIdent: invalidPragma(conf, n)
-      if cmpIgnoreStyle(n[i][0].ident.s, name) == 0:
-        return n[i][1]
-    elif i == pos:
-      return n[i]
+  case n.kind
+  of nkWithoutSons: return
+  of nkWithSons:
+    for i in 1..<n.len:
+      if n[i].kind == nkExprEqExpr:
+        if n[i][0].kind != nkIdent: invalidPragma(conf, n)
+        if cmpIgnoreStyle(n[i][0].ident.s, name) == 0:
+          return n[i][1]
+      elif i == pos:
+        return n[i]
 
 proc charArg*(conf: ConfigRef; n: PNode, name: string, pos: int, default: char): char =
   var x = getArg(conf, n, name, pos)
@@ -55,7 +57,7 @@ proc charArg*(conf: ConfigRef; n: PNode, name: string, pos: int, default: char):
 proc strArg*(conf: ConfigRef; n: PNode, name: string, pos: int, default: string): string =
   var x = getArg(conf, n, name, pos)
   if x == nil: result = default
-  elif x.kind in {nkStrLit..nkTripleStrLit}: result = x.strVal
+  elif x.kind in nkStrLiterals: result = x.strVal
   else: invalidPragma(conf, n)
 
 proc boolArg*(conf: ConfigRef; n: PNode, name: string, pos: int, default: bool): bool =

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -103,7 +103,7 @@ proc getMagic*(op: PNode): TMagic =
   else: result = mNone
 
 proc isConstExpr*(n: PNode): bool =
-  const atomKinds = nkLiterals + nkNilLit # Char, Int, UInt, Str, Float and Nil literals
+  const atomKinds = nkLiterals # Char, Int, UInt, Str, Float and Nil literals
   n.kind in atomKinds or nfAllConst in n.flags
 
 proc isCaseObj*(n: PNode): bool =
@@ -113,7 +113,7 @@ proc isCaseObj*(n: PNode): bool =
 
 proc isDeepConstExpr*(n: PNode; preventInheritance = false): bool =
   case n.kind
-  of nkLiterals, nkNilLit:
+  of nkLiterals:
     result = true
   of nkExprEqExpr, nkExprColonExpr, nkHiddenStdConv, nkHiddenSubConv:
     result = isDeepConstExpr(n[1], preventInheritance)

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -10,7 +10,14 @@
 ## tree helper routines
 
 import
-  ast, wordrecg, idents
+  compiler/ast/[
+    ast,
+    wordrecg,
+    idents,
+  ],
+  compiler/utils/[
+    idioms,
+  ]
 
 proc cyclicTreeAux(n: PNode, visited: var seq[PNode]): bool =
   if n == nil: return
@@ -55,7 +62,7 @@ proc exprStructuralEquivalent*(a, b: PNode; strictSymEquality=false): bool =
     of nkCommentStmt: result = a.comment == b.comment
     of nkNone, nkEmpty, nkNilLit, nkType: result = true
     of nkError:
-      result = true # XXX: This seems wrong
+      unreachable()
     of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:
@@ -86,7 +93,7 @@ proc sameTree*(a, b: PNode): bool =
     of nkCommentStmt: result = a.comment == b.comment
     of nkNone, nkEmpty, nkNilLit, nkType: result = true
     of nkError:
-      result = true # XXX: This seems wrong
+      unreachable()
     of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -110,8 +110,7 @@ proc getMagic*(op: PNode): TMagic =
   else: result = mNone
 
 proc isConstExpr*(n: PNode): bool =
-  const atomKinds = nkLiterals # Char, Int, UInt, Str, Float and Nil literals
-  n.kind in atomKinds or nfAllConst in n.flags
+  n.kind in nkLiterals or nfAllConst in n.flags
 
 proc isCaseObj*(n: PNode): bool =
   if n.kind == nkRecCase: return true

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -17,7 +17,7 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode]): bool =
   for v in visited:
     if v == n: return true
   case n.kind
-  of nkNone, nkEmpty..nkNilLit, nkCommentStmt:
+  of nkWithoutSons - nkError:
     discard
   of nkError:
     visited.add(n)
@@ -49,9 +49,9 @@ proc exprStructuralEquivalent*(a, b: PNode; strictSymEquality=false): bool =
         # don't go nuts here: same symbol as string is enough:
         result = a.sym.name.id == b.sym.name.id
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = sameFloatIgnoreNan(a.floatVal, b.floatVal)
-    of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
+    of nkIntLiterals: result = a.intVal == b.intVal
+    of nkFloatLiterals: result = sameFloatIgnoreNan(a.floatVal, b.floatVal)
+    of nkStrLiterals: result = a.strVal == b.strVal
     of nkCommentStmt: result = a.comment == b.comment
     of nkNone, nkEmpty, nkNilLit, nkType: result = true
     of nkError:
@@ -76,13 +76,13 @@ proc sameTree*(a, b: PNode): bool =
       # don't go nuts here: same symbol as string is enough:
       result = a.sym.name.id == b.sym.name.id
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkUInt64Lit:
+    of nkIntLiterals:
       result = a.intVal == b.intVal and
                a.intLitBase == b.intLitBase
-    of nkFloatLit..nkFloat64Lit:
+    of nkFloatLiterals:
       result = sameFloatIgnoreNan(a.floatVal, b.floatVal) and
                a.floatLitBase == b.floatLitBase
-    of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
+    of nkStrLiterals: result = a.strVal == b.strVal
     of nkCommentStmt: result = a.comment == b.comment
     of nkNone, nkEmpty, nkNilLit, nkType: result = true
     of nkError:
@@ -103,7 +103,7 @@ proc getMagic*(op: PNode): TMagic =
   else: result = mNone
 
 proc isConstExpr*(n: PNode): bool =
-  const atomKinds = {nkCharLit..nkNilLit} # Char, Int, UInt, Str, Float and Nil literals
+  const atomKinds = nkLiterals + nkNilLit # Char, Int, UInt, Str, Float and Nil literals
   n.kind in atomKinds or nfAllConst in n.flags
 
 proc isCaseObj*(n: PNode): bool =
@@ -113,7 +113,7 @@ proc isCaseObj*(n: PNode): bool =
 
 proc isDeepConstExpr*(n: PNode; preventInheritance = false): bool =
   case n.kind
-  of nkCharLit..nkNilLit:
+  of nkLiterals, nkNilLit:
     result = true
   of nkExprEqExpr, nkExprColonExpr, nkHiddenStdConv, nkHiddenSubConv:
     result = isDeepConstExpr(n[1], preventInheritance)

--- a/compiler/ast/treetab.nim
+++ b/compiler/ast/treetab.nim
@@ -17,7 +17,7 @@ proc hashTree*(n: PNode): Hash =
     return
   result = ord(n.kind)
   case n.kind
-  of nkEmpty, nkNilLit, nkType:
+  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
     discard
   of nkIdent:
     result = result !& n.ident.h
@@ -31,7 +31,7 @@ proc hashTree*(n: PNode): Hash =
       result = result !& toInt(n.floatVal)
   of nkStrLit..nkTripleStrLit:
     result = result !& hash(n.strVal)
-  else:
+  of nkWithSons:
     for i in 0..<n.len:
       result = result !& hashTree(n[i])
   result = !$result
@@ -43,13 +43,13 @@ proc treesEquivalent(a, b: PNode): bool =
     result = true
   elif (a != nil) and (b != nil) and (a.kind == b.kind):
     case a.kind
-    of nkEmpty, nkNilLit, nkType: result = true
+    of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: result = true
     of nkSym: result = a.sym.id == b.sym.id
     of nkIdent: result = a.ident.id == b.ident.id
     of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
     of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
-    else:
+    of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:
           if not treesEquivalent(a[i], b[i]): return

--- a/compiler/ast/treetab.nim
+++ b/compiler/ast/treetab.nim
@@ -23,13 +23,13 @@ proc hashTree*(n: PNode): Hash =
     result = result !& n.ident.h
   of nkSym:
     result = result !& n.sym.id
-  of nkCharLit..nkUInt64Lit:
+  of nkIntLiterals:
     if (n.intVal >= low(int)) and (n.intVal <= high(int)):
       result = result !& int(n.intVal)
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     if (n.floatVal >= - 1000000.0) and (n.floatVal <= 1000000.0):
       result = result !& toInt(n.floatVal)
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     result = result !& hash(n.strVal)
   of nkWithSons:
     for i in 0..<n.len:
@@ -46,9 +46,9 @@ proc treesEquivalent(a, b: PNode): bool =
     of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: result = true
     of nkSym: result = a.sym.id == b.sym.id
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
-    of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
+    of nkIntLiterals: result = a.intVal == b.intVal
+    of nkFloatLiterals: result = a.floatVal == b.floatVal
+    of nkStrLiterals: result = a.strVal == b.strVal
     of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -166,10 +166,10 @@ proc iterOverNode(marker: var IntSet, n: PNode, iter: TTypeIter,
                   closure: RootRef): bool =
   if n != nil:
     case n.kind
-    of nkNone..nkNilLit:
+    of nkNone..nkNilLit, nkCommentStmt, nkError:
       # a leaf
       result = iterOverTypeAux(marker, n.typ, iter, closure)
-    else:
+    of nkWithSons:
       for i in 0..<n.len:
         result = iterOverNode(marker, n[i], iter, closure)
         if result: return
@@ -344,9 +344,9 @@ proc canFormAcycleNode(marker: var IntSet, n: PNode, startId: int): bool =
     result = canFormAcycleAux(marker, n.typ, startId)
     if not result:
       case n.kind
-      of nkNone..nkNilLit:
+      of nkNone..nkNilLit, nkCommentStmt, nkError:
         discard
-      else:
+      of nkWithSons:
         for i in 0..<n.len:
           result = canFormAcycleNode(marker, n[i], startId)
           if result: return
@@ -395,10 +395,10 @@ proc mutateNode(marker: var IntSet, n: PNode, iter: TTypeMutator,
     result = copyNode(n)
     result.typ = mutateTypeAux(marker, n.typ, iter, closure)
     case n.kind
-    of nkNone..nkNilLit:
+    of nkNone..nkNilLit, nkCommentStmt, nkError:
       # a leaf
       discard
-    else:
+    of nkWithSons:
       for i in 0..<n.len:
         result.add mutateNode(marker, n[i], iter, closure)
 

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -109,11 +109,11 @@ proc getOrdValue*(n: PNode; onError = high(Int128)): Int128 =
       n.kind
 
   case k
-  of nkCharLit, nkUIntLit..nkUInt64Lit:
+  of nkUIntLiterals:
     # XXX: enable this assert
     #assert n.typ == nil or isUnsigned(n.typ), $n.typ
     toInt128(cast[uint64](n.intVal))
-  of nkIntLit..nkInt64Lit:
+  of nkSIntLiterals:
     # XXX: enable this assert
     #assert n.typ == nil or not isUnsigned(n.typ), $n.typ.kind
     toInt128(n.intVal)
@@ -166,7 +166,7 @@ proc iterOverNode(marker: var IntSet, n: PNode, iter: TTypeIter,
                   closure: RootRef): bool =
   if n != nil:
     case n.kind
-    of nkNone..nkNilLit, nkCommentStmt, nkError:
+    of nkWithoutSons:
       # a leaf
       result = iterOverTypeAux(marker, n.typ, iter, closure)
     of nkWithSons:
@@ -344,7 +344,7 @@ proc canFormAcycleNode(marker: var IntSet, n: PNode, startId: int): bool =
     result = canFormAcycleAux(marker, n.typ, startId)
     if not result:
       case n.kind
-      of nkNone..nkNilLit, nkCommentStmt, nkError:
+      of nkWithoutSons:
         discard
       of nkWithSons:
         for i in 0..<n.len:
@@ -395,7 +395,7 @@ proc mutateNode(marker: var IntSet, n: PNode, iter: TTypeMutator,
     result = copyNode(n)
     result.typ = mutateTypeAux(marker, n.typ, iter, closure)
     case n.kind
-    of nkNone..nkNilLit, nkCommentStmt, nkError:
+    of nkWithoutSons:
       # a leaf
       discard
     of nkWithSons:

--- a/compiler/ast/typesrenderer.nim
+++ b/compiler/ast/typesrenderer.nim
@@ -144,9 +144,9 @@ proc addTypeHeader*(result: var string, conf: ConfigRef; typ: PType; prefer: TPr
 proc valueToString(a: PNode): string =
   ## Returns `int`, `float`, or `string` literals from the node, otherwise returns `<invalid value>`.
   case a.kind
-  of nkCharLit..nkUInt64Lit: result = $a.intVal
-  of nkFloatLit..nkFloat64Lit: result = $a.floatVal
-  of nkStrLit..nkTripleStrLit: result = a.strVal
+  of nkIntLiterals: result = $a.intVal
+  of nkFloatLiterals: result = $a.floatVal
+  of nkStrLiterals: result = a.strVal
   else: result = "<invalid value>"
 
 proc rangeToStr(n: PNode): string =

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -117,9 +117,9 @@ proc sexp*(node: PNode): SexpNode =
   result.add newSSymbol(($node.kind)[2 ..^ 1])
   case node.kind
   of nkNone, nkEmpty, nkType, nkCommentStmt: discard
-  of nkCharLit..nkUInt64Lit:    result.add sexp(node.intVal)
-  of nkFloatLit..nkFloat64Lit:  result.add sexp(node.floatVal)
-  of nkStrLit..nkTripleStrLit:  result.add sexp(node.strVal)
+  of nkIntLiterals:             result.add sexp(node.intVal)
+  of nkFloatLiterals:           result.add sexp(node.floatVal)
+  of nkStrLiterals:             result.add sexp(node.strVal)
   of nkSym:                     result.add newSSymbol(node.sym.name.s)
   of nkIdent:                   result.add newSSymbol(node.ident.s)
   of nkError:                   result.add sexp(node.diag.wrongNode)

--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -195,7 +195,7 @@ proc aliveCode(c: var AliveContext; g: PackedModuleGraph; tree: PackedTree; n: N
   ## Marks the symbols we encounter when we traverse the AST at `tree[n]` as alive, unless
   ## it is purely in a declarative context (type section etc.).
   case n.kind
-  of nkNone..pred(nkSym), succ(nkSym)..nkNilLit:
+  of nkWithoutSons - nkSym:
     discard "ignore non-sym atoms"
   of nkSym:
     # This symbol is alive and everything its body references.
@@ -209,9 +209,8 @@ proc aliveCode(c: var AliveContext; g: PackedModuleGraph; tree: PackedTree; n: N
     let otherModule = toFileIndexCached(c.decoder, g, c.thisModule, m).int
     followLater(c, g, otherModule, item)
   of nkMacroDef, nkTemplateDef, nkTypeSection, nkTypeOfExpr,
-     nkCommentStmt, nkIncludeStmt,
-     nkImportStmt, nkImportExceptStmt, nkExportStmt, nkExportExceptStmt,
-     nkFromStmt, nkStaticStmt:
+     nkIncludeStmt, nkImportStmt, nkImportExceptStmt,
+     nkExportStmt, nkExportExceptStmt, nkFromStmt, nkStaticStmt:
     discard
   of nkVarSection, nkLetSection, nkConstSection:
     # XXX ignore the defining local variable name?

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -103,7 +103,7 @@ proc toString*(tree: PackedTree; n: NodePos; m: PackedModule; nesting: int;
   result.add $tree[pos].kind
   case tree.nodes[pos].kind
   of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: discard
-  of nkIdent, nkStrLit..nkTripleStrLit:
+  of nkIdent, nkStrLiterals:
     result.add " "
     result.add m.strings[LitId tree.nodes[pos].operand]
   of nkSym:
@@ -118,7 +118,7 @@ proc toString*(tree: PackedTree; n: NodePos; m: PackedModule; nesting: int;
   of externUIntLit:
     result.add " "
     result.addInt cast[uint64](m.numbers[LitId tree.nodes[pos].operand])
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     result.add " "
     result.addFloat cast[BiggestFloat](m.numbers[LitId tree.nodes[pos].operand])
   of nkWithSons:
@@ -471,11 +471,11 @@ proc toPackedNode*(n: PNode; ir: var PackedTree; c: var PackedEncoder; m: var Pa
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags,
                             operand: int32 getOrIncl(m.numbers, n.intVal),
                             typeId: storeTypeLater(n.typ, c, m), info: info)
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags,
                             operand: int32 getOrIncl(m.strings, n.strVal),
                             typeId: storeTypeLater(n.typ, c, m), info: info)
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags,
                             operand: int32 getOrIncl(m.numbers, cast[BiggestInt](n.floatVal)),
                             typeId: storeTypeLater(n.typ, c, m), info: info)
@@ -786,9 +786,9 @@ proc loadNodes*(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;
     result.intVal = tree.nodes[n.int].operand
   of externIntLit:
     result.intVal = g[thisModule].fromDisk.numbers[n.litId]
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     result.strVal = g[thisModule].fromDisk.strings[n.litId]
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     result.floatVal = cast[BiggestFloat](g[thisModule].fromDisk.numbers[n.litId])
   of nkModuleRef:
     let (n1, n2) = sons2(tree, n)

--- a/compiler/ic/integrity.nim
+++ b/compiler/ic/integrity.nim
@@ -79,9 +79,9 @@ proc checkNode(c: var CheckedContext; tree: PackedTree; n: NodePos) =
     checkLocalSym(c, tree.nodes[n.int].operand)
   of directIntLit:
     discard
-  of externIntLit, nkFloatLit..nkFloat64Lit:
+  of externIntLit, nkFloatLiterals:
     assert c.g.packed[c.thisModule].fromDisk.numbers.hasLitId n.litId
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     assert c.g.packed[c.thisModule].fromDisk.strings.hasLitId n.litId
   of nkModuleRef:
     let (n1, n2) = sons2(tree, n)

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -349,10 +349,8 @@ when false:
     result = tree.sh.strings[LitId tree.nodes[n.int].operand]
 
 const
-  externSIntLit* =
-    {nkIntLit, nkInt8Lit, nkInt16Lit, nkInt64Lit} # nkInt32Lit is missing by design!
-  externUIntLit* =
-    {nkCharLit, nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit}
+  externSIntLit* = nkSIntLiterals - nkInt32Lit # nkInt32Lit is excluded by design!
+  externUIntLit* = nkUIntLiterals
   externIntLit* = externSIntLit + externUIntLit
   directIntLit* = nkInt32Lit
 

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -140,8 +140,7 @@ proc addSymDef*(tree: var PackedTree; s: SymId; info: PackedLineInfo) =
   tree.nodes.add PackedNode(kind: nkSym, operand: int32(s), info: info)
 
 proc isAtom*(tree: PackedTree; pos: int): bool {.inline.} =
-  let kind = tree.nodes[pos].kind
-  kind <= nkNilLit or kind == nkCommentStmt
+  tree.nodes[pos].kind in nkWithoutSons
 
 proc copyTree*(dest: var PackedTree; tree: PackedTree; n: NodePos) =
   # and this is why the IR is superior. We can copy subtrees
@@ -179,7 +178,7 @@ proc prepare*(dest: var PackedTree; source: PackedTree; sourcePos: NodePos): Pat
 
 proc patch*(tree: var PackedTree; pos: PatchPos) =
   let pos = pos.int
-  assert not isAtom(tree, pos)
+  assert not isAtom(tree, pos), $tree.nodes[pos].kind
   let distance = int32(tree.nodes.len - pos)
   tree.nodes[pos].operand = distance
 
@@ -197,7 +196,7 @@ proc nextChild(tree: PackedTree; pos: var int) {.inline.} =
 
 iterator sonsReadonly*(tree: PackedTree; n: NodePos): NodePos =
   var pos = n.int
-  assert not isAtom(tree, pos)
+  assert not isAtom(tree, pos), $tree.nodes[pos].kind
   let last = pos + tree.nodes[pos].operand
   inc pos
   while pos < last:
@@ -218,7 +217,7 @@ iterator isons*(dest: var PackedTree; tree: PackedTree;
 
 iterator sonsFrom1*(tree: PackedTree; n: NodePos): NodePos =
   var pos = n.int
-  assert not isAtom(tree, pos)
+  assert not isAtom(tree, pos), $tree.nodes[pos].kind
   let last = pos + tree.nodes[pos].operand
   inc pos
   if pos < last:
@@ -350,19 +349,11 @@ when false:
     result = tree.sh.strings[LitId tree.nodes[n.int].operand]
 
 const
-  externIntLit* = {nkCharLit,
-    nkIntLit,
-    nkInt8Lit,
-    nkInt16Lit,
-    nkInt64Lit,
-    nkUIntLit,
-    nkUInt8Lit,
-    nkUInt16Lit,
-    nkUInt32Lit,
-    nkUInt64Lit} # nkInt32Lit is missing by design!
-
-  externSIntLit* = {nkIntLit, nkInt8Lit, nkInt16Lit, nkInt64Lit}
-  externUIntLit* = {nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit}
+  externSIntLit* =
+    {nkIntLit, nkInt8Lit, nkInt16Lit, nkInt64Lit} # nkInt32Lit is missing by design!
+  externUIntLit* =
+    {nkCharLit, nkUIntLit, nkUInt8Lit, nkUInt16Lit, nkUInt32Lit, nkUInt64Lit}
+  externIntLit* = externSIntLit + externUIntLit
   directIntLit* = nkInt32Lit
 
 when false:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2108,7 +2108,7 @@ proc constDataToMir*(env: var MirEnv, n: PNode): MirTree =
         bu.use toValue(env.constants.add(n.sym), n.sym.typ)
       else:
         unreachable()
-    of nkLiterals, nkNilLit, nkRange:
+    of nkLiterals, nkRange:
       bu.use literal(n)
     of nkHiddenStdConv, nkHiddenSubConv:
       # doesn't translate to a MIR node itself, but the type overrides

--- a/compiler/mir/proto_mir.nim
+++ b/compiler/mir/proto_mir.nim
@@ -594,7 +594,7 @@ proc exprToPmir(c: TranslateCtx, result: var seq[ProtoItem], n: PNode, sink: boo
     result.add ProtoItem(orig: n, typ: n.typ, kind: k, field: val)
 
   case n.kind
-  of nkLiterals, nkNilLit, nkRange, nkNimNodeLit:
+  of nkLiterals, nkRange, nkNimNodeLit:
     node pirLiteral
   of nkLambdaKinds:
     node pirProc, sym, n[namePos].sym

--- a/compiler/mir/proto_mir.nim
+++ b/compiler/mir/proto_mir.nim
@@ -594,7 +594,7 @@ proc exprToPmir(c: TranslateCtx, result: var seq[ProtoItem], n: PNode, sink: boo
     result.add ProtoItem(orig: n, typ: n.typ, kind: k, field: val)
 
   case n.kind
-  of nkCharLit..nkNilLit, nkRange, nkNimNodeLit:
+  of nkLiterals, nkNilLit, nkRange, nkNimNodeLit:
     node pirLiteral
   of nkLambdaKinds:
     node pirProc, sym, n[namePos].sym

--- a/compiler/sem/closureiters.nim
+++ b/compiler/sem/closureiters.nim
@@ -195,8 +195,8 @@ type
     idgen: IdGenerator
 
 const
-  nkSkip = {nkEmpty..nkNilLit, nkTemplateDef, nkTypeSection, nkStaticStmt,
-            nkCommentStmt, nkMixinStmt, nkBindStmt} + procDefs
+  nkSkip = nkWithoutSons + {nkTemplateDef, nkTypeSection, nkStaticStmt,
+            nkMixinStmt, nkBindStmt} + procDefs
 
 proc boolLit(ctx: Ctx, info: TLineInfo, val: bool): PNode =
   result = newIntTypeNode(ord val, ctx.g.getSysType(info, tyBool))

--- a/compiler/sem/dfa.nim
+++ b/compiler/sem/dfa.nim
@@ -793,7 +793,7 @@ proc gen(c: var Con; n: PNode) =
         genNoReturn(c, n)
     else:
       genCall(c, n)
-  of nkCharLit..nkNilLit: discard
+  of nkLiterals, nkNilLit: discard
   of nkAsgn, nkFastAsgn:
     gen(c, n[1])
 

--- a/compiler/sem/dfa.nim
+++ b/compiler/sem/dfa.nim
@@ -793,7 +793,7 @@ proc gen(c: var Con; n: PNode) =
         genNoReturn(c, n)
     else:
       genCall(c, n)
-  of nkLiterals, nkNilLit: discard
+  of nkLiterals: discard
   of nkAsgn, nkFastAsgn:
     gen(c, n[1])
 

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -104,7 +104,7 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
       result.add newNodeI(nkEmpty, templ.info)
   of nkError:
     c.config.internalError(templ.info, "unreported error")
-  else:
+  of nkWithSons:
     let parentIsDeclarative = c.isDeclarative
     if templ.kind in routineDefs + {nkTypeSection, nkVarSection, nkLetSection, nkConstSection}:
       c.isDeclarative = true

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -23,6 +23,7 @@ import
   compiler/utils/[
     saturate,
     int128,
+    idioms,
   ],
   compiler/modules/[
     magicsys,
@@ -455,8 +456,10 @@ proc sameTree*(a, b: PNode): bool =
     of nkFloatLiterals: result = a.floatVal == b.floatVal
     of nkStrLiterals: result = a.strVal == b.strVal
     of nkType: result = a.typ == b.typ
-    of nkNone, nkEmpty, nkNilLit, nkCommentStmt, nkError:
-      result = true # XXX: Should nkCommentStmt, nkError be handled?
+    of nkNone, nkEmpty, nkNilLit, nkCommentStmt:
+      result = true # Ignore comments
+    of nkError:
+      unreachable()
     of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:
@@ -468,7 +471,7 @@ proc hasSubTree(n, x: PNode): bool =
   else:
     case n.kind
     of nkWithoutSons - nkFormalParams:
-      result = n.sameTree(x) # XXX: Should nkCommentStmt, nkError be handled?
+      result = n.sameTree(x)
     of nkFormalParams:
       discard
     of nkWithSons - nkFormalParams:

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -62,7 +62,7 @@ const
   someMin = {mMinI}
   someBinaryOp = someAdd+someSub+someMul+someMax+someMin
 
-proc isValue(n: PNode): bool = n.kind in {nkCharLit..nkNilLit}
+proc isValue(n: PNode): bool = n.kind in nkLiterals + nkNilLit
 proc isLocation(n: PNode): bool = not n.isValue
 
 proc isLet(n: PNode): bool =
@@ -173,34 +173,34 @@ proc buildCall*(op: PSym; a, b: PNode): PNode =
 
 proc `|+|`(a, b: PNode): PNode =
   result = copyNode(a)
-  if a.kind in {nkCharLit..nkUInt64Lit}: result.intVal = a.intVal |+| b.intVal
+  if a.kind in nkIntLiterals: result.intVal = a.intVal |+| b.intVal
   else: result.floatVal = a.floatVal + b.floatVal
 
 proc `|-|`(a, b: PNode): PNode =
   result = copyNode(a)
-  if a.kind in {nkCharLit..nkUInt64Lit}: result.intVal = a.intVal |-| b.intVal
+  if a.kind in nkIntLiterals: result.intVal = a.intVal |-| b.intVal
   else: result.floatVal = a.floatVal - b.floatVal
 
 proc `|*|`(a, b: PNode): PNode =
   result = copyNode(a)
-  if a.kind in {nkCharLit..nkUInt64Lit}: result.intVal = a.intVal |*| b.intVal
+  if a.kind in nkIntLiterals: result.intVal = a.intVal |*| b.intVal
   else: result.floatVal = a.floatVal * b.floatVal
 
 proc `|div|`(a, b: PNode): PNode =
   result = copyNode(a)
-  if a.kind in {nkCharLit..nkUInt64Lit}: result.intVal = a.intVal div b.intVal
+  if a.kind in nkIntLiterals: result.intVal = a.intVal div b.intVal
   else: result.floatVal = a.floatVal / b.floatVal
 
 proc negate(a, b, res: PNode; o: Operators): PNode =
-  if b.kind in {nkCharLit..nkUInt64Lit} and b.intVal != low(BiggestInt):
+  if b.kind in nkIntLiterals and b.intVal != low(BiggestInt):
     var b = copyNode(b)
     b.intVal = -b.intVal
-    if a.kind in {nkCharLit..nkUInt64Lit}:
+    if a.kind in nkIntLiterals:
       b.intVal = b.intVal |+| a.intVal
       result = b
     else:
       result = buildCall(o.opAdd, a, b)
-  elif b.kind in {nkFloatLit..nkFloat64Lit}:
+  elif b.kind in nkFloatLiterals:
     var b = copyNode(b)
     b.floatVal = -b.floatVal
     result = buildCall(o.opAdd, a, b)
@@ -247,7 +247,7 @@ proc reassociation(n: PNode; o: Operators): PNode =
   else: discard
 
 proc pred(n: PNode): PNode =
-  if n.kind in {nkCharLit..nkUInt64Lit} and n.intVal != low(BiggestInt):
+  if n.kind in nkIntLiterals and n.intVal != low(BiggestInt):
     result = copyNode(n)
     dec result.intVal
   else:
@@ -451,9 +451,9 @@ proc sameTree*(a, b: PNode): bool =
       if not result and a.sym.magic != mNone:
         result = a.sym.magic == b.sym.magic or sameOpr(a.sym, b.sym)
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
-    of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
+    of nkIntLiterals: result = a.intVal == b.intVal
+    of nkFloatLiterals: result = a.floatVal == b.floatVal
+    of nkStrLiterals: result = a.strVal == b.strVal
     of nkType: result = a.typ == b.typ
     of nkNone, nkEmpty, nkNilLit, nkCommentStmt, nkError:
       result = true # XXX: Should nkCommentStmt, nkError be handled?
@@ -467,7 +467,7 @@ proc hasSubTree(n, x: PNode): bool =
   if n.sameTree(x): result = true
   else:
     case n.kind
-    of nkNone, nkEmpty..nkNilLit, nkCommentStmt, nkError:
+    of nkWithoutSons - nkFormalParams:
       result = n.sameTree(x) # XXX: Should nkCommentStmt, nkError be handled?
     of nkFormalParams:
       discard
@@ -500,7 +500,7 @@ proc impliesEq(fact, eq: PNode): TImplication =
   else: discard
 
 proc leImpliesIn(x, c, aSet: PNode): TImplication =
-  if c.kind in {nkCharLit..nkUInt64Lit}:
+  if c.kind in nkIntLiterals:
     # fact:  x <= 4;  question x in {56}?
     # --> true if every value <= 4 is in the set {56}
     #
@@ -516,7 +516,7 @@ proc leImpliesIn(x, c, aSet: PNode): TImplication =
       elif neg == i: result = impNo
 
 proc geImpliesIn(x, c, aSet: PNode): TImplication =
-  if c.kind in {nkCharLit..nkUInt64Lit}:
+  if c.kind in nkIntLiterals:
     # fact:  x >= 4;  question x in {56}?
     # --> true iff every value >= 4 is in the set {56}
     #
@@ -564,7 +564,7 @@ proc impliesIn(fact, loc, aSet: PNode): TImplication =
 
 proc valueIsNil(n: PNode): TImplication =
   if n.kind == nkNilLit: impYes
-  elif n.kind in {nkStrLit..nkTripleStrLit, nkBracket, nkObjConstr}: impNo
+  elif n.kind in nkStrLiterals + {nkBracket, nkObjConstr}: impNo
   else: impUnknown
 
 proc impliesIsNil(fact, eq: PNode): TImplication =
@@ -733,7 +733,7 @@ proc simpleSlice*(a, b: PNode): BiggestInt =
   # returns 'c' if a..b matches (i+c)..(i+c), -1 otherwise. (i)..(i) is matched
   # as if it is (i+0)..(i+0).
   if guards.sameTree(a, b):
-    if a.getMagic in someAdd and a[2].kind in {nkCharLit..nkUInt64Lit}:
+    if a.getMagic in someAdd and a[2].kind in nkIntLiterals:
       result = a[2].intVal
     else:
       result = 0
@@ -745,7 +745,7 @@ template isMul(x): untyped = x.getMagic in someMul
 template isDiv(x): untyped = x.getMagic in someDiv
 template isAdd(x): untyped = x.getMagic in someAdd
 template isSub(x): untyped = x.getMagic in someSub
-template isVal(x): untyped = x.kind in {nkCharLit..nkUInt64Lit}
+template isVal(x): untyped = x.kind in nkIntLiterals
 template isIntVal(x, y): untyped = x.intVal == y
 
 import macros
@@ -784,7 +784,7 @@ macro `=~`(x: PNode, pat: untyped): bool =
   result = nestList(ident"and", conds)
 
 proc isMinusOne(n: PNode): bool =
-  n.kind in {nkCharLit..nkUInt64Lit} and n.intVal == -1
+  n.kind in nkIntLiterals and n.intVal == -1
 
 proc pleViaModel(model: TModel; aa, bb: PNode): TImplication
 

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -62,7 +62,7 @@ const
   someMin = {mMinI}
   someBinaryOp = someAdd+someSub+someMul+someMax+someMin
 
-proc isValue(n: PNode): bool = n.kind in nkLiterals + nkNilLit
+proc isValue(n: PNode): bool = n.kind in nkLiterals
 proc isLocation(n: PNode): bool = not n.isValue
 
 proc isLet(n: PNode): bool =

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -455,8 +455,9 @@ proc sameTree*(a, b: PNode): bool =
     of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkType: result = a.typ == b.typ
-    of nkEmpty, nkNilLit: result = true
-    else:
+    of nkNone, nkEmpty, nkNilLit, nkCommentStmt, nkError:
+      result = true # XXX: Should nkCommentStmt, nkError be handled?
+    of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:
           if not sameTree(a[i], b[i]): return
@@ -466,11 +467,11 @@ proc hasSubTree(n, x: PNode): bool =
   if n.sameTree(x): result = true
   else:
     case n.kind
-    of nkEmpty..nkNilLit:
-      result = n.sameTree(x)
+    of nkNone, nkEmpty..nkNilLit, nkCommentStmt, nkError:
+      result = n.sameTree(x) # XXX: Should nkCommentStmt, nkError be handled?
     of nkFormalParams:
       discard
-    else:
+    of nkWithSons - nkFormalParams:
       for i in 0..<n.len:
         if hasSubTree(n[i], x): return true
 

--- a/compiler/sem/isolation_check.nim
+++ b/compiler/sem/isolation_check.nim
@@ -89,7 +89,7 @@ proc checkIsolate*(n: PNode): bool =
     # XXX Maybe require that 'n.typ' is acyclic. This is not much
     # worse than the already exisiting inheritance and closure restrictions.
     case n.kind
-    of nkLiterals, nkNilLit:
+    of nkLiterals:
       result = true
     of nkCallKinds:
       # XXX: as long as we don't update the analysis while examining arguments

--- a/compiler/sem/isolation_check.nim
+++ b/compiler/sem/isolation_check.nim
@@ -89,7 +89,7 @@ proc checkIsolate*(n: PNode): bool =
     # XXX Maybe require that 'n.typ' is acyclic. This is not much
     # worse than the already exisiting inheritance and closure restrictions.
     case n.kind
-    of nkCharLit..nkNilLit:
+    of nkLiterals, nkNilLit:
       result = true
     of nkCallKinds:
       # XXX: as long as we don't update the analysis while examining arguments

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -98,7 +98,7 @@ proc considerQuotedIdent*(c: PContext; n: PNode): PIdentResult =
 
   const
     atomicIdentKinds = {nkIdent, nkSym}
-    renderableLiterals = nkLiterals - nkFloatLiterals
+    renderableLiterals = nkLiterals - nkFloatLiterals - nkNilLit
     renderableKinds = atomicIdentKinds + renderableLiterals
     allNodeKinds = {low(TNodeKind)..high(TNodeKind)}
 

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -1244,10 +1244,10 @@ proc check(n: PNode, ctx: NilCheckerContext, map: NilMap): Check =
     result = checkTry(n, ctx, map)
   of nkWhileStmt:
     result = checkWhile(n, ctx, map)
-  of nkNone..pred(nkSym), succ(nkSym)..nkNilLit, nkTypeSection, nkProcDef, nkConverterDef,
+  of nkWithoutSons - nkSym, nkTypeSection, nkProcDef, nkConverterDef,
       nkMethodDef, nkIteratorDef, nkMacroDef, nkTemplateDef, nkLambda, nkDo,
       nkFuncDef, nkConstSection, nkConstDef, nkIncludeStmt, nkImportStmt,
-      nkExportStmt, nkPragma, nkCommentStmt, nkTypeOfExpr, nkMixinStmt,
+      nkExportStmt, nkPragma, nkTypeOfExpr, nkMixinStmt,
       nkBindStmt:
 
     discard "don't follow this : same as varpartitions"

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -1304,8 +1304,7 @@ proc preVisitNode(ctx: NilCheckerContext, node: PNode, conf: ConfigRef) =
             ctx.dependants.setLen(baseIndex + 1.ExprIndex)
           ctx.dependants[baseIndex].incl(index.int)
   case node.kind:
-  of nkSym, nkNone, nkEmpty, nkNilLit, nkType, nkIdent, nkCharLit .. nkUInt64Lit,
-     nkFloatLit .. nkFloat64Lit, nkStrLit .. nkTripleStrLit, nkCommentStmt, nkError:
+  of nkWithoutSons:
     discard
   of nkDotExpr:
     # visit only the base

--- a/compiler/sem/nilcheck.nim
+++ b/compiler/sem/nilcheck.nim
@@ -1304,12 +1304,13 @@ proc preVisitNode(ctx: NilCheckerContext, node: PNode, conf: ConfigRef) =
             ctx.dependants.setLen(baseIndex + 1.ExprIndex)
           ctx.dependants[baseIndex].incl(index.int)
   case node.kind:
-  of nkSym, nkEmpty, nkNilLit, nkType, nkIdent, nkCharLit .. nkUInt64Lit, nkFloatLit .. nkFloat64Lit, nkStrLit .. nkTripleStrLit:
+  of nkSym, nkNone, nkEmpty, nkNilLit, nkType, nkIdent, nkCharLit .. nkUInt64Lit,
+     nkFloatLit .. nkFloat64Lit, nkStrLit .. nkTripleStrLit, nkCommentStmt, nkError:
     discard
   of nkDotExpr:
     # visit only the base
     ctx.preVisitNode(node[0], conf)
-  else:
+  of nkWithSons - nkDotExpr:
     for element in node:
       ctx.preVisitNode(element, conf)
 

--- a/compiler/sem/parampatterns.nim
+++ b/compiler/sem/parampatterns.nim
@@ -356,7 +356,7 @@ proc matchNodeKinds*(p, n: PNode): bool =
     of ppNot: stack[sp-1] = not stack[sp-1]
     of ppSym: push n.kind == nkSym
     of ppAtom: push isAtom(n)
-    of ppLit: push n.kind in nkLiterals + nkNilLit
+    of ppLit: push n.kind in nkLiterals
     of ppIdent: push n.kind == nkIdent
     of ppCall: push n.kind in nkCallKinds
     of ppSymKind:

--- a/compiler/sem/parampatterns.nim
+++ b/compiler/sem/parampatterns.nim
@@ -188,7 +188,7 @@ proc checkForSideEffects*(n: PNode): TSideEffectAnalysis =
       if ret == seSideEffect: return ret
       elif ret == seUnknown and result == seNoSideEffect:
         result = seUnknown
-  of nkNone..nkNilLit:
+  of nkWithoutSons:
     # an atom cannot produce a side effect:
     result = seNoSideEffect
   else:
@@ -356,7 +356,7 @@ proc matchNodeKinds*(p, n: PNode): bool =
     of ppNot: stack[sp-1] = not stack[sp-1]
     of ppSym: push n.kind == nkSym
     of ppAtom: push isAtom(n)
-    of ppLit: push n.kind in {nkCharLit..nkNilLit}
+    of ppLit: push n.kind in nkLiterals + nkNilLit
     of ppIdent: push n.kind == nkIdent
     of ppCall: push n.kind in nkCallKinds
     of ppSymKind:

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -21,6 +21,9 @@ import
     sigmatch,
     aliases,
     parampatterns
+  ],
+  compiler/utils/[
+    idioms
   ]
 
 type
@@ -182,8 +185,10 @@ proc matches(c: PPatternContext, p, n: PNode): bool =
     of nkIntLiterals: result = p.intVal == n.intVal
     of nkFloatLiterals: result = p.floatVal == n.floatVal
     of nkStrLiterals: result = p.strVal == n.strVal
-    of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
-      result = true # XXX: Should nkCommentStmt, nkError be handled?
+    of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt:
+      result = true # Ignore comments
+    of nkError:
+      unreachable()
     of nkWithSons:
       # special rule for p(X) ~ f(...); this also works for stuff like
       # partial case statements, etc! - Not really ... :-/

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -50,7 +50,7 @@ proc canonKind(n: PNode): TNodeKind =
   result = n.kind
   case result
   of nkCallKinds: result = nkCall
-  of nkStrLit..nkTripleStrLit: result = nkStrLit
+  of nkStrLiterals: result = nkStrLit
   of nkFastAsgn: result = nkAsgn
   else: discard
 
@@ -62,9 +62,9 @@ proc sameTrees*(a, b: PNode): bool =
     case a.kind
     of nkSym: result = a.sym == b.sym
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
-    of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
+    of nkIntLiterals: result = a.intVal == b.intVal
+    of nkFloatLiterals: result = a.floatVal == b.floatVal
+    of nkStrLiterals: result = a.strVal == b.strVal
     of nkNone, nkEmpty, nkNilLit, nkCommentStmt, nkError:
       result = true # XXX: Should nkCommentStmt, nkError be handled?
     of nkType: result = sameTypeOrNil(a.typ, b.typ)
@@ -179,9 +179,9 @@ proc matches(c: PPatternContext, p, n: PNode): bool =
     case p.kind
     of nkSym: result = p.sym == n.sym
     of nkIdent: result = p.ident.id == n.ident.id
-    of nkCharLit..nkUInt64Lit: result = p.intVal == n.intVal
-    of nkFloatLit..nkFloat64Lit: result = p.floatVal == n.floatVal
-    of nkStrLit..nkTripleStrLit: result = p.strVal == n.strVal
+    of nkIntLiterals: result = p.intVal == n.intVal
+    of nkFloatLiterals: result = p.floatVal == n.floatVal
+    of nkStrLiterals: result = p.strVal == n.strVal
     of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
       result = true # XXX: Should nkCommentStmt, nkError be handled?
     of nkWithSons:

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -68,8 +68,10 @@ proc sameTrees*(a, b: PNode): bool =
     of nkIntLiterals: result = a.intVal == b.intVal
     of nkFloatLiterals: result = a.floatVal == b.floatVal
     of nkStrLiterals: result = a.strVal == b.strVal
-    of nkNone, nkEmpty, nkNilLit, nkCommentStmt, nkError:
-      result = true # XXX: Should nkCommentStmt, nkError be handled?
+    of nkNone, nkEmpty, nkNilLit, nkCommentStmt:
+      result = true # Ignore comments
+    of nkError:
+      unreachable()
     of nkType: result = sameTypeOrNil(a.typ, b.typ)
     of nkWithSons:
       if a.len == b.len:

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -62,12 +62,13 @@ proc sameTrees*(a, b: PNode): bool =
     case a.kind
     of nkSym: result = a.sym == b.sym
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkInt64Lit: result = a.intVal == b.intVal
+    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
     of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
-    of nkEmpty, nkNilLit: result = true
+    of nkNone, nkEmpty, nkNilLit, nkCommentStmt, nkError:
+      result = true # XXX: Should nkCommentStmt, nkError be handled?
     of nkType: result = sameTypeOrNil(a.typ, b.typ)
-    else:
+    of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:
           if not sameTrees(a[i], b[i]): return
@@ -178,12 +179,12 @@ proc matches(c: PPatternContext, p, n: PNode): bool =
     case p.kind
     of nkSym: result = p.sym == n.sym
     of nkIdent: result = p.ident.id == n.ident.id
-    of nkCharLit..nkInt64Lit: result = p.intVal == n.intVal
+    of nkCharLit..nkUInt64Lit: result = p.intVal == n.intVal
     of nkFloatLit..nkFloat64Lit: result = p.floatVal == n.floatVal
     of nkStrLit..nkTripleStrLit: result = p.strVal == n.strVal
-    of nkEmpty, nkNilLit, nkType:
-      result = true
-    else:
+    of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
+      result = true # XXX: Should nkCommentStmt, nkError be handled?
+    of nkWithSons:
       # special rule for p(X) ~ f(...); this also works for stuff like
       # partial case statements, etc! - Not really ... :-/
       let v = lastSon(p)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -283,7 +283,7 @@ proc intLitToIntOrErr(c: PContext, n: PNode): (int, PNode) =
   else:
     n[1] = c.semConstExpr(c, n[1])
     case n[1].kind
-    of nkIntLit..nkInt64Lit:
+    of nkSIntLiterals:
       (int(n[1].intVal), nil)
     else:
       (-1, c.config.newError(n, PAstDiag(kind: adSemIntLiteralExpected)))
@@ -371,7 +371,7 @@ proc getLib(c: PContext, kind: TLibKind, path: PNode): LibId =
 
   var lib = initLib(kind)
   lib.path = path
-  if path.kind in {nkStrLit..nkTripleStrLit}:
+  if path.kind in nkStrLiterals:
     lib.isOverriden = options.isDynlibOverride(c.config, path.strVal)
 
   result = c.addLib(lib)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -960,13 +960,14 @@ proc pragmaLocks(c: PContext, it: PNode): (TLockLevel, PNode) =
         result = (UnknownLockLevel, wrapError(c.config, it))
     else:
       let (x, err) = intLitToIntOrErr(c, it)
-      if err.isNil:
-        if x < 0 or x > MaxLockLevel:
-          it[1] = c.config.newError(it[1], PAstDiag(
-            kind: adSemLocksPragmaBadLevelRange))
-          result = (UnknownLockLevel, wrapError(c.config, it))
-        else:
-          result = (TLockLevel(x), nil)
+      if err != nil:
+        result = (UnknownLockLevel, err)
+      elif x < 0 or x > MaxLockLevel:
+        it[1] = c.config.newError(it[1], PAstDiag(
+          kind: adSemLocksPragmaBadLevelRange))
+        result = (UnknownLockLevel, wrapError(c.config, it))
+      else:
+        result = (TLockLevel(x), nil)
 
 proc typeBorrow(c: PContext; sym: PSym, n: PNode): PNode =
   result = n

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -1152,7 +1152,7 @@ proc warnAboutDeprecated(conf: ConfigRef; info: TLineInfo; s: PSym) =
   if pragmaNode != nil:
     for it in pragmaNode:
       if whichPragma(it) == wDeprecated and it.safeLen == 2 and
-          it[1].kind in {nkStrLit..nkTripleStrLit}:
+          it[1].kind in nkStrLiterals:
         localReport(conf, info, reportSym(
           rsemDeprecated, s, str = it[1].strVal))
         return
@@ -1164,7 +1164,7 @@ proc userError(conf: ConfigRef; info: TLineInfo; s: PSym) =
   if pragmaNode != nil:
     for it in pragmaNode:
       if whichPragma(it) == wError and it.safeLen == 2 and
-          it[1].kind in {nkStrLit..nkTripleStrLit}:
+          it[1].kind in nkStrLiterals:
         localReport(conf, info, reportSym(
           rsemUsageIsError, s, str = it[1].strVal))
         return

--- a/compiler/sem/semfields.nim
+++ b/compiler/sem/semfields.nim
@@ -23,7 +23,7 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
     result = newNode(nkEmpty)
     return
   case n.kind
-  of nkNone, nkEmpty..pred(nkIdent), succ(nkSym)..nkNilLit, nkCommentStmt, nkError:
+  of nkWithoutSons - {nkIdent, nkSym}:
     result = copyNode(n)
   of nkIdent, nkSym:
     result = n

--- a/compiler/sem/semfields.nim
+++ b/compiler/sem/semfields.nim
@@ -23,7 +23,8 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
     result = newNode(nkEmpty)
     return
   case n.kind
-  of nkEmpty..pred(nkIdent), succ(nkSym)..nkNilLit: result = copyNode(n)
+  of nkNone, nkEmpty..pred(nkIdent), succ(nkSym)..nkNilLit, nkCommentStmt, nkError:
+    result = copyNode(n)
   of nkIdent, nkSym:
     result = n
     let (ident, err) = considerQuotedIdent(c.c, n)
@@ -50,7 +51,7 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
           result.add(tupl)
           result.add(newSymNode(c.field, n.info))
         break
-  else:
+  of nkWithSons:
     if n.kind == nkContinueStmt:
       localReport(c.c.config, n, reportSem rsemFieldsIteratorCannotContinue)
     result = shallowCopy(n)

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -54,7 +54,7 @@ type
 
 const
   ExpressionNodes = nkCallKinds + nkLiterals + nkTypeExprs + {
-    nkSym, nkEmpty, nkNimNodeLit, nkNilLit,
+    nkSym, nkEmpty, nkNimNodeLit,
 
     nkRange, nkBracket, nkCurly, nkObjConstr, nkTupleConstr,
 
@@ -673,7 +673,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
       else:
         result = newSymNodeTypeDesc(s, idgen, n.info)
     else: discard
-  of nkLiterals, nkNilLit:
+  of nkLiterals:
     result = copyNode(n)
   of nkIfExpr:
     result = getConstIfExpr(m, n, idgen, g)
@@ -838,7 +838,7 @@ proc foldConstExprAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Fo
 
   # first step: fold the sub-expressions
   case n.kind
-  of nkEmpty, nkLiterals, nkNimNodeLit, nkNilLit:
+  of nkEmpty, nkLiterals, nkNimNodeLit:
     # short-circuit the following ``getConstExpr`` call, so that no
     # unnecessary copy of the node is created
     return

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -217,7 +217,7 @@ proc evalOp*(m: TMagic, n, a, b, c: PNode; idgen: IdGenerator; g: ModuleGraph): 
   of mLengthSeq, mLengthOpenArray, mLengthStr:
     if a.kind == nkNilLit:
       result = newIntNodeT(Zero, n, idgen, g)
-    elif a.kind in {nkStrLit..nkTripleStrLit}:
+    elif a.kind in nkStrLiterals:
       if a.typ.kind == tyString:
         result = newIntNodeT(toInt128(a.strVal.len), n, idgen, g)
       elif a.typ.kind == tyCstring:
@@ -401,15 +401,15 @@ proc getConstIfExpr(c: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNod
 proc leValueConv*(a, b: PNode): bool =
   result = false
   case a.kind
-  of nkCharLit..nkUInt64Lit:
+  of nkIntLiterals:
     case b.kind
-    of nkCharLit..nkUInt64Lit: result = a.getInt <= b.getInt
-    of nkFloatLit..nkFloat64Lit: result = a.intVal <= round(b.floatVal).int
+    of nkIntLiterals: result = a.getInt <= b.getInt
+    of nkFloatLiterals: result = a.intVal <= round(b.floatVal).int
     else: result = false #internalError(a.info, "leValueConv")
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     case b.kind
-    of nkFloatLit..nkFloat64Lit: result = a.floatVal <= b.floatVal
-    of nkCharLit..nkUInt64Lit: result = a.floatVal <= toFloat64(b.getInt)
+    of nkFloatLiterals: result = a.floatVal <= b.floatVal
+    of nkIntLiterals: result = a.floatVal <= toFloat64(b.getInt)
     else: result = false # internalError(a.info, "leValueConv")
   else: result = false # internalError(a.info, "leValueConv")
 
@@ -562,7 +562,7 @@ proc foldArrayAccess(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNo
     else:
       result = outOfBounds(n, x, y, g.config)
 
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     if 0 <= idx and idx < x.strVal.len:
       result = newNodeIT(nkCharLit, x.info, n.typ)
       result.intVal = ord(x.strVal[int(idx)])
@@ -673,7 +673,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
       else:
         result = newSymNodeTypeDesc(s, idgen, n.info)
     else: discard
-  of nkCharLit..nkNilLit:
+  of nkLiterals, nkNilLit:
     result = copyNode(n)
   of nkIfExpr:
     result = getConstIfExpr(m, n, idgen, g)

--- a/compiler/sem/semgnrc.nim
+++ b/compiler/sem/semgnrc.nim
@@ -235,7 +235,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     let a = n.sym
     let b = getGenSym(c, a)
     if b != a: n.sym = b
-  of nkEmpty, succ(nkSym)..nkNilLit, nkCommentStmt:
+  of nkWithoutSons - {nkIdent, nkSym}:
     # see tests/compile/tgensymgeneric.nim:
     # We need to open the gensym'ed symbol again so that the instantiation
     # creates a fresh copy; but this is wrong the very first reason for gensym

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -105,7 +105,7 @@ proc semIsPartOf(c: PContext, n: PNode, flags: TExprFlags): PNode =
 proc expectIntLit(c: PContext, n: PNode): int =
   let x = c.semConstExpr(c, n)
   case x.kind
-  of nkIntLit..nkInt64Lit: result = int(x.intVal)
+  of nkSIntLiterals: result = int(x.intVal)
   else: localReport(c.config, n, reportSem rsemIntLiteralExpected)
 
 proc semInstantiationInfo(c: PContext, n: PNode): PNode =

--- a/compiler/sem/semobjconstr.nim
+++ b/compiler/sem/semobjconstr.nim
@@ -222,7 +222,7 @@ proc checkConstructFields(c: PContext, n: PNode,
 
       if discriminatorVal != nil and discriminatorVal.kind != nkError:
         discriminatorVal = discriminatorVal.skipHidden
-        if discriminatorVal.kind notin nkLiterals and (
+        if discriminatorVal.kind notin nkLiterals - nkNilLit and (
             not isOrdinalType(discriminatorVal.typ, true) or
             lengthOrd(c.config, discriminatorVal.typ) > MaxSetElements or
             lengthOrd(c.config, n[0].typ) > MaxSetElements):

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -164,7 +164,7 @@ proc getLockLevel(t: PType): TLockLevel =
   # tyGenericInst(TLock {tyGenericBody}, tyStatic, tyObject):
   if t.kind == tyGenericInst and t.len == 3: t = t[1]
   if t.kind == tyStatic and t.n != nil and t.n.kind in nkIntLiterals:
-    assert t.n.nkind in nkSIntLiterals
+    assert t.n.kind in nkSIntLiterals
     result = t.n.intVal.TLockLevel
 
 proc lockLocations(a: PEffects; pragma: PNode) =

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -163,7 +163,7 @@ proc getLockLevel(t: PType): TLockLevel =
   var t = t
   # tyGenericInst(TLock {tyGenericBody}, tyStatic, tyObject):
   if t.kind == tyGenericInst and t.len == 3: t = t[1]
-  if t.kind == tyStatic and t.n != nil and t.n.kind in nkIntLiterals:
+  if t.kind == tyStatic and t.n != nil and t.n.kind in nkSIntLiterals:
     result = t.n.intVal.TLockLevel
 
 proc lockLocations(a: PEffects; pragma: PNode) =

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -163,7 +163,8 @@ proc getLockLevel(t: PType): TLockLevel =
   var t = t
   # tyGenericInst(TLock {tyGenericBody}, tyStatic, tyObject):
   if t.kind == tyGenericInst and t.len == 3: t = t[1]
-  if t.kind == tyStatic and t.n != nil and t.n.kind in nkSIntLiterals:
+  if t.kind == tyStatic and t.n != nil and t.n.kind in nkIntLiterals:
+    assert t.n.nkind in nkSIntLiterals
     result = t.n.intVal.TLockLevel
 
 proc lockLocations(a: PEffects; pragma: PNode) =

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -163,7 +163,7 @@ proc getLockLevel(t: PType): TLockLevel =
   var t = t
   # tyGenericInst(TLock {tyGenericBody}, tyStatic, tyObject):
   if t.kind == tyGenericInst and t.len == 3: t = t[1]
-  if t.kind == tyStatic and t.n != nil and t.n.kind in {nkCharLit..nkInt64Lit}:
+  if t.kind == tyStatic and t.n != nil and t.n.kind in nkIntLiterals:
     result = t.n.intVal.TLockLevel
 
 proc lockLocations(a: PEffects; pragma: PNode) =
@@ -694,7 +694,7 @@ proc notNilCheck(tracked: PEffects, n: PNode, paramType: PType) =
         # addr(x[]) can't be proven, but addr(x) can:
         if not containsNode(n, {nkDerefExpr, nkHiddenDeref}): return
       elif (n.kind == nkSym and n.sym.kind in routineKinds) or
-          (n.kind in procDefs+{nkObjConstr, nkBracket, nkClosure, nkStrLit..nkTripleStrLit}) or
+          (n.kind in procDefs + {nkObjConstr, nkBracket, nkClosure} + nkStrLiterals) or
           (n.kind in nkCallKinds and n[0].kind == nkSym and n[0].sym.magic == mArrToSeq) or
           n.typ.kind == tyTypeDesc:
         # 'p' is not nil obviously:
@@ -1008,7 +1008,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
       let arg = n[1]
       initVarViaNew(tracked, arg)
       if arg.typ.len != 0 and {tfRequiresInit} * arg.typ.lastSon.flags != {}:
-        if a.sym.magic == mNewSeq and n[2].kind in {nkCharLit..nkUInt64Lit} and
+        if a.sym.magic == mNewSeq and n[2].kind in nkIntLiterals and
             n[2].intVal == 0:
           # var s: seq[notnil];  newSeq(s, 0)  is a special case!
           discard
@@ -1124,14 +1124,14 @@ proc trackInnerProc(tracked: PEffects, n: PNode) =
     let s = n.sym
     if s.kind == skParam and s.owner == tracked.owner:
       tracked.escapingParams.incl s.id
-  of nkNone..pred(nkSym), succ(nkSym)..nkNilLit:
+  of nkWithoutSons - nkSym:
     discard
   of nkProcDef, nkConverterDef, nkMethodDef, nkIteratorDef, nkLambda, nkFuncDef, nkDo:
     if n[0].kind == nkSym and n[0].sym.ast != nil:
       trackInnerProc(tracked, getBody(tracked.graph, n[0].sym))
-  of nkTypeSection, nkMacroDef, nkTemplateDef, nkError,
+  of nkTypeSection, nkMacroDef, nkTemplateDef,
      nkConstSection, nkConstDef, nkIncludeStmt, nkImportStmt,
-     nkExportStmt, nkPragma, nkCommentStmt, nkTypeOfExpr, nkMixinStmt,
+     nkExportStmt, nkPragma, nkTypeOfExpr, nkMixinStmt,
      nkBindStmt:
     discard
   else:
@@ -1139,7 +1139,7 @@ proc trackInnerProc(tracked: PEffects, n: PNode) =
 
 proc allowCStringConv(n: PNode): bool =
   case n.kind
-  of nkStrLit..nkTripleStrLit: result = true
+  of nkStrLiterals: result = true
   of nkSym: result = n.sym.kind in {skConst, skParam}
   of nkAddr: result = isCharArrayPtr(n.typ, true)
   of nkCallKinds:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -339,7 +339,7 @@ proc fitRemoveHiddenConv(c: PContext, typ: PType, n: PNode): PNode =
   case result.kind
   of nkHiddenStdConv, nkHiddenSubConv:
     let r1 = result[1]
-    if r1.kind in {nkCharLit..nkUInt64Lit} and
+    if r1.kind in nkIntLiterals and
        typ.skipTypes(abstractRange).kind in {tyFloat..tyFloat64}:
       result = newFloatNode(nkFloatLit, BiggestFloat r1.intVal)
       result.info = n.info

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -648,7 +648,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   of nkMixinStmt:
     if c.scopeN > 0: result = semTemplBodySons(c, n)
     else: result = semMixinStmt(c.c, n, c.toMixin)
-  of nkEmpty, nkSym..nkNilLit:
+  of nkWithoutSons - nkIdent:
     discard
   of nkIfStmt:
     for i in 0..<n.len:
@@ -954,8 +954,6 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
 
       if result[i].isError:
         hasError = true
-  of nkError, nkCommentStmt:
-    result = n
   else:
     result = semTemplBodySons(c, n)
   
@@ -1009,7 +1007,7 @@ proc semTemplBodyDirty(c: var TemplCtx, n: PNode): PNode =
     result = semTemplBodyDirty(c, n[0])
   of nkBindStmt:
     result = semBindStmt(c.c, n, c.toBind)
-  of nkEmpty, nkSym..nkNilLit, nkError, nkCommentStmt:
+  of nkWithoutSons - nkIdent:
     discard
   of nkDotExpr, nkAccQuoted:
     # dotExpr is ambiguous: note that we explicitly allow 'x.TemplateParam',
@@ -1220,7 +1218,7 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
           # more flexibility
   of nkBindStmt:
     result = semBindStmt(c.c, n, c.toBind)
-  of nkEmpty, nkSym..nkNilLit:
+  of nkWithoutSons - nkIdent:
     discard
   of nkCurlyExpr:
     # we support '(pattern){x}' to bind a subpattern to a parameter 'x';

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -412,8 +412,8 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
     elif enumHasHoles(rangeT[0]):
       localReport(c.config, n.info, reportTyp(rsemExpectedUnholyEnum, rangeT[0]))
 
-  if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and result.n[0].floatVal.isNaN) or
-      (result.n[1].kind in {nkFloatLit..nkFloat64Lit} and result.n[1].floatVal.isNaN):
+  if (result.n[0].kind in nkFloatLiterals and result.n[0].floatVal.isNaN) or
+      (result.n[1].kind in nkFloatLiterals and result.n[1].floatVal.isNaN):
     localReport(c.config, n, reportSem rsemRangeDoesNotSupportNan)
 
   if weakLeValue(result.n[0], result.n[1]) == impNo:
@@ -427,14 +427,14 @@ proc semRange(c: PContext, n: PNode, prev: PType): PType =
     if isRange(n[1]):
       result = semRangeAux(c, n[1], prev)
       let n = result.n
-      if n[0].kind in {nkCharLit..nkUInt64Lit} and n[0].intVal > 0:
+      if n[0].kind in nkIntLiterals and n[0].intVal > 0:
         incl(result.flags, tfRequiresInit)
-      elif n[1].kind in {nkCharLit..nkUInt64Lit} and n[1].intVal < 0:
+      elif n[1].kind in nkIntLiterals and n[1].intVal < 0:
         incl(result.flags, tfRequiresInit)
-      elif n[0].kind in {nkFloatLit..nkFloat64Lit} and
+      elif n[0].kind in nkFloatLiterals and
           n[0].floatVal > 0.0:
         incl(result.flags, tfRequiresInit)
-      elif n[1].kind in {nkFloatLit..nkFloat64Lit} and
+      elif n[1].kind in nkFloatLiterals and
           n[1].floatVal < 0.0:
         incl(result.flags, tfRequiresInit)
     else:
@@ -481,7 +481,7 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
 
     # an expression that doesn't reference type variables
     e = semExprWithType(c, e)
-    if e.kind in {nkIntLit..nkUInt64Lit}:
+    if e.kind in nkIntLiterals:
       if e.intVal < 0:
         localReport(c.config, n.info,
           SemReport(
@@ -492,7 +492,7 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
       result = makeRangeType(c, 0, e.intVal-1, n.info, e.typ)
     else:
       let x = semConstExpr(c, e)
-      if x.kind in {nkIntLit..nkUInt64Lit}:
+      if x.kind in nkIntLiterals:
         result = makeRangeType(c, 0, x.intVal-1, n.info,
                              x.typ.skipTypes({tyTypeDesc}))
       else:

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -306,7 +306,7 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
   if n.typ != nil:
     result.typ = replaceTypeVarsT(cl, n.typ)
   case n.kind
-  of nkNone..pred(nkSym), succ(nkSym)..nkNilLit:
+  of nkWithoutSons - nkSym:
     discard
   of nkOpenSymChoice, nkClosedSymChoice: result = n
   of nkSym:

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -90,13 +90,13 @@ proc hashTree(c: var MD5Context, n: PNode; flags: set[ConsiderFlag]) =
     hashSym(c, n.sym)
     if CoHashTypeInsideNode in flags and n.sym.typ != nil:
       hashType(c, n.sym.typ, flags)
-  of nkCharLit..nkUInt64Lit:
+  of nkIntLiterals:
     let v = n.intVal
     lowlevel v
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     let v = n.floatVal
     lowlevel v
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     c &= n.strVal
   of nkWithSons:
     for i in 0..<n.len: hashTree(c, n[i], flags)
@@ -364,11 +364,11 @@ proc hashBodyTree(graph: ModuleGraph, c: var MD5Context, n: PNode) =
       c &= hashNonProc(n.sym)
   of nkProcDef, nkFuncDef, nkTemplateDef, nkMacroDef:
     discard # we track usage of proc symbols not their definition
-  of nkCharLit..nkUInt64Lit:
+  of nkIntLiterals:
     c &= n.intVal
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     c &= n.floatVal
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     c &= n.strVal
   of nkWithSons - {nkProcDef, nkFuncDef, nkTemplateDef, nkMacroDef} :
     for i in 0..<n.len:

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -295,9 +295,9 @@ proc transformConstSection(c: PTransf, v: PNode): PNode =
 
 proc hasContinue(n: PNode): bool =
   case n.kind
-  of nkEmpty..nkNilLit, nkCommentStmt, nkForStmt, nkWhileStmt: discard
+  of nkNone, nkEmpty..nkNilLit, nkCommentStmt, nkError, nkForStmt, nkWhileStmt: discard
   of nkContinueStmt: result = true
-  else:
+  of nkWithSons - {nkForStmt, nkWhileStmt, nkContinueStmt}:
     for i in 0..<n.len:
       if hasContinue(n[i]): return true
 

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -295,7 +295,7 @@ proc transformConstSection(c: PTransf, v: PNode): PNode =
 
 proc hasContinue(n: PNode): bool =
   case n.kind
-  of nkNone, nkEmpty..nkNilLit, nkCommentStmt, nkError, nkForStmt, nkWhileStmt: discard
+  of nkWithoutSons, nkForStmt, nkWhileStmt: discard
   of nkContinueStmt: result = true
   of nkWithSons - {nkForStmt, nkWhileStmt, nkContinueStmt}:
     for i in 0..<n.len:
@@ -420,7 +420,7 @@ proc introduceNewLocalVars(c: PTransf, n: PNode): PNode =
   case n.kind
   of nkSym:
     result = transformSym(c, n)
-  of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit, nkCommentStmt:
+  of nkWithoutSons - nkSym:
     # nothing to be done for leaves:
     result = n
   of callableDefs:
@@ -721,13 +721,13 @@ proc findWrongOwners(c: PTransf, n: PNode) =
 proc isSimpleIteratorVar(c: PTransf; iter: PSym): bool =
   proc rec(n: PNode; owner: PSym; dangerousYields: var int) =
     case n.kind
-    of nkEmpty..nkNilLit: discard
+    of nkWithoutSons: discard
     of nkYieldStmt:
       if n[0].kind == nkSym and n[0].sym.owner == owner:
         discard "good: yield a single variable that we own"
       else:
         inc dangerousYields
-    else:
+    of nkWithSons - nkYieldStmt:
       for c in n: rec(c, owner, dangerousYields)
 
   var dangerousYields = 0
@@ -1136,7 +1136,7 @@ proc transform(c: PTransf, n: PNode): PNode =
     unreachable("errors can't reach here")
   of nkSym:
     result = transformSym(c, n)
-  of nkEmpty..pred(nkSym), succ(nkSym)..nkNilLit:
+  of nkWithoutSons - {nkSym, nkError}:
     # nothing to be done for leaves:
     result = n
   of nkBracketExpr: result = transformArrayAccess(c, n)
@@ -1212,7 +1212,7 @@ proc transform(c: PTransf, n: PNode): PNode =
         # ensure that e.g. discard "some comment" gets optimized away
         # completely:
         result = newNode(nkCommentStmt)
-  of nkCommentStmt, nkTemplateDef, nkImportStmt, nkStaticStmt,
+  of nkTemplateDef, nkImportStmt, nkStaticStmt,
       nkExportStmt, nkExportExceptStmt:
     return n
   of nkConstSection:

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -38,7 +38,7 @@ proc typeAllowedNode(marker: var IntSet, n: PNode, kind: TSymKind,
     result = typeAllowedAux(marker, n.typ, kind, c, flags)
     if result == nil:
       case n.kind
-      of nkNone..nkNilLit, nkCommentStmt, nkError:
+      of nkWithoutSons:
         discard
       of nkWithSons:
         #if n.kind == nkRecCase and kind in {skProc, skFunc, skConst}:

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -38,9 +38,9 @@ proc typeAllowedNode(marker: var IntSet, n: PNode, kind: TSymKind,
     result = typeAllowedAux(marker, n.typ, kind, c, flags)
     if result == nil:
       case n.kind
-      of nkNone..nkNilLit:
+      of nkNone..nkNilLit, nkCommentStmt, nkError:
         discard
-      else:
+      of nkWithSons:
         #if n.kind == nkRecCase and kind in {skProc, skFunc, skConst}:
         #  return n[0].typ
         for i in 0..<n.len:

--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -292,7 +292,7 @@ proc connect(v: var Partitions; a, b: PSym; info: TLineInfo) =
 
 proc borrowFromConstExpr(n: PNode): bool =
   case n.kind
-  of nkLiterals, nkNilLit:
+  of nkLiterals:
     result = true
   of nkExprEqExpr, nkExprColonExpr, nkHiddenStdConv, nkHiddenSubConv,
       nkCast, nkObjUpConv, nkObjDownConv:
@@ -440,7 +440,7 @@ proc destMightOwn(c: var Partitions; dest: var VarIndex; n: PNode) =
   ## Analyse if 'n' is an expression that owns the data, if so mark 'dest'
   ## with 'ownsData'.
   case n.kind
-  of nkEmpty, nkLiterals, nkNilLit:
+  of nkEmpty, nkLiterals:
     # primitive literals including the empty are harmless:
     discard
 

--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -292,7 +292,7 @@ proc connect(v: var Partitions; a, b: PSym; info: TLineInfo) =
 
 proc borrowFromConstExpr(n: PNode): bool =
   case n.kind
-  of nkCharLit..nkNilLit:
+  of nkLiterals, nkNilLit:
     result = true
   of nkExprEqExpr, nkExprColonExpr, nkHiddenStdConv, nkHiddenSubConv,
       nkCast, nkObjUpConv, nkObjDownConv:
@@ -440,7 +440,7 @@ proc destMightOwn(c: var Partitions; dest: var VarIndex; n: PNode) =
   ## Analyse if 'n' is an expression that owns the data, if so mark 'dest'
   ## with 'ownsData'.
   case n.kind
-  of nkEmpty, nkCharLit..nkNilLit:
+  of nkEmpty, nkLiterals, nkNilLit:
     # primitive literals including the empty are harmless:
     discard
 
@@ -665,11 +665,11 @@ proc deps(c: var Partitions; dest, src: PNode) =
                 c.s[vid].flags.incl preventCursor
 
 const
-  nodesToIgnoreSet = {nkNone..pred(nkSym), succ(nkSym)..nkNilLit,
+  nodesToIgnoreSet = nkWithoutSons - nkSym + {
     nkTypeSection, nkProcDef, nkConverterDef,
     nkMethodDef, nkIteratorDef, nkMacroDef, nkTemplateDef, nkLambda, nkDo,
     nkFuncDef, nkConstSection, nkConstDef, nkIncludeStmt, nkImportStmt,
-    nkExportStmt, nkPragma, nkCommentStmt, nkTypeOfExpr, nkMixinStmt,
+    nkExportStmt, nkPragma, nkTypeOfExpr, nkMixinStmt,
     nkBindStmt}
 
 proc potentialMutationViaArg(c: var Partitions; n: PNode; callee: PType) =

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -892,7 +892,7 @@ proc genDeprecationMsg(d: PDoc, n: PNode): string =
     result = getConfigVar(d.conf, "doc.deprecationmsg") % [
        "label" , "Deprecated", "message", ""]
   of 2: # Deprecated w/ a message
-    if n[1].kind in {nkStrLit..nkTripleStrLit}:
+    if n[1].kind in nkStrLiterals:
       result = getConfigVar(d.conf, "doc.deprecationmsg") % [
           "label", "Deprecated:", "message", xmltree.escape(n[1].strVal)]
   else:

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -693,7 +693,7 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode], count: var int): bool =
       else:
         n
 
-    for nSon in nWithSons.sons:
+    for nSon in nWithSons.items:
       if cyclicTreeAux(nSon, visited, count):
         return true
 

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -686,14 +686,14 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode], count: var int): bool =
   of nkWithSons, nkError:
     visited.add(n)
 
-    let sons =
+    let nWithSons =
       case n.kind
       of nkError:
-        @[n.diag.wrongNode]
+        n.diag.wrongNode
       else:
-        n.sons
+        n
 
-    for nSon in sons:
+    for nSon in nWithSons.sons:
       if cyclicTreeAux(nSon, visited, count):
         return true
 

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -691,7 +691,7 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode], count: var int): bool =
       of nkError:
         @[n.diag.wrongNode]
       else:
-        @[] # XXX: This is a bug!
+        n.sons
 
     for nSon in sons:
       if cyclicTreeAux(nSon, visited, count):

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -681,9 +681,9 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode], count: var int): bool =
 
   inc count
   case n.kind
-  of {nkEmpty..nkNilLit}:
+  of nkWithoutSons - nkError:
     discard
-  else:
+  of nkWithSons, nkError:
     visited.add(n)
 
     let sons =
@@ -691,7 +691,7 @@ proc cyclicTreeAux(n: PNode, visited: var seq[PNode], count: var int): bool =
       of nkError:
         @[n.diag.wrongNode]
       else:
-        @[]
+        @[] # XXX: This is a bug!
 
     for nSon in sons:
       if cyclicTreeAux(nSon, visited, count):

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -854,12 +854,12 @@ proc treeRepr*(
         add "\"" & n.strVal + style.strLit & "\""
         postLiteral()
 
-      of nkCharLit .. nkUInt64Lit:
+      of nkIntLiterals:
         add " "
         add $n.intVal + style.number
         postLiteral()
 
-      of nkFloatLit .. nkFloat64Lit:
+      of nkFloatLiterals:
         add " "
         add $n.floatVal + style.floatLit
         postLiteral()
@@ -909,7 +909,7 @@ proc treeRepr*(
       else:
         discard
 
-    if n.kind notin {nkNone .. nkNilLit, nkCommentStmt}:
+    if n.kind notin nkWithoutSons - nkError:
       addFlags()
       if (n.kind == nkError and trfSkipAuxError notin rconf) or
           (n.kind != nkError and n.len > 0):

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -733,12 +733,12 @@ proc loadNode(dec: var TypeInfoDecoder, ps: PackedEnv, id: NodeId): (PNode, int3
   case n.kind
   of nkEmpty, nkType, nkNilLit, nkCommentStmt:
     discard "do nothing"
-  of nkCharLit..nkUInt64Lit:
+  of nkIntLiterals:
     r.intVal = ps.numbers[n.operand.LitId]
-  of nkFloatLit..nkFloat64Lit:
+  of nkFloatLiterals:
     # use a `cast` to preserve the bit representation:
     r.floatVal = cast[BiggestFloat](ps.numbers[n.operand.LitId])
-  of nkStrLit..nkTripleStrLit:
+  of nkStrLiterals:
     r.strVal = ps.strings[n.operand.LitId]
   of nkSym:
     r.sym = dec.loadSym(ps, n.operand.SymId)

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2388,7 +2388,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       let src = regs[rb].nimNode
       # TODO: This if-else block should be reordered so as to match the
       #       expectation of occurence
-      if src.kind in {nkEmpty..nkNilLit, nkError}:
+      if src.kind in nkWithoutSons:
         raiseVmError(VmEvent(kind: vmEvtCannotGetChild, ast: src))
       elif idx >=% src.len:
         raiseVmError(reportVmIdx(idx, src.len - 1))
@@ -2400,7 +2400,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       var dest = regs[ra].nimNode
       if nfSem in dest.flags:
         raiseVmError(VmEvent(kind: vmEvtCannotModifyTypechecked))
-      elif dest.kind in {nkEmpty..nkNilLit, nkError}:
+      elif dest.kind in nkWithoutSons:
         raiseVmError(VmEvent(kind: vmEvtCannotSetChild, ast: dest))
       elif idx >=% dest.len:
         raiseVmError(reportVmIdx(idx, dest.len - 1))
@@ -2411,7 +2411,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       var u = regs[rb].nimNode
       if nfSem in u.flags:
         raiseVmError(VmEvent(kind: vmEvtCannotModifyTypechecked))
-      elif u.kind in {nkEmpty..nkNilLit, nkError}:
+      elif u.kind in nkWithoutSons:
         raiseVmError(VmEvent(kind: vmEvtCannotAddChild, ast: u))
       else:
         u.add(regs[rc].nimNode)
@@ -2427,7 +2427,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       var u = regs[rb].nimNode
       if nfSem in u.flags:
         raiseVmError(VmEvent(kind: vmEvtCannotModifyTypechecked))
-      elif u.kind in {nkEmpty..nkNilLit, nkError}:
+      elif u.kind in nkWithoutSons:
         raiseVmError(VmEvent(kind: vmEvtCannotAddChild, ast: u))
       else:
         let L = arrayLen(x)
@@ -2452,7 +2452,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
     of opcNIntVal:
       decodeB(rkInt)
       let a = regs[rb].nimNode
-      if a.kind in {nkCharLit..nkUInt64Lit}:
+      if a.kind in nkIntLiterals:
         regs[ra].intVal = a.intVal
       elif a.kind == nkSym and a.sym.kind == skEnumField:
         regs[ra].intVal = a.sym.position
@@ -2462,7 +2462,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       decodeB(rkFloat)
       let a = regs[rb].nimNode
       case a.kind
-      of nkFloatLit..nkFloat64Lit: regs[ra].floatVal = a.floatVal
+      of nkFloatLiterals: regs[ra].floatVal = a.floatVal
       else: raiseVmError(VmEvent(kind: vmEvtFieldNotFound, msg: "floatVal"))
     of opcNodeId:
       decodeB(rkInt)
@@ -2540,7 +2540,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       decodeB(akString)
       let a = regs[rb].nimNode
       case a.kind
-      of nkStrLit..nkTripleStrLit:
+      of nkStrLiterals:
         regs[ra].strVal = a.strVal
       of nkCommentStmt:
         regs[ra].strVal = a.comment
@@ -2726,7 +2726,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
     of opcNSetIntVal:
       decodeB(rkNimNode)
       var dest = regs[ra].nimNode
-      if dest.kind in {nkCharLit..nkUInt64Lit}:
+      if dest.kind in nkIntLiterals:
         dest.intVal = regs[rb].intVal
       elif dest.kind == nkSym and dest.sym.kind == skEnumField:
         raiseVmError(VmEvent(
@@ -2737,7 +2737,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
     of opcNSetFloatVal:
       decodeB(rkNimNode)
       var dest = regs[ra].nimNode
-      if dest.kind in {nkFloatLit..nkFloat64Lit}:
+      if dest.kind in nkFloatLiterals:
         dest.floatVal = regs[rb].floatVal
       else:
         raiseVmError(VmEvent(kind: vmEvtFieldNotFound, msg: "floatVal"))
@@ -2746,7 +2746,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       checkHandle(regs[rb])
       var dest = regs[ra].nimNode
       assert regs[rb].handle.typ.kind == akString
-      if dest.kind in {nkStrLit..nkTripleStrLit}:
+      if dest.kind in nkStrLiterals:
         dest.strVal = $regs[rb].strVal
       elif dest.kind == nkCommentStmt:
         dest.comment = $regs[rb].strVal

--- a/tests/errmsgs/tnnodeindexkind.nim
+++ b/tests/errmsgs/tnnodeindexkind.nim
@@ -1,8 +1,17 @@
 discard """
-  errormsg: "cannot set child of node kind: nnkStrLit"
-  line: 7
+  matrix: "--errorMax:2"
+  action: reject
+  nimout: '''
+tnnodeindexkind.nim(11, 4) Error: cannot set child of node kind: nnkStrLit
+tnnodeindexkind.nim(15, 7) Error: cannot set child of node kind: nnkCommentStmt
+'''
 """
 import macros
 macro t(x: untyped): untyped =
   x[0] = newEmptyNode()
 t("abc")
+
+macro t2(x: untyped): untyped =
+  x[0][0] = newEmptyNode()
+t2:
+  ## comment

--- a/tests/lang_experimental/trmacros/trmacros_various2.nim
+++ b/tests/lang_experimental/trmacros/trmacros_various2.nim
@@ -6,6 +6,8 @@ output: '''
 hel
 lo
 my awesome concat
+1
+TRM
 '''
 """
 
@@ -87,3 +89,13 @@ in_to_out(char, int)
 
 # This works
 proc to_out2(x: char{lit}): int = result = ord(x)
+
+# Unsigned literals
+template times3is1{`*`(u,3'u)}(u: uint): uint = 1
+var u = 3'u
+echo u * 3'u # 1
+
+# Char literals
+template dontAppendE{`&`(s, 'E')}(s: string): string = s
+var s = "T"
+echo s & 'E' & 'R' & 'M'

--- a/tests/pragmas/tlocks.nim
+++ b/tests/pragmas/tlocks.nim
@@ -17,7 +17,7 @@ proc plain2*() {.locks: "unknown".} =
   discard
 
 # ensure char literals are rejected
-assert not compiles (;
+doAssert not compiles (;
   proc plain3() {.locks: 'c'.} =
     discard
   )

--- a/tests/pragmas/tlocks.nim
+++ b/tests/pragmas/tlocks.nim
@@ -11,3 +11,13 @@ method testMethod(g: SomeDerived) =
 # ensure int literals still work
 proc plain*() {.locks: 0.} =
   discard
+
+# ensure unknown locklevel works
+proc plain2*() {.locks: "unknown".} =
+  discard
+
+# ensure char literals are rejected
+assert not compiles (;
+  proc plain3() {.locks: 'c'.} =
+    discard
+  )


### PR DESCRIPTION
## Summary
* Move  `nkLiterals`  and its more specific literal subsets to 
`ast_types`  and include  `nkNilLit`  in  `nkLiterals` 
* Introduce node kind sets  `nkSIntLiterals` ,  `nkUIntLiterals`  for
signed and unsigned integer literals
* Make more use of node kind set constants across the compiler and make
some case statements exhaustive
* A few minor bugs have been fixed along the way and tests for them
added

## Details
* Fix a bug that made  `astrepr.cyclicTreeAux`  ignore the children of
non-error nodes (only used by the  `astrepr.treeRepr`  debugging
facility)
* Fix the assertion failures encountered when running the  `ic`  tests
with a debug or release compiler
* Fix the  `locks`  pragma erroneously accepting unsigned integers and
char literals (see  `tests/pragmas/tlocks.nim` )
* Fix unsigned integers and char literals causing crashes with term
rewriting macros (see 
`tests/lang_experimental/trmacros/trmacros_various2.nim` )
* Fix the VM crashing when trying to access the non-existent sons of a 
`nnkCommentStmt`  node (see  `tests/errmsgs/tnnodeindexkind.nim` )