### PR TITLE
mir: add dedicated 'mutable' version for view creation

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -971,7 +971,7 @@ proc exprToIr(tree: MirBody, cl: var TranslateCl,
     op cnkConv, valueToIr(tree, cl, cr)
   of mnkStdConv:
     op cnkHiddenConv, valueToIr(tree, cl, cr)
-  of mnkToSlice, mnkMutToSlice:
+  of mnkToSlice, mnkToMutSlice:
     treeOp cnkToSlice:
       res.add valueToIr(tree, cl, cr)
   of mnkAddr:

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -971,14 +971,14 @@ proc exprToIr(tree: MirBody, cl: var TranslateCl,
     op cnkConv, valueToIr(tree, cl, cr)
   of mnkStdConv:
     op cnkHiddenConv, valueToIr(tree, cl, cr)
-  of mnkToSlice:
+  of mnkToSlice, mnkMutToSlice:
     treeOp cnkToSlice:
       res.add valueToIr(tree, cl, cr)
   of mnkAddr:
     op cnkAddr, lvalueToIr(tree, cl, cr)
   of mnkDeref:
     op cnkDeref, atomToIr(tree, cl, cr)
-  of mnkView:
+  of mnkView, mnkMutView:
     op cnkHiddenAddr, lvalueToIr(tree, cl, cr)
   of mnkDerefView:
     op cnkDerefView, atomToIr(tree, cl, cr)

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1835,13 +1835,13 @@ proc genx(c: var TCtx, e: PMirExpr, i: int) =
     c.buildOp mnkStdConv, n.typ:
       recurse()
   of pirToSlice:
-    c.buildOp pick(n.typ, mnkMutToSlice, mnkToSlice), n.typ:
+    c.buildOp pick(n.typ, mnkToMutSlice, mnkToSlice), n.typ:
       recurse()
   of pirToSubSlice:
     # the array operand is a PMIR expression already, but the operands
     # specifying the bounds are not
     let
-      op = pick(n.typ, mnkMutToSlice, mnkToSlice)
+      op = pick(n.typ, mnkToMutSlice, mnkToSlice)
       a = n.orig[2]
       b = n.orig[3]
     if optBoundsCheck in c.userOptions and needsBoundCheck(n.orig[1], a, b):

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -132,6 +132,7 @@ type
     mnkDeref  ## dereference a ``ptr`` or ``ref`` value
 
     mnkView      ## create a first-class safe alias from an lvalue
+    mnkMutView   ## create a safe mutable view from an lvalue
     mnkDerefView ## dereference a first-class safe alias
 
     mnkStdConv    ## a standard conversion. Produce a new value.
@@ -148,6 +149,7 @@ type
                   ##   upper bound
     # XXX: consider using a separate operator for the slice-from-sub-sequence
     #      operation
+    mnkMutToSlice ## version of ``mnkMutToSlice`` for creating a mutable slice
 
     mnkCall   ## invoke a procedure and pass along the provided arguments.
               ## Used for both static and dynamic calls
@@ -343,7 +345,7 @@ const
                          mnkAddr, mnkDeref, mnkView, mnkDerefView, mnkStdConv,
                          mnkConv, mnkCast, mnkRaise, mnkTag, mnkArg,
                          mnkName, mnkConsume, mnkVoid, mnkCopy, mnkMove,
-                         mnkSink, mnkDestroy}
+                         mnkSink, mnkDestroy, mnkMutView, mnkMutToSlice}
     ## Nodes that start sub-trees but that always have a single sub node.
 
   ArgumentNodes* = {mnkArg, mnkName, mnkConsume}
@@ -380,8 +382,8 @@ const
                       mnkPathConv, mnkDeref, mnkDerefView, mnkTemp, mnkAlias,
                       mnkLocal, mnkParam, mnkConst, mnkGlobal}
   RvalueExprKinds* = {mnkType, mnkProc, mnkConv, mnkStdConv, mnkCast, mnkAddr,
-                      mnkView, mnkToSlice} + UnaryOps + BinaryOps +
-                     LiteralDataNodes
+                      mnkView, mnkMutView, mnkToSlice, mnkMutToSlice} +
+                     UnaryOps + BinaryOps + LiteralDataNodes
   ExprKinds* =       {mnkCall, mnkCheckedCall, mnkSetConstr, mnkArrayConstr,
                       mnkSeqConstr, mnkTupleConstr, mnkClosureConstr,
                       mnkObjConstr} + LvalueExprKinds + RvalueExprKinds +

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -149,7 +149,7 @@ type
                   ##   upper bound
     # XXX: consider using a separate operator for the slice-from-sub-sequence
     #      operation
-    mnkMutToSlice ## version of ``mnkMutToSlice`` for creating a mutable slice
+    mnkToMutSlice ## version of ``mnkToSlice`` for creating a mutable slice
 
     mnkCall   ## invoke a procedure and pass along the provided arguments.
               ## Used for both static and dynamic calls
@@ -345,7 +345,7 @@ const
                          mnkAddr, mnkDeref, mnkView, mnkDerefView, mnkStdConv,
                          mnkConv, mnkCast, mnkRaise, mnkTag, mnkArg,
                          mnkName, mnkConsume, mnkVoid, mnkCopy, mnkMove,
-                         mnkSink, mnkDestroy, mnkMutView, mnkMutToSlice}
+                         mnkSink, mnkDestroy, mnkMutView, mnkToMutSlice}
     ## Nodes that start sub-trees but that always have a single sub node.
 
   ArgumentNodes* = {mnkArg, mnkName, mnkConsume}
@@ -382,7 +382,7 @@ const
                       mnkPathConv, mnkDeref, mnkDerefView, mnkTemp, mnkAlias,
                       mnkLocal, mnkParam, mnkConst, mnkGlobal}
   RvalueExprKinds* = {mnkType, mnkProc, mnkConv, mnkStdConv, mnkCast, mnkAddr,
-                      mnkView, mnkMutView, mnkToSlice, mnkMutToSlice} +
+                      mnkView, mnkMutView, mnkToSlice, mnkToMutSlice} +
                      UnaryOps + BinaryOps + LiteralDataNodes
   ExprKinds* =       {mnkCall, mnkCheckedCall, mnkSetConstr, mnkArrayConstr,
                       mnkSeqConstr, mnkTupleConstr, mnkClosureConstr,

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -350,10 +350,10 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
   of mnkAddr:
     tree "addr ":
       valueToStr()
-  of mnkView:
+  of mnkView, mnkMutView:
     tree "borrow ":
       valueToStr()
-  of mnkToSlice:
+  of mnkToSlice, mnkMutToSlice:
     tree "toOpenArray ":
       commaSeparated:
         valueToStr()

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -353,7 +353,7 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
   of mnkView, mnkMutView:
     tree "borrow ":
       valueToStr()
-  of mnkToSlice, mnkMutToSlice:
+  of mnkToSlice, mnkToMutSlice:
     tree "toOpenArray ":
       commaSeparated:
         valueToStr()

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -256,14 +256,14 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
     # handles aren't tracked however, the operation is conservatively
     # treated as a mutation
     emitLvalueOp(env, opMutate, tree, at, tree.operand(source))
-  of mnkView:
+  of mnkView, mnkMutView:
     # if the created view supports mutation, treat the creation as a
     # mutation itself
     let opc =
-      if tree[source].typ.kind == tyVar: opMutate
-      else:                              opUse
+      if tree[source].kind == mnkView: opUse
+      else:                            opMutate
     emitLvalueOp(env, opc, tree, at, tree.operand(source))
-  of mnkToSlice:
+  of mnkToSlice, mnkMutToSlice:
     # slices aren't tracked at the moment, so the mere creation of a slice is
     # treated as a usage of the sequence. If the resulting openArray supports
     # mutation, creation of the slice is treated as a mutation. To ensure the
@@ -274,8 +274,8 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
       emitLvalueOp(env, opUse, tree, at, tree.operand(source, 2))
 
     let opc =
-      if tree[source].typ.kind == tyVar: opMutate
-      else:                              opUse
+      if tree[source].kind == mnkToSlice: opUse
+      else:                               opMutate
     emitLvalueOp(env, opc, tree, at, tree.operand(source, 0))
   of mnkCopy, mnkSink:
     # until it's collapsed, a sink is conservatively treated as only a

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -263,7 +263,7 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
       if tree[source].kind == mnkView: opUse
       else:                            opMutate
     emitLvalueOp(env, opc, tree, at, tree.operand(source))
-  of mnkToSlice, mnkMutToSlice:
+  of mnkToSlice, mnkToMutSlice:
     # slices aren't tracked at the moment, so the mere creation of a slice is
     # treated as a usage of the sequence. If the resulting openArray supports
     # mutation, creation of the slice is treated as a mutation. To ensure the

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -121,13 +121,16 @@ Semantics
          | Addr     LVALUE               # create a pointer from the lvalue
          | View     LVALUE               # create a view (`var`/`lent`) of the
                                          # lvalue
+         | MutView  LVALUE
          | ToSlice  VALUE                # create an `openArray` slice of
                                          # the full sequence
+         | MutToSlice LVALUE
          | ToSlice  VALUE, VALUE, VALUE  # create an `openArray` slice from the
                                          # first operand, starting at the lower
                                          # bound (second parameter) and ending
                                          # at the upper bound (inclusive, third
                                          # parameter)
+         | MutToSlice LVALUE, VALUE, VALUE
 
   ASGN_SRC = RVALUE
            | VALUE


### PR DESCRIPTION
## Summary

Encode in syntax whether a `mnkView`/`mnkToSlice` creates a mutable
views, by introducing two new node kinds. This allows creation of a
data-flow graph without access to type information.

## Details

* add `mnkMutView` and `mnkToMutSlice` to the MIR
* `mirgen` picks which operation to use based on the expressions
  return type
* `mirexec.computeDfg` now decides the data-flow operation(s) for a
  view creation operation based purely on syntax
* the mutable versions are currently pretty-printed in the same way as
  their non-mutable counterpart
* no new CGIR node kinds are introduced, as they're not needed