### PR TITLE
fix(sem): crash with `void` fields in instantiated tuple types

### DIFF
--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -658,24 +658,31 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
           attachedAsgn, col)
       excl mm.flags, tfFromGeneric
 
-proc eraseVoidParams*(t: PType) =
-  # transform '(): void' into '()' because old parts of the compiler really
-  # don't deal with '(): void':
-  if t[0] != nil and t[0].kind == tyVoid:
-    t[0] = nil
-
-  for i in 1..<t.len:
+proc eraseVoidTypes(t: PType; start = 0) =
+  ## Removes all ``tyVoid`` items from `t`. If `t` has attached AST, the slots
+  ## corresponding to the type items are removed too.
+  for i in start..<t.len:
     # don't touch any memory unless necessary
     if t[i].kind == tyVoid:
       var pos = i
       for j in i+1..<t.len:
         if t[j].kind != tyVoid:
           t[pos] = t[j]
-          t.n[pos] = t.n[j]
+          if t.n != nil:
+            t.n[pos] = t.n[j]
           inc pos
       setLen t.sons, pos
-      setLen t.n.sons, pos
+      if t.n != nil:
+        setLen t.n.sons, pos
       break
+
+proc eraseVoidParams*(t: PType) =
+  # transform '(): void' into '()' because old parts of the compiler really
+  # don't deal with '(): void':
+  if t[0] != nil and t[0].kind == tyVoid:
+    t[0] = nil
+
+  eraseVoidTypes(t, start=1)
 
 proc skipIntLiteralParams*(t: PType; idgen: IdGenerator) =
   for i in 0..<t.len:
@@ -690,20 +697,6 @@ proc skipIntLiteralParams*(t: PType; idgen: IdGenerator) =
   # param, the results gets infected with static as well:
   if t[0] != nil and t[0].kind == tyStatic:
     t[0] = t[0].base
-
-proc propagateFieldFlags(t: PType, n: PNode) =
-  # This is meant for objects and tuples
-  # The type must be fully instantiated!
-  if n.isNil:
-    return
-  #internalAssert n.kind != nkRecWhen
-  case n.kind
-  of nkSym:
-    propagateToOwner(t, n.sym.typ)
-  of nkRecList, nkRecCase, nkOfBranch, nkElse:
-    for son in n:
-      propagateFieldFlags(t, son)
-  else: discard
 
 proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
   template bailout =
@@ -800,21 +793,38 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
           result[i] = r
           if result.kind != tyArray or i != 0:
             propagateToOwner(result, r)
-      # bug #4677: Do not instantiate effect lists
-      result.n = replaceTypeVarsN(cl, result.n, ord(result.kind==tyProc))
       case result.kind
       of tyArray:
         let idx = result[0]
         internalAssert(cl.c.config, idx.kind != tyStatic, "[FIXME]")
 
       of tyTuple:
-        propagateFieldFlags(result, result.n)
+        if result.n != nil:
+          # update the record description
+          result.n = shallowCopy(t.n)
+          var pos = 0
+          for i, it in t.n.pairs:
+            # don't copy void fields, they're removed afterwards
+            if result[i].kind != tyVoid:
+              # always copy the symbol to make sure we can modify it
+              let s = copySym(it.sym, nextSymId cl.c.idgen)
+              s.typ = result[i]
+              incl(s.flags, sfFromGeneric)
+              s.position = pos
+              inc pos
+              result.n[i] = newSymNode(s, it.info)
+
+        # now erase the void types, which will also eliminate the empty slots
+        eraseVoidTypes(result)
 
       of tyProc:
+        # bug #4677: Do not instantiate effect lists
+        result.n = replaceTypeVarsN(cl, result.n, 1)
         eraseVoidParams(result)
         skipIntLiteralParams(result, cl.c.idgen)
 
       of tyRange:
+        result.n = replaceTypeVarsN(cl, result.n, 0)
         result[0] = result[0].skipTypes({tyStatic, tyDistinct})
 
       else: discard

--- a/tests/lang_callable/generics/tgeneric_tuple_with_void_param.nim
+++ b/tests/lang_callable/generics/tgeneric_tuple_with_void_param.nim
@@ -1,0 +1,67 @@
+discard """
+  description: '''
+    Ensure that fields whose type is substituted with `void` are properly
+    removed from tuple types during instantiation
+  '''
+"""
+
+type
+  Anon[A, B, C] = (A, B, C)
+  Named[A, B, C] = tuple[a: A, b: B, c: C]
+
+block trailing_field_is_void:
+  var x: Anon[int, string, void]
+  doAssert x is (int, string)
+  doAssert sizeof(x) == sizeof((int, string))
+  doAssert not compiles(x[2])
+  # make sure the fields are accessible:
+  x[0] = 1
+  x[1] = ""
+
+  # with generic named tuple:
+  var y: Named[int, string, void]
+  doAssert y is tuple[a: int, b: string]
+  doAssert sizeof(y) == sizeof((int, string))
+  doAssert not compiles(y.c)
+  # make sure the fields are accessible:
+  y.a = 1
+  y.b = ""
+
+block middle_field_is_void:
+  var x: Anon[int, void, string]
+  doAssert x is (int, string)
+  doAssert sizeof(x) == sizeof((int, string))
+  doAssert not compiles(x[2])
+  # make sure the fields are accessible:
+  x[0] = 1
+  x[1] = ""
+
+  # with generic named tuple:
+  var y: Named[int, void, string]
+  doAssert y is tuple[a: int, c: string]
+  doAssert sizeof(y) == sizeof((int, string))
+  doAssert not compiles(y.b)
+  y.a = 1
+  y.c = ""
+
+block all_fields_are_void:
+  var x: Anon[void, void, void]
+  doAssert sizeof(x) == 1
+  doAssert not compiles(x[0])
+
+  var y: Named[void, void, void]
+  doAssert sizeof(y) == 1
+  doAssert not compiles(y.a)
+
+block non_generic_field:
+  type Tup[T] = tuple[a: T, b: int]
+
+  # instantiate the type with a non-void parameter first
+  var x: Tup[string]
+  x.a = ""
+  x.b = 0
+
+  # instantiating the type with a void parameter must not affect previous
+  # instantiations (code generation would fail if it does)
+  var y: Tup[void]
+  y.b = 0


### PR DESCRIPTION
## Summary

Handle removal of `void` fields from tuple types properly when
instantiating generic types, fixing various compiler crashes.

Fixes https://github.com/nim-works/nimskull/issues/1316.

## Details

The problem was that `void` fields weren't removed from the type, like
what happens for `tyObject` and `tyProc` types. Therefore:
* `tyVoid` types unexpectedly reached the code generators as part of
  records
* `computeSizeAlign` crashed because it expects the `nkRecList` of a
  `tyTuple` to only contain `nkSym` nodes, but `replaceTypeVarsN`
  replaced the `nkSym` node for `void` fields with empty `nkRecList`
  nodes earlier

In order to remove the `void` fields properly:
* custom logic is used for the tuple's record AST, which - compared to
  `replaceTypeVarsN` - also updates the fields' position
* the type and record slots of void are removed with a generalized
  version of `eraseVoidParams` (`eraseVoidTypes`)

Finally, the `propagateFieldFlags` call for tuple types is removed. It
is redundant,  since the type flags are already propagated when the
type variables are replaced.