### PR TITLE
changelog: move "Other" into categories

### DIFF
--- a/.github/changelog.json
+++ b/.github/changelog.json
@@ -80,9 +80,13 @@
           "exhaustive": true
         }
       ]
+    },
+    {
+      "title": "## 💬 Other",
+      "labels": []
     }
   ],
-  "template": "# What's Changed\n\n#{{CHANGELOG}}\n\n<details>\n<summary>\n\n## 💬 Other\n\n</summary>\n\n#{{UNCATEGORIZED}}\n\n</details>\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+  "template": "# What's Changed\n\n#{{CHANGELOG}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
   "empty_template": "**Full Changelog**: #{{RELEASE_DIFF}}",
   "pr_template": "* #{{TITLE}} by @#{{AUTHOR}} in #{{URL}}",
   "sort": "DSC",


### PR DESCRIPTION
While this will no longer allow the category to be collapsible, it will
allow the category to be omitted when nothing goes there.

This addresses the empty "Other" section as seen in
https://github.com/nim-works/nimskull/releases/tag/0.1.0-dev.21377