### PR TITLE
transf: remove unreachable code

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -188,9 +188,10 @@ proc isCursor(n: PNode): bool =
   else:
     false
 
-func doesReturn(n: PNode): bool =
-  # the void type indicates that the expression/statement doesn't return
-  n.typ == nil or n.typ.kind != tyVoid
+template doesReturn(n: PNode): bool =
+  ## Returns whether `n` is a statement with a structured exit.
+  mixin c
+  n.typ != c.graph.noreturnType
 
 func initDestination(v: sink Value, isFirst, sink: bool): Destination =
   var flags: set[DestFlag]

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1802,7 +1802,8 @@ proc genTry(c: var TCtx, n: PNode, dest: Destination) =
   if hasFinally:
     # the finally clause also applies to the except clauses, so it's
     # pushed first
-    c.blocks.add Block(kind: bkTryFinally)
+    c.blocks.add Block(kind: bkTryFinally,
+                       doesntExit: not doesReturn(n[^1][0]))
 
   if hasExcept:
     c.blocks.add Block(kind: bkTryExcept)

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -139,6 +139,9 @@ type
     passes*: seq[TPass]
     idgen*: IdGenerator
     operators*: Operators
+    noreturnType*: PType
+      ## special type used for marking statements as not returning. Currently
+      ## only used in mid-end
     when defined(nimsuggest):
       onMarkUsed*: SuggestCallback
         ## callback decouples regular compiler code `markUsed` from suggest
@@ -522,6 +525,7 @@ proc newModuleGraph*(cache: IdentCache; config: ConfigRef): ModuleGraph =
   result.symBodyHashes = initTable[int, SigHash]()
   result.operators = initOperators(result)
   result.emittedTypeInfo = initTable[string, FileIndex]()
+  result.noreturnType = newType(tyVoid, nextTypeId(result.idgen), nil)
 
 proc resetAllModules*(g: ModuleGraph) =
   initStrTable(g.packageSyms)

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -42,7 +42,8 @@ import
     closureiters,
     semfold,
     lambdalifting,
-    lowerings
+    lowerings,
+    unreachable_elim
   ],
   compiler/backend/[
     cgmeth
@@ -1433,6 +1434,7 @@ proc transformBody*(g: ModuleGraph, idgen: IdGenerator, prc: PSym, body: PNode):
   (result, c.env) = liftLambdas(g, prc, body, c.idgen)
   result = processTransf(c, result, prc)
   liftDefer(c, result)
+  result = eliminateUnreachable(g, result)
 
   if prc.isIterator:
     result = g.transformClosureIterator(c.idgen, prc, result)
@@ -1479,6 +1481,7 @@ proc transformStmt*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode):
     var c = PTransf(graph: g, module: module, idgen: idgen)
     result = processTransf(c, n, module)
     liftDefer(c, result)
+    result = eliminateUnreachable(g, result)
     #result = liftLambdasForTopLevel(module, result)
     incl(result.flags, nfTransf)
 
@@ -1489,6 +1492,7 @@ proc transformExpr*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode):
     var c = PTransf(graph: g, module: module, idgen: idgen)
     result = processTransf(c, n, module)
     liftDefer(c, result)
+    result = eliminateUnreachable(g, result)
     # expressions are not to be injected with destructor calls as that
     # the list of top level statements needs to be collected before.
     incl(result.flags, nfTransf)

--- a/compiler/sem/unreachable_elim.nim
+++ b/compiler/sem/unreachable_elim.nim
@@ -327,7 +327,7 @@ proc process(c: var PassContext, n: PNode): PNode =
     result = n
   of callableDefs, nkConstSection, nkTypeSection, nkBindStmt, nkMixinStmt,
      nkIncludeStmt, nkImportStmt, nkImportExceptStmt, nkFromStmt, nkExportStmt,
-     nkExportExceptStmt:
+     nkExportExceptStmt, nkTypeOfExpr:
     # ignore declarative statements
     result = n
   else:

--- a/compiler/sem/unreachable_elim.nim
+++ b/compiler/sem/unreachable_elim.nim
@@ -141,7 +141,7 @@ proc process(c: var PassContext, n: PNode): PNode =
         result.sons.setLen(i + 1)
         # turn the expressions so far into statements by wrapping them in a
         # 'discard' statement
-        for i in 0..i:
+        for i in 0..<i:
           # the argument might be a 'void' (unit, really) expression, no
           # discard must be used then
           if result[i].typ != nil:
@@ -162,7 +162,7 @@ proc process(c: var PassContext, n: PNode): PNode =
       if doesntReturn(n[i][1]):
         # turn the operands so far into a valid statement list:
         result = newNodeIT(nkStmtList, n.info, c.voidType, i - 1)
-        for j in 1..i:
+        for j in 1..<i:
           result[j - 1] = newTreeI(nkDiscardStmt, n[j][1].info, n[j][1])
         return
 

--- a/compiler/sem/unreachable_elim.nim
+++ b/compiler/sem/unreachable_elim.nim
@@ -170,7 +170,7 @@ proc process(c: var PassContext, n: PNode): PNode =
   of nkLetSection, nkVarSection:
     for i, it in n.pairs:
       assert it.kind in {nkIdentDefs, nkVarTuple}
-      let rhs = it[^1]
+      let rhs = recurse(it[^1])
       if doesntReturn(rhs):
         if i == 0:
           return rhs # discard the rest

--- a/compiler/sem/unreachable_elim.nim
+++ b/compiler/sem/unreachable_elim.nim
@@ -1,0 +1,308 @@
+## Implements elimination of unreachable statements and expression within an
+## AST already processed by early ``transf``. The transformation makes sure
+## that a non-returning statement is not immediately followed by other code.
+##
+## For example, for:
+##
+## .. code-block:: nim
+##
+##   return 1
+##   echo "a"
+##
+## The ``echo`` statement needs to be removed. This makes further processing
+## easier, since detecting whether a block of code returns is now possible by
+## inspecting just the trailing AST node.
+##
+## For later inspection, all non-returning statements (such as break, return,
+## etc.) have the 'void' type assigned to them.
+
+import
+  compiler/ast/[
+    ast_types,
+    ast_query,
+    ast,
+    lineinfos
+  ],
+  compiler/modules/[
+    modulegraphs,
+    magicsys
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+type
+  PassContext = object
+    blocks: seq[tuple[label: PSym, used: bool]]
+    voidType: PType
+
+iterator mitems(x: PNode): var PNode =
+  for i in 0..<x.len:
+    yield x[i]
+
+iterator mpairs(x: PNode): (int, var PNode) =
+  for i in 0..<x.len:
+    yield (i, x[i])
+
+func doesntReturn(x: PNode): bool =
+  x.typ != nil and x.typ.kind == tyVoid
+
+proc process(c: var PassContext, n: PNode): PNode =
+  ## Transforms a single tree layer. The AST is mutated in-place, and the
+  ## transformed node is returned.
+  ##
+  ## For signaling that the statement/expression doesn't return, it has the
+  ## 'void' type assigned to it; non-returning expressions are turned into
+  ## statements.
+  template recurse(n: PNode): PNode =
+    process(c, n)
+
+  case n.kind
+  of nkWithoutSons, nkSymChoices, nkNimNodeLit:
+    result = n # nothing to do
+  of nkCast, nkHiddenStdConv, nkHiddenSubConv, nkConv:
+    # single operand expressions with the operand in the second slot
+    let x = recurse(n[1])
+    if doesntReturn(x):
+      result = x
+    else:
+      result = n
+      result[1] = x
+
+  of nkHiddenAddr, nkAddr, nkHiddenDeref, nkDerefExpr, nkStringToCString,
+     nkCStringToString, nkObjDownConv, nkObjUpConv, nkCheckedFieldExpr,
+     nkReturnStmt, nkDiscardStmt, nkYieldStmt, nkRaiseStmt:
+    # statements and expressions where only the first operand is relevant
+    let x = recurse(n[0])
+    if doesntReturn(x):
+      result = x
+    else:
+      result = n
+      result[0] = x
+
+      if n.kind in {nkReturnStmt, nkRaiseStmt}:
+        # mark as noreturn
+        result.typ = c.voidType
+  of nkAsgn, nkFastAsgn, nkBracketExpr, nkDotExpr, nkRange:
+    # statements/expressions with two operands
+    let lhs = recurse(n[0])
+    if doesntReturn(lhs):
+      result = lhs
+    else:
+      let rhs = recurse(n[1])
+      if doesntReturn(rhs):
+        result = nkStmtList.newTreeIT(n.info, c.voidType,
+          nkDiscardStmt.newTreeI(lhs.info, lhs),
+          rhs)
+      else:
+        result = n
+        result[0] = lhs
+        result[1] = rhs
+  of nkStmtList:
+    result = n
+    for i, it in result.mpairs:
+      it = recurse(it)
+      if doesntReturn(it):
+        result.sons.setLen(i + 1)
+        result.typ = c.voidType
+        return
+
+  of nkStmtListExpr:
+    result = n
+    for i in 0..<n.len-1:
+      result[i] = recurse(n[i])
+      if doesntReturn(result[i]):
+        result.transitionSonsKind(nkStmtList)
+        # cut off the remaining statements
+        result.sons.setLen(i + 1)
+        result.typ = c.voidType
+        return
+
+    result[^1] = recurse(n[^1])
+    if doesntReturn(result[^1]):
+      # ends in a statement
+      result.transitionSonsKind(nkStmtList)
+      result.typ = c.voidType
+  of nkCallKinds, nkBracket, nkCurly, nkClosure, nkTupleConstr, nkChckRange,
+     nkChckRange64, nkChckRangeF, nkAsmStmt:
+    # some call-like operation with left-to-right evaluation. If an operand
+    # doesn't return, the remaining operands plus the operation itself are
+    # removed
+    for i, it in n.mpairs:
+      # destructively omit the expr-colon-expr; it's not needed beyond this
+      # point anyway
+      it = recurse(it.skipColon)
+      if doesntReturn(it):
+        result = n
+        result.transitionSonsKind(nkStmtList)
+        result.typ = c.voidType
+        # cut off the remaining expressions/statements; they're dead code
+        result.sons.setLen(i + 1)
+        # turn the expressions so far into statements by wrapping them in a
+        # 'discard' statement
+        for i in 0..i:
+          # the argument might be a 'void' (unit, really) expression, no
+          # discard must be used then
+          if result[i].typ != nil:
+            result[i] = newTreeI(nkDiscardStmt, n.info, result[i])
+
+        return
+
+    result = n
+    if result.kind in nkCallKinds and result[0].kind == nkSym and
+       result[0].sym.kind in routineKinds and
+       sfNoReturn in result[0].sym.flags:
+      # calls to noreturn procedures don't return
+      result.typ = c.voidType
+  of nkObjConstr:
+    # similar to the call-like handling
+    for i in 1..<n.len:
+      n[i][1] = recurse(n[i][1])
+      if doesntReturn(n[i][1]):
+        # turn the operands so far into a valid statement list:
+        result = newNodeIT(nkStmtList, n.info, c.voidType, i - 1)
+        for j in 1..i:
+          result[j - 1] = newTreeI(nkDiscardStmt, n[j][1].info, n[j][1])
+        return
+
+    result = n
+  of nkLetSection, nkVarSection:
+    for i, it in n.pairs:
+      assert it.kind in {nkIdentDefs, nkVarTuple}
+      let rhs = it[^1]
+      if doesntReturn(rhs):
+        if i == 0:
+          return rhs # discard the rest
+        else:
+          # cut off the identdefs past and including the current one
+          n.sons.setLen(i)
+          # wrap the section in a statement list and append the non-returning
+          # expression
+          result = newTreeIT(nkStmtList, n.info, c.voidType, n, rhs)
+          return
+
+    result = n
+  of nkBlockExpr, nkBlockStmt:
+    c.blocks.add (n[0].sym, false) # push a new block
+    let body = recurse(n[1])
+    let info = c.blocks.pop() # pop the block again
+
+    result = n
+    if doesntReturn(body):
+      # it's a statement
+      result.transitionSonsKind(nkBlockStmt)
+      if not info.used:
+        # the block is never broken out of and the body doesn't return -> the
+        # block doesn't return
+        result.typ = c.voidType
+
+    result[1] = body
+  of nkIfExpr, nkIfStmt:
+    result = n
+    var exits = 0 ## number of branches that return
+    for i, it in result.pairs:
+      case it.kind
+      of nkElifBranch, nkElifExpr:
+        let cond = recurse(it[0])
+        if doesntReturn(cond):
+          # the condition expression doesn't return; everything that follows
+          # is dead code
+          if i == 0:
+            return cond
+          else:
+            # turn into an else branch and cut off the remaining branches
+            result[i] = newTreeI(nkElse, cond.info, cond)
+            result.sons.setLen(i + 1)
+            break
+
+        it[1] = recurse(it[1])
+        exits += ord(not doesntReturn(it[1]))
+      of nkElse, nkElseExpr:
+        it[0] = recurse(it[0])
+        exits += ord(not doesntReturn(it[0]))
+      else:
+        unreachable(it.kind)
+
+    if exits == 0 and result[^1].kind in {nkElse, nkElseExpr}:
+      # exhaustive 'if' statement/expression and no branch returns -> it's a
+      # noreturn statement
+      result.transitionSonsKind(nkIfStmt)
+      result.typ = c.voidType
+  of nkCaseStmt:
+    let x = recurse(n[0])
+    if doesntReturn(x):
+      return x # the body is dead code
+
+    result = n
+    result[0] = x
+
+    # process all branches and count the number of exits:
+    var exits = 0
+    for i in 1..<n.len:
+      result[i][^1] = recurse(n[i][^1])
+      exits += ord(not doesntReturn(result[i][^1]))
+
+    if exits == 0:
+      # none of the branches return -> the case doesn't return
+      result.typ = c.voidType
+  of nkTryStmt, nkHiddenTryStmt:
+    result = n
+    var exits = 0
+    for it in result.mitems:
+      case it.kind
+      of nkExceptBranch:
+        it[^1] = recurse(it[^1])
+        exits += ord(not doesntReturn(it[^1]))
+      of nkFinally:
+        it[0] = recurse(it[0])
+      else:
+        # must be the main body
+        it = recurse(it)
+        exits += ord(not doesntReturn(it))
+
+    if exits == 0 or
+       (result[^1].kind == nkFinally and doesntReturn(result[^1][0])):
+      # the try/except or intercepting finally doesn't exit
+      result.typ = c.voidType
+  of nkWhileStmt:
+    result = n
+    result[^1] = recurse(n[1])
+    result.typ = c.voidType # ``while true`` statements never return
+  of nkBreakStmt:
+    # mark the break target as being broken out of:
+    for it in c.blocks.mitems:
+      if it.label.id == n[0].sym.id:
+        it.used = true
+        break
+
+    result = n
+    result.typ = c.voidType # mark as noreturn
+  of nkWhenStmt:
+    result = n
+    # process both branches of the ``when nimvm`` statement/expression
+    result[0][1] = recurse(n[0][1])
+    result[1][0] = recurse(n[1][0])
+    if doesntReturn(result[0][1]) and doesntReturn(result[1][0]):
+      # if both branches don't return, neither does the 'when'
+      result.typ = c.voidType
+    # XXX: if only one branches doesn't return, collapsing the 'when' to the
+    #      one that doesn't results in the unreachable code persisting
+  of nkPragmaBlock:
+    result = n
+    result[1] = recurse(n[1])
+    if doesntReturn(result[1]):
+      result.typ = c.voidType
+  of callableDefs, nkConstSection, nkTypeSection, nkBindStmt, nkMixinStmt,
+     nkIncludeStmt, nkImportStmt, nkImportExceptStmt, nkFromStmt, nkExportStmt,
+     nkExportExceptStmt, nkPragma:
+    # ignore declarative statements
+    result = n
+  else:
+    unreachable(n.kind)
+
+proc eliminateUnreachable*(graph: ModuleGraph, n: PNode): PNode =
+  ## Entry point into the pass. Removes all unreachable statements/expression,
+  ## making sure that a non-returning statement is always the last statement
+  ## in a block of code.
+  var c = PassContext(voidType: graph.getSysType(unknownLineInfo, tyVoid))
+  result = process(c, n)

--- a/compiler/sem/unreachable_elim.nim
+++ b/compiler/sem/unreachable_elim.nim
@@ -317,6 +317,8 @@ proc process(c: var PassContext, n: PNode): PNode =
             # wrap the previous operands in discard statements:
             for j in 0..<i:
               stmts[j] = newTreeI(nkDiscardStmt, args[j].info, args[j])
+            # assign the terminal expression and combine with the pragma:
+            stmts[i] = x
             return newTreeIT(nkStmtList, n.info, c.voidType, n, stmts)
 
       else:

--- a/tests/lang_exprs/tnon_returning_expressions.nim
+++ b/tests/lang_exprs/tnon_returning_expressions.nim
@@ -1,0 +1,188 @@
+discard """
+  description: '''
+    Ensure that the compiler can correctly handle all forms of:
+    * expression that don't return
+    * statements that don't return
+  '''
+  targets: c js vm
+"""
+
+proc noret() {.noreturn.} =
+  raise CatchableError.newException("")
+
+# ------------------------------
+# establish that the basics work
+
+proc testBreak() =
+  block:
+    var x = (;break; 1)
+    doAssert false
+
+testBreak()
+
+proc testReturn() =
+  var x = (;return; 1)
+  doAssert false
+
+testReturn()
+
+proc testRaise() =
+  var x = (;raise CatchableError.newException(""); 1)
+  doAssert false
+
+try: testRaise() except: discard
+
+proc testNoreturnCall() =
+  var x = (noret(); 1)
+  doAssert false
+
+try: testNoreturnCall() except: discard
+
+# ----------
+# statements
+
+template testStmt(body: untyped) =
+  # provides the fixture for testing statements
+  proc p(): int {.gensym.} =
+    body
+    doAssert false
+  discard p()
+
+proc call(a, b: int) = discard
+
+# callee:
+testStmt: (;return; call)(1, 2)
+# arguments:
+testStmt: call((;return; 1), 2)
+testStmt: call((;return; var val = 0; 1), val)
+
+# ------------------------------------
+# complex statements that don't return
+
+# discard operand doesn't return:
+testStmt:
+  discard (;return; 1)
+
+# raise operand doesn't return:
+testStmt:
+  raise (;return; CatchableError.newException(""))
+
+# first definition doesn't return:
+testStmt:
+  let
+    x = (;return; var a = 2; 1)
+    y = a
+
+# second (non-trailing) definition doesn't return:
+testStmt:
+  let
+    x = 1
+    y = (;return; var a = 3; 2)
+    z = a
+
+# lhs in assignment doesn't return:
+testStmt:
+  var x = 0
+  (;return; var y = 1; x) = y
+
+# rhs in assignment doesn't return:
+testStmt:
+  var x = 0
+  x = (;return; 1)
+
+# condition expression in if doesn't return:
+testStmt:
+  let x = 1
+  if (;return; x == 1):
+    doAssert false
+
+# condition in trailing elif-branch doesn't return:
+testStmt:
+  let x = 2
+  if x == 1:
+    doAssert false
+  elif (;return; x == 2):
+    doAssert false
+
+# case statement selector expression doesn't return
+testStmt:
+  let x = 1
+  case (;return; x)
+  of 1:
+    doAssert false
+  else:
+    doAssert false
+
+when defined(c):
+  block:
+    var value = 0
+    testStmt:
+      {.emit: "`value` = 1;", emit: [value, "=", (;return; 2)].}
+
+    # make sure the first emitted statement was evaluated:
+    doAssert value == 1
+
+
+# -----------
+# expressions
+
+template testExpr(body: untyped) =
+  # provides the fixture for testing expressions
+  proc p() {.gensym.} =
+    let x = body
+    doAssert false
+  p()
+
+var global = 0
+
+proc effect(): int =
+  # effectful procedure
+  inc global
+  result = 1
+
+template testExprWithEffect(expect: int, body: untyped) =
+  # provides the fixture for testing expressions where some side-effect needs
+  # to be computed (or not)
+  global = 0
+  testExpr: body
+  doAssert global == expect
+
+type Obj = object
+  a, b, c: int
+
+# construction expressions:
+testExprWithEffect 0:
+  [(;return; var val = 0; 1), val, effect()]
+testExprWithEffect 0:
+  ((;return; var val = 0; 1), val, effect())
+testExprWithEffect 0:
+  Obj(a: (;return; var val = 0; 1), b: val, c: effect())
+
+# cast:
+testExprWithEffect 0:
+  cast[int]((;return; effect()))
+
+# conversion:
+testExprWithEffect 0:
+  int((;return; effect()))
+
+# object field access:
+testExpr:
+  let o = Obj(a: 1)
+  (;return; o).a
+
+# tuple field access:
+testExpr:
+  let t = (1, 2)
+  (;return; t)[0]
+
+# array operand expression doesn't return:
+testExprWithEffect 0:
+  var s = @[0, 1]
+  (;return; s)[effect()]
+
+# index operand expression doesn't return:
+testExprWithEffect 1:
+  var s = @[1, 2]
+  # the array operand must still be evaluated for side-effects
+  (;discard effect(); s)[(;return; 1)]


### PR DESCRIPTION
## Summary

Eliminate unreachable statements and expression during `transf`,
instead of in `mirgen`. This:
* removes some workarounds from `mirgen`
* improves the quality of unreachable code elimination
* fixes a compiler crash related to non-returning expressions

## Details

Statement lists can have trailing unreachable code, and expressions can
therefore be non-returning (e.g., `(;break; 1)`).

`mirgen` made an attempt at eliminating both, but the approach used
was indirect and didn't handle expressions well, leading to crashes for
code such as `f((;return; var x = 0; 1), x)`, because the `var x`
definition wasn't translated, but the subsequent usage of `x` was.

Removing unreachable statements/expressions is now done by an AST-based
pass that's run after early `transf` (so that iterator inlining took
place and the AST is less complex) but before the `closureiters`
transformation. The pass is implemented by the `unreachable_elim`
module.

Beyond fixing the crashes, this has the additional benefits that:
* the `closureiters` transformation doesn't take unreachable code into
  account
* `mirgen` can detect `finally` clauses that have no structured exit
  and emit better code for them. The handling for the no-structured-
  exit case already existed (`doesntExit`), just the detection was
  missing
* more straightforward MIR translation, using less conditionals

A test for the various possible scenarios of unreachable expressions/
statements is added.