### PR TITLE
mir: use `Local` instead of `PSym` for locals

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -383,6 +383,7 @@ proc produceFragmentsForGlobals(
     # the fragments need to be wrapped in scopes; some MIR passes depend
     # on this
     if bu.front.len == 0:
+      discard bu.addLocal(Local()) # empty result slot
       bu.add(m.add(n)): MirNode(kind: mnkScope)
 
   func finish(bu: sink MirBuilder, m: var SourceMap, n: PNode
@@ -515,6 +516,7 @@ proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
   extname.typ = graph.getSysType(lib.path.info, tyCstring)
 
   var bu = initBuilder(result.source.add(path))
+  discard bu.addLocal(Local()) # empty result slot
 
   let dest =
     if sym.kind in routineKinds:

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -332,7 +332,7 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
 
     if graph.config.arcToExpand.hasKey(prc.name.s):
       graph.config.msgWrite("--expandArc: " & prc.name.s & "\n")
-      graph.config.msgWrite(render(body.code, addr env))
+      graph.config.msgWrite(render(body.code, addr env, addr body))
       graph.config.msgWrite("\n-- end of expandArc ------------------------\n")
 
   let target =

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -12,11 +12,16 @@ import
     lineinfos
   ],
   compiler/mir/[
+    mirbodies,
     mirtrees
   ],
   compiler/utils/[
     containers
   ]
+
+# compatibility exports for symbols originally defined here
+export Local
+export LocalId
 
 type
   CgNodeKind* = enum
@@ -156,28 +161,10 @@ const
   cnkLiterals* = {cnkIntLit, cnkUIntLit, cnkFloatLit, cnkStrLit}
 
 type
-  Local* = object
-    ## Static information about a local variable. Initialized prior to code
-    ## generation and only read (but not written) by the code generators.
-    typ*: PType
-    alignment*: uint32
-    flags*: TSymFlags
-    isImmutable*: bool
-      ## whether the local is expected to not be mutated, from a high-level
-      ## language perspective. Note that this doesn't meant that it really
-      ## isn't mutated, rather this information is intended to help the
-      ## the code generators optimize
-    # future direction: merge `flags` and `isImmutable` into a single set of
-    # flags
-    name*: PIdent
-      ## either the user-defined name or 'nil'
-
   BlockId* = distinct uint32
     ## Identifies a block within another block -- the IDs are **not** unique
     ## within a ``Body``. An outermost block has ID 0, a block within the
     ## block ID 1, etc.
-  LocalId* = distinct uint32
-    ## Identifies a local within a procedure.
 
   CgNode* {.acyclic.} = ref object
     ## A node in the tree structure representing code during the code
@@ -273,7 +260,6 @@ proc newOp*(kind: CgNodeKind; info: TLineInfo, typ: PType,
 func newLocalRef*(id: LocalId, info: TLineInfo, typ: PType): CgNode =
   CgNode(kind: cnkLocal, info: info, typ: typ, local: id)
 
-proc `==`*(x, y: LocalId): bool {.borrow.}
 proc `==`*(x, y: BlockId): bool {.borrow.}
 
 proc merge*(dest: var Body, source: Body): CgNode =

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -22,6 +22,7 @@ import
 # compatibility exports for symbols originally defined here
 export Local
 export LocalId
+export resultId
 
 type
   CgNodeKind* = enum
@@ -199,10 +200,6 @@ type
     ## procedure.
     locals*: Store[LocalId, Local] ## all locals belonging to the body
     code*: CgNode
-
-const
-  resultId* = LocalId(0)
-    ## the ID of the local representing the ``result`` variable
 
 func len*(n: CgNode): int {.inline.} =
   n.kids.len

--- a/compiler/mir/analysis.nim
+++ b/compiler/mir/analysis.nim
@@ -206,7 +206,7 @@ func isLastWrite*(tree: MirTree, cfg: DataFlowGraph, span: Subgraph, loc: Path,
 
   result = (true, state.exit, state.escapes)
 
-func computeAliveOp*[T: PSym | GlobalId | TempId](
+func computeAliveOp*[T: LocalId | GlobalId | TempId](
   tree: MirTree, loc: T, op: Opcode, n: OpValue): AliveState =
   ## Computes the state of `loc` at the *end* of the given operation. The
   ## operands are expected to *not* alias with each other. The analysis
@@ -217,8 +217,8 @@ func computeAliveOp*[T: PSym | GlobalId | TempId](
       n.kind == mnkTemp and n.temp == loc
     elif T is GlobalId:
       n.kind == mnkGlobal and n.global == loc
-    elif T is PSym:
-      n.kind in {mnkLocal, mnkParam} and n.sym.id == loc.id
+    elif T is LocalId:
+      n.kind in {mnkLocal, mnkParam} and n.local == loc
     else:
       {.error.}
 

--- a/compiler/mir/mirbodies.nim
+++ b/compiler/mir/mirbodies.nim
@@ -41,6 +41,11 @@ type
     source*: SourceMap
     code*: MirTree
 
+const
+  resultId* = LocalId(0)
+    ## the ID of the result variable. A slot for the result variable is always
+    ## reserved, even if there is no result variable for a body
+
 func `[]`*(body: MirBody, n: NodePosition): lent MirNode {.inline.} =
   body.code[n]
 

--- a/compiler/mir/mirbodies.nim
+++ b/compiler/mir/mirbodies.nim
@@ -11,6 +11,22 @@ import
   ]
 
 type
+  Local* = object
+    ## Static information about a local location ('let' or 'var'). Not modified
+    ## after initialization.
+    typ*: PType
+      ## type of the local
+    alignment*: uint32
+      ## alignment of the location, measured in bytes. 0 means "use default"
+    flags*: TSymFlags
+    isImmutable*: bool
+      ## whether the local was originally defined with ``let``. Used for
+      ## optimization purposes
+    # future direction: merge `flags` and `isImmutable` into a single set of
+    # flags
+    name*: PIdent
+      ## either the user-defined name or 'nil'
+
   MirBody* = object
     ## A ``MirBody`` represents a self-contained piece of MIR code. This can
     ## either be:

--- a/compiler/mir/mirbodies.nim
+++ b/compiler/mir/mirbodies.nim
@@ -8,6 +8,9 @@ import
   compiler/mir/[
     mirtrees,
     sourcemaps
+  ],
+  compiler/utils/[
+    containers
   ]
 
 type
@@ -27,6 +30,8 @@ type
     name*: PIdent
       ## either the user-defined name or 'nil'
 
+  Locals* = Store[LocalId, Local]
+
   MirBody* = object
     ## A ``MirBody`` represents a self-contained piece of MIR code. This can
     ## either be:
@@ -38,6 +43,8 @@ type
     ## In each case, ``MirBody`` stores all the local data referenced and
     ## needed by the body's MIR code. It also store additional information
     ## associated with a body, such as how far the lowering is along.
+    locals*: Locals
+      ## all locals part of the body
     source*: SourceMap
     code*: MirTree
 
@@ -51,3 +58,7 @@ func `[]`*(body: MirBody, n: NodePosition): lent MirNode {.inline.} =
 
 func sourceFor*(body: MirBody, n: NodePosition): PNode {.inline.} =
   body.source[body.code[n].info]
+
+func `[]`*(body: MirBody, id: LocalId): lent Local {.inline.} =
+  ## Returns the local corresponding to `id`.
+  body.locals[id]

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -95,8 +95,9 @@ func toValue*(id: GlobalId, typ: PType): Value =
 func toValue*(id: ProcedureId, typ: PType): Value =
   Value(node: MirNode(kind: mnkProc, typ: typ, prc: id))
 
-func toValue*(kind: range[mnkParam..mnkLocal], sym: PSym): Value =
-  Value(node: MirNode(kind: kind, typ: sym.typ, sym: sym))
+func toValue*(kind: range[mnkParam..mnkLocal], id: LocalId,
+              typ: PType): Value =
+  Value(node: MirNode(kind: kind, typ: typ, local: id))
 
 # --------- MirBuffer interface ----------
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2099,8 +2099,8 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
   swap(c.env, env) # swap back
 
   # move the buffers into the result body
-  MirBody(source: move c.sp.map,
-          code: finish(move c.builder))
+  let (code, locals) = finish(move c.builder, default(Store[LocalId, Local]))
+  MirBody(locals: locals, source: move c.sp.map, code: code)
 
 proc constDataToMir*(env: var MirEnv, n: PNode): MirTree =
   ## Translates the construction expression AST `n` representing some
@@ -2148,4 +2148,4 @@ proc constDataToMir*(env: var MirEnv, n: PNode): MirTree =
   # push and pop the content so that ``constToMirAux`` places the nodes into
   # the staging buffer, which is necessary for after-the-fact type patching
   bu.pop(bu.push(constToMirAux(bu, env, n)))
-  bu.finish()
+  bu.finish()[0]

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1262,6 +1262,10 @@ proc genLocDef(c: var TCtx, n: PNode, val: PNode) =
       # the definition doesn't imply default intialization
       discard
   else:
+    if kind == pirLocal:
+      # translate the symbol of the local:
+      discard c.addLocal(s)
+
     c.buildStmt (if sfCursor in s.flags: mnkDefCursor else: mnkDef):
       c.add nameNode(c, s)
       if hasInitializer:

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -277,7 +277,7 @@ type
     of mnkConst:
       cnst*: ConstId
     of mnkParam, mnkLocal:
-      sym*: PSym
+      local*: LocalId
     of mnkField, mnkPathNamed, mnkPathVariant:
       field*: PSym
     of mnkLiteral:
@@ -343,9 +343,6 @@ const
   ModifierNodes* = {mnkCopy, mnkMove, mnkSink}
     ## Assignment modifiers. Nodes that can only appear directly in the source
     ## slot of assignments.
-
-  SymbolLike* = {mnkParam, mnkLocal}
-    ## Nodes for which the `sym` field is available
 
   ConstrTreeNodes* = {mnkConstr, mnkObjConstr, mnkLiteral, mnkProc,
                       mnkArg, mnkField, mnkEnd}

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -11,7 +11,7 @@ import
   ]
 
 type
-  LocalId {.used.} = distinct uint32
+  LocalId* = distinct uint32
     ## Identifies a local inside a code fragment
   GlobalId* = distinct uint32
     ## Identifies a global across all MIR code
@@ -378,6 +378,7 @@ const
   CallKinds* = {mnkCall, mnkCheckedCall}
 
 func `==`*(a, b: SourceId): bool {.borrow.}
+func `==`*(a, b: LocalId): bool {.borrow.}
 func `==`*(a, b: TempId): bool {.borrow.}
 func `==`*(a, b: LabelId): bool {.borrow.}
 func `==`*(a, b: ConstId): bool {.borrow.}

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -32,8 +32,8 @@ func `$`(n: MirNode): string =
     result.add " global: "
     result.addInt n.global.uint32
   of mnkParam, mnkLocal:
-    result.add " sym: "
-    result.add $n.sym.name.s
+    result.add " local: "
+    result.addInt n.local.uint32
   of mnkField, mnkPathNamed, mnkPathVariant:
     result.add " field:"
     result.add $n.field.name.s

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -15,6 +15,7 @@ import
     typesrenderer,
   ],
   compiler/mir/[
+    mirbodies,
     mirenv,
     mirtrees
   ]
@@ -120,7 +121,10 @@ proc treeRepr*(tree: MirTree, pos = NodePosition(0)): string =
 # ------- MIR pretty printer --------
 
 type
-  EnvPtr = ptr MirEnv
+  RenderCtx = object
+    ## Contextual immutable data for the renderer.
+    env: ptr MirEnv   ## may be nil
+    body: ptr MirBody ## may be nil
 
 template treeParam(): untyped =
   ## Expands to ``nodes`` or ``tree``, depending on how the parameter is
@@ -135,30 +139,42 @@ func next(tree: MirTree, i: var int): lent MirNode =
   result = tree[i]
   inc i
 
-func addName[I](result: var string, id: I, open: string, env: EnvPtr) =
-  if env.isNil:
+func addName[I](result: var string, id: I, open: string, c: RenderCtx) =
+  if c.env.isNil:
     # just render the ID
     result.add open
     result.addInt id.uint32
     result.add ">"
   else:
-    result.add env[][id].name.s
+    result.add c.env[][id].name.s
 
-proc singleToStr(n: MirNode, result: var string, env: EnvPtr) =
+func addLocalName(result: var string, id: LocalId, open: string,
+                  c: RenderCtx) =
+  if c.body.isNil:
+    # render just the ID
+    result.add open
+    result.addInt id.uint32
+    result.add ">"
+  else:
+    result.add c.body[][id].name.s
+
+proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
   case n.kind
-  of SymbolLike:
-    result.add n.sym.name.s
+  of mnkParam:
+    result.addLocalName(n.local, "<Param", c)
+  of mnkLocal:
+    result.addLocalName(n.local, "<L", c)
   of mnkConst:
     if isAnon(n.cnst):
       result.add "<D" # "D" for "Data"
       result.addInt extract(n.cnst).uint32
       result.add ">"
     else:
-      result.addName(n.cnst, "<C", env)
+      result.addName(n.cnst, "<C", c)
   of mnkGlobal:
-    result.addName(n.global, "<G", env)
+    result.addName(n.global, "<G", c)
   of mnkProc:
-    result.addName(n.prc, "<P", env)
+    result.addName(n.prc, "<P", c)
   of mnkTemp, mnkAlias:
     result.add "_" & $n.temp.int
   of mnkNone:
@@ -172,17 +188,17 @@ proc singleToStr(n: MirNode, result: var string, env: EnvPtr) =
   of AllNodeKinds - Atoms:
     result.add "<error: " & $n.kind & ">"
 
-proc singleToStr(tree: MirTree, i: var int, result: var string, env: EnvPtr) =
-  singleToStr(next(tree, i), result, env)
+proc singleToStr(tree: MirTree, i: var int, result: var string, c: RenderCtx) =
+  singleToStr(next(tree, i), result, c)
 
 template singleToStr() =
-  singleToStr(treeParam(), i, result, env)
+  singleToStr(treeParam(), i, result, c)
 
 template valueToStr() =
   mixin valueToStr
-  valueToStr(treeParam(), i, result, env)
+  valueToStr(treeParam(), i, result, c)
 
-proc valueToStr(nodes: MirTree, i: var int, result: var string, env: EnvPtr) =
+proc valueToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
   template tree(start: string, body: untyped) =
     result.add start
     body
@@ -217,11 +233,11 @@ proc valueToStr(nodes: MirTree, i: var int, result: var string, env: EnvPtr) =
       singleToStr()
       result.add "[]"
   of AtomNodes:
-    singleToStr(n, result, env)
+    singleToStr(n, result, c)
   else:
     result.add "<error: " & $n.kind & ">"
 
-proc calleeToStr(tree: MirTree, i: var int, result: var string, env: EnvPtr) =
+proc calleeToStr(tree: MirTree, i: var int, result: var string, c: RenderCtx) =
   case tree[i].kind
   of mnkMagic:
     # cut off the 'm' prefix and use a lowercase first character
@@ -232,7 +248,7 @@ proc calleeToStr(tree: MirTree, i: var int, result: var string, env: EnvPtr) =
   else:
     valueToStr()
 
-proc argToStr(tree: MirTree, i: var int, result: var string, env: EnvPtr) =
+proc argToStr(tree: MirTree, i: var int, result: var string, c: RenderCtx) =
   var n {.cursor.} = next(tree, i)
   case n.kind
   of mnkArg:     result.add "arg "
@@ -251,9 +267,9 @@ proc argToStr(tree: MirTree, i: var int, result: var string, env: EnvPtr) =
   inc i # skip the end node
 
 template argToStr() =
-  argToStr(treeParam(), i, result, env)
+  argToStr(treeParam(), i, result, c)
 
-proc exprToStr(nodes: MirTree, i: var int, result: var string, env: EnvPtr) =
+proc exprToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
   template tree(start: string, body: untyped) =
     result.add start
     inc i # skip the start node
@@ -304,14 +320,14 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, env: EnvPtr) =
       result.add ")"
   of mnkCall:
     tree "":
-      calleeToStr(nodes, i, result, env)
+      calleeToStr(nodes, i, result, c)
       result.add "("
       commaSeparated:
         argToStr()
       result.add ")"
   of mnkCheckedCall:
     tree "":
-      calleeToStr(nodes, i, result, env)
+      calleeToStr(nodes, i, result, c)
       result.add "("
       commaSeparated:
         argToStr()
@@ -344,28 +360,28 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, env: EnvPtr) =
     inc i
 
 template exprToStr() =
-  exprToStr(nodes, i, result, env)
+  exprToStr(nodes, i, result, c)
 
 proc renderNameWithType(tree: MirTree, i: var int, result: var string,
-                        env: EnvPtr) =
+                        c: RenderCtx) =
   let n {.cursor.} = next(tree, i)
-  singleToStr(n, result, env)
+  singleToStr(n, result, c)
   result.add ": "
   result.add typeToString(n.typ)
 
 proc renderList(tree: MirTree, i: var int, indent: int, result: var string,
-                env: EnvPtr)
+                c: RenderCtx)
 
 template renderList(indent: int) =
   mixin renderList
-  renderList(treeParam(), i, indent, result, env)
+  renderList(treeParam(), i, indent, result, c)
 
 template stmtToStr(indent: int) =
   mixin stmtToStr
-  stmtToStr(treeParam(), i, indent, result, env)
+  stmtToStr(treeParam(), i, indent, result, c)
 
 proc stmtToStr(nodes: MirTree, i: var int, indent: int, result: var string,
-               env: EnvPtr) =
+               c: RenderCtx) =
   template tree(str: string, body: untyped) =
     result.add repeat("  ", indent)
     result.add str
@@ -382,7 +398,7 @@ proc stmtToStr(nodes: MirTree, i: var int, indent: int, result: var string,
   case n.kind
   of mnkDef, mnkDefUnpack:
     tree "def ":
-      renderNameWithType(nodes, i, result, env)
+      renderNameWithType(nodes, i, result, c)
       if nodes[i].kind != mnkNone:
         result.add " = "
         exprToStr()
@@ -391,19 +407,19 @@ proc stmtToStr(nodes: MirTree, i: var int, indent: int, result: var string,
     result.add "\n"
   of mnkDefCursor:
     tree "def_cursor ":
-      renderNameWithType(nodes, i, result, env)
+      renderNameWithType(nodes, i, result, c)
       result.add " = "
       exprToStr()
     result.add "\n"
   of mnkBind:
     tree "bind ":
-      renderNameWithType(nodes, i, result, env)
+      renderNameWithType(nodes, i, result, c)
       result.add " = "
       valueToStr()
     result.add "\n"
   of mnkBindMut:
     tree "bind_mut ":
-      renderNameWithType(nodes, i, result, env)
+      renderNameWithType(nodes, i, result, c)
       result.add " = "
       valueToStr()
     result.add "\n"
@@ -506,23 +522,26 @@ proc stmtToStr(nodes: MirTree, i: var int, indent: int, result: var string,
   i += ord(n.kind in SubTreeNodes)
 
 proc renderList(tree: MirTree, i: var int, indent: int, result: var string,
-                env: EnvPtr) =
+                c: RenderCtx) =
   while i < tree.len and tree[i].kind != mnkEnd:
     stmtToStr(indent)
 
-proc exprToStr*(tree: MirTree, n: NodePosition, env: EnvPtr = nil): string =
+proc exprToStr*(tree: MirTree, n: NodePosition; env: ptr MirEnv = nil;
+                body: ptr MirBody = nil): string =
   ## Renders the expression at `n` into a human-readable text representation.
   var i = n.int
-  exprToStr(tree, i, result, env)
+  exprToStr(tree, i, result, RenderCtx(env: env, body: body))
 
-proc stmtToStr*(tree: MirTree, n: NodePosition, env: EnvPtr = nil): string =
+proc stmtToStr*(tree: MirTree, n: NodePosition; env: ptr MirEnv = nil;
+                body: ptr MirBody = nil): string =
   ## Renders the statement at `n` into a human-readable text representation.
   var i = n.int
-  stmtToStr(tree, i, 0, result, env)
+  stmtToStr(tree, i, 0, result, RenderCtx(env: env, body: body))
 
-proc render*(tree: MirTree, env: EnvPtr = nil): string =
+proc render*(tree: MirTree; env: ptr MirEnv = nil;
+             body: ptr MirBody = nil): string =
   ## Renders `tree` into a human-readable text representation. The output is
   ## meant for debugging and tracing and is not guaranteed to have a stable
   ## format.
   var i = 0
-  renderList(tree, i, 0, result, env)
+  renderList(tree, i, 0, result, RenderCtx(env: env, body: body))

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -60,8 +60,8 @@ type
     long: seq[PathInstr]
 
 const
-  Roots = {mnkProc, mnkConst, mnkGlobal, mnkTemp, mnkCall, mnkDeref,
-           mnkDerefView} + SymbolLike
+  Roots = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp, mnkCall,
+           mnkDeref, mnkDerefView}
   PathOps = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv,
              mnkPathVariant}
 
@@ -71,7 +71,7 @@ func isSameRoot(an, bn: MirNode): bool =
 
   case an.kind
   of mnkParam, mnkLocal:
-    result = an.sym.id == bn.sym.id
+    result = an.local == bn.local
   of mnkProc:
     result = an.prc == bn.prc
   of mnkConst:

--- a/tests/compiler/ttreechangesets.nim
+++ b/tests/compiler/ttreechangesets.nim
@@ -112,7 +112,7 @@ block insert_shared_start:
   bu.add temp(0)
   bu.subTree mnkStmtList: discard
   bu.add temp(3)
-  var tree = finish(bu)
+  var (tree, _) = finish(bu)
 
   test(tree, [temp(0), temp(1), temp(2), temp(3)]):
     c.replace 1, temp(2)
@@ -138,7 +138,7 @@ block insert_shared_end:
   bu.add temp(0)
   bu.subTree mnkStmtList: discard
   bu.add temp(3)
-  var tree = finish(bu)
+  var (tree, _) = finish(bu)
 
   test(tree, [temp(0), temp(1), temp(2), temp(3)]):
     c.replace 1, temp(1)


### PR DESCRIPTION
## Summary

For parameters and locals, replace `PSym` with `LocalId` -- the actual
data (name, type, etc.) is stored separately as a list of `Local`s. The
idea is to:
* remove another difference between the MIR and CGIR
* remove another `PSym` usage from the MIR (less GC'ed type usage, less
  coupling between sem and the mid-/back-end)

## Details

### MIR

* `mnkParam` and `mnkLocal` nodes store a `LocalId`; the `SymbolLike`
  set is removed
* the list of `Local`s is stored in `MirBody` (looked up via `LocalId`)
* the `Local` type and `resultId` constant are moved from the `cgir` to
  the `mirbodies` module
* new locals are registered through a `MirBuilder` instance
* the pretty-printing procedures accept an optional `ptr MirBody`; it's
  needed for rendering the original names of the locals/parameters

### New Container: `PartialStore`

* `PartialStore` is intended for recording additions to a `Store` out-
  of-place
* upon finishing recording additions, a `PartialStore` can either be
  dropped or joined with the `Store` it was forked from

### Translation

* `mirgen` translates `PSym`s to `Local`, in the same way as `cgirgen`
  previously did
* `cgirgen` is still responsible for creating `Local`s for temporaries
* when manually creating `MirBody`s, a slot for the result variable has
  to be reserved