### PR TITLE
support multiple external C files having the same name

### DIFF
--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -393,6 +393,11 @@ proc toObjFile*(conf: ConfigRef; filename: AbsoluteFile): AbsoluteFile =
   # Object file for compilation
   result = AbsoluteFile(filename.string & "." & CC[conf.cCompiler].objExt)
 
+proc externalObjFile*(conf: ConfigRef; cfile: AbsoluteFile): AbsoluteFile =
+  ## Returns the path of the object file to output for the external C file
+  ## `cfile`.
+  result = toObjFile(conf, completeGeneratedExtFilePath(conf, cfile))
+
 proc addFileToCompile*(conf: ConfigRef; cf: Cfile) =
   conf.toCompile.add(cf)
 

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1300,6 +1300,19 @@ proc completeGeneratedFilePath*(conf: ConfigRef; f: AbsoluteFile,
   result = subdir / RelativeFile f.string.splitPath.tail
   #echo "completeGeneratedFilePath(", f, ") = ", result
 
+proc completeGeneratedExtFilePath*(conf: ConfigRef, f: AbsoluteFile
+                                  ): AbsoluteFile =
+  ## Returns the absolute file path within the cache directory for file `f`.
+  ## This procedure is meant to be used for external files with names not
+  ## controlled by the compiler -- a sub-directory is used to prevent
+  ## collisions.
+  let subdir = getNimcacheDir(conf.active) / RelativeDir("external")
+  try:
+    createDir(subdir.string)
+  except OSError:
+    conf.quitOrRaise "cannot create directory: " & subdir.string
+  result = subdir / RelativeFile(f.string.splitPath.tail)
+
 proc toRodFile*(conf: ConfigRef; f: AbsoluteFile; ext = RodExt): AbsoluteFile =
   result = changeFileExt(completeGeneratedFilePath(conf,
     withPackageName(conf, f)), ext)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -775,8 +775,10 @@ proc processCompile(c: PContext, n: PNode): PNode =
         found = findFile(c.config, file)
         if found.isEmpty: found = AbsoluteFile file
 
-    let obj = toObjFile(c.config):
-      completeCfilePath(c.config, withPackageName(c.config, found), false)
+    # prepend the package name derived from the file path to `found`, in order
+    # to prevent name collisions when there are multiple external C files with
+    # the same name
+    let obj = externalObjFile(c.config, withPackageName(c.config, found))
     docompile(c, n, found, obj, (if n.len == 2: "" else: result[2].strVal))
   else:
     # too many arguments

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -775,7 +775,8 @@ proc processCompile(c: PContext, n: PNode): PNode =
         found = findFile(c.config, file)
         if found.isEmpty: found = AbsoluteFile file
 
-    let obj = toObjFile(c.config, completeCfilePath(c.config, found, false))
+    let obj = toObjFile(c.config):
+      completeCfilePath(c.config, withPackageName(c.config, found), false)
     docompile(c, n, found, obj, (if n.len == 2: "" else: result[2].strVal))
   else:
     # too many arguments

--- a/tests/pragmas/sub/cfunction.c
+++ b/tests/pragmas/sub/cfunction.c
@@ -1,0 +1,3 @@
+int cfunction2(void) {
+  return NUMBER_HERE;
+}

--- a/tests/pragmas/tcompile_pragma.nim
+++ b/tests/pragmas/tcompile_pragma.nim
@@ -1,9 +1,14 @@
 discard """
-  output: '''34'''
+  description: "Tests for the `compile` pragma"
+  targets: "c"
 """
 
 {.compile("cfunction.c", "-DNUMBER_HERE=34").}
+# ensure that compiling a second C file with the same name works:
+{.compile("sub/cfunction.c", "-DNUMBER_HERE=1").}
 
 proc cfunction(): cint {.importc.}
+proc cfunction2(): cint {.importc.}
 
-echo cfunction()
+doAssert cfunction() == 34
+doAssert cfunction2() == 1


### PR DESCRIPTION
## Summary

Adding multiple C files sharing the same name to the build via the
`compile` pragma is now supported.

Closes https://github.com/nim-works/nimskull/issues/1291.

## Details

For the non-pattern `compile` pragma, the C file name is turned into a
unique object file name via `withPackageName`, mirroring what the C
backend does for the C files it generates.

To prevent the object files for the external C files from colliding
with the NimSkull module object files, they're placed under the
`external` sub-directory within the cache directory.