### PR TITLE
actions/setup-mingw: bump release-downloader to 1.10

### DIFF
--- a/.github/actions/setup-mingw/action.yml
+++ b/.github/actions/setup-mingw/action.yml
@@ -18,7 +18,7 @@ runs:
 
     - name: Download from niXman/mingw-builds-binaries
       id: download
-      uses: robinraju/release-downloader@v1.8
+      uses: robinraju/release-downloader@v1.10
       with:
         repository: niXman/mingw-builds-binaries
         tag: ${{ inputs.mingw-version }}
@@ -31,8 +31,7 @@ runs:
         Join-Path $env:RUNNER_TEMP "mingw64" "bin" | Out-File -Append $env:GITHUB_PATH
       shell: pwsh
       env:
-        MINGW_ARCHIVE:
-          ${{ fromJson(steps.download.outputs.downloaded_files)[0] }}
+        MINGW_ARCHIVE: ${{ fromJson(steps.download.outputs.downloaded_files)[0] }}
       working-directory: ${{ runner.temp }}
 
     - name: Print GCC version


### PR DESCRIPTION
## Summary
No functional changes other than a bump to NodeJS 20 since 16 has been
deprecated by GitHub.

## Details
* GitHub has deprecated version 16 since Oct 2023:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/