### PR TITLE
ci: replace vcpkg-action with simpler setup-vcpkg

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -1,0 +1,62 @@
+name: Setup vcpkg
+description: Clone and setup vcpkg
+inputs:
+  triplet:
+    description: Specify the target triplet
+    required: false
+  host-triplet:
+    description: Specify the host triplet
+    required: false
+  overlay-triplets:
+    description: Additional directories to search to triplets, one entry per line
+    required: false
+  revision:
+    description: The revision of the vcpkg registry to be used
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Clone vcpkg
+      uses: actions/checkout@v4
+      with:
+        repository: microsoft/vcpkg
+        ref: ${{ inputs.revision }}
+        filter: tree:0
+        path: vcpkg
+
+    - name: Setup environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          // Configuration for GitHub Actions cache
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+          // vcpkg configuration
+          const path = require('node:path');
+          const vcpkg_root = path.join(process.env.GITHUB_WORKSPACE, 'vcpkg');
+          core.exportVariable('VCPKG_ROOT', vcpkg_root);
+          core.addPath(vcpkg_root);
+
+          core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite');
+          const triplet = process.env.AINPUT_TRIPLET;
+          if (triplet) {
+            core.exportVariable('VCPKG_DEFAULT_TRIPLET', triplet);
+          }
+          const hostTriplet = process.env.AINPUT_HOST_TRIPLET;
+          if (hostTriplet) {
+            core.exportVariable('VCPKG_DEFAULT_HOST_TRIPLET', hostTriplet);
+          }
+          const tripletOverlays = process.env.AINPUT_OVERLAY_TRIPLETS?.replace(/\n/, path.delimiter);
+          if (tripletOverlays) {
+            core.exportVariable('VCPKG_OVERLAY_TRIPLETS', tripletOverlays);
+          }
+      env:
+        AINPUT_TRIPLET: ${{ inputs.triplet }}
+        AINPUT_HOST_TRIPLET: ${{ inputs.host-triplet }}
+        AINPUT_OVERLAY_TRIPLETS: ${{ inputs.overlay-triplets }}
+
+    - run: ./vcpkg/bootstrap-vcpkg.sh
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,18 +135,18 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/setup-mingw
 
+      - name: Setup vcpkg (Windows)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: x64-mingw-dynamic-release
+          host-triplet: x64-mingw-dynamic-release
+          revision: 2024.01.12
+          overlay-triplets: ${{ github.workspace }}/tools/vcpkg/triplets
+
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
-        uses: johnwason/vcpkg-action@v6
-        with:
-          pkgs: >-
-            pcre
-            sqlite3
-          triplet: x64-mingw-dynamic-release
-          extra-args: --overlay-triplets=${{ github.workspace }}/tools/vcpkg/triplets --host-triplet=x64-mingw-dynamic-release
-          revision: 2024.01.12
-          github-binarycache: true
-          token: ${{ github.token }}
+        run: vcpkg install pcre sqlite3
 
       - name: Download CA certificates (Windows)
         if: runner.os == 'Windows'
@@ -393,18 +393,18 @@ jobs:
           # Pipe from zstd to tar because macOS' tar does not support unpacking zstd
           zstd -c -d "$archive" | tar -xf - --strip-components 1
 
+      - name: Setup vcpkg (Windows)
+        if: runner.os == 'Windows'
+        uses: ./git-src/.github/actions/setup-vcpkg
+        with:
+          triplet: x64-mingw-dynamic-release
+          host-triplet: x64-mingw-dynamic-release
+          revision: 2024.01.12
+          overlay-triplets: ${{ github.workspace }}/tools/vcpkg/triplets
+
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
-        uses: johnwason/vcpkg-action@v6
-        with:
-          pkgs: >-
-            pcre
-            sqlite3
-          triplet: x64-mingw-dynamic-release
-          extra-args: --overlay-triplets=${{ github.workspace }}/tools/vcpkg/triplets --host-triplet=x64-mingw-dynamic-release
-          revision: 2024.01.12
-          github-binarycache: true
-          token: ${{ github.token }}
+        run: vcpkg install pcre sqlite3
 
       - name: Add DLLs to PATH (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
johnwason/vcpkg-action depends on various other actions that are now
out-of-date and is using deprecated NodeJS 16. Given that vcpkg
configuration and bootstrap is very simple, replace our usage with a
simpler homemade setup-vcpkg instead.

## Details
* Added a new  `setup-vcpkg`  action. This action is rather simple and
consist only of exporting environment variables to configure vcpkg.
* Replace usage of `johnwason/vcpkg-action` with `setup-vcpkg`.