### PR TITLE
Report error for foreign forward declared generic

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -360,6 +360,7 @@ type
 
     rsemCannotInstantiate
     rsemCannotInstantiateWithParameter
+    rsemCannotInstantiateForwarded
     rsemCannotGenerateGenericDestructor
     rsemUndeclaredField
     rsemExpectedOrdinal

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -790,6 +790,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
           r.ownerSym.name.s
         )
 
+    of rsemCannotInstantiateForwarded:
+      result = "cannot instantiate generic procedure forward-declared in " &
+               "another module"
+
     of rsemTypeKindMismatch:
       result = r.str
       result.add  " got '$1'" % typeToString(r.actualType)

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -401,6 +401,11 @@ proc generateInstance(c: PContext, fn: PSym, pt: TIdTable,
   n[genericParamsPos] = c.graph.emptyNode
   var oldPrc = genericCacheGet(c.graph, fn, entry[], c.compilesContextId)
   if oldPrc == nil:
+    if sfForward in fn.flags and fn.itemId.module != c.module.itemId.module:
+      localReport(c.config, info, reportSem(rsemCannotInstantiateForwarded))
+      # don't abort instantiation; let it complete for the sake of error
+      # correction (check/suggest)
+
     # we MUST not add potentially wrong instantiations to the caching mechanism.
     # This means recursive instantiations behave differently when in
     # a ``compiles`` context but this is the lesser evil. See

--- a/tests/lang_callable/generics/mgeneric_cycle_forward.nim
+++ b/tests/lang_callable/generics/mgeneric_cycle_forward.nim
@@ -1,0 +1,5 @@
+import tgeneric_cycle_forward
+
+forwarded[int]() # was already instantiated; works
+# try to instantiate the incomplete generic routine:
+forwarded[float]()

--- a/tests/lang_callable/generics/tgeneric_cycle_forward.nim
+++ b/tests/lang_callable/generics/tgeneric_cycle_forward.nim
@@ -1,0 +1,20 @@
+discard """
+  description: '''
+    Ensure instantiating foreign, incomplete generic procedures leads to a
+    proper error.
+  '''
+  errormsg: "cannot instantiate generic procedure forward-declared in another module"
+  file: "mgeneric_cycle_forward.nim"
+  line: 5
+"""
+
+proc forwarded*[T]()
+
+# instantiate with `int` before starting the import cycle
+forwarded[int]()
+
+import mgeneric_cycle_forward # start the recursive import
+
+# complete the forward declaration:
+proc forwarded[T]() =
+  discard


### PR DESCRIPTION
## Summary

Fix the compiler or backend crashing when using an incomplete generic
procedure from another module. A proper compiler error is now reported
in this case.

Fixes https://github.com/nim-works/nimskull/issues/1368.

## Details

The issues can only occur in the presence of cyclic imports.
Instantiating a generic routine registers it in the instantiating
module, preventing its body from being patched when the generic routine
is complete. Using the instantiation cache when completing a forward-
declared generic won't work, since the module an instantiation comes
from might be closed already.

Instead, this situation is now detected and an error is reported. No
error is reported if no instantiation takes place (i.e., because the
instantiation was cached already), meaning that previously working
code stays working.