### PR TITLE
fix: VM crash with implicit object conversion

### DIFF
--- a/tests/lang_callable/generics/tobjecttyperel.nim
+++ b/tests/lang_callable/generics/tobjecttyperel.nim
@@ -1,8 +1,4 @@
 discard """
-  knownIssue.vm: '''
-    Fails for the VM target because ``cgirgen`` emits the incorrect conversion
-    operator for ``ref`` types involving generics.
-  '''
   output: '''(peel: 0, color: 15)
 (color: 15)
 17


### PR DESCRIPTION
## Summary

Fix a bug with `cgirgen` where incorrect CGIR was produced for implicit
object conversions involving generic types, resulting in an internal VM
error when using the VM backend or running code at compile-time.

## Details

In `cgirgen.handleSpecialConv`, type skipping was missing when testing
for whether the element type of a pointer-like type is an object type,
resulting in the conversion not being detected as an object conversion.
Code generators, such as `vmgen`, where the distinction between plain
lvalue and object conversion matters therefore produced wrong code.

`handleSpecialConv` is changed such that the types are skipped
properly. The object up- or down-conversion node now also uses the
correct line information.