### PR TITLE
lower `mChckObj` magic with MIR pass

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1571,16 +1571,6 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
     initLocExpr(p, e[2], a)
     initLocExpr(p, e[3], b)
     genBoundsCheck(p, arr, a, b, e.exit)
-  of mChckObj:
-    var a: TLoc
-    initLocExpr(p, e[1], a)
-    var nilCheck = ""
-    let r = rdMType(p, a, nilCheck)
-    assert nilCheck != "", "not a pointer-like value?"
-    # the nil-check is expected to have taken place already
-    linefmt(p, cpsStmts, "if (!#isObj($2, $3)){ #raiseObjectConversionError(); $4}$n",
-            [nilCheck, r, genTypeInfo2Name(p.module, e[2].typ),
-             raiseInstr(p, e.exit)])
   of mSamePayload:
     var a, b: TLoc
     initLocExpr(p, e[1], a)

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1825,10 +1825,11 @@ proc genx(c: var TCtx, e: PMirExpr, i: int) =
               c.buildMagicCall mIsNil, BoolType:
                 c.emitByVal val
       # the check:
-      c.subTree mnkVoid:
-        c.buildDefectMagicCall mChckObj, VoidType:
-          c.emitByVal val
-          c.emitByVal typeLit(c.typeToMir(n.check))
+      c.subTree mnkScope:
+        c.subTree mnkVoid:
+          c.buildDefectMagicCall mChckObj, VoidType:
+            c.emitByVal val
+            c.emitByVal typeLit(c.typeToMir(n.check))
 
     c.buildOp mnkPathConv, typ:
       c.use val

--- a/compiler/mir/rtchecks.nim
+++ b/compiler/mir/rtchecks.nim
@@ -267,6 +267,30 @@ proc emitFieldCheck(tree; source: SourceMap; call; graph; env; bu) =
       bu.emitByVal msgVal
       bu.emitByVal extra
 
+proc emitObjectCheck(tree; call; graph; env; bu) =
+  ## For ``chckObj(o, typ)`` emits:
+  ##   def _1 = of(arg o[], arg typ)
+  ##   def _2 = not(arg _1)
+  ##   if _2:
+  ##     raiseObjectConversionError()
+  let
+    arg = bu.inline(tree, NodePosition tree.argument(call, 0))
+    typ = env[arg.typ].skipTypes(abstractInst + tyUserTypeClasses)
+
+  let cond = bu.wrapTemp BoolType:
+    bu.buildMagicCall mOf, BoolType:
+      # dereference first. Object checks are always guarded by an ``!= nil``
+      # check, so the pointer/ref is guaranteed to be non-nil
+      bu.subTree mnkArg:
+        bu.subTree mnkDeref, env.types.add(typ[^1]):
+          bu.use arg
+      bu.subTree mnkArg:
+        bu.emitFrom(tree, NodePosition tree.argument(call, 1))
+
+  bu.buildIfNot cond:
+    bu.emitCall(tree, call, env.addCompilerProc(graph, "raiseObjectConversionError")):
+      discard
+
 proc lowerChecks*(body; graph; env; changes: var Changeset) =
   ## Lowers all magic calls implementing the run-time checks.
   template tree: MirTree = body.code
@@ -294,5 +318,9 @@ proc lowerChecks*(body; graph; env; changes: var Changeset) =
         # make sure to take the ``mnkVoid`` wrapper into account
         changes.replaceMulti(tree, tree.parent(call), bu):
           emitFieldCheck(tree, body.source, call, graph, env, bu)
+      of mChckObj:
+        let call = tree.parent(i)
+        changes.replaceMulti(tree, tree.parent(call), bu):
+          emitObjectCheck(tree, call, graph, env, bu)
       else:
         discard "not relevant"

--- a/tests/exception/truntime_check_panics.nim
+++ b/tests/exception/truntime_check_panics.nim
@@ -22,7 +22,8 @@ scope:
   def _11: bool = isNil(arg r)
   def _10: bool = not(arg _11)
   if _10:
-    chckObj(arg r, arg type(Sub:ObjectType))
+    scope:
+      chckObj(arg r, arg type(Sub:ObjectType))
   discard r.(Sub)
   def _12: float = mulF64(arg f, arg f)
   chckNaN(arg _12)


### PR DESCRIPTION
## Summary

Lower the `mChckObj` magic with a MIR pass instead of as part of C code
generation, shrinking down `cgen`.

## Details

* the lowering is integrated into `rtchecks.lowerChecks`
* it's a straightforward MIR port of how `cgen` handled the `mChckObj`
  magic
* so that the syntax stays correct after lowering, `mirgen`now wraps
  the `mChckObj` call in a scope