### PR TITLE
fix(sem): wrong error reported for `raise`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1351,6 +1351,8 @@ type
         adSemDotOperatorsNotEnabled,
         adSemCallOperatorsNotEnabled,
         adSemUnexpectedPattern,
+        adSemCannotBeRaised,
+        adSemCannotRaiseNonException,
         adSemIsOperatorTakes2Args,
         adSemNoTupleTypeForConstructor,
         adSemInvalidOrderInArrayConstructor,
@@ -1555,8 +1557,6 @@ type
       defNameSymData*: AdSemDefNameSym
     of adSemInvalidControlFlow:
       label*: PSym
-    of adSemCannotBeRaised, adSemCannotRaiseNonException:
-      excType*: PType
 
   AdSemDefNameSymKind* = enum
     adSemDefNameSymExpectedKindMismatch

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1191,6 +1191,8 @@ type
     adSemDotOperatorsNotEnabled
     adSemCallOperatorsNotEnabled
     adSemUnexpectedPattern
+    adSemCannotBeRaised
+    adSemCannotRaiseNonException
     # types
     adSemTypeKindMismatch
     # semexprs
@@ -1553,6 +1555,8 @@ type
       defNameSymData*: AdSemDefNameSym
     of adSemInvalidControlFlow:
       label*: PSym
+    of adSemCannotBeRaised, adSemCannotRaiseNonException:
+      excType*: PType
 
   AdSemDefNameSymKind* = enum
     adSemDefNameSymExpectedKindMismatch

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3837,7 +3837,7 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       reportInst: diag.instLoc.toReportLineInfo,
       kind: kind,
       ast: diag.wrongNode,
-      typ: diag.excType)
+      typ: diag.wrongNode[0].typ)
   of adVmError:
     let
       kind = diag.vmErr.kind.astDiagVmToLegacyReportKind()

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3831,6 +3831,13 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       ast: diag.wrongNode,
       str: diag.compilerOpt.getStr,
       compilerOptArg: diag.compilerOptArg.getStr)
+  of adSemCannotBeRaised, adSemCannotRaiseNonException:
+    semRep = SemReport(
+      location: some diag.location,
+      reportInst: diag.instLoc.toReportLineInfo,
+      kind: kind,
+      ast: diag.wrongNode,
+      typ: diag.excType)
   of adVmError:
     let
       kind = diag.vmErr.kind.astDiagVmToLegacyReportKind()

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -531,6 +531,8 @@ func astDiagToLegacyReportKind*(
   of adSemDotOperatorsNotEnabled: rsemEnableDotOperatorsExperimental
   of adSemCallOperatorsNotEnabled: rsemEnableCallOperatorExperimental
   of adSemUnexpectedPattern: rsemUnexpectedPattern
+  of adSemCannotBeRaised: rsemCannotBeRaised
+  of adSemCannotRaiseNonException: rsemCannotRaiseNonException
   of adSemConstantOfTypeHasNoValue: rsemConstantOfTypeHasNoValue
   of adSemTypeConversionArgumentMismatch: rsemTypeConversionArgumentMismatch
   of adSemUnexpectedEqInObjectConstructor: rsemUnexpectedEqInObjectConstructor

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1746,10 +1746,10 @@ proc semRaise(c: PContext, n: PNode): PNode =
       let refTyp = typ.skipTypes({tyAlias, tyGenericInst})
       if refTyp.kind != tyRef:
         result = c.config.newError(result,
-          PAstDiag(kind: adSemCannotBeRaised, excType: typ))
+          PAstDiag(kind: adSemCannotBeRaised))
       elif not isException(refTyp.lastSon):
         result = c.config.newError(result,
-          PAstDiag(kind: adSemCannotRaiseNonException, excType: typ))
+          PAstDiag(kind: adSemCannotRaiseNonException))
 
 proc addGenericParamListToScope(c: PContext, n: PNode) =
   if n.kind != nkGenericParams:

--- a/tests/errmsgs/terror_in_raise.nim
+++ b/tests/errmsgs/terror_in_raise.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "undeclared identifier: 'doesntExist'"
+  line: 6
+"""
+
+raise doesntExist


### PR DESCRIPTION
## Summary

Fix errors in expressions within `raise` statements being hidden
behind an "only a 'ref object' can be raised" error.

Fixes https://github.com/nim-works/nimskull/issues/112 

## Details

* make `semRaise` `nkError`-aware (proper error propagation)
* don't modify input AST in `semRaise`
* replace `localReport` in `semRaise` with `nkError`; the necessary
  diagnostics corresponding to the legacy reports are introduced