### PR TITLE
sem: proper error when alignof is called on generic type

### DIFF
--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -62,20 +62,13 @@ proc semSizeOf(c: PContext, n: PNode): PNode =
                                             magic: mSizeOf))
 
 proc semAlignOf(c: PContext, n: PNode): PNode =
-  case n.len
-  of 2:
-    n[1] = semExprWithType(c, n[1])
-    if containsGenericType(n[1].typ):
-      # report the type, not the typedesc
-      n[1] = c.config.newError(n[1], PAstDiag(kind: adSemTIsNotAConcreteType,
-                                              wrongType: n[1].typ[0]))
-      result = n
-    else:
-      n.typ = getSysType(c.graph, n.info, tyInt)
-      result = foldAlignOf(c.config, n, n)
+  if containsGenericType(n[1].typ):
+    # report the type, not the typedesc
+    n[1] = c.config.newError(n[1], PAstDiag(kind: adSemTIsNotAConcreteType,
+                                            wrongType: n[1].typ[0]))
+    result = c.config.wrapError(n)
   else:
-    result = c.config.newError(n, PAstDiag(kind: adSemMagicExpectTypeOrValue,
-                                            magic: mAlignOf))
+    result = foldAlignOf(c.config, n, n)
 
 type
   SemAsgnMode = enum asgnNormal, noOverloadedSubscript, noOverloadedAsgn
@@ -438,7 +431,7 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   of mSizeOf:
     result = semSizeOf(c, n)
   of mAlignOf:
-    result = semAlignOf(c, n) 
+    result = semAlignOf(c, n)
   of mOffsetOf:
     result = foldOffsetOf(c.config, n, n)
   of mArrGet:

--- a/tests/lang_callable/generics/talignof_generic_error.nim
+++ b/tests/lang_callable/generics/talignof_generic_error.nim
@@ -1,0 +1,10 @@
+discard """
+  errormsg: "'GenericType' is not a concrete type"
+  line: 10
+"""
+
+type
+  GenericType[K, V] = object
+    field: (K, V)
+
+let alignment = alignof(GenericType)

--- a/tests/lang_callable/generics/talignof_generic_error_overloaded.nim
+++ b/tests/lang_callable/generics/talignof_generic_error_overloaded.nim
@@ -1,0 +1,13 @@
+discard """
+  errormsg: "'GenericType' is not a concrete type"
+  line: 13
+"""
+
+type
+  GenericType[K, V] = object
+    field: (K, V)
+
+# Overload alignof
+proc alignof(a, b: int) = discard
+
+let alignment = alignof(GenericType)


### PR DESCRIPTION
## Summary
*  `alignof`  calls on generic arguments resulted in 
`Fatal: Internal unreachable code executed`  (C backend)
* This fix causes the compiler to report a proper error in such cases: 
`<type> is not a concrete type` 

## Details
* To do this we have to check that the argument to  `alignof`  is a
concrete type before it reaches the backend.
* We add `semAlignOf` to do this.
* Handles overloaded `alignof`.