### PR TITLE
sem: remove float analysis from `sem/guards`

### DIFF
--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -39,14 +39,22 @@ from compiler/ast/reports_sem import reportAst,
 from compiler/ast/report_enums import ReportKind
 
 const
-  someEq = {mEqI, mEqF64, mEqEnum, mEqCh, mEqB, mEqRef, mEqProc,
+  # Float operations are not analysed as
+  # it is currently unclear wether they
+  # can be analysed in a sound manner
+  # with the approach used here
+  someEq = {mEqI, mEqEnum, mEqCh, mEqB, mEqRef, mEqProc,
     mEqStr, mEqSet, mEqCString}
+    # `mEqF64` excluded here as it lacks the
+    # substition and reflexivity property
 
   # set excluded here as the semantics are vastly different:
-  someLe = {mLeI, mLeF64, mLeU, mLeEnum,
+  someLe = {mLeI, mLeU, mLeEnum,
             mLeCh, mLeB, mLePtr, mLeStr}
+    # `mLeF64` excluded here since it's not a total order
   someLt = {mLtI, mLtF64, mLtU, mLtEnum,
             mLtCh, mLtB, mLtPtr, mLtStr}
+    # `mLtF64` excluded here since it's not a strict total order
 
   someLen = {mLengthOpenArray, mLengthStr, mLengthArray, mLengthSeq}
 
@@ -55,10 +63,14 @@ const
   someHigh = {mHigh}
   # we don't list unsigned here because wrap around semantics suck for
   # proving anything:
-  someAdd = {mAddI, mAddF64, mSucc}
-  someSub = {mSubI, mSubF64, mPred}
-  someMul = {mMulI, mMulF64}
-  someDiv = {mDivI, mDivF64}
+  someAdd = {mAddI, mSucc}
+    # No `mAddF64` since float ops aren't analysed
+  someSub = {mSubI, mPred}
+    # No `mSubF64` since float ops aren't analysed
+  someMul = {mMulI}
+    # No `mMulF64` since float ops aren't analysed
+  someDiv = {mDivI}
+    # No `mDivF64` since float ops aren't analysed
   someMax = {mMaxI}
   someMin = {mMinI}
   someBinaryOp = someAdd+someSub+someMul+someMax+someMin

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -40,7 +40,7 @@ from compiler/ast/report_enums import ReportKind
 
 const
   # Float operations are not analysed as
-  # it is currently unclear wether they
+  # it is currently unclear whether they
   # can be analysed in a sound manner
   # with the approach used here
   someEq = {mEqI, mEqEnum, mEqCh, mEqB, mEqRef, mEqProc,


### PR DESCRIPTION
## Summary

Remove float analysis from `sem/guards` since it's currently unsound.

## Details

`sem/guards`  is only used for static bounds checking (
`--staticBoundChecks` ),  `not nil`  checking, warning for checked field
accesses ( `--warning:ProveField` ) and field accesses of fields
annotated with  `{.guard: ...}` .
Since object variants with a  `float`  discriminator are invalid and
bound checks only concern integers, only conversions to float range
types would be affected under  `--staticBoundChecks` .

It's not clear whether the analysis method here can work with floats
without special treatment in a lot of cases, due to float equality
lacking the subsitution and reflexivity property or the comparison
relations not being total.