### PR TITLE
sem: `NimNode` equality respects `nkType`'s type

### DIFF
--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -97,7 +97,6 @@ makeTreeEquivalenceProc(exprStructuralEquivalentStrictSymAndComm,
   relaxedKindCheck = false,
   symCheck     = a.sym == b.sym,
   floatCheck   = sameFloatIgnoreNan(a.floatVal, b.floatVal),
-  typeCheck    = true,
   typeCheck    = a.typ == b.typ,
   commentCheck = a.comment == b.comment
 )

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -98,6 +98,7 @@ makeTreeEquivalenceProc(exprStructuralEquivalentStrictSymAndComm,
   symCheck     = a.sym == b.sym,
   floatCheck   = sameFloatIgnoreNan(a.floatVal, b.floatVal),
   typeCheck    = true,
+  typeCheck    = a.typ == b.typ,
   commentCheck = a.comment == b.comment
 )
 export exprStructuralEquivalentStrictSymAndComm

--- a/tests/lang_callable/macros/tmacros_various.nim
+++ b/tests/lang_callable/macros/tmacros_various.nim
@@ -13,6 +13,7 @@ macrocache ok
 CommentStmt "comment 1"
 CommentStmt "comment 2"
 false
+false
 '''
 
   output: '''
@@ -365,4 +366,23 @@ block:
       discard
     except Exception2:
       discard
+  )
+
+  macro checkEqOfTry(a, b: typed) =
+    echo a[0][1][1] == b[0][1][1]
+
+  checkEqOfTry (;
+    block:
+      type E = object of Exception1
+      try:
+        discard
+      except E:
+        discard
+  ), (;
+    block:
+      type E = object of Exception2
+      try:
+        discard
+      except E:
+        discard
   )

--- a/tests/lang_callable/macros/tmacros_various.nim
+++ b/tests/lang_callable/macros/tmacros_various.nim
@@ -12,6 +12,7 @@ Infix
 macrocache ok
 CommentStmt "comment 1"
 CommentStmt "comment 2"
+false
 '''
 
   output: '''
@@ -346,3 +347,22 @@ block:
   static:
     echo treeRepr(C1[1])
     echo treeRepr(C2[1])
+
+block:
+  # Ensure nkType equality is not ignored by `==` for NimNode
+  macro checkEq(a, b: typed) =
+    echo a == b
+
+  type Exception1 = object of Exception
+  type Exception2 = object of Exception
+  checkEq (;
+    try:
+      discard
+    except Exception1:
+      discard
+  ), (;
+    try:
+      discard
+    except Exception2:
+      discard
+  )


### PR DESCRIPTION
## Summary
`exprStructuralEquivalentStrictSymAndComm`  no longer ignores type
equality for  `nkType`  nodes.
This affects  ``macros.`==` ``  for NimNodes and  `macrocache.incl` 
(and  `ic` ).

## Details
A test using ``macros.`==` `` has been added.