### PR TITLE
vmjit: remove expression-related workaround

### DIFF
--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -208,16 +208,6 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
   ##   call(arg a.b.c)
   var ct = initCountTable[uint32]()
 
-  proc isDangerous(tree: MirTree, n: NodePosition): bool =
-    # HACK: this is a tremendous hack to detect whether `n` is part of a
-    #       loose expression, which are currently required by expression
-    #       support for ``vmjit``. Remove as soon as no longer needed
-    var i = int n
-    while i < tree.len and tree[i].kind notin StmtNodes:
-      inc i
-
-    result = i >= tree.len
-
   # first pass: gather all single-use temporaries that are created from
   # lvalues and are eligible for elimination.
   var i = NodePosition 0
@@ -240,10 +230,7 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
       #      looking for names
       let id = tree[i].local
       if hasKey(ct, id.uint32):
-        if isDangerous(tree, i):
-          ct.del(id.uint32)
-        else:
-          ct.inc(id.uint32)
+        ct.inc(id.uint32)
 
       inc i
     of mnkDeref, mnkDerefView:


### PR DESCRIPTION
## Summary

Make the MIR tree produced for standalone expressions (e.g., 
initializer of a `const`) syntactically well-formed. Previously, these
trees contained a trailing MIR expression, which required various
workarounds in other places (all of which are now removed).

## Details

* add the `exprToMir` procedure to `mirgen`; it produces a proper MIR
  body for standalone expressions by assigning the expression to the
  result variable
  * the body is wrapped in a scope (`mnkScope`), which means passes can
    now rely on the presence of an outermost scope block
* use `exprToMir` in `vmjit` for producing the MIR body for standalone
  expressions
* remove the dedicated code generation for standalone expressions from
  `vmgen` (`genExpr`)
* unify the expression/statement handling in `vmjit`
* remove the workarounds for trailing expressions from `cgirgen` and
  `mirpasses`

To replicate the previous behaviour, where no copy of the value was
introduced for lvalue expressions, `vmjit` wraps standalone lvalue
expressions in an `nkHiddenAddr`, prior to passing the AST to
`exprToMir`.