### PR TITLE
compiler: add the `--showir` switch

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -390,7 +390,7 @@ proc translate*(id: ProcedureId, body: PNode, graph: ModuleGraph,
 
   echoInput(graph.config, prc, body)
   result = generateCode(graph, env, prc, config.tconfig, body)
-  echoMir(graph.config, prc, result)
+  echoMir(graph.config, prc, result, env)
 
   # now apply the passes:
   process(result, prc, graph, idgen, env)
@@ -580,7 +580,7 @@ proc produceLoader(graph: ModuleGraph, m: Module, data: var DiscoveryData,
 
   echoInput(graph.config, sym, body)
   result = generateCode(graph, env, owner, conf.tconfig, body)
-  echoMir(graph.config, sym, result)
+  echoMir(graph.config, sym, result, env)
 
 # ----- discovery and queueing logic -----
 

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -399,6 +399,7 @@ proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
                  owner: PSym, body: sink MirBody): Body =
   ## Translates the MIR code provided by `code` into ``CgNode`` IR and,
   ## if enabled, echoes the result.
+  echoOutput(graph.config, owner, body, env)
   result = cgirgen.generateIR(graph, idgen, env, owner, body)
   echoOutput(graph.config, owner, result)
 

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -187,6 +187,15 @@ type
              ## argument
     pimFile  ## the main module is a file
 
+  IrName* = enum
+    ## Names of the IRs that can be rendered to the standard output for
+    ## debugging purposes.
+    irTransf = "transf"
+    irMirIn  = "mir_in"
+    irMirOut = "mir_out"
+    irCgir   = "cgir"
+    irVm     = "vm"
+
   ReportHook* = proc(conf: ConfigRef, report: Report): TErrorHandling {.closure.}
 
   HackController* = object
@@ -308,6 +317,13 @@ type
     when defined(nimDebugUtils):
       debugUtilsStack*: seq[string] ## which proc name to stop trace output
       ## len is also used for output indent level
+
+    toDebugProc*: StringTableRef
+      ## maps identifiers to the name of the IR to print to the standard
+      ## output
+    toDebugIr*: set[IrName]
+      ## the IRs which should always be always printed to the standard
+      ## output
 
     when defined(nimDebugUnreportedErrors):
       unreportedErrors*: OrderedTable[NodeId, PNode]
@@ -903,6 +919,7 @@ proc initConfigRefCommon(conf: ConfigRef) =
   conf.notes = NotesVerbosity.main[conf.verbosity]
   conf.hack = defaultHackController
   conf.mainPackageNotes = NotesVerbosity.main[conf.verbosity]
+  conf.toDebugProc = newStringTable(modeStyleInsensitive)
   when defined(nimDebugUtils):
     # ensures that `nimDebugUtils` is defined for the compiled code so it can
     # access the `system.nimCompilerDebugRegion` template

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1606,3 +1606,8 @@ func inDebug*(conf: ConfigRef): bool {.
   noSideEffect.} =
   ## Check whether 'nim compiler debug' is defined right now.
   return conf.isDefined("nimCompilerDebug")
+
+template isDebugEnabled*(c: ConfigRef, ir: IrName, name: string): bool =
+  ## Whether printing the `ir` IR is enabled specifically for the given `name`.
+  # a template is used so that `$ir` can be folded when `ir` is constant
+  c.toDebugProc.getOrDefault(name) == $ir

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -62,6 +62,13 @@ proc echoMir*(config: ConfigRef, owner: PSym, body: MirBody, env: MirEnv) =
     writeBody(config, "-- MIR: " & owner.name.s):
       config.writeln(render(body.code, addr env, addr body))
 
+proc echoOutput*(config: ConfigRef, owner: PSym, body: MirBody, env: MirEnv) =
+  ## If enabled, renders the output IR `body` and outputs the result to
+  ## ``config.writeLine``.
+  if config.isEnabled(irMirOut, owner.name.s):
+    writeBody(config, "-- MIR: " & owner.name.s):
+      config.writeln(render(body.code, addr env, addr body))
+
 proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
   ## If requested via the define, renders the output IR `body` and writes the
   ## result out through ``config.writeLine``.

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -55,12 +55,12 @@ proc echoInput*(config: ConfigRef, owner: PSym, body: PNode) =
     writeBody(config, "-- input AST: " & owner.name.s):
       config.writeln(treeRepr(config, body, reprConfig))
 
-proc echoMir*(config: ConfigRef, owner: PSym, body: MirBody) =
+proc echoMir*(config: ConfigRef, owner: PSym, body: MirBody, env: MirEnv) =
   ## If requested via the define, renders the `body` and writes the result out
   ## through ``config.writeln``.
   if config.isEnabled(irMirIn, owner.name.s):
     writeBody(config, "-- MIR: " & owner.name.s):
-      config.writeln(treeRepr(body.code))
+      config.writeln(render(body.code, addr env, addr body))
 
 proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
   ## If requested via the define, renders the output IR `body` and writes the

--- a/compiler/mir/mirbridge.nim
+++ b/compiler/mir/mirbridge.nim
@@ -30,12 +30,6 @@ import
 
 export GenOption
 
-proc getStrDefine(config: ConfigRef, name: string): string =
-  if config.isDefined(name):
-    result = config.getDefined(name)
-  else:
-    result = ""
-
 template writeBody(config: ConfigRef, header: string, body: untyped) =
   # NOTE: if the debug traces should be kept, they should be properly
   #       integrated into the tracing pipeline
@@ -50,29 +44,29 @@ let reprConfig = block:
   rc.flags.incl trfShowSymKind
   rc
 
-# NOTE: the ``echoX`` are used as a temporary solution for inspecting inputs
-# and outputs in the context of compiler debugging until a more
-# structured/integrated solution is implemented
+template isEnabled(config: ConfigRef, ir: IrName, name: string): bool =
+  # debugging the IR must be enabled globally or locally
+  ir in config.toDebugIr or config.isDebugEnabled(ir, name)
 
 proc echoInput*(config: ConfigRef, owner: PSym, body: PNode) =
   ## If requested via the define, renders the input AST `body` and writes the
   ## result out through ``config.writeLine``.
-  if config.getStrDefine("nimShowMirInput") == owner.name.s:
+  if config.isEnabled(irTransf, owner.name.s):
     writeBody(config, "-- input AST: " & owner.name.s):
       config.writeln(treeRepr(config, body, reprConfig))
 
 proc echoMir*(config: ConfigRef, owner: PSym, body: MirBody) =
   ## If requested via the define, renders the `body` and writes the result out
   ## through ``config.writeln``.
-  if config.getStrDefine("nimShowMir") == owner.name.s:
+  if config.isEnabled(irMirIn, owner.name.s):
     writeBody(config, "-- MIR: " & owner.name.s):
       config.writeln(treeRepr(body.code))
 
 proc echoOutput*(config: ConfigRef, owner: PSym, body: Body) =
   ## If requested via the define, renders the output IR `body` and writes the
   ## result out through ``config.writeLine``.
-  if config.getStrDefine("nimShowMirOutput") == owner.name.s:
-    writeBody(config, "-- output AST: " & owner.name.s):
+  if config.isEnabled(irCgir, owner.name.s):
+    writeBody(config, "-- CGIR: " & owner.name.s):
       config.writeln(treeRepr(body.code))
 
 proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
@@ -82,7 +76,7 @@ proc canonicalize*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
   echoInput(graph.config, owner, body)
   # step 1: generate a ``MirTree`` from the input AST
   let body = generateCode(graph, env, owner, config, body)
-  echoMir(graph.config, owner, body)
+  echoMir(graph.config, owner, body, env)
 
   # step 2: generate the ``CgNode`` tree
   result = cgirgen.generateIR(graph, idgen, env, owner, body)

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -169,7 +169,7 @@ proc typeToStr(result: var string, t: TypeId, env: ptr MirEnv) =
 
 func addLocalName(result: var string, id: LocalId, open: string,
                   c: RenderCtx) =
-  if c.body.isNil:
+  if c.body.isNil or c.body[][id].name.isNil:
     # render just the ID
     idToStr(result, id, open)
   else:

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -119,15 +119,10 @@ func `$`(e: ExecErrorReport): string {.error.}
 proc logBytecode(c: TCtx, owner: PSym, start: int) =
   ## If enabled, renders the bytecode ranging from `start` to the current end
   ## into text that is then written to the standard output.
-  const Symbol = "expandVmListing"
-  if owner != nil and c.config.isDefined(Symbol):
-    let name = c.config.getDefined(Symbol)
-    # if no value is specified for the conditional sym (i.e.,
-    # ``--define:expandVmListing``), `name` is 'true', which we interpret
-    # as "log everything"
-    if name == "true" or name == owner.name.s:
-      let listing = codeListing(c, start)
-      c.config.msgWrite: renderCodeListing(c.config, owner, listing)
+  if irVm in c.config.toDebugIr or
+     (owner != nil and c.config.isDebugEnabled(irVm, owner.name.s)):
+    let listing = codeListing(c, start)
+    c.config.msgWrite: renderCodeListing(c.config, owner, listing)
 
 proc putIntoReg(dest: var TFullReg; jit: var JitState, c: var TCtx, n: PNode,
                 formal: PType) =

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -260,7 +260,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
 
   echoInput(c.config, s, body)
   var mirBody = generateCode(c.graph, jit.gen.env, s, selectOptions(c), body)
-  echoMir(c.config, s, mirBody)
+  echoMir(c.config, s, mirBody, jit.gen.env)
   applyPasses(c, jit.gen.env, s, mirBody)
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -265,6 +265,7 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   for _ in discover(jit.gen.env, cp):
     discard "nothing to register"
 
+  echoOutput(c.config, s, mirBody, jit.gen.env)
   let outBody = generateIR(c.graph, c.idgen, jit.gen.env, s, mirBody)
   echoOutput(c.config, s, outBody)
 

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -423,35 +423,33 @@ MIR Input and Output
 ====================
 
 For debugging issues related to the MIR but also code-generator issues in
-general, one can print the input and output to the MIR canonicalization step
-plus the corresponding `PNode`-AST output.
+general, one can print the various IRs used during the mid-/back-end phase.
 
-To print the `PNode`-AST that reaches `mirgen`, `--define:nimShowMirInput=name`
-is used. This will print out the `PNode`-AST of all procedures and modules of
-which the name is equal to the specified `name` in the console. Because of how
-dead-code-elimination works, only the AST of alive procedures (i.e. used ones)
-is printed. If a procedure is used at both compile- and run-time, it will be
-printed twice.
+This is done by using one of the following options with the
+`--showir`:option: switch:
+* `transf`:option: : shows the post `transf` AST that gets translated to the
+  MIR
+* `mir_in`:option: : shows the MIR produced by `mirgen`, without any passes
+  applied
+* `mir_out`:option: : shows the MIR after all passes were applied, right before
+  translation to the CGIR
+* `cgir`:option: : shows the CGIR as produced by `cgirgen`
 
-To print the generated MIR code for a procedure, `--define:nimShowMir=name`
-can be used. The same limitation as for `nimShowMirInput` apply.
-
-`--define:nimShowMirOutput=name` prints the `CgNode`-IR that is output by
-`cgirgen`. This is IR that the code generators operate on.
-
-While all of the defines listed above can be used simultaneously, only a single
-occurrence of each is considered. Each further occurrence will override the
-respective name.
+If a procedure is used at both compile- and run-time, it will show up in the
+output twice, though potentially with different bodies, as different passes are
+applied. Only procedures actually used in alive code are processed during the
+MIR and back-end phase; if a procedure is not alive, the IR for cannot be
+shown with `--showir`:option: .
 
 VM Codegen and Execution
 ========================
 
 For echoing the VM bytecode generated for compile-time procedures and macros,
-`--define:expandVmListing=vmTarget`:option: can be passed to the compiler (no
-special build of the compiler is required). The bytecode for all routines of
-which the name is `vmTarget` is then echoed to the standard output. Leaving
-`vmTarget` empty enables echoing for *all* VM bytecode that is generated as
-part of compile-time execution.
+`--showir:vm:vmTarget`:option: can be passed to the compiler (no special build
+of the compiler is required). The bytecode for all routines of which the name
+is `vmTarget` is then echoed to the standard output. Leaving `vmTarget` empty
+enables echoing for *all* VM bytecode that is generated as part of compile-time
+execution.
 
 For example (generated listing might not match exactly)
 
@@ -471,7 +469,7 @@ For example (generated listing might not match exactly)
 
 .. code-block:: cmd
 
-  nim c --filenames:canonical --define:expandVmListing=vmTarget file.nim
+  nim c --filenames:canonical --showir:vm:vmTarget file.nim
 
 
 .. code-block:: literal


### PR DESCRIPTION
## Summary

* replace the debug defines for enabling IR printing with the proper
  `--showir` switch
* the switch has two forms: `--showir:<ir>` (enable globally) and
  `--showir:<ir>:<name>` (enable for procedures with given name)
* the supported IR names are: `transf`, `mir_in`, `mir_out`, `cgir`,
  and `vm`
* the old debug defines are removed (they now do nothing)

Using a proper compiler switch brings some usability improvements
(validation, style-insensitive names), and will make extending the
functionality in the future a bit easier.

## Details

* the enabled names are stored `ConfigRef` using in a `StringTableRef`,
  to allow for style-insensitive name lookup
* a `StringTableRef` only supports string-to-string mappings so
  only the showing of one IR per name is supported at the moment
* the `mir_out` option is new: it shows the MIR as it looks like right
  before `cgirgen`
* `mir_in` (corresponding to the previous `nimShowMir` define), now
  shows pretty-printed MIR, instead of the tree representation
* the `debug.rst` documentation mentioning the obsolete defines is
  updated 

### Misc

* a bug with the MIR pretty-printer, where rendering locals with no
  name crashed the compiler, is fixed