### PR TITLE
Produce a meaningful error message for invalid module name

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1636,7 +1636,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "using '.' instead of '/' in import paths is deprecated"
 
     of rsemInvalidModuleName:
-      result = "invalid module name: '$1'" % r.ast.render
+      if r.sym != nil:
+        result = "invalid module name: '$1'" % r.symstr
+      else:
+        result = "invalid module name: '$1'" % r.ast.render
 
     of rsemInvalidMethodDeclarationOrder:
       result = "invalid declaration order; cannot attach '" & r.symbols[0].name.s &

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -104,7 +104,11 @@ proc newModule(graph: ModuleGraph; fileIdx: FileIndex): PSym =
                 name: getModuleIdent(graph, filename),
                 info: newLineInfo(fileIdx, 1, 1))
   if not isNimIdentifier(result.name.s):
-    localReport(graph.config, reportSym(rsemInvalidModuleName, result))
+    localReport(
+      graph.config,
+      newLineInfo(fileIdx, 0, -1),
+      reportSym(rsemInvalidModuleName, result)
+    )
 
   partialInitModule(result, graph, fileIdx, filename)
   graph.registerModule(result)

--- a/tests/errmsgs/tinvalid-name.nim
+++ b/tests/errmsgs/tinvalid-name.nim
@@ -1,4 +1,6 @@
 discard """
-  description: Test that a proper error message is printed for a module with invalid name
+  description: '''
+    Test that a proper error message is printed for a module with invalid name
+  '''
   errormsg: "invalid module name: 'tinvalid-name'"
 """

--- a/tests/errmsgs/tinvalid-name.nim
+++ b/tests/errmsgs/tinvalid-name.nim
@@ -1,0 +1,4 @@
+discard """
+  description: Test that a proper error message is printed for a module with invalid name
+  errormsg: "invalid module name: 'tinvalid-name'"
+"""


### PR DESCRIPTION
## Summary
While the AST form of the error generated by  `modules/modulepaths`  is
handled in  `cli_reporter` , the symbol form was not, creating terrible
error messages such as:

    Error: invalid module name '<nil tree>'

This PR makes cli_reporter aware of the symbol form generated by 
`modules/modules` , fixing the bad error message.

## Details
*  `cli_reporter`  now handles the symbol form of 
`rsemInvalidModuleName`  correctly.
*  `modules/modules`  now raises  `rsemInvalidModuleName`  with line
information, allowing user and tools to know which file the error
originated from.

Fixes https://github.com/nim-works/nimskull/issues/720