### PR TITLE
sem: keep shape of array constructors in typed AST

### DIFF
--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -759,7 +759,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
   of nkBracket, nkCurly:
     result = copyNode(n)
     for i, son in n.pairs:
-      let a = getConstExpr(m, son, idgen, g)
+      let a = getConstExpr(m, son.skipColon, idgen, g)
       if a == nil: return nil
       result.add a
     incl(result.flags, nfAllConst)
@@ -881,7 +881,7 @@ proc foldConstExprAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Fo
     # the last node is an expression
     result.add foldConstExprAux(m, n[^1], idgen, g)
   of nkExprColonExpr:
-    # comes here from tuple/object constructions
+    # comes here from array/tuple/object constructions
     result.add n[0]
     result.add foldConstExprAux(m, n[1], idgen, g)
     return

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1364,6 +1364,11 @@ proc transform(c: PTransf, n: PNode): PNode =
   of nkPragmaExpr:
     # not needed in transformed AST -> drop it
     result = transform(c, n.lastSon)
+  of nkBracket:
+    # replace elements where the index is specified with just the expression
+    result = shallowCopy(n)
+    for i, it in n.pairs:
+      result[i] = transform(c, it.skipColon)
   else:
     result = transformSons(c, n)
   when false:

--- a/tests/lang_exprs/ttyped_array_constr_expr.nim
+++ b/tests/lang_exprs/ttyped_array_constr_expr.nim
@@ -1,0 +1,21 @@
+discard """
+  description: '''
+    Ensure that the shape of literal array construction expresions is
+    preserved in typed AST
+  '''
+  action: compile
+"""
+
+import std/macros
+
+macro m(x: typed) =
+  doAssert treeRepr(x) == """Bracket
+  ExprColonExpr
+    IntLit 1
+    StrLit "a"
+  StrLit "b"
+  ExprColonExpr
+    IntLit 3
+    StrLit "c""""
+
+m([1: "a", "b", 3: "c"])


### PR DESCRIPTION
## Summary

Explicit indices in array constructors now stay in the AST after
typing. Since macros are able to observe this, this change is a
**breaking change**.

## Details

Keeping the explicit indices is also necessary for being able to
retype the AST after it was typed once (without the index, array
constructors for arrays not starting at zero would have a
different type afterwards).

Instead of dropping the explicit index together with the parent
`nkExprColonExpr` node, both are kept by `semArrayConstr`, and then
later discarded by `semfold` (during constant evaluation) and `transf`,
where they are no longer needed.