### PR TITLE
fix `result` not being cleaned up when procedure raises

### DIFF
--- a/compiler/mir/mirgen_blocks.nim
+++ b/compiler/mir/mirgen_blocks.nim
@@ -45,6 +45,8 @@ type
     of bkTryFinally:
       doesntExit*: bool
         ## whether structured control-flow doesn't reach the end of the finally
+      errorOnly*: bool
+        ## whether only exceptional control-flow is intercepted
       exits*: seq[LabelId]
         ## unordered set of follow-up targets
     of bkTryExcept, bkFinally, bkExcept:
@@ -129,6 +131,11 @@ proc blockLeaveActions(c; bu; targetBlock: int): bool =
 
         last -= b.numRegistered
     of bkTryFinally:
+      if c.blocks[i].errorOnly and targetBlock >= 0 and
+         c.blocks[targetBlock].kind != bkTryExcept:
+        # ignore the finally; it only applies to exceptional control-flow
+        continue
+
       let label = bu.requestLabel(c.blocks[i])
       # register as outgoing edge of the preceding finally (if any):
       if previous != -1:

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -13,7 +13,7 @@ doing shady stuff...
   nimout: '''--expandArc: newTarget
 
 scope:
-  def splat: tuple[dir: string, name: string, ext: string] = splitFile(arg path) -> [Resume]
+  def splat: tuple[dir: string, name: string, ext: string] = splitFile(arg path) -> [L0, Resume]
   bind_mut _7: string = splat.0
   def _3: string = move _7
   wasMoved(name _7)
@@ -26,6 +26,10 @@ scope:
   def _6: Target = (consume _3, consume _4, consume _5)
   result := move _6
   =destroy(name splat)
+  goto [L1]
+finally (L0):
+  continue {}
+L1:
 -- end of expandArc ------------------------
 --expandArc: delete
 
@@ -190,16 +194,20 @@ scope:
         goto [L1, L2]
   def_cursor _5: sink string = x
   def _6: int = lengthStr(arg _5)
-  def _7: string = $(arg _6) -> [L1, Resume]
-  echo(arg type(array[0..0, string]), arg _7) -> [L3, L1, Resume]
-  goto [L3, L1, L4]
-  finally (L3):
+  def _7: string = $(arg _6) -> [L1, L3, Resume]
+  echo(arg type(array[0..0, string]), arg _7) -> [L4, L1, L3, Resume]
+  goto [L4, L1, L5]
+  finally (L4):
     =destroy(name _7)
     continue {L1}
   finally (L1):
     =destroy(name x)
-    continue {L2, L4}
-  L4:
+    continue {L2, L3, L5}
+  L5:
+goto [L2]
+finally (L3):
+  =destroy(name result)
+  continue {}
 L2:
 
 -- end of expandArc ------------------------

--- a/tests/lang_objects/destructor/tdestroy_result_when_raise.nim
+++ b/tests/lang_objects/destructor/tdestroy_result_when_raise.nim
@@ -1,0 +1,32 @@
+discard """
+  description: '''
+    Ensure that the result variable is cleaned up when already initialized and
+    the procedure exits due to a `raise`
+  '''
+  targets: c js vm
+"""
+
+import mhelper
+
+proc test(doRaise: bool): Resource =
+  result = initResource()
+  if doRaise:
+    raise CatchableError.newException("")
+
+block no_raise:
+  # make sure the result isn't destroyed too early when no exception is
+  # raised
+  var v = test(false)
+  doAssert numDestroy == 0
+
+doAssert numDestroy == 1
+numDestroy = 0
+
+block do_raise:
+  try:
+    var v = test(true)
+    # `v` must not be destroyed, otherwise there'd be a double-free
+  except CatchableError:
+    discard
+
+  doAssert numDestroy == 1

--- a/tests/optimization/tno_destroy_for_empty_result.nim
+++ b/tests/optimization/tno_destroy_for_empty_result.nim
@@ -1,0 +1,39 @@
+discard """
+  description: '''
+    Ensure that the destructor call for the result variable is optimized away
+    when possible
+  '''
+  matrix: "--expandArc:test --hints:off"
+  nimoutfull: true
+  nimout: '''--expandArc: test
+scope:
+  scope:
+    if x:
+      scope:
+        doRaise() -> [L1, Resume]
+  def _2: Object = ()
+  result := move _2
+goto [L2]
+finally (L1):
+  continue {}
+L2:
+
+-- end of expandArc ------------------------
+'''
+"""
+
+type Object = object
+
+proc `=destroy`(x: var Object) =
+  discard
+
+proc doRaise() =
+  raise CatchableError.newException("")
+
+proc test(x: bool): Object {.exportc.} =
+  if x:
+    # raise with a separate procedure so that the ``--expandArc`` output is
+    # shorter
+    doRaise()
+
+  result = Object()


### PR DESCRIPTION
## Summary

The `result` variable is now destroyed when the procedure exits due to
a raised exception, fixing a memory/resource leak. All backends were
affected.

Fixes https://github.com/nim-works/nimskull/issues/1305.

## Details

* the `result` is destroyed within a special try-finally that only
  intercepts exceptional control-flow
* the new `errorOnly` field designates a `bkTryFinally` as only
  intercepting exceptional control-flow
* `mirgen` handles emitting the destroy operation and injecting the
  `try`

When the `result` variable is not initialized on any control-flow paths
leading to the destroy operation, the destroy is elided by the "destroy
elimination" pass; a test (`tno_destroy_for_empty_result.nim`) is added
to ensure this works.