### PR TITLE
refactor: remove `aliasanalysis.isCursor`

### DIFF
--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -114,16 +114,6 @@ proc getRoot*(tree: MirTree, n: OpValue): OpValue =
   else:
     result = pos
 
-func isCursor*(tree: MirTree, path: Path): bool =
-  ## Returns whether the path `n` denotes a cursor location.
-  # XXX: this is an intermediate solution. ``mirgen`` is going to handle
-  #      all cursor-related behaviour in the future, which will make this
-  #      procedure obsolete
-  for i in 0..<path.len:
-    if path[i].kind == pikNamed and sfCursor in tree[path[i].node].field.flags:
-      result = true
-      break
-
 proc computePath*(tree: MirTree, at: NodePosition): Path =
   ## Computes the ``Path`` for the given expression. The expression not being
   ## a path expression is allowed too.

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -294,8 +294,7 @@ func computeOwnership(tree: MirTree, cfg: DataFlowGraph, entities: EntityDict,
     #       visit it first
     var exists = false
     let info = entities.findScope(toName(tree[lval.root]), start, exists)
-    exists and not isCursor(tree, lval) and
-      isLastRead(tree, cfg, info.scope, lval, start)
+    exists and isLastRead(tree, cfg, info.scope, lval, start)
   else:
     unreachable()
 


### PR DESCRIPTION
## Summary

The procedure and its usage are obsolete, as `mirgen` already takes
care of cursor location handling.

## Details

With commit
https://github.com/nim-works/nimskull/commit/94837f4ca9c6b01c12ba4ae57986390b95fe887d
([PR](https://github.com/nim-works/nimskull/pull/1195)),
no `sink` operations (i.e., the only assignment modifier for which
ownership computation is required) are inserted for cursor
locations, meaning that the `isCursor` call in `computeOwnership`
always returned false.