### PR TITLE
fix: move analyzer regression with variants

### DIFF
--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -418,6 +418,7 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
     tree "(":
       commaSeparated:
         fieldToStr(next(nodes, i).field, typ, result, c)
+        result.add ": "
         argToStr()
       result.add ")"
   of mnkCall:

--- a/tests/optimization/tmove_from_non_variant_field.nim
+++ b/tests/optimization/tmove_from_non_variant_field.nim
@@ -1,0 +1,43 @@
+discard """
+  description: '''
+    Ensure that a discriminator assignment doesn't prevent automatic moves
+    from fields outside the record-case
+  '''
+  action: compile
+  matrix: "--expandArc:test --checks:off"
+  nimout: '''--expandArc: test
+scope:
+  def _3: WithHooks = ()
+  def x: Object = (a: consume _3, kind: consume true)
+  bind_mut _4: WithHooks = x.a
+  result := move _4
+  wasMoved(name _4)
+  bind_mut _5: bool = x.kind
+  def _6: bool = copy kind
+  def _7: bool = eqB(arg _5, arg _6)
+  def _8: bool = not(arg _7)
+  if _8:
+    =destroy(name x)
+  _5 = _6
+  =destroy(name x)
+
+-- end of expandArc ------------------------'''
+"""
+
+type
+  WithHooks = object
+  Object = object
+    a: WithHooks
+    case kind: bool
+    of true, false:
+      b: WithHooks
+
+proc `=destroy`(x: var WithHooks) =
+  discard
+
+proc test(kind: bool): WithHooks {.exportc.} =
+  var x = Object(a: WithHooks(), kind: true)
+  result = x.a # can be moved
+  # the discriminator assignment must not prevent `x.a` from being moved out
+  # of
+  x.kind = kind


### PR DESCRIPTION
## Summary

Separate the `switch` lowering and destructor injection into two proper
passes and apply them concurrently, fixing a move analyzer regression.

## Details

* move the `switch` lowering out of `injectDestructorCalls`
* pass a `Changeset` instead of a mutable `MirBody` to the two passes
  in `injectdestructors`
* destructor injection and `switch` lowering are applied in a single
  batch by `backends.process` 
* the `switch` lowering is still disabled for the VM backend
* update the doc comment of `injectDestructorCalls` to reflect reality

### Move Analyzer

Applying both passes concurrently - instead of the destructor-
injection/move-analysis after `switch` lowering - fixes a regression
from ae543125c222693c915e3cfaa3cc3edb0110c569

The move analyzer now sees a discriminator assignment as:
```nim
x.discr = y
```
instead of:
```nim
if x.discr != y:
  =destroy(x) # variant destructor
x.discr = y
```

allowing it to perform automatic moves from non-variant fields again
(refer to `tmove_from_non_variant_field.nim`).

### Misc

* fix MIR pretty-printing for object/ref constructors -- the colon was
  missing between the field and value