### PR TITLE
CI: Workaround leak sanitizer test failures due to high `vm.mmap_rnd_bits` 

### DIFF
--- a/.github/workflows/leak.yml
+++ b/.github/workflows/leak.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Decrease kernel address randomization
+        # Works around https://github.com/actions/runner-images/issues/9491
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
Works around a leak sanitizer crash when  `vm.mmap_rnd_bits`  is 32 bits
by setting it to 28. This currently blocks all CI runs.

See https://github.com/actions/runner-images/issues/9491