### PR TITLE
fix: `move` not resetting source location

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1502,23 +1502,6 @@ proc skipAddr(n: CgNode): CgNode =
   if n.kind == cnkHiddenAddr: n.operand
   else:                       n
 
-proc genWasMoved(p: BProc; n: CgNode) =
-  var a: TLoc
-  let n1 = n[1].skipAddr
-  if true:
-    initLocExpr(p, n1, a, {lfWantLvalue})
-    resetLoc(p, a)
-    #linefmt(p, cpsStmts, "#nimZeroMem((void*)$1, sizeof($2));$n",
-    #  [addrLoc(p.config, a), getTypeDesc(p.module, a.t)])
-
-proc genMove(p: BProc; n: CgNode; d: var TLoc) =
-  var a: TLoc
-  initLocExpr(p, n[1], a, {lfWantLvalue})
-  if true:
-    if d.k == locNone: getTemp(p, n.typ, d)
-    genAssignment(p, d, a)
-    resetLoc(p, a)
-
 proc genDestroy(p: BProc; n: CgNode) =
     let arg = n[1].skipAddr
     let t = arg.typ.skipTypes(abstractInst)
@@ -1661,8 +1644,6 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
     initLocExpr(p, e[2], b)
     genDeepCopy(p, a, b)
   of mDotDot, mEqCString: genCall(p, e, d)
-  of mWasMoved: genWasMoved(p, e)
-  of mMove: genMove(p, e, d)
   of mDestroy: genDestroy(p, e)
   of mAccessTypeField: genAccessTypeField(p, e, d)
   of mTrace: discard "no code to generate"

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1732,25 +1732,6 @@ proc genDefault(p: PProc, n: CgNode; r: var TCompRes) =
   else:
     r.res = createVar(p, n.typ, indirect = false)
 
-proc genReset(p: PProc, n: CgNode) =
-  var x: TCompRes
-  useMagic(p, "genericReset")
-  gen(p, n[1], x)
-  if x.typ == etyBaseIndex:
-    lineF(p, "$1 = null, $2 = 0;$n", [x.address, x.res])
-  else:
-    lineF(p, "$1 = genericReset($1, $2);$n", [x.rdLoc,
-                  genTypeInfo(p, n[1].typ)])
-
-proc genMove(p: PProc; n: CgNode; r: var TCompRes) =
-  var a: TCompRes
-  r.kind = resVal
-  r.res = p.getTemp()
-  gen(p, n[1], a)
-  lineF(p, "$1 = $2;$n", [r.rdLoc, a.rdLoc])
-  genReset(p, n)
-  #lineF(p, "$1 = $2;$n", [dest.rdLoc, src.rdLoc])
-
 proc genJSArrayConstr(p: PProc, n: CgNode, r: var TCompRes) =
   var a: TCompRes
   r.res = rope("[")
@@ -1894,7 +1875,6 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
   of mNewSeqOfCap: unaryExpr(p, n, r, "", "[]")
   of mOf: genOf(p, n, r)
   of mDefault: genDefault(p, n, r)
-  of mWasMoved: genReset(p, n)
   of mEcho: genEcho(p, n, r)
   of mNLen..mNError:
     localReport(p.config, n.info, reportSym(
@@ -1908,8 +1888,6 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
   of mParseBiggestFloat:
     useMagic(p, "nimParseBiggestFloat")
     genCall(p, n, r)
-  of mMove:
-    genMove(p, n, r)
   # of mAccessEnv:
   #   unaryExpr(p, n, r, "accessEnv", "accessEnv($1)")
   of mFinished:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1760,29 +1760,6 @@ func fitsRegister(t: PType): bool =
   st.kind in { tyBool, tyInt..tyUInt64, tyChar, tyPtr, tyPointer} or
     (st.sym != nil and st.sym.magic == mPNimrodNode) # NimNode goes into register too
 
-func usesRegister(c: TCtx, n: CgNode): bool =
-  ## Analyses and returns whether the value of the location named by l-value
-  ## expression `n` is stored in a register instead of a memory location
-  # XXX: instead of using a separate analysis, compute and return this as part
-  #      of ``genLValue`` and
-  case n.kind
-  of cnkLocal:
-    usesRegister(c, n.local)
-  of cnkProc, cnkConst, cnkGlobal:
-    false
-  of cnkDeref, cnkDerefView, cnkFieldAccess, cnkArrayAccess, cnkTupleAccess,
-     cnkLvalueConv, cnkObjDownConv, cnkObjUpConv:
-    false
-  else:
-    unreachable(n.kind)
-
-proc genNoLoad(c: var TCtx, n: CgNode): tuple[reg: TRegister, isDirect: bool] =
-  ## Similar to ``genLValue``, but also returns whether the register storing
-  ## the result stores a handle or a value.
-  var dest = noDest
-  genLvalue(c, n, dest)
-  result = (TRegister(dest), usesRegister(c, n))
-
 proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   case m
   of mSubI:
@@ -2006,19 +1983,6 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
     c.freeTemp(tmp1)
     c.freeTemp(tmp2)
     c.freeTemp(tmp3)
-  of mWasMoved:
-    unused(c, n, dest)
-    let
-      (dest, isDirect) = genNoLoad(c, n[1])
-      typ = n[1].typ.skipTypes({tyVar, tyLent})
-
-    if isDirect:
-      # the location uses a register -> load it with the empty value
-      c.gABx(n, opcLdNullReg, dest, c.genType(typ))
-    else:
-      c.gABx(n, opcReset, dest, c.genType(typ))
-
-    c.freeTemp(dest)
   of mDefault:
     if fitsRegister(n.typ):
       prepare(c, dest, n.typ)
@@ -2203,21 +2167,6 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mRunnableExamples:
     discard "just ignore any call to runnableExamples"
   of mDestroy, mTrace: discard "ignore calls to the default destructor"
-  of mMove:
-    let arg = n[1]
-    if fitsRegister(n.typ):
-      gen(c, arg, dest)
-    else:
-      assert dest != noDest
-      let tmp = genLvalue(c, arg)
-      # perform a normal copy
-      c.gABC(n, opcWrLoc, dest, tmp)
-      c.freeTemp(tmp)
-    # XXX use ldNullOpcode() here?
-    # Don't zero out the arg for now #17199
-    # c.gABx(n, opcLdNull, a, c.genType(arg.typ))
-    # c.gABx(n, opcNodeToReg, a, a)
-    # c.genAsgnPatch(arg, a)
   of mNodeId:
     c.genUnaryABC(n, dest, opcNodeId)
   of mFinished:

--- a/tests/magics/tdestructive_move.nim
+++ b/tests/magics/tdestructive_move.nim
@@ -1,0 +1,19 @@
+discard """
+  description: "Ensure that a `move` resets the source location"
+  targets: "c js vm"
+"""
+
+type Object = object
+  a, b: int
+
+# test with primitive type:
+var a = 1
+let b = move(a)
+doAssert b == 1
+doAssert a == 0
+
+# test with aggregate type:
+var c = Object(a: 1, b: 2)
+let d = move(c)
+doAssert d.a == 1 and d.b == 2
+doAssert c.a == 0 and c.b == 0

--- a/tests/stdlib/os/tisolation.nim
+++ b/tests/stdlib/os/tisolation.nim
@@ -1,12 +1,12 @@
 discard """
-  targets: "c"
+  targets: "c vm"
 """
 
 import std/[isolation, json]
 
 
 
-proc main(moveZeroesOut: static bool) =
+proc main() =
   block:
     type
       Empty = ref object
@@ -18,76 +18,64 @@ proc main(moveZeroesOut: static bool) =
   block: # string literals
     var data = isolate("string")
     doAssert data.extract == "string"
-    if moveZeroesOut:
-      doAssert data.extract == ""
+    doAssert data.extract == ""
 
   block: # string literals
     var data = isolate("")
     doAssert data.extract == ""
-    if moveZeroesOut:
-      doAssert data.extract == ""
+    doAssert data.extract == ""
 
   block:
     var src = "string"
     var data = isolate(move src)
     doAssert data.extract == "string"
-    if moveZeroesOut:
-      doAssert src.len == 0
+    doAssert src.len == 0
 
   block: # int literals
     var data = isolate(1)
     doAssert data.extract == 1
-    if moveZeroesOut:
-      doAssert data.extract == 0
+    doAssert data.extract == 0
 
   block: # float literals
     var data = isolate(1.6)
     doAssert data.extract == 1.6
-    if moveZeroesOut:
-      doAssert data.extract == 0.0
+    doAssert data.extract == 0.0
 
   block:
     var data = isolate(@["1", "2"])
     doAssert data.extract == @["1", "2"]
-    if moveZeroesOut:
-      doAssert data.extract == @[]
+    doAssert data.extract == @[]
 
   block:
     var data = isolate(@["1", "2", "3", "4", "5"])
     doAssert data.extract == @["1", "2", "3", "4", "5"]
-    if moveZeroesOut:
-      doAssert data.extract == @[]
+    doAssert data.extract == @[]
 
   block:
     var data = isolate(@["", ""])
     doAssert data.extract == @["", ""]
-    if moveZeroesOut:
-      doAssert data.extract == @[]
+    doAssert data.extract == @[]
 
   block:
     var src = @["1", "2"]
     var data = isolate(move src)
     doAssert data.extract == @["1", "2"]
-    if moveZeroesOut:
-      doAssert src.len == 0
+    doAssert src.len == 0
 
   block:
     var data = isolate(@[1, 2])
     doAssert data.extract == @[1, 2]
-    if moveZeroesOut:
-      doAssert data.extract == @[]
+    doAssert data.extract == @[]
 
   block:
     var data = isolate(["1", "2"])
     doAssert data.extract == ["1", "2"]
-    if moveZeroesOut:
-      doAssert data.extract == ["", ""]
+    doAssert data.extract == ["", ""]
 
   block:
     var data = isolate([1, 2])
     doAssert data.extract == [1, 2]
-    if moveZeroesOut:
-      doAssert data.extract == [0, 0]
+    doAssert data.extract == [0, 0]
 
   block:
     type
@@ -130,5 +118,5 @@ proc main(moveZeroesOut: static bool) =
     doAssert $x == """@[(value: "1234")]"""
 
 
-static: main(moveZeroesOut = false)
-main(moveZeroesOut = true)
+static: main()
+main()

--- a/tests/stdlib/os/tisolation.nim
+++ b/tests/stdlib/os/tisolation.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c vm"
+  targets: "c"
 """
 
 import std/[isolation, json]


### PR DESCRIPTION
## Summary

Use a MIR pass to lower the `move` and `wasMoved` magic calls into
assignments, fixing `move` not always resetting the source location for
both the VM and JS backends. The C backend was not affected.

## Details

A `x = move(y)` call is now lowered into the following MIR:
```
x = move y
y = default()
```
and a `wasMoved(x)` call into:
```
x = default()
```
which is equivalent in behaviour to the code previously produced by
`cgen` -- using a shared MIR pass for the lowering ensures that the
behaviour is consistent across all backends.

The implementation of the two magics is removed from each code
generator, and a test for making sure `move` works correctly is added.

### Previous behaviour

For the VM backend, the source location was never reset on `move`,
while for the JS backend, the source location was reset with
`genericReset`, which left record-like locations empty (reading the
fields then yield `undefined`) and ignores primitive types like int or
float.