### PR TITLE
fix: exception handler not entered for indirect calls

### DIFF
--- a/tests/exception/tindirect_call_raises.nim
+++ b/tests/exception/tindirect_call_raises.nim
@@ -1,0 +1,24 @@
+discard """
+  description: '''
+    Regression test for indirect calls of callables without explicit `.raises`
+    specification being treated as not being able to raise.
+
+    Refer to https://github.com/nim-works/nimskull/issues/1253
+  '''
+  matrix: "--panics:on"
+  output: "caught"
+"""
+
+# important: the procedural type must have no explicit `.raises` specification
+type Proc = proc () {.nimcall.}
+
+proc test(x: Proc) =
+  try:
+    x()
+  except CatchableError:
+    # the exception raised from `x` was previously not caught
+    echo "caught"
+
+test(proc() =
+  raise CatchableError.newException("")
+)


### PR DESCRIPTION
## Summary

Fix exception handlers sometimes being ignored for indirect calls when
building with `--panics:on`.

Fixes https://github.com/nim-works/nimskull/issues/1253

## Details

The `canRaise` procedure treated callables with a `tyProc` without an
exception effect list as not being able to raise, which is incorrect.
No exception effect list means that the exception effects are unknown,
not that there are none.

When panics are enabled, the result of `canRaise` decides whether a
routine call is a checked call (one that can potentially raise).
Procedural values with a type without an explicit `.raises`
specification have no exception effect list, so calls of them were
treated as not raising, leading to the enclosing exception handlers
being elided, if there are no other statements potentially entering the
handler.

`canRaise` is changed to conservatively consider a missing exception
effect list to mean "can raise". In addition, the procedure is
partially refactored to use a case statement, making it not ignore
invalid `tyProc` types anymore.