### PR TITLE
sem: proper error propagation for set construction

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2980,55 +2980,73 @@ proc semWhen(c: PContext, n: PNode, semCheck = true): PNode =
     result.typ = typ
 
 proc semSetConstr(c: PContext, n: PNode): PNode =
-  result = newNodeI(nkCurly, n.info)
+  ## Analyses and types a set construction expression (``nkCurly``). Produces
+  ## a typed expression, or an error.
+  result = shallowCopy(n)
   result.typ = newTypeS(tySet, c)
   result.typ.flags.incl tfIsConstructor
   if n.len == 0:
     rawAddSon(result.typ, newTypeS(tyEmpty, c))
   else:
+    var
+      typ: PType = nil
+      diag: PAstDiag ## the error diagnostic, if an error occurred
+
     # only semantic checking for all elements, later type checking:
-    var typ: PType = nil
-    for i in 0..<n.len:
-      if isRange(n[i]):
-        checkSonsLen(n[i], 3, c.config)
-        n[i][1] = semExprWithType(c, n[i][1])
-        n[i][2] = semExprWithType(c, n[i][2])
-        if typ == nil:
-          typ = skipTypes(n[i][1].typ,
-                          {tyGenericInst, tyVar, tyLent, tyOrdinal, tyAlias, tySink})
-        n[i].typ = n[i][2].typ # range node needs type too
+    for i, it in n.pairs:
+      var elem: PType
+      if isRange(it):
+        checkSonsLen(it, 3, c.config)
+        result[i] =
+          newTreeI(nkRange, it.info,
+                   semExprWithType(c, it[1]),
+                   semExprWithType(c, it[2]))
+        elem = result[i][0].typ
       elif n[i].kind == nkRange:
-        # already semchecked
-        if typ == nil:
-          typ = skipTypes(n[i][0].typ,
-                          {tyGenericInst, tyVar, tyLent, tyOrdinal, tyAlias, tySink})
+        checkSonsLen(n[i], 2, c.config)
+        result[i] =
+          newTreeI(nkRange, it.info,
+                   semExprWithType(c, it[0]),
+                   semExprWithType(c, it[1]))
+        elem = result[i][0].typ
       else:
-        n[i] = semExprWithType(c, n[i])
-        if typ == nil:
-          typ = skipTypes(n[i].typ, {tyGenericInst, tyVar, tyLent, tyOrdinal, tyAlias, tySink})
+        result[i] = semExprWithType(c, n[i])
+        elem = result[i].typ
+
+      if typ.isNil:
+        typ = skipTypes(elem, {tyGenericInst, tyOrdinal, tyAlias, tySink})
+
     if not isOrdinalType(typ, allowEnumWithHoles=true):
-      localReport(c.config, n, reportSem rsemExpectedOrdinal)
+      if typ.kind != tyError:
+        diag = PAstDiag(kind: adSemExpectedOrdinal, nonOrdTyp: typ)
       typ = makeRangeType(c, 0, MaxSetElements - 1, n.info)
 
     elif lengthOrd(c.config, typ) > MaxSetElements:
       typ = makeRangeType(c, 0, MaxSetElements - 1, n.info)
 
     addSonSkipIntLit(result.typ, typ, c.idgen)
-    for i in 0..<n.len:
-      var m: PNode
-      let info = n[i].info
-      if isRange(n[i]):
-        m = newNodeI(nkRange, info)
-        m.add fitNode(c, typ, n[i][1], info)
-        m.add fitNode(c, typ, n[i][2], info)
 
-      elif n[i].kind == nkRange:
-        m = n[i] # already semchecked
+    var hasError = false
+    template handleError(n: PNode): PNode =
+      let x = n
+      hasError = hasError or x.kind == nkError
+      x
 
+    # second pass: type checking and error detection
+    for i in 0..<result.len:
+      let info = result[i].info
+      case result[i].kind
+      of nkRange:
+        result[i][0] = handleError fitNode(c, typ, result[i][0], info)
+        result[i][1] = handleError fitNode(c, typ, result[i][1], info)
       else:
-        m = fitNode(c, typ, n[i], info)
+        result[i] = handleError fitNode(c, typ, result[i], info)
 
-      result.add m
+    # wrap with the appropriate error (or none)
+    if diag != nil:
+      result = c.config.newError(result, diag)
+    elif hasError:
+      result = c.config.wrapError(result)
 
 proc semTableConstr(c: PContext, n: PNode): PNode =
   # we simply transform ``{key: value, key2, key3: value}`` to

--- a/tests/lang_exprs/tset_construction_ast.nim
+++ b/tests/lang_exprs/tset_construction_ast.nim
@@ -1,0 +1,14 @@
+discard """
+  description: '''
+    Ensure that valid `nkRange` AST in a set construction emitted by a macro
+    is correctly semantically anaylsed
+  '''
+  targets: native
+"""
+
+import std/macros
+
+macro m(): untyped =
+  result = nnkCurly.newTree(nnkRange.newTree(newLit(1'u8), newLit(3'u8)))
+
+doAssert m() == {1'u8, 2'u8, 3'u8}


### PR DESCRIPTION
## Summary

Refactor/fix set construction analysis such that:
* `nkRange` nodes are properly analyzed after macro expansion
* errors within set constructions are propagated properly

## Details

Only `semSetConstr` is modified:
* use `shallowCopy` instead of creating a new node (no sequence
  resizing, keeps the persistent node flags)
* always re-analyze `nkRange` nodes (they were previously never typed)
* guard against ill-formed `nkRange` AST (could previously crash the
  compiler)
* don't modify the input AST
* replace `localReport` with using `nkError`
* propagate `nkError`