### PR TITLE
Fix error message `<nil tree>` when importing module with illegal name

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1633,7 +1633,7 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "using '.' instead of '/' in import paths is deprecated"
 
     of rsemInvalidModuleName:
-      result = "invalid module name: '$1'" % r.ast.render
+      result = "invalid module name: '$1'" % r.symstr
 
     of rsemInvalidMethodDeclarationOrder:
       result = "invalid declaration order; cannot attach '" & r.symbols[0].name.s &


### PR DESCRIPTION
## Summary

This fixes the error message:

``` 
  Error: invalid module name: '<nil tree>'
```

when trying to import a module with invalid name (for example, a module containing a hyphen in the name).

This fixes issue #720.

## Details

Alternatively, when just removing the `isNimIdentifier()` check for the module name alltogther, we could just allow module names with hyphens to work. I'm not sure if this will give unintended interactions with specific platform file systems though.
