### PR TITLE
lower integer overflow checks with MIR pass

### DIFF
--- a/compiler/mir/rtchecks.nim
+++ b/compiler/mir/rtchecks.nim
@@ -412,8 +412,9 @@ const ArithChcks: array[mAddI..mModI, array[tyInt..tyInt64, string]] = block:
 
     # the inner array stores the per-width names, which is the base name
     # suffixed with the width
-    for i in 0..3:
-      it[[tyInt8, tyInt16, tyInt32, tyInt64][i]] = base & $(8 shl i)
+    const intKinds = [tyInt8, tyInt16, tyInt32, tyInt64]
+    for i, k in intKinds.pairs:
+      it[k] = base & $(8 shl i)
 
     # for the moment, there's still a generic-width version
     it[tyInt] = base

--- a/compiler/mir/rtchecks.nim
+++ b/compiler/mir/rtchecks.nim
@@ -456,7 +456,7 @@ proc emitCheckedBinaryIntOp(tree; call; graph; env; bu): Value =
   let kind = t.skipTypes({tyEnum}).kind
   if kind in {tyUInt..tyUInt64, tyBool}:
     # enums using an unsigned integer as the underlying type can reach here
-    # (due to lowering ``succ`` and ``pred`` lowering), and no integer overflow
+    # (due to ``succ`` and ``pred`` lowering), and no integer overflow
     # check is performed for them -- the same goes for the bool typ
     # XXX: no checked operation should be emitted for bool and unsigned enum
     #      types in the first place
@@ -507,7 +507,7 @@ proc emitCheckedBinaryIntOp(tree; call; graph; env; bu): Value =
         discard
 
 proc emitUnaryOverflowCheck(tree; call; graph; env; bu) =
-  ## Emits the overflow check for a integer negation operation:
+  ## Emits the overflow check for an integer negation operation:
   ##   if x == low(x):
   ##     raiseOverflow()
   let

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -568,26 +568,34 @@ NIM_STATIC_ASSERT(sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(NI)*8, ""
 
 /* these exist to make the codegen logic simpler */
 #define nimModInt(a, b, res) (((*res) = (a) % (b)), 0)
+#define nimModInt8(a, b, res) (((*res) = (a) % (b)), 0)
+#define nimModInt16(a, b, res) (((*res) = (a) % (b)), 0)
+#define nimModInt32(a, b, res) (((*res) = (a) % (b)), 0)
 #define nimModInt64(a, b, res) (((*res) = (a) % (b)), 0)
 
 #if (!defined(_MSC_VER) || defined(__clang__)) && !defined(NIM_EmulateOverflowChecks)
   /* these exist because we cannot have .compilerProcs that are importc'ed
     by a different name */
 
-  #define nimAddInt64(a, b, res) __builtin_saddll_overflow(a, b, (long long int*)res)
-  #define nimSubInt64(a, b, res) __builtin_ssubll_overflow(a, b, (long long int*)res)
-  #define nimMulInt64(a, b, res) __builtin_smulll_overflow(a, b, (long long int*)res)
+  #define nimAddInt8(a, b, res) __builtin_add_overflow(a, b, res)
+  #define nimSubInt8(a, b, res) __builtin_sub_overflow(a, b, res)
+  #define nimMulInt8(a, b, res) __builtin_mul_overflow(a, b, res)
 
-  #if NIM_INTBITS == 32
-    #define nimAddInt(a, b, res) __builtin_sadd_overflow(a, b, res)
-    #define nimSubInt(a, b, res) __builtin_ssub_overflow(a, b, res)
-    #define nimMulInt(a, b, res) __builtin_smul_overflow(a, b, res)
-  #else
-    /* map it to the 'long long' variant */
-    #define nimAddInt(a, b, res) __builtin_saddll_overflow(a, b, (long long int*)res)
-    #define nimSubInt(a, b, res) __builtin_ssubll_overflow(a, b, (long long int*)res)
-    #define nimMulInt(a, b, res) __builtin_smulll_overflow(a, b, (long long int*)res)
-  #endif
+  #define nimAddInt16(a, b, res) __builtin_add_overflow(a, b, res)
+  #define nimSubInt16(a, b, res) __builtin_sub_overflow(a, b, res)
+  #define nimMulInt16(a, b, res) __builtin_mul_overflow(a, b, res)
+
+  #define nimAddInt32(a, b, res) __builtin_add_overflow(a, b, res)
+  #define nimSubInt32(a, b, res) __builtin_sub_overflow(a, b, res)
+  #define nimMulInt32(a, b, res) __builtin_mul_overflow(a, b, res)
+
+  #define nimAddInt64(a, b, res) __builtin_add_overflow(a, b, res)
+  #define nimSubInt64(a, b, res) __builtin_sub_overflow(a, b, res)
+  #define nimMulInt64(a, b, res) __builtin_mul_overflow(a, b, res)
+
+  #define nimAddInt(a, b, res) __builtin_add_overflow(a, b, res)
+  #define nimSubInt(a, b, res) __builtin_sub_overflow(a, b, res)
+  #define nimMulInt(a, b, res) __builtin_mul_overflow(a, b, res)
 #endif
 
 #define NIM_NOALIAS __restrict

--- a/lib/system/integerops.nim
+++ b/lib/system/integerops.nim
@@ -26,6 +26,18 @@ when not defined(nimEmulateOverflowChecks):
   proc nimSubInt(a, b: int, res: ptr int): bool {.nimbaseH.}
   proc nimMulInt(a, b: int, res: ptr int): bool {.nimbaseH.}
 
+  proc nimAddInt8(a, b: int8, res: ptr int8): bool {.nimbaseH.}
+  proc nimSubInt8(a, b: int8, res: ptr int8): bool {.nimbaseH.}
+  proc nimMulInt8(a, b: int8, res: ptr int8): bool {.nimbaseH.}
+
+  proc nimAddInt16(a, b: int16, res: ptr int16): bool {.nimbaseH.}
+  proc nimSubInt16(a, b: int16, res: ptr int16): bool {.nimbaseH.}
+  proc nimMulInt16(a, b: int16, res: ptr int16): bool {.nimbaseH.}
+
+  proc nimAddInt32(a, b: int32, res: ptr int32): bool {.nimbaseH.}
+  proc nimSubInt32(a, b: int32, res: ptr int32): bool {.nimbaseH.}
+  proc nimMulInt32(a, b: int32, res: ptr int32): bool {.nimbaseH.}
+
   proc nimAddInt64(a, b: int64; res: ptr int64): bool {.nimbaseH.}
   proc nimSubInt64(a, b: int64; res: ptr int64): bool {.nimbaseH.}
   proc nimMulInt64(a, b: int64; res: ptr int64): bool {.nimbaseH.}
@@ -36,6 +48,9 @@ when not defined(nimEmulateOverflowChecks):
 # check for 0 to the codgen.
 proc nimModInt(a, b: int; res: ptr int): bool {.nimbaseH.}
 
+proc nimModInt8(a, b: int8; res: ptr int8): bool {.nimbaseH.}
+proc nimModInt16(a, b: int16; res: ptr int16): bool {.nimbaseH.}
+proc nimModInt32(a, b: int32; res: ptr int32): bool {.nimbaseH.}
 proc nimModInt64(a, b: int64; res: ptr int64): bool {.nimbaseH.}
 
 # Platform independent versions.
@@ -50,6 +65,9 @@ template addImplFallback(name, T, U) {.dirty.} =
         result = true
 
 addImplFallback(nimAddInt, int, uint)
+addImplFallback(nimAddInt8, int8, uint8)
+addImplFallback(nimAddInt16, int16, uint16)
+addImplFallback(nimAddInt32, int32, uint32)
 addImplFallback(nimAddInt64, int64, uint64)
 
 template subImplFallback(name, T, U) {.dirty.} =
@@ -62,6 +80,9 @@ template subImplFallback(name, T, U) {.dirty.} =
         result = true
 
 subImplFallback(nimSubInt, int, uint)
+subImplFallback(nimSubInt8, int8, uint8)
+subImplFallback(nimSubInt16, int16, uint16)
+subImplFallback(nimSubInt32, int32, uint32)
 subImplFallback(nimSubInt64, int64, uint64)
 
 template mulImplFallback(name, T, U, conv) {.dirty.} =
@@ -108,6 +129,9 @@ template mulImplFallback(name, T, U, conv) {.dirty.} =
           result = true
 
 mulImplFallback(nimMulInt, int, uint, toFloat)
+mulImplFallback(nimMulInt8, int8, uint8, toFloat)
+mulImplFallback(nimMulInt16, int16, uint16, toFloat)
+mulImplFallback(nimMulInt32, int32, uint32, toFloat)
 mulImplFallback(nimMulInt64, int64, uint64, toBiggestFloat)
 
 
@@ -120,6 +144,9 @@ template divImplFallback(name, T) {.dirty.} =
       res[] = a div b
 
 divImplFallback(nimDivInt, int)
+divImplFallback(nimDivInt8, int8)
+divImplFallback(nimDivInt16, int16)
+divImplFallback(nimDivInt32, int32)
 divImplFallback(nimDivInt64, int64)
 
 proc raiseFloatInvalidOp {.errorPrc.} =


### PR DESCRIPTION
## Summary

Lower the integer overflow checks with an MIR pass, instead of as part
of C code generation. This is mainly a refactoring, with the goal of
shrinking down the C code generator. As a side-effect, overflow checks
are very slightly faster.

## Details

The MIR produced by the lowering is similar to what the C code
generator previously output, but with one major difference: integer
operands smaller than the target's integer size now use dedicated
compilerprocs instead of first converting to `int`, performing the
checked arithmetic, and then comparing against the integer bounds.

The main reason for this change is that it makes the lowering pass
simpler and requires less MIR code, but it also has the benefit of
producing more efficient code. Run-time behaviour is not affected.

No dedicated gcc built-ins for overflow-checked arithmetic with
`short int` (int16) and `signed char` (int8) exists, so all checked
arithmetic compilerprocs now map to the generic gcc built-ins.