### PR TITLE
sem: don't analyze dependent operands to `static`

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -914,6 +914,7 @@ proc myOpen(graph: ModuleGraph; module: PSym;
   c.semTypeNode = semTypeNode
   c.instTypeBoundOp = sigmatch.instTypeBoundOp
   c.hasUnresolvedArgs = hasUnresolvedArgs
+  c.semGenericExpr = semGenericExpr
   c.templInstCounter = new int
 
   pushProcCon(c, module)

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -637,6 +637,9 @@ type
                             op: TTypeAttachedOp; col: int): PSym {.nimcall.}
       ## read to break cyclic dependencies, init in sem during module open and
       ## read in liftdestructors and semtypinst
+    semGenericExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.}
+      ## read to break cyclic dependencies, init in sem during module open and
+      ## read in sigmatch
     # -------------------------------------------------------------------------
     # end: not entirely clear why, function pionters for certain sem calls?
     # -------------------------------------------------------------------------

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1696,6 +1696,13 @@ proc semStmtListType(c: PContext, n: PNode, prev: PType): PType =
   else:
     result = nil
 
+proc semGenericExpr(c: PContext, n: PNode): PNode =
+  ## Runs the generic pre-pass on `n` and returns the result. Similar to
+  ## ``semGenericStmt``, but makes sure that all generic parameter symbols
+  ## were bound.
+  result = semGenericStmt(c, n)
+  discard fixupTypeVars(c, result)
+
 proc semGenericParamInInvocation(c: PContext, n: PNode): PType =
   result = semTypeNode(c, n, nil)
   n.typ = makeTypeDesc(c, result)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -3214,7 +3214,7 @@ proc matchesType(c: PContext, n: PNode, m: var TCandidate,
           arg.typ = makeTypeFromExpr(c, copyNodeWithKids(arg))
       else:
         # we don't know the argument's type, nor can we enforce that it'll
-        # matche the formal type later -> type mismatch
+        # match the formal type later -> type mismatch
         m.call[formal.position + 1] = copyNodeWithKids(operand)
         m.call[formal.position + 1].typ = makeTypeFromExpr(c, operand)
         break

--- a/tests/lang_callable/generics/tdependent_operands_to_static.nim
+++ b/tests/lang_callable/generics/tdependent_operands_to_static.nim
@@ -1,0 +1,27 @@
+discard """
+  description: '''
+    Various tests for operands to `static` constrained generic type parameters
+    where the operand's type depends on unresolved type variables.
+  '''
+"""
+
+type
+  Type1[T: static] = object ## only must be *some* static value
+  Type2[T: static int] = object ## must a be a static int
+
+proc eval[T](x: T): T {.compileTime.} =
+  x
+
+proc p1[T](): Type1[eval(default(T))] = discard
+proc p2[T](): Type2[eval(default(T))] = discard
+# ^^ whether the ``Type2`` can be instantiated depends on the later
+# supplied `T`
+
+discard p1[int]()    # works
+discard p1[float]()  # works
+discard p1[string]() # works
+
+discard p2[int]()    # int is convertible to int -> works
+discard p2[float]()  # float is convertible to int -> works
+# string is not convertible to float -> fails:
+doAssert not compiles(p3[string]())

--- a/tests/lang_callable/generics/tdependent_operands_to_static_2.nim
+++ b/tests/lang_callable/generics/tdependent_operands_to_static_2.nim
@@ -12,7 +12,7 @@ discard """
 """
 
 type
-  Type[T: string | static float] = object ## must be an int or static float
+  Type[T: string | static float] = object ## must be a string or static float
 
 proc eval[T](x: T): T {.compileTime.} = x
 

--- a/tests/lang_callable/generics/tdependent_operands_to_static_2.nim
+++ b/tests/lang_callable/generics/tdependent_operands_to_static_2.nim
@@ -1,0 +1,21 @@
+discard """
+  description: '''
+    Operands with a type not known upfront cannot be used as arguments to
+    complex static
+  '''
+  errormsg: "cannot instantiate Type"
+  line: 21
+  knownIssue: '''
+    `Type`s generic parameter is not detected as containing a `static`, thus
+    full analysis is not disabled (which subsequently fails)
+  '''
+"""
+
+type
+  Type[T: string | static float] = object ## must be an int or static float
+
+proc eval[T](x: T): T {.compileTime.} = x
+
+# the operand's type is not known and no concrete type can be derived from
+# the constraint -> reject early
+proc p[T](): Type[eval(default(T))] = discard


### PR DESCRIPTION
## Summary

Makes instantiations such as `Generic[someProc(T)]` work, where
`T` is some generic parameter (and receiving type parameter is a
`static` one) -- the `someProc(T)` expression is typed once `T` is
substituted, making the behaviour consistent with `array` and `range`.

## Details

Fully analyzing (i.e., with `semExpr`) arbitrary expressions that might
reference unresolved type variables generally doesn't work. Operands to
generic invocations were eagerly analyzed (in `matchesAux`), usually
resulting in errors when the operand needs to be a `static` value.

Disallowing expressions dependent on unresolved type variables in this
context would be a regression, since some expressions are special-cased
to work (such as `sizeof(T)`).

To address the problem, before typing the operand, it's first checked
whether it depends on unresolved type variables. If it does, the
expression is treated as a generic expression, with a `tyFromExpr`
assigned as its type -- otherwise it's analyzed as usual.

If the operand has an unknown type (`tyFromExpr`), it's wrapped in a
conversion to a type derived from the generic parameter's constraint,
to make sure the operand types later. If no concrete type can be
derived from the constraint, a type mismatch is reported.

To not convolute `matchesAux` further, the argument matching where the
callee is a `tyGenericBody` is moved into the new `matchesType`. It
does largely the same as `matchesAux`, but with everything not
applicable to types removed (such as the varargs handling).