### PR TITLE
mir: shrink size of `MirNode`

### DIFF
--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -309,7 +309,7 @@ type
       effect*: EffectKind ## the effect that happens when the operator the
                           ## tagged value is passed to is executed
     else:
-      len*: int
+      len*: uint32
 
   MirTree* = seq[MirNode]
   MirNodeSeq* = seq[MirNode]


### PR DESCRIPTION
## Summary

Shrink the size of a `MirNode` from 24 byte (on a 64bit target) to 16
byte, reducing memory consumption and copying cost, as well as
increasing the number of nodes fitting in a cache line.

## Details

The `len` field was an int, resulting in the case having an
alignment requirement and size of 8 byte (for a 64bit target).
Since the `len` field is never negative, it's changed into a `uint32`
field. This also makes the size of a `MirNode` target-independent.