### PR TITLE
show error on invalid module name

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1633,7 +1633,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "using '.' instead of '/' in import paths is deprecated"
 
     of rsemInvalidModuleName:
-      result = "invalid module name: '$1'" % r.ast.render
+      result = "invalid module name: '$1'" % r.str
 
     of rsemInvalidMethodDeclarationOrder:
       result = "invalid declaration order; cannot attach '" & r.symbols[0].name.s &

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -104,7 +104,7 @@ proc newModule(graph: ModuleGraph; fileIdx: FileIndex): PSym =
                 name: getModuleIdent(graph, filename),
                 info: newLineInfo(fileIdx, 1, 1))
   if not isNimIdentifier(result.name.s):
-    localReport(graph.config, reportSym(rsemInvalidModuleName, result))
+    discard report(graph.config, reportSym(rsemInvalidModuleName, nil, str=result.name.s))
 
   partialInitModule(result, graph, fileIdx, filename)
   graph.registerModule(result)


### PR DESCRIPTION
## Summary

Now trying to compile a file with `-` in its name will not crash the compiler.

```
❯ nimskull c sol-nimskull.nim
.......................................................
Error: invalid module name: 'sol-nimskull' [rsemInvalidModuleName]
modules.nim(107, 19) compiler msg instantiated here [MsgOrigin]
(0, 1) compiler report submitted here [MsgOrigin]
.
Hint: gc: orc; opt: none (DEBUG BUILD, `-d: release` generates faster code);  14741 lines; 0.510s; 23.938MiB peakmem; proj: /home/user/computing/lang/nimskull/sol-nimskull.nim; out: /home/user/computing/lang/nimskull/sol-nimskull [SuccessX]
```

## TODO

- [ ] the compiler should (probably) stop compiling after showing this error message

## Details

Fixes #720 

