### PR TITLE
make locals' lifetimes bounded by lexical scope for `if`

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1459,12 +1459,13 @@ proc genIf(c: var TCtx, n: PNode, dest: Destination) =
 
   template genElifBranch(branch: PNode, extra: untyped) =
     ## Generates the code for a single ``nkElif(Branch|Expr)``
-    let v = genUse(c, branch[0])
-    c.subTree mnkIf:
-      c.use v
-      c.scope:
-        genBranch(c, branch.lastSon, dest)
-        extra
+    c.scope:
+      let v = genUse(c, branch[0])
+      c.subTree mnkIf:
+        c.use v
+        c.scope:
+          genBranch(c, branch.lastSon, dest)
+          extra
 
   if n.len == 1:
     # an ``if`` statement/expression with a single branch. Don't emit the

--- a/tests/arc/tcontrolflow.nim
+++ b/tests/arc/tcontrolflow.nim
@@ -1,12 +1,12 @@
 discard """
   output: '''begin A
 elif
-end A
 destroyed
+end A
 begin false
 if
-end false
 destroyed
+end false
 begin true
 if
 end true
@@ -18,6 +18,9 @@ true
 """
 # we use the -d:danger switch to detect uninitialized stack
 # slots more reliably (there shouldn't be any, of course).
+
+# XXX: the test here need to be improved and turned into a proper
+#      specification
 
 type
   Foo = object

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -7,10 +7,11 @@ scope:
   try:
     def_cursor x: (string, int) = <D0>
     block L0:
-      if cond:
-        scope:
-          x = <D1>
-          break L0
+      scope:
+        if cond:
+          scope:
+            x = <D1>
+            break L0
       scope:
         x = <D2>
     def_cursor _0: (string, int) = x
@@ -35,11 +36,13 @@ scope:
               while true:
                 scope:
                   def_cursor _1: File = f
-                  def _2: bool = readLine(arg _1, name res) (raises)
-                  def _3: bool = not(arg _2)
-                  if _3:
-                    scope:
-                      break L0
+                  def :tmp: bool = readLine(arg _1, name res) (raises)
+                  scope:
+                    def_cursor _2: bool = :tmp
+                    def _3: bool = not(arg _2)
+                    if _3:
+                      scope:
+                        break L0
                   scope:
                     scope:
                       def_cursor x: string = res

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -98,11 +98,13 @@ scope:
           while true:
             scope:
               def_cursor _1: int = i
-              def _2: bool = ltI(arg _1, arg L)
-              def _3: bool = not(arg _2)
-              if _3:
-                scope:
-                  break L0
+              def :tmp: bool = ltI(arg _1, arg L)
+              scope:
+                def_cursor _2: bool = :tmp
+                def _3: bool = not(arg _2)
+                if _3:
+                  scope:
+                    break L0
               scope:
                 scope:
                   try:
@@ -110,12 +112,13 @@ scope:
                     def line: lent string = borrow a[_4]
                     def_cursor _5: string = line[]
                     def splitted: seq[string] = split(arg _5, arg " ", arg -1) (raises)
-                    def_cursor _6: string = splitted[0]
-                    def _7: bool = eqStr(arg _6, arg "opt")
-                    if _7:
-                      scope:
-                        def_cursor _10: string = splitted[1]
-                        =copy(name lan_ip, arg _10)
+                    scope:
+                      def_cursor _6: string = splitted[0]
+                      def _7: bool = eqStr(arg _6, arg "opt")
+                      if _7:
+                        scope:
+                          def_cursor _10: string = splitted[1]
+                          =copy(name lan_ip, arg _10)
                     def_cursor _8: string = lan_ip
                     echo(arg type(array[0..0, string]), arg _8) (raises)
                     def_cursor _9: string = splitted[1]
@@ -143,11 +146,13 @@ scope:
           while true:
             scope:
               def_cursor _2: int = i
-              def _3: bool = ltI(arg _2, arg L)
-              def _4: bool = not(arg _3)
-              if _4:
-                scope:
-                  break L0
+              def :tmp: bool = ltI(arg _2, arg L)
+              scope:
+                def_cursor _3: bool = :tmp
+                def _4: bool = not(arg _3)
+                if _4:
+                  scope:
+                    break L0
               scope:
                 scope:
                   def_cursor _5: int = i
@@ -164,14 +169,15 @@ scope:
 scope:
   try:
     def x: sink string
-    def_cursor _0: sink string = x
-    def _1: int = lengthStr(arg _0)
-    def _2: bool = eqI(arg _1, arg 2)
-    if _2:
-      scope:
-        result := move x
-        wasMoved(name x)
-        return
+    scope:
+      def_cursor _0: sink string = x
+      def _1: int = lengthStr(arg _0)
+      def _2: bool = eqI(arg _1, arg 2)
+      if _2:
+        scope:
+          result := move x
+          wasMoved(name x)
+          return
     def_cursor _3: sink string = x
     def _4: int = lengthStr(arg _3)
     def _5: string = $(arg _4) (raises)
@@ -189,14 +195,15 @@ scope:
     this[].isValid = fileExists(arg _0) (raises)
     def _1: tuple[dir: string, front: string]
     block L0:
-      def_cursor _2: string = this[].value
-      def _3: bool = dirExists(arg _2) (raises)
-      if _3:
-        scope:
-          def _4: string
-          =copy(name _4, arg this[].value)
-          _1 := construct (consume _4, consume "")
-          break L0
+      scope:
+        def_cursor _2: string = this[].value
+        def _3: bool = dirExists(arg _2) (raises)
+        if _3:
+          scope:
+            def _4: string
+            =copy(name _4, arg this[].value)
+            _1 := construct (consume _4, consume "")
+            break L0
       scope:
         try:
           def_cursor _5: string = this[].value
@@ -214,15 +221,16 @@ scope:
           =destroy(name _6)
     def par: tuple[dir: string, front: string] = move _1
     block L1:
-      def_cursor _10: string = par.0
-      def _11: bool = dirExists(arg _10) (raises)
-      if _11:
-        scope:
-          def_cursor _12: string = par.0
-          def_cursor _13: string = par.1
-          def _14: seq[string] = getSubDirs(arg _12, arg _13) (raises)
-          =sink(name this[].matchDirs, arg _14)
-          break L1
+      scope:
+        def_cursor _10: string = par.0
+        def _11: bool = dirExists(arg _10) (raises)
+        if _11:
+          scope:
+            def_cursor _12: string = par.0
+            def_cursor _13: string = par.1
+            def _14: seq[string] = getSubDirs(arg _12, arg _13) (raises)
+            =sink(name this[].matchDirs, arg _14)
+            break L1
       scope:
         def _15: seq[string] = construct ()
         =sink(name this[].matchDirs, arg _15)

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -11,11 +11,13 @@ scope:
         scope:
           def_cursor _0: Node = it
           def _1: bool = eqRef(arg _0, arg nil)
-          def _2: bool = not(arg _1)
-          def _3: bool = not(arg _2)
-          if _3:
-            scope:
-              break L0
+          def :tmp: bool = not(arg _1)
+          scope:
+            def_cursor _2: bool = :tmp
+            def _3: bool = not(arg _2)
+            if _3:
+              scope:
+                break L0
           scope:
             def_cursor _4: Node = it
             def_cursor _5: string = _4[].s
@@ -29,11 +31,13 @@ scope:
         scope:
           def_cursor _7: Node = jt
           def _8: bool = eqRef(arg _7, arg nil)
-          def _9: bool = not(arg _8)
-          def _10: bool = not(arg _9)
-          if _10:
-            scope:
-              break L1
+          def :tmp: bool = not(arg _8)
+          scope:
+            def_cursor _9: bool = :tmp
+            def _10: bool = not(arg _9)
+            if _10:
+              scope:
+                break L1
           scope:
             def_cursor _11: Node = jt
             def_cursor ri: Node = _11[].ri

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -8,11 +8,12 @@ scope:
   def b: seq[seq[int]]
   def x: seq[int] = f() (raises)
   block L0:
-    if cond:
-      scope:
-        def _0: seq[int] = move x
-        add(name a, consume _0)
-        break L0
+    scope:
+      if cond:
+        scope:
+          def _0: seq[int] = move x
+          add(name a, consume _0)
+          break L0
     scope:
       def _1: seq[int] = move x
       add(name b, consume _1)
@@ -35,29 +36,33 @@ scope:
           while true:
             scope:
               def_cursor _0: int = i
-              def _1: bool = ltI(arg _0, arg b)
-              def _2: bool = not(arg _1)
-              if _2:
-                scope:
-                  break L0
+              def :tmp: bool = ltI(arg _0, arg b)
+              scope:
+                def_cursor _1: bool = :tmp
+                def _2: bool = not(arg _1)
+                if _2:
+                  scope:
+                    break L0
               scope:
                 scope:
                   def_cursor i: int = i
-                  def _3: bool = eqI(arg i, arg 2)
-                  if _3:
-                    scope:
-                      return
+                  scope:
+                    def _3: bool = eqI(arg i, arg 2)
+                    if _3:
+                      scope:
+                        return
                   def _4: seq[int]
                   =copy(name _4, arg x)
                   add(name a, consume _4)
                 i = addI(arg i, arg 1) (raises)
     block L1:
-      if cond:
-        scope:
-          def _5: seq[int] = move x
-          wasMoved(name x)
-          add(name a, consume _5)
-          break L1
+      scope:
+        if cond:
+          scope:
+            def _5: seq[int] = move x
+            wasMoved(name x)
+            add(name a, consume _5)
+            break L1
       scope:
         def _6: seq[int] = move x
         wasMoved(name x)
@@ -72,17 +77,19 @@ scope:
   try:
     def str: string
     def x: string = boolToStr(arg cond)
-    if cond:
-      scope:
-        return
+    scope:
+      if cond:
+        scope:
+          return
     def _0: string = boolToStr(arg cond)
     str := move _0
-    def _1: bool = not(arg cond)
-    if _1:
-      scope:
-        result := move str
-        wasMoved(name str)
-        return
+    scope:
+      def _1: bool = not(arg cond)
+      if _1:
+        scope:
+          result := move str
+          wasMoved(name str)
+          return
   finally:
     =destroy(name x)
     =destroy(name str)


### PR DESCRIPTION
## Summary

Temporaries and locals that start their storage duration within
`if`/`elif` condition expressions are now destroyed, if necessary,
at the end of the `if`/`elif` branch, not at the end of the `if`'s
enclosing scope. This makes the end of their storage duration
consistent with the end of their lexical scope.

## Details

Making the storage duration end at the end of the `if`/`elif` is
achieved by `mirgen` wrapping the code for each `nkElifBranch` in a
`scope`.

### `while` Lowering

Each `nkElifBranch` being wrapped in a (lifetime) scope, means that
lowering `while cond` into `while true: (if not cond: break; body)`
no longer works, since locals and temporaries starting their
storage duration during evaluation of the `cond` expression would
be destroyed at the end of the `if`, instead of at the end of the
`while`'s body.

To ensure correct and expected lifetimes, `cond` is first assigned
to a temporary, which the `if` then uses for branching. For
example, `while (let x = y; x > 1): body` is lowered by `transf`
into:
```nim
while true:
  let tmp = (let x = y; x > 1)
  if not tmp:
    break
  body
```

Turning `while cond` into `while true: (if cond: body else: break)`
would work too, but it's decide against, because:
* it, currently, results in worse cursor inference results (meaning
  more copies)
* it expands to more MIR code (more work for data-flow analysis)