### PR TITLE
fix(sem): issues with method-call syntax in templates

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -147,12 +147,12 @@ const
     ## not be performed for arguments to these magics.
 
 proc getPIdent*(a: PNode): PIdent {.inline.} =
-  ## Returns underlying `PIdent` for `{nkSym, nkIdent}`, or `nil`.
-  # xxx consider whether also returning the 1st ident for {nkOpenSymChoice, nkClosedSymChoice}
-  # which may simplify code.
+  ## Returns underlying `PIdent` for `{nkSym, nkIdent, nkOpenSymChoice,
+  ## nkClosedSymChoice}`, or `nil`.
   case a.kind
   of nkSym: a.sym.name
   of nkIdent: a.ident
+  of nkSymChoices: a[0].sym.name
   else: nil
 
 proc getIdentLineInfo*(n: PNode): TLineInfo =

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -147,12 +147,12 @@ const
     ## not be performed for arguments to these magics.
 
 proc getPIdent*(a: PNode): PIdent {.inline.} =
-  ## Returns underlying `PIdent` for `{nkSym, nkIdent, nkOpenSymChoice,
-  ## nkClosedSymChoice}`, or `nil`.
+  ## Returns underlying `PIdent` for `{nkSym, nkIdent}`, or `nil`.
+  # xxx consider whether also returning the 1st ident for {nkOpenSymChoice, nkClosedSymChoice}
+  # which may simplify code.
   case a.kind
   of nkSym: a.sym.name
   of nkIdent: a.ident
-  of nkSymChoices: a[0].sym.name
   else: nil
 
 proc getIdentLineInfo*(n: PNode): TLineInfo =

--- a/compiler/ast/renderer.nim
+++ b/compiler/ast/renderer.nim
@@ -958,9 +958,13 @@ proc infixArgument(g: var TSrcGen, n: PNode, i: int) =
   if needsParenthesis:
     put(g, tkParRi, ")")
 
-proc isCustomLit(n: PNode): bool =
+proc isCustomLit(n: PNode, g: TSrcGen): bool =
   if n.len == 2 and n[0].kind == nkRStrLit:
-    let ident = n[1].getPIdent
+    let ident =
+      if n[1].kind in nkSymChoices:
+        getPIdent(n[1][0])
+      else:
+        getPIdent(n[1])
     result = ident != nil and ident.s.startsWith('\'')
 
 proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
@@ -1187,7 +1191,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
     gcomma(g, n, c)
     put(g, tkBracketRi, "]")
   of nkDotExpr:
-    if isCustomLit(n):
+    if isCustomLit(n, g):
       put(g, tkCustomLit, n[0].strVal)
       gsub(g, n, 1)
     else:

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -12,6 +12,7 @@
 import
   std/[
     strutils,
+    hashes,
     math,
     strtabs,
     intsets,

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -917,19 +917,6 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     let s = qualifiedLookUp(c.c, n, {})
 
     if s.isNil:
-      discard
-    elif s.isError:
-      result = s.ast
-    else:
-      if contains(c.toBind, s.id):
-        return symChoice(c.c, n, s, scClosed, c.noGenSym > 0)
-      elif contains(c.toMixin, s.name.id):
-        return symChoice(c.c, n, s, scForceOpen, c.noGenSym > 0)
-      else:
-        return symChoice(c.c, n, s, scOpen, c.noGenSym > 0)
-
-    case n.kind
-    of nkDotExpr:
       result = n
 
       result[0] = semTemplBody(c, n[0])
@@ -940,8 +927,16 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
 
       if nkError in {result[0].kind, result[1].kind}:
         result = c.c.config.wrapError(result)
+    elif s.isError:
+      result = s.ast
     else:
-      unreachable("should never have gotten here")
+      if contains(c.toBind, s.id):
+        return symChoice(c.c, n, s, scClosed, c.noGenSym > 0)
+      elif contains(c.toMixin, s.name.id):
+        return symChoice(c.c, n, s, scForceOpen, c.noGenSym > 0)
+      else:
+        return symChoice(c.c, n, s, scOpen, c.noGenSym > 0)
+
   of nkExprColonExpr, nkExprEqExpr:
     let s = qualifiedLookUp(c.c, n[0], {})
     # template parameters can be substituted into the name position of a

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -94,7 +94,7 @@ type
     scClosed, scOpen, scForceOpen
 
 proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
-               isField = false): PNode =
+               noGenSyms = false): PNode =
   var
     a: PSym
     o: TOverloadIter
@@ -112,11 +112,11 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
     # XXX this makes more sense but breaks bootstrapping for now:
     # (s.kind notin routineKinds or s.magic != mNone):
     # for instance 'nextTry' is both in tables.nim and astalgo.nim ...
-    if not(isField and sfGenSym in s.flags):
+    if noGenSyms and sfGenSym in s.flags:
+      result = n
+    else:
       result = newSymNode(s, info)
       markUsed(c, info, s)
-    else:
-      result = n
   else:
     # semantic checking requires a type; `fitNode` deals with it
     # appropriately
@@ -125,7 +125,7 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
     result = newNodeIT(kind, info, newTypeS(tyNone, c))
     a = initOverloadIter(o, c, n)
     while a != nil:
-      if a.kind != skModule and not(isField and sfGenSym in s.flags):
+      if a.kind != skModule and not(noGenSyms and sfGenSym in a.flags):
         incl(a.flags, sfUsed)
         markOwnerModuleAsUsed(c, a)
         result.add newSymNode(a, info)

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5731,41 +5731,6 @@ no semantics outside of a template definition and cannot be abstracted over:
 To get rid of hygiene in templates, one can use the `dirty`:idx: pragma for
 a template. `inject` and `gensym` have no effect in `dirty` templates.
 
-`gensym`'ed symbols cannot be used as `field` in the `x.field` syntax.
-Nor can they be used in the `ObjectConstruction(field: value)`
-and `namedParameterCall(field = value)` syntactic constructs.
-
-The reason for this is that code like
-
-.. code-block:: nim
-    :test: "nim c $1"
-
-  type
-    T = object
-      f: int
-
-  template tmp(x: T) =
-    let f = 34
-    echo x.f, T(f: 4)
-
-
-should work as expected.
-
-However, this means that the method call syntax is not available for
-`gensym`'ed symbols:
-
-.. code-block:: nim
-    :test: "nim c $1"
-    :status: 1
-
-  template tmp(x) =
-    type
-      T {.gensym.} = int
-
-    echo x.T # invalid: instead use:  'echo T(x)'.
-
-  tmp(12)
-
 
 
 Limitations of the method call syntax

--- a/tests/lang_callable/template/mmethod_call_symbol_binding.nim
+++ b/tests/lang_callable/template/mmethod_call_symbol_binding.nim
@@ -1,0 +1,5 @@
+proc p(x: int): int = x
+
+template templ*(x: untyped): untyped =
+  # `p` is a symbol that's not overloaded
+  x.p()

--- a/tests/lang_callable/template/tclosed_symbol_with_method_call.nim
+++ b/tests/lang_callable/template/tclosed_symbol_with_method_call.nim
@@ -1,0 +1,26 @@
+discard """
+  description: '''
+    Ensure that non-overloaded symbols used as the method in the method-call
+    syntax are closed symbols
+  '''
+  action: reject
+  knownIssue: '''
+    Non-overloaded symbols used as the callee with the method call syntax
+    are always open
+  '''
+"""
+
+proc p(x: int) =
+  discard
+
+template test(x: string) =
+  # `p` is not overloaded at this point, and it's thus a closed symbol
+  x.p()
+
+# the overload with which the call would work:
+proc p(x: string) =
+  discard
+
+# the symbol of the callee is bound early and is closed, so the correct
+# overload cannot be picked, meaning that an error ensues
+test("")

--- a/tests/lang_callable/template/template_issues.nim
+++ b/tests/lang_callable/template/template_issues.nim
@@ -304,3 +304,19 @@ block static_parameter_with_default:
     discard int(b)
 
   x() # the default value for the parameter must be used
+
+block method_call_syntax_with_gensym_routine:
+  # using the method-call syntax with gensym'ed routines didn't work
+  template test(x: int): untyped =
+    proc p(v: int): int {.gensym.} = v
+    x.p()
+
+  doAssert test(1) == 1
+
+block method_call_syntax_with_gensym_type:
+  # using the method-call syntax with gensym'ed types didn't work
+  template test(x: int): float =
+    type Typ {.gensym.} = float
+    x.Typ
+
+  doAssert test(1) == 1.0

--- a/tests/lang_callable/template/tmethod_call_symbol_binding.nim
+++ b/tests/lang_callable/template/tmethod_call_symbol_binding.nim
@@ -1,0 +1,12 @@
+discard """
+  description: '''
+    Ensure that non-overloaded symbols from a template's definition scope are
+    bound early when using the method-call syntax.
+
+    Derived from https://github.com/nim-works/nimskull/issues/1292.
+  '''
+"""
+
+import mmethod_call_symbol_binding
+
+doAssert templ(1) == 1


### PR DESCRIPTION
## Summary

Fix two issues with the method-call syntax in non-dirty templates:
* non-overloaded symbols weren't bound early, falling back to late
  binding (https://github.com/nim-works/nimskull/issues/1292)
* gensym'ed symbols couldn't be used as the callee

## Details

### `semTemplBody` restructuring

Restructure `semTemplBody` so that the `TemplCtx.noGenSym` field
becomes unnecessary:
* the name part of `nkExprColonExpr`/`nkExprEqExpr` can only bind to
  template parameters, so `qualifiedLookUp` is used directly
* resolving an identifier to a symbol or symbol choice is moved to
  `templBindSym`
* for dot expressions (`a.b`), handling symbol binding for the `b` part
  is done manually via symbol lookup + `templBindSym`

### Missing early binding

* if `b` in `a.b` is a non-overloaded symbol, wrap it in a symbol-
  choice, to prevent `dotTransformation` from discarding it again
* for backwards-compatibility an *open* symbol choice is used in this
  case, not a *closed* one (non-overloaded symbols are closed by
  default)
* a `knownIssue` test is added for the incorrect symbol binding in dot
  expressions (`tclosed_symbol_with_method_call`)

### Bind `gensym` symbols

* if `b` in `a.b` resolves to a gensym, the symbols is now bound
* only routine, type, and generic parameter symbols are bound for `b`
  in `a.b`. This prevents, incorrect symbol binding in cases such as
  `var x = 1; a.x = 2`
* to still allow `a.b` resolving to a field access even if a gensym was
  bound to `b` (and later turned into `b'gensym` identifier),
  `builtInFieldAccess` and `propertyWriteAccess` strip the `'gensym`
  suffix from the identifier before trying to use it
* so that rendering of custom string literals (which reach `sem` as
  `(DotExpr (...) (Ident 'suffix))` stays the same,
  `renderer.isCustomLit` has to account for symbol-choices in the
  second slot

A bug with `symChoice` uncovered by the other changes is fixed: gensyms
were added to the symbol choice, even if `isField` (now rename to the
more accurately named `noGenSyms`) was true.

### Misc

* various comments documenting issues with how the symbol binding works
  are added