### PR TITLE
make the REPL (`nim secret`) work again

### DIFF
--- a/compiler/ast/llstream.nim
+++ b/compiler/ast/llstream.nim
@@ -75,6 +75,7 @@ when not declared(readLineFromStdin):
   # fallback implementation:
   proc readLineFromStdin(prompt: string, line: var string): bool =
     stdout.write(prompt)
+    stdout.flushFile()
     result = readLine(stdin, line)
     if not result:
       stdout.write("\n")

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -2617,8 +2617,7 @@ To create a stacktrace, rerun compilation with './koch temp $1 <file>'
       )
 
     of rintEchoMessage:
-      result = if conf.cmd == cmdInteractive: ">>> " & r.msg
-               else:                          r.msg
+      result = r.msg
 
     of rintCannotOpenFile, rintWarnCannotOpenFile:
       result = "cannot open file: $1" % r.file

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -505,7 +505,7 @@ proc mainCommand*(graph: ModuleGraph) =
 
   ## command prepass
   if conf.cmd == cmdCrun: conf.incl {optRun, optUseNimcache}
-  if conf.cmd notin cmdBackends + {cmdTcc, cmdNimscript}:
+  if conf.cmd notin cmdBackends + {cmdTcc, cmdNimscript, cmdInteractive}:
     customizeForBackend(graph, conf, backendC)
   if conf.outDir.isEmpty:
     # doc like commands can generate a lot of files (especially with --project)
@@ -675,7 +675,9 @@ proc mainCommand*(graph: ModuleGraph) =
     wantMainModule(conf)
     commandView(graph)
     #msgWriteln(conf, "Beware: Indentation tokens depend on the parser's state!")
-  of cmdInteractive: commandInteractive(graph)
+  of cmdInteractive:
+    customizeForBackend(graph, conf, backendNimVm)
+    commandInteractive(graph)
   of cmdNimscript:
     if conf.inputMode == pimFile and not fileExists(conf.projectFull):
       localReport(conf, InternalReport(

--- a/tests/compilerfeatures/trepl.nim
+++ b/tests/compilerfeatures/trepl.nim
@@ -1,0 +1,54 @@
+discard """
+  description: "Ensure that the basic REPL functionality works"
+  targets: native
+"""
+
+import std/[streams, os, osproc]
+
+const Compiler = getCurrentCompilerExe()
+
+let
+  repl = startProcess("bin/nim", args=["secret"], options={poStdErrToStdOut})
+  output = repl.inputStream()  # for writing to
+  input  = repl.outputStream() # for reading from
+
+template expectLine(expect: string) =
+  var line: string
+  doAssert readLine(input, line)
+  doAssert line == expect, "got: " & line
+
+template expect(expect: static string) =
+  var got = readStr(input, expect.len)
+  doAssert got == expect, "got: " & got
+
+template writeLine(line: string) =
+  writeLine(output, line)
+  flush(output)
+
+expect ">>> "
+# okay, startup was successful; no error was reported
+
+# test a simple echo statement
+writeLine "echo \"hello\""
+expectLine "hello"
+
+# test a simple procedure definition
+expect ">>> "
+writeLine "proc p() ="
+expect "... "
+writeLine "  echo \"here\""
+expect "... "
+writeLine ""
+expect ">>> "
+writeLine "p()" # call the procedure
+expectLine "here"
+
+# quit the REPL
+expect ">>> "
+writeLine "quit()"
+
+# make sure shutdown worked without an error
+let code = waitForExit(repl)
+doAssert code == 0, "non-zero exit code: " & $code
+
+repl.close()

--- a/tests/compilerfeatures/trepl.nim
+++ b/tests/compilerfeatures/trepl.nim
@@ -1,6 +1,7 @@
 discard """
   description: "Ensure that the basic REPL functionality works"
   targets: native
+  timeout: "5"
 """
 
 import std/[streams, os, osproc]


### PR DESCRIPTION
## Summary

Properly configure the compiler when running the `nim secret`
command, making the compiler built-in REPL usable again.

## Details

* the compiler is configured for the VM backend when the
  `cmdInteractive` command is active
* `echo` output is no longer prefixed by `>>>`
* a test is added to ensure the basic REPL functionality works
* the standard output stream is flushed after writing `>>>` or `...`,
  so that the test is able to read the output