### PR TITLE
mir: improve set construction syntax

### DIFF
--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -171,14 +171,18 @@ proc translate*(t: MirTree): CgNode =
           cnkArrayConstr
         of tyTuple:
           cnkTupleConstr
-        of tySet:
-          cnkSetConstr
         of tyProc:
           cnkClosureConstr
         else:
           unreachable()
 
       tree kind:
+        translateAux(t, i)
+    of mnkSetConstr:
+      tree cnkSetConstr:
+        translateAux(t, i)
+    of mnkRange:
+      tree cnkRange:
         translateAux(t, i)
     of mnkArg:
       let x = translateAux(t, i)

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -47,15 +47,13 @@ func hashTree(tree: ConstrTree): Hash =
           hash(n.intVal)
         of nkNilLit:
           Hash(0)
-        of nkRange:
-          hashLit(n[0]) !& hashLit(n[1])
         else:
           unreachable(n.kind)
 
       result = result !& hashLit(n.lit)
     of mnkProc:
       result = result !& hash(n.prc.ord)
-    of mnkObjConstr, mnkConstr:
+    of mnkConstr, mnkSetConstr, mnkRange, mnkObjConstr:
       result = result !& hash(n.len)
     of mnkField:
       result = result !& hash(n.field.id)
@@ -88,8 +86,6 @@ func cmp(a, b: PNode): bool =
     a.strVal == b.strVal
   of nkNilLit:
     true
-  of nkRange:
-    cmp(a[0], b[0]) and cmp(a[1], b[1])
   else:
     unreachable(a.kind)
 
@@ -104,7 +100,7 @@ proc cmp(a, b: ConstrTree): bool =
       cmp(a.lit, b.lit)
     of mnkProc:
       a.prc == b.prc
-    of mnkConstr, mnkObjConstr:
+    of mnkConstr, mnkSetConstr, mnkRange, mnkObjConstr:
       a.len == b.len
     of mnkField:
       a.field.id == b.field.id

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -321,7 +321,7 @@ proc eliminateTemporaries(tree: MirTree, changes: var Changeset) =
       of LvalueExprKinds:
         # usage in an lvalue expression -> the temporary can be elided
         elide = true
-      of RvalueExprKinds:
+      of RvalueExprKinds, mnkSetConstr:
         elide = true
       of mnkConstr, mnkObjConstr:
         # if the lvalue doesn't overlap with the assignment destination, the

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -171,6 +171,9 @@ type
     mnkConstr     ## constructs a either new aggregate value or set value made
                   ## up of the input values. Whether the resulting value is
                   ## owned depends on whether one the context it's used in
+    mnkSetConstr  ## constructor for set values
+    mnkRange      ## range constructor. May only appear in set constructions
+                  ## and as a branch label
     mnkObjConstr  ## either allocate a new managed heap cell and returns a
                   ## ``ref`` to it, or or constructs a new aggregate value
                   ## with named fields
@@ -335,8 +338,8 @@ const
     ## Assignment modifiers. Nodes that can only appear directly in the source
     ## slot of assignments.
 
-  ConstrTreeNodes* = {mnkConstr, mnkObjConstr, mnkLiteral, mnkProc,
-                      mnkArg, mnkField, mnkEnd}
+  ConstrTreeNodes* = {mnkConstr, mnkSetConstr, mnkRange, mnkObjConstr,
+                      mnkLiteral, mnkProc, mnkArg, mnkField, mnkEnd}
     ## Nodes that can appear in the MIR subset used for constant expressions.
 
   # --- semantics-focused sets:
@@ -360,8 +363,9 @@ const
   RvalueExprKinds* = {mnkLiteral, mnkType, mnkProc, mnkConv, mnkStdConv,
                       mnkCast, mnkAddr, mnkView, mnkToSlice} + UnaryOps +
                      BinaryOps
-  ExprKinds* =       {mnkCall, mnkCheckedCall, mnkConstr, mnkObjConstr} +
-                     LvalueExprKinds + RvalueExprKinds + ModifierNodes
+  ExprKinds* =       {mnkCall, mnkCheckedCall, mnkConstr, mnkSetConstr,
+                      mnkObjConstr} + LvalueExprKinds + RvalueExprKinds +
+                     ModifierNodes
 
   CallKinds* = {mnkCall, mnkCheckedCall}
 

--- a/compiler/mir/proto_mir.nim
+++ b/compiler/mir/proto_mir.nim
@@ -594,7 +594,7 @@ proc exprToPmir(c: TranslateCtx, result: var seq[ProtoItem], n: PNode, sink: boo
     result.add ProtoItem(orig: n, typ: n.typ, kind: k, field: val)
 
   case n.kind
-  of nkLiterals, nkRange, nkNimNodeLit:
+  of nkLiterals, nkNimNodeLit:
     node pirLiteral
   of nkLambdaKinds:
     node pirProc, sym, n[namePos].sym

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -309,6 +309,16 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
       commaSeparated:
         argToStr()
       result.add ")"
+  of mnkSetConstr:
+    tree "{":
+      commaSeparated:
+        exprToStr(nodes, i, result, c)
+      result.add "}"
+  of mnkRange:
+    tree "":
+      valueToStr()
+      result.add " .. "
+      valueToStr()
   of mnkObjConstr:
     tree "(":
       commaSeparated:

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -238,6 +238,14 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
   case tree[source].kind
   of mnkCall, mnkCheckedCall, mnkConstr, mnkObjConstr:
     emitForArgs(env, tree, at, source)
+  of mnkSetConstr:
+    for it in subNodes(tree, source):
+      case tree[it].kind
+      of mnkRange:
+        emitLvalueOp(env, opUse, tree, at, tree.operand(it, 0))
+        emitLvalueOp(env, opUse, tree, at, tree.operand(it, 1))
+      else:
+        emitLvalueOp(env, opUse, tree, at, OpValue it)
   of mnkConv, mnkStdConv, mnkCast:
     # a read is performed on the source operand (if it's an lvalue)
     emitLvalueOp(env, opUse, tree, at, tree.operand(source))

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -98,15 +98,17 @@ Semantics
                     | CheckedCall LVALUE CALL_ARG ...  EX_TARGET
                     | CheckedCall <Magic> CALL_ARG ... EX_TARGET
 
+  SET_CONSTR_ARG = VALUE
+                 | Range VALUE VALUE     # range construction
 
   RVALUE = UNARY_OP
          | BINARY_OP
          | CALL_EXPR
          | CHECKED_CALL_EXPR
-         | Constr   CONSTR_ARG ...       # construct a tuple, closure, set, or
+         | Constr   CONSTR_ARG ...       # construct a tuple, closure, or array
+         | SetConstr SET_CONSTR_ARG ...
          | ObjConstr (<Field> CONSTR_ARG) ... # construct an `object` or
                                          # `ref object`
-                                         # array
          | StdConv  VALUE                # number conversion or conversion
                                          # between cstring and string
          | Conv     VALUE                # same as `StdConv`. Only duplicate
@@ -211,6 +213,7 @@ Semantics
 
   BRANCH_LABEL = <Literal>
                | <Const>
+               | Range <Literal> <Literal>
   BRANCH_LIST = (Branch BRANCH_LABEL ... STATEMENT) ... # a list of branches
               | (Branch BRANCH_LABEL ... TARGET) ...
 
@@ -385,5 +388,9 @@ ones).
 
   ARG = Arg VALUE
 
+  SET_CONSTR_ARG = <Literal>
+                 | Range <Literal> <Literal>
+
   COMPLEX = Constr ARG...
+          | SetConstr SET_CONSTR_ARG...
           | ObjConstr (<Field> ARG)...

--- a/tests/stdlib/types/sets/tsets.nim
+++ b/tests/stdlib/types/sets/tsets.nim
@@ -92,3 +92,12 @@ block:
 
   doAssert k99 notin s1
   doAssert k99 notin s2
+
+block set_construction_with_dynamic_range:
+  # constructing a set value using dynamic ranges crashed the compiler
+  var
+    a = 1'u8
+    b = 4'u8
+  let se = {a..b}
+  doAssert 3'u8 in se
+  doAssert 5'u8 notin se


### PR DESCRIPTION
## Summary

Introduce a dedicated node representation for set constructions in the
MIR, making their data layout more terse and fixing a set construction
like `{a .. b}` crashing the compiler when `a` or `b` are non-constant
expressions.

## Details

* add the `mnkSetConstr` and `mnkRange` node kinds
  * since `set`s are *not* aggregate types, wrapping the operands of
    the construction in argument nodes is unnecessary
  * `mnkSetConstr` is pretty-printed as `{...}` instead of the generic
    `construct (...)`
* don't treat `nkRange` as literal data
* translate `nkRange` to `mnkRange` for both branch labels and in set
  constructions
  * dynamic ranges are now properly considered by `mirgen`
* hashing/comparison for `DataTable`, constant expression
  serialization, and data-flow graph creation are adjusted to the new
  tree shapes
* translate `mnkSetConstr` and `mnkRange` to `cnkSetConstr` and
  `cnkRange` in `cgirgen`
  * both set construction elements and branch labels use
    `setElementToIr`, even though this doesn't reject incorrect syntax
    for branch labels

In addition to fixing the aforementioned compiler crash, the dedicated
`mnkSetConstr` and `mnkRange` node kinds:
* remove a difference between the MIR and CGIR
* encode set construction semantics directly in the MIR, removing a
  source of having to dispatch over the nodes' type