### PR TITLE
cgen: better code generation for `.noreturn` calls

### DIFF
--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -76,18 +76,30 @@ proc isHarmlessStore(p: BProc; ri: CgNode, d: TLoc): bool =
 
 proc exitCall(p: BProc, call: CgNode) =
   ## Emits the exceptional control-flow related post-call logic.
+  let isNoReturn = call[0].kind == cnkProc and
+                   sfNoReturn in p.env[call[0].prc].flags
   if call.kind == cnkCheckedCall:
-    if nimErrorFlagDisabled in p.flags:
-      if call[0].kind == cnkProc and sfNoReturn in p.env[call[0].prc].flags and
-         canRaiseConservative(p.env, call[0]):
-        # when using goto-exceptions, noreturn doesn't map to "doesn't return"
-        # at the C-level. In order to still support dispatching to wrapper
-        # procedures around ``raise`` from inside ``.compilerprocs``, we emit
-        # an exit after the call
+    if isNoReturn:
+      # the callee raises and doesn't have a normal exit -> testing the error
+      # flag is unnecessary
+      if nimErrorFlagDisabled in p.flags:
+        # don't jump to the error target. Both exception handlers and
+        # finalizers require disabling error mode, but due to the flag being
+        # inaccessible, that's not going to work
+        # XXX: as an interim solution, skipping handlers is safer than
+        #      attempting to execute them. Ultimately, the error flag needs
+        #      to be available everywhere
         p.flags.incl beforeRetNeeded
         lineF(p, cpsStmts, "goto BeforeRet_;$n", [])
+      else:
+        # jump to the handler/finalizer
+        lineF(p, cpsStmts, "$1$n", [raiseInstr(p, call[^1])])
     else:
       raiseExit(p, call[^1])
+  elif isNoReturn:
+    # mark the control-flow path following the call as unreachable
+    if hasAssume in CC[p.config.cCompiler].props:
+      lineF(p, cpsStmts, "__assume(0);$n", [])
 
 proc fixupCall(p: BProc, le, ri: CgNode, d: var TLoc,
                callee, params: Rope) =

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -102,12 +102,6 @@ proc isDeepConstExpr*(n: CgNode): bool =
   else:
     result = false
 
-proc canRaiseConservative*(env: MirEnv, fn: CgNode): bool =
-  ## Duplicate of `canRaiseConservative <ast_query.html#canRaiseConservative,PNode>`_.
-  # ``mNone`` is also included in the set, therefore this check works even for
-  # non-magic calls
-  getCalleeMagic(env, fn) in magicsThatCanRaise
-
 proc toBitSet*(conf: ConfigRef; s: CgNode): TBitSet =
   ## Duplicate of `toBitSet <nimsets.html#toBitSet,ConfigRef,PNode>`_
   bitSetInit(result, int(getSize(conf, s.typ)))


### PR DESCRIPTION
## Summary

Improve C code generation for `.noreturn` calls, by omitting the
unnecessary error flag check for them.

## Details

If a procedure only returns due to exceptional unwinding, the
`if(NIM_UNLIKELY(*nimErr_))` guard guarding the unwinding is
unnecessary, since it's guaranteed that the error flag is set (all
exits of the procedure are due to exceptional unwinding).

Unconditionally jumping to the error handling target makes it clear
to the C compiler that control-flow doesn't continue normally after
the call

### Other improvements

In addition, the `canRaiseConservative` usage is unnecessary too, since
a `cnkCheckedCall` already signals that the call can raise. The
procedure has no more users and is thus removed.

Finally, for compilers that support it, a call to a `.noreturn`
procedure that doesn't raise is now followed by an `__assume(0)`
statement, communicating to the C compiler that control-flow never
returns to the caller.