### PR TITLE
vm: don't use ref-counted cells for globals

### DIFF
--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -684,21 +684,17 @@ proc getGlobalValue*(c: EvalContext, s: PSym): PNode =
   ## Does not perform type checking, so ensure that `s.typ` matches the
   ## global's type
   internalAssert(c.vm.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
-  let
-    slotIdx = c.vm.globals[c.jit.getGlobal(s)]
-    slot = c.vm.heap.slots[slotIdx]
-
-  result = c.vm.deserialize(slot.handle, s.typ, s.info)
+  let slot = c.vm.globals[c.jit.getGlobal(s)]
+  result = c.vm.deserialize(slot, s.typ, s.info)
 
 proc setGlobalValue*(c: var EvalContext; s: PSym, val: PNode) =
   ## Does not do type checking so ensure the `val` matches the `s.typ`
   internalAssert(c.vm.config, s.kind in {skLet, skVar} and sfGlobal in s.flags)
   let
-    slotIdx = c.vm.globals[c.jit.getGlobal(s)]
-    slot = c.vm.heap.slots[slotIdx]
+    slot = c.vm.globals[c.jit.getGlobal(s)]
     data = constDataToMir(c.vm, c.jit, val)
 
-  initFromExpr(slot.handle, data, c.jit.env, c.vm)
+  initFromExpr(slot, data, c.jit.env, c.vm)
 
 ## what follows is an implementation of the ``passes`` interface that evaluates
 ## the code directly inside the VM. It is used for NimScript execution and by

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2235,9 +2235,8 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
 
     of opcLdGlobal:
       let rb = instr.regBx - wordExcess
-      let slot = c.globals[rb]
       ensureKind(rkHandle)
-      regs[ra].setHandle(c.heap.slots[slot].handle)
+      regs[ra].setHandle(c.globals[rb])
 
     of opcLdCmplxConst:
       decodeBx(rkHandle)

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -696,7 +696,7 @@ type
       ## instruction raising
     ehCode*: seq[EhInstr]
       ## stores the instructions for the exception handling (EH) mechanism
-    globals*: seq[HeapSlotHandle] ## Stores each global's corresponding heap slot
+    globals*: seq[LocHandle] ## global slots
     constants*: seq[VmConstant] ## constant data
     complexConsts*: seq[LocHandle] ## complex constants (i.e. everything that
                                    ## is not a int/float/string literal)

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -126,7 +126,7 @@ proc updateEnvironment(c: var TCtx, env: var MirEnv, cp: EnvCheckpoint) =
   # globals (which includes threadvars)
   for id, sym in since(env.globals, cp.globals):
     let typ = c.getOrCreate(sym.typ)
-    c.globals.add c.heap.heapNew(c.allocator, typ)
+    c.globals.add c.allocator.allocSingleLocation(typ)
 
   # constants
   for id, data in since(env.data, cp.data):

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -163,7 +163,7 @@ proc loadIntoContext(c: var TCtx, p: PackedEnv) =
   c.allocator.byteType = c.typeInfoCache.charType
 
   mapList(c.globals, p.globals, x):
-    c.heap.heapNew(c.allocator, c.types[x])
+    c.allocator.allocSingleLocation(c.types[x])
 
   mapList(c.complexConsts, p.cconsts, x):
     let


### PR DESCRIPTION
## Summary

Store a handle to a normal memory cell in the `globals` table, instead
of a handle to a ref-counted cell.

## Details

VM globals are normal locations that exists as long as the VM
environment does; they don't need to be reference-counted, which they
also never were.

Storing a handle to the memory cell in the global table directly
removes and unnecessary indirection through `HeapSlotHandle`, and thus
speeds up loading a global a tiny bit.