### PR TITLE
refactor(pragmas): improve `processCompile`

### DIFF
--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -709,9 +709,9 @@ proc relativeFile(c: PContext; name: string, info: TLineInfo;
 
 proc processCompile(c: PContext, n: PNode): PNode =
   ## compile pragma
-  ## produces (mutates) `n`, which must be a callable, analysing its arg, or returning
-  ## `n` wrapped in an error.
-  result = n
+  ## Produces the pragma with all arguments evaluated, or returns an error.
+  ## If the pragma is well-formed, the external files to compile are added to
+  ## the build.
   proc docompile(c: PContext; it: PNode; src, dest: AbsoluteFile; customArgs: string) =
     var cf = Cfile(nimname: splitFile(src).name,
                    cname: src, obj: dest, flags: {CfileFlag.External},
@@ -719,65 +719,68 @@ proc processCompile(c: PContext, n: PNode): PNode =
     extccomp.addExternalFileToCompile(c.config, cf)
     recordPragma(c, it, "compile", src.string, dest.string, customArgs)
 
-  proc getStrLit(c: PContext, n: PNode; i: int): (string, PNode) =
-    n[i] = c.semConstExpr(c, n[i])
-    case n[i].kind
-    of nkStrLit, nkRStrLit, nkTripleStrLit:
-      shallowCopy(result[0], n[i].strVal)
-      result[1] = nil
+  proc expectString(c: PContext, n: PNode): PNode =
+    result = c.semConstExpr(c, n)
+    case result.kind
+    of nkStrLiterals:
+      discard "all good"
     else:
-      result = ("", c.config.newError(
-        n, PAstDiag(kind: adSemStringLiteralExpected)))
+      result = c.config.newError(n, PAstDiag(kind: adSemStringLiteralExpected))
 
-  let it = if n.kind in nkPragmaCallKinds and n.len == 2: n[1] else: n
-  if it.kind in {nkPar, nkTupleConstr} and it.len == 2:
-    let
-      (s, sErr) = getStrLit(c, it, 0)
-      (dest, destErr) = getStrLit(c, it, 1)
+  if n.kind notin nkPragmaCallKinds:
+    result = invalidPragma(c, n)
+  elif n.len == 2 and n[1].kind == nkTupleConstr and n[1].len == 2:
+    # the pattern matching version of the pragma
+    result = shallowCopy(n)
+    result[0] = n[0]
+    # both operands need to be strings:
+    let tup = shallowCopy(n[1])
+    tup[0] = expectString(c, n[1][0]) # input pattern
+    tup[1] = expectString(c, n[1][1]) # object file pattern
+    result[1] = tup
 
-    if sErr != nil:
-      result = sErr
-    elif destErr != nil:
-      result = destErr
+    if nkError in {tup[0].kind, tup[1].kind}:
+      return c.config.wrapError(result)
+
+    # add all files matching the pattern to the build:
+    let found = parentDir(toFullPath(c.config, n.info)) / tup[0].strVal
+    for f in os.walkFiles(found):
+      let obj = completeCfilePath(c.config,
+                                  AbsoluteFile(tup[1].strVal % extractFilename(f)))
+      docompile(c, n, AbsoluteFile f, obj, "")
+
+  elif n.len <= 3:
+    # the single file version. Can either have 1 or 2 arguments, both which must
+    # be strings
+    result = shallowCopy(n)
+    result[0] = n[0] # use the identifier as is
+    var hasError = false
+    for i in 1..<n.len:
+      result[i] = expectString(c, n[i])
+      hasError = hasError or result[i].isError
+
+    if hasError:
+      return c.config.wrapError(result)
+
+    # find the file and add it to the build:
+    let file = result[1].strVal # file path
+    var found: AbsoluteFile
+    if isAbsolute(file):
+      found = AbsoluteFile file
     else:
-      var found = parentDir(toFullPath(c.config, n.info)) / s
-      for f in os.walkFiles(found):
-        let obj = completeCfilePath(c.config, AbsoluteFile(dest % extractFilename(f)))
-        docompile(c, it, AbsoluteFile f, obj, "")
-  else:
-    var
-      s = ""
-      customArgs = ""
-      err: PNode
-    if n.kind in nkCallKinds:
-      (s, err) = getStrLit(c, n, 1)
-      if err.isNil:
-        if n.len <= 3:
-          (customArgs, err) = getStrLit(c, n, 2)
-          if err != nil:
-            result = err
-            return
-        else:
-          result = c.config.newError(n, PAstDiag(
-            kind: adSemExcessiveCompilePragmaArgs))
-          return
-      else:
-        result = err
-        return
-    else:
-      (s, err) = strLitToStrOrErr(c, n)
-      if err != nil:
-        result = err
-        return
+      # first, look for the file relative to the current directory
+      found = AbsoluteFile(parentDir(toFullPath(c.config, n.info)) / file)
+      if not fileExists(found):
+        # look up the file relative to the search paths:
+        found = findFile(c.config, file)
+        if found.isEmpty: found = AbsoluteFile file
 
-    var found = AbsoluteFile(parentDir(toFullPath(c.config, n.info)) / s)
-    if not fileExists(found):
-      if isAbsolute(s): found = AbsoluteFile s
-      else:
-        found = findFile(c.config, s)
-        if found.isEmpty: found = AbsoluteFile s
     let obj = toObjFile(c.config, completeCfilePath(c.config, found, false))
-    docompile(c, it, found, obj, customArgs)
+    docompile(c, n, found, obj, (if n.len == 2: "" else: result[2].strVal))
+  else:
+    # too many arguments
+    result = c.config.newError(n,
+      PAstDiag(kind: adSemExcessiveCompilePragmaArgs))
 
 proc processLink(c: PContext, n: PNode): PNode =
   result = n

--- a/tests/lang/s05_pragmas/s01_interop/t06_compile_pattern.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t06_compile_pattern.nim
@@ -1,0 +1,22 @@
+discard """
+  description: '''
+    The `compile` pragma can also be used to compile all files matching a
+    pattern, by providing a two-element tuple argument.
+  '''
+  targets: "c"
+  joinable: false
+"""
+
+## The first operand is a file pattern for matching the C files to add to the
+## build. Only `*.suffix` patterns are guaranteed to work. The pattern is
+## relative to the current module's parent directory.
+##
+## The second operand specifies a pattern for the object file name. The object
+## file(s) are always placed in the project's cache directory, even if the
+## pattern evaluates to an absolute or relative file path. Similarily, the file
+## extension in the pattern is ignored too.
+{.compile: ("*.c", "~/cache/$1_generated.suffix").}
+
+proc c_compiled_only(arg: cint): cint {.importc.}
+
+doAssert c_compiled_only(1) == 2


### PR DESCRIPTION
## Summary

Refactor the `pragmas.processCompile` procedure to not mutate input
AST, and add a specification test for the undocumented pattern-matching
version of `.compile`.

## Details

For `pragmas.processCompile`:
* don't mutate input AST
* use proper error propagation (i.e., keep the shape of the AST intact)
* test that the specified path is relative before trying to interpret
  it as a relative path (less work)

The `.compile` pragma has a pattern-matching version, but this was
not documented anywhere. A specification test derived from the current
behaviour is added for it.