### PR TITLE
fix: crash when defining call/dot operators

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3238,8 +3238,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemSelectorMustBeOfCertainTypes,
       adSemInvalidPragmaBlock,
       adSemConceptPredicateFailed,
-      adSemDotOperatorsNotEnabled,
-      adSemCallOperatorsNotEnabled,
       adSemUnexpectedPattern,
       adSemIsOperatorTakes2Args,
       adSemNoTupleTypeForConstructor,
@@ -3274,6 +3272,14 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind,
         ast: diag.wrongNode)
+  of adSemDotOperatorsNotEnabled,
+     adSemCallOperatorsNotEnabled:
+    semRep = SemReport(
+        location: some diag.location,
+        reportInst: diag.instLoc.toReportLineInfo,
+        kind: kind,
+        ast: diag.wrongNode,
+        sym: diag.wrongNode.sym)
   of adSemInvalidTupleSubscript:
     semRep = SemReport(
         location: some diag.location,

--- a/tests/errmsgs/tenable_call_operator.nim
+++ b/tests/errmsgs/tenable_call_operator.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: '''
+    the overloaded () operator has to be enabled with {.experimental: "callOperator".}
+  '''
+  line: 8
+"""
+
+proc `()`(a: int) = discard

--- a/tests/errmsgs/tenable_dot_operator.nim
+++ b/tests/errmsgs/tenable_dot_operator.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: '''
+    the overloaded . operator has to be enabled with {.experimental: "dotOperators".}
+  '''
+  line: 8
+"""
+
+proc `.`(a: int) = discard


### PR DESCRIPTION
## Summary

Fix the compiler crashing when defining dot or call operator overloads
and the respective experimental feature is not enabled.

## Details

The formatting of the "call/dot operator not enabled" error messages
expects a symbol, but none was provided, resulting in an NPE.

For both "call/dot operator not enabled" diagnostics, when turning
them into reports, the symbol is now taken from the wrong node and
passed into the report.