### PR TITLE
fix(sem): generic distinct types getting the same hooks

### DIFF
--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -976,12 +976,11 @@ proc createTypeBoundOps(g: ModuleGraph; c: PContext; orig: PType; info: TLineInf
   if isEmptyContainer(skipped) or skipped.kind == tyStatic: return
 
   var canon: PType
-  if skipped.kind == tyObject:
+  if skipped.kind in {tyObject, tyDistinct}:
     # for nominal types, the type itself is already the canonical one (each one
     # is unique)
     # XXX: ^^ at present, this is only true for object types. Phantom
-    #      ``tyDistinct`` and ``tyEnum`` types still don't have unique
-    #      instances
+    #      ``tyEnum`` types still don't have unique instances
     canon = skipped
   else:
     # structural types use canonicalization

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -543,7 +543,7 @@ proc instantiate(cl: var TReplTypeVars, t: PType): PType =
     result = instCopyType(cl, t)
     result[0] = replaceTypeVarsT(cl, t[0])
 
-    # always create a new symbol, even if
+    # the type also needs a proper symbol
     result.sym = copySym(t.sym, nextSymId cl.c.idgen)
     result.sym.flags.incl sfFromGeneric
     result.sym.owner = t.sym

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -537,6 +537,18 @@ proc instantiate(cl: var TReplTypeVars, t: PType): PType =
 
     if cl.c.computeRequiresInit(cl.c, result):
       result.flags.incl tfRequiresInit
+  of tyDistinct:
+    # same as with object types, create a new type instance even if the body
+    # doesn't change during instantiation
+    result = instCopyType(cl, t)
+    result[0] = replaceTypeVarsT(cl, t[0])
+
+    # always create a new symbol, even if
+    result.sym = copySym(t.sym, nextSymId cl.c.idgen)
+    result.sym.flags.incl sfFromGeneric
+    result.sym.owner = t.sym
+    result.sym.ast = t.sym.ast
+    result.sym.typ = result
   else:
     # XXX: these types also need new symbols...
     result = replaceTypeVarsT(cl, t)

--- a/tests/lang_objects/destructor/tphantom_distinct_hooks.nim
+++ b/tests/lang_objects/destructor/tphantom_distinct_hooks.nim
@@ -1,0 +1,36 @@
+discard """
+  description: '''
+    Ensure that phantom distinct types can use generic hooks, and that every
+    instance gets its own instantiations thereof
+  '''
+  targets: "c js vm"
+  matrix: "--cursorInference:off"
+"""
+
+type
+  Phantom[T] = distinct int
+
+var trace: seq[string]
+
+proc `=copy`[T](x: var Phantom[T], y: Phantom[T]) =
+  trace.add("copy " & $T)
+
+proc `=sink`[T](x: var Phantom[T], y: Phantom[T]) =
+  trace.add("sink " & $T)
+
+proc `=destroy`[T](x: var Phantom[T]) =
+  trace.add("destroy " & $T)
+
+proc test[T](a: sink Phantom[T] = default(Phantom[T])) =
+  var x: Phantom[T]
+  x = a # copies
+  x = a # sinks
+  # `x` is destroyed
+
+test[int]()
+test[float]()
+
+# make sure that both types got their own hook instantiations
+doAssert trace == ["copy int", "sink int", "destroy int",
+                   "copy float", "sink float", "destroy float"],
+         $trace

--- a/tests/typerel/tphantom_distinct_types.nim
+++ b/tests/typerel/tphantom_distinct_types.nim
@@ -1,0 +1,26 @@
+discard """
+  description: '''
+    Ensure that instantiating a generic distinct type where the generic
+    parameter is not used in the body yields distinct types for different
+    parameters
+  '''
+  action: compile
+"""
+
+type
+  TypeA[T] = distinct T
+  TypeB[T] = distinct int
+
+static:
+  doAssert TypeA[int] is    TypeA[int]
+  # make sure two separate generic types result in distinct instances:
+  doAssert TypeA[int] isnot TypeB[int]
+  doAssert TypeB[int] isnot TypeA[int]
+
+  # try with a different parameter type:
+  doAssert TypeA[float] is    TypeA[float]
+  doAssert TypeA[float] isnot TypeB[float]
+  doAssert TypeB[float] isnot TypeA[float]
+
+  # ensure that different paramaters result in different types:
+  doAssert TypeA[int] isnot TypeA[float]


### PR DESCRIPTION
## Summary

Fix instantiating a generic distinct type with generic parameters not
used in the body not resulting in a unique type internally, resulting
in all instances thereof sharing the very same generic hook
instantiations.

## Details

There were two issues in `semtypinst`:
1. no new type instance was created for `tyDistinct` types when there
   are no generic parameters used in the body
2. no new symbol being created for the `tyDistinct` when instantiating
   it

As a consequence of point 1, `sameType` and `hashType` treated the
instantiated `tyDistinct` types as being the same. `hashType` is used
by hook lifting for fetching the canonical type, so all `tyDistinct`
types resulting from a generic type with phantom type information got
the same set of hooks.

For point 2, the consequence was that the symbol for instantiated
generic distinct types always pointed to the original `tyGenericBody`,
not the instantiated type.

Same as with `tyObject` types (which are also nominal types), a new
`tyDistinct` instance is always created during instantiation, and a new
symbol is created for it.

### Tests

* the `tphantom_distinct_hooks` test is added, which is largely a copy
  of `tphantom_object_hooks`
* the `tphantom_distinct_types` typerel test is added for preventing
  future regressions. It already succeeded previously