### PR TITLE
mir: store string data separately from nodes

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -467,7 +467,8 @@ proc genLibSetup(graph: ModuleGraph, env: var MirEnv, conf: BackendConfig,
       bu.add MirNode(kind: mnkStmtList) # manual, for less visual nesting
       for candidate in candidates.items:
         var tmp = genLoadLib(bu, graph, env, val):
-          literal(newStrNode(candidate, graph.getSysType(path.info, tyString)))
+          literal(env.getOrIncl(candidate),
+                  graph.getSysType(path.info, tyString))
 
         tmp = bu.wrapTemp(graph.getSysType(path.info, tyBool)):
           bu.buildMagicCall mNot, graph.getSysType(path.info, tyBool):
@@ -480,7 +481,7 @@ proc genLibSetup(graph: ModuleGraph, env: var MirEnv, conf: BackendConfig,
       # if none of the candidates worked, a run-time error is reported:
       bu.subTree mnkVoid:
         bu.buildCall env.procedures.add(errorProc), errorProc.typ, voidTyp:
-          bu.emitByVal literal(path)
+          bu.emitByVal literal(env.getOrIncl(path.strVal), path.typ)
       bu.add endNode(mnkStmtList)
   else:
     # the name of the dynamic library to load the procedure from is only known
@@ -559,7 +560,7 @@ proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
     let tmp = bu.wrapTemp(loadProc.typ[0]):
       bu.buildCall env.procedures.add(loadProc), loadProc.typ, loadProc.typ[0]:
         bu.emitByVal toValue(libVar, lib.name.typ)
-        bu.emitByVal literal(extname)
+        bu.emitByVal literal(env.getOrIncl(extname.strVal), extname.typ)
 
     bu.subTree mnkVoid:
       bu.buildMagicCall mAsgnDynlibVar, voidTyp:

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -101,6 +101,9 @@ const
     ## the procedure contains top-level code, which currently affects how
     ## emit, asm, and error handling works
 
+template getString(p: BProc, n: CgNode): untyped =
+  p.env[n.strVal]
+
 proc findPendingModule(m: BModule, s: PSym): BModule =
   let ms = s.itemId.module  #getModule(s)
   result = m.g.modules[ms]

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -101,7 +101,7 @@ const
     ## the procedure contains top-level code, which currently affects how
     ## emit, asm, and error handling works
 
-template getString(p: BProc, n: CgNode): untyped =
+template getString(p: BProc, n: CgNode): string =
   p.env[n.strVal]
 
 proc findPendingModule(m: BModule, s: PSym): BModule =

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -11,7 +11,6 @@
 
 import
   std/[
-    hashes,
     intsets,
     tables,
     sets
@@ -95,8 +94,6 @@ type
     name*: string             ## the name of the C function in the generated
                               ## code
     params*: seq[TLoc]        ## the locs of the parameters
-
-  StrNode* = distinct CgNode
 
   TLabel* = Rope              ## for the C generator a label is just a rope
   TCFileSection* = enum       ## the sections a generated C file consists of
@@ -249,9 +246,9 @@ type
     defaultCache*: Table[SigHash, int]
       ## maps a type hash to the name of a C constant storing the type's
       ## default value
-    strCache*: Table[StrNode, int]
-      ## associates a string node with the label of a C constant generated for
-      ## it
+    strCache*: Table[StringId, int]
+      ## associates a string with the label of the C constant generated
+      ## for it
       ## TODO: strings should be turned into data-only constants (``DataId``)
       ##       during the MIR phase
     dataNames*: Table[DataId, int]
@@ -349,15 +346,6 @@ func contains*[T](m: SymbolMap[T], sym: PSym): bool {.inline.} =
 iterator items*[T](m: SymbolMap[T]): lent T =
   for it in m.store.items:
     yield it
-
-proc `==`(a, b: StrNode): bool =
-  a.CgNode.strVal == b.CgNode.strVal
-
-proc hash(x: StrNode): Hash =
-  hash(x.CgNode.strVal)
-
-proc getOrPut*(t: var Table[StrNode, int], n: CgNode, label: int): int =
-  mgetOrPut(t, StrNode(n), label)
 
 func isFilled*(x: TLoc): bool {.inline.} =
   x.k != locNone

--- a/compiler/backend/cgir.nim
+++ b/compiler/backend/cgir.nim
@@ -179,7 +179,7 @@ type
       # future direction: use a ``BiggestUint`` for uint values
       intVal*: BiggestInt
     of cnkFloatLit:   floatVal*: BiggestFloat
-    of cnkStrLit:     strVal*: string
+    of cnkStrLit:     strVal*: StringId
     of cnkAstLit:     astLit*: PNode
     of cnkField:      field*: PSym
     of cnkProc:       prc*: ProcedureId

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -369,7 +369,7 @@ proc lvalueToIr(tree: MirBody, cl: var TranslateCl, n: MirNode,
     # XXX: this needs to be removed once there is a dedicated run-time-
     #      sequence access operator
     let arg =
-      if tree[cr].kind == mnkLiteral:
+      if tree[cr].kind in LiteralDataNodes:
         atomToIr(tree, cl, cr)
       else:
         recurse()
@@ -395,7 +395,7 @@ proc valueToIr(tree: MirBody, cl: var TranslateCl,
                cr: var TreeCursor): CgNode =
   case tree[cr].kind
   of mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp, mnkAlias,
-     mnkLiteral, mnkType:
+     mnkType, LiteralDataNodes:
     atomToIr(tree, cl, cr)
   of mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv, mnkPathVariant,
      mnkDeref, mnkDerefView:
@@ -417,7 +417,7 @@ proc argToIr(tree: MirBody, cl: var TranslateCl,
     # it is one, the expression must be an lvalue
     result = (true, lvalueToIr(tree, cl, cr))
     leave(tree, cr)
-  of mnkLiteral, mnkType, mnkProc, mnkNone:
+  of LiteralDataNodes, mnkType, mnkProc, mnkNone:
     # not a tag but an atom
     result = (false, atomToIr(n, cl, cr.info))
   of LvalueExprKinds:
@@ -915,7 +915,7 @@ proc setElementToIr(tree: MirBody, cl: var TranslateCl,
   ## Translates a sub-tree appearing as a branch label or in a set
   ## construction to the CGIR.
   case tree[cr].kind
-  of LvalueExprKinds, mnkLiteral:
+  of LvalueExprKinds, LiteralDataNodes:
     result = valueToIr(tree, cl, cr)
   of mnkRange:
     discard enter(tree, cr)

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -215,8 +215,6 @@ proc translateLit*(val: PNode): CgNode =
       node(cnkFloatLit, floatVal, val.floatVal.float32.float64)
     else:
       unreachable()
-  of nkStrKinds:
-    node(cnkStrLit, strVal, val.strVal)
   of nkNilLit:
     newNode(cnkNilLit, val.info, val.typ)
   of nkNimNodeLit:
@@ -312,6 +310,8 @@ proc atomToIr(n: MirNode, cl: TranslateCl, info: TLineInfo): CgNode =
     newOp(cnkDerefView, info, typ.base, newLocalRef(id, info, typ))
   of mnkLiteral:
     translateLit(n.lit)
+  of mnkStrLit:
+    CgNode(kind: cnkStrLit, info: info, typ: n.typ, strVal: n.strVal)
   of mnkType:
     newTypeNode(info, n.typ)
   of mnkNone:

--- a/compiler/backend/cgirutils.nim
+++ b/compiler/backend/cgirutils.nim
@@ -34,7 +34,7 @@ proc treeRepr*(n: CgNode): string =
       result.add $n.floatVal
     of cnkStrLit:
       result.add "strVal: \""
-      result.add n.strVal
+      result.addInt n.strVal.uint32
       result.add "\""
     of cnkField:
       result.add "field: "

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -190,6 +190,9 @@ proc translate*(t: MirTree): CgNode =
       x
     of mnkLiteral:
       translateLit(n.lit)
+    of mnkStrLit:
+      CgNode(kind: cnkStrLit, info: unknownLineInfo, typ: n.typ,
+             strVal: n.strVal)
     of mnkField:
       CgNode(kind: cnkField, info: unknownLineInfo, field: n.field)
     of mnkProc:

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -137,9 +137,6 @@ proc newSymNode*(env: MirEnv, s: PSym): CgNode {.inline.} =
   else:
     unreachable(s.kind)
 
-proc newStrNode*(str: sink string): CgNode {.inline.} =
-  CgNode(kind: cnkStrLit, info: unknownLineInfo, strVal: str)
-
 proc translate*(t: MirTree): CgNode =
   ## Compatibility routine for translating a MIR constant-expression (`t`) to
   ## a ``CgNode`` tree. Obsolete once the code generators use the MIR

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -234,7 +234,7 @@ func analyseIfAddressTaken(n: CgNode, addrTaken: var PackedSet[LocalId]) =
 template config*(p: PProc): ConfigRef = p.module.config
 template env*(p: PProc): untyped = p.g.env
 
-template getString(p: PProc, n: CgNode): untyped =
+template getString(p: PProc, n: CgNode): string =
   p.g.env[n.strVal]
 
 proc indentLine(p: PProc, r: Rope): Rope =

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -234,6 +234,9 @@ func analyseIfAddressTaken(n: CgNode, addrTaken: var PackedSet[LocalId]) =
 template config*(p: PProc): ConfigRef = p.module.config
 template env*(p: PProc): untyped = p.g.env
 
+template getString(p: PProc, n: CgNode): untyped =
+  p.g.env[n.strVal]
+
 proc indentLine(p: PProc, r: Rope): Rope =
   for i in 0..<p.extraIndent:
     result.add "  "
@@ -873,7 +876,7 @@ proc genCaseJS(p: PProc, desc: StructDesc, stmts: openArray[CgNode], n: CgNode) 
           if stringSwitch:
             case e.kind
             of cnkStrLit: lineF(p, "case $1:$n",
-                [makeJSString(e.strVal, false)])
+                [makeJSString(getString(p, e), false)])
             else: internalError(p.config, e.info, "jsgen.genCaseStmt: 2")
           else:
             gen(p, e, cond)
@@ -902,7 +905,7 @@ proc genAsmOrEmitStmt(p: PProc, n: CgNode) =
     let it = n[i]
     case it.kind
     of cnkStrLit:
-      p.body.add(it.strVal)
+      p.body.add(getString(p, it))
     of cnkProc, cnkConst, cnkGlobal, cnkLocal:
       # for backwards compatibility we don't deref syms here :-(
       if false:
@@ -1081,7 +1084,7 @@ proc genFieldCheck(p: PProc, e: CgNode) =
   useMagic(p, "reprDiscriminant") # no need to offset by firstOrd unlike for cgen
   lineF(p, "if ($1[$2]$3undefined) { raiseFieldError2(makeNimstrLit($4), reprDiscriminant($2, $5)); }$n",
     setx.res, val.rdLoc, if invert: ~"!==" else: ~"===",
-    makeJSString(e[4].strVal), genTypeInfo(p, e[2].typ))
+    makeJSString(getString(p, e[4])), genTypeInfo(p, e[2].typ))
 
 proc genArrayAddr(p: PProc, n: CgNode, r: var TCompRes) =
   var
@@ -2527,13 +2530,13 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
       r.kind = resExpr
   of cnkStrLit:
     if skipTypes(n.typ, abstractVarRange).kind == tyString:
-      if n.strVal.len != 0:
+      if getString(p, n).len != 0:
         useMagic(p, "makeNimstrLit")
-        r.res = "makeNimstrLit($1)" % [makeJSString(n.strVal)]
+        r.res = "makeNimstrLit($1)" % [makeJSString(getString(p, n))]
       else:
         r.res = rope"[]"
     else:
-      r.res = makeJSString(n.strVal, false)
+      r.res = makeJSString(getString(p, n), false)
     r.kind = resExpr
   of cnkFloatLit:
     let f = n.floatVal

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -41,8 +41,6 @@ func hashTree(tree: ConstrTree): Hash =
           # make sure to hash the bit representation, so that NaNs are
           # accounted for
           hash(cast[BiggestInt](n.floatVal))
-        of nkStrKinds:
-          hash(n.strVal)
         of nkIntKinds:
           hash(n.intVal)
         of nkNilLit:
@@ -51,6 +49,8 @@ func hashTree(tree: ConstrTree): Hash =
           unreachable(n.kind)
 
       result = result !& hashLit(n.lit)
+    of mnkStrLit:
+      result = result !& hash(n.strVal)
     of mnkProc:
       result = result !& hash(n.prc.ord)
     of mnkConstr, mnkSetConstr, mnkRange, mnkObjConstr:
@@ -98,6 +98,8 @@ proc cmp(a, b: ConstrTree): bool =
     case a.kind
     of mnkLiteral:
       cmp(a.lit, b.lit)
+    of mnkStrLit:
+      a.strVal == b.strVal
     of mnkProc:
       a.prc == b.prc
     of mnkConstr, mnkSetConstr, mnkRange, mnkObjConstr:

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -2,6 +2,7 @@
 
 import
   compiler/ast/[
+    ast_query,
     ast_types
   ],
   compiler/mir/[
@@ -75,7 +76,11 @@ func typeLit*(t: PType): Value =
   Value(node: MirNode(kind: mnkType, typ: t))
 
 func literal*(n: PNode): Value =
+  assert n.kind notin nkStrKinds
   Value(node: MirNode(kind: mnkLiteral, typ: n.typ, lit: n))
+
+func literal*(str: StringId, typ: PType): Value =
+  Value(node: MirNode(kind: mnkStrLit, typ: typ, strVal: str))
 
 func temp*(typ: PType, id: LocalId): Value =
   Value(node: MirNode(kind: mnkTemp, typ: typ, local: id))

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -14,6 +14,9 @@ import
     datatables,
     mirtrees
   ],
+  compiler/ic/[
+    bitabs
+  ],
   compiler/utils/[
     containers
   ]
@@ -39,6 +42,9 @@ type
     globals*:    SymbolTable[GlobalId, PSym]
       ## includes both normal globals and threadvars
     procedures*: SymbolTable[ProcedureId, PSym]
+
+    strings*: BiTable[string]
+      ## all string data referenced by the MIR
 
     bodies*: OrdinalSeq[ConstId, DataId]
       ## associates each user-defined constant with its content
@@ -102,6 +108,13 @@ func `[]`*(env: MirEnv, id: ProcedureId): lent PSym {.inline.} =
 
 func `[]`*(env: MirEnv, id: DataId): lent ConstrTree {.inline.} =
   env.data[id]
+
+func `[]`*(env: MirEnv, id: StringId): lent string {.inline.} =
+  env.strings[LitId id]
+
+func getOrIncl*(env: var MirEnv, str: string): StringId {.inline.} =
+  ## If not registered already, adds `str` to the environment.
+  StringId env.strings.getOrIncl(str)
 
 func setData*(env: var MirEnv, id: ConstId, data: DataId) =
   ## Sets the body for the constant identified by `id`.

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -550,8 +550,8 @@ proc genFieldCheck(c: var TCtx, access: Value, call: PNode, inverted: bool,
       # inverted flag:
       c.emitByVal literal(newIntTypeNode(ord(inverted), call.typ))
       # error message operand:
-      c.emitByVal literal(newStrNode(genFieldDefect(conf, field, discr),
-                                     c.graph.getSysType(call.info, tyString)))
+      c.emitByVal strLiteral(c.env, genFieldDefect(conf, field, discr),
+                             c.graph.getSysType(call.info, tyString))
 
 proc genCheckedVariantAccess(c: var TCtx, variant: Value, name: PIdent,
                              check: PNode): PSym =
@@ -1170,8 +1170,8 @@ proc genRaise(c: var TCtx, n: PNode) =
           # lvalue conversion to the base ``Exception`` type:
           c.buildTree mnkPathConv, cp.typ[1]:
             c.use tmp
-        c.emitByVal literal(newStrNode(typ.sym.name.s,
-                                       c.graph.getSysType(n.info, tyCstring)))
+        c.emitByVal strLiteral(c.env, typ.sym.name.s,
+                               c.graph.getSysType(n.info, tyCstring))
 
     # emit the raise statement:
     c.buildStmt mnkRaise:

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -358,14 +358,13 @@ proc extractStringLiterals(tree: MirTree, env: var MirEnv,
   ## Extracts all string literals and promotes them to anonymous constants,
   ## replacing the string literals with a usage of the constants they were
   ## promoted to.
-  for i in search(tree, {mnkLiteral}):
+  for i in search(tree, {mnkStrLit}):
     # note: both normal string *and* cstring literals are currently included
-    if tree[i].lit.kind in nkStrLiterals:
-      # create an anonymous constant from the literal:
-      let c = toConstId env.data.getOrPut(@[tree[i]])
-      # replace the usage of the literal with the anonymous constant:
-      changes.replaceMulti(tree, i, bu):
-        bu.use toValue(c, tree[i].typ)
+    # create an anonymous constant from the literal:
+    let c = toConstId env.data.getOrPut(@[tree[i]])
+    # replace the usage of the literal with the anonymous constant:
+    changes.replaceMulti(tree, i, bu):
+      bu.use toValue(c, tree[i].typ)
 
 proc injectResultInit(tree: MirTree, resultTyp: PType, changes: var Changeset) =
   ## Injects a default-initialization for the result variable, if deemed

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -181,6 +181,13 @@ proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
     result.add "<none>"
   of mnkLiteral:
     result.add $n.lit
+  of mnkStrLit:
+    if c.env.isNil:
+      result.add "<Str: "
+      result.addInt n.strVal.uint32
+      result.add ">"
+    else:
+      result.addQuoted c.env[][n.strVal]
   of mnkType:
     result.add "type("
     result.add $n.typ

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -42,6 +42,9 @@ func `$`(n: MirNode): string =
     result.add " lit: "
     {.cast(noSideEffect).}:
       result.add renderTree(n.lit)
+  of mnkStrLit:
+    result.add " strVal: "
+    result.addInt n.strVal.uint32
   of mnkPathPos:
     result.add " position: "
     result.add $n.position

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -290,7 +290,7 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
   of LvalueExprKinds:
     # raw usage of an lvalue
     emitLvalueOp(env, opUse, tree, at, OpValue source)
-  of mnkNone, mnkLiteral, mnkProc:
+  of mnkNone, LiteralDataNodes, mnkProc:
     discard "okay, ignore"
   of AllNodeKinds - ExprKinds - {mnkNone} + {mnkType}:
     unreachable(tree[source].kind)

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -139,7 +139,7 @@ proc putIntoReg(dest: var TFullReg; jit: var JitState, c: var TCtx, n: PNode,
     dest.nimNode = data[0].lit
   else:
     dest.initLocReg(typ, c.memory)
-    initFromExpr(dest.handle, data, c)
+    initFromExpr(dest.handle, data, jit.env, c)
 
 proc unpackResult(res: sink ExecutionResult; config: ConfigRef, node: PNode): PNode =
   ## Unpacks the execution result. If the result represents a failure, returns
@@ -680,7 +680,7 @@ proc setGlobalValue*(c: var EvalContext; s: PSym, val: PNode) =
     slot = c.vm.heap.slots[slotIdx]
     data = constDataToMir(c.vm, c.jit, val)
 
-  initFromExpr(slot.handle, data, c.vm)
+  initFromExpr(slot.handle, data, c.jit.env, c.vm)
 
 ## what follows is an implementation of the ``passes`` interface that evaluates
 ## the code directly inside the VM. It is used for NimScript execution and by

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -378,7 +378,6 @@ func storeLiteral(enc: var DataEncoder, e: var PackedEnv, n: PNode) =
     of EmbeddedInts:  (pdkIntLit, cast[uint32](n.intVal))
     of ExternalInts:  (pdkInt,    e.getLitId(n.intVal).uint32)
     of nkFloatKinds:  (pdkFloat,  e.getLitId(n.floatVal).uint32)
-    of nkStrKinds:    (pdkString, e.getLitId(n.strVal).uint32)
     of nkNilLit:
       if n.typ.skipTypes(abstractInst).callConv == ccClosure:
         # XXX: some unexpanded `nil` closure literals reach here, so we have
@@ -399,6 +398,9 @@ func storeDataNode(enc: var DataEncoder, e: var PackedEnv,
   case t[n].kind
   of mnkLiteral:
     storeLiteral(enc, e, t[n].lit)
+  of mnkStrLit:
+    # the ID indexes into the string BiTable, it can be packed directly
+    enc.put e, PackedDataNode(kind: pdkString, pos: t[n].strVal.uint32)
   of mnkProc:
     # the ID is stable, it can be packed directly
     enc.put e, PackedDataNode(kind: pdkIntLit, pos: t[n].prc.uint32)

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -308,7 +308,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
   # pack the data and write it to the ouput file:
   var
     enc: PackedEncoder
-    penv: PackedEnv
+    penv = PackedEnv(strings: move c.gen.env.strings)
 
   enc.init(env.types)
   storeEnv(enc, penv, env)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -70,6 +70,10 @@ type
     gen: CodeGenCtx
       ## code generator state
 
+func env*(jit: JitState): lent MirEnv {.inline.} =
+  ## The JIT code generator's MIR environment.
+  jit.gen.env
+
 func selectOptions(c: TCtx): TranslationConfig =
   result = TranslationConfig(options: {goIsNimvm}, magicsToKeep: MagicsToKeep)
   # include additional options based on the JIT's configuration
@@ -125,7 +129,7 @@ proc updateEnvironment(c: var TCtx, env: var MirEnv, cp: EnvCheckpoint) =
       typ = c.getOrCreate(data[0].typ)
       handle = c.allocator.allocConstantLocation(typ)
 
-    initFromExpr(handle, data, c)
+    initFromExpr(handle, data, env, c)
 
     c.complexConsts.add handle
 


### PR DESCRIPTION
## Summary

Instead of storing string values via `PNode`s in `MirNode`, the
`string` data is stored in a separate table, indexed by `StringId`.
This removes a `PNode` dependency from the MIR and eliminates the
string copy at the MIR/CGIR edge.

## Details

### MIR

* the `mnkStrLit` node kind and variant are introduced. The variant
  stores a `StringId`
* the actual string data is stored in a `BiTable[string]` in `MirEnv`
* internally, `StringId` is a `LitId`, which is used for `BiTable`
  lookup
* `mnkLiteral` no longer covers string literals
* the `LiteralDataNodes` set is introduced, currently covering
  `mnkLiteral` and `mnkStrLit`
* `mirgen` translates string literals to `mnkStrLit` nodes, adding the
  string values to the environment in the process

### CGIR

* `CgNode` also uses the indirection via a `StringId` instead of
  storing the raw string directly

### Code generation

* `cgen` and `jsgen` use the `getString` routine added to both code
  generators, for querying a node's string value from the
  environment
* as an interim solution, for generating the C constant for a raw
  string value, a new `genStringLiteral` overload is added to
  `ccgliterals`
* `compat.newStrNode` is obsolete and thus removed

### VM back-end

* `vmserialize.initFromExpr` needs access to a `MirEnv` to look up the
  string data
* `vmjit` provides read-only access to a `JitState`'s `MirEnv` through
  the new public `env` accessor (the `compilerbridge` module need it
  for the `initFromExpr` calls)
* the `MirEnv`'s string table is re-used for the created `PackedEnv`

### Other

* `DataTable` lookup becomes slightly faster, since only the ID for
  strings needs to be compared and hashed
* the `extractStringLiterals` MIR pass can search for string literals
  (`mnkStrLit`) without an extra conditional