### PR TITLE
internal: fix an incorrect assertion

### DIFF
--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -794,7 +794,9 @@ proc lowerBranchSwitch(bu: var MirBuilder, body: MirTree, graph: ModuleGraph,
     typ = body[target].field.typ
 
   assert body[target].kind == mnkPathVariant
-  assert body[stmt, 1].kind in ModifierNodes
+  # the source expression must either be an rvalue, or there must be a
+  # modifier present
+  assert body[stmt, 1].kind notin LvalueExprKinds
 
   let
     a = bu.wrapMutAlias(typ):


### PR DESCRIPTION
## Summary

An assertion in the `injectdestructors` module was incorrect, which led
to the compiler aborting on `x.a = f()` assignments, where `a` is a
discriminator field.

## Details

Only raw lvalue expressions must not appear as the source operand of a
branch-switch assignment, rvalue expression (which aren't included in
`ModifierNodes`) are okay.