### PR TITLE
fix(vmgen): string literal changing at run-time

### DIFF
--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1184,6 +1184,16 @@ proc genCall(c: var TCtx; n: CgNode; dest: var TDest) =
       let tmp = c.genx(n[i])
       c.gABC(n[i], opcAsgnComplex, r, tmp)
       c.freeTemp(tmp)
+    elif n[i].kind == cnkConst and i < fntyp.len and
+         fntyp[i].kind == tySink and fntyp[i][0].kind == tyString:
+      # HACK: passing a string literal (lifted into a constant) directly to a
+      #       sink parameter is wrong, since it allows the callee to modify the
+      #       constant data; a copy has to be introduced. This needs to
+      #       eventually be fixed in ``mirgen``, by introducing a intermediate
+      #       temporary for the argument
+      let tmp = c.genx(n[i])
+      c.gABC(n[i], opcAsgnComplex, r, tmp)
+      c.freeTemp(tmp)
     else:
       c.gen(n[i], r)
 

--- a/tests/lang_types/sink/tsink_string_literal.nim
+++ b/tests/lang_types/sink/tsink_string_literal.nim
@@ -1,0 +1,20 @@
+discard """
+  description: '''
+    Ensure string character data is not modified when passing a string literal
+    to a sink parameter
+  '''
+  targets: "c js vm"
+"""
+
+proc f_sink(x: sink string) =
+  x[0] = '0'
+
+# pass a string literal directly to a sink parameter:
+f_sink("abc")
+
+# the underlying constant string data storage must not have been
+# modified:
+proc test(x: string) =
+  doAssert x[0] == 'a'
+
+test("abc")


### PR DESCRIPTION
## Summary

Fix a string literal's underlying storage being modified when passing
a string literal to a `sink string` parameter, where the parameter is
modified within the callee. Only the VM backend was affected.

## Details

No copy of the string literal (which was lifted into a constant
earlier) is created for string literals passed to `sink` parameters.
This is not a problem for the C (copy-on-write strings are used) and
JS backend (a new run-time string instance is created on each string
literal usage), but it is for the VM backend.

Without a copy, the callee can directly modify the constant string's
underlying character storage, affecting all string literal usage
throughout the program.

`mirgen` should introduce an intermediate temporary for the argument in
this case, but - at the moment - doing so would lead to worse code
generation for all code generators, so the problem is worked around in
`vmgen`, by creating a copy of the string constant when passed to a
`sink string` parameter.