### PR TITLE
fix: wrong code generation for synthesized object hooks

### DIFF
--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -196,7 +196,12 @@ proc fillBodyObj(c: var TLiftCtx; n, body, x, y: PNode; enforceDefaultOp: bool) 
 
 proc fillBodyObjTImpl(c: var TLiftCtx; t: PType, body, x, y: PNode) =
   if t.len > 0 and t[0] != nil:
-    fillBody(c, skipTypes(t[0], abstractPtrs), body, x, y)
+    # also apply the operation to the super type. An up-conversion is required
+    # for proper typing
+    let
+      base = skipTypes(t[0], abstractPtrs)
+      obj = newTreeIT(nkObjUpConv, x.info, base, x)
+    fillBody(c, base, body, obj, y)
   fillBodyObj(c, t.n, body, x, y, enforceDefaultOp = false)
 
 proc fillBodyObjT(c: var TLiftCtx; t: PType, body, x, y: PNode) =

--- a/tests/lang_objects/destructor/tsuper_type_destructor_bug.nim
+++ b/tests/lang_objects/destructor/tsuper_type_destructor_bug.nim
@@ -1,0 +1,23 @@
+discard """
+  description: '''
+    Regression test for an internal typing issue with synthesized hooks for
+    objects using inheritance
+  '''
+  targets: c js vm
+"""
+
+type
+  Parent = object of RootObj
+    x: int
+  Sub = object of Parent
+
+proc `=destroy`(x: var Parent) =
+  # ensure that the parameter is at least accessible at run-time
+  doAssert x.x == 1
+
+# the destroy hook for `Sub` is synthesized by the compiler
+
+proc test() =
+  var x = Sub(x: 1)
+
+test()


### PR DESCRIPTION
## Summary

Fix a bug with synthesis of lifetime-tracking hooks for object types
using inheritance, which showed up as a C compiler error when using
recent versions of clang or gcc.

Fixes https://github.com/nim-works/nimskull/issues/1337.

## Details

When synthesizing the hooks for object types using inheritance, the
destination accessor expression wasn't wrapped in an object conversion
prior to emitting the parent object handling.

Without the conversion, the synthesized hook passed along its own
parameter to the call of the super type's hook as-is. This is wrong
in general (the argument's type doesn't match the parameter's), but
didn't cause concrete issues until gcc and clang started to disallow
implicit conversions between incompatible pointer types.