### PR TITLE
macros: fix compiler crash with `parseExpr`

### DIFF
--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -67,7 +67,7 @@ import
   ]
 
 # xxx: reports are a code smell meaning data types are misplaced
-from compiler/ast/reports_sem import SemReport
+from compiler/ast/reports_vm import VMReport
 from compiler/ast/report_enums import ReportKind
 
 # xxx: `Report` is faaaar too wide a type for what the VM needs, even with all
@@ -2560,7 +2560,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
             assert ast.kind == nkStmtList
             Res.ok:  ast[0]
           else:
-            Res.err: SemReport(kind: rvmOpcParseExpectedExpression).wrap()
+            Res.err: VMReport(kind: rvmOpcParseExpectedExpression).wrap()
 
       if parsed.isOk:
         # success! Write the parsed AST to the result register and return an

--- a/tests/lang_callable/macros/ttryparseexpr.nim
+++ b/tests/lang_callable/macros/ttryparseexpr.nim
@@ -19,3 +19,9 @@ static:
   doAssert test("foo&&") == "Error: expression expected, but found '[EOF]'"
   doAssert test("valid") == 45
   doAssert test("\"")    == "Error: closing \" expected" # bug #2504
+
+  const error = "Error: expected expression, but got multiple statements"
+  # test with empty string
+  doAssert test("") == error
+  # test with multiple declarative statements
+  doAssert test("type A = int\ntype A = int") == error

--- a/tests/lang_callable/macros/ttryparseexpr.nim
+++ b/tests/lang_callable/macros/ttryparseexpr.nim
@@ -1,9 +1,8 @@
 discard """
-  target: "!vm"
-  outputsub: '''Error: expression expected, but found '[EOF]' 45'''
+  description: "Ensure that `parseExpr` raises a catchable exception on error"
+  action: compile
+  targets: native
 """
-
-# disabled for VM until we support `getCurrentExceptionMsg` (knownIssue)
 
 # feature request #1473
 import std/macros
@@ -14,10 +13,9 @@ macro test(text: string): untyped =
   except ValueError:
     result = newLit getCurrentExceptionMsg()
 
-const
-  valid = 45
-  a = test("foo&&")
-  b = test("valid")
-  c = test("\"") # bug #2504
+const valid = 45
 
-echo a, " ", b
+static:
+  doAssert test("foo&&") == "Error: expression expected, but found '[EOF]'"
+  doAssert test("valid") == 45
+  doAssert test("\"")    == "Error: closing \" expected" # bug #2504


### PR DESCRIPTION
## Summary

Fix a bug with `parseExpr` error handling that caused a compiler crash
when:
* an empty string was passed as the argument
* parsing the string returned more than one statement block

## Details

A `SemReport` was used instead of the correct `VMReport`. Since
`rvmOpcParseExpectedExpression` is not a valid report kind for
`SemReport`, the assertion in `wrap` failed and the compiler crashed.

The `ttryparseexpr` test is cleaned up and extended with two test cases
for the cases that trigger the "expected expression" case, ensuring
that previously faulty branch now has test coverage.