### PR TITLE
make MCS work when left-hand operand is erroneous

### DIFF
--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -358,6 +358,8 @@ proc resolveOverloads(c: PContext, n, nOrig: PNode,
     if overloadsState == csEmpty and result.state == csEmpty:
       if efNoUndeclared notin flags: # for tests/pragmas/tcustom_pragma.nim
         if n[0] != nil and n[0].kind == nkIdent and n[0].ident.s in [".", ".="] and n[2].kind == nkIdent:
+          # the first operand might have not been analyzed yet; make sure it is
+          n[1] = semExprWithType(c, n[1])
           let sym = n[1].typ.typSym
           if sym == nil:
             let msg = getMsgDiagnostic(c, flags, n, f)

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5771,22 +5771,6 @@ However, this means that the method call syntax is not available for
 Limitations of the method call syntax
 -------------------------------------
 
-The expression `x` in `x.f` needs to be semantically checked (that means
-symbol lookup and type checking) before it can be decided that it needs to be
-rewritten to `f(x)`. Therefore the dot syntax has some limitations when it
-is used to invoke templates/macros:
-
-.. code-block:: nim
-    :test: "nim c $1"
-    :status: 1
-
-  template declareVar(name: untyped) =
-    const name {.inject.} = 45
-
-  # Doesn't compile:
-  unknownIdentifier.declareVar
-
-
 It is also not possible to use fully qualified identifiers with module
 symbol in method call syntax. The order in which the dot operator
 binds to symbols prohibits this.

--- a/tests/lang_exprs/tmcs_with_erroneous_operand.nim
+++ b/tests/lang_exprs/tmcs_with_erroneous_operand.nim
@@ -1,0 +1,22 @@
+discard """
+  description: '''
+    Ensure that using the method-call syntax doesn't result in an error when
+    the LHS cannot be typed, but an eligible template/macro with an untyped
+    parameter exists.
+  '''
+  action: compile
+"""
+
+template f(x: untyped) =
+  discard
+
+template f(x, y: untyped) =
+  discard
+
+template `f=`(x, y: untyped) =
+  discard
+
+# must not result in an "undeclared identifier" error
+nonexistentName.f
+nonexistentName.f(1)
+nonexistentName.f = 1


### PR DESCRIPTION
## Summary

When using the method-call syntax, templates/macros with `untyped`
parameters are now properly resolved to for `a.f`, `a.f(b)`, and
`a.f = b`, when `a` is itself not semantically valid. The manual is
updated accordingly.

Fixes https://github.com/nim-works/nimskull/issues/1255. 

## Details

In `builtinFieldAccess`, the typed left-hand expression was directly
written back to the input AST, meaning that in case of an error, the
resulting `nkDotCall` already contained an error, preventing recovery
via an `untyped` template/macro.

The input AST is now only modified if the left-hand expression is not
an error, so that the dot-call rewrite gets the original AST. A
regression test covering the three basic dot expression rewrites is
added.

Since the first operand in a `.(a, b)` (originating from `a.b`) can
now be untyped, `resolveOverloads` now needs to ensure that said
operand is typed before attempting to access the expression's type.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
* `builtinFieldAccess` should not modify the input AST at all, but that requires a larger refactor

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
