### PR TITLE
Remove nkNone and replace it with nkError

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -483,7 +483,7 @@ template copyNodeImpl(dst, src, processSonsStmt) =
   of nkSym: dst.sym = src.sym
   of nkIdent: dst.ident = src.ident
   of nkStrLiterals: dst.strVal = src.strVal
-  of nkEmpty, nkNone, nkNilLit, nkType, nkCommentStmt: discard "no children"
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt: discard "no children"
   of nkError: dst.diag = src.diag # do cheap copies
   of nkWithSons: processSonsStmt
 

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -52,10 +52,8 @@ type
   TNodeKind* = enum
     ## order is important, because ranges are used to check whether a node
     ## belongs to a certain class
-
-    nkNone                ## unknown node kind: indicates an error
-                          ## Expressions:
-                          ## Atoms:
+    ## Expressions:
+    ## Atoms:
     nkEmpty               ## the node is empty
     nkIdent               ## node is an identifier
     nkSym                 ## node is a symbol
@@ -254,7 +252,7 @@ const
   nkLiterals*      = nkIntLiterals + nkFloatLiterals + nkStrLiterals + nkNilLit
 
   nkWithoutSons* =
-    {nkEmpty, nkNone} +
+    {nkEmpty} +
     {nkIdent, nkSym} +
     {nkType} +
     nkLiterals +
@@ -1592,7 +1590,7 @@ type
       sym*: PSym
     of nkIdent:
       ident*: PIdent
-    of nkEmpty, nkNone, nkType, nkNilLit, nkCommentStmt:
+    of nkEmpty, nkType, nkNilLit, nkCommentStmt:
       discard
     of nkError:
       diag*: PAstDiag

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -54,6 +54,7 @@ type
     ## belongs to a certain class
     ## Expressions:
     ## Atoms:
+    nkError               ## erroneous AST node see `errorhandling`
     nkEmpty               ## the node is empty
     nkIdent               ## node is an identifier
     nkSym                 ## node is a symbol
@@ -232,7 +233,6 @@ type
                           ## transformation
     nkFuncDef             ## a func
     nkTupleConstr         ## a tuple constructor
-    nkError               ## erroneous AST node see `errorhandling`
     nkNimNodeLit          ## a ``NimNode`` literal. Stores a single sub node
                           ## that represents the ``NimNode`` AST
     nkModuleRef           ## for .rod file support: A (moduleId, itemId) pair

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -60,7 +60,7 @@ proc exprStructuralEquivalent*(a, b: PNode; strictSymEquality=false): bool =
     of nkFloatLiterals: result = sameFloatIgnoreNan(a.floatVal, b.floatVal)
     of nkStrLiterals: result = a.strVal == b.strVal
     of nkCommentStmt: result = a.comment == b.comment
-    of nkNone, nkEmpty, nkNilLit, nkType: result = true
+    of nkEmpty, nkNilLit, nkType: result = true
     of nkError:
       unreachable()
     of nkWithSons:
@@ -91,7 +91,7 @@ proc sameTree*(a, b: PNode): bool =
                a.floatLitBase == b.floatLitBase
     of nkStrLiterals: result = a.strVal == b.strVal
     of nkCommentStmt: result = a.comment == b.comment
-    of nkNone, nkEmpty, nkNilLit, nkType: result = true
+    of nkEmpty, nkNilLit, nkType: result = true
     of nkError:
       unreachable()
     of nkWithSons:

--- a/compiler/ast/treetab.nim
+++ b/compiler/ast/treetab.nim
@@ -17,7 +17,7 @@ proc hashTree*(n: PNode): Hash =
     return
   result = ord(n.kind)
   case n.kind
-  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
+  of nkError, nkEmpty, nkNilLit, nkType, nkCommentStmt:
     discard
   of nkIdent:
     result = result !& n.ident.h
@@ -43,7 +43,7 @@ proc treesEquivalent(a, b: PNode): bool =
     result = true
   elif (a != nil) and (b != nil) and (a.kind == b.kind):
     case a.kind
-    of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: result = true
+    of nkError, nkEmpty, nkNilLit, nkType, nkCommentStmt: result = true
     of nkSym: result = a.sym.id == b.sym.id
     of nkIdent: result = a.ident.id == b.ident.id
     of nkIntLiterals: result = a.intVal == b.intVal

--- a/compiler/ast/treetab.nim
+++ b/compiler/ast/treetab.nim
@@ -17,7 +17,7 @@ proc hashTree*(n: PNode): Hash =
     return
   result = ord(n.kind)
   case n.kind
-  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
     discard
   of nkIdent:
     result = result !& n.ident.h
@@ -43,7 +43,7 @@ proc treesEquivalent(a, b: PNode): bool =
     result = true
   elif (a != nil) and (b != nil) and (a.kind == b.kind):
     case a.kind
-    of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: result = true
+    of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: result = true
     of nkSym: result = a.sym.id == b.sym.id
     of nkIdent: result = a.ident.id == b.ident.id
     of nkIntLiterals: result = a.intVal == b.intVal

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -76,3 +76,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimskullNoFloat128")
   defineSymbol("nimskullNewExceptionRt")
   defineSymbol("nimskullNoNkStmtListTypeAndNkBlockType")
+  defineSymbol("nimskullNoNkNone")

--- a/compiler/front/sexp_reporter.nim
+++ b/compiler/front/sexp_reporter.nim
@@ -116,7 +116,7 @@ proc sexp*(node: PNode): SexpNode =
   result = newSList()
   result.add newSSymbol(($node.kind)[2 ..^ 1])
   case node.kind
-  of nkNone, nkEmpty, nkType, nkCommentStmt: discard
+  of nkEmpty, nkType, nkCommentStmt: discard
   of nkIntLiterals:             result.add sexp(node.intVal)
   of nkFloatLiterals:           result.add sexp(node.floatVal)
   of nkStrLiterals:             result.add sexp(node.strVal)

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -102,7 +102,7 @@ proc toString*(tree: PackedTree; n: NodePos; m: PackedModule; nesting: int;
 
   result.add $tree[pos].kind
   case tree.nodes[pos].kind
-  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: discard
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: discard
   of nkIdent, nkStrLiterals:
     result.add " "
     result.add m.strings[LitId tree.nodes[pos].operand]
@@ -446,7 +446,7 @@ proc toPackedNode*(n: PNode; ir: var PackedTree; c: var PackedEncoder; m: var Pa
     return
   let info = toPackedInfo(n.info, c, m)
   case n.kind
-  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags, operand: 0,
                             typeId: storeTypeLater(n.typ, c, m), info: info)
   of nkIdent:
@@ -776,7 +776,7 @@ proc loadNodes*(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;
   result.flags = n.flags
 
   case k
-  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
     discard
   of nkIdent:
     result.ident = getIdent(c.cache, g[thisModule].fromDisk.strings[n.litId])

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -102,7 +102,7 @@ proc toString*(tree: PackedTree; n: NodePos; m: PackedModule; nesting: int;
 
   result.add $tree[pos].kind
   case tree.nodes[pos].kind
-  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError: discard
+  of nkError, nkEmpty, nkNilLit, nkType, nkCommentStmt: discard
   of nkIdent, nkStrLiterals:
     result.add " "
     result.add m.strings[LitId tree.nodes[pos].operand]
@@ -446,7 +446,7 @@ proc toPackedNode*(n: PNode; ir: var PackedTree; c: var PackedEncoder; m: var Pa
     return
   let info = toPackedInfo(n.info, c, m)
   case n.kind
-  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
+  of nkError, nkEmpty, nkNilLit, nkType, nkCommentStmt:
     ir.nodes.add PackedNode(kind: n.kind, flags: n.flags, operand: 0,
                             typeId: storeTypeLater(n.typ, c, m), info: info)
   of nkIdent:
@@ -776,7 +776,7 @@ proc loadNodes*(c: var PackedDecoder; g: var PackedModuleGraph; thisModule: int;
   result.flags = n.flags
 
   case k
-  of nkEmpty, nkNilLit, nkType, nkCommentStmt, nkError:
+  of nkError, nkEmpty, nkNilLit, nkType, nkCommentStmt:
     discard
   of nkIdent:
     result.ident = getIdent(c.cache, g[thisModule].fromDisk.strings[n.litId])

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -92,7 +92,7 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
           result.add newSymNode(x, if c.instLines: actual.info else: templ.info)
     else:
       result.add copyNode(c, templ, actual)
-  of nkNone..nkIdent, nkType..nkNilLit: # atom
+  of nkEmpty..nkIdent, nkType..nkNilLit: # atom
     result.add copyNode(c, templ, actual)
   of nkCommentStmt:
     # for the documentation generator we don't keep documentation comments

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -456,7 +456,7 @@ proc sameTree*(a, b: PNode): bool =
     of nkFloatLiterals: result = a.floatVal == b.floatVal
     of nkStrLiterals: result = a.strVal == b.strVal
     of nkType: result = a.typ == b.typ
-    of nkNone, nkEmpty, nkNilLit, nkCommentStmt:
+    of nkEmpty, nkNilLit, nkCommentStmt:
       result = true # Ignore comments
     of nkError:
       unreachable()

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -447,6 +447,8 @@ proc sameTree*(a, b: PNode): bool =
     result = true
   elif a != nil and b != nil and a.kind == b.kind:
     case a.kind
+    of nkError:
+      unreachable()
     of nkSym:
       result = a.sym == b.sym
       if not result and a.sym.magic != mNone:
@@ -458,8 +460,6 @@ proc sameTree*(a, b: PNode): bool =
     of nkType: result = a.typ == b.typ
     of nkEmpty, nkNilLit, nkCommentStmt:
       result = true # Ignore comments
-    of nkError:
-      unreachable()
     of nkWithSons:
       if a.len == b.len:
         for i in 0..<a.len:

--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -151,8 +151,6 @@ proc group(n: PNode, decl, imperative: var seq[PNode]) =
   of nkEmpty, nkError:
     # errors were already reported earlier
     discard "drop errors and empty nodes"
-  of nkNone:
-    unreachable()
   of nkStmtList:
     # flatten statement lists
     for it in n.items:

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -68,10 +68,10 @@ proc sameTrees*(a, b: PNode): bool =
     of nkIntLiterals: result = a.intVal == b.intVal
     of nkFloatLiterals: result = a.floatVal == b.floatVal
     of nkStrLiterals: result = a.strVal == b.strVal
-    of nkEmpty, nkNilLit, nkCommentStmt:
-      result = true # Ignore comments
     of nkError:
       unreachable()
+    of nkEmpty, nkNilLit, nkCommentStmt:
+      result = true # Ignore comments
     of nkType: result = sameTypeOrNil(a.typ, b.typ)
     of nkWithSons:
       if a.len == b.len:
@@ -182,6 +182,8 @@ proc matches(c: PPatternContext, p, n: PNode): bool =
         result = bindOrCheck(c, p[1].sym, n)
   elif sameKinds(p, n):
     case p.kind
+    of nkError:
+      unreachable()
     of nkSym: result = p.sym == n.sym
     of nkIdent: result = p.ident.id == n.ident.id
     of nkIntLiterals: result = p.intVal == n.intVal
@@ -189,8 +191,6 @@ proc matches(c: PPatternContext, p, n: PNode): bool =
     of nkStrLiterals: result = p.strVal == n.strVal
     of nkEmpty, nkNilLit, nkType, nkCommentStmt:
       result = true # Ignore comments
-    of nkError:
-      unreachable()
     of nkWithSons:
       # special rule for p(X) ~ f(...); this also works for stuff like
       # partial case statements, etc! - Not really ... :-/

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -68,7 +68,7 @@ proc sameTrees*(a, b: PNode): bool =
     of nkIntLiterals: result = a.intVal == b.intVal
     of nkFloatLiterals: result = a.floatVal == b.floatVal
     of nkStrLiterals: result = a.strVal == b.strVal
-    of nkNone, nkEmpty, nkNilLit, nkCommentStmt:
+    of nkEmpty, nkNilLit, nkCommentStmt:
       result = true # Ignore comments
     of nkError:
       unreachable()
@@ -187,7 +187,7 @@ proc matches(c: PPatternContext, p, n: PNode): bool =
     of nkIntLiterals: result = p.intVal == n.intVal
     of nkFloatLiterals: result = p.floatVal == n.floatVal
     of nkStrLiterals: result = p.strVal == n.strVal
-    of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt:
+    of nkEmpty, nkNilLit, nkType, nkCommentStmt:
       result = true # Ignore comments
     of nkError:
       unreachable()

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -603,7 +603,7 @@ proc tryConstExpr(c: PContext, n: PNode): PNode =
 
   result = evalConstExpr(c.module, c.idgen, c.graph, result)
   case result.kind
-  of nkEmpty, nkError:
+  of nkError, nkEmpty:
     result = nil
   else:
     discard

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3571,7 +3571,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     # because of the changed symbol binding, this does not mean that we
     # don't have to check the symbol for semantics here again!
     result = semSym(c, n, n.sym, flags)
-  of nkEmpty, nkNone, nkCommentStmt, nkType:
+  of nkEmpty, nkCommentStmt, nkType:
     discard
   of nkNilLit:
     if result.typ == nil: result.typ = getNilType(c)

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -83,7 +83,7 @@ proc hashTree(c: var MD5Context, n: PNode; flags: set[ConsiderFlag]) =
   # we really must not hash line information. 'n.typ' is debatable but
   # shouldn't be necessary for now and avoids potential infinite recursions.
   case n.kind
-  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt:
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt:
     discard # ignore comments (could appear in a tyFromExpr)
   of nkError:
     unreachable()
@@ -354,7 +354,7 @@ proc hashBodyTree(graph: ModuleGraph, c: var MD5Context, n: PNode) =
     return
   c &= char(n.kind)
   case n.kind
-  of nkNone, nkEmpty, nkNilLit, nkType, nkCommentStmt:
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt:
     discard # ignore comments
   of nkError:
     unreachable()

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -83,10 +83,10 @@ proc hashTree(c: var MD5Context, n: PNode; flags: set[ConsiderFlag]) =
   # we really must not hash line information. 'n.typ' is debatable but
   # shouldn't be necessary for now and avoids potential infinite recursions.
   case n.kind
-  of nkEmpty, nkNilLit, nkType, nkCommentStmt:
-    discard # ignore comments (could appear in a tyFromExpr)
   of nkError:
     unreachable()
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt:
+    discard # ignore comments (could appear in a tyFromExpr)
   of nkIdent:
     c &= n.ident.s
   of nkSym:
@@ -354,10 +354,10 @@ proc hashBodyTree(graph: ModuleGraph, c: var MD5Context, n: PNode) =
     return
   c &= char(n.kind)
   case n.kind
-  of nkEmpty, nkNilLit, nkType, nkCommentStmt:
-    discard # ignore comments
   of nkError:
     unreachable()
+  of nkEmpty, nkNilLit, nkType, nkCommentStmt:
+    discard # ignore comments
   of nkIdent:
     c &= n.ident.s
   of nkSym:

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -667,8 +667,8 @@ func storeNode(enc: var TypeInfoEncoder, ps: var PackedEnv, n: PNode): NodeId =
     of nkWithSons:
       hasSons = true
       n.sons.len.int32
-    of nkError, nkNone:
-      unreachable("errors and invalid nodes must not reach here")
+    of nkError:
+      unreachable("errors must not reach here")
 
   result = ps.nimNodes.len.NodeId
   ps.nimNodes.add(PackedNodeLite(kind: n.kind, flags: n.flags,
@@ -753,7 +753,7 @@ proc loadNode(dec: var TypeInfoDecoder, ps: PackedEnv, id: NodeId): (PNode, int3
       nextId += skip
 
     return (r, nextId - id.int32)
-  of nkNone, nkError:
+  of nkError:
     # should have not been stored in the first place
     unreachable()
 

--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -10,6 +10,7 @@ contains:
 
   type
     NimNodeKind = enum     ## kind of a node; only explanatory
+      nnkError,            ## erroneous AST node
       nnkEmpty,            ## empty node
       nnkIdent,            ## node contains an identifier
       nnkIntLit,           ## node contains an int literal (example: 10)

--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -10,7 +10,6 @@ contains:
 
   type
     NimNodeKind = enum     ## kind of a node; only explanatory
-      nnkNone,             ## invalid node kind
       nnkEmpty,            ## empty node
       nnkIdent,            ## node contains an identifier
       nnkIntLit,           ## node contains an int literal (example: 10)
@@ -22,7 +21,7 @@ contains:
     NimNode = ref NimNodeObj
     NimNodeObj = object
       case kind: NimNodeKind           ## the node's kind
-      of nnkNone, nnkEmpty, nnkNilLit:
+      of nnkEmpty, nnkNilLit:
         discard                        ## node contains no additional fields
       of nnkCharLit..nnkUInt64Lit:
         intVal: BiggestInt             ## the int literal

--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -22,7 +22,7 @@ contains:
     NimNode = ref NimNodeObj
     NimNodeObj = object
       case kind: NimNodeKind           ## the node's kind
-      of nnkEmpty, nnkNilLit:
+      of nnkError, nnkEmpty, nnkNilLit:
         discard                        ## node contains no additional fields
       of nnkCharLit..nnkUInt64Lit:
         intVal: BiggestInt             ## the int literal

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -48,8 +48,7 @@ template skipEnumValue(define: untyped, predecessor: untyped; gap = 1): untyped 
 type
   NimNodeKind* = enum
     nnkError,  ## erroneous AST node
-    nnkEmpty,
-    nnkIdent, nnkSym,
+    nnkEmpty, nnkIdent, nnkSym,
     nnkType, nnkCharLit, nnkIntLit, nnkInt8Lit,
     nnkInt16Lit, nnkInt32Lit, nnkInt64Lit, nnkUIntLit, nnkUInt8Lit,
     nnkUInt16Lit, nnkUInt32Lit, nnkUInt64Lit, nnkFloatLit,

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -47,7 +47,8 @@ template skipEnumValue(define: untyped, predecessor: untyped; gap = 1): untyped 
 
 type
   NimNodeKind* = enum
-    nnkEmpty = skipEnumValue(nimskullNoNkNone, -1),
+    nnkError,  ## erroneous AST node
+    nnkEmpty,
     nnkIdent, nnkSym,
     nnkType, nnkCharLit, nnkIntLit, nnkInt8Lit,
     nnkInt16Lit, nnkInt32Lit, nnkInt64Lit, nnkUIntLit, nnkUInt8Lit,
@@ -112,8 +113,7 @@ type
     nnkGotoState,
     nnkFuncDef = skipEnumValue(nimHasNkBreakStateNodeRemoved, nnkGotoState, 2),
     nnkTupleConstr,
-    nnkError,  ## erroneous AST node
-    nnkNimNodeLit
+    nnkNimNodeLit = skipEnumValue(nimskullNoNkNone, nnkTupleConstr)
 
   NimNodeKinds* = set[NimNodeKind]
   NimTypeKind* = enum  # some types are no longer used, see ast.nim

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -47,7 +47,8 @@ template skipEnumValue(define: untyped, predecessor: untyped; gap = 1): untyped 
 
 type
   NimNodeKind* = enum
-    nnkNone, nnkEmpty, nnkIdent, nnkSym,
+    nnkEmpty = skipEnumValue(nimskullNoNkNone, -1),
+    nnkIdent, nnkSym,
     nnkType, nnkCharLit, nnkIntLit, nnkInt8Lit,
     nnkInt16Lit, nnkInt32Lit, nnkInt64Lit, nnkUIntLit, nnkUInt8Lit,
     nnkUInt16Lit, nnkUInt32Lit, nnkUInt64Lit, nnkFloatLit,
@@ -843,8 +844,6 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indent
     res.add(" " & $n.floatVal)
   of nnkStrLit .. nnkTripleStrLit, nnkCommentStmt, nnkIdent, nnkSym:
     res.add(" " & $n.strVal.newLit.repr)
-  of nnkNone:
-    assert false
   elif n.kind in {nnkOpenSymChoice, nnkClosedSymChoice} and collapseSymChoice:
     res.add(" " & $n.len)
     if n.len > 0:
@@ -885,7 +884,7 @@ proc astGenRepr*(n: NimNode): string {.benign.} =
   ## See also `repr`, `treeRepr`, and `lispRepr`.
 
   const
-    NodeKinds = {nnkEmpty, nnkIdent, nnkSym, nnkNone, nnkCommentStmt}
+    NodeKinds = {nnkEmpty, nnkIdent, nnkSym, nnkCommentStmt}
     LitKinds = {nnkCharLit..nnkInt64Lit, nnkFloatLit..nnkFloat64Lit, nnkStrLit..nnkTripleStrLit}
 
   proc traverse(res: var string, level: int, n: NimNode) {.benign.} =
@@ -906,7 +905,6 @@ proc astGenRepr*(n: NimNode): string {.benign.} =
     of nnkFloatLit..nnkFloat64Lit: res.add($n.floatVal)
     of nnkStrLit..nnkTripleStrLit, nnkCommentStmt, nnkIdent, nnkSym:
       res.add(n.strVal.newLit.repr)
-    of nnkNone: assert false
     elif n.kind in {nnkOpenSymChoice, nnkClosedSymChoice} and collapseSymChoice:
       res.add(", # unrepresentable symbols: " & $n.len)
       if n.len > 0:
@@ -1098,7 +1096,7 @@ proc last*(node: NimNode): NimNode = node[node.len-1]
 const
   RoutineNodes* = {nnkProcDef, nnkFuncDef, nnkMethodDef, nnkDo, nnkLambda,
                    nnkIteratorDef, nnkTemplateDef, nnkConverterDef, nnkMacroDef}
-  AtomicNodes* = {nnkNone..nnkNilLit}
+  AtomicNodes* = {nnkEmpty..nnkNilLit}
   CallNodes* = {nnkCall, nnkInfix, nnkPrefix, nnkPostfix, nnkCommand,
     nnkCallStrLit, nnkHiddenCallConv}
 

--- a/tests/lang_callable/macros/tdumpast2.nim
+++ b/tests/lang_callable/macros/tdumpast2.nim
@@ -13,7 +13,7 @@ proc dumpit(n: NimNode): string {.compileTime.} =
   of nnkFloatLit..nnkFloat64Lit: add(result, $n.floatVal)
   of nnkStrLit..nnkTripleStrLit: add(result, n.strVal)
   of nnkIdent:                   add(result, n.strVal)
-  of nnkSym, nnkNone:            assert false
+  of nnkSym:                     assert false
   else:
     add(result, dumpit(n[0]))
     for j in 1..n.len-1:

--- a/tests/lang_callable/macros/tincremental.nim
+++ b/tests/lang_callable/macros/tincremental.nim
@@ -41,7 +41,7 @@ macro graph_discovery(n: typed{nkSym}): untyped =
   var visited: seq[NimNode]
   proc discover(n: NimNode) = 
     case n.kind:
-      of nnkNone..pred(nnkSym), succ(nnkSym)..nnkNilLit: discard
+      of nnkEmpty..pred(nnkSym), succ(nnkSym)..nnkNilLit: discard
       of nnkSym:
         if n.symKind in {nskFunc, nskProc}:
           if n notin visited:

--- a/tests/lang_callable/macros/tmacro3.nim
+++ b/tests/lang_callable/macros/tmacro3.nim
@@ -21,7 +21,7 @@ macro test2*(a: untyped): untyped =
     echo "That's weird"
     var o : NimNode = nil
     echo "  no its not!"
-    o = newNimNode(nnkNone)
+    o = newNimNode(nnkEmpty)
     if recurse > 0:
       testproc(recurse - 1)
   testproc(5)

--- a/tests/lang_callable/macros/trecmacro.nim
+++ b/tests/lang_callable/macros/trecmacro.nim
@@ -6,7 +6,7 @@ discard """
 
 macro dump(n: untyped): untyped =
   dump(n)
-  if kind(n) == nnkNone:
+  if kind(n) == nnkEmpty:
     nil
   else:
     hint($kind(n))

--- a/tests/lang_callable/template/tparams_gensymed.nim
+++ b/tests/lang_callable/template/tparams_gensymed.nim
@@ -30,7 +30,7 @@ template genNodeKind(kind, name: untyped) =
     for c in children:
       result.add(c)
 
-genNodeKind(nnkNone, None)
+genNodeKind(nnkEmpty, None)
 
 
 # Test that generics in templates still work (regression to fix #1915)

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -2,7 +2,7 @@ discard """
   description: "`defer` must have exactly one child node (macro input)."
   errormsg: "illformed AST"
   file: "macros.nim"
-  line: 619
+  line: 618
 """
 
 import std/macros

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -2,7 +2,7 @@ discard """
   description: "`defer` must have exactly one child node (macro input)."
   errormsg: "illformed AST"
   file: "macros.nim"
-  line: 618
+  line: 619
 """
 
 import std/macros


### PR DESCRIPTION
## Summary
* Remove `nkNone` and replace it with `nkError`
* Move some  `nkError`  branches to the start of the their case
statements

## Details
`nkNone`  could be replaced by either  `nkEmpty`  or  `nkError` . I've
decided for  `nkError`  here, as  `nkNone`  nodes already signified
errors, albeit compiler bugs.
That means that an uninitialized node that would previously be of kind 
`nkNone`  is now of kind  `nkError`  and will cause a crash if it's
uninitialized  `diag`  field is accessed.
This is IMO preferable to  silently bubbling up uninitialized nodes
(that signify a compiler bug), but should not actually matter in
practice, as I don't think there are any recent or open known cases
where  `nkNone`  nodes were actually produced.