### PR TITLE
remove unnecessary `ccgutils` dependency

### DIFF
--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -199,6 +199,32 @@ proc addAbiCheck(m: BModule, t: PType, name: Rope) =
     m.s[cfsTypeInfo].addf("NIM_STATIC_ASSERT(sizeof($1) == $2, $3);$n", [name, rope(size), msg2.rope])
     # see `testCodegenABICheck` for example error message it generates
 
+proc ccgIntroducedPtr(conf: ConfigRef; s: PSym, retType: PType): bool =
+  var pt = skipTypes(s.typ, typedescInst)
+  assert skResult != s.kind
+
+  if tfByRef in pt.flags: return true
+  elif tfByCopy in pt.flags: return false
+  case pt.kind
+  of tyObject:
+    if s.typ.sym != nil and sfForward in s.typ.sym.flags:
+      # forwarded objects are *always* passed by pointers for consistency!
+      result = true
+    elif (optByRef in s.options) or (getSize(conf, pt) > conf.target.floatSize * 3):
+      result = true           # requested anyway
+    elif (tfFinal in pt.flags) and (pt[0] == nil):
+      result = false          # no need, because no subtyping possible
+    else:
+      result = true           # ordinary objects are always passed by reference,
+                              # otherwise casting doesn't work
+  of tyTuple:
+    result = (getSize(conf, pt) > conf.target.floatSize*3) or (optByRef in s.options)
+  else:
+    result = false
+  # first parameter and return type is 'lent T'? --> use pass by pointer
+  if s.position == 0 and retType != nil and retType.kind == tyLent:
+    result = not (pt.kind in {tyVar, tyArray, tyOpenArray, tyVarargs, tyRef, tyPtr, tyPointer} or
+      pt.kind == tySet and mapSetType(conf, pt) == ctArray)
 
 proc initResultParamLoc(conf: ConfigRef; param: CgNode): TLoc =
   result = initLoc(locParam, param, "Result", OnStack)

--- a/compiler/backend/ccgutils.nim
+++ b/compiler/backend/ccgutils.nim
@@ -14,19 +14,13 @@ import
     hashes, strutils
   ],
   compiler/ast/[
-    ast,
-    types
+    ast
   ],
   compiler/front/[
     options
   ],
   compiler/utils/[
     platform
-  ],
-  compiler/sem/[
-  ],
-  compiler/backend/[
-    cgendata,
   ]
 
 proc hashString*(conf: ConfigRef; s: string): BiggestInt =

--- a/compiler/backend/ccgutils.nim
+++ b/compiler/backend/ccgutils.nim
@@ -108,39 +108,3 @@ proc mangle*(name: string): string =
       requiresUnderscore = true
   if requiresUnderscore:
     result.add "_"
-
-proc mapSetType(conf: ConfigRef; typ: PType): TCTypeKind =
-  case int(getSize(conf, typ))
-  of 1: result = ctInt8
-  of 2: result = ctInt16
-  of 4: result = ctInt32
-  of 8: result = ctInt64
-  else: result = ctArray
-
-proc ccgIntroducedPtr*(conf: ConfigRef; s: PSym, retType: PType): bool =
-  var pt = skipTypes(s.typ, typedescInst)
-  assert skResult != s.kind
-
-  if tfByRef in pt.flags: return true
-  elif tfByCopy in pt.flags: return false
-  case pt.kind
-  of tyObject:
-    if s.typ.sym != nil and sfForward in s.typ.sym.flags:
-      # forwarded objects are *always* passed by pointers for consistency!
-      result = true
-    elif (optByRef in s.options) or (getSize(conf, pt) > conf.target.floatSize * 3):
-      result = true           # requested anyway
-    elif (tfFinal in pt.flags) and (pt[0] == nil):
-      result = false          # no need, because no subtyping possible
-    else:
-      result = true           # ordinary objects are always passed by reference,
-                              # otherwise casting doesn't work
-  of tyTuple:
-    result = (getSize(conf, pt) > conf.target.floatSize*3) or (optByRef in s.options)
-  else:
-    result = false
-  # first parameter and return type is 'lent T'? --> use pass by pointer
-  if s.position == 0 and retType != nil and retType.kind == tyLent:
-    result = not (pt.kind in {tyVar, tyArray, tyOpenArray, tyVarargs, tyRef, tyPtr, tyPointer} or
-      pt.kind == tySet and mapSetType(conf, pt) == ctArray)
-

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -37,9 +37,6 @@ import
     semdata,
     sighashes,
     lowerings
-  ],
-  compiler/backend/[
-    ccgutils
   ]
 
 from compiler/ast/reports_sem import reportAst,
@@ -224,15 +221,6 @@ proc fillBodyObjT(c: var TLiftCtx; t: PType, body, x, y: PNode) =
     # for every field (dependent on dest.kind):
     #   `=` dest.field, src.field
     # =destroy(blob)
-    var dummy = newSym(skTemp, getIdent(c.g.cache, lowerings.genPrefix), nextSymId c.idgen, c.fn, c.info)
-    dummy.typ = y.typ
-    if ccgIntroducedPtr(c.g.config, dummy, y.typ):
-      # Because of potential aliasing when the src param is passed by ref, we need to check for equality here,
-      # because the wasMoved(dest) call would zero out src, if dest aliases src.
-      var cond = newTree(nkCall, newSymNode(c.g.getSysMagic(c.info, "==", mEqRef)),
-        newTreeIT(nkAddr, c.info, makePtrType(c.fn, x.typ, c.idgen), x), newTreeIT(nkAddr, c.info, makePtrType(c.fn, y.typ, c.idgen), y))
-      cond.typ = getSysType(c.g, x.info, tyBool)
-      body.add genIf(c, cond, newTreeI(nkReturnStmt, c.info, newNodeI(nkEmpty, c.info)))
     var temp = newSym(skTemp, getIdent(c.g.cache, lowerings.genPrefix), nextSymId c.idgen, c.fn, c.info)
     temp.typ = x.typ
     incl(temp.flags, sfFromGeneric)


### PR DESCRIPTION
## Summary

Remove an obsolete usage of `ccgIntroducedPtr` from sem, breaking an
import dependency between sem and the code generator, and allowing for
`ccgIntroducedPtr` to move back to `ccgtypes`.

## Details

It was originally possible for the arguments to a copy hook overlapping
in memory (a parameter aliasing violation), resulting in incorrect
behaviour when copying variant objects if they do.

ed126794b6af8b39960a7acc603cee1abc73da4a worked around this by checking
whether both parameters were (hidden) pointers to the same location,
skipping the copy if they are, with `ccgIntroducedPtr` used to check
whether the source parameter is passed as via a pointer indirection.

This is a layering violation, and also no longer necessary, since
`injecthooks` ensures that the immutable argument doesn't refer to the
same memory location as the mutable one -- the workaround in
`liftdestructors` can thus be removed.