### PR TITLE
asyncjs: don't use JavaScript `async`

### DIFF
--- a/tests/js/tasyncjs.nim
+++ b/tests/js/tasyncjs.nim
@@ -111,6 +111,16 @@ proc main() {.async.} =
     doAssert reason.name == "Error"
     doAssert "foobar: 7" == $reason.message
 
+  block catch_awaited_exception:
+    # make sure `await` re-raises the exception the promise was rejected with
+    var raised = false
+    try:
+      discard await(fn(7))
+    except:
+      raised = true
+
+    doAssert raised
+
   echo "done" # justified here to make sure we're running this, since it's inside `async`
 
 discard main()


### PR DESCRIPTION
## Summary

* `asyncjs` no longer uses JavaScript's `async`
* `result` in `.async` procedures now works like it does everywhere else
* `method`s can no longer use `.async`

## Details

* the goal is removing the usage of the deprecated `.codegenDecl` pragma
* routines marked with the `.async` pragma internally use a closure
  iterator that is `then` chained to a promise object when `await`ing

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## To-Do
- [ ] make imported exceptions properly catchable within closure iterators (separate PR)
- [ ] re-add support for returning `Future`s from `.async` procedures
- [ ] write a proper commit message

## Notes for Reviewers
* prior discussion about this can be found [here](https://gist.github.com/zerbina/d09b55530a596bc9e2cb12a0460ca074?permalink_comment_id=5012850#gistcomment-5012850)
* an important prerequisite for the new JavaScript code generator 

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
