### PR TITLE
forbid hook routines raising exceptions

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -422,6 +422,7 @@ type
     rsemCallingConventionMismatch
     rsemHasSideEffects
     rsemCantPassProcvar
+    rsemHookCannotRaise
     rsemUnlistedRaises
     rsemUnlistedEffects
     rsemOverrideSafetyMismatch

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1303,6 +1303,9 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemXCannotRaiseY:
       result = "'$1' cannot raise '$2'" % [r.ast.render, r.raisesList.render]
 
+    of rsemHookCannotRaise:
+      result = "a hook routine is not allowed to raise. ($1)" % r.typ.render
+
     of rsemUnlistedRaises, rsemWarnUnlistedRaises:
       result.add("$1 can raise an unlisted exception: " % r.ast.render,
                  r.typ.render)

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2058,6 +2058,10 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
 
   c.scopeDepth = 1
   c.add MirNode(kind: mnkScope)
+  if sfNeverRaises in owner.flags:
+    c.add MirNode(kind: mnkTry, len: 1)
+    c.add MirNode(kind: mnkStmtList)
+
   if owner.kind in routineKinds:
     # add a 'def' for each ``sink`` parameter. This simplifies further
     # processing and analysis
@@ -2070,6 +2074,21 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
           c.add MirNode(kind: mnkNone)
 
   gen(c, body)
+
+  if sfNeverRaises in owner.flags:
+    # if it's enforced that the procedure never raises, exceptions escaping
+    # the procedure terminate the program. This is achieved by wrapping the
+    # body in a catch-all exception handler
+    c.add endNode(mnkStmtList)
+    c.subTree MirNode(kind: mnkExcept, len: 1):
+      c.subTree mnkBranch:
+        c.subTree mnkVoid:
+          let p = c.graph.getCompilerProc("nimUnhandledException")
+          c.builder.buildCall c.env.procedures.add(p), p.typ,
+                              typeOrVoid(c, p.typ[0]):
+            discard
+    c.add endNode(mnkTry)
+
   c.add endNode(mnkScope)
 
   swap(c.env, env) # swap back

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -225,7 +225,9 @@ proc buildError(c: TCtx, thread: VmThread, event: sink VmEvent): ExecErrorReport
   ## Creates an `ExecErrorReport` with the `event` and a stack-trace for
   ## `thread`
   let stackTrace =
-    if event.kind == vmEvtUnhandledException:
+    if event.kind == vmEvtUnhandledException and event.trace.len > 0:
+      # HACK: an unhandled exception can be reported without providing a trace.
+      #       Ideally, that shouldn't happen
       createStackTrace(c, event.trace)
     else:
       createStackTrace(c, thread)

--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -428,3 +428,13 @@ proc errorReportToString*(c: ConfigRef, error: Report): string =
               # the report, so need to add `"Error: "`
               # manally to stay consistent with the old
               # output.
+
+proc toExceptionAst*(name, msg: sink string): PNode =
+  ## Creates the AST as for an exception object as expected by the report.
+  # TODO: the report should take the two strings directly instead
+  let empty = newNode(nkEmpty)
+  newTree(nkObjConstr,
+          empty, # constructor type; unused
+          empty, # unused
+          newStrNode(nkStrLit, name),
+          newStrNode(nkStrLit, msg))

--- a/lib/std/tasks.nim
+++ b/lib/std/tasks.nim
@@ -61,7 +61,7 @@ type
   Task* = object ## `Task` contains the callback and its arguments.
     callback: proc (args: pointer) {.nimcall, gcsafe.}
     args: pointer
-    destroy: proc (args: pointer) {.nimcall, gcsafe.}
+    destroy: proc (args: pointer) {.nimcall, gcsafe, raises: [].}
 
 
 proc `=copy`*(x: var Task, y: Task) {.error.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2348,6 +2348,9 @@ elif isNimVmTarget:
   proc prepareException(e: ref Exception, ename: cstring) {.compilerproc.} =
     discard
 
+  proc nimUnhandledException() {.compilerproc.} =
+    discard
+
   proc closureIterSetupExc(e: ref Exception) {.compilerproc, inline.} =
     ## Used by the closure transformation pass for preparing for exception
     ## handling. Implemented as a callback.

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -427,6 +427,12 @@ when true:
       currException = nil
       quit(1)
 
+proc nimUnhandledException() {.compilerproc, noreturn.} =
+  ## Called from generated code when propgation of an exception crosses a
+  ## routine boundary it shouldn't.
+  reportUnhandledError(currException)
+  quit(1)
+
 proc pushActiveException(e: sink(ref Exception)) =
   e.up = activeException
   activeException = e

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -115,8 +115,7 @@ proc writeStackTrace() =
 proc getStackTrace*(): string = rawWriteStackTrace()
 proc getStackTrace*(e: ref Exception): string = e.trace
 
-proc unhandledException(e: ref Exception) {.
-    compilerproc, asmNoStackFrame.} =
+proc unhandledExceptionString(e: ref Exception): string =
   var buf = ""
   if e.msg.len != 0:
     add(buf, "Error: unhandled exception: ")
@@ -128,7 +127,11 @@ proc unhandledException(e: ref Exception) {.
   add(buf, "]\n")
   when NimStackTrace:
     add(buf, rawWriteStackTrace())
-  let cbuf = cstring(buf)
+  result = buf
+
+proc unhandledException(e: ref Exception) {.
+    compilerproc, asmNoStackFrame.} =
+  let cbuf = cstring(unhandledExceptionString(e))
   framePtr = nil
   {.emit: """
   if (typeof(Error) !== "undefined") {
@@ -142,13 +145,25 @@ proc unhandledException(e: ref Exception) {.
 proc nimUnhandledException() {.compilerproc, asmNoStackFrame.} =
   # |NimSkull| exceptions are turned into JavaScript errors for the purpose
   # of better error messages
-  asm """
-    if (lastJSError.m_type !== undefined) {
-      `unhandledException`(lastJSError);
-    } else {
-      throw lastJSError;
-    }
-  """
+  when defined(nodejs):
+    {.emit: """
+      if (lastJSError.m_type !== undefined) {
+        console.log(`toJSStr`(`unhandledExceptionString`(`lastJSError`)));
+      } else {
+        console.log('Error: unhandled exception: ', `lastJSError`)
+      }
+      process.exit(1);
+    """.}
+  else:
+    # it's currently not possible to truly panic (abort excution) for non-
+    # node.js JavaScript
+    {.emit: """
+      if (lastJSError.m_type !== undefined) {
+        `unhandledException`(lastJSError);
+      } else {
+        throw lastJSError;
+      }
+    """.}
 
 proc prepareException(e: ref Exception, ename: cstring) {.
     compilerproc, asmNoStackFrame.} =

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -139,6 +139,17 @@ proc unhandledException(e: ref Exception) {.
   }
   """.}
 
+proc nimUnhandledException() {.compilerproc, asmNoStackFrame.} =
+  # |NimSkull| exceptions are turned into JavaScript errors for the purpose
+  # of better error messages
+  asm """
+    if (lastJSError.m_type !== undefined) {
+      `unhandledException`(lastJSError);
+    } else {
+      throw lastJSError;
+    }
+  """
+
 proc prepareException(e: ref Exception, ename: cstring) {.
     compilerproc, asmNoStackFrame.} =
   if e.name.isNil:

--- a/lib/system/orc.nim
+++ b/lib/system/orc.nim
@@ -27,7 +27,7 @@ const
   logOrc = defined(nimArcIds)
 
 type
-  TraceProc = proc (p, env: pointer) {.nimcall, benign.}
+  TraceProc = proc (p, env: pointer) {.nimcall, benign, raises: [], tags: [].}
   DisposeProc = proc (p: pointer) {.nimcall, benign.}
 
 template color(c): untyped = c.rc and colorMask
@@ -472,7 +472,7 @@ proc GC_prepareOrc*(): int {.inline.} = roots.len
 proc GC_partialCollect*(limit: int) =
   partialCollect(limit)
 
-proc GC_fullCollect* =
+proc GC_fullCollect*() {.raises: [].} =
   ## Forces a full garbage collection pass. With `--gc:orc` triggers the cycle
   ## collector. This is an alias for `GC_runOrc`.
   collectCycles()

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -112,7 +112,8 @@ type
     x: int
 
 proc `=destroy`(x: var AObj) =
-  close(x.io)
+  {.cast(raises: []).}:
+    close(x.io)
   echo "closed"
 
 var x = B(io: newStringStream("thestream"))

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -33,17 +33,17 @@ scope:
   def_cursor _0: Node = target[]
   def_cursor _1: Node = _0[].parent
   def sibling: Node
-  =copy(name sibling, arg _1[].left) (raises)
+  =copy(name sibling, arg _1[].left)
   def_cursor _2: Node = sibling
   def saved: Node
-  =copy(name saved, arg _2[].right) (raises)
+  =copy(name saved, arg _2[].right)
   def_cursor _3: Node = sibling
   def_cursor _4: Node = saved
   def_cursor _6: Node = _4[].left
-  =copy(name _3[].right, arg _6) (raises)
+  =copy(name _3[].right, arg _6)
   def_cursor _5: Node = sibling
-  =sink(name _5[].parent, arg saved) (raises)
-  =destroy(name sibling) (raises)
+  =sink(name _5[].parent, arg saved)
+  =destroy(name sibling)
 -- end of expandArc ------------------------
 --expandArc: p1
 
@@ -130,7 +130,7 @@ scope:
 scope:
   try:
     def shadowScope: Scope
-    =copy(name shadowScope, arg c[].currentScope) (raises)
+    =copy(name shadowScope, arg c[].currentScope)
     rawCloseScope(arg c) (raises)
     scope:
       def_cursor _0: Scope = shadowScope
@@ -157,7 +157,7 @@ scope:
                   addInterfaceDecl(arg c, consume _6) (raises)
                 i = addI(arg i, arg 1) (raises)
   finally:
-    =destroy(name shadowScope) (raises)
+    =destroy(name shadowScope)
 -- end of expandArc ------------------------
 --expandArc: treturn
 

--- a/tests/errmsgs/tprefer_raise_spec_error.nim
+++ b/tests/errmsgs/tprefer_raise_spec_error.nim
@@ -1,0 +1,16 @@
+discard """
+  description: '''
+    An error for violating the explicit `.raises` specification is preferred
+    over the error that hooks cannot raise
+  '''
+  errormsg: "doRaise() can raise an unlisted exception: ref CatchableError"
+  line: 16
+"""
+
+type Obj = object
+
+proc doRaise() =
+  raise CatchableError.newException("")
+
+proc `=copy`(a: var Obj, b: Obj) {.raises: [].} =
+  doRaise()

--- a/tests/gc/gctest.nim
+++ b/tests/gc/gctest.nim
@@ -60,8 +60,7 @@ proc caseTree(lvl: int = 0): PCaseNode =
 
 proc `=destroy`(n: var TNode) =
   assert(addr(n) != nil)
-  write(stdout, "finalizing: ")
-  writeLine(stdout, "not nil")
+  debugEcho "finalizing: not nil"
 
 var
   id: int = 1

--- a/tests/lang/s02_core/s99_hooks/README.md
+++ b/tests/lang/s02_core/s99_hooks/README.md
@@ -1,0 +1,21 @@
+## What belongs here
+
+This section contains tests related to hook procedures, that is, procedures:
+- to which calls are statically inserted by the compiler
+- that are invoked by the runtime at run-time
+
+This should cover:
+- syntax
+- restrictions on the routine definitions
+- restrictions on the run-time behaviour (if any)
+- where the hooks are injected
+
+## Assumptions
+
+- nothing beyond a single module/file
+- assertions may still be built-ins
+- user-defined types are supported and work
+- procedures and calls thereof work
+- `var T` is supported as a parameter's type
+- raising and catching exceptions work
+- tag effect tracking works

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/README.md
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/README.md
@@ -1,0 +1,3 @@
+If a Defect is raised from a hook routine at run-time, the program immediately
+terminates (i.e., panics) and an unhandled exception is reported. This is the
+case for both automatic and explicit calls of the hooks.

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t01_copy_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t01_copy_hook.nim
@@ -1,0 +1,17 @@
+discard """
+  description: "`=copy` hooks panic when a defect escapes"
+  outputsub: "Error: unhandled exception:  [Defect]"
+  exitcode: 1
+"""
+
+type Type = object
+
+proc `=copy`(a: var Type, b: Type) =
+  raise (ref Defect)()
+
+try:
+  var x: Type
+  `=copy`(x, Type())
+finally:
+  # finally sections are not reached and no cleanup is performed
+  doAssert false

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t01_copy_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t01_copy_hook.nim
@@ -1,13 +1,13 @@
 discard """
   description: "`=copy` hooks panic when a defect escapes"
-  outputsub: "Error: unhandled exception:  [Defect]"
+  outputsub: "Error: unhandled exception: error [Defect]"
   exitcode: 1
 """
 
 type Type = object
 
 proc `=copy`(a: var Type, b: Type) =
-  raise (ref Defect)()
+  raise (ref Defect)(msg: "error")
 
 try:
   var x: Type

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t02_sink_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t02_sink_hook.nim
@@ -1,0 +1,17 @@
+discard """
+  description: "`=sink` hooks panic when a defect escapes"
+  outputsub: "Error: unhandled exception:  [Defect]"
+  exitcode: 1
+"""
+
+type Type = object
+
+proc `=sink`(a: var Type, b: Type) =
+  raise (ref Defect)()
+
+try:
+  var x: Type
+  `=sink`(x, Type())
+finally:
+  # finally sections are not reached and no cleanup is performed
+  doAssert false

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t02_sink_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t02_sink_hook.nim
@@ -1,13 +1,13 @@
 discard """
   description: "`=sink` hooks panic when a defect escapes"
-  outputsub: "Error: unhandled exception:  [Defect]"
+  outputsub: "Error: unhandled exception: error [Defect]"
   exitcode: 1
 """
 
 type Type = object
 
 proc `=sink`(a: var Type, b: Type) =
-  raise (ref Defect)()
+  raise (ref Defect)(msg: "error")
 
 try:
   var x: Type

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t03_destroy_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t03_destroy_hook.nim
@@ -1,0 +1,17 @@
+discard """
+  description: "`=destroy` hooks panic when a defect escapes"
+  outputsub: "Error: unhandled exception:  [Defect]"
+  exitcode: 1
+"""
+
+type Type = object
+
+proc `=destroy`(a: var Type) =
+  raise (ref Defect)()
+
+try:
+  var x: Type
+  `=destroy`(x)
+finally:
+  # finally sections are not reached and no cleanup is performed
+  doAssert false

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t03_destroy_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t03_destroy_hook.nim
@@ -1,13 +1,13 @@
 discard """
   description: "`=destroy` hooks panic when a defect escapes"
-  outputsub: "Error: unhandled exception:  [Defect]"
+  outputsub: "Error: unhandled exception: error [Defect]"
   exitcode: 1
 """
 
 type Type = object
 
 proc `=destroy`(a: var Type) =
-  raise (ref Defect)()
+  raise (ref Defect)(msg: "error")
 
 try:
   var x: Type

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t04_trace_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t04_trace_hook.nim
@@ -1,13 +1,13 @@
 discard """
   description: "`=trace` hooks panic when a defect escapes"
-  outputsub: "Error: unhandled exception:  [Defect]"
+  outputsub: "Error: unhandled exception: error [Defect]"
   exitcode: 1
 """
 
 type Type = object
 
 proc `=trace`(a: var Type, p: pointer) =
-  raise (ref Defect)()
+  raise (ref Defect)(msg: "error")
 
 try:
   var x: Type

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t04_trace_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t04_trace_hook.nim
@@ -1,0 +1,17 @@
+discard """
+  description: "`=trace` hooks panic when a defect escapes"
+  outputsub: "Error: unhandled exception:  [Defect]"
+  exitcode: 1
+"""
+
+type Type = object
+
+proc `=trace`(a: var Type, p: pointer) =
+  raise (ref Defect)()
+
+try:
+  var x: Type
+  `=trace`(x, nil)
+finally:
+  # finally sections are not reached and no cleanup is performed
+  doAssert false

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t05_deepcopy_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t05_deepcopy_hook.nim
@@ -1,13 +1,13 @@
 discard """
-  description: "`=copy` hooks panic when a defect escapes"
-  outputsub: "Error: unhandled exception:  [Defect]"
+  description: "`=deepcopy` hooks panic when a defect escapes"
+  outputsub: "Error: unhandled exception: error [Defect]"
   exitcode: 1
 """
 
 type Type = ref object
 
 proc `=deepcopy`(a: Type): Type =
-  raise (ref Defect)()
+  raise (ref Defect)(msg: "error")
 
 try:
   var x = `=deepcopy`(Type())

--- a/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t05_deepcopy_hook.nim
+++ b/tests/lang/s02_core/s99_hooks/s99_escaping_defects/t05_deepcopy_hook.nim
@@ -1,0 +1,16 @@
+discard """
+  description: "`=copy` hooks panic when a defect escapes"
+  outputsub: "Error: unhandled exception:  [Defect]"
+  exitcode: 1
+"""
+
+type Type = ref object
+
+proc `=deepcopy`(a: Type): Type =
+  raise (ref Defect)()
+
+try:
+  var x = `=deepcopy`(Type())
+finally:
+  # finally sections are not reached and no cleanup is performed
+  doAssert false

--- a/tests/lang/s02_core/s99_hooks/t99_cannot_raise.nim
+++ b/tests/lang/s02_core/s99_hooks/t99_cannot_raise.nim
@@ -1,0 +1,30 @@
+discard """
+  description: '''
+    Hook routines are not allowed to raise exception. If they're inferred to
+    raise, a compile-time error is reported.
+  '''
+  action: reject
+  matrix: "--errorMax:5"
+"""
+
+type Type = object
+
+proc `=copy`(a: var Type, b: Type) =
+  raise (ref CatchableError)() #[tt.Error
+  ^ a hook routine is not allowed to raise. (ref CatchableError)]#
+
+proc `=sink`(a: var Type, b: Type) =
+  raise (ref CatchableError)() #[tt.Error
+  ^ a hook routine is not allowed to raise. (ref CatchableError)]#
+
+proc `=destroy`(a: var Type) =
+  raise (ref CatchableError)() #[tt.Error
+  ^ a hook routine is not allowed to raise. (ref CatchableError)]#
+
+proc `=trace`(a: var Type, env: pointer) =
+  raise (ref CatchableError)() #[tt.Error
+  ^ a hook routine is not allowed to raise. (ref CatchableError)]#
+
+proc `=deepCopy`(a: ref Type): ref Type =
+  raise (ref CatchableError)() #[tt.Error
+  ^ a hook routine is not allowed to raise. (ref CatchableError)]#

--- a/tests/misc/tnew.nim
+++ b/tests/misc/tnew.nim
@@ -20,8 +20,7 @@ type
   TStressTest = ref array[0..45, array[1..45, TNode]]
 
 proc `=destroy`(n: var TNode) =
-  write(stdout, n.data)
-  write(stdout, " is now freed\n")
+  debugEcho n.data, " is now freed"
 
 proc newNode(data: int, le, ri: PNode): PNode =
   new(result)


### PR DESCRIPTION
## Summary

This is enforced as follows:
* if a hook routine potentially raises an exception, a compile-time
  error is reported
* if a hook routine raises a defect at run-time, the program panics

Exception effects of hooks side-steps effect tracking for
procedures, and if a hook does raise at run-time, behaviour was
previously undefined. Disallowing hooks to raise exceptions resolves
both issues.

Performance of the produced executables also improves significantly
(depending on the code), as destroy hooks not being able to raise
results in better code generation.

## Details

The implementation is made up of three parts:
* statically enforcing that no exceptions are raised by hooks (in
  `sempass2`)
* preventing exceptions from exiting hooks at run-time (in `mirgen`/
  `liftdestructors`)
* support in the runtime for panicking on unhandled exceptions

### Static Detection

* for hooks, identified by the presence of the `sfOverriden` flag,
  `sempass2` tests against an empty `.raises` specification, ensuring
  that no (tracked) exceptions can be raised
* the existing exception specification is always replaced
* no error is reported when `.raises: []` was explicitly specified, to
  give precedence to the `can raise unlisted exception` error.
* the symbol of hooks is marked with `sfNeverRaises`, to enforce at
  run-time that no exceptions (defects) leave the routine

The meaning of `sfNeverRaises` is changed from being a hint/guarantee
to being a request.

### Enforcement

* `mirgen` wraps the body of `sfNeverRaises` procedure in a
  `try: ... except: nimUnhandledException()`
* elimination of unreachable code in `cgirgen` removes the `except` if
  it's not used in practice
* all synthesized hook procedure (`liftdestructors`) are flagged with
  `sfNeverRaises`; the `canRaise` tracking is removed

### Runtimes

* C runtime: `nimUnhandledException` displays the exception and quits
  the process
* node.js JS runtime: `nimUnhandledException` displays the exception
  and quits the process
* non-node.js JS runtime: `nimUnhandledException` re-raises the
  exception (there's currently no way to terminate the program)
* VM: `nimUnhandledException` is a  `vmop` that raises a
  `vmEvtUnhandledException` event, which aborts execution

### Standard Library and Tests

* fix the `Task` `=destroy` hook being inferred to raise exceptions
* fix `GC_fullCollect` being inferred to raise exceptions

### Tests

Three individual tests need to be adjusted to the language change:
* `tnew` and `gctest` use `debugEcho` instead of `write` (the former
  has no effects)
* `tarcmisc` has to cast away the raise effects of `Stream.close` for
  now

### Specification

The beginnings of a specification test category for hook routines is
added. At the moment, it only covers the exception behaviour.