### PR TITLE
cgen: better code-gen for `seq.len`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1118,21 +1118,12 @@ proc genArrayLen(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   of tyCstring:
     if op == mHigh: unaryExpr(p, e, d, "($1 ? (#nimCStrLen($1)-1) : -1)")
     else: unaryExpr(p, e, d, "($1 ? #nimCStrLen($1) : 0)")
-  of tyString:
+  of tyString, tySequence:
     var a: TLoc
     initLocExpr(p, e[1], a)
     var x = lenExpr(p, a)
     if op == mHigh: x = "($1-1)" % [x]
     putIntoDest(p, d, e, x)
-  of tySequence:
-    # we go through a temporary here because people write bullshit code.
-    var a, tmp: TLoc
-    initLocExpr(p, e[1], a)
-    getIntTemp(p, tmp)
-    var x = lenExpr(p, a)
-    if op == mHigh: x = "($1-1)" % [x]
-    lineCg(p, cpsStmts, "$1 = $2;$n", [tmp.r, x])
-    putIntoDest(p, d, e, tmp.r)
   of tyArray:
     # YYY: length(sideeffect) is optimized away incorrectly?
     if op == mHigh: putIntoDest(p, d, e, rope(lastOrd(p.config, typ)))

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -484,15 +484,6 @@ proc getTemp(p: BProc, t: PType, result: var TLoc) =
         echo "ENORMOUS TEMPORARY! ", p.config $ p.lastLineInfo
       writeStackTrace()
 
-proc getIntTemp(p: BProc, result: var TLoc) =
-  inc(p.labels)
-  result.r = "T" & rope(p.labels) & "_"
-  linefmt(p, cpsLocals, "NI $1;$n", [result.r])
-  result.k = locTemp
-  result.storage = OnStack
-  result.lode = lodeTyp getSysType(p.module.g.graph, unknownLineInfo, tyInt)
-  result.flags = {}
-
 proc localVarDecl(p: BProc; n: CgNode, decl: Local): Rope =
   let loc = initLoc(locLocalVar, n, mangleLocalName(p, decl.name, n.local),
                     OnStack)


### PR DESCRIPTION
## Summary

Don't store the result of a `seq.len` in an additional temporary. An
optimizing C compiler can easily eliminate such temporaries, but doing
it on the NimSkull side reduces the amount of work for the C compiler.

## Details

* the temporary is a leftover from when argument expression purity
  wasn't guaranteed
* the `cgen.getIntTemp` procedure is now obsolete and thus removed