### PR TITLE
lower `mChckIndex` with MIR pass

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -620,38 +620,6 @@ proc genBoundsCheck(p: BProc; arr, a, b: TLoc, exit: CgNode) =
   else:
     unreachable(ty.kind)
 
-proc genIndexCheck(p: BProc; x: CgNode, arr, idx: TLoc, exit: CgNode) =
-  ## Emits the index check logic + subsequent raise operation. `x` is
-  ## the array expression the `arr` loc resulted from from.
-  let ty = arr.t.skipTypes(abstractVar + tyUserTypeClasses +
-                           {tyPtr, tyRef, tyLent, tyVar})
-  case ty.kind
-  of tyArray:
-    var first = intLiteral(firstOrd(p.config, ty))
-    if firstOrd(p.config, ty) == 0 and lastOrd(p.config, ty) >= 0:
-      linefmt(p, cpsStmts, "if ((NU)($1) > (NU)($2)){ #raiseIndexError2($1, $2); $3}$n",
-              [rdCharLoc(idx), intLiteral(lastOrd(p.config, ty)),
-               raiseInstr(p, exit)])
-    else:
-      linefmt(p, cpsStmts, "if ($1 < $2 || $1 > $3){ #raiseIndexError3($1, $2, $3); $4}$n",
-              [rdCharLoc(idx), first, intLiteral(lastOrd(p.config, ty)),
-               raiseInstr(p, exit)])
-  of tySequence, tyString:
-    linefmt(p, cpsStmts,
-            "if ((NU)($1) >= (NU)$2){ #raiseIndexError2($1,$2-1); $3}$n",
-            [rdCharLoc(idx), lenExpr(p, arr), raiseInstr(p, exit)])
-  of tyOpenArray, tyVarargs:
-    if reifiedOpenArray(p, x):
-      linefmt(p, cpsStmts, "if ((NU)($1) >= (NU)($2.Field1)){ #raiseIndexError2($1,$2.Field1-1); $3}$n",
-              [rdCharLoc(idx), rdLoc(arr), raiseInstr(p, exit)])
-    else:
-      linefmt(p, cpsStmts, "if ((NU)($1) >= (NU)($2Len_0)){ #raiseIndexError2($1,$2Len_0-1); $3}$n",
-              [rdCharLoc(idx), rdLoc(arr), raiseInstr(p, exit)])
-  of tyCstring:
-    discard "no bound checks"
-  else:
-    unreachable()
-
 proc genOpenArrayElem(p: BProc, n, x, y: CgNode, d: var TLoc) =
   var a, b: TLoc
   initLocExpr(p, x, a)
@@ -1536,11 +1504,6 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
       typ.add "*"
 
     linefmt(p, cpsStmts, "$1 = ($2)($3);$n", [a.r, typ, rdLoc(b)])
-  of mChckIndex:
-    var arr, a: TLoc
-    initLocExpr(p, e[1], arr)
-    initLocExpr(p, e[2], a)
-    genIndexCheck(p, e[1], arr, a, e.exit)
   of mChckBounds:
     var arr, a, b: TLoc
     initLocExpr(p, e[1], arr)

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -41,6 +41,8 @@ type
     types: Store[TypeId, PType]
     sizeType: TypeId
       ## the target-dependent integer type to use for size values
+    usizeType: TypeId
+      ## the target-dependent unsigned integer type to use for size values
 
 const
   VoidType*    = TypeId 0
@@ -64,7 +66,8 @@ proc initTypeEnv*(graph: ModuleGraph): TypeEnv =
   ## Returns a fully initialized type environment instance.
   result = TypeEnv(map: default(TypeTable[TypeId]),
                    types: default(Store[TypeId, PType]),
-                   sizeType: VoidType)
+                   sizeType: VoidType,
+                   usizeType: VoidType)
 
   template add(kind: TTypeKind, expect: TypeId) =
     let
@@ -96,10 +99,10 @@ proc initTypeEnv*(graph: ModuleGraph): TypeEnv =
   add(tyInt,   TypeId(ord(PointerType) + 1))
   add(tyFloat, TypeId(ord(PointerType) + 2))
 
-  result.sizeType =
+  (result.sizeType, result.usizeType) =
     case graph.config.target.intSize
-    of 1, 2, 4: Int32Type
-    of 8:       Int64Type
+    of 1, 2, 4: (Int32Type, UInt32Type)
+    of 8:       (Int64Type, UInt64Type)
     else:       unreachable()
 
 proc add*(env: var TypeEnv, t: PType): TypeId =
@@ -116,3 +119,8 @@ func sizeType*(env: TypeEnv): TypeId {.inline.} =
   ## Returns the type to use for values representing some size. This is a
   ## signed integer type of target-dependent bit-width.
   env.sizeType
+
+func usizeType*(env: TypeEnv): TypeId {.inline.} =
+  ## Returns the type to use for values representing some size. This is an
+  ## unsigned integer type of target-dependent bit-width.
+  env.usizeType

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -381,7 +381,7 @@ func computeDfg*(tree: MirTree): DataFlowGraph =
       # patch the join-to-instruction mapping:
       env.joins[id] = env.instrs.high.InstrPos
     else:
-      unreachable("unused join point")
+      discard "label is not used, ignore"
 
   template goto(pos: NodePosition, label: LabelId) =
     env.instrs.add Instr(op: opGoto, node: pos, dest: map(env, label))

--- a/tests/lang_types/array/tout_of_range_index_check.nim
+++ b/tests/lang_types/array/tout_of_range_index_check.nim
@@ -1,0 +1,29 @@
+discard """
+  description: '''
+    Ensure that accessing an array works when the index operand's type cannot
+    be safely converted to the array's index type
+  '''
+  knownIssue.c: '''
+    The boundary checks are implemented improperly, leading to the array
+    appearing to effectively be empty
+  '''
+  knownIssue.vm: '''
+    Arrays with a start index outside of -128..127 crash the code generator
+  '''
+"""
+
+proc test1(index: int): int =
+  # try with an index range that overlaps with the `int` range
+  var arr: array[uint(high(int))..(uint(high(int)) + 2), int] = [1, 2, 3]
+  # not all valid array indices can be represented by `int`
+  result = arr[index]
+
+# the index is valid, no index error must be raised
+doAssert test1(high(int)) == 1
+
+proc test2(index: uint): int =
+  var arr: array[-1..1, int] = [1, 2, 3]
+  # not all valid array indices can be represented by `uint`
+  result = arr[index]
+
+doAssert test2(1) == 3


### PR DESCRIPTION
## Summary

Lower `mChckIndex` magic calls with an MIR pass, instead of as part of
C code generation. This is a pure refactoring, with the goal of
shrinking down the C code generator.

## Details

The lowering is integrated into `rtchecks`, and is a MIR port of the
lowering previously performed by `cgen.genIndexCheck` (which is now
removed), including two pre-existing bugs. The two bugs are documented
in the code, and a test (`tout_of_range_index_check.nim`) is added for
one them.

The lowering needs to query the unsigned version of the "size type", so
the `usizeType` query is added for `TypeEnv`.

Finally, a leftover `unreachable` debug statement that triggers on
unused labels is removed from `mirexec`: it would trigger when an index
check on a `cstring` (which gets eliminated by the lowering) is the
only jump-source for a label.