### PR TITLE
clean up symbol error reporting

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1154,7 +1154,6 @@ type
     adSemUndeclaredField
     adSemCannotInstantiate
     adSemWrongNumberOfGenericParams
-    adSemCalleeHasAnError
     # sem
     adSemExpressionHasNoType
     adSemDefNameSym   ## when creating a sym node from `nkIdentKinds`
@@ -1461,8 +1460,6 @@ type
     of adSemWrongNumberOfGenericParams:
       countMismatch*: tuple[expected, got: int]
       gnrcCallLineInfo*: TLineInfo
-    of adSemCalleeHasAnError:
-      callee*: PSym
     of adSemIllformedAstExpectedOneOf:
       expectedKinds*: TNodeKinds
     of adSemImplementationExpected:

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -417,7 +417,6 @@ type
     rsemIsOperatorTakes2Args
     rsemWrongNumberOfVariables
     rsemWrongNumberOfGenericParams
-    rsemCalleeHasAnError
     rsemNoGenericParamsAllowed
     rsemAmbiguousCall
     rsemCallingConventionMismatch

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1836,10 +1836,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         $r.countMismatch.expected
       )
 
-    of rsemCalleeHasAnError:
-      result = "cannot call '$1'; its definition has an error [defined at '$2']" %
-               [r.symstr, conf.toFileLineCol(r.sym.info)]
-
     of rsemNoGenericParamsAllowed:
       result = "no generic parameters allowed for $1" % r.symstr
 
@@ -3512,13 +3508,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       kind: rsemWrongNumberOfGenericParams,
       ast: diag.wrongNode,
       countMismatch: diag.countMismatch)
-  of adSemCalleeHasAnError:
-    semRep = SemReport(
-      location: some diag.location,
-      reportInst: diag.instLoc.toReportLineInfo,
-      kind: rsemCalleeHasAnError,
-      ast: diag.wrongNode,
-      sym: diag.callee)
   of adSemIllformedAstExpectedPragmaOrIdent:
     semRep = SemReport(
       location: some diag.location,

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -500,7 +500,6 @@ func astDiagToLegacyReportKind*(
   of adSemUndeclaredField: rsemUndeclaredField
   of adSemCannotInstantiate: rsemCannotInstantiate
   of adSemWrongNumberOfGenericParams: rsemWrongNumberOfGenericParams
-  of adSemCalleeHasAnError: rsemCalleeHasAnError
   of adSemExpressionHasNoType: rsemExpressionHasNoType
   of adSemTypeExpected: rsemTypeExpected
   of adSemStringRangeNotAllowed: rsemStringRangeNotAllowed

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -602,9 +602,11 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
     result =
       case r.calleeSym.ast.kind
       of nkError:
-        # the symbol refers to an erroneous entity
-        c.config.newError(r.call):
-          PAstDiag(kind: adSemCalleeHasAnError, callee: r.calleeSym)
+        # the definition has an error; don't attempt to fully resolve the call
+        let x = r.call
+        x[0] = newSymNodeOrError(c.config, r.calleeSym, getCallLineInfo(x[0]))
+        #      ^^ will return an error node
+        c.config.wrapError(x)
       else:
         semResolvedCall(c, r, n, flags)
 

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -882,9 +882,6 @@ proc semNormalizedLetOrVar(c: PContext, n: PNode, symkind: TSymKind): PNode =
       else:
         internalError(c.config, "should never happen")
 
-    if v.ast.isError:
-      v.transitionToError(v.ast)
-
     # set the symbol type and add the symbol to the production
     producedDecl[i] = setSymType(c, r, v, vTyp)
 
@@ -1225,12 +1222,6 @@ proc semNormalizedConst(c: PContext, n: PNode): PNode =
         v.ast = producedDecl[^1]
       else:
         internalError(c.config, "should never happen")
-
-    if v.ast.isError:
-      # XXX: although this mirrors the behaviour of ``semNormalizedLetOrVar``,
-      #      it seems wrong. For example, the type of the symbol is set to a
-      #      valid type instead of ``tyError``
-      v.transitionToError(v.ast)
 
     # set the symbol type and add the symbol to the production
     producedDecl[i] = setSymType(c, r, v, vTyp)

--- a/tests/error_propagation/tproc_with_error.nim
+++ b/tests/error_propagation/tproc_with_error.nim
@@ -1,0 +1,15 @@
+discard """
+  cmd: "nim check --hints:off $options $file"
+  action: reject
+  nimoutFull: true
+  nimout: '''
+tproc_with_error.nim(11, 11) Error: undeclared identifier: 'missing'
+'''
+"""
+
+proc p() =
+  discard missing # <- error
+
+# calling the procedure doesn't result in errors being reported to the
+# programmer
+p()

--- a/tests/error_propagation/tvar_let_const_with_error.nim
+++ b/tests/error_propagation/tvar_let_const_with_error.nim
@@ -1,0 +1,17 @@
+discard """
+  cmd: "nim check --hints:off $options $file"
+  action: reject
+  nimoutFull: true
+  nimout: '''
+tvar_let_const_with_error.nim(12, 12) Error: undeclared identifier: 'missing'
+tvar_let_const_with_error.nim(13, 12) Error: undeclared identifier: 'missing'
+tvar_let_const_with_error.nim(14, 12) Error: undeclared identifier: 'missing'
+'''
+"""
+
+var va   = missing
+let le   = missing
+const co = missing
+
+# using the symbols doesn't result in errors being reported to the programmer
+echo va, le, co

--- a/tests/lang_callable/generics/tpointerprocs.nim
+++ b/tests/lang_callable/generics/tpointerprocs.nim
@@ -3,11 +3,11 @@ cmd: "nim check $options --hints:off $file"
 action: "reject"
 nimout:'''
 tpointerprocs.nim(14, 11) Error: 'foo' doesn't have a concrete type, due to unspecified generic parameters.
-tpointerprocs.nim(15, 11) Error: identifier 'bar' found but it has errors, see: tpointerprocs.nim(14, 5)
 tpointerprocs.nim(26, 11) Error: cannot instantiate: 'foo[int]'; got 1 typeof(s) but expected 2
-tpointerprocs.nim(27, 11) Error: identifier 'bar' found but it has errors, see: tpointerprocs.nim(26, 5)
 '''
 """
+
+
 block:
   proc foo(x: int | float): float = result = 1.0
   let


### PR DESCRIPTION
## Summary

* don't report "cannot call" error when using symbol of routines
  where the definition has an error
* don't report "only identifier found is an error" when using `let`/
  `var`/`const` symbol where the initializer expression has an error
* these errors don't provide any additional information and only
  clutter compiler and nimsuggest output

## Details

* use a common erroneous symbol handling path in `semSym`
* don't turn `skLet`, `skVar`, and `skConst` into `skError`s when the
  definition AST has an error
* use the silent `adWrappedSymError` diagnostic for erroneous callees
* remove the `CalleeHasAnError` diagnostic and report
* add tests to make sure the new error reporting behaviour works
* adjust the `tpointerprocs.nim`, which is affected by the different
  error reporting