### PR TITLE
mir: remove statement nesting

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -283,7 +283,7 @@ func isEmpty*(tree: MirTree): bool =
   ## Returns whether `tree` contains either no nodes or only nodes that have
   ## no meaning by themselves.
   for n in tree.items:
-    if n.kind notin {mnkScope, mnkEnd}:
+    if n.kind notin {mnkScope, mnkEndScope, mnkEnd}:
       return false
 
   result = true
@@ -416,13 +416,14 @@ proc produceFragmentsForGlobals(
     # on this
     if bu.front.len == 0:
       discard bu.addLocal(Local()) # empty result slot
-      bu.add(m.add(n)): MirNode(kind: mnkScope)
+      bu.setSource(m.add(n))
+      bu.subTree mnkScope: discard
 
   func finish(bu: sink MirBuilder, m: var SourceMap, n: PNode
              ): auto {.nimcall.} =
     if bu.front.len > 0:
       bu.setSource(m.add(n))
-      bu.add endNode(mnkScope)
+      bu.subTree mnkEndScope: discard
     # we're creating a body here, so there is no list of locals yet
     result = finish(bu, default(Store[LocalId, Local]))
 

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -104,12 +104,11 @@ proc isUsedForSink(tree: MirTree, stmt: NodePosition): bool =
         break
     of mnkScope:
       inc depth
-    of mnkEnd:
-      if tree[n].kind == mnkScope:
-        dec depth
-        if depth < 0:
-          # the end of the temporary's surrounding scope is reached
-          break
+    of mnkEndScope:
+      dec depth
+      if depth < 0:
+        # the end of the temporary's surrounding scope is reached
+        break
     else:
       discard
 

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -312,8 +312,9 @@ template stmtList*(bu: var MirBuilder, body: untyped) =
     body
 
 template scope*(bu: var MirBuilder, body: untyped) =
-  bu.subTree MirNode(kind: mnkScope):
-    body
+  bu.subTree mnkScope: discard
+  body
+  bu.subTree mnkEndScope: discard
 
 func allocTemp(bu: MirBuilder, t: TypeId; id: LocalId, alias: bool): Value =
   ## Allocates a new temporary or alias and returns it.

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -277,7 +277,7 @@ template subTree(c: var TCtx, n: MirNode, body: untyped) =
 
 template scope(c: var TCtx, body: untyped) =
   inc c.scopeDepth
-  c.builder.subTree mnkScope:
+  c.builder.scope:
     let prev = c.blocks.startScope()
     body
     c.blocks.closeScope(c.builder, prev, not c.unreachable)
@@ -2013,11 +2013,12 @@ proc genx(c: var TCtx, e: PMirExpr, i: int; fromMove = false) =
                 c.emitByVal val
     do:
       # the check:
-      c.buildStmt mnkScope:
-        c.subTree mnkVoid:
-          c.buildDefectMagicCall mChckObj, VoidType:
-            c.emitByVal val
-            c.emitByVal typeLit(c.typeToMir(n.check))
+      c.buildStmt mnkScope: discard
+      c.buildStmt mnkVoid:
+        c.buildDefectMagicCall mChckObj, VoidType:
+          c.emitByVal val
+          c.emitByVal typeLit(c.typeToMir(n.check))
+      c.buildStmt mnkEndScope: discard
 
     c.buildOp mnkPathConv, typ:
       c.use val

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -451,14 +451,14 @@ proc injectProfilerCalls(tree: MirTree, graph: ModuleGraph, env: var MirEnv,
     prcId = env.procedures.add(graph.getCompilerProc("nimProfile"))
 
   # insert the entry call within the outermost scope:
-  changes.insert(tree, tree.child(NodePosition 0, 0), NodePosition 0, bu):
+  changes.insert(tree, tree.sibling(NodePosition 0), NodePosition 0, bu):
     bu.subTree mnkVoid:
       bu.buildCall prcId, VoidType:
         discard "no arguments"
 
   for i in search(tree, {mnkLoop}):
     # insert the call before the loop end:
-    changes.insert(tree, i - 1, i, bu):
+    changes.insert(tree, i, i, bu):
       bu.subTree mnkVoid:
         bu.buildCall prcId, VoidType:
           discard "no arguments"

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -434,7 +434,7 @@ proc injectResultInit(tree: MirTree, resultTyp: TypeId, changes: var Changeset) 
 
   if requiresInit(tree):
     assert tree[0].kind == mnkScope
-    let at = tree.child(NodePosition 0, 0)
+    let at = tree.sibling(NodePosition 0)
     changes.insert(tree, at, at, bu):
       bu.subTree mnkInit:
         bu.use toValue(mnkLocal, resultId, resultTyp)

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -213,9 +213,12 @@ type
               ## * syntactic statement node for representing void calls
               ## * statement acting as a use of the given lvalue
 
-    mnkScope  ## the only way to introduce a scope. Scopes can be nested and
-              ## dictate the lifetime of the locals that are directly enclosed
-              ## by them
+    mnkScope  ## starts a scope, which are used to delimit lifetime of locals
+              ## they enclose. Can be nested, but must always be paired with
+              ## exactly one ``mnkEndScope`` statement
+    mnkEndScope## closes the current scope. Must always be paired with a
+              ## ``mnkScope`` statement
+    # future direction: both mnkScope and mnkEndScope should become atoms
 
     mnkGoto   ## unconditional jump
     mnkIf     ## depending on the run-time value of `x`, transfers control-
@@ -354,7 +357,7 @@ const
   StmtNodes* = {mnkScope, mnkGoto, mnkIf, mnkCase, mnkLoop, mnkJoin,
                 mnkLoopJoin, mnkExcept, mnkFinally, mnkContinue, mnkEndStruct,
                 mnkInit, mnkAsgn, mnkSwitch, mnkVoid, mnkRaise, mnkDestroy,
-                mnkEmit, mnkAsm} + DefNodes
+                mnkEmit, mnkAsm, mnkEndScope} + DefNodes
     ## Nodes that are treated like statements, in terms of syntax.
 
   # --- semantics-focused sets:

--- a/compiler/mir/rtchecks.nim
+++ b/compiler/mir/rtchecks.nim
@@ -49,7 +49,7 @@ template subTree(bu; k: MirNodeKind, t: TypeId, body: untyped) =
 
 template buildIf(bu; cond: Value, body: untyped) =
   bu.buildIf (;bu.use(cond)):
-    bu.subTree mnkScope:
+    bu.scope:
       body
 
 template buildIfNot(bu; cond: Value, body: untyped) =

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -519,21 +519,12 @@ proc renderNameWithType(tree: MirTree, i: var int, result: var string,
   result.add ": "
   typeToStr(result, n.typ, c.env)
 
-proc renderList(tree: MirTree, i: var int, indent: int, result: var string,
-                c: RenderCtx)
-
 proc stmtToStr(nodes: MirTree, i: var int, indent: var int, result: var string,
                c: RenderCtx) =
   template tree(str: string, body: untyped) =
     result.add repeat("  ", indent)
     result.add str
     body
-
-  template tab(body: untyped) =
-    ## Runs `body` with the indentation increased by 1.
-    inc indent
-    body
-    dec indent
 
   let n {.cursor.} = next(nodes, i)
   case n.kind
@@ -601,9 +592,10 @@ proc stmtToStr(nodes: MirTree, i: var int, indent: var int, result: var string,
 
     inc indent
   of mnkScope:
-    tree "scope:\n":
-      tab:
-        renderList(nodes, i, indent, result, c)
+    tree "scope:\n": discard
+    inc indent
+  of mnkEndScope:
+    dec indent # just dedent
   of mnkIf:
     tree "if ":
       valueToStr()

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -137,9 +137,10 @@ Semantics
   SHALLOW_SRC = RVALUE
               | VALUE
 
-  STATEMENT = Scope STATEMENT           # wrap the statement in a scope, which
+  STATEMENT = Scope                     # starts a new scope, which
                                         # delimits the lifetime of all
                                         # definitions within
+            | EndScope                  # close the current scope
             | Def NAME none             # definition
             | Def NAME ASGN_SRC         # definition + initial value assignment
             | DefCursor NAME            # definition of non-owning location


### PR DESCRIPTION
## Summary

Scopes are now no longer subtrees that can have other statements nested
within them. This removes the last of case of statement nesting from
the MIR, meaning that all bodies are now made up of flat statement
lists.

## Details

Statement nesting complicates tree traversal, and - more importantly -
prevents the eventual removal of the `mnkEnd` nodes. Without `mnkEnd`
nodes, the number of sub-nodes is going to be explicitly stored in the
subtree nodes, which cannot efficiently work in the `Changeset`
architecture when statements can be nested.

Construction of MIR trees is updated accordingly (`subTree` cannot be
used for wrapping statements in a scope; the `scope` template is used
instead), as well as tree traversal.