### PR TITLE
mir: distinguish between proc values and references

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -281,7 +281,7 @@ iterator deps*(tree: MirTree): lent MirNode =
       # skip over the name slot:
       i = NodePosition tree.operand(i, 1)
       continue
-    of mnkProc:
+    of mnkProc, mnkProcLit:
       yield tree[i]
     of mnkGlobal:
       yield tree[i]

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -281,7 +281,7 @@ iterator deps*(tree: MirTree): lent MirNode =
       # skip over the name slot:
       i = NodePosition tree.operand(i, 1)
       continue
-    of mnkProc, mnkProcLit:
+    of mnkProc, mnkProcVal:
       yield tree[i]
     of mnkGlobal:
       yield tree[i]

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -436,7 +436,7 @@ proc genLoadLib(bu: var MirBuilder, graph: ModuleGraph, env: var MirEnv,
 
   bu.subTree MirNode(kind: mnkAsgn):
     bu.use loc
-    bu.buildCall env.procedures.add(loadLib), loadLib.typ, loadLib.typ[0]:
+    bu.buildCall env.procedures.add(loadLib), loadLib.typ[0]:
       bu.emitByVal name
 
   bu.wrapTemp(graph.getSysType(unknownLineInfo, tyBool)):
@@ -480,7 +480,7 @@ proc genLibSetup(graph: ModuleGraph, env: var MirEnv, conf: BackendConfig,
 
       # if none of the candidates worked, a run-time error is reported:
       bu.subTree mnkVoid:
-        bu.buildCall env.procedures.add(errorProc), errorProc.typ, voidTyp:
+        bu.buildCall env.procedures.add(errorProc), voidTyp:
           bu.emitByVal literal(env.getOrIncl(path.strVal), path.typ)
       bu.add endNode(mnkStmtList)
   else:
@@ -498,7 +498,7 @@ proc genLibSetup(graph: ModuleGraph, env: var MirEnv, conf: BackendConfig,
     bu.subTree mnkIf:
       bu.use cond
       bu.subTree mnkVoid:
-        bu.buildCall env.procedures.add(errorProc), errorProc.typ, voidTyp:
+        bu.buildCall env.procedures.add(errorProc), voidTyp:
           bu.emitByVal nameTemp
 
 proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
@@ -558,7 +558,7 @@ proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
 
     # generate the code for ``sym = cast[typ](nimGetProcAddr(lib, extname))``
     let tmp = bu.wrapTemp(loadProc.typ[0]):
-      bu.buildCall env.procedures.add(loadProc), loadProc.typ, loadProc.typ[0]:
+      bu.buildCall env.procedures.add(loadProc), loadProc.typ[0]:
         bu.emitByVal toValue(libVar, lib.name.typ)
         bu.emitByVal literal(env.getOrIncl(extname.strVal), extname.typ)
 

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -200,7 +200,7 @@ proc translate*(t: MirTree, env: MirEnv): CgNode =
     of mnkAstLit:
       CgNode(kind: cnkAstLit, info: unknownLineInfo, typ: n.typ,
              astLit: env[n.ast])
-    of mnkProc:
+    of mnkProcLit:
       CgNode(kind: cnkProc, info: unknownLineInfo, prc: n.prc, typ: n.typ)
     of AllNodeKinds - ConstrTreeNodes + {mnkEnd, mnkField}:
       # 'end' nodes are skipped manually

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -200,7 +200,7 @@ proc translate*(t: MirTree, env: MirEnv): CgNode =
     of mnkAstLit:
       CgNode(kind: cnkAstLit, info: unknownLineInfo, typ: n.typ,
              astLit: env[n.ast])
-    of mnkProcLit:
+    of mnkProcVal:
       CgNode(kind: cnkProc, info: unknownLineInfo, prc: n.prc, typ: n.typ)
     of AllNodeKinds - ConstrTreeNodes + {mnkEnd, mnkField}:
       # 'end' nodes are skipped manually

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -39,7 +39,7 @@ func hashTree(tree: ConstrTree): Hash =
       result = result !& hash(n.strVal)
     of mnkAstLit:
       result = result !& hash(n.ast)
-    of mnkProc:
+    of mnkProcLit:
       result = result !& hash(n.prc.ord)
     of mnkSetConstr, mnkRange, mnkArrayConstr, mnkSeqConstr, mnkTupleConstr,
        mnkClosureConstr, mnkObjConstr:
@@ -73,7 +73,7 @@ proc cmp(a, b: ConstrTree): bool =
       a.strVal == b.strVal
     of mnkAstLit:
       a.ast == b.ast
-    of mnkProc:
+    of mnkProcLit:
       a.prc == b.prc
     of mnkSetConstr, mnkRange, mnkArrayConstr, mnkSeqConstr, mnkTupleConstr,
        mnkClosureConstr, mnkObjConstr:

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -39,7 +39,7 @@ func hashTree(tree: ConstrTree): Hash =
       result = result !& hash(n.strVal)
     of mnkAstLit:
       result = result !& hash(n.ast)
-    of mnkProcLit:
+    of mnkProcVal:
       result = result !& hash(n.prc.ord)
     of mnkSetConstr, mnkRange, mnkArrayConstr, mnkSeqConstr, mnkTupleConstr,
        mnkClosureConstr, mnkObjConstr:
@@ -73,7 +73,7 @@ proc cmp(a, b: ConstrTree): bool =
       a.strVal == b.strVal
     of mnkAstLit:
       a.ast == b.ast
-    of mnkProcLit:
+    of mnkProcVal:
       a.prc == b.prc
     of mnkSetConstr, mnkRange, mnkArrayConstr, mnkSeqConstr, mnkTupleConstr,
        mnkClosureConstr, mnkObjConstr:

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -98,7 +98,7 @@ func toValue*(id: GlobalId, typ: PType): Value =
   Value(node: MirNode(kind: mnkGlobal, typ: typ, global: id))
 
 func toValue*(id: ProcedureId, typ: PType): Value =
-  Value(node: MirNode(kind: mnkProc, typ: typ, prc: id))
+  Value(node: MirNode(kind: mnkProcLit, typ: typ, prc: id))
 
 func toValue*(kind: range[mnkParam..mnkLocal], id: LocalId,
               typ: PType): Value =

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -98,7 +98,7 @@ func toValue*(id: GlobalId, typ: PType): Value =
   Value(node: MirNode(kind: mnkGlobal, typ: typ, global: id))
 
 func toValue*(id: ProcedureId, typ: PType): Value =
-  Value(node: MirNode(kind: mnkProcLit, typ: typ, prc: id))
+  Value(node: MirNode(kind: mnkProcVal, typ: typ, prc: id))
 
 func toValue*(kind: range[mnkParam..mnkLocal], id: LocalId,
               typ: PType): Value =

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -356,12 +356,12 @@ template buildMagicCall*(bu: var MirBuilder, m: TMagic, t: PType,
     bu.add MirNode(kind: mnkMagic, magic: m)
     body
 
-template buildCall*(bu: var MirBuilder, prc: ProcedureId, pt, t: PType,
+template buildCall*(bu: var MirBuilder, prc: ProcedureId, t: PType,
                     body: untyped) =
   ## Build and emits a call tree to the active buffer. `pt` is the type of the
   ## procedure.
   bu.subTree MirNode(kind: mnkCall, typ: t):
-    bu.use toValue(prc, pt)
+    bu.add procNode(prc)
     body
 
 func emitByVal*(bu: var MirBuilder, y: Value) =

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -685,7 +685,7 @@ proc genCallee(c: var TCtx, n: PNode) =
     let s = n.sym
     if s.magic == mNone or s.magic in c.config.magicsToKeep:
       # reference the procedure by symbol
-      c.use toValue(c.env.procedures.add(s), s.typ)
+      c.add procNode(c.env.procedures.add(s))
     else:
       # don't use a symbol
       c.add MirNode(kind: mnkMagic, magic: s.magic)
@@ -1215,7 +1215,7 @@ proc genRaise(c: var TCtx, n: PNode) =
       cp = c.graph.getCompilerProc("prepareException")
     c.buildStmt mnkVoid:
       c.buildTree mnkCall, typeOrVoid(c, nil):
-        c.use toValue(c.env.procedures.add(cp), cp.typ)
+        c.add procNode(c.env.procedures.add(cp))
         c.subTree mnkArg:
           # lvalue conversion to the base ``Exception`` type:
           c.buildTree mnkPathConv, cp.typ[1]:
@@ -2234,8 +2234,7 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
       c.subTree mnkBranch:
         c.subTree mnkVoid:
           let p = c.graph.getCompilerProc("nimUnhandledException")
-          c.builder.buildCall c.env.procedures.add(p), p.typ,
-                              typeOrVoid(c, p.typ[0]):
+          c.builder.buildCall c.env.procedures.add(p), typeOrVoid(c, p.typ[0]):
             discard
     c.add endNode(mnkTry)
 

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -428,13 +428,12 @@ proc injectProfilerCalls(tree: MirTree, graph: ModuleGraph, env: var MirEnv,
   ## * at the end of a loop's body
   let
     voidType = graph.getSysType(unknownLineInfo, tyVoid)
-    prc = graph.getCompilerProc("nimProfile")
-    prcId = env.procedures.add(prc)
+    prcId = env.procedures.add(graph.getCompilerProc("nimProfile"))
 
   # insert the entry call within the outermost scope:
   changes.insert(tree, tree.child(NodePosition 0, 0), NodePosition 0, bu):
     bu.subTree mnkVoid:
-      bu.buildCall prcId, prc.typ, voidType:
+      bu.buildCall prcId, voidType:
         discard "no arguments"
 
   for i in search(tree, {mnkEnd}):
@@ -442,7 +441,7 @@ proc injectProfilerCalls(tree: MirTree, graph: ModuleGraph, env: var MirEnv,
       # insert the call before the end node:
       changes.insert(tree, i - 1, i, bu):
         bu.subTree mnkVoid:
-          bu.buildCall prcId, prc.typ, voidType:
+          bu.buildCall prcId, voidType:
             discard "no arguments"
 
 proc applyPasses*(body: var MirBody, prc: PSym, env: var MirEnv,

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -57,7 +57,7 @@ type
     mnkNone
 
     # entity names:
-    mnkProc   ## procedure
+    mnkProc   ## procedure reference; only allowed in callee slots
     mnkConst  ## named constant
     mnkGlobal ## global location
     mnkParam  ## parameter
@@ -69,6 +69,7 @@ type
 
     mnkField  ## declarative node only allowed in special contexts
 
+    mnkProcLit ## procedural value
     mnkNilLit  ## nil literal
     mnkIntLit  ## reference to signed integer literal
     mnkUIntLit ## reference to unsigend integer literal
@@ -278,7 +279,7 @@ type
       ## non-critical meta-data associated with the node (e.g., origin
       ## information)
     case kind*: MirNodeKind
-    of mnkProc:
+    of mnkProc, mnkProcLit:
       prc*: ProcedureId
     of mnkGlobal:
       global*: GlobalId
@@ -360,12 +361,12 @@ const
 
   ConstrTreeNodes* = {mnkSetConstr, mnkRange, mnkArrayConstr, mnkSeqConstr,
                       mnkTupleConstr, mnkClosureConstr, mnkObjConstr,
-                      mnkProc, mnkArg, mnkField, mnkEnd} + LiteralDataNodes
+                      mnkProcLit, mnkArg, mnkField, mnkEnd} + LiteralDataNodes
     ## Nodes that can appear in the MIR subset used for constant expressions.
 
   # --- semantics-focused sets:
 
-  Atoms* = {mnkNone .. mnkType} - {mnkField}
+  Atoms* = {mnkNone .. mnkType} - {mnkField, mnkProc}
     ## Nodes that may be appear in atom-expecting slots.
 
   StmtNodes* = {mnkScope, mnkStmtList, mnkIf, mnkCase, mnkRepeat, mnkTry,
@@ -381,9 +382,9 @@ const
   LvalueExprKinds* = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathVariant,
                       mnkPathConv, mnkDeref, mnkDerefView, mnkTemp, mnkAlias,
                       mnkLocal, mnkParam, mnkConst, mnkGlobal}
-  RvalueExprKinds* = {mnkType, mnkProc, mnkConv, mnkStdConv, mnkCast, mnkAddr,
-                      mnkView, mnkMutView, mnkToSlice, mnkToMutSlice} +
-                     UnaryOps + BinaryOps + LiteralDataNodes
+  RvalueExprKinds* = {mnkType, mnkProcLit, mnkConv, mnkStdConv, mnkCast,
+                      mnkAddr, mnkView, mnkMutView, mnkToSlice,
+                      mnkToMutSlice} + UnaryOps + BinaryOps + LiteralDataNodes
   ExprKinds* =       {mnkCall, mnkCheckedCall, mnkSetConstr, mnkArrayConstr,
                       mnkSeqConstr, mnkTupleConstr, mnkClosureConstr,
                       mnkObjConstr} + LvalueExprKinds + RvalueExprKinds +

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -58,6 +58,7 @@ type
 
     # entity names:
     mnkProc   ## procedure reference; only allowed in callee slots
+    mnkProcVal## procedural value
     mnkConst  ## named constant
     mnkGlobal ## global location
     mnkParam  ## parameter
@@ -69,7 +70,6 @@ type
 
     mnkField  ## declarative node only allowed in special contexts
 
-    mnkProcLit ## procedural value
     mnkNilLit  ## nil literal
     mnkIntLit  ## reference to signed integer literal
     mnkUIntLit ## reference to unsigend integer literal
@@ -279,7 +279,7 @@ type
       ## non-critical meta-data associated with the node (e.g., origin
       ## information)
     case kind*: MirNodeKind
-    of mnkProc, mnkProcLit:
+    of mnkProc, mnkProcVal:
       prc*: ProcedureId
     of mnkGlobal:
       global*: GlobalId
@@ -361,7 +361,7 @@ const
 
   ConstrTreeNodes* = {mnkSetConstr, mnkRange, mnkArrayConstr, mnkSeqConstr,
                       mnkTupleConstr, mnkClosureConstr, mnkObjConstr,
-                      mnkProcLit, mnkArg, mnkField, mnkEnd} + LiteralDataNodes
+                      mnkProcVal, mnkArg, mnkField, mnkEnd} + LiteralDataNodes
     ## Nodes that can appear in the MIR subset used for constant expressions.
 
   # --- semantics-focused sets:
@@ -382,7 +382,7 @@ const
   LvalueExprKinds* = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathVariant,
                       mnkPathConv, mnkDeref, mnkDerefView, mnkTemp, mnkAlias,
                       mnkLocal, mnkParam, mnkConst, mnkGlobal}
-  RvalueExprKinds* = {mnkType, mnkProcLit, mnkConv, mnkStdConv, mnkCast,
+  RvalueExprKinds* = {mnkType, mnkProcVal, mnkConv, mnkStdConv, mnkCast,
                       mnkAddr, mnkView, mnkMutView, mnkToSlice,
                       mnkToMutSlice} + UnaryOps + BinaryOps + LiteralDataNodes
   ExprKinds* =       {mnkCall, mnkCheckedCall, mnkSetConstr, mnkArrayConstr,

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -25,7 +25,7 @@ import
 func `$`(n: MirNode): string =
   result.add substr($n.kind, 3) # cut off the prefix
   case n.kind
-  of mnkProc:
+  of mnkProc, mnkProcLit:
     result.add " prc: "
     result.addInt n.prc.uint32
   of mnkConst:
@@ -205,7 +205,8 @@ proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
       result.addName(n.cnst, "<C", c)
   of mnkGlobal:
     result.addName(n.global, "<G", c)
-  of mnkProc:
+  of mnkProc, mnkProcLit:
+    # procedure references are also handled here for simplicity
     result.addName(n.prc, "<P", c)
   of mnkTemp, mnkAlias:
     result.add "_" & $n.local.int
@@ -243,7 +244,7 @@ proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
     result.add "type("
     result.add $n.typ
     result.add ")"
-  of AllNodeKinds - Atoms:
+  of AllNodeKinds - Atoms - mnkProc:
     result.add "<error: " & $n.kind & ">"
 
 proc singleToStr(tree: MirTree, i: var int, result: var string, c: RenderCtx) =

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -25,7 +25,7 @@ import
 func `$`(n: MirNode): string =
   result.add substr($n.kind, 3) # cut off the prefix
   case n.kind
-  of mnkProc, mnkProcLit:
+  of mnkProc, mnkProcVal:
     result.add " prc: "
     result.addInt n.prc.uint32
   of mnkConst:
@@ -205,7 +205,7 @@ proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
       result.addName(n.cnst, "<C", c)
   of mnkGlobal:
     result.addName(n.global, "<G", c)
-  of mnkProc, mnkProcLit:
+  of mnkProc, mnkProcVal:
     # procedure references are also handled here for simplicity
     result.addName(n.prc, "<P", c)
   of mnkTemp, mnkAlias:

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -60,7 +60,7 @@ type
     long: seq[PathInstr]
 
 const
-  Roots = {mnkProcLit, mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp,
+  Roots = {mnkProcVal, mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp,
            mnkCall, mnkDeref, mnkDerefView}
   PathOps = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv,
              mnkPathVariant}
@@ -72,7 +72,7 @@ func isSameRoot(an, bn: MirNode): bool =
   case an.kind
   of mnkParam, mnkLocal, mnkTemp:
     result = an.local == bn.local
-  of mnkProcLit:
+  of mnkProcVal:
     result = an.prc == bn.prc
   of mnkConst:
     result = an.cnst == bn.cnst

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -60,8 +60,8 @@ type
     long: seq[PathInstr]
 
 const
-  Roots = {mnkProc, mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp, mnkCall,
-           mnkDeref, mnkDerefView}
+  Roots = {mnkProcLit, mnkConst, mnkGlobal, mnkParam, mnkLocal, mnkTemp,
+           mnkCall, mnkDeref, mnkDerefView}
   PathOps = {mnkPathPos, mnkPathNamed, mnkPathArray, mnkPathConv,
              mnkPathVariant}
 
@@ -72,7 +72,7 @@ func isSameRoot(an, bn: MirNode): bool =
   case an.kind
   of mnkParam, mnkLocal, mnkTemp:
     result = an.local == bn.local
-  of mnkProc:
+  of mnkProcLit:
     result = an.prc == bn.prc
   of mnkConst:
     result = an.cnst == bn.cnst

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -502,8 +502,7 @@ template buildVoidCall*(bu: var MirBuilder, env: var MirEnv, p: PSym,
                        body: untyped) =
   let prc = p # prevent multi evaluation
   bu.subTree mnkVoid:
-    bu.subTree MirNode(kind: mnkCall, typ: getVoidType(graph)):
-      bu.use toValue(env.procedures.add(prc), prc.typ)
+    bu.buildCall env.procedures.add(prc), getVoidType(graph):
       body
 
 proc genWasMoved(bu: var MirBuilder, graph: ModuleGraph, target: Value) =

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -291,7 +291,7 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
   of LvalueExprKinds:
     # raw usage of an lvalue
     emitLvalueOp(env, opUse, tree, at, OpValue source)
-  of mnkNone, LiteralDataNodes, mnkProcLit:
+  of mnkNone, LiteralDataNodes, mnkProcVal:
     discard "okay, ignore"
   of AllNodeKinds - ExprKinds - {mnkNone} + {mnkType}:
     unreachable(tree[source].kind)

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -224,7 +224,7 @@ func emitForArgs(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
       emitLvalueOp(env, opConsume, tree, at, tree.operand(it))
     of mnkName:
       emitForValue(env, tree, at, tree.skip(tree.operand(it), mnkTag))
-    of mnkField, mnkMagic:
+    of mnkField, mnkMagic, mnkProc:
       discard
     else:
       emitLvalueOp(env, opUse, tree, at, OpValue it)
@@ -291,7 +291,7 @@ func emitForExpr(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
   of LvalueExprKinds:
     # raw usage of an lvalue
     emitLvalueOp(env, opUse, tree, at, OpValue source)
-  of mnkNone, LiteralDataNodes, mnkProc:
+  of mnkNone, LiteralDataNodes, mnkProcLit:
     discard "okay, ignore"
   of AllNodeKinds - ExprKinds - {mnkNone} + {mnkType}:
     unreachable(tree[source].kind)

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -391,7 +391,7 @@ func storeDataNode(enc: var DataEncoder, e: var PackedEnv,
   of mnkStrLit:
     # the ID indexes into the string BiTable, it can be packed directly
     enc.put e, PackedDataNode(kind: pdkString, pos: t[n].strVal.uint32)
-  of mnkProc:
+  of mnkProcLit:
     # the ID is stable, it can be packed directly
     enc.put e, PackedDataNode(kind: pdkIntLit, pos: t[n].prc.uint32)
   of mnkArrayConstr, mnkSeqConstr:

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -391,7 +391,7 @@ func storeDataNode(enc: var DataEncoder, e: var PackedEnv,
   of mnkStrLit:
     # the ID indexes into the string BiTable, it can be packed directly
     enc.put e, PackedDataNode(kind: pdkString, pos: t[n].strVal.uint32)
-  of mnkProcLit:
+  of mnkProcVal:
     # the ID is stable, it can be packed directly
     enc.put e, PackedDataNode(kind: pdkIntLit, pos: t[n].prc.uint32)
   of mnkArrayConstr, mnkSeqConstr:

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -44,7 +44,7 @@ Semantics
          | DerefView   NAME              # dereference a `var` or `lent`
 
   VALUE = <Literal>
-        | <ProcLit>
+        | <ProcVal>
         | <Type>
         | LVALUE
 
@@ -388,7 +388,7 @@ ones).
 
 .. code-block:: literal
 
-  VALUE = <ProcLit>
+  VALUE = <ProcVal>
         | <Literal>
         | COMPLEX
 

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -44,7 +44,7 @@ Semantics
          | DerefView   NAME              # dereference a `var` or `lent`
 
   VALUE = <Literal>
-        | <Proc>
+        | <ProcLit>
         | <Type>
         | LVALUE
 
@@ -388,7 +388,7 @@ ones).
 
 .. code-block:: literal
 
-  VALUE = <Proc>
+  VALUE = <ProcLit>
         | <Literal>
         | COMPLEX
 


### PR DESCRIPTION
## Summary

Introduce `mnkProcVal`, for taking over the "procedural value" meaning
of `mnkProc`, the latter which only means "reference to procedure" now.
This clarifies the syntax a bit, but, more importantly, allows
`mnkProc` nodes to not require a type.

## Details

* add the `mnkProcVal` kind and update the grammar
* where the value interpretation was used, replace usages of `mnkProc`
  with `mnkProcVal`
* for the sake of keeping the code generators as is, `mnkProc` is still
  translated to a typed `cnkProc`
* `mirconstr.buildCall` no longer requires a procedure type
* all static calls use `mnkProc` instead of `mnkProcVal`