### PR TITLE
sem: reduce cascading errors in call expressions

### DIFF
--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -530,7 +530,10 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   if x.hasFauxMatch:
     result = x.call
     result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))
-    if containsGenericType(result.typ) or x.fauxMatch == tyUnknown:
+    if x.fauxMatch == tyError:
+      # at least one argument expression was erroneous
+      result = c.config.wrapError(result)
+    elif containsGenericType(result.typ) or x.fauxMatch == tyUnknown:
       result.typ = newTypeS(x.fauxMatch, c)
       if result.typ.kind == tyError: incl result.typ.flags, tfCheckedForDestructor
     return

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -394,7 +394,11 @@ proc resolveOverloads(c: PContext, n, nOrig: PNode,
     c.config.internalAssert result.state == csMatch
     #writeMatches(result)
     #writeMatches(alt)
-    if c.config.m.errorOutputs == {}:
+    if result.fauxMatch == tyError:
+      # don't report an ambiguity error when the candidates both only matched
+      # due to errors
+      assert alt.fauxMatch == tyError
+    elif c.config.m.errorOutputs == {}:
       # quick error message for performance of 'compiles' built-in:
       globalReport(c.config, n.info, reportSem(rsemAmbiguous))
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1714,7 +1714,15 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     m.isNoCall = true
     matches(c, n, copyNodeWithKids(n), m)
 
-    if m.state != csMatch:
+    case m.state
+    of csMatch:
+      if m.fauxMatch == tyError:
+        # not a real match, report the errors and return
+        # XXX: this needs to use proper error propagation
+        for it in walkErrors(c.config, m.call):
+          localReport(c.config, it)
+        return newOrPrevType(tyError, prev, c)
+    else:
       localReport(c.config, n.info):
         block:
           var r = reportTyp(rsemCannotInstantiateWithParameter, t, ast = n)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -140,6 +140,7 @@ proc initCandidate*(ctx: PContext, c: var TCandidate, callee: PType) =
   c.calleeSym = nil
   c.call = nil
   c.baseTypeMatch = false
+  c.fauxMatch = tyNone
   c.genericConverter = false
   c.inheritancePenalty = 0
   c.error = SemCallMismatch()

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -285,6 +285,15 @@ proc writeMatches*(c: TCandidate) =
   echo "  inheritance: ", c.inheritancePenalty
 
 proc cmpCandidates*(a, b: TCandidate): int =
+  # an non-erroneous candidate is always preferred over a non-erroneous one.
+  # This is only necessary to allow recovery through ``untyped``
+  if a.fauxMatch == tyError:
+    if b.fauxMatch != tyError:
+      return -1
+    # for two errorneous candidates, pick the better one
+  elif b.fauxMatch == tyError:
+    return 1
+
   result = a.exactMatches - b.exactMatches
   if result != 0: return
   result = a.genericMatches - b.genericMatches

--- a/nimsuggest/tests/tcon1.nim
+++ b/nimsuggest/tests/tcon1.nim
@@ -16,7 +16,7 @@ test("hello here", #[!]#)
 testB(#[!]#
 
 # dot expressions
-"from behind".test(#[!]#
+"from behind".test(#[!]#)
 
 # two params matched, so disqualify the lower airity `test`
 # TODO: this doesn't work, because dot exprs, overloads, etc aren't currently

--- a/tests/errmsgs/tcall_argument_error.nim
+++ b/tests/errmsgs/tcall_argument_error.nim
@@ -1,0 +1,49 @@
+discard """
+  description: '''
+    Ensure no redundant errors are reported in check mode when a call argument
+    has an error
+  '''
+  cmd: "$nim check --hints:off $options $file"
+  action: reject
+  nimoutfull: true
+  nimout: '''
+tcall_argument_error.nim(44, 14) Error: undeclared identifier: 'missing'
+tcall_argument_error.nim(46, 21) Error: undeclared identifier: 'missing'
+tcall_argument_error.nim(48, 11) Error: undeclared identifier: 'missing'
+tcall_argument_error.nim(48, 10) Error: type mismatch: got <>
+but expected one of:
+proc p(x, y: int): int
+  first type mismatch at position: 2
+  missing parameter: y
+proc p(x, y: string): string
+  first type mismatch at position: 2
+  missing parameter: y
+
+expression: p(missing)
+tcall_argument_error.nim(49, 11) Error: undeclared identifier: 'missing'
+tcall_argument_error.nim(49, 10) Error: type mismatch: got <>
+but expected one of:
+proc p(x, y: int): int
+  first type mismatch at position: 3
+  extra argument given
+proc p(x, y: string): string
+  first type mismatch at position: 2
+  required type for y: string
+  but expression '1' is of type: int literal(1)
+
+expression: p(missing, 1, 2)
+'''
+"""
+
+proc p(x, y: string): string =
+  discard
+
+proc p(x, y: int): int =
+  discard
+
+discard p(1, missing)
+# nested call, where the inner call expression has an error:
+discard p("", p("", missing))
+# if an argument is erroneous, arity is still considered:
+discard p(missing) # no overload with matching arity
+discard p(missing, 1, 2) # no overload with matching arity

--- a/tests/errmsgs/tcall_argument_error_ambigous.nim
+++ b/tests/errmsgs/tcall_argument_error_ambigous.nim
@@ -1,0 +1,20 @@
+discard """
+  description: '''
+    Ensure no "ambiguous call" error is reported when an argument, of which
+    the type is needed for disambiguating, is erroneous
+  '''
+  cmd: "$nim check --hints:off $options $file"
+  action: reject
+  nimoutfull: true
+  nimout: '''
+tcall_argument_error_ambigous.nim(20, 14) Error: undeclared identifier: 'missing'
+'''
+"""
+
+proc p(x: int, y: float): int =
+  discard
+
+proc p(x: int, y: int): int =
+  discard
+
+discard p(1, missing)

--- a/tests/lang_callable/overload/tuntyped_overload_tie_with_typed_with_error.nim
+++ b/tests/lang_callable/overload/tuntyped_overload_tie_with_typed_with_error.nim
@@ -1,14 +1,10 @@
 discard """
   description: '''
-    Ensure that overloads separated by `typed` and `untyped` parameters tie,
-    resulting in an ambiguity error, if that argument is an `nkError`.
-
-    This isn't ideal, but it works until `untyped` parameters result in eager
-    matching over any other parameter type.
+    Ensure that overloads separated by `typed` and `untyped` parameters don't
+    result in a tie, if the argument in question is erroneous (i.e., an
+    `nkError`).
   '''
-  errormsg: "ambiguous call"
-  line: 22
-  column: 2
+  action: compile
 """
 
 import std/macros


### PR DESCRIPTION
## Summary

* reduce cascading errors in call expressions when there's one or more
  erroneous argument expressions (especially noticeable with
  `nim check` and `nimsuggest`)
* reduce cascading errors with generic type instantiation expressions
* a macro/template with an `untyped` parameter is no longer ambiguous
  with another macro/template that has a `typed` parameter, when the
  argument has an error

## Details

There was already support for "faux matches", but it stopped working
with the proliferation of `nkError` usage. A "faux match" is a match
during overload resolution that could only work because unknown types
where treated as wildcards.

Upon encountering an erroneous argument, instead of failing the match,
`matchesAux` now continues, with `paramTypesMatchAux` also letting the
error node through. This restores basic faux match support in the case
of errors.

Multiple other changes/fixes are required to make faux matches work
properly for errors:
* the `fauxMatch` field of `TCandidate` wasn't reset by
  `initCandidate`, leading to faux matches carrying over to other
  candidates
* for proper error propagation, `semResolvedCall` needs to wrap error
  matches in a wrapper error
* `semGeneric` needs to account for faux matches, by reporting the
  errors, if any

Special-casing `typed` parameters is no longer needed -- the same
parameter type matching as with other non-`untyped` parameters apply.

### Recovery through `untyped`

So that error-recovery through `untyped` templates/macros continues to
work, `cmpCandidates` always gives a higher weight to non-erroneous
candidates. If both candidates are erroneous, the normal comparison
applies.

This also fixes the overload tie behaviour between `typed` and
`untyped` parameters in the face of errors (refer to
`tuntyped_overload_tie_with_typed_with_error.nim`).

### Ambiguous faux matches

If overload resolution finds two equally well matching candidates, but
both only matched because of errors, `resolveOverloads` doesn't report
an ambiguity error, since it'd only be follow-up error.

### Other tests

`tcon1.nim` had to be adjusted to produce the same results. Due to the
missing closing parentheses, and faux matches now working again,
the `p` overload three parameter was marked as being used *twice*,
leading to it being shown before the other overload (which was
considered to only be used *once*).

Finally, two new tests are added for preventing future regressions with
faux matches.