### PR TITLE
std/macros: const for nodes requring special init

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -149,9 +149,13 @@ type
 
 const
   nnkLiterals* = {nnkCharLit..nnkNilLit}
+    ## `NimNodeKind`s that represent syntax literals
   nnkCallKinds* = {nnkCall, nnkInfix, nnkPrefix, nnkPostfix, nnkCommand,
                    nnkCallStrLit}
   nnkPragmaCallKinds = {nnkExprColonExpr, nnkCall, nnkCallStrLit}
+  nnkRequireInitKinds* = {nnkError, nnkIdent, nnkSym, nnkType}
+    ## `NimNodeKind`s that require initialization and cannot be created via
+    ## general construction routines e.g. `newNimNode`.
 
 proc `==`*(a, b: NimNode): bool {.magic: "EqNimrodNode", noSideEffect.}
   ## Compare two Nim nodes. Return true if nodes are structurally

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -2,7 +2,7 @@ discard """
   description: "`defer` must have exactly one child node (macro input)."
   errormsg: "illformed AST"
   file: "macros.nim"
-  line: 618
+  line: 622
 """
 
 import std/macros

--- a/tests/stdlib/metaprogramming/tmacros.nim
+++ b/tests/stdlib/metaprogramming/tmacros.nim
@@ -144,3 +144,13 @@ block: # extractDocCommentsAndRunnables
     
   proc c() {.checkComments("Hello world").} =
     ## Hello world
+
+block some_node_kinds_require_specialize_initialization:
+  ## ensure we can init all the rest as a "negative" test
+  const kindsNotRequiringInit = {low(NimNodeKind)..high(NimNodeKind)} -
+                                  nnkRequireInitKinds
+
+  doAssert kindsNotRequiringInit.len > 0
+
+  for k in kindsNotRequiringInit.items:
+    discard newNimNode(k)

--- a/tests/stdlib/metaprogramming/tmacros.nim
+++ b/tests/stdlib/metaprogramming/tmacros.nim
@@ -150,7 +150,8 @@ block some_node_kinds_require_specialize_initialization:
   const kindsNotRequiringInit = {low(NimNodeKind)..high(NimNodeKind)} -
                                   nnkRequireInitKinds
 
-  doAssert kindsNotRequiringInit.len > 0
+  static:
+    doAssert kindsNotRequiringInit.len > 0
 
-  for k in kindsNotRequiringInit.items:
-    discard newNimNode(k)
+    for k in kindsNotRequiringInit.items:
+      discard newNimNode(k)


### PR DESCRIPTION
## Summary

Introduce a constant  `nnkRequireInitKinds`  for all nodes that require
special initialization, and therefore cannot be constructed via 
`newNimNode` . This allows imports of  `std/macros`  that construct
arbitrary nodes to create a filter.

## Details

Added the constant to  `std/macros` , with export, as well as a test to
ensure we can detect any node kinds not in the list in  `tmacros` .