### PR TITLE
mirbodies: track next label in `MirBody`

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -420,13 +420,13 @@ proc produceFragmentsForGlobals(
       bu.setSource(m.add(n))
       bu.subTree mnkScope: discard
 
-  func finish(bu: sink MirBuilder, m: var SourceMap, n: PNode
-             ): auto {.nimcall.} =
+  func finish(bu: sink MirBuilder, n: PNode, body: var MirBody) {.nimcall.} =
+    var map = move body.source
     if bu.front.len > 0:
-      bu.setSource(m.add(n))
+      bu.setSource(map.add(n))
       bu.subTree mnkEndScope: discard
-    # we're creating a body here, so there is no list of locals yet
-    result = finish(bu, default(Store[LocalId, Local]))
+
+    body = createBody(bu, map)
 
   var init, deinit, threadDeinit: MirBuilder
 
@@ -459,12 +459,9 @@ proc produceFragmentsForGlobals(
           # also emit a destructor into the thread-deinit fragment:
           destroyOp(threadDeinit, result.threadDeinit.source)
 
-  (result.init.code, result.init.locals) =
-    finish(init, result.init.source, graph.emptyNode)
-  (result.deinit.code, result.deinit.locals) =
-    finish(deinit, result.deinit.source, graph.emptyNode)
-  (result.threadDeinit.code, result.threadDeinit.locals) =
-    finish(threadDeinit, result.threadDeinit.source, graph.emptyNode)
+  finish(init, graph.emptyNode, result.init)
+  finish(deinit, graph.emptyNode, result.deinit)
+  finish(threadDeinit, graph.emptyNode, result.threadDeinit)
 
 # ----- dynlib handling -----
 

--- a/compiler/mir/mirbodies.nim
+++ b/compiler/mir/mirbodies.nim
@@ -45,6 +45,10 @@ type
     ## associated with a body, such as how far the lowering is along.
     locals*: Locals
       ## all locals part of the body
+    nextLabel*: LabelId
+      ## the ID to use for a new label. Incremented when allocating a new
+      ## label
+
     source*: SourceMap
     code*: MirTree
 

--- a/compiler/mir/mirchangesets.nim
+++ b/compiler/mir/mirchangesets.nim
@@ -50,14 +50,8 @@ template remove*(c: var Changeset, tree: MirTree, at: NodePosition) =
 func initChangeset*(body: MirBody): Changeset =
   ## Sets up a changeset for `body`. The changeset either needs to be
   ## discarded, or applied to the same ``MirBody`` instance it was created for.
-  result = Changeset(locals: fork(body.locals))
-  # compute the next ID to use for new labels:
-  for i, n in body.code.pairs:
-    case n.kind
-    of mnkLabel:
-      result.nextLabel = max(n.label.uint32 + 1, result.nextLabel)
-    else:
-      discard
+  Changeset(locals: fork(body.locals),
+            nextLabel: body.nextLabel.uint32)
 
 func initBuilder(c: var Changeset, buffer: var MirNodeSeq,
                  info: SourceId): MirBuilder =
@@ -99,3 +93,4 @@ func apply*(body: var MirBody, c: sink Changeset) =
   ## Applies the changeset `c` to `body`.
   apply(body.code, prepare(move c.inner))
   join(body.locals, move c.locals)
+  body.nextLabel = LabelId(c.nextLabel)

--- a/compiler/mir/mirconstr.nim
+++ b/compiler/mir/mirconstr.nim
@@ -7,7 +7,8 @@ import
   ],
   compiler/mir/[
     mirtrees,
-    mirbodies
+    mirbodies,
+    sourcemaps
   ],
   compiler/utils/[
     containers,
@@ -558,3 +559,8 @@ func finish*(bu: sink MirBuilder, locals: sink Store[LocalId, Local]): auto =
   result = (tree, move locals)
   # join the partial store into the base store:
   join(result[1], partial)
+
+proc createBody*(builder: sink MirBuilder, sm: sink SourceMap): MirBody =
+  ## Creates a MIR body from `builder` and `sm`.
+  result = MirBody(nextLabel: builder.nextLabel.LabelId, source: sm)
+  (result.code, result.locals) = builder.finish(default Store[LocalId, Local])

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2395,9 +2395,7 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
 
   env = c.env
 
-  # move the buffers into the result body
-  let (code, locals) = finish(move c.builder, default(Store[LocalId, Local]))
-  MirBody(locals: locals, source: move c.sp.map, code: code)
+  createBody(move c.builder, move c.sp.map)
 
 proc exprToMir*(graph: ModuleGraph, env: var MirEnv,
                 config: TranslationConfig, e: PNode): MirBody =
@@ -2428,8 +2426,7 @@ proc exprToMir*(graph: ModuleGraph, env: var MirEnv,
 
   env = move c.env
 
-  let (code, locals) = finish(move c.builder, default(Store[LocalId, Local]))
-  MirBody(locals: locals, source: move c.sp.map, code: code)
+  createBody(move c.builder, move c.sp.map)
 
 proc constDataToMir*(env: var MirEnv, n: PNode): MirTree =
   ## Translates the construction expression AST `n` representing some


### PR DESCRIPTION
## Summary

Track the ID to use for new labels in `MirBody`. This greatly reduces
the overhead of `Changeset` creation, since the source body doesn't
have to be scanned.

## Details

* track the next label ID with `MirBody.nextLabel`
* on creation, the `Changeset` next label ID is initialized from the ID
  stored with the `MirBody`
* add the `createBody` routine for creating a proper `MirBody` from a
  `MirBuilder` instance
* use `createBody` to replace manual `MirBody` construction

### Performance

Compile times are effectively unaffected. A small improvement of a few
milliseconds is measurable, but it's insignificant. However, using more
batches in the future will make the improvement more pronounced.