### PR TITLE
mirgen: better code generation for `high`

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -940,6 +940,16 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
         c.userOptions = {}
         genx(c, n[1])
         c.userOptions = orig
+  of mHigh:
+    # custom translation in order to skip both explicit and implicit to-slice
+    # conversions; those are unnecessary
+    c.buildMagicCall mHigh, rtyp:
+      var arg = n[1]
+      while arg.kind in {nkConv, nkHiddenStdConv, nkHiddenSubConv} and
+            classifyBackendView(arg.typ) == bvcSequence:
+        arg = arg[^1]
+
+      c.emitOperandTree arg, sink=false
 
   # arithmetic operations:
   of mAddI, mSubI, mMulI, mDivI, mModI, mPred, mSucc:

--- a/tests/optimization/README.md
+++ b/tests/optimization/README.md
@@ -1,0 +1,2 @@
+Tests that, for the purpose of ensuring that some optimization takes place (or
+not), inspect compiler output belong here.

--- a/tests/optimization/tno_conv_for_seq_high.nim
+++ b/tests/optimization/tno_conv_for_seq_high.nim
@@ -1,0 +1,16 @@
+discard """
+  description: '''
+    Ensure that no to-slice conversion is emitted for `high` calls with
+    `seq` arguments
+  '''
+  action: compile
+  matrix: "--expandArc:test"
+  nimout: '''--expandArc: test
+scope:
+  result = high(arg x)
+
+-- end of expandArc ------------------------'''
+"""
+
+proc test(x: seq[int]): int {.exportc.} =
+  result = high(x)


### PR DESCRIPTION
## Summary

Omit unnecessary to-slice conversions for `high(x)` calls where `x` is
a `seq` value, resulting in a small compiler speed up. All backends are
affected.

## Details

There's no dedicated `high` overload for `seq`, so the `openArray`
overload is picked for `seq` arguments. The implicit argument
conversion was previously translated as is, resulting in an extra
temporary and conversion operation, both which are unnecessary, since
all three code generators support `high` for `tySequence` operands.

While an optimizing C compiler is able to eliminate the conversion,
doing it on the NimSkull side still benefits debug builds and the
JavaScript and VM target, as well as reduce the workload for the MIR
passes and code generators.

### Tests

* add a new test category for optimization-related tests
* add a test to ensure there's no conversion for `high(seq)` calls