### PR TITLE
fix(testament): batching being ignored for megatest

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -360,9 +360,12 @@ proc runJoinedTest(r: var TResults, targets: set[TTarget], testsDir, options: st
       for file in walkDirRec(testsDir / cat):
         if isTestFile(file):
           try:
-            let spec = parseSpec(file, cat.Category.defaultTargets, nativeTarget())
-            if isJoinableSpec(spec, targets, computeEarly(spec, true)):
-              specs.add spec
+            # setup a pseudo test instance for the purpose of computing
+            # whether it can be joined
+            let test = initTest(file, "", cat.Category):
+              parseSpec(file, cat.Category.defaultTargets, nativeTarget())
+            if isJoinableSpec(test.spec, targets, computeEarly(test)):
+              specs.add test.spec
           except ValueError:
             msg Undefined:
               "parseSpec raised ValueError for: '$1', assuming this will be handled outside of megatest" % file

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -1147,6 +1147,9 @@ proc computeEarly(spec: TSpec, inCurrentBatch: bool): TResultEnum =
   else:
     reSuccess
 
+proc computeEarly(test: TTest): TResultEnum {.inline.} =
+  computeEarly(test.spec, test.inCurrentBatch)
+
 proc produceRuns(r: var TResults, test: TTest, early: TResultEnum,
                   runs: var seq[TestRun]) =
   ## Takes a test description (`test`) and the computed early result and


### PR DESCRIPTION
## Summary

Fix batching being ignored for the megatest. Only tests part of the
current batch are now joined into the megatest.

Fixes https://github.com/nim-works/nimskull/issues/1037

## Details

In order to not duplicate the computation of whether the test is in the
current batch, a pseudo `TTest` instance is created that's then passed
to `computeEarly`.