### PR TITLE
js: support variant destructors

### DIFF
--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -813,14 +813,19 @@ proc lowerBranchSwitch(bu: var MirBuilder, body: MirTree, graph: ModuleGraph,
       bu.buildMagicCall mNot, boolTyp:
          bu.emitByVal val
 
+    var src = body.child(NodePosition target, 0)
+    # skip all ``mnkPathVariant`` nodes:
+    while body[src].kind == mnkPathVariant:
+      src = body.child(src, 0)
+
     bu.subTree mnkIf:
       bu.use val
       # ``=destroy`` call:
       bu.buildVoidCall(env, branchDestructor):
-        # pass the original variant access to the destroy call
+        # pass the object access expression to the destroy call
         bu.subTree mnkName:
-          bu.subTree MirNode(kind: mnkTag, effect: ekInvalidate):
-            bu.emitFrom(body, NodePosition target)
+          bu.subTree MirNode(kind: mnkTag, effect: ekMutate):
+            bu.emitFrom(body, src)
 
   else:
     # the object doesn't need destruction, which means that neither does one

--- a/tests/lang_objects/destructor/tcaseobj_transition_2.nim
+++ b/tests/lang_objects/destructor/tcaseobj_transition_2.nim
@@ -4,6 +4,9 @@ discard """
     changing the active case object branch
   '''
   targets: "c js vm"
+  knownIssue.vm: '''
+    Lowering branch switch statements is disabled for the VM backend
+  '''
 """
 
 type

--- a/tests/lang_objects/destructor/tcaseobj_transition_2.nim
+++ b/tests/lang_objects/destructor/tcaseobj_transition_2.nim
@@ -1,0 +1,36 @@
+discard """
+  description: '''
+    Ensure that the destructor of a field within a case obj is triggered when
+    changing the active case object branch
+  '''
+  targets: "c js vm"
+"""
+
+type
+  Object = object
+    name: int
+
+var steps: seq[int]
+
+proc `=destroy`(x: var Object) =
+  steps.add x.name
+
+type
+  WithVariant = object
+    outer: Object
+      ## field not within the case object; unaffected by branch changing
+    case kind: bool
+    of false:
+      a: Object
+    of true:
+      b: Object
+
+proc test() =
+  var o = WithVariant(outer: Object(name: 1), kind: false, a: Object(name: 2))
+  o.kind = true # change branch; `a` is destroyed
+  doAssert o.b.name == 0 # uninitialized
+  o.b.name = 3
+  # on destruction, both `b` and `outer` must be destroyed
+
+test()
+doAssert steps == [2, 1, 3], $steps


### PR DESCRIPTION
## Summary

Fix destructors not being properly executed for fields within case
objects when changing the active branch, and using the JS backend.

## Details

The destructor produced by `produceDestructorForDiscriminator` took a
reference to the *discriminant field* and used pointer arithmetic to
compute the address of the enclosing object. Not only is this
unnecessarily complex, it also doesn't work with the JS backend.

Instead, the destructor now takes a mutable reference to the
discriminant field's enclosing object type -- the MIR emitted for the
call is adjusted accordingly.

Since the destructor definitely modifies the object, `ekMutate` is used
instead of `ekInvalidate` for the parameter passing. This results in a
small move analyzer regression:
```nim
var x = Object()
var y = x.fieldOutsideOfVariant # not automatically moved anymore
x.kind = ... # potential branch switch that requires destruction
```

Finally, a test is added for ensuring proper destruction when changing
the active branch.