### PR TITLE
lower float overflow checks with MIR pass

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1386,20 +1386,6 @@ proc genStrEquals(p: BProc, e: CgNode, d: var TLoc) =
   else:
     binaryExpr(p, e, d, "#eqStrings($1, $2)")
 
-proc binaryFloatArith(p: BProc, e: CgNode, d: var TLoc, m: TMagic) =
-  if true:
-    const opr: array[mAddF64..mDivF64, string] = ["+", "-", "*", "/"]
-    var a, b: TLoc
-    assert(e[1].typ != nil)
-    assert(e[2].typ != nil)
-    initLocExpr(p, e[1], a)
-    initLocExpr(p, e[2], b)
-    putIntoDest(p, d, e, ropecg(p.module, "(($4)($2) $1 ($4)($3))",
-                              [opr[m], rdLoc(a), rdLoc(b),
-                              getSimpleTypeDesc(p.module, e[1].typ)]))
-    linefmt(p, cpsStmts, "if ($1 != 0.0 && $1*0.5 == $1) { #raiseFloatOverflow($1); $2}$n",
-            [rdLoc(d), raiseInstr(p, e.exit)])
-
 proc skipAddr(n: CgNode): CgNode =
   if n.kind == cnkHiddenAddr: n.operand
   else:                       n
@@ -1461,7 +1447,6 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   case op
   of mNot..mUnaryPlusF64: unaryArith(p, e, e[1], d, op)
   of mUnaryMinusI, mUnaryMinusI64: unaryArithOverflow(p, e, d, op)
-  of mAddF64..mDivF64: binaryFloatArith(p, e, d, op)
   of mShrI..mXor: binaryArith(p, e, e[1], e[2], d, op)
   of mEqProc: genEqProc(p, e, d)
   of mAddI..mPred: binaryArithOverflow(p, e, d, op)


### PR DESCRIPTION
## Summary

Lower checked float arithmetic operations with an MIR pass, instead
of as part of C code generation. This is a pure refactoring, with the
goal of shrinking down the C code generator.

## Details

* the checked float arithmetic operations are turned into an unchecked
  operation + infinity check (replicating what `cgen` did)
* the lowering in `cgen` for float arithmetic is removed