### PR TITLE
fix(js): slow code generation

### DIFF
--- a/compiler/backend/jsflow.nim
+++ b/compiler/backend/jsflow.nim
@@ -173,15 +173,13 @@ proc sort(structs: var seq[Structure]) =
       order[idx] = orderVal
       inc orderVal
 
-  var
-    stack: seq[tuple[pos: int, order: int]]
-    i = 0
+  var stack: seq[tuple[pos: int, order: int]]
 
   # now we want to establish the following: for each parent/child opening, the
   # parent has a *greater* order value than the child. Structure, catch, and
   # finally openings must stay associated with their original statement -- they
   # cannot move
-  while i < structs.len:
+  for i in 0..<structs.len:
     template invariant(): bool =
       # the loop invariant
       stack.len < 2 or stack[^2].order > stack[^1].order
@@ -226,8 +224,6 @@ proc sort(structs: var seq[Structure]) =
       discard
 
     assert invariant()
-    # we're always making progress, the loop is guaranteed to terminate
-    inc i
 
 proc toStructureList*(stmts: openArray[CgNode]): StructDesc =
   ## Creates and returns the JavaScript control-flow-construct-focused

--- a/compiler/backend/jsflow.nim
+++ b/compiler/backend/jsflow.nim
@@ -59,6 +59,15 @@ type
 const
   Terminators = {stkReturn, stkTerminator}
 
+proc rotateRight[T](s: var seq[T], a, b: int) =
+  ## Rotates the items in slice a..b to the right by one element.
+  let backup = s[b]
+  var i = b
+  while i > a:
+    s[i] = s[i - 1]
+    dec i
+  s[a] = backup
+
 func finalTarget*(n: CgNode): CgNode =
   ## Given a label or target list, retrieves the target.
   case n.kind
@@ -143,6 +152,83 @@ func endsInTerminator(structs: seq[Structure], start: int): bool =
 
   result = false # doesn't end in a terminator
 
+proc sort(structs: var seq[Structure]) =
+  ## Reorders the openings in `structs` such that each opening is paired with
+  ## its corresponding end. Pre-conditions:
+  ## * all ends have the correct relative order to each other
+  ## * if a block encloses a ``stkStructStart``, the end of the block is not
+  ##   enclosed by the ``stkStructStart``
+  var
+    order: seq[int] # indexed by LabelId
+    orderVal = 0
+
+  # associate a unique "order" value with each label. We need it to establish a
+  # correct ordering between parent and child openings
+  for i, it in structs.pairs:
+    if it.kind == stkEnd:
+      let idx = it.label.int
+      if idx >= order.len:
+        order.setLen(idx + 1)
+
+      order[idx] = orderVal
+      inc orderVal
+
+  var
+    stack: seq[tuple[pos: int, order: int]]
+    i = 0
+
+  # now we want to establish the following: for each parent/child opening, the
+  # parent has a *greater* order value than the child. Structure, catch, and
+  # finally openings must stay associated with their original statement -- they
+  # cannot move
+  while i < structs.len:
+    template invariant(): bool =
+      # the loop invariant
+      stack.len < 2 or stack[^2].order > stack[^1].order
+
+    let it = structs[i]
+    case it.kind
+    of stkTry, stkBlock:
+      stack.add (i, order[it.label.int])
+      if not invariant():
+        # restore the loop invariant by shifting the new item to the first
+        # position where the invariant holds again
+        var insert = stack.len - 2
+        while insert >= 0 and stack[insert].order < stack[^1].order:
+          dec insert
+        insert += 1
+
+        # attach the opening to the same statement as the opening we're placing
+        # it before:
+        structs[i].stmt = structs[stack[insert].pos].stmt
+        # shift the opening in the `structs` list and reflect the shift in the
+        # `stack`:
+        rotateRight(structs, stack[insert].pos, i)
+        rotateRight(stack, insert, stack.high)
+
+        # we've moved some items in the `structs` list, and the affected stack
+        # items need to reflect that
+        stack[insert].pos = stack[insert + 1].pos
+        for x in (insert + 1) ..< stack.len:
+          inc stack[x].pos
+
+    of stkStructStart:
+      stack.add (i, order[it.label.int])
+    of stkFinally, stkCatch:
+      # keep the 'try'-opening on the stack
+      assert stack[^1].order == order[it.label.int]
+    of stkEnd:
+      # if the pre-conditions hold, the end corresponds to opening at the stack
+      # head -- pop the block
+      let e = stack.pop()
+      assert e.order == order[it.label.int]
+    of stkTerminator, stkReturn:
+      discard
+
+    assert invariant()
+    # we're always making progress, the loop is guaranteed to terminate
+    inc i
+
 proc toStructureList*(stmts: openArray[CgNode]): StructDesc =
   ## Creates and returns the JavaScript control-flow-construct-focused
   ## representation for `stmts`.
@@ -226,66 +312,9 @@ proc toStructureList*(stmts: openArray[CgNode]): StructDesc =
     else:
       discard "not relevant"
 
-  # the list of openings and closing produced by the first pass will in most
-  # cases not be valid JavaScript code. We have to "solve" the representation
-  # by reordering the openings until they're matched with their corresponding
-  # end. ``stkCatch``, ``stkFinally``, ``stkStructStart``, and ``stkEnd`` must
-  # keep their relative order and stay attached to the same statements, only
-  # ``stkTry`` and ``stkBlock`` can be moved, but only backwards
-  var i = structs.high
-  while i > 0:
-    if structs[i].kind in {stkTry, stkBlock}:
-      # compute the difference in nesting between the try/block and its
-      # corresponding end:
-      var
-        depth = 1
-        j = i
-      while true:
-        inc j
-        case structs[j].kind
-        of stkTry, stkBlock, stkStructStart:
-          inc depth
-        of stkFinally, stkCatch:
-          if structs[j].label == structs[i].label:
-            dec depth
-            break
-        of stkEnd:
-          dec depth
-          if structs[j].label == structs[i].label:
-            break
-        of Terminators:
-          discard "not relevant"
-
-      # depth < 0 means that the try/block start is more nested than its end.
-      # In other words, the try or block start is currently too nested. Move
-      # it backwards (i.e., associate it with an earlier statement) until it's
-      # at the same level as its end
-      let moved = depth < 0
-      var x = i
-      while depth < 0:
-        # change the associated statement...
-        structs[x].stmt = structs[x - 1].stmt
-        # ... then swap
-        swap(structs[x], structs[x - 1])
-
-        case structs[x].kind
-        of stkEnd:
-          dec depth
-        of stkBlock, stkTry, stkStructStart:
-          inc depth
-        of Terminators, stkCatch, stkFinally:
-          # catch and finally don't change the nesting (the try's body is at
-          # the same level as catch/finally's body)
-          discard
-
-        dec x
-
-      if moved:
-        # a different item than before is in the slot now; it needs to be
-        # processed too
-        continue # skip the following decrement
-
-    dec i
+  # now make sure that all openings in the list are matched with their
+  # respective end
+  sort(structs)
 
   # note: changing what statements a 'try' encloses can alter semantics! That's
   # none of our concern here, however: the code generator is reponsible for


### PR DESCRIPTION
## Summary

Replace an algorithm - used by the JavaScript code generator -
potentially taking an exponential amount of time with one taking
linear time. In some edge cases, the previous algorithm was so slow
that the compiler would effectively get stuck.

## Details

`jsflow` is responsible for translating the goto-based control-flow of
the CGIR into JavaScript control-flow (`break`, `try`, etc.). This
requires reordering the initial list of block starts (openings) and
ends such that all openings are paired with their corresponding end.

### Previous Algorithm

The algorithm used for reordering the list works by:
1. start with the last slot in the list
2. shift the block/try opening in the slot backwards (towards the
   start) until it is on the same nesting depth as its corresponding
   end
3. repeat 2 until a fixpoint is reached (the item in the slot no longer
   requires shifting)
4. repeat the previous two steps with the previous slot

Consider the following (where `n` is a value >= 2):
```
block { // 0
  block { // n
    ... // (n - 2) .. 1
    block { // n - 1
    } // 0
  } // 1
  ...
} // n
```

In the situation show above, reaching a fixpoint for the slot
originally containing the `n - 1` block requires `3 * (2 ^ (n - 2))`
iterations/shifts (exponential time).

For large `n` (> 30), the time spent on sorting grew so large that the
compiler would appear to be effectively stuck.

### New Algorithm

The new algorithm requires `n` number of shifts in the worst-case,
where `n` is the number of labels in the input CGIR.

It works by first computing an order value for every label, based on
the position of the label. The relevant openings (block and try) are
then reordered such that they're only enclosed by openings with a
higher order value.