### PR TITLE
profiler: prevent infinite recursion

### DIFF
--- a/tests/compilerfeatures/tprofiler.nim
+++ b/tests/compilerfeatures/tprofiler.nim
@@ -21,14 +21,10 @@ var
 
 proc enabledCallback(): bool =
   result = enabled
-  # XXX: an issue with the profiler runtime requires disabling the callback
-  #      until the `profileCallback` is done
-  enabled = false
 
 proc profileCallback(st: StackTrace) =
   traces[numTraces] = st
   inc numTraces
-  enabled = true # re-enable
 
 {.pop.}
 


### PR DESCRIPTION
## Summary

The profiler runtime enabled with `--profiler:on` now guards against
infinite recursion when the profiler callbacks call instrumented
procedures. This fixes crashes caused by a stack overflow when
using `nimprof`.

## Details

* a thread-local boolean is used to guard against `nimProfile`
  recursing
* the workaround previously required in `tprofiler.nim` is obsolete
  and thus removed