### PR TITLE
fix: internal compiler errors with closure iterators

### DIFF
--- a/compiler/sem/closureiters.nim
+++ b/compiler/sem/closureiters.nim
@@ -690,7 +690,7 @@ proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
         [st, n]
 
   of nkCast, nkHiddenStdConv, nkHiddenSubConv, nkConv, nkObjUpConv,
-      nkDerefExpr, nkHiddenDeref:
+     nkObjDownConv, nkDerefExpr, nkHiddenDeref:
     var ns = false
     for i in ord(n.kind == nkCast)..<n.len:
       n[i] = ctx.lowerStmtListExprs(n[i], ns)
@@ -743,8 +743,7 @@ proc lowerStmtListExprs(ctx: var Ctx, n: PNode, needsSplit: var bool): PNode =
 
   of nkWhileStmt:
     assert isTrue(n[0])
-    var bodyNeedsSplit = false
-    n[1] = ctx.lowerStmtListExprs(n[1], bodyNeedsSplit)
+    n[1] = ctx.lowerStmtListExprs(n[1], needsSplit)
 
   of nkDotExpr, nkCheckedFieldExpr:
     var ns = false

--- a/tests/lang_callable/iter/titer_issues.nim
+++ b/tests/lang_callable/iter/titer_issues.nim
@@ -278,3 +278,31 @@ block ref_construction_argument:
 
   for i in iter(RefObj(i: 1)):
     doAssert i == 3
+
+block while_loop_in_closure_iterator_expression:
+  # a ``while`` loop with a yield inside and part of an expression was
+  # not transformed properly, leading to an internal compiler error
+  iterator iter() {.closure.} =
+    var val = block:
+      while true: # while loop part of a block expression
+        yield
+      1
+    doAssert val == 1
+
+  let it = iter
+  it()
+  it()
+
+block yield_in_obj_down_conversion:
+  # an object down-conversion containing a yield wasn't processed properly,
+  # leading to an internal compiler error
+  type Obj = ref object of RootObj
+
+  iterator iter() {.closure.} =
+    var x: ref RootObj
+    var val = Obj((;yield; x))
+    doAssert val.isNil
+
+  let it = iter
+  it()
+  it()


### PR DESCRIPTION
## Summary

Fix two bugs with the closure iterator transformation that resulted in
internal compiler errors. One affected yields in `while` loops, the
other yields in object down-conversion expressions.

## Details

1. whether a split is required wasn't propagated upwards for
   `nkWhileStmt` statements, leading to their enclosing statement-list
   expressions to not be lifted, if there was no other source for
   splits
2. the `nkObjDownConv` node wasn't properly handled by
   `lowerStmtListExpr`, meaning that the statement-list expression
   unpacking wasn't performed

Two regression tests are added to `titer_issues.nim`.