### PR TITLE
mir: use `Local` for temporaries

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -58,8 +58,6 @@ type
 
     owner: PSym
 
-    tempMap: SeqMap[TempId, LocalId]
-      ## maps a ``TempId`` to the ID of the local created for it
     blocks: seq[tuple[input, actual: LabelId]]
       ## the stack of enclosing blocks for the currently processed node
 
@@ -80,7 +78,8 @@ type
       ## unreachable code
 
     locals: Store[LocalId, Local]
-      ## the in-progress list of all locals in the translated body
+      ## the list of all locals in the body, taken from the ``MirBody``.
+      ## Only needed for updating the type for alias locals
 
     # a 'def' in the MIR means that the the local starts to exists and that it
     # is accessible in all connected basic blocks part of the enclosing
@@ -99,11 +98,6 @@ type
     ## A cursor into a ``MirBody``.
     pos: uint32 ## the index of the currently pointed to node
     origin {.cursor.}: PNode ## the source node
-
-template isFilled(x: LocalId): bool =
-  # '0' is a valid ID, but this procedure is only used for
-  # temporaries, which can never map to the result variable
-  x.int != 0
 
 func delete[T](s: var seq[T], a, b: int) =
   # XXX: this procedure is a workaround for ``sequtils.delete`` not handling
@@ -322,14 +316,12 @@ proc atomToIr(n: MirNode, cl: TranslateCl, info: TLineInfo): CgNode =
     CgNode(kind: cnkGlobal, info: info, typ: n.typ, global: n.global)
   of mnkConst:
     CgNode(kind: cnkConst, info: info, typ: n.typ, cnst: n.cnst)
-  of mnkLocal, mnkParam:
+  of mnkLocal, mnkParam, mnkTemp:
     newLocalRef(n.local, info, cl.locals[n.local].typ)
-  of mnkTemp:
-    newLocalRef(cl.tempMap[n.temp], info, n.typ)
   of mnkAlias:
     # the type of the node doesn't match the real one
     let
-      id = cl.tempMap[n.temp]
+      id = n.local
       typ = cl.locals[id].typ
     # the view is auto-dereferenced here for convenience
     newOp(cnkDerefView, info, typ.base, newLocalRef(id, info, typ))
@@ -341,7 +333,7 @@ proc atomToIr(n: MirNode, cl: TranslateCl, info: TLineInfo): CgNode =
     # type arguments do use `mnkNone` in some situtations, so keep
     # the type
     CgNode(kind: cnkEmpty, info: info, typ: n.typ)
-  else:
+  of AllNodeKinds - Atoms:
     unreachable("not an atom: " & $n.kind)
 
 proc atomToIr(tree: MirBody, cl: var TranslateCl,
@@ -517,7 +509,7 @@ proc defToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
   var def: CgNode
 
   case entity.kind
-  of mnkLocal:
+  of mnkLocal, mnkTemp:
     let id = entity.local
     def = newLocalRef(id, info, cl.locals[id].typ)
   of mnkParam:
@@ -526,16 +518,6 @@ proc defToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
   of mnkGlobal:
     def = CgNode(kind: cnkGlobal, info: info, typ: entity.typ,
                  global: entity.global)
-  of mnkTemp:
-    # MIR temporaries are like normal locals, with the difference that they
-    # are created ad-hoc and don't have any extra information attached
-    assert entity.typ != nil
-    let tmp = cl.locals.add Local(typ: entity.typ)
-
-    assert entity.temp notin cl.tempMap, "re-definition of temporary"
-    cl.tempMap[entity.temp] = tmp
-
-    def = newLocalRef(tmp, info, entity.typ)
   of mnkAlias:
     # MIR aliases are translated to var/lent views
     assert n.kind in {mnkBind, mnkBindMut}, "alias can only be defined by binds"
@@ -543,12 +525,10 @@ proc defToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
     let
       typ = makeVarType(cl.owner, entity.typ, cl.idgen,
                         if n.kind == mnkBind: tyLent else: tyVar)
-      tmp = cl.locals.add Local(typ: typ)
+    # override the original type
+    cl.locals[entity.local].typ = typ
 
-    assert entity.temp notin cl.tempMap, "re-definition of temporary"
-    cl.tempMap[entity.temp] = tmp
-
-    def = newLocalRef(tmp, info, typ)
+    def = newLocalRef(entity.local, info, typ)
   else:
     unreachable()
 

--- a/compiler/mir/analysis.nim
+++ b/compiler/mir/analysis.nim
@@ -206,19 +206,17 @@ func isLastWrite*(tree: MirTree, cfg: DataFlowGraph, span: Subgraph, loc: Path,
 
   result = (true, state.exit, state.escapes)
 
-func computeAliveOp*[T: LocalId | GlobalId | TempId](
+func computeAliveOp*[T: LocalId | GlobalId](
   tree: MirTree, loc: T, op: Opcode, n: OpValue): AliveState =
   ## Computes the state of `loc` at the *end* of the given operation. The
   ## operands are expected to *not* alias with each other. The analysis
   ## result will be wrong if they do
 
   func isAnalysedLoc[T](n: MirNode, loc: T): bool =
-    when T is TempId:
-      n.kind == mnkTemp and n.temp == loc
-    elif T is GlobalId:
+    when T is GlobalId:
       n.kind == mnkGlobal and n.global == loc
     elif T is LocalId:
-      n.kind in {mnkLocal, mnkParam} and n.local == loc
+      n.kind in {mnkLocal, mnkParam, mnkTemp} and n.local == loc
     else:
       {.error.}
 

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -97,7 +97,7 @@ proc isUsedForSink(tree: MirTree, stmt: NodePosition): bool =
     case tree[n].kind
     of mnkConsume:
       let x = tree.operand(n)
-      if tree[x].kind == mnkTemp and tree[x].temp == tree[def].temp:
+      if tree[x].kind == mnkTemp and tree[x].local == tree[def].local:
         # the temporary is used for sink parameter passing
         result = true
         break

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -80,11 +80,11 @@ func typeLit*(t: PType): Value =
 func literal*(n: PNode): Value =
   Value(node: MirNode(kind: mnkLiteral, typ: n.typ, lit: n))
 
-func temp*(typ: PType, id: TempId): Value =
-  Value(node: MirNode(kind: mnkTemp, typ: typ, temp: id))
+func temp*(typ: PType, id: LocalId): Value =
+  Value(node: MirNode(kind: mnkTemp, typ: typ, local: id))
 
-func alias*(typ: PType, id: TempId): Value =
-  Value(node: MirNode(kind: mnkAlias, typ: typ, temp: id))
+func alias*(typ: PType, id: LocalId): Value =
+  Value(node: MirNode(kind: mnkAlias, typ: typ, local: id))
 
 func toValue*(id: ConstId, typ: PType): Value =
   Value(node: MirNode(kind: mnkConst, typ: typ, cnst: id))

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -55,9 +55,6 @@ type
 
     locals*: PartialStore[LocalId, Local]
       ## new locals created with the builder
-    numTemps*: uint32
-      ## tracks the number of existing temporaries. Used for allocating new
-      ## IDs.
 
     # XXX: the internal fields are currently exported for the integration
     #      with changesets to work, but future refactorings should focus
@@ -297,18 +294,17 @@ template scope*(bu: var MirBuilder, body: untyped) =
   bu.subTree MirNode(kind: mnkScope):
     body
 
-func allocTemp(bu: MirBuilder, t: PType; id: TempId, alias: bool): Value =
+func allocTemp(bu: MirBuilder, t: PType; id: LocalId, alias: bool): Value =
   ## Allocates a new temporary or alias and returns it.
   let kind = if alias: mnkAlias
              else:     mnkTemp
   {.cast(uncheckedAssign).}:
-    result = Value(node: MirNode(kind: kind, typ: t, temp: id),
+    result = Value(node: MirNode(kind: kind, typ: t, local: id),
                    info: someOpt bu.currentSourceId)
 
 template allocTemp*(bu: var MirBuilder, t: PType, alias = false): Value =
   # XXX: the only purpose of this is to work around a ``strictFuncs`` bug
-  let id = TempId bu.numTemps
-  inc bu.numTemps
+  let id = bu.addLocal(Local(typ: t))
   allocTemp(bu, t, id, alias)
 
 func use*(bu: var MirBuilder, val: sink Value) {.inline.} =

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -41,13 +41,6 @@ type
 template indexLike*(_: typedesc[SourceId]) = discard
 
 type
-  ## Different to the ID types above, how and what the following ID types
-  ## represent is dictated by the MIR
-  TempId* = distinct uint32
-    ## ID of a temporary location. A temporary location is created and
-    ## inserted by the compiler. The only difference to other named locations
-    ## is that temporaries are allowed to be elided (by an optimization pass,
-    ## for example) if it's deemed to have no effect on the codes' semantics
   LabelId* = distinct uint32
     ## ID of a label, used to identify a block (``mnkBlock``).
 
@@ -63,8 +56,8 @@ type
     mnkGlobal ## global location
     mnkParam  ## parameter
     mnkLocal  ## local location
-    mnkTemp   ## temporary introduced during the MIR phase. Has the same
-              ## semantics as ``mnkLocal``
+    mnkTemp   ## like ``mnkLocal``, but the local was introduced by the
+              ## compiler during the MIR phase
     mnkAlias  ## local run-time handle. This is essentially a ``var T`` or
               ## ``lent T`` local
 
@@ -276,14 +269,12 @@ type
       global*: GlobalId
     of mnkConst:
       cnst*: ConstId
-    of mnkParam, mnkLocal:
+    of mnkParam, mnkLocal, mnkTemp, mnkAlias:
       local*: LocalId
     of mnkField, mnkPathNamed, mnkPathVariant:
       field*: PSym
     of mnkLiteral:
       lit*: PNode
-    of mnkTemp, mnkAlias:
-      temp*: TempId
     of mnkPathPos:
       position*: uint32 ## the 0-based position of the field
     of mnkCall, mnkCheckedCall:
@@ -376,7 +367,6 @@ const
 
 func `==`*(a, b: SourceId): bool {.borrow.}
 func `==`*(a, b: LocalId): bool {.borrow.}
-func `==`*(a, b: TempId): bool {.borrow.}
 func `==`*(a, b: LabelId): bool {.borrow.}
 func `==`*(a, b: ConstId): bool {.borrow.}
 func `==`*(a, b: GlobalId): bool {.borrow.}

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -598,7 +598,8 @@ iterator arguments*(tree: MirTree, n: NodePosition): (ArgKinds, OpValue) =
 func findDef*(tree: MirTree, n: NodePosition): NodePosition =
   ## Finds and returns the first definition for the name of the temporary
   ## at node `n`. No control-flow analysis is performed.
-  let expected = tree[n].temp
+  assert tree[n].kind in {mnkTemp, mnkAlias}
+  let expected = tree[n].local
   # first, unwind until the closest statement
   result = n
   while tree[result].kind notin StmtNodes:
@@ -608,7 +609,8 @@ func findDef*(tree: MirTree, n: NodePosition): NodePosition =
   while result > NodePosition 0:
     if tree[result].kind in DefNodes:
       let name = tree.operand(result, 0)
-      if tree[name].kind in {mnkTemp, mnkAlias} and tree[name].temp == expected:
+      if tree[name].kind in {mnkTemp, mnkAlias} and
+         tree[name].local == expected:
         return
 
     result = tree.previous(result)

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -32,7 +32,7 @@ func `$`(n: MirNode): string =
   of mnkGlobal:
     result.add " global: "
     result.addInt n.global.uint32
-  of mnkParam, mnkLocal:
+  of mnkParam, mnkLocal, mnkTemp, mnkAlias:
     result.add " local: "
     result.addInt n.local.uint32
   of mnkField, mnkPathNamed, mnkPathVariant:
@@ -42,9 +42,6 @@ func `$`(n: MirNode): string =
     result.add " lit: "
     {.cast(noSideEffect).}:
       result.add renderTree(n.lit)
-  of mnkTemp, mnkAlias:
-    result.add " temp: "
-    result.add $ord(n.temp)
   of mnkPathPos:
     result.add " position: "
     result.add $n.position
@@ -176,7 +173,7 @@ proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
   of mnkProc:
     result.addName(n.prc, "<P", c)
   of mnkTemp, mnkAlias:
-    result.add "_" & $n.temp.int
+    result.add "_" & $n.local.int
   of mnkNone:
     result.add "<none>"
   of mnkLiteral:

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -70,7 +70,7 @@ func isSameRoot(an, bn: MirNode): bool =
     return false
 
   case an.kind
-  of mnkParam, mnkLocal:
+  of mnkParam, mnkLocal, mnkTemp:
     result = an.local == bn.local
   of mnkProc:
     result = an.prc == bn.prc
@@ -78,8 +78,6 @@ func isSameRoot(an, bn: MirNode): bool =
     result = an.cnst == bn.cnst
   of mnkGlobal:
     result = an.global == bn.global
-  of mnkTemp:
-    result = an.temp == bn.temp
   of mnkCall, mnkDeref, mnkDerefView:
     result = false
   of AllNodeKinds - Roots:

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -171,10 +171,12 @@ func toName(n: MirNode): EntityName =
   result.a[0] = n.kind.int
   result.a[1] =
     case n.kind
-    of mnkParam, mnkLocal: n.local.int
-    of mnkGlobal:  n.global.int
-    of mnkTemp:    n.temp.int
-    else:          unreachable(n.kind)
+    of mnkParam, mnkLocal, mnkTemp:
+      n.local.int
+    of mnkGlobal:
+      n.global.int
+    else:
+      unreachable(n.kind)
 
 func findScope(entities: EntityDict, name: EntityName, at: InstrPos,
                exists: var bool): EntityInfo =
@@ -351,7 +353,7 @@ func requiresDestruction(tree: MirTree, cfg: DataFlowGraph,
       # unpacked tuples don't need to be destroyed because all elements are
       # moved out of them
       if tree[def].kind != mnkDefUnpack:
-        computeAlive(entity.temp, computeAliveOp[TempId])
+        computeAlive(entity.local, computeAliveOp[LocalId])
       else:
         (alive: false, escapes: false)
     else:

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -14,19 +14,19 @@ scope:
             break L0
       scope:
         x = <D2>
-    def_cursor _0: (string, int) = x
-    def _1: string = $(arg _0) (raises)
-    echo(arg type(array[0..0, string]), arg _1) (raises)
+    def_cursor _3: (string, int) = x
+    def _4: string = $(arg _3) (raises)
+    echo(arg type(array[0..0, string]), arg _4) (raises)
   finally:
-    =destroy(name _1)
+    =destroy(name _4)
 -- end of expandArc ------------------------
 --expandArc: sio
 
 scope:
   scope:
     def_cursor filename: string = "debug.txt"
-    def_cursor _0: string = filename
-    def f: File = open(arg _0, arg fmRead, arg 8000) (raises)
+    def_cursor _3: string = filename
+    def f: File = open(arg _3, arg fmRead, arg 8000) (raises)
     try:
       scope:
         try:
@@ -35,25 +35,25 @@ scope:
             scope:
               while true:
                 scope:
-                  def_cursor _1: File = f
-                  def :tmp: bool = readLine(arg _1, name res) (raises)
+                  def_cursor _6: File = f
+                  def :tmp: bool = readLine(arg _6, name res) (raises)
                   scope:
-                    def_cursor _2: bool = :tmp
-                    def _3: bool = not(arg _2)
-                    if _3:
+                    def_cursor _7: bool = :tmp
+                    def _8: bool = not(arg _7)
+                    if _8:
                       scope:
                         break L0
                   scope:
                     scope:
                       def_cursor x: string = res
-                      def_cursor _4: string = x
-                      echo(arg type(array[0..0, string]), arg _4) (raises)
+                      def_cursor _10: string = x
+                      echo(arg type(array[0..0, string]), arg _10) (raises)
         finally:
           =destroy(name res)
     finally:
       scope:
-        def_cursor _5: File = f
-        close(arg _5) (raises)
+        def_cursor _11: File = f
+        close(arg _11) (raises)
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -14,54 +14,54 @@ doing shady stuff...
 
 scope:
   def splat: tuple[dir: string, name: string, ext: string] = splitFile(arg path) (raises)
-  bind_mut _4: string = splat.0
-  def _0: string = move _4
-  wasMoved(name _4)
-  bind_mut _5: string = splat.1
-  def _1: string = move _5
-  wasMoved(name _5)
-  bind_mut _6: string = splat.2
-  def _2: string = move _6
-  wasMoved(name _6)
-  def _3: Target = construct (consume _0, consume _1, consume _2)
-  result := move _3
+  bind_mut _7: string = splat.0
+  def _3: string = move _7
+  wasMoved(name _7)
+  bind_mut _8: string = splat.1
+  def _4: string = move _8
+  wasMoved(name _8)
+  bind_mut _9: string = splat.2
+  def _5: string = move _9
+  wasMoved(name _9)
+  def _6: Target = construct (consume _3, consume _4, consume _5)
+  result := move _6
   =destroy(name splat)
 -- end of expandArc ------------------------
 --expandArc: delete
 
 scope:
-  def_cursor _0: Node = target[]
-  def_cursor _1: Node = _0[].parent
+  def_cursor _3: Node = target[]
+  def_cursor _4: Node = _3[].parent
   def sibling: Node
-  =copy(name sibling, arg _1[].left)
-  def_cursor _2: Node = sibling
+  =copy(name sibling, arg _4[].left)
+  def_cursor _6: Node = sibling
   def saved: Node
-  =copy(name saved, arg _2[].right)
-  def_cursor _3: Node = sibling
-  def_cursor _4: Node = saved
-  def_cursor _6: Node = _4[].left
-  =copy(name _3[].right, arg _6)
-  def_cursor _5: Node = sibling
-  =sink(name _5[].parent, arg saved)
+  =copy(name saved, arg _6[].right)
+  def_cursor _7: Node = sibling
+  def_cursor _8: Node = saved
+  def_cursor _10: Node = _8[].left
+  =copy(name _7[].right, arg _10)
+  def_cursor _9: Node = sibling
+  =sink(name _9[].parent, arg saved)
   =destroy(name sibling)
 -- end of expandArc ------------------------
 --expandArc: p1
 
 scope:
-  def _0: array[0..0, int] = construct (consume 123)
-  def lresult: seq[int] = arrToSeq(consume _0)
+  def _2: array[0..0, int] = construct (consume 123)
+  def lresult: seq[int] = arrToSeq(consume _2)
   def lvalue: seq[int]
   def lnext: string
-  def _1: seq[int] = move lresult
-  def _: (seq[int], string) = construct (consume _1, consume ";")
-  bind_mut _3: seq[int] = _.0
-  lvalue := move _3
-  wasMoved(name _3)
-  bind_mut _4: string = _.1
-  lnext := move _4
-  wasMoved(name _4)
-  def _2: seq[int] = move(name lvalue)
-  result.value := move _2
+  def _6: seq[int] = move lresult
+  def _: (seq[int], string) = construct (consume _6, consume ";")
+  bind_mut _8: seq[int] = _.0
+  lvalue := move _8
+  wasMoved(name _8)
+  bind_mut _9: string = _.1
+  lnext := move _9
+  wasMoved(name _9)
+  def _7: seq[int] = move(name lvalue)
+  result.value := move _7
   =destroy(name _)
   =destroy(name lnext)
   =destroy(name lvalue)
@@ -71,16 +71,16 @@ scope:
 scope:
   try:
     def_cursor it: KeyValue = x
-    def _0: seq[int]
-    =copy(name _0, arg it.0)
-    def _1: seq[int]
-    =copy(name _1, arg it.1)
-    def a: (seq[int], seq[int]) = construct (consume _0, consume _1)
-    def_cursor _2: (seq[int], seq[int]) = a
-    def _3: string = $(arg _2) (raises)
-    echo(arg type(array[0..0, string]), arg _3) (raises)
+    def _4: seq[int]
+    =copy(name _4, arg it.0)
+    def _5: seq[int]
+    =copy(name _5, arg it.1)
+    def a: (seq[int], seq[int]) = construct (consume _4, consume _5)
+    def_cursor _6: (seq[int], seq[int]) = a
+    def _7: string = $(arg _6) (raises)
+    echo(arg type(array[0..0, string]), arg _7) (raises)
   finally:
-    =destroy(name _3)
+    =destroy(name _7)
     =destroy(name a)
 -- end of expandArc ------------------------
 --expandArc: extractConfig
@@ -91,38 +91,38 @@ scope:
     scope:
       def_cursor a: seq[string] = txt
       def i: int = 0
-      def_cursor _0: seq[string] = a
-      def L: int = lengthSeq(arg _0)
+      def_cursor _5: seq[string] = a
+      def L: int = lengthSeq(arg _5)
       block L0:
         scope:
           while true:
             scope:
-              def_cursor _1: int = i
-              def :tmp: bool = ltI(arg _1, arg L)
+              def_cursor _7: int = i
+              def :tmp: bool = ltI(arg _7, arg L)
               scope:
-                def_cursor _2: bool = :tmp
-                def _3: bool = not(arg _2)
-                if _3:
+                def_cursor _8: bool = :tmp
+                def _9: bool = not(arg _8)
+                if _9:
                   scope:
                     break L0
               scope:
                 scope:
                   try:
-                    def_cursor _4: int = i
-                    def line: lent string = borrow a[_4]
-                    def_cursor _5: string = line[]
-                    def splitted: seq[string] = split(arg _5, arg " ", arg -1) (raises)
+                    def_cursor _11: int = i
+                    def line: lent string = borrow a[_11]
+                    def_cursor _13: string = line[]
+                    def splitted: seq[string] = split(arg _13, arg " ", arg -1) (raises)
                     scope:
-                      def_cursor _6: string = splitted[0]
-                      def _7: bool = eqStr(arg _6, arg "opt")
-                      if _7:
+                      def_cursor _14: string = splitted[0]
+                      def _15: bool = eqStr(arg _14, arg "opt")
+                      if _15:
                         scope:
-                          def_cursor _10: string = splitted[1]
-                          =copy(name lan_ip, arg _10)
-                    def_cursor _8: string = lan_ip
-                    echo(arg type(array[0..0, string]), arg _8) (raises)
-                    def_cursor _9: string = splitted[1]
-                    echo(arg type(array[0..0, string]), arg _9) (raises)
+                          def_cursor _18: string = splitted[1]
+                          =copy(name lan_ip, arg _18)
+                    def_cursor _16: string = lan_ip
+                    echo(arg type(array[0..0, string]), arg _16) (raises)
+                    def_cursor _17: string = splitted[1]
+                    echo(arg type(array[0..0, string]), arg _17) (raises)
                   finally:
                     =destroy(name splitted)
                 i = addI(arg i, arg 1) (raises)
@@ -136,30 +136,30 @@ scope:
     =copy(name shadowScope, arg c[].currentScope)
     rawCloseScope(arg c) (raises)
     scope:
-      def_cursor _0: Scope = shadowScope
-      def_cursor a: seq[Symbol] = _0[].symbols
+      def_cursor _4: Scope = shadowScope
+      def_cursor a: seq[Symbol] = _4[].symbols
       def i: int = 0
-      def_cursor _1: seq[Symbol] = a
-      def L: int = lengthSeq(arg _1)
+      def_cursor _7: seq[Symbol] = a
+      def L: int = lengthSeq(arg _7)
       block L0:
         scope:
           while true:
             scope:
-              def_cursor _2: int = i
-              def :tmp: bool = ltI(arg _2, arg L)
+              def_cursor _9: int = i
+              def :tmp: bool = ltI(arg _9, arg L)
               scope:
-                def_cursor _3: bool = :tmp
-                def _4: bool = not(arg _3)
-                if _4:
+                def_cursor _10: bool = :tmp
+                def _11: bool = not(arg _10)
+                if _11:
                   scope:
                     break L0
               scope:
                 scope:
-                  def_cursor _5: int = i
-                  def sym: lent Symbol = borrow a[_5]
-                  def _6: Symbol
-                  =copy(name _6, arg sym[])
-                  addInterfaceDecl(arg c, consume _6) (raises)
+                  def_cursor _13: int = i
+                  def sym: lent Symbol = borrow a[_13]
+                  def _14: Symbol
+                  =copy(name _14, arg sym[])
+                  addInterfaceDecl(arg c, consume _14) (raises)
                 i = addI(arg i, arg 1) (raises)
   finally:
     =destroy(name shadowScope)
@@ -170,20 +170,20 @@ scope:
   try:
     def x: sink string
     scope:
-      def_cursor _0: sink string = x
-      def _1: int = lengthStr(arg _0)
-      def _2: bool = eqI(arg _1, arg 2)
-      if _2:
+      def_cursor _2: sink string = x
+      def _3: int = lengthStr(arg _2)
+      def _4: bool = eqI(arg _3, arg 2)
+      if _4:
         scope:
           result := move x
           wasMoved(name x)
           return
-    def_cursor _3: sink string = x
-    def _4: int = lengthStr(arg _3)
-    def _5: string = $(arg _4) (raises)
-    echo(arg type(array[0..0, string]), arg _5) (raises)
+    def_cursor _5: sink string = x
+    def _6: int = lengthStr(arg _5)
+    def _7: string = $(arg _6) (raises)
+    echo(arg type(array[0..0, string]), arg _7) (raises)
   finally:
-    =destroy(name _5)
+    =destroy(name _7)
     =destroy(name x)
 
 -- end of expandArc ------------------------
@@ -191,49 +191,49 @@ scope:
 
 scope:
   try:
-    def_cursor _0: string = this[].value
-    this[].isValid = fileExists(arg _0) (raises)
-    def _1: tuple[dir: string, front: string]
+    def_cursor _2: string = this[].value
+    this[].isValid = fileExists(arg _2) (raises)
+    def _4: tuple[dir: string, front: string]
     block L0:
       scope:
-        def_cursor _2: string = this[].value
-        def _3: bool = dirExists(arg _2) (raises)
-        if _3:
+        def_cursor _5: string = this[].value
+        def _6: bool = dirExists(arg _5) (raises)
+        if _6:
           scope:
-            def _4: string
-            =copy(name _4, arg this[].value)
-            _1 := construct (consume _4, consume "")
+            def _7: string
+            =copy(name _7, arg this[].value)
+            _4 := construct (consume _7, consume "")
             break L0
       scope:
         try:
-          def_cursor _5: string = this[].value
-          def _6: string = parentDir(arg _5) (raises)
-          def _7: string
-          =copy(name _7, arg this[].value)
-          def _8: tuple[head: string, tail: string] = splitPath(consume _7) (raises)
-          bind_mut _16: string = _8.1
-          def _9: string = move _16
-          wasMoved(name _16)
-          _1 := construct (consume _6, consume _9)
-          wasMoved(name _6)
+          def_cursor _8: string = this[].value
+          def _9: string = parentDir(arg _8) (raises)
+          def _10: string
+          =copy(name _10, arg this[].value)
+          def _11: tuple[head: string, tail: string] = splitPath(consume _10) (raises)
+          bind_mut _19: string = _11.1
+          def _12: string = move _19
+          wasMoved(name _19)
+          _4 := construct (consume _9, consume _12)
+          wasMoved(name _9)
         finally:
-          =destroy(name _8)
-          =destroy(name _6)
-    def par: tuple[dir: string, front: string] = move _1
+          =destroy(name _11)
+          =destroy(name _9)
+    def par: tuple[dir: string, front: string] = move _4
     block L1:
       scope:
-        def_cursor _10: string = par.0
-        def _11: bool = dirExists(arg _10) (raises)
-        if _11:
+        def_cursor _13: string = par.0
+        def _14: bool = dirExists(arg _13) (raises)
+        if _14:
           scope:
-            def_cursor _12: string = par.0
-            def_cursor _13: string = par.1
-            def _14: seq[string] = getSubDirs(arg _12, arg _13) (raises)
-            =sink(name this[].matchDirs, arg _14)
+            def_cursor _15: string = par.0
+            def_cursor _16: string = par.1
+            def _17: seq[string] = getSubDirs(arg _15, arg _16) (raises)
+            =sink(name this[].matchDirs, arg _17)
             break L1
       scope:
-        def _15: seq[string] = construct ()
-        =sink(name this[].matchDirs, arg _15)
+        def _18: seq[string] = construct ()
+        =sink(name this[].matchDirs, arg _18)
   finally:
     =destroy(name par)
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -9,41 +9,41 @@ scope:
     scope:
       while true:
         scope:
-          def_cursor _0: Node = it
-          def _1: bool = eqRef(arg _0, arg nil)
-          def :tmp: bool = not(arg _1)
+          def_cursor _4: Node = it
+          def _5: bool = eqRef(arg _4, arg nil)
+          def :tmp: bool = not(arg _5)
           scope:
-            def_cursor _2: bool = :tmp
-            def _3: bool = not(arg _2)
-            if _3:
+            def_cursor _6: bool = :tmp
+            def _7: bool = not(arg _6)
+            if _7:
               scope:
                 break L0
           scope:
-            def_cursor _4: Node = it
-            def_cursor _5: string = _4[].s
-            echo(arg type(array[0..0, string]), arg _5) (raises)
-            def_cursor _6: Node = it
-            it = _6[].ri
+            def_cursor _8: Node = it
+            def_cursor _9: string = _8[].s
+            echo(arg type(array[0..0, string]), arg _9) (raises)
+            def_cursor _10: Node = it
+            it = _10[].ri
   def_cursor jt: Node = root
   block L1:
     scope:
       while true:
         scope:
-          def_cursor _7: Node = jt
-          def _8: bool = eqRef(arg _7, arg nil)
-          def :tmp: bool = not(arg _8)
+          def_cursor _13: Node = jt
+          def _14: bool = eqRef(arg _13, arg nil)
+          def :tmp: bool = not(arg _14)
           scope:
-            def_cursor _9: bool = :tmp
-            def _10: bool = not(arg _9)
-            if _10:
+            def_cursor _15: bool = :tmp
+            def _16: bool = not(arg _15)
+            if _16:
               scope:
                 break L1
           scope:
-            def_cursor _11: Node = jt
-            def_cursor ri: Node = _11[].ri
-            def_cursor _12: Node = jt
-            def_cursor _13: string = _12[].s
-            echo(arg type(array[0..0, string]), arg _13) (raises)
+            def_cursor _18: Node = jt
+            def_cursor ri: Node = _18[].ri
+            def_cursor _19: Node = jt
+            def_cursor _20: string = _19[].s
+            echo(arg type(array[0..0, string]), arg _20) (raises)
             jt = ri
 -- end of expandArc ------------------------'''
 """

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -11,12 +11,12 @@ scope:
     scope:
       if cond:
         scope:
-          def _0: seq[int] = move x
-          add(name a, consume _0)
+          def _5: seq[int] = move x
+          add(name a, consume _5)
           break L0
     scope:
-      def _1: seq[int] = move x
-      add(name b, consume _1)
+      def _6: seq[int] = move x
+      add(name b, consume _6)
   =destroy(name b)
   =destroy(name a)
 -- end of expandArc ------------------------
@@ -35,38 +35,38 @@ scope:
         scope:
           while true:
             scope:
-              def_cursor _0: int = i
-              def :tmp: bool = ltI(arg _0, arg b)
+              def_cursor _9: int = i
+              def :tmp: bool = ltI(arg _9, arg b)
               scope:
-                def_cursor _1: bool = :tmp
-                def _2: bool = not(arg _1)
-                if _2:
+                def_cursor _10: bool = :tmp
+                def _11: bool = not(arg _10)
+                if _11:
                   scope:
                     break L0
               scope:
                 scope:
                   def_cursor i: int = i
                   scope:
-                    def _3: bool = eqI(arg i, arg 2)
-                    if _3:
+                    def _13: bool = eqI(arg i, arg 2)
+                    if _13:
                       scope:
                         return
-                  def _4: seq[int]
-                  =copy(name _4, arg x)
-                  add(name a, consume _4)
+                  def _14: seq[int]
+                  =copy(name _14, arg x)
+                  add(name a, consume _14)
                 i = addI(arg i, arg 1) (raises)
     block L1:
       scope:
         if cond:
           scope:
-            def _5: seq[int] = move x
+            def _15: seq[int] = move x
             wasMoved(name x)
-            add(name a, consume _5)
+            add(name a, consume _15)
             break L1
       scope:
-        def _6: seq[int] = move x
+        def _16: seq[int] = move x
         wasMoved(name x)
-        add(name b, consume _6)
+        add(name b, consume _16)
   finally:
     =destroy(name x)
     =destroy(name b)
@@ -81,11 +81,11 @@ scope:
       if cond:
         scope:
           return
-    def _0: string = boolToStr(arg cond)
-    str := move _0
+    def _4: string = boolToStr(arg cond)
+    str := move _4
     scope:
-      def _1: bool = not(arg cond)
-      if _1:
+      def _5: bool = not(arg cond)
+      if _5:
         scope:
           result := move str
           wasMoved(name str)

--- a/tests/compiler/ttreechangesets.nim
+++ b/tests/compiler/ttreechangesets.nim
@@ -13,7 +13,7 @@ import
 type Changeset = TreeChangeset
 
 proc temp(x: int): MirNode =
-  MirNode(kind: mnkTemp, temp: x.TempId)
+  MirNode(kind: mnkTemp, local: x.TempId)
 
 func `==`(a: TempId, b: int): bool =
   a.int == b
@@ -29,7 +29,7 @@ func `==`(a, b: MirNode): bool =
   # only implements the comparisons needed by the tests
   case a.kind
   of mnkTemp:
-    result = a.temp == b.temp
+    result = a.local == b.local
   else:
     doAssert false
 

--- a/tests/compiler/ttreechangesets.nim
+++ b/tests/compiler/ttreechangesets.nim
@@ -13,9 +13,9 @@ import
 type Changeset = TreeChangeset
 
 proc temp(x: int): MirNode =
-  MirNode(kind: mnkTemp, local: x.TempId)
+  MirNode(kind: mnkTemp, local: x.LocalId)
 
-func `==`(a: TempId, b: int): bool =
+func `==`(a: LocalId, b: int): bool =
   a.int == b
 
 func insert(c: var Changeset, i: int, n: sink MirNode) =

--- a/tests/exception/truntime_check_panics.nim
+++ b/tests/exception/truntime_check_panics.nim
@@ -13,19 +13,19 @@ scope:
   chckIndex(arg a, arg i)
   discard a[i]
   chckBounds(arg a, arg 0, arg i)
-  def _0: openArray[int] = toOpenArray a, 0, i
-  def _1: int = addI(arg i, arg i)
-  def _2: int = unaryMinusI(arg i)
-  def _3: range 0..1(int) = chckRange(arg i, arg 0, arg 1)
+  def _6: openArray[int] = toOpenArray a, 0, i
+  def _7: int = addI(arg i, arg i)
+  def _8: int = unaryMinusI(arg i)
+  def _9: range 0..1(int) = chckRange(arg i, arg 0, arg 1)
   chckField(arg <D0>, arg o.kind, arg false, arg "field \'x\' is not accessible for type \'Object\' using \'kind = ")
   discard o.kind.x
-  def _5: bool = isNil(arg r)
-  def _4: bool = not(arg _5)
-  if _4:
+  def _11: bool = isNil(arg r)
+  def _10: bool = not(arg _11)
+  if _10:
     chckObj(arg r, arg type(Sub:ObjectType))
   discard r.(Sub)
-  def _6: float = mulF64(arg f, arg f)
-  chckNaN(arg _6)
+  def _12: float = mulF64(arg f, arg f)
+  chckNaN(arg _12)
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -7,27 +7,41 @@ destroying O1'''
   nimout: '''--expandArc: main
 scope:
   try:
-    def _0: string = newString(arg 100)
-    def_cursor _1: seq[byte] = cast _0
-    def _2: openArray[byte] = toOpenArray _1
-    def _3: seq[byte] = encode(arg _2) (raises)
-    def_cursor _4: string = cast _3
+    def _2: string = newString(arg 100)
+    def_cursor _3: seq[byte] = cast _2
+    def _4: openArray[byte] = toOpenArray _3
+    def _5: seq[byte] = encode(arg _4) (raises)
+    def_cursor _6: string = cast _5
     def data: string
-    =copy(name data, arg _4)
+    =copy(name data, arg _6)
   finally:
     =destroy(name data)
-    =destroy(name _3)
-    =destroy(name _0)
+    =destroy(name _5)
+    =destroy(name _2)
 -- end of expandArc ------------------------
 --expandArc: main1
 scope:
   try:
     def s: string = newString(arg 100)
-    def_cursor _0: string = s
-    def _1: int = lengthStr(arg _0)
-    def _2: int = subI(arg _1, arg 1) (raises)
-    chckBounds(arg s, arg 0, arg _2) (raises)
-    def _3: openArray[byte] = toOpenArray s, 0, _2
+    def_cursor _3: string = s
+    def _4: int = lengthStr(arg _3)
+    def _5: int = subI(arg _4, arg 1) (raises)
+    chckBounds(arg s, arg 0, arg _5) (raises)
+    def _6: openArray[byte] = toOpenArray s, 0, _5
+    def _7: seq[byte] = encode(arg _6) (raises)
+    def_cursor _8: string = cast _7
+    def data: string
+    =copy(name data, arg _8)
+  finally:
+    =destroy(name data)
+    =destroy(name _7)
+    =destroy(name s)
+-- end of expandArc ------------------------
+--expandArc: main2
+scope:
+  try:
+    def s: seq[byte] = newSeq(arg 100) (raises)
+    def _3: openArray[byte] = toOpenArray s
     def _4: seq[byte] = encode(arg _3) (raises)
     def_cursor _5: string = cast _4
     def data: string
@@ -37,33 +51,19 @@ scope:
     =destroy(name _4)
     =destroy(name s)
 -- end of expandArc ------------------------
---expandArc: main2
-scope:
-  try:
-    def s: seq[byte] = newSeq(arg 100) (raises)
-    def _0: openArray[byte] = toOpenArray s
-    def _1: seq[byte] = encode(arg _0) (raises)
-    def_cursor _2: string = cast _1
-    def data: string
-    =copy(name data, arg _2)
-  finally:
-    =destroy(name data)
-    =destroy(name _1)
-    =destroy(name s)
--- end of expandArc ------------------------
 --expandArc: main3
 scope:
   try:
-    def _0: seq[byte] = newSeq(arg 100) (raises)
-    def _1: openArray[byte] = toOpenArray _0
-    def _2: seq[byte] = encode(arg _1) (raises)
-    def_cursor _3: string = cast _2
+    def _2: seq[byte] = newSeq(arg 100) (raises)
+    def _3: openArray[byte] = toOpenArray _2
+    def _4: seq[byte] = encode(arg _3) (raises)
+    def_cursor _5: string = cast _4
     def data: string
-    =copy(name data, arg _3)
+    =copy(name data, arg _5)
   finally:
     =destroy(name data)
+    =destroy(name _4)
     =destroy(name _2)
-    =destroy(name _0)
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/misc/tdont_fold_procedure_cast.nim
+++ b/tests/misc/tdont_fold_procedure_cast.nim
@@ -8,10 +8,10 @@ discard """
   nimout: '''
 --expandArc: test
 scope:
-  def_cursor _0: proc (x: float){.nimcall.} = cast other
-  def p: proc (x: float){.nimcall.} = copy _0
-  def_cursor _1: proc (x: int){.nimcall.} = cast p
-  _1(arg 1) (raises)
+  def_cursor _2: proc (x: float){.nimcall.} = cast other
+  def p: proc (x: float){.nimcall.} = copy _2
+  def_cursor _3: proc (x: int){.nimcall.} = cast p
+  _3(arg 1) (raises)
 -- end of expandArc ------------------------
   '''
   output: "1"


### PR DESCRIPTION
## Summary

In the MIR, temporaries are now real locals that use `Local` and
`LocalId`. Previously, they only existed as IDs (`TempId`), which were
then materialized into real locals by `cgirgen`.

This further shrinks down `cgirgen`, preparing for its eventual
removal. Temporaries and normal locals using the same `MirNode` variant
also unifies some code paths.

## Details

* `mnkTemp` and `mnkAlias` use the same variant as `mnkLocal` and
  `mnkParam`
* the `TempId` type is removed
* allocating new temporaries now uses `addLocal` underneath, removing
  the `numTemps` tracking
* `Changeset` initialization is faster now, since the MIR tree doesn't
  need to be scanned for temporaries anymore
* since temporaries now share their namespace with locals, their names
  in pretty-printed MIR are different, which affects the `--expandArc`-
  using tests