### PR TITLE
std/socket: Use 0 as default protocol number

### DIFF
--- a/lib/posix/posix_freertos_consts.nim
+++ b/lib/posix/posix_freertos_consts.nim
@@ -199,6 +199,7 @@ var LWIP_NSC_IPV6_ADDR_STATE_CHANGED* {.importc: "LWIP_NSC_IPV6_ADDR_STATE_CHANG
 var IF_NAMESIZE* {.importc: "IF_NAMESIZE", header: "<net/if.h>".}: cint
 
 # <sys/socket.h>
+const IPPROTO_DEFAULT* = cint(0)
 var IPPROTO_IP* {.importc: "IPPROTO_IP", header: "<sys/socket.h>".}: cint
 var IPPROTO_IPV6* {.importc: "IPPROTO_IPV6", header: "<sys/socket.h>".}: cint
 var IPPROTO_ICMP* {.importc: "IPPROTO_ICMP", header: "<sys/socket.h>".}: cint

--- a/lib/posix/posix_linux_amd64_consts.nim
+++ b/lib/posix/posix_linux_amd64_consts.nim
@@ -305,6 +305,7 @@ const EAI_OVERFLOW* = cint(-12)
 const IF_NAMESIZE* = cint(16)
 
 # <netinet/in.h>
+const IPPROTO_DEFAULT* = cint(0)
 const IPPROTO_IP* = cint(0)
 const IPPROTO_IPV6* = cint(41)
 const IPPROTO_ICMP* = cint(1)

--- a/lib/posix/posix_nintendoswitch_consts.nim
+++ b/lib/posix/posix_nintendoswitch_consts.nim
@@ -234,6 +234,7 @@ const EAI_OVERFLOW* = cint(14)
 const IF_NAMESIZE* = cint(16)
 
 # <netinet/in.h>
+const IPPROTO_DEFAULT* = cint(0)
 const IPPROTO_IP* = cint(0)
 const IPPROTO_IPV6* = cint(41)
 const IPPROTO_ICMP* = cint(1)

--- a/lib/posix/posix_other_consts.nim
+++ b/lib/posix/posix_other_consts.nim
@@ -301,6 +301,7 @@ var EAI_OVERFLOW* {.importc: "EAI_OVERFLOW", header: "<netdb.h>".}: cint
 var IF_NAMESIZE* {.importc: "IF_NAMESIZE", header: "<net/if.h>".}: cint
 
 # <netinet/in.h>
+const IPPROTO_DEFAULT* = cint(0)
 var IPPROTO_IP* {.importc: "IPPROTO_IP", header: "<netinet/in.h>".}: cint
 var IPPROTO_IPV6* {.importc: "IPPROTO_IPV6", header: "<netinet/in.h>".}: cint
 var IPPROTO_ICMP* {.importc: "IPPROTO_ICMP", header: "<netinet/in.h>".}: cint

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -753,7 +753,7 @@ proc newConnection(client: HttpClient,
           nativesockets.Port(80)
       else: nativesockets.Port(connectionUrl.port.parseInt)
 
-    client.socket = net.dial(connectionUrl.hostname, port)
+    client.socket = net.dial(connectionUrl.hostname, port, SOCK_STREAM)
 
     when defined(ssl):
       if isSsl:

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -69,6 +69,7 @@ type
     SOCK_SEQPACKET = 5 ## reliable sequenced packet service
 
   Protocol* = enum    ## third argument to `socket` proc
+    IPPROTO_DEFAULT = 0,
     IPPROTO_TCP = 6,  ## Transmission control protocol.
     IPPROTO_UDP = 17, ## User datagram protocol.
     IPPROTO_IP,       ## Internet protocol.
@@ -153,6 +154,7 @@ when not useWinVersion:
 
   proc toInt(p: Protocol): cint =
     case p
+    of IPPROTO_DEFAULT: result = posix.IPPROTO_DEFAULT
     of IPPROTO_TCP: result = posix.IPPROTO_TCP
     of IPPROTO_UDP: result = posix.IPPROTO_UDP
     of IPPROTO_IP: result = posix.IPPROTO_IP
@@ -178,7 +180,7 @@ else:
 
   proc toInt(p: Protocol): cint =
     case p
-    of IPPROTO_IP:
+    of IPPROTO_IP, IPPROTO_DEFAULT:
       result = 0.cint
     of IPPROTO_ICMP:
       result = 1.cint
@@ -254,7 +256,7 @@ proc createNativeSocket*(domain: cint, sockType: cint, protocol: cint,
 
 proc createNativeSocket*(domain: Domain = AF_INET,
                          sockType: SockType = SOCK_STREAM,
-                         protocol: Protocol = IPPROTO_TCP,
+                         protocol: Protocol = IPPROTO_DEFAULT,
                          inheritable: bool = defined(nimInheritHandles)): SocketHandle =
   ## Creates a new socket; returns `osInvalidSocket` if an error occurs.
   ##
@@ -278,7 +280,7 @@ proc listen*(socket: SocketHandle, backlog = SOMAXCONN): cint {.tags: [
 
 proc getAddrInfo*(address: string, port: Port, domain: Domain = AF_INET,
                   sockType: SockType = SOCK_STREAM,
-                  protocol: Protocol = IPPROTO_TCP): ptr AddrInfo =
+                  protocol: Protocol = IPPROTO_DEFAULT): ptr AddrInfo =
   ##
   ##
   ## .. warning:: The resulting `ptr AddrInfo` must be freed using `freeAddrInfo`!

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -195,15 +195,6 @@ else:
     else:
       result = cint(ord(p))
 
-proc toSockType*(protocol: Protocol): SockType =
-  result = case protocol
-  of IPPROTO_TCP:
-    SOCK_STREAM
-  of IPPROTO_UDP:
-    SOCK_DGRAM
-  of IPPROTO_IP, IPPROTO_IPV6, IPPROTO_RAW, IPPROTO_ICMP, IPPROTO_ICMPV6:
-    SOCK_RAW
-
 proc getProtoByName*(name: string): int {.since: (1, 3, 5).} =
   ## Returns a protocol code from the database that matches the protocol `name`.
   when useWinVersion:

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -237,7 +237,7 @@ proc toOSFlags*(socketFlags: set[SocketFlag]): cint =
 
 proc newSocket*(fd: SocketHandle, domain: Domain = AF_INET,
     sockType: SockType = SOCK_STREAM,
-    protocol: Protocol = IPPROTO_TCP, buffered = true): owned(Socket) =
+    protocol: Protocol = IPPROTO_DEFAULT, buffered = true): owned(Socket) =
   ## Creates a new socket as specified by the params.
   assert fd != osInvalidSocket
   result = Socket(
@@ -269,7 +269,7 @@ proc newSocket*(domain, sockType, protocol: cint, buffered = true,
                      buffered)
 
 proc newSocket*(domain: Domain = AF_INET, sockType: SockType = SOCK_STREAM,
-                protocol: Protocol = IPPROTO_TCP, buffered = true,
+                protocol: Protocol = IPPROTO_DEFAULT, buffered = true,
                 inheritable = defined(nimInheritHandles)): owned(Socket) =
   ## Creates a new socket.
   ##
@@ -1650,7 +1650,6 @@ proc recvFrom*[T: string | IpAddress](socket: Socket, data: var string, length: 
     else:
       raiseOSError(osLastError())
 
-  assert(socket.protocol != IPPROTO_TCP, "Cannot `recvFrom` on a TCP socket")
   # TODO: Buffered sockets
   data.setLen(length)
 
@@ -1732,7 +1731,6 @@ proc sendTo*(socket: Socket, address: string, port: Port, data: pointer,
   ## which is defined below.
   ##
   ## **Note:** This proc is not available for SSL sockets.
-  assert(socket.protocol != IPPROTO_TCP, "Cannot `sendTo` on a TCP socket")
   assert(not socket.isClosed, "Cannot `sendTo` on a closed socket")
   var aiList = getAddrInfo(address, port, af, socket.sockType, socket.protocol)
   # try all possibilities:
@@ -1777,7 +1775,6 @@ proc sendTo*(socket: Socket, address: IpAddress, port: Port,
   ## If an error occurs an OSError exception will be raised.
   ##
   ## This is the high-level version of the above `sendTo` function.
-  assert(socket.protocol != IPPROTO_TCP, "Cannot `sendTo` on a TCP socket")
   assert(not socket.isClosed, "Cannot `sendTo` on a closed socket")
 
   var sa: Sockaddr_storage
@@ -1915,7 +1912,7 @@ proc `$`*(address: IpAddress): string =
           printedLastGroup = true
 
 proc dial*(address: string, port: Port,
-           protocol = IPPROTO_TCP, buffered = true): owned(Socket)
+           protocol = IPPROTO_DEFAULT, buffered = true): owned(Socket)
            {.tags: [ReadIOEffect, WriteIOEffect].} =
   ## Establishes connection to the specified `address`:`port` pair via the
   ## specified protocol. The procedure iterates through possible

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1911,15 +1911,14 @@ proc `$`*(address: IpAddress): string =
 
           printedLastGroup = true
 
-proc dial*(address: string, port: Port,
+proc dial*(address: string, port: Port, sockType: SockType,
            protocol = IPPROTO_DEFAULT, buffered = true): owned(Socket)
            {.tags: [ReadIOEffect, WriteIOEffect].} =
   ## Establishes connection to the specified `address`:`port` pair via the
-  ## specified protocol. The procedure iterates through possible
+  ## specified socket type and protocol. The procedure iterates through possible
   ## resolutions of the `address` until it succeeds, meaning that it
   ## seamlessly works with both IPv4 and IPv6.
   ## Returns Socket ready to send or receive data.
-  let sockType = protocol.toSockType()
 
   let aiList = getAddrInfo(address, port, AF_UNSPEC, sockType, protocol)
 


### PR DESCRIPTION
## Summary



* The default protocol number is changed to 0, as specified by POSIX.
* We are changing it to align the standard library to POSIX standards.



---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers

Prior as https://github.com/nim-lang/Nim/pull/19674.

I don't know what I am doing. I only know that the default protocol number should be 0 (default protocol for AF & socket type, to be determined by the OS).

`nativesocket.nim` has a lot of duplicated code that could be simplified with meta-programming techniques. We should clean that up.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
