### PR TITLE
fix behaviour of closed-over locals in `and`/`or` expressions

### DIFF
--- a/tests/lang_callable/closure/tclosure_issues.nim
+++ b/tests/lang_callable/closure/tclosure_issues.nim
@@ -122,3 +122,28 @@ block:
     inner()
 
   test()
+
+block closed_over_local_in_or_expression:
+  # regression test: closed-over locals defined in ``or`` expressions
+  # behaved differently compared to when not being closed over
+
+  proc test() =
+    var i = 0
+    var take = false
+    while i < 2: # run the body two times
+      if (let x = 1; take) or (let y = 2; not take):
+        proc inner() =
+          # close over `y`
+          discard y
+
+        inner()
+
+        if take:
+          doAssert y == 0
+        else:
+          doAssert y == 2
+
+      take = true # enable short-circuiting
+      inc i
+
+  test()


### PR DESCRIPTION
## Summary

Fix closed-over locals defined as part of `and`/`or` expressions not
having their default value when their defined-in sub-expression was
short-circuited.

## Details

Bindings part of `and`/`or` expressions were so far hoisted to the
start of their scope by the "unscoped def" handling in `cgirgen`, which
doesn't apply to lifted locals, since these don't have a `def` (they're
part of the environment object).

Performing the hoisting in `transf` makes sure the behaviour of closed-
over locals matches that of not closed-over ones, and it also removes
the reliance on `cgirgen`.

The hoisting works by scanning transformed `and`/`or` expressions for
bindings that are within the *same* scope as the `and`/`or` expression,
and moving them to the start of the `and`/`or` expression.

For example, `(let a = 0; x) or (let b = 0; y)` is transformed into
`(let a; let b; (a = 0; x) or (b = 0; y))`.

Lifted globals (`.global` and `.thread`) have to be accounted for by
the hoisting pass, since they weren't lifted at this point.