### PR TITLE
mir: use `TypeId`

### DIFF
--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -500,7 +500,7 @@ proc localVarDecl(p: BProc; n: CgNode, decl: Local): Rope =
   if decl.alignment > 0:
     result.addf("NIM_ALIGN($1) ", [$decl.alignment])
 
-  result.add getTypeDesc(p.module, decl.typ)
+  result.add getTypeDesc(p.module, p.module.g.env[decl.typ])
   if true:
     if sfRegister in decl.flags: result.add(" register")
     if sfVolatile in decl.flags: result.add(" volatile")

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -310,7 +310,8 @@ proc newProc*(prc: PSym, module: BModule): BProc =
 
 proc newModuleList*(g: ModuleGraph): BModuleList =
   BModuleList(typeInfoMarker: initTable[SigHash, tuple[str: Rope, owner: int32]](),
-    config: g.config, graph: g, nimtvDeclared: initIntSet())
+    config: g.config, graph: g, nimtvDeclared: initIntSet(),
+    env: initMirEnv(g))
 
 iterator cgenModules*(g: BModuleList): BModule =
   for m in g.modulesClosed:

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -141,6 +141,10 @@ proc translate*(t: MirTree, env: MirEnv): CgNode =
   ## a ``CgNode`` tree. Obsolete once the code generators use the MIR
   ## directly.
   proc translateAux(t: MirTree, i: var int, env: MirEnv): CgNode =
+    let
+      n {.cursor.}   = t[i]
+      typ {.cursor.} = env[n.typ]
+
     template recurse(): CgNode =
       translateAux(t, i, env)
 
@@ -155,9 +159,6 @@ proc translate*(t: MirTree, env: MirEnv): CgNode =
       inc i # consume the end node
       res
 
-    let
-      n {.cursor.} = t[i]
-      typ {.cursor.} = env[n.typ]
     inc i # advance to the first child node
     case n.kind
     of mnkObjConstr:

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -121,7 +121,7 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
   ## Entry point into the JS backend. Generates the code for all modules and
   ## writes it to the output file.
   let
-    globals = newGlobals()
+    globals = newGlobals(graph)
     bconf = BackendConfig(tconfig: TranslationConfig(magicsToKeep: NonMagics))
 
   var

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1521,7 +1521,7 @@ proc setupLocalLoc(p: PProc, id: LocalId, kind: TSymKind; name = "") =
   ## computing the storage flags and a non-empty `name` overrides the
   ## mangled name.
   var loc = Loc(name: mangleName(p.fullBody[id], id),
-                typ: p.fullBody[id].typ,
+                typ: p.env[p.fullBody[id].typ],
                 storage: storage(p.fullBody[id].flags, kind,
                                  id in p.addrTaken))
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -264,9 +264,8 @@ template endBlock(p: PProc, frmt: FormatStr = "}$n", args: varargs[Rope]) =
   dec p.extraIndent
   lineF(p, frmt, args)
 
-proc newGlobals*(): PGlobals =
-  new(result)
-  result.typeInfoGenerated = initIntSet()
+proc newGlobals*(g: ModuleGraph): PGlobals =
+  PGlobals(env: initMirEnv(g))
 
 proc rdLoc(a: TCompRes): Rope {.inline.} =
   if a.typ != etyBaseIndex:

--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -225,7 +225,7 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   #  during `setupVM`
   # - NimScript has access to the macro/compile-time APIs
   registerAdditionalOps(vm, disallowDanger)
-  graph.vm = PEvalContext(vm: vm, jit: initJit(graph))
+  graph.vm = PVmCtx(context: vm)
 
   graph.compileSystemModule()
   discard graph.processModule(m, idgen, stream)

--- a/compiler/front/scripting.nim
+++ b/compiler/front/scripting.nim
@@ -45,7 +45,7 @@ import
   ]
 
 from compiler/vm/vmlegacy import legacyReportsVmTracer
-from compiler/vm/vmjit import registerCallback
+from compiler/vm/vmjit import registerCallback, initJit
 
 # we support 'cmpIgnoreStyle' natively for efficiency:
 from std/strutils import cmpIgnoreStyle, contains
@@ -225,7 +225,7 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   #  during `setupVM`
   # - NimScript has access to the macro/compile-time APIs
   registerAdditionalOps(vm, disallowDanger)
-  graph.vm = PEvalContext(vm: vm)
+  graph.vm = PEvalContext(vm: vm, jit: initJit(graph))
 
   graph.compileSystemModule()
   discard graph.processModule(m, idgen, stream)

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -5,10 +5,6 @@ import
   std/[
     hashes
   ],
-  compiler/ast/[
-    ast_types,
-    types
-  ],
   compiler/mir/[
     mirtrees
   ],
@@ -55,9 +51,7 @@ func hashTree(tree: ConstrTree): Hash =
   for _, it in tree.pairs:
     result = result !& hash(it)
 
-  # only hash the kind of the type. This trades more collisions for faster
-  # hashing
-  result = result !& hash(tree[0].typ.kind)
+  result = result !& hash(tree[0].typ)
   result = !$(result)
 
 proc cmp(a, b: ConstrTree): bool =
@@ -85,7 +79,7 @@ proc cmp(a, b: ConstrTree): bool =
     of AllNodeKinds - ConstrTreeNodes:
       unreachable(a.kind)
 
-  if not a[0].typ.sameBackendType(b[0].typ) or a.len != b.len:
+  if a[0].typ != b[0].typ or a.len != b.len:
     # the (backend-)type is different -> not the same constant expressions
     return false
 

--- a/compiler/mir/mirbodies.nim
+++ b/compiler/mir/mirbodies.nim
@@ -17,7 +17,7 @@ type
   Local* = object
     ## Static information about a local location ('let' or 'var'). Not modified
     ## after initialization.
-    typ*: PType
+    typ*: TypeId
       ## type of the local
     alignment*: uint32
       ## alignment of the location, measured in bytes. 0 means "use default"

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -15,6 +15,9 @@ import
     mirtrees,
     mirtypes
   ],
+  compiler/modules/[
+    modulegraphs
+  ],
   compiler/ic/[
     bitabs
   ],

--- a/compiler/mir/mirenv.nim
+++ b/compiler/mir/mirenv.nim
@@ -12,7 +12,8 @@ import
   ],
   compiler/mir/[
     datatables,
-    mirtrees
+    mirtrees,
+    mirtypes
   ],
   compiler/ic/[
     bitabs
@@ -42,6 +43,8 @@ type
     globals*:    SymbolTable[GlobalId, PSym]
       ## includes both normal globals and threadvars
     procedures*: SymbolTable[ProcedureId, PSym]
+    types*: TypeEnv
+      ## the type environment
 
     numbers*: BiTable[BiggestInt]
       ## all numerical values referenced by the MIR, stored as bit patterns
@@ -102,6 +105,9 @@ func checkpoint*[I, T](tab: SymbolTable[I, T]): Checkpoint =
 
 # ------- MirEnv API --------
 
+proc initMirEnv*(g: ModuleGraph): MirEnv =
+  MirEnv(types: initTypeEnv(g))
+
 func `[]`*(env: MirEnv, id: ConstId): lent PSym {.inline.} =
   env.constants.data[id]
 
@@ -137,6 +143,9 @@ func getOrIncl*(env: var MirEnv, v: BiggestInt|BiggestUInt|BiggestFloat
 func getOrIncl*(env: var MirEnv, str: string): StringId {.inline.} =
   ## If not registered already, adds `str` to the environment.
   StringId env.strings.getOrIncl(str)
+
+template `[]`*(env: MirEnv, id: TypeId): PType =
+  env.types[id]
 
 func setData*(env: var MirEnv, id: ConstId, data: DataId) =
   ## Sets the body for the constant identified by `id`.

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -784,7 +784,7 @@ proc genMacroCallArgs(c: var TCtx, n: PNode, kind: TSymKind, fntyp: PType) =
     genCallee(c, n[1])
   of skTemplate:
     # for late template invocations, the callee template is an argument
-    c.emitByVal astLiteral(c.env, n[1], n[1].typ)
+    c.emitByVal literal(c.env.asts.add(n[1]), VoidType)
   else:
     unreachable(kind)
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1169,16 +1169,7 @@ proc genClosureConstr(c: var TCtx, n: PNode, isConsume: bool) =
     # transf wraps the procedure operand in a conversion that we don't
     # need
 
-    c.subTree (if isConsume: mnkConsume else: mnkArg): # the environment
-      if n[1].kind == nkNilLit:
-        # it can happen that a ``nkNilLit`` has no type (i.e. its typ is nil) -
-        # we ensure that the nil literal has the correct type
-        # TODO: prevent a ``nkNilLit`` with no type information from being
-        #       created instead
-        c.add MirNode(kind: mnkNilLit,
-                      typ: c.graph.getSysType(n[1].info, tyNil))
-      else:
-        genArgExpression(c, n[1], isConsume)
+    c.emitOperandTree n[1], isConsume # the environment
 
 proc genObjConstr(c: var TCtx, n: PNode, isConsume: bool) =
   let isRef = n.typ.skipTypes(abstractInst).kind == tyRef

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -35,10 +35,8 @@ type
   DataId* = distinct uint32
     ## Identifies a complete constant expression
 
-  TypeInstance {.used.} = distinct uint32
-    ## Refers to an existing type instance
-  TypeId {.used.} = distinct uint32
-    ## The ID of a type instance or nil
+  TypeId* = distinct uint32
+    ## Identifies a type
 
   SourceId* = distinct range[0'u32 .. high(uint32)-1]
     ## The ID of a source-mapping that's stored separately from the MIR nodes.
@@ -274,7 +272,7 @@ type
     geMutateGlobal ## the operation mutates global state
 
   MirNode* = object
-    typ*: PType ## non-nil for all expressions
+    typ*: TypeId ## valid for all expression, including all calls
     info*: SourceId
       ## non-critical meta-data associated with the node (e.g., origin
       ## information)
@@ -402,6 +400,7 @@ func `==`*(a, b: DataId): bool {.borrow.}
 func `==`*(a, b: NumberId): bool {.borrow.}
 func `==`*(a, b: StringId): bool {.borrow.}
 func `==`*(a, b: AstId): bool {.borrow.}
+func `==`*(a, b: TypeId): bool {.borrow.}
 
 func isAnon*(id: ConstId): bool =
   ## Returns whether `id` represents an anonymous constant.

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -84,6 +84,11 @@ proc initTypeEnv*(graph: ModuleGraph): TypeEnv =
   add(tyCstring, CstringType)
   add(tyPointer, PointerType)
 
+  # also register the built-in unspecified-width types. This prevents int/float
+  # literal types from being added to the environment
+  add(tyInt,   TypeId(ord(PointerType) + 1))
+  add(tyFloat, TypeId(ord(PointerType) + 2))
+
 proc add*(env: var TypeEnv, t: PType): TypeId =
   ## If not registered yet, adds `t` to `env` and returns the ID to later
   ## look it up with. Basic structural type unification is performed.

--- a/compiler/mir/typemaps.nim
+++ b/compiler/mir/typemaps.nim
@@ -1,0 +1,187 @@
+## Implements a Table-like type for mapping a ``PType`` to some value. The
+## ``PType`` keys undergo basic canoncalization, meaning that two
+## different - in terms of reference equality - ``PType`` instances can
+## represent the same key.
+##
+## The canonicalization makes sure to not ignore type information relevant to
+## the mid-end and code generation stages.
+
+import
+  std/[
+    hashes,
+    tables
+  ],
+  compiler/ast/[
+    ast_types,
+    ast_query
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+type
+  Type = distinct PType
+    # a distinct type so that a new hash and equality operator can be
+    # attached
+  TypeTable*[T] = object
+    inner: Table[Type, T]
+
+proc safeId(n: PNode): NodeId {.inline.} =
+  if n != nil: n.id
+  else:        NodeId -1
+
+proc cmp(a, b: PType): bool {.noSideEffect.}
+
+proc cmpElements(a, b: PType): bool =
+  if a.len != b.len:
+    return false
+
+  for i in 0..<a.len:
+    if not cmp(a[i], b[i]):
+      return false
+
+  result = true
+
+proc cmpProc(a, b: PType): bool =
+  if a.len != b.len:
+    return false
+
+  # nil in the return type slot means 'void'; handle it separately
+  if a[0].isNil != b[0].isNil or (a[0] != nil and not cmp(a[0], b[0])):
+    return false
+
+  for i in 1..<a.len:
+    if not cmp(a[i], b[i]):
+      return false
+
+  result = true
+
+proc cmp(a, b: PNode): bool =
+  if a.kind != b.kind:
+    return false
+  case a.kind
+  of nkFloatLiterals:
+    result = cast[BiggestInt](a.floatVal) == cast[BiggestInt](b.floatVal)
+  of nkIntLiterals:
+    result = a.intVal == b.intVal
+  else:
+    unreachable()
+
+proc cmp(a, b: PType): bool =
+  # generic types are also handled here, since they can be part of
+  # ``tyTypeDesc``s
+  if a.id == b.id: # quick check: same type instance?
+    # FIXME: user type-classes are sometimes improperly instantiated,
+    #        producing different types that share the same ID.
+    #        ``concepts/tcomparable.nim`` is a test where removing the extra
+    #        condition would cause a failure
+    a.kind notin tyUserTypeClasses
+  elif a.kind != b.kind or a.sym != b.sym:
+    false
+  elif a.sym != nil and a.kind == tyObject and a.sym == b.sym:
+    # note: only object types have proper symbols at the moment. For all other
+    # types, instantiations of a generic invocation all use the symbol of the
+    # generic type
+    true
+  else:
+    case a.kind
+    of tyVoid, tyBool, tyChar, tyPointer, tyNil, tyInt..tyInt64,
+       tyUInt..tyUInt64, tyFloat..tyFloat64, tyString, tyCstring, tyEmpty,
+       tyAnything:
+      true
+    of tySet, tySequence, tyOpenArray, tyVarargs, tyUncheckedArray, tyPtr,
+       tyRef, tyLent, tyVar, tyAlias, tyOrdinal, tySink, tyTypeDesc, tyNot:
+      # simple structural-like types that are equal if their element types are
+      cmp(a[^1], b[^1])
+    of tyArray:
+      cmp(a[0], b[0]) and cmp(a[1], b[1])
+    of tyRange:
+      # only the range description matters
+      cmp(a.n[0], b.n[0]) and cmp(a.n[1], b.n[1])
+    of tyTuple:
+      # named and unnamed tuple distinction matters
+      safeId(a.n) == safeId(b.n) and cmpElements(a, b)
+    of tyProc:
+      # also consider the flags
+      a.flags == b.flags and a.callConv == b.callConv and cmpProc(a, b)
+    of tyAnd, tyOr:
+      cmp(a[0], b[1]) and cmp(a[1], b[1])
+    of tyBuiltInTypeClass:
+      a[0].kind == b[0].kind
+    of tyObject, tyDistinct, tyEnum, tyGenericInst, tyStatic,
+       tyUserTypeClasses, tyCompositeTypeClass, tyInferred:
+      # ids are not the same, so it must be a different type
+      # XXX: ideally, ``tyStatic`` would not be supported here, but ``mirgen``
+      #      does add those types
+      # FIXME: ``tyInferred`` reaches here, but shouldn't. Needs further
+      #        investigation.
+      false
+    else:
+      unreachable()
+
+proc hash(n: PNode): Hash =
+  case n.kind
+  of nkFloatLiterals:
+    hash(cast[BiggestInt](n.floatVal))
+  of nkIntLiterals:
+    hash(n.intVal)
+  else:
+    unreachable(n.kind)
+
+proc hash(t: PType): Hash =
+  # ``hash(a)`` must be ``== hash(b)`` if ``cmp(a, b)`` is true
+  if t.sym != nil:
+    # for types with symbols, only the symbol matters
+    result = !$(hash(true) !& hash(t.sym.id))
+  else:
+    result = hash(false) !& hash(t.kind)
+    case t.kind
+    of tyVoid, tyBool, tyChar, tyPointer, tyNil, tyInt..tyInt64,
+       tyUInt..tyUInt64, tyFloat..tyFloat64, tyString, tyCstring, tyEmpty:
+      discard "leaf type"
+    of tySet, tySequence, tyOpenArray, tyVarargs, tyUncheckedArray, tyPtr,
+       tyRef, tyLent, tyVar, tyTypeDesc, tyAlias, tyOrdinal, tySink:
+      result = result !& hash(t[0])
+    of tyArray:
+      result = result !& hash(t[0]) !& hash(t[1])
+    of tyTuple:
+      # only hash the number of elements
+      result = result !& hash(t.len) !& hash(safeId t.n)
+    of tyRange:
+      result = result !& hash(t.n[0]) !& hash(t.n[1])
+    of tyProc:
+      # only hash the number of parameters
+      result = result !& hash(t.flags) !& hash(t.callConv) !& hash(t.len)
+    of tyAnd, tyOr:
+      result = result !& hash(t[0]) !& hash(t[1])
+    of tyBuiltInTypeClass:
+      result = result !& hash(t[0].kind)
+    of tyObject, tyDistinct, tyEnum, tyGenericInst, tyStatic,
+       tyUserTypeClasses, tyCompositeTypeClass, tyInferred:
+      result = result !& hash(t.id)
+    else:
+      unreachable()
+
+    result = !$(result)
+
+# note: hash and the equality procedure need to be be exported for symbol
+# binding in ``Table`` routines to work properly
+
+proc `==`*(a, b: Type): bool {.inline.} =
+  ## Leaked implementation detail -- do not use.
+  cmp(a.PType, b.PType)
+
+proc hash*(x: Type): Hash {.inline.} =
+  ## Leaked implementation detail -- do not use.
+  hash(PType x)
+
+proc `[]`*[T](t: TypeTable[T], key: PType): lent T {.inline.} =
+  ## Looks up the item for `key`.
+  t.inner[Type key]
+
+proc `[]=`*[T](t: var TypeTable[T], key: PType, val: sink T) {.inline.} =
+  t.inner[Type key] = val
+
+proc mgetOrPut*[T](t: var TypeTable, key: PType, val: T): var T =
+  ## If `key` has no mapping in `t`, adds one with `val` as the value first.
+  t.inner.mgetOrPut(Type(key), val)

--- a/compiler/mir/typemaps.nim
+++ b/compiler/mir/typemaps.nim
@@ -26,13 +26,13 @@ type
   TypeTable*[T] = object
     inner: Table[Type, T]
 
-proc safeId(n: PNode): NodeId {.inline.} =
+func safeId(n: PNode): NodeId {.inline.} =
   if n != nil: n.id
   else:        NodeId -1
 
-proc cmp(a, b: PType): bool {.noSideEffect.}
+func cmp(a, b: PType): bool
 
-proc cmpElements(a, b: PType): bool =
+func cmpElements(a, b: PType): bool =
   if a.len != b.len:
     return false
 
@@ -42,7 +42,7 @@ proc cmpElements(a, b: PType): bool =
 
   result = true
 
-proc cmpProc(a, b: PType): bool =
+func cmpProc(a, b: PType): bool =
   if a.len != b.len:
     return false
 
@@ -56,7 +56,7 @@ proc cmpProc(a, b: PType): bool =
 
   result = true
 
-proc cmp(a, b: PNode): bool =
+func cmp(a, b: PNode): bool =
   if a.kind != b.kind:
     return false
   case a.kind
@@ -67,7 +67,7 @@ proc cmp(a, b: PNode): bool =
   else:
     unreachable()
 
-proc cmp(a, b: PType): bool =
+func cmp(a, b: PType): bool =
   # generic types are also handled here, since they can be part of
   # ``tyTypeDesc``s
   if a.id == b.id: # quick check: same type instance?
@@ -119,7 +119,7 @@ proc cmp(a, b: PType): bool =
     else:
       unreachable()
 
-proc hash(n: PNode): Hash =
+func hash(n: PNode): Hash =
   case n.kind
   of nkFloatLiterals:
     hash(cast[BiggestInt](n.floatVal))
@@ -128,7 +128,7 @@ proc hash(n: PNode): Hash =
   else:
     unreachable(n.kind)
 
-proc hash(t: PType): Hash =
+func hash(t: PType): Hash =
   # ``hash(a)`` must be ``== hash(b)`` if ``cmp(a, b)`` is true
   if t.sym != nil:
     # for types with symbols, only the symbol matters
@@ -167,11 +167,11 @@ proc hash(t: PType): Hash =
 # note: hash and the equality procedure need to be be exported for symbol
 # binding in ``Table`` routines to work properly
 
-proc `==`*(a, b: Type): bool {.inline.} =
+func `==`*(a, b: Type): bool {.inline.} =
   ## Leaked implementation detail -- do not use.
   cmp(a.PType, b.PType)
 
-proc hash*(x: Type): Hash {.inline.} =
+func hash*(x: Type): Hash {.inline.} =
   ## Leaked implementation detail -- do not use.
   hash(PType x)
 

--- a/compiler/mir/typemaps.nim
+++ b/compiler/mir/typemaps.nim
@@ -180,6 +180,7 @@ proc `[]`*[T](t: TypeTable[T], key: PType): lent T {.inline.} =
   t.inner[Type key]
 
 proc `[]=`*[T](t: var TypeTable[T], key: PType, val: sink T) {.inline.} =
+  ## Assign a `val` for the `key`.
   t.inner[Type key] = val
 
 proc mgetOrPut*[T](t: var TypeTable, key: PType, val: T): var T =

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -19,7 +19,8 @@ import
   compiler/mir/[
     mirbodies,
     mirenv,
-    mirtrees
+    mirtrees,
+    mirtypes
   ]
 
 func `$`(n: MirNode): string =
@@ -71,9 +72,9 @@ func `$`(n: MirNode): string =
     result.add " len: "
     result.add $n.len
 
-  if n.typ != nil:
+  if n.typ != VoidType:
     result.add " typ: "
-    result.add $n.typ.kind
+    result.addInt n.typ.uint32
 
 proc treeRepr*(tree: MirTree, pos = NodePosition(0)): string =
   ## Renders the node or sub-tree at `pos` to a string in a tree-layout-

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -95,13 +95,22 @@ type
   ExecutionResult* = Result[PNode, ExecErrorReport]
 
   PEvalContext* = ref EvalContext
-  EvalContext* = object of TPassContext
+  EvalContext* {.final.} = object of RootObj
     ## All state required to on-demand translate AST to VM bytecode and execute
     ## it. An ``EvalContext`` instance makes up everything that is required
     ## for running code at compile-time.
     vm*: TCtx
     jit*: JitState
 
+  PVmCtx* = ref object of RootObj
+    ## Wrapper type intended for storing only a VM instance (without a JIT
+    ## environment) in the module graph.
+    context*: TCtx
+
+  PEvalPassContext = ref object of PPassContext
+    ## Pass context for the evaluation pass.
+    graph: ModuleGraph
+    module: PSym
     oldErrorCount: int
 
 # prevent a default `$` implementation from being generated
@@ -461,6 +470,11 @@ proc setupGlobalCtx*(module: PSym; graph: ModuleGraph; idgen: IdGenerator) =
     registerAdditionalOps(ctx, disallowDangerous)
 
     graph.vm = PEvalContext(vm: ctx, jit: initJit(graph))
+  elif graph.vm of PVmCtx:
+    # take the VM instance provided by the wrapper and create a proper
+    # evaluation context from it
+    let ctx = move PVmCtx(graph.vm).context
+    graph.vm = PEvalContext(vm: ctx, jit: initJit(graph))
   else:
     let c = PEvalContext(graph.vm)
     refresh(c.vm, module, idgen)
@@ -691,26 +705,39 @@ proc setGlobalValue*(c: var EvalContext; s: PSym, val: PNode) =
 ## the ``nimeval`` interface
 
 proc myOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext {.nosinks.} =
-  #var c = newEvalContext(module, emRepl)
-  #c.features = {allowCast, allowInfiniteLoops}
-  #pushStackFrame(c, newStackFrame())
+  result = PEvalPassContext(idgen: idgen, graph: graph, module: module)
 
-  # XXX produce a new 'globals' environment here:
-  setupGlobalCtx(module, graph, idgen)
-  result = PEvalContext graph.vm
+proc isDecl(n: PNode): bool =
+  case n.kind
+  of nkStmtList:
+    # if one sub-node is not declarative, neither is `n`
+    for it in n.items:
+      if not isDecl(it):
+        return false
+    result = true
+  of nkEmpty, nkTypeSection, nkConstSection, nkImportStmt, nkImportAs,
+     nkImportExceptStmt, nkFromStmt, nkCommentStmt, routineDefs:
+    result = true
+  else:
+    result = false
 
 proc myProcess(c: PPassContext, n: PNode): PNode =
-  let c = PEvalContext(c)
-  # don't eval errornous code:
-  if c.oldErrorCount == c.vm.config.errorCounter and not n.isError:
-    let r = evalStmt(c.jit, c.vm, n)
-    reportIfError(c.vm.config, r)
+  let c = PEvalPassContext(c)
+  # don't eval errornous code. Also skip declarative nodes, as those represent
+  # type definitions required for bootstrapping the basic type environment
+  if c.oldErrorCount == c.graph.config.errorCounter and not n.isError and
+     not isDecl(n):
+    setupGlobalCtx(c.module, c.graph, c.idgen)
+    let eval = PEvalContext(c.graph.vm)
+
+    let r = evalStmt(eval.jit, eval.vm, n)
+    reportIfError(c.graph.config, r)
     # TODO: use the node returned by evalStmt as the result and don't report
     #       the error here
     result = newNodeI(nkEmpty, n.info)
   else:
     result = n
-  c.oldErrorCount = c.vm.config.errorCounter
+  c.oldErrorCount = c.graph.config.errorCounter
 
 proc myClose(graph: ModuleGraph; c: PPassContext, n: PNode): PNode =
   result = myProcess(c, n)

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -460,7 +460,7 @@ proc setupGlobalCtx*(module: PSym; graph: ModuleGraph; idgen: IdGenerator) =
     ctx.flags = {cgfAllowMeta}
     registerAdditionalOps(ctx, disallowDangerous)
 
-    graph.vm = PEvalContext(vm: ctx)
+    graph.vm = PEvalContext(vm: ctx, jit: initJit(graph))
   else:
     let c = PEvalContext(graph.vm)
     refresh(c.vm, module, idgen)

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -174,7 +174,7 @@ proc createInterpreter*(
     # Register basic system operations and parts of stdlib modules
     for o in basicOps():
       vm.registerCallback(o.pattern, o.prc)
-  graph.vm = PEvalContext(vm: vm, jit: initJit(graph))
+  graph.vm = PVmCtx(context: vm)
   graph.compileSystemModule()
   result = Interpreter(mainModule: m, graph: graph, scriptName: scriptName, idgen: idgen)
 
@@ -219,8 +219,7 @@ proc runRepl*(
   var idgen = idGeneratorFromModule(m)
 
   if supportNimscript:
-    graph.vm = PEvalContext(jit: initJit(graph),
-                            vm: setupVM(m, cache, "stdin", graph, idgen))
+    graph.vm = PVmCtx(context: setupVM(m, cache, "stdin", graph, idgen))
 
   graph.compileSystemModule()
   processModule(graph, m, idgen, llStreamOpenStdIn(r))

--- a/compiler/vm/nimeval.nim
+++ b/compiler/vm/nimeval.nim
@@ -174,7 +174,7 @@ proc createInterpreter*(
     # Register basic system operations and parts of stdlib modules
     for o in basicOps():
       vm.registerCallback(o.pattern, o.prc)
-  graph.vm = PEvalContext(vm: vm)
+  graph.vm = PEvalContext(vm: vm, jit: initJit(graph))
   graph.compileSystemModule()
   result = Interpreter(mainModule: m, graph: graph, scriptName: scriptName, idgen: idgen)
 
@@ -219,7 +219,8 @@ proc runRepl*(
   var idgen = idGeneratorFromModule(m)
 
   if supportNimscript:
-    graph.vm = PEvalContext(vm: setupVM(m, cache, "stdin", graph, idgen))
+    graph.vm = PEvalContext(jit: initJit(graph),
+                            vm: setupVM(m, cache, "stdin", graph, idgen))
 
   graph.compileSystemModule()
   processModule(graph, m, idgen, llStreamOpenStdIn(r))

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -31,7 +31,8 @@ import
     mirbodies,
     mirenv,
     mirgen,
-    mirtrees
+    mirtrees,
+    mirtypes
   ],
   compiler/modules/[
     modulegraphs,
@@ -265,8 +266,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
                                 magicsToKeep: MagicsToKeep))
 
   var c =
-    GenCtx(graph: g,
-           gen: CodeGenCtx(config: g.config, graph: g, mode: emStandalone))
+    GenCtx(graph: g, gen: initCodeGen(g))
 
   c.gen.typeInfoCache.init()
   c.gen.typeInfoCache.initRootRef(g.config, g.getCompilerProc("RootObj").typ)

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -236,7 +236,7 @@ proc storeData(enc: var PackedEncoder, dst: var PackedEnv,
                config: ConfigRef,
                consts: seq[(PVmType, DataId)], env: MirEnv) =
   ## Packs all constant data (`consts`) and stores it into `dst`.
-  var denc = DataEncoder(config: config)
+  var denc = DataEncoder(config: config, types: addr env.types)
   denc.startEncoding(dst)
 
   mapList(dst.cconsts, consts, it):

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -300,7 +300,7 @@ proc generateCode*(g: ModuleGraph, mlist: sink ModuleList) =
   # produce a list with the type of each constant:
   var consts = newSeq[(PVmType, DataId)](c.gen.env.data.len)
   for i, data in c.gen.env.data.pairs:
-    let typ = c.gen.typeInfoCache.lookup(conf, data[0].typ)
+    let typ = c.gen.typeInfoCache.lookup(conf, c.gen.env[data[0].typ])
     consts[ord(i)] = (get(typ), i)
 
   env.typeInfoCache = move c.gen.typeInfoCache

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -180,7 +180,6 @@ type
     # immutable input parameters:
     graph*: ModuleGraph
     config*: ConfigRef
-    mode*: TEvalMode
     features*: TSandboxFlags
     module*: PSym
 
@@ -216,6 +215,9 @@ const
 
   noDest = TDest(-1)
   slotSomeTemp* = slotTempUnknown
+
+proc initCodeGen*(g: ModuleGraph): CodeGenCtx =
+  CodeGenCtx(graph: g, config: g.config, env: initMirEnv(g))
 
 proc getOrCreate*(c: var TCtx, typ: PType;
                   noClosure = false): PVmType {.inline.} =

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -52,7 +52,8 @@ import
   ],
   compiler/mir/[
     mirenv,
-    mirtrees
+    mirtrees,
+    mirtypes
   ],
   compiler/front/[
     msgs,
@@ -1085,7 +1086,7 @@ proc writeBackResult(c: var TCtx, info: CgNode) =
   ## If the result value fits into a register but is not stored in one
   ## (because it has its address taken, etc.), emits the code for storing it
   ## back into a register. `info` is only used to provide line information.
-  let typ = c.prc.body[resultId].typ
+  let typ = c.env[c.prc.body[resultId].typ]
   if not isEmptyType(typ) and fitsRegister(typ) and not isDirectView(typ) and
      c.prc[resultId].isIndirect:
       # a write-back is required. Load the value into temporary register and
@@ -1246,10 +1247,10 @@ proc genRegLoad(c: var TCtx, n: CgNode, dest, src: TRegister) {.inline.} =
 proc genFieldCheck(c: var TCtx; n: CgNode)
 proc genSym(c: var TCtx, n: CgNode, dest: var TDest, load = true)
 
-func usesRegister(p: BProc, s: LocalId): bool =
+func usesRegister(c: TCtx, s: LocalId): bool =
   ## Returns whether the location identified by `s` is backed by a register
   ## (that is, whether the value is stored in a register directly)
-  fitsRegister(p.body[s].typ) and not p[s].isIndirect
+  fitsRegister(c.env[c.prc.body[s].typ]) and not c.prc[s].isIndirect
 
 proc genNew(c: var TCtx; n: CgNode, dest: var TDest) =
   prepare(c, dest, n, n.typ)
@@ -1759,14 +1760,14 @@ func fitsRegister(t: PType): bool =
   st.kind in { tyBool, tyInt..tyUInt64, tyChar, tyPtr, tyPointer} or
     (st.sym != nil and st.sym.magic == mPNimrodNode) # NimNode goes into register too
 
-func usesRegister(p: BProc, n: CgNode): bool =
+func usesRegister(c: TCtx, n: CgNode): bool =
   ## Analyses and returns whether the value of the location named by l-value
   ## expression `n` is stored in a register instead of a memory location
   # XXX: instead of using a separate analysis, compute and return this as part
   #      of ``genLValue`` and
   case n.kind
   of cnkLocal:
-    usesRegister(p, n.local)
+    usesRegister(c, n.local)
   of cnkProc, cnkConst, cnkGlobal:
     false
   of cnkDeref, cnkDerefView, cnkFieldAccess, cnkArrayAccess, cnkTupleAccess,
@@ -1780,7 +1781,7 @@ proc genNoLoad(c: var TCtx, n: CgNode): tuple[reg: TRegister, isDirect: bool] =
   ## the result stores a handle or a value.
   var dest = noDest
   genLvalue(c, n, dest)
-  result = (TRegister(dest), usesRegister(c.prc, n))
+  result = (TRegister(dest), usesRegister(c, n))
 
 proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   case m
@@ -2484,7 +2485,7 @@ proc genAsgnToLocal(c: var TCtx, le, ri: CgNode) =
       genToSlice(c, ri, dest, reified=false)
     else:
       gen(c, ri, dest)
-  elif usesRegister(c.prc, le.local):
+  elif usesRegister(c, le.local):
     gen(c, ri, dest)
   elif fitsRegister(le.typ):
     # the local is stored in-memory, a temporary register is needed
@@ -2640,7 +2641,7 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
     discard genType(c, n.typ) # make sure the type exists
     # somewhat hack-y, but the orchestrator later queries the type of the data
     # (which might be a different PType that maps to the same VM type)
-    discard genType(c, c.env[DataId pos][0].typ)
+    discard genType(c, c.env[c.env[DataId pos][0].typ])
   of cnkGlobal:
     # a global location
     let pos = useGlobal(c, n)
@@ -2657,7 +2658,7 @@ proc genSym(c: var TCtx; n: CgNode; dest: var TDest; load = true) =
   of cnkLocal:
       let local = c.prc[n.local].reg
       internalAssert(c.config, c.prc.regInfo[local].kind < slotSomeTemp)
-      if usesRegister(c.prc, n.local) or not load or not fitsRegister(n.typ):
+      if usesRegister(c, n.local) or not load or not fitsRegister(n.typ):
         if dest.isUnset:
           dest = local
         else:
@@ -2905,7 +2906,7 @@ proc genDef(c: var TCtx; a: CgNode) =
             # no initializer; only setup the register (and memory location,
             # if used)
             let reg = setSlot(c.prc, s)
-            let opc = if usesRegister(c.prc, s): opcLdNullReg
+            let opc = if usesRegister(c, s): opcLdNullReg
                       else: opcLdNull
 
             c.gABx(a, opc, reg, c.genType(typ))
@@ -2915,7 +2916,7 @@ proc genDef(c: var TCtx; a: CgNode) =
             # initialization is in progress:
             c.prc.regInfo[reg].kind = slotNoValue
             # XXX: checking for views here is wrong but necessary
-            if not usesRegister(c.prc, s) and not isDirectView(typ):
+            if not usesRegister(c, s) and not isDirectView(typ):
               # only setup a memory location if the local uses one
               c.gABx(a, opcLdNull, reg, c.genType(typ))
 
@@ -3207,7 +3208,7 @@ proc genStmt*(c: var TCtx; body: sink Body): Result[int, VmGenDiag] =
   except VmGenError as e:
     return typeof(result).err(move e.diag)
 
-  if not isEmptyType(c.prc.body[resultId].typ):
+  if c.prc.body[resultId].typ != VoidType:
     # the body has a result, emit a return
     c.gABC(n, opcRet, c.prc[resultId].reg)
 
@@ -3335,7 +3336,7 @@ proc genProcBody(c: var TCtx): int =
     # result register is setup at the start of macro evaluation
     # XXX: initializing the ``result`` of a macro should be handled through
     #      inserting the necessary code either in ``sem` or here
-    let rt = c.prc.body[resultId].typ
+    let rt = c.env[c.prc.body[resultId].typ]
     if not isEmptyType(rt) and fitsRegister(rt):
       # initialize the register holding the result
       if s.kind == skMacro:
@@ -3369,7 +3370,7 @@ proc genProcBody(c: var TCtx): int =
       # may pass it as a super type
       let env = TRegister(s.routineSignature.n.len)
       c.gABC(body, opcObjConv, env, env)
-      c.gABx(body, opcObjConv, 0, c.genType(c.prc.body[LocalId env].typ))
+      c.gABx(body, opcObjConv, 0, c.genType(c.env[c.prc.body[LocalId env].typ]))
 
     let eh = genSetEh(c, body.info)
     gen(c, body)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -131,7 +131,7 @@ proc updateEnvironment(c: var TCtx, env: var MirEnv, cp: EnvCheckpoint) =
   # constants
   for id, data in since(env.data, cp.data):
     let
-      typ = c.getOrCreate(data[0].typ)
+      typ = c.getOrCreate(env.types[data[0].typ])
       handle = c.allocator.allocConstantLocation(typ)
 
     initFromExpr(handle, data, env, c)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -36,9 +36,11 @@ import
     mirgen,
     mirpasses,
     mirtrees,
+    mirtypes
   ],
   compiler/modules/[
-    magicsys
+    magicsys,
+    modulegraphs
   ],
   compiler/sem/[
     transf
@@ -70,6 +72,10 @@ type
     gen: CodeGenCtx
       ## code generator state
 
+proc initJit*(graph: ModuleGraph): JitState =
+  ## Returns an initialized ``JitState`` instance.
+  JitState(gen: initCodeGen(graph))
+
 func env*(jit: JitState): lent MirEnv {.inline.} =
   ## The JIT code generator's MIR environment.
   jit.gen.env
@@ -93,7 +99,6 @@ func swapState(c: var TCtx, gen: var CodeGenCtx) =
   # input parameters:
   swap(graph)
   swap(config)
-  swap(mode)
   swap(features)
   swap(module)
   swap(callbackKeys)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -172,7 +172,7 @@ proc generateMirCode(c: var TCtx, env: var MirEnv, n: PNode;
 
     result = exprToMir(c.graph, env, selectOptions(c), n)
 
-proc generateIR(c: var TCtx, env: MirEnv, body: sink MirBody): Body =
+proc generateIR(c: var TCtx, env: var MirEnv, body: sink MirBody): Body =
   backends.generateIR(c.graph, c.idgen, env, c.module, body)
 
 proc setupRootRef(c: var TCtx) =

--- a/compiler/vm/vmserialize.nim
+++ b/compiler/vm/vmserialize.nim
@@ -87,7 +87,7 @@ proc initFromExpr(dest: LocHandle, tree: MirTree, n: var int, env: MirEnv,
     else:
       # allocate a managed heap location and fill it:
       let
-        t = c.getOrCreate(tree[n].typ)
+        t = c.getOrCreate(env[tree[n].typ])
         slot = c.heap.heapNew(c.allocator, t.targetType)
       recurse(c.heap.unsafeDeref(slot))
       deref(dest).refVal = slot
@@ -97,7 +97,7 @@ proc initFromExpr(dest: LocHandle, tree: MirTree, n: var int, env: MirEnv,
       toInt(val - first)
 
     let first =
-      if tree[n].len > 0: firstOrd(c.config, tree[n].typ)
+      if tree[n].len > 0: firstOrd(c.config, env[tree[n].typ])
       else:               Zero
     # XXX: ^^ ``set[empty]``-typed literals reach here, but they shouldn't. The
     #      len guard works around the issue
@@ -126,7 +126,7 @@ proc initFromExpr(dest: LocHandle, tree: MirTree, n: var int, env: MirEnv,
       iterTree(j):
         arg recurse(dest.getFieldHandle(j.FieldPosition))
     of mnkObjConstr:
-      let typ = tree[n].typ.skipTypes(abstractPtrs) ## the object's type
+      let typ = env[tree[n].typ].skipTypes(abstractPtrs) ## the object's type
       iterTree(i):
         let
           sym = lookupInType(typ, next().field)

--- a/tests/compiler/tdatatables.nim
+++ b/tests/compiler/tdatatables.nim
@@ -4,17 +4,18 @@ discard """
 """
 
 import compiler/ast/ast
+import compiler/mir/mirtypes
 include compiler/mir/datatables
 
 # some placeholder types to assing to the nodes. For object types, a different
 # ID means that it's a different type
 let
-  t1 = PType(itemId: ItemId(item: 1), kind: tyObject, sons: @[PType nil])
-  t2 = PType(itemId: ItemId(item: 2), kind: tyObject, sons: @[PType nil])
-  t3 = PType(itemId: ItemId(item: 3), kind: tyObject, sons: @[PType nil])
+  t1 = Int8Type
+  t2 = Int16Type
+  t3 = Int32Type
 
 # node constructor
-template node(k: MirNodeKind, t: PType, field, val: untyped): MirNode =
+template node(k: MirNodeKind, t: TypeId, field, val: untyped): MirNode =
   MirNode(kind: k, typ: t, field: val)
 template node(k: MirNodeKind, field, val: untyped): MirNode =
   MirNode(kind: k, field: val)


### PR DESCRIPTION
## Summary

Store references to types as `TypeId` instead of `PType`, making
`MirNode` a plain data-type. Besides speeding up the compiler, this
also paves the way to a data-oriented type IR for the MIR.

## Details

### Overview

* all MIR-level types use `TypeId` instead of `PType` (currently only
  `MirNode` and `Local`)
* the new `TypeEnv` type from the `mirtypes` module manages the type
  storage and mappings
* a `TypeEnv` instance is embedded in `MirEnv`
* registering a `PType` with `TypeEnv` yields a `TypeId`
* querying type information requires access to a `TypeEnv` instance

### Mapping Types

`TypeEnv` stores the `PType`-to-`TypeId` mappings in a `TypeTable`.
`TypeTable`, provided by the new `typemaps` module, is a custom
`Table` type that de-duplicates the `PType` keys by using structural
or symbolic comparison/hashing for the keys, thereby significantly
reducing the number of mappings and registered types.

At the moment, `PType` is still used as the type IR, so `TypeEnv` only
stores a `PType` for each `TypeId`.

The built-in types are mapped to statically known IDs, making some
translation and MIR construction easier.

### Constant expressions

To not require passing a `TypeEnv` to `datatables.getOrPut`, only the
type IDs are compared. This doesn't produce the same results as
`sameBackendType`, which ignores, for example, the distinct type
modifiers and aliases. As a result, `IntAlias(1)` and `int(1)` now
result in two `DataTable` entries instead of one.

Only using `TypeId` comparison/hashing does speed up `getOrPut`,
however.

### CGIR

* the CGIR still uses `PType`
* `cgirgen` turns the input `TypeId`s back into `PType`s
* since `cgirgen` creates new `PType` and assigns them to `Local`s,
  access to a *mutable* `MirEnv` is now required (in order to register
  the new `PType`s)

### VM backend

Packing constant data requires querying type information, and access to
a `TypeEnv` is thus required. A pointer to the `TypeEnv` instance is
passed along in `DataEncoder`.

### VM Evaluation Pass

Initializing the JIT environment requires a basic type environment,
which is not present when using the VM evaluation pass, as the `system`
module isn't yet processed at the time the `PEvalContext` is
initialized.

To delay setting up the JIT environment as much as necessary, the
evaluation pass is restructured:
* only a VM instance is assigned to the `ModuleGraph` at the start
* `setupGlobalCtx` creates a proper evaluation context from the
  instance
* evaluating statements, which now calls `setupGlobalCtx`, is prevented
  for declarative statements

This ensures that `initJit` is only called after the processing of the
`system` module has set up the basic type environment.

### Compiler Performance

`MirNode` being a plain data-type (no destructor) significantly speeds
up all MIR processing that creates new nodes or copies/moves them,
especially `TreeChangeset` application (~ -70%).

In addition, no copy/sink/destroy needing to be injected for `MirNode`s
also speeds up bootstrapping, since it means less work for the
destructor injection pass.