### PR TITLE
remove the `.goto` pragma/feature

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -433,7 +433,6 @@ const
 
   sfNoForward*     = sfRegister       ## forward declarations are not required (per module)
   sfExperimental*  = sfOverriden      ## module uses the .experimental switch
-  sfGoto*          = sfOverriden      ## var is used for 'goto' code generation
   sfWrittenTo*     = sfBorrow         ## param is assigned to
   sfEscapes*       = sfProcvar        ## param escapes
   sfBase*          = sfDiscriminant

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -630,9 +630,7 @@ type
     # Codegen
     rsemRttiRequestForIncompleteObject
     rsemExpectedNimcallProc
-    rsemDisallowedRangeForComputedGoto
     rsemExpectedParameterForJsPattern
-    rsemExpectedLiteralForGoto
     rsemRequiresDeepCopyEnabled
     rsemDisallowedOfForPureObjects
     rsemCannotCodegenCompiletimeProc

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1993,15 +1993,9 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemRequiresDeepCopyEnabled:
       result = "for --gc:arc|orc 'deepcopy' support has to be enabled with --deepcopy:on"
 
-    of rsemExpectedLiteralForGoto:
-      result = "'goto' target must be a literal value"
-
     of rsemExpectedParameterForJsPattern:
       result =  "wrong importjs pattern; expected parameter at position " &
         $r.countMismatch.expected & " but got only: " & $r.countMismatch.got
-
-    of rsemDisallowedRangeForComputedGoto:
-      result = "range notation not available for computed goto"
 
     of rsemExpectedNimcallProc:
       result = r.symstr & " needs to have the 'nimcall' calling convention"

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -119,7 +119,7 @@ const
     wMagic, wHeader, wCompilerProc, wCore, wDynlib,
     wNoInit, wCompileTime, wGlobal,
     wGensym, wInject,
-    wGuard, wGoto, wCursor, wNoalias, wAlign}
+    wGuard, wCursor, wNoalias, wAlign}
   constPragmas* = declPragmas + {wHeader, wMagic,
     wGensym, wInject,
     wIntDefine, wStrDefine, wBoolDefine, wCompilerProc, wCore}
@@ -1446,10 +1446,6 @@ proc applySymbolPragma(c: PContext, sym: PSym, it: PNode): PNode =
             result = sym.guard.ast
           else:
             result = it
-      of wGoto:
-        result = noVal(c, it)
-        assert sym.kind in {skVar, skLet}
-        sym.flags.incl sfGoto
       of wExportNims:
           # XXX: modifying the module graph during application of a symbol
           #      operator doesn't seem like a good idea...


### PR DESCRIPTION
## Summary

The `.goto` pragma is neither documented nor tested, and most of the
compiler is unaware of it. Everything related to the feature is removed
from the compiler.

## Details

* the `.goto` pragma could be used on variables of enum type,
  turning all assignments to the variable into jumps to branches of an
  associated `case` statement
* remove the `sfGoto` symbol flag
* remove the reports associated with the `.goto` pragma
* keep the `wGoto` enum; it's part of the C keyword set