### PR TITLE
fix index check bugs affecting the C backend

### DIFF
--- a/tests/lang_types/array/tout_of_range_index_check.nim
+++ b/tests/lang_types/array/tout_of_range_index_check.nim
@@ -3,10 +3,6 @@ discard """
     Ensure that accessing an array works when the index operand's type cannot
     be safely converted to the array's index type
   '''
-  knownIssue.c: '''
-    The boundary checks are implemented improperly, leading to the array
-    appearing to effectively be empty
-  '''
   knownIssue.vm: '''
     Arrays with a start index outside of -128..127 crash the code generator
   '''

--- a/tests/lang_types/array/tout_of_range_index_check.nim
+++ b/tests/lang_types/array/tout_of_range_index_check.nim
@@ -23,3 +23,9 @@ proc test2(index: uint): int =
   result = arr[index]
 
 doAssert test2(1) == 3
+
+# regression test: make sure that an index that is valid after conversion to
+# uint gets caught by the index check
+when not defined(vm): # catching defects is not supported by the VM
+  doAssertRaises IndexDefect:
+    discard test1(low(int))


### PR DESCRIPTION
## Summary

Fix two bugs with index checks:
* accessing an `array` with a negative base index with a `uint` operand
  could result in false positive errors
* in some edge cases, array access would "wrap around", instead of a
  index error being reported; regression from
  https://github.com/nim-works/nimskull/pull/1324

Only the C backend was affected.

## Details

The MIR code produced by the `mChckIndex` lowering used different types
for the comparison operands, resulting in the C integer promotion rules
to apply, causing false positive and false negative results.

To fix the bug, the suggestion provided by the fixme is implemented,
namely that the boundary values are first converted to the index
operand's type prior to comparison.

If a boundary index value is not representable with the index operand's
type, the boundary test is omitted. Take, for example,
`array[-1..1, int]` that is index with a `uint` value: `uint` is
guaranteed to be >= 0, so the `-1 < idx` test can be folded away.

It's guaranteed that only one comparisons can be omitted, because
otherwise the array access can statically be proven to work, and no
index check must have been emitted by `mirgen` in the first place.

### Tests

* the `tout_of_range_index_check.nim` test is enabled for the C target
* a regression test for the fixed false negative check is added