### PR TITLE
mirpasses: implement string COW handling with MIR pass

### DIFF
--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -171,8 +171,6 @@ proc genOpenArraySlice(p: BProc; q: CgNode; formalType, destType: PType): (Rope,
               lengthExpr)
   of tyString, tySequence:
     let atyp = skipTypes(a.t, abstractInst)
-    if formalType.skipTypes(abstractInst).kind in {tyVar} and atyp.kind == tyString:
-      linefmt(p, cpsStmts, "#nimPrepareStrMutationV2($1);$n", [byRefLoc(p, a)])
     if atyp.kind in {tyVar}:
       result = ("((*$1).p != NIM_NIL ? ($4*)(*$1)$3+$2 : NIM_NIL)" %
                   [rdLoc(a), rdLoc(b), dataField(p), dest],

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -492,9 +492,9 @@ proc genAsgn(p: BProc, e: CgNode) =
     let ri = e[1]
     var a: TLoc
     initLoc(a, locNone, le, OnUnknown)
-    a.flags.incl {lfEnforceDeref, lfPrepareForMutation, lfWantLvalue}
+    a.flags.incl {lfEnforceDeref, lfWantLvalue}
     expr(p, le, a)
-    a.flags.excl {lfPrepareForMutation, lfWantLvalue}
+    a.flags.excl {lfWantLvalue}
     assert(a.t != nil)
     genLineDir(p, ri)
     loadInto(p, le, ri, a)

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -79,7 +79,6 @@ type
     lfEnforceDeref           ## a copyMem is required to dereference if this a
                              ## ptr array due to C array limitations.
                              ## See #1181, #6422, #11171
-    lfPrepareForMutation     ## string location is about to be mutated
     lfWantLvalue             ## on empty locs, signals that a C lvalue is
                              ## expected
 


### PR DESCRIPTION
## Summary

Perform the injection of runtime procedure calls for handling copy-on-
write strings with an MIR pass, instead of doing it in the C code
generator, removing another responsibility from the latter.

## Details

The new MIR pass does the equivalent of what `cgen` previously did,
that is, injecting `nimPrepareStrMutationV2` calls wherever a string's
underlying storage might be modified.

The injection logic, together with the `lfPrepareForMutation` flag, is
removed from `cgen`.