### PR TITLE
annotate more compiler stacktraces

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -98,6 +98,9 @@ import
 
 import std/options as std_options
 
+when defined(nimCompilerStacktraceHints):
+  import compiler/utils/debugutils
+
 type
   DestFlag = enum
     ## Extra information about an assignment destination. The flags are used to
@@ -400,6 +403,9 @@ proc exprToPmir(c: var TCtx, n: PNode, sink, mutable: bool): PMirExpr =
              n, sink, mutable)
 
 proc genx(c: var TCtx, n: PNode; consume: bool = false) =
+  when defined(nimCompilerStacktraceHints):
+    frameMsg(c.graph.config, n)
+
   let e = exprToPmir(c, n, consume, false)
   genx(c, e, e.high)
 

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -54,6 +54,9 @@ import
 
 from compiler/sem/semdata import makeVarType
 
+when defined(nimCompilerStacktraceHints):
+  import compiler/utils/debugutils
+
 type
   PTransCon = ref object # part of TContext; stackable
     mapping: TIdNodeTable     # mapping from symbols to nodes
@@ -1205,6 +1208,9 @@ proc commonOptimizations*(g: ModuleGraph; idgen: IdGenerator; c: PSym, n: PNode)
       result = n
 
 proc transform(c: PTransf, n: PNode): PNode =
+  when defined(nimCompilerStacktraceHints):
+    frameMsg(c.graph.config, n)
+
   when false:
     var oldDeferAnchor: PNode
     if n.kind in {nkElifBranch, nkOfBranch, nkExceptBranch, nkElifExpr,


### PR DESCRIPTION
## Summary

Stacktraces from within `mirgen` and `transf` are now also annotated
with the line information of the currently processed node, providing
more context for compiler crashes when using `nim_dbg`.