### PR TITLE
fix incorrect typing in closure-iterator C code-gen

### DIFF
--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -683,6 +683,7 @@ proc closureSetup(p: BProc, prc: PSym) =
   # prc.ast[paramsPos].last contains the type we're after:
   var ls = lastSon(prc.ast[paramsPos])
   p.config.internalAssert(ls.kind == nkSym, prc.info, "closure generation failed")
+  p.config.internalAssert(ls.typ == ls.sym.typ) # sanity check
   var env = ls.sym.position + 1 # parameters start at ID 1
 
   let n = newLocalRef(LocalId(env), ls.info, ls.typ)

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -769,6 +769,8 @@ proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode;
       param = getHiddenParam(g, fn)
     else:
       param.typ = t # replace with the correct type
+      # also update the symbol *node's* type
+      fn.ast[paramsPos][^1].typ = t
 
     prepareInnerRoutines(d, idgen, t, fn.info)
     # the environment instance is not setup here; that's done at the iterator's


### PR DESCRIPTION
## Summary

Fix the C code generator emitting incorrectly typed code for closure
closure-iterators, which recent, stricter C compilers report errors
for.

Fixes https://github.com/nim-works/nimskull/issues/1353.

## Details

When computing the environment for a closure iterator where the
iterator closes over some outer locals, there's already a symbol in
the hidden parameter slot, using the environment type of the enclosing
routine.

The symbol is retyped during closure iterator environment computation,
but the *node* referencing it was not updated. `cgen` used the MIR
local's type for the definition, but the *node's* type (which was still
the enclosing procedure's environment type) for the cast, resulting in
a pointer type mismatch.

The node referencing the symbol is now also updated, and an assertion
to make sure the types match is added in `cgen`.