### PR TITLE
improve code generation for `@[...]`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -991,13 +991,6 @@ proc genSeqConstr(p: BProc, n: CgNode, d: var TLoc) =
 
 proc genArrToSeq(p: BProc, n: CgNode, d: var TLoc) =
   var elem, a, arr: TLoc
-  if n[1].kind == cnkArrayConstr:
-    # XXX: dead code, but kept as a reminder
-    n[1].typ = n.typ
-    genSeqConstr(p, n[1], d)
-    return
-  if d.k == locNone:
-    getTemp(p, n.typ, d)
   # generate call to newSeq before adding the elements per hand:
   let L = toInt(lengthOrd(p.config, n[1].typ))
   block:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1829,14 +1829,9 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
   of mNew: genNew(p, n, r)
   of mChr: gen(p, n[1], r)
   of mArrToSeq:
-    # only array literals doesn't need copy
-    if n[1].kind == cnkArrayConstr:
-      genJSArrayConstr(p, n[1], r)
-    else:
-      var x: TCompRes
-      gen(p, n[1], x)
-      useMagic(p, "nimCopy")
-      r.res = "nimCopy(null, $1, $2)" % [x.rdLoc, genTypeInfo(p, n.typ)]
+    # the argument is guaranteed to be moveable, it can simply be assigned to
+    # the destination
+    gen(p, n[1], r)
   of mDestroy, mTrace: discard "ignore calls to the default destructor"
   of mOrd: genOrd(p, n, r)
   of mLengthStr, mLengthSeq, mLengthOpenArray, mLengthArray:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1000,6 +1000,14 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
         arg = arg[^1]
 
       c.emitOperandTree arg, sink=false
+  of mArrToSeq:
+    if n[1].kind == nkBracket:
+      # optimization: translate ``@[...]`` to a sequence construction
+      c.buildTree mnkSeqConstr, rtyp:
+        for it in n[1].items:
+          c.emitOperandTree it, sink=true
+    else:
+      genCall(c, n)
 
   # arithmetic operations:
   of mAddI, mSubI, mMulI, mDivI, mModI, mPred, mSucc:

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -48,20 +48,19 @@ scope:
 --expandArc: p1
 
 scope:
-  def _2: array[0..0, int] = [consume 123]
-  def lresult: seq[int] = arrToSeq(consume _2)
+  def lresult: seq[int] = @[consume 123]
   def lvalue: seq[int]
   def lnext: string
-  def _6: seq[int] = move lresult
-  def _: (seq[int], string) = (consume _6, consume ";")
-  bind_mut _8: seq[int] = _.0
-  lvalue := move _8
+  def _5: seq[int] = move lresult
+  def _: (seq[int], string) = (consume _5, consume ";")
+  bind_mut _7: seq[int] = _.0
+  lvalue := move _7
+  wasMoved(name _7)
+  bind_mut _8: string = _.1
+  lnext := move _8
   wasMoved(name _8)
-  bind_mut _9: string = _.1
-  lnext := move _9
-  wasMoved(name _9)
-  def _7: seq[int] = move(name lvalue)
-  result.value := move _7
+  def _6: seq[int] = move(name lvalue)
+  result.value := move _6
   =destroy(name _)
   =destroy(name lnext)
   =destroy(name lvalue)


### PR DESCRIPTION
## Summary

Don't use an intermediate temporary for the array construction but
instead move the items into the constructed seq directly. All backends
are affected.

## Details

`mirgen` now translates a `@[...]` expression into a `mnkSeqConstr`
tree rather than:
```
def _1 = [...] # array construction
def _2 = arrToSeq(consume _1)
```
This gets rid of the unnecessary temporary and shallow array copy.

Handling of `mArrToSeq` in the code generators is also improved /
cleaned up:
* the handling of `cnkArrayConstr` operands is removed (it's a leftover
  from before the MIR rework)
* `jsgen`: the operand to `mArrToSeq` call is guaranteed to be owned,
  so no extra copy is required
* `cgen`: the `TLoc` passed to `genArrToSeq` is always a non-empty
  loc, so the `if d.k == locNone` check is unnecessary and thus removed