### PR TITLE
deprecate the `.codegenDecl` pragma

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -734,6 +734,7 @@ type
     rsemLockLevelMismatch        = "LockLevel"
     rsemTypelessParam            = "TypelessParam"
     rsemOwnedTypeDeprecated
+    rsemCodegenDeclDeprecated    = "Deprecated"
 
     rsemWarnUnlistedRaises = "Effect" ## `sempass2.checkRaisesSpec` had
     ## `emitWarnings: bool` parameter which was supposedly used to control

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -428,6 +428,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemOwnedTypeDeprecated:
       result = "the `owned` type-operator is deprecated and treated as a no-op"
 
+    of rsemCodegenDeclDeprecated:
+      result = "the `.codegenDecl` pragma is deprecated; support for it " &
+               "will be removed in the future"
+
     of rsemLinterReport:
       result.addf("'$1' should be: '$2'", r.linterFail.got, r.linterFail.wanted)
 

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -299,6 +299,8 @@ proc processCodegenDecl(c: PContext, n: PNode, sym: PSym): PNode =
   ## the string literal from `n`
   result = getStrLitNode(c, n)
   sym.constraint = result
+  # issue a deprecation warning:
+  c.config.localReport(n.info, reportSem(rsemCodegenDeclDeprecated))
 
 proc processMagic(c: PContext, n: PNode, s: PSym): PNode =
   ## produces an error if `n` is not a pragmacall kinds, otherwise `n` is


### PR DESCRIPTION
## Summary

The `.codegenDecl` pragma is going to be removed eventually. For a
transition period, a deprecation warning is now reported when using it.