### PR TITLE
sem: clean up `case` analysis and fix edge cases

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1159,6 +1159,8 @@ type
     adSemDefNameSym   ## when creating a sym node from `nkIdentKinds`
     # semtypes
     adSemTypeExpected
+    adSemStringRangeNotAllowed
+    adSemRangeIsEmpty
     # semtempl
     adSemIllformedAst
     adSemIllformedAstExpectedPragmaOrIdent
@@ -1336,6 +1338,8 @@ type
         adSemCallInCompilesContextNotAProcOrField,
         adSemExpressionHasNoType,
         adSemTypeExpected,
+        adSemStringRangeNotAllowed,
+        adSemRangeIsEmpty,
         adSemIllformedAst,
         adSemIllformedAstExpectedPragmaOrIdent,
         adSemInvalidExpression,

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3225,6 +3225,8 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemCallInCompilesContextNotAProcOrField,
       adSemExpressionHasNoType,
       adSemTypeExpected,
+      adSemStringRangeNotAllowed,
+      adSemRangeIsEmpty,
       adSemIllformedAst,
       adSemInvalidExpression,
       adSemExpectedNonemptyPattern,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -501,6 +501,8 @@ func astDiagToLegacyReportKind*(
   of adSemCalleeHasAnError: rsemCalleeHasAnError
   of adSemExpressionHasNoType: rsemExpressionHasNoType
   of adSemTypeExpected: rsemTypeExpected
+  of adSemStringRangeNotAllowed: rsemStringRangeNotAllowed
+  of adSemRangeIsEmpty: rsemRangeIsEmpty
   of adSemIllformedAst: rsemIllformedAst
   of adSemIllformedAstExpectedPragmaOrIdent: rsemIllformedAst
   of adSemIllformedAstExpectedOneOf: rsemIllformedAst

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -616,7 +616,6 @@ proc evalConstExpr(c: PContext, n: PNode): PNode =
   ## Tries to turn the expression `n` into AST that represents a concrete
   ## value. If this fails, an `nkError` node is returned
   addInNimDebugUtils(c.config, "evalConstExpr", n, result)
-  assert not n.isError
 
   # this happens when the overloadableEnums is enabled. We short-circuit
   # evaluation in this case, as neither ``vmgen`` nor ``semfold`` know what to

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1675,7 +1675,6 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
         suggestEnum(c, x, caseTyp)
     case x.kind
     of nkOfBranch:
-      checkMinSonsLen(x, 2, c.config)
       let branch = semCaseBranch(c, n[0].typ, x, covered)
       # XXX: errors need to be propagated
       for e in walkErrors(c.config, branch):

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1641,16 +1641,16 @@ proc semFor(c: PContext, n: PNode; flags: TExprFlags): PNode =
   closeScope(c)
 
 proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
-  result = n
   checkMinSonsLen(n, 2, c.config)
+  result = copyNodeWithKids(n)
   openScope(c)
-  pushCaseContext(c, n)
-  n[0] = semExprWithType(c, n[0])
+  result[0] = semExprWithType(c, n[0]) # selector operand
+  let selector = result[0].typ
   var chckCovered = false
   var covered: Int128 = toInt128(0)
   var typ = commonTypeBegin
   var hasElse = false
-  let caseTyp = skipTypes(n[0].typ, abstractVar-{tyTypeDesc})
+  let caseTyp = skipTypes(selector, abstractInst-{tyTypeDesc})
   const shouldChckCovered = {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt64, tyBool}
   case caseTyp.kind
   of shouldChckCovered:
@@ -1659,79 +1659,86 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
     if skipTypes(caseTyp[0], abstractInst).kind in shouldChckCovered:
       chckCovered = true
   of tyFloat..tyFloat64, tyString:
-    # xxx: possible case statement macro bug, as it'll be skipped here
-    discard
+    discard "not all possible values have to be covered"
   else:
-    popCaseContext(c)
     closeScope(c)
-    result[0] = c.config.newError(n[0],
+    result[0] = c.config.newError(result[0],
                           PAstDiag(kind: adSemSelectorMustBeOfCertainTypes))
+    result = c.config.wrapError(result)
     return
+
+  pushCaseContext(c, result) # push the in-progress case context
   for i in 1..<n.len:
     setCaseContextIdx(c, i)
-    var x = n[i]
+    let x = n[i]
     when defined(nimsuggest):
       if c.config.ideCmd == ideSug and c.config.m.trackPos == x.info and caseTyp.kind == tyEnum:
         suggestEnum(c, x, caseTyp)
     case x.kind
     of nkOfBranch:
-      let branch = semCaseBranch(c, n[0].typ, x, covered)
-      # XXX: errors need to be propagated
-      for e in walkErrors(c.config, branch):
-        localReport(c.config, e)
-
-      n[i] = branch
-      checkBranchForOverlap(c, n, i, n[i].len - 1)
+      let branch = semCaseBranch(c, selector, x, covered)
+      result[i] = branch
+      checkBranchForOverlap(c, result, i, result[i].len - 1)
       branch.add semExprBranchScope(c, x[^1])
-      typ = commonType(c, typ, branch[^1])
     of nkElifBranch:
       chckCovered = false
       checkSonsLen(x, 2, c.config)
       openScope(c)
-      x[0] = forceBool(c, semExprWithType(c, x[0]))
-      x[1] = semExprBranch(c, x[1])
-      typ = commonType(c, typ, x[1])
+      let branch = shallowCopy(x)
+      branch[0] = forceBool(c, semExprWithType(c, x[0]))
+      branch[1] = semExprBranch(c, x[1])
       closeScope(c)
+      result[i] = branch
     of nkElse:
       checkSonsLen(x, 1, c.config)
-      x[0] = semExprBranchScope(c, x[0])
-      typ = commonType(c, typ, x[0])
-      if (chckCovered and covered == toCover(c, n[0].typ)) or hasElse:
+      let branch = shallowCopy(x)
+      branch[0] = semExprBranchScope(c, x[0])
+      result[i] = branch
+      if (chckCovered and covered == toCover(c, selector)) or hasElse:
         localReport(c.config, x.info, SemReport(kind: rsemUnreachableElse))
       hasElse = true
       chckCovered = false
     else:
       semReportIllformedAst(c.config, x, {nkElse, nkElifBranch, nkOfBranch})
 
+    # update the expression type:
+    typ = commonType(c, typ, result[i][^1])
+
   if chckCovered:
-    if covered == toCover(c, n[0].typ):
+    if covered == toCover(c, selector):
       hasElse = true
-    elif n[0].typ.skipTypes(abstractRange).kind in {tyEnum, tyChar}:
-      localReport(c.config, n, SemReport(
+    elif selector.skipTypes(abstractRange).kind in {tyEnum, tyChar}:
+      localReport(c.config, result, SemReport(
         kind: rsemMissingCaseBranches,
-        nodes: formatMissingBranches(c, n)))
+        nodes: formatMissingBranches(c, result)))
 
     else:
-      localReport(c.config, n, reportSem rsemMissingCaseBranches)
+      localReport(c.config, result, reportSem rsemMissingCaseBranches)
 
   popCaseContext(c)
   closeScope(c)
   if isEmptyType(typ) or typ.kind in {tyNil, tyUntyped} or
       (not hasElse and efInTypeof notin flags):
-    for i in 1..<n.len:
-      n[i][^1] = discardCheck(c, n[i][^1], flags)
-      if n[i][^1].isError:
-        return wrapError(c.config, n)
+    for _, it in branches(result):
+      it[^1] = discardCheck(c, it[^1], flags)
+
     # propagate any enforced VoidContext:
     if typ == c.enforceVoidContext:
       result.typ = c.enforceVoidContext
   else:
-    for i in 1..<n.len:
-      var it = n[i]
+    for i, it in branches(result):
       let j = it.len-1
       if not endsInNoReturn(it[j]):
         it[j] = fitNode(c, typ, it[j], it[j].info)
+
     result.typ = typ
+
+  # wrap in an error, if necessary:
+  for _, b in branches(result):
+    # check a single layer, everything else had error propagated already
+    for it in b.items:
+      if it.kind == nkError:
+        return c.config.wrapError(result)
 
 proc semRaise(c: PContext, n: PNode): PNode =
   checkSonsLen(n, 1, c.config)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1679,7 +1679,10 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
       let branch = semCaseBranch(c, selector, x, covered)
       result[i] = branch
       checkBranchForOverlap(c, result, i, result[i].len - 1)
-      branch.add semExprBranchScope(c, x[^1])
+      # the branch node might be inspected from within the body, so make sure
+      # it is syntactically valid prior to the analysis
+      branch.add c.graph.emptyNode
+      branch[^1] = semExprBranchScope(c, x[^1])
     of nkElifBranch:
       chckCovered = false
       checkSonsLen(x, 2, c.config)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1676,10 +1676,15 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
     case x.kind
     of nkOfBranch:
       checkMinSonsLen(x, 2, c.config)
-      semCaseBranch(c, n, x, i, covered)
-      var last = x.len-1
-      x[last] = semExprBranchScope(c, x[last])
-      typ = commonType(c, typ, x[last])
+      let branch = semCaseBranch(c, n[0].typ, x, covered)
+      # XXX: errors need to be propagated
+      for e in walkErrors(c.config, branch):
+        localReport(c.config, e)
+
+      n[i] = branch
+      checkBranchForOverlap(c, n, i, n[i].len - 1)
+      branch.add semExprBranchScope(c, x[^1])
+      typ = commonType(c, typ, branch[^1])
     of nkElifBranch:
       chckCovered = false
       checkSonsLen(x, 2, c.config)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -807,6 +807,7 @@ proc semCaseBranch(c: PContext, typ: PType, branch: PNode,
         to.add x
         inc covered
 
+  checkMinSonsLen(branch, 2, c.config)
   # not a one-to-one mapping between the input and output AST
   result = copyNode(branch)
 
@@ -957,7 +958,6 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
     let b = n[i]
     case n[i].kind
     of nkOfBranch:
-      checkMinSonsLen(b, 2, c.config)
       a.add semCaseBranch(c, a[0].typ, b, covered)
       checkBranchForOverlap(c, a, i, a[^1].len - 1)
       # XXX: errors need to be propagated

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -737,7 +737,9 @@ proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
     result = semIdentVis(c, kind, n, allowed)
 
 proc checkForOverlap(c: PContext, t: PNode, currentEx, branchIndex: int) =
-  let ex = t[branchIndex][currentEx].skipConv
+  ## Given the in-progress ``nkCaseStmt`` production `t`, reports an error for
+  ## each value in branch `branchIndex` that already appears elsewhere.
+  let ex = t[branchIndex][currentEx]
   for i in 1..branchIndex:
     for j in 0..<t[i].len - 1:
       if i == branchIndex and j == currentEx: break
@@ -746,6 +748,10 @@ proc checkForOverlap(c: PContext, t: PNode, currentEx, branchIndex: int) =
           kind: rsemDuplicateCaseLabel,
           ast: ex,
           overlappingGroup: t[i][j].skipConv))
+
+proc checkBranchForOverlap(c: PContext, caseStmt: PNode, branch, last: int) =
+  for i in 0..last:
+    checkForOverlap(c, caseStmt, i, branch)
 
 proc semBranchRange(c: PContext, typ: PType, a, b: PNode,
                     covered: var Int128): PNode =
@@ -770,63 +776,69 @@ proc semBranchRange(c: PContext, typ: PType, a, b: PNode,
     # all good; no error
     covered = covered + getOrdValue(b) + 1 - getOrdValue(a)
 
-proc semCaseBranchRange(c: PContext, t, b: PNode,
+proc semCaseBranchRange(c: PContext, typ: PType, b: PNode,
                         covered: var Int128): PNode =
   checkSonsLen(b, 3, c.config)
-  result = semBranchRange(c, t[0].typ, b[1], b[2], covered)
+  result = semBranchRange(c, typ, b[1], b[2], covered)
 
-proc semCaseBranchSetElem(c: PContext, t, b: PNode,
-                          covered: var Int128): PNode =
-  if isRange(b):
-    # TODO: cannot ever happen; remove
-    result = semCaseBranchRange(c, t, b, covered)
-  elif b.kind == nkRange:
-    checkSonsLen(b, 2, c.config)
-    result = semBranchRange(c, t[0].typ, b[0], b[1], covered)
-  else:
-    result = fitNode(c, t[0].typ, b, b.info)
-    inc(covered)
+proc semCaseBranch(c: PContext, typ: PType, branch: PNode,
+                   covered: var Int128): PNode =
+  ## Analyses the ``nkOfBranch`` AST `branch`, producing either an error or
+  ## the typed AST. Note that the production does *not* include the action
+  ## slot.
+  ##
+  ## Productions with no items are valid: they result from, e.g., ``of {}:``.
+  proc fitAndAdd(to: PNode, c: PContext, typ: PType, n: PNode,
+                 covered: var Int128) {.nimcall.} =
+    if n.kind == nkError:
+      to.add n
+      return
 
-proc semCaseBranch(c: PContext, t, branch: PNode, branchIndex: int,
-                   covered: var Int128) =
-  let lastIndex = branch.len - 2
-  for i in 0..lastIndex:
-    var b = branch[i]
-    if b.kind == nkRange:
-      branch[i] = b
-    elif isRange(b):
-      branch[i] = semCaseBranchRange(c, t, b, covered)
-    else:
-      # constant sets and arrays are allowed:
-      var r = semConstExpr(c, b)
-      if r.kind in {nkCurly, nkBracket} and r.len == 0 and branch.len == 2:
-        # discarding ``{}`` and ``[]`` branches silently
-        delSon(branch, 0)
-        return
-      elif r.kind notin {nkCurly, nkBracket} or r.len == 0:
-        checkMinSonsLen(t, 1, c.config)
-        var tmp = fitNode(c, t[0].typ, r, r.info)
-        # the call to fitNode may introduce a call to a converter
-        if tmp.kind in {nkHiddenCallConv}: tmp = semConstExpr(c, tmp)
-        branch[i] = skipConv(tmp)
-        inc(covered)
+    # errors are ignored here; they're handled later
+    for it in n.items:
+      case it.kind
+      of nkRange:
+        to.add semBranchRange(c, typ, it[0], it[1], covered)
       else:
-        if r.kind == nkCurly:
-          r = deduplicate(c.config, r)
+        var x = fitNode(c, typ, it, it.info)
+        # fitting the element may introduce a conversion
+        if x.kind in {nkHiddenCallConv, nkHiddenStdConv, nkHiddenSubConv}:
+          x = evalConstExpr(c, x)
+        to.add x
+        inc covered
 
-        # first element is special and will overwrite: branch[i]:
-        branch[i] = semCaseBranchSetElem(c, t, r[0], covered)
+  # not a one-to-one mapping between the input and output AST
+  result = copyNode(branch)
 
-        # other elements have to be added to ``branch``
-        for j in 1..<r.len:
-          branch.add(semCaseBranchSetElem(c, t, r[j], covered))
-          # caution! last son of branch must be the actions to execute:
-          swap(branch[^2], branch[^1])
-    checkForOverlap(c, t, i, branchIndex)
-
-  # Elements added above needs to be checked for overlaps.
-  for i in lastIndex.succ..<branch.len - 1:
-    checkForOverlap(c, t, i, branchIndex)
+  for i in 0..<branch.len-1:
+    let b = branch[i]
+    if b.kind == nkRange:
+      result.add semBranchRange(c, typ, b[0], b[1], covered)
+    elif isRange(b):
+      result.add semCaseBranchRange(c, typ, b, covered)
+    else:
+      var r = semExprWithType(c, b, {})
+      # XXX: distincts are currently skipped, but it would make sense to
+      #      not, thus preventing, e.g., a distinct set from being usable
+      #      in a label slot without explicit conversion
+      case r.typ.skipTypes(abstractRange).kind
+      of tySet:
+        # constant sets are allowed
+        r = evalConstExpr(c, r)
+        if r.kind == nkError:
+          result.add r
+        elif r.len > 0:
+          # duplicates from the evaluated set need to be eliminated
+          result.fitAndAdd(c, typ, deduplicate(c.config, r), covered)
+        else:
+          discard "do nothing for empty sets"
+      of tyArray, tySequence:
+        # constant arrays and sequences are allowed too
+        r = evalConstExpr(c, r)
+        result.fitAndAdd(c, typ, r, covered)
+      else:
+        result.add evalConstExpr(c, fitNode(c, typ, r, r.info))
+        inc covered
 
 proc toCover(c: PContext, t: PType): Int128 =
   let t2 = skipTypes(t, abstractVarRange-{tyTypeDesc})
@@ -942,25 +954,29 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
       sym: a[0].sym))
 
   for i in 1..<n.len:
-    var b = copyTree(n[i])
-    a.add b
+    let b = n[i]
     case n[i].kind
     of nkOfBranch:
       checkMinSonsLen(b, 2, c.config)
-      semCaseBranch(c, a, b, i, covered)
+      a.add semCaseBranch(c, a[0].typ, b, covered)
+      checkBranchForOverlap(c, a, i, a[^1].len - 1)
+      # XXX: errors need to be propagated
+      for e in walkErrors(c.config, a[^1]):
+        localReport(c.config, e)
     of nkElse:
       checkSonsLen(b, 1, c.config)
       if chckCovered and covered == toCover(c, a[0].typ):
         localReport(c.config, b.info, SemReport(kind: rsemUnreachableElse))
       chckCovered = false
+      # copy without the action slot:
+      a.add copyNode(b)
     else:
       semReportIllformedAst(
         c.config, n,
         "Expected ofBranch or else for object case statement, but found" &
           $n[i].kind)
 
-    delSon(b, b.len - 1)
-    semRecordNodeAux(c, lastSon(n[i]), check, pos, b, rectype, hasCaseFields = true)
+    semRecordNodeAux(c, lastSon(n[i]), check, pos, a[^1], rectype, hasCaseFields = true)
   if chckCovered and covered != toCover(c, a[0].typ):
     if a[0].typ.skipTypes(abstractRange).kind == tyEnum:
       localReport(c.config, a.info, SemReport(

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -811,8 +811,7 @@ proc semCaseBranch(c: PContext, typ: PType, branch: PNode,
   # not a one-to-one mapping between the input and output AST
   result = copyNode(branch)
 
-  for i in 0..<branch.len-1:
-    let b = branch[i]
+  for _, b in branchLabels(branch):
     if b.kind == nkRange:
       result.add semBranchRange(c, typ, b[0], b[1], covered)
     elif isRange(b):

--- a/tests/lang_stmts/casestmt/tbranch_with_empty_set.nim
+++ b/tests/lang_stmts/casestmt/tbranch_with_empty_set.nim
@@ -1,0 +1,22 @@
+discard """
+  description: '''
+    Regression test for where an empty set/array value in a label position
+    counted towards the number of required labels, leading to errors being
+    reported for valid case statements.
+  '''
+  action: compile
+"""
+
+var x: bool
+
+case x
+of true, []: # would cause "not all cases are covered"
+  discard
+of false:
+  discard
+
+case x
+of true, {}: # would cause "not all cases are covered"
+  discard
+of false:
+  discard

--- a/tests/lang_stmts/casestmt/tlabel_considers_converter.nim
+++ b/tests/lang_stmts/casestmt/tlabel_considers_converter.nim
@@ -1,0 +1,30 @@
+discard """
+  description: '''
+    Ensure that converters are considered with each 'of'-branch label syntax.
+  '''
+"""
+
+converter f2i(x: float): int8 =
+  int8(x)
+
+proc test(x: int8): int =
+  case x
+  of 1.0:
+    1
+  of 2.2 .. 3.3: # with range syntax: 2 .. 3
+    2
+  of [4.1, 6.1]: # with array constructor syntax: 4, 6
+    3
+  of @[10.1] & @[12.1]: # with compile-time-evaluated sequence: 10, 12
+    4
+  else:
+    5
+
+doAssert test(1) == 1
+doAssert test(2) == 2
+doAssert test(3) == 2
+doAssert test(4) == 3
+doAssert test(6) == 3
+doAssert test(10) == 4
+doAssert test(12) == 4
+doAssert test(11) == 5 # covered by the else branch


### PR DESCRIPTION
## Summary

Clean up, improve, and fix `case` analysis. Errors are properly
propagated, input AST is no longer modified, and multiple bugs are
fixed:
* `nkRange` nodes in `nkOfBranch` AST in macro output is properly
  analyzed
* converters are correctly taken into account for branch labels
  (previously resulted in a compiler crash)
* empty set, array, and seq values in otherwise non-empty `of` branches
  no longer result in spurious "not all cases are covered" errors

## Details

Both the `case` statements and `case`-object declarations are affected.
For the range syntax analysis (`semBranchRange`):
* evaluating the expression happens *after* fitting, so that converter
  calls are accounted for (they previously stayed, crashing the
  compiler later on)
* the `localReport`s are replaced with diagnostics; two new diagnostics
  corresponding to the previously used reports are added
* errors are wrapped properly
* "cannot be string range" errors now take precedence over
  "empty range" errors
* the operand type is passed directly as a parameter, instead of
  indirectly via the case statement AST

For the `of` branch analysis (`semCaseBranch`):
* `semConstExpr` (which uses `localReport`) is replaced with
  `semExprWithType` + `evalConstExpr`
* the input AST is no longer modified
* empty set, array, and seq values no longer, erroneously, count
  towards the number of values that need to be covered
* `nkRange` nodes are always (re-)analyzed
* only the selector's type is passed as the parameter, checking for
  duplicates moves to the callsite

The `case` statement analysis (`semCase`) is changed to not modify
input AST. For wrapping the `nkCaseStmt` in an error, the AST is
scanned for errors afterwards.