### PR TITLE
threads: improve interface and fix bugs

### DIFF
--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -181,12 +181,6 @@ when emulatedThreadVars:
 const nimTlsSize {.intdefine.} = 16000
 type
   ThreadLocalStorage = array[0..(nimTlsSize div sizeof(float)), float]
-  PGcThread = ptr GcThread
-  GcThread {.pure, inheritable.} = object
-    when emulatedThreadVars:
-      tls: ThreadLocalStorage
-    else:
-      nil
 
 when emulatedThreadVars:
   var globalsSlot {.noInit.}: ThreadVarSlot
@@ -195,10 +189,11 @@ when emulatedThreadVars:
   # here
 
   when not defined(useNimRtl):
-    var mainThread: GcThread
+    var mainThread: ThreadLocalStorage
+      ## the thread-local storage of the main thread
 
   proc GetThreadLocalVars(): pointer {.compilerRtl, inl.} =
-    result = addr(cast[PGcThread](threadVarGetValue(globalsSlot)).tls)
+    result = cast[ptr ThreadLocalStorage](threadVarGetValue(globalsSlot))
 
   proc initThreadVarsEmulation() {.compilerproc, inline.} =
     when not defined(useNimRtl):

--- a/tests/threads/tinternal_thread_cleanup.nim
+++ b/tests/threads/tinternal_thread_cleanup.nim
@@ -1,0 +1,43 @@
+discard """
+  description: "Ensure that the internal thread management-data is freed"
+  joinable: false
+"""
+
+import std/os
+
+let startMem = getOccupiedSharedMem()
+
+proc run(signal: ptr int) =
+  # busy-wait until the signal is signaled
+  while atomicLoadN(signal, ATOMIC_SEQ_CST) == 0:
+    discard
+
+block detached_thread:
+  # case 1: detached thread (the spawned thread does the cleanup)
+  var
+    signal = 0
+    thread: Thread[ptr int]
+
+  thread.createThread(run, addr signal)
+  # don't wake the thread up
+  thread.reset()
+  # now wake the thread up
+  atomicStoreN(addr signal, 1, ATOMIC_SEQ_CST)
+
+  # without the handle there's no way to know when the thread is finished,
+  # so we sleep for some time
+  sleep(100)
+  doAssert getOccupiedSharedMem() == startMem
+
+block joined_thread:
+  # case 2: joined thread (the current thread does the cleanup)
+  var
+    signal = 0
+    thread: Thread[ptr int]
+
+  thread.createThread(run, addr signal)
+  atomicStoreN(addr signal, 1, ATOMIC_SEQ_CST)
+  thread.joinThread() # wait for the thread to finish
+  reset thread # destroy the thread
+
+  doAssert getOccupiedSharedMem() == startMem

--- a/tests/threads/tthread_param_is_destroyed.nim
+++ b/tests/threads/tthread_param_is_destroyed.nim
@@ -1,0 +1,22 @@
+discard """
+  description: "Ensure that thread parameters are destroyed properly"
+  joinable: false
+"""
+
+var counter: int
+
+type Param = object
+  init: bool
+
+proc `=destroy`(x: var Param) =
+  if x.init:
+    discard atomicInc(counter, 1, ATOMIC_SEQ_CST)
+
+proc run(x: Param) {.thread.} =
+  discard
+
+var thread: Thread[Param]
+thread.createThread(run, Param(init: true))
+thread.joinThread()
+
+doAssert atomicLoadN(addr counter, ATOMIC_SEQ_CST) == 1


### PR DESCRIPTION
## Summary

Make `Thread` a proper thread handle, fixing multiple bugs and making
the interface more robust:
* a thread is now officially allowed to outlive the `Thread` instance
  (which would previously lead to crashes)
* a `Thread` handle for a running thread can now be safely moved around
* there's now a `createThread` overload that returns a `Thread`
  instance
* `Thread.finished` having a race condition

## Details

The management-data for a thread was previously part of the `Thread`
type itself, with a pointer to the `Thread` instance passed to the
internal thread procedure, requiring the `Thread` instance for a
running thread to always stay at the same memory location.

As a consequence of this design, moving the `Thread` instance, or the
`Thread` instance going out of scope before the thread is finished,
resulted in undefined behaviour.

To address this problem, the management-data is made part of a heap-
allocated structure (`ThreadCore`), which is then shared between the
handle and spawned thread. The type uses manual reference counting in
order to support detached threads (threads that outlive their handle).

Since a `Thread` instance can now be moved around in memory, the base
`createThread` procedure can now return a `Thread`, which is the better
interface, as it prevents leaks caused by forgetting to destroy the
`Thread` instance first. For backwards compatibility, an in-place
`createThread` overload is added.

### Tests

Two new tests are added:
* a test for ensuring that the thread's internal data is freed
  correctly
* a test for ensuring that the thread parameter is destroyed

The pre-existing `tthread_destroy_before_finish.nim` test had a few
issues, which are now fixed:
* it had no proper description
* it wasn't guaranteed to actually fail (in the edge-case that the
  spawned thread finishes before the `reset` call)
* access to the `ok` global was not atomic (resulting in a race
  condition)
* it unnecessarily imported `std/os`