### PR TITLE
macros: keep instantiation parameters with `getType`

### DIFF
--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -159,17 +159,13 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
     for i in 0..<t.len:
       result.add mapTypeToAst(t[i], info)
   of tyGenericInst:
-    if inst:
-      if allowRecursion:
-        result = mapTypeToAstR(t.lastSon, info)
-      else:
-        result = newNodeX(nkBracketExpr)
-        #result.add mapTypeToAst(t.lastSon, info)
-        result.add mapTypeToAst(t[0], info)
-        for i in 1..<t.len-1:
-          result.add mapTypeToAst(t[i], info)
+    if inst and allowRecursion:
+      result = mapTypeToAstR(t.lastSon, info)
     else:
-      result = mapTypeToAstX(cache, t.lastSon, info, idgen, inst, allowRecursion)
+      result = newNodeX(nkBracketExpr)
+      result.add mapTypeToAst(t[0], info)
+      for i in 1..<t.len-1:
+        result.add mapTypeToAst(t[i], info)
   of tyGenericBody:
     if inst:
       result = mapTypeToAstR(t.lastSon, info)

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -11,7 +11,8 @@ import std/macros
 from std/typetraits import OrdinalEnum, HoleyEnum
 
 macro enumFullRange(a: typed): untyped =
-  newNimNode(nnkCurly).add(a.getType[1][1..^1])
+  let typ = getTypeImpl(getType(a)[1]) # the ``nnkEnumTy`` AST
+  newNimNode(nnkCurly).add(typ[1..^1])
 
 # xxx `genEnumCaseStmt` needs tests and runnableExamples
 

--- a/tests/lang_callable/macros/tgettype2.nim
+++ b/tests/lang_callable/macros/tgettype2.nim
@@ -11,8 +11,8 @@ gt(bar):	distinct[int]
 gt(baz):	int, int
 gt(v):	seq[int]
 gt(vv):	seq[float]
-gt(t):	distinct[tuple[int, int]]
-gt(tt):	distinct[tuple[float, float]]
+gt(t):	MyType[int]
+gt(tt):	MyType[float]
 gt(s):	distinct[tuple[int, int]]
 #############
 #### gt2 ####
@@ -70,8 +70,8 @@ echo gt(baz) # int, int          I would prefer Baz, int
 
 echo gt(v)   # seq[int], ok
 echo gt(vv)  # seq[float], ok
-echo gt(t)   # MyType, distinct[tuple[int, int]]      I would prefer MyType[int],   distinct[tuple[int, int]]
-echo gt(tt)  # MyType, distinct[tuple[float, float]]  I would prefer MyType[float], distinct[tuple[int, int]]
+echo gt(t)   # MyType[int], ok
+echo gt(tt)  # MyType[float], ok
 echo gt(s)   # distinct[tuple[int, int]]              I would prefer MySimpleType, distinct[tuple[int,int]]
 
 echo "#############"

--- a/tests/lang_callable/macros/tgettype3.nim
+++ b/tests/lang_callable/macros/tgettype3.nim
@@ -27,6 +27,10 @@ proc getTypeName(t: NimNode, skipVar = false): string =
             result = "vec4"
         elif $(t[0]) == "distinct":
             result = getTypeName(t[1], skipVar)
+        # --------- not part of the original test case
+        elif $(t[0]) == "vecBase":
+            result = "vec2"
+        # ---------
     of nnkSym:
         case $t
         of "vecBase": result = getTypeName(getType(t), skipVar)


### PR DESCRIPTION
## Summary

`getType` now keeps instantiation parameters, which were previously
irrecoverably lost. This also allows retrieving the instantiation
parameters when only having access to an alias of the instantiated
type.

Fixes #1223.

## Details

Expanding `tyGenericInst` to `(BracketExpr <Callee> ...)` is the only
way of keeping the type information intact, since `tyGenericInst` do
not have symbols attached to them (in which case translating to an
`nnkSym` would be preferable, as it'd keep the AST flat).

Existing tests are adjusted.

### Aliases

A second goal of changing `getType` behaviour for `tyGenericInst` is to
allow retrieving the instantiation parameters in the presence of
type aliases. Given:
```nim
type
  Generic[A, B] = object
  Alias = Generic[int, string]
```

it was previously not possible to retrieve the instantiation
parameters for `Generic[int, string]` when given the expression
`Alias`, but now it is (with `getType`).

### Other

The internal `enumutils.enumFullRange` macro relied on the old
`getType` behaviour. To restore its functionality, it now uses
`getTypeImpl`.