### PR TITLE
cgen: improve code generation for `seq` types

### DIFF
--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -470,9 +470,6 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
     if fieldType.kind == tyUncheckedArray:
       result.addf("$1 $2[SEQ_DECL_SIZE];$n",
           [getTypeDescAux(m, fieldType.elemType, check), sname])
-    elif fieldType.kind == tySequence:
-      # we need to use a weak dependency here for trecursive_table.
-      result.addf("$1$3 $2;$n", [getTypeDescWeak(m, field.typ, check), sname, noAlias])
     elif field.bitsize != 0:
       result.addf("$1$4 $2:$3;$n", [getTypeDescAux(m, field.typ, check), sname, rope($field.bitsize), noAlias])
     else:
@@ -591,12 +588,10 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
         et = elemType(etB)
       etB = et.skipTypes(abstractInst)
     case etB.kind
-    of tyObject, tyTuple:
+    of tyObject, tyTuple, tySequence:
       # no restriction! We have a forward declaration for structs
       let name = getTypeForward(m, et, hashType et)
       result = name & star
-    of tySequence:
-        result = getTypeDescWeak(m, et, check) & star
     of tyOpenArray:
       result = getTypeDescAux(m, etB, check)
     else:

--- a/tests/ccgbugs/trecursive_table.nim
+++ b/tests/ccgbugs/trecursive_table.nim
@@ -13,5 +13,5 @@ type
     of eY:
       nil
 
-proc p*(x: Table[string, T]) =
+proc p*(x: Table[string, T]) {.exportc.} =
   discard


### PR DESCRIPTION
## Summary

* only emit a single `seq` payload type definition per C file
* only emit the full C type definition for a `seq` if not used in a
  pointer-like type (e.g.: `ptr seq[T]`, `ref seq[T]`) 

Together, these improvements reduce the amount of C code output by the
NimSkull compiler, slightly improving compile times.

## Details

Move the `tySequence` handling from `getTypeDescWeak` to
`getTypeDescAux`, preventing different instances referring to the same
type, or the same instance, being pushed to the type stack multiple
times within a single module.

For each `tySequence` type instance pushed to the type stack, a payload
is emitted, with preventing duplicates previously being deferred to the
C compiler through use of a C pre-processor guard (`#ifdef`). Since the
type instance is now only pushed to the type stack once per module, the
pre-processor guard is unnecessary and thus removed.

In addition, for `ptr seq`, `ref seq`, etc. types, only a forward-
declaration of the sequence type is requested, preventing the full type
and all its dependencies being pulled in.

Finally, the `trecursive_table` test, intended to catch C code
generator bugs with recursive `seq` types, is fixed. Since `p` was
neither used nor exported, the `T` type was never actually processed by
the code generator.