### PR TITLE
fix(js): compiler crash with globals

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1457,8 +1457,6 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
       result = "new $1($2)" % [rope(jsTyp), rope(length)]
     elif length > 32:
       useMagic(p, "arrayConstr")
-      # XXX: arrayConstr depends on nimCopy. This line shouldn't be necessary.
-      useMagic(p, "nimCopy")
       result = "arrayConstr($1, $2, $3)" % [rope(length),
           createVar(p, e, false), genTypeInfo(p, e)]
     else:

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -696,7 +696,7 @@ proc arrayConstr(len: int, value: JSRef, typ: PNimType): JSRef {.
   # types are fake
   asm """
     var result = new Array(`len`);
-    for (var i = 0; i < `len`; ++i) result[i] = nimCopy(null, `value`, `typ`);
+    for (var i = 0; i < `len`; ++i) result[i] = `nimCopy`(null, `value`, `typ`);
     return result;
   """
 

--- a/tests/js/tlarge_array_crash.nim
+++ b/tests/js/tlarge_array_crash.nim
@@ -1,0 +1,9 @@
+discard """
+  description: '''
+    Regression test for a compiler crash caused by the JavaScript code
+    generator
+  '''
+"""
+
+# every array length > 32 caused the crash
+var global: array[33, (int, int)]


### PR DESCRIPTION
## Summary

Fix a compiler crash that happened when having globals with type
`array[N, T]`, where `N` is greater than 32 and `T` is a non-primitive
type. Only the JavaScript backend was affected.

## Details

Defer adding the `arrayConstr` compilerproc to the MIR environment if
not within a proper procedure context. This prevents modifications of
the MIR environment from within `defineGlobal` (which calls
`createVar`), which is what caused the assertion in `backends.flush` to
fail.

Registration is deferred until the procedure is code generated, which
works due to discovery of a global currently being guaranteed to
precede code generation of some procedure.