### PR TITLE
add the `supportsZeroMem` type trait

### DIFF
--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -77,3 +77,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimskullNewExceptionRt")
   defineSymbol("nimskullNoNkStmtListTypeAndNkBlockType")
   defineSymbol("nimskullNoNkNone")
+  defineSymbol("nimskullHasSupportsZeroMem")

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -93,6 +93,12 @@ proc supportsCopyMem*(t: typedesc): bool {.magic: "TypeTrait".}
   ##
   ## Other languages name a type like these `blob`:idx:.
 
+proc supportsZeroMem*(t: typedesc): bool {.magic: "TypeTrait".}
+  ## This trait returns true if using `zeroMem`:idx: on a location of type `t`
+  ## brings the location into its "default-initialized" state. This doesn't
+  ## imply that using `zeroMem`:idx: on a location already storing a value is
+  ## valid.
+
 proc isNamedTuple*(T: typedesc): bool {.magic: "TypeTrait".} =
   ## Returns true for named tuples, false for any other type.
   runnableExamples:

--- a/tests/lang_experimental/package_level_objects/tno_supports_zero_mem.nim
+++ b/tests/lang_experimental/package_level_objects/tno_supports_zero_mem.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    Until completed, a package-level object type counts as not supporting
+    zero-initialization
+  '''
+  action: compile
+"""
+
+import std/typetraits
+
+type
+  mypackage.Foo = object
+
+static:
+  doAssert not supportsZeroMem(Foo)


### PR DESCRIPTION
## Summary

The type is intended for libraries to figure out whether `zeroMem`
leaves a location in its "default-initialized" state, something that's
useful to know for optimization or correctness purposes in generic
code.

## Details

Without the type trait, either approximation via `is`, or a type-
inspection macro would have to be used. A built-in type trait is
better than a macro, since it's both more efficient and usable in
the `system` module.

The only types not supporting `zeroMem` for initialization are:
* types that don't have a zero-default (such as `range` types, enums
  not starting at zero, `.requiresInit` types, not-nil pointers, etc.)
* object types that have a type header field (non-pure object types
  that can be inherited from)
* incomplete package-level object types
* aggregate types containing the former three

The `nimskullHasSupportsZeroMem` conditional symbol is added so that
support for type-trait can be detected at compile-time.