### PR TITLE
mir: add a dedicated IR for types

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -498,7 +498,7 @@ template transitionSymKindCommon*(k: TSymKind) =
   s[] = TSym(kind: k, itemId: obj.itemId, magic: obj.magic, typ: obj.typ, name: obj.name,
              info: obj.info, owner: obj.owner, flags: obj.flags, ast: obj.ast,
              options: obj.options, position: obj.position, offset: obj.offset,
-             extname: obj.extname, extFlags: obj.extFlags, locId: obj.locId,
+             extname: obj.extname, extFlags: obj.extFlags,
              annex: obj.annex, constraint: obj.constraint)
   when defined(nimsuggest):
     s.allUsages = obj.allUsages

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1724,8 +1724,6 @@ type
                               ## generated name is to be used
     extFlags*: ExternalFlags  ## additional flags that are relevant to code
                               ## generation
-    locId*: uint32            ## associates the symbol with a loc in the C code
-                              ## generator. 0 means unset.
     annex*: LibId             ## additional fields (seldom used, so we use a
                               ## reference to another object to save space)
     constraint*: PNode        ## additional constraints like 'lit|result'; also

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1557,3 +1557,32 @@ proc classifyBackendView*(t: PType): BackendViewKind =
      tyGenericParam, tyForward, tyBuiltInTypeClass, tyCompositeTypeClass,
      tyAnd, tyOr, tyNot, tyAnything, tyFromExpr:
     unreachable()
+
+proc isPassByRef*(conf: ConfigRef; s: PSym, retType: PType): bool =
+  var pt = skipTypes(s.typ, typedescInst)
+  assert skResult != s.kind
+
+  if tfByRef in pt.flags: return true
+  elif tfByCopy in pt.flags: return false
+  case pt.kind
+  of tyObject:
+    if s.typ.sym != nil and sfForward in s.typ.sym.flags:
+      # forwarded objects are *always* passed by pointers for consistency!
+      result = true
+    elif (optByRef in s.options) or (getSize(conf, pt) > conf.target.floatSize * 3):
+      result = true           # requested anyway
+    elif (tfFinal in pt.flags) and (pt[0] == nil):
+      result = false          # no need, because no subtyping possible
+    else:
+      result = true           # ordinary objects are always passed by reference,
+                              # otherwise casting doesn't work
+  of tyTuple:
+    result = (getSize(conf, pt) > conf.target.floatSize*3) or (optByRef in s.options)
+  else:
+    result = false
+
+  # first parameter and return type is 'lent T'? --> use pass by pointer if
+  # not already a pointer-like type
+  if s.position == 0 and retType != nil and retType.kind == tyLent:
+    result = pt.kind notin {tyVar, tyOpenArray, tyVarargs, tyRef, tyPtr,
+                            tyPointer}

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -140,7 +140,7 @@ proc genArg(p: BProc, n: CgNode, param: PSym; call: CgNode): Rope =
       result = "$1.Field0, $1.Field1" % [rdLoc(a)]
     else:
       result = "$1, $1Len_0" % [rdLoc(a)]
-  elif ccgIntroducedPtr(p.config, param, call[0].typ[0]):
+  elif ccgIntroducedPtr(p.module, param, call[0].typ[0]):
     initLocExpr(p, n, a)
     if n.kind in cnkLiterals + {cnkNilLit}:
       result = addrLoc(p.module, literalsNeedsTmp(p, a))

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -105,6 +105,7 @@ proc genOpenArraySlice(p: BProc; q: CgNode; formalType, destType: PType): (Rope,
     result = ("($3*)($1)+($2)" % [rdLoc(a), rdLoc(b), dest],
               lengthExpr)
   of tyString, tySequence:
+    requestFullDesc(p.module, a.t)
     let atyp = skipTypes(a.t, abstractInst)
     if atyp.kind in {tyVar}:
       result = ("((*$1).p != NIM_NIL ? ($4*)(*$1)$3+$2 : NIM_NIL)" %

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -53,7 +53,7 @@ proc fixupCall(p: BProc, le, ri: CgNode, d: var TLoc,
         # procedure
         if d.k == locNone:
           getTemp(p, typ[0], d)
-        pl.add(addrLoc(p.config, d))
+        pl.add(addrLoc(p.module, d))
         pl.add(~");$n")
         line(p, cpsStmts, pl)
         exitCall(p, ri)
@@ -142,9 +142,9 @@ proc genArg(p: BProc, n: CgNode, param: PSym; call: CgNode): Rope =
   elif ccgIntroducedPtr(p.config, param, call[0].typ[0]):
     initLocExpr(p, n, a)
     if n.kind in cnkLiterals + {cnkNilLit}:
-      result = addrLoc(p.config, literalsNeedsTmp(p, a))
+      result = addrLoc(p.module, literalsNeedsTmp(p, a))
     else:
-      result = addrLoc(p.config, a)
+      result = addrLoc(p.module, a)
   else:
     initLocExprSingleUse(p, n, a)
     result = rdLoc(a)
@@ -217,7 +217,7 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
         # procedure
         if d.k == locNone:
           getTemp(p, typ[0], d)
-        pl.add(addrLoc(p.config, d))
+        pl.add(addrLoc(p.module, d))
         genCallPattern()
         exitCall(p, ri)
     else:

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -44,7 +44,7 @@ proc fixupCall(p: BProc, le, ri: CgNode, d: var TLoc,
   # getUniqueType() is too expensive here:
   var typ = skipTypes(ri[0].typ, abstractInst)
   if typ[0] != nil:
-    if isInvalidReturnType(p.config, typ[0]):
+    if isInvalidReturnType(p.module, typ[0]):
       if params != "": pl.add(~", ")
       # the destination is guaranteed to be either a temporary or an lvalue
       # that can be modified in-place
@@ -208,7 +208,7 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
 
   let rawProc = getClosureType(p.module, typ, clHalf)
   if typ[0] != nil:
-    if isInvalidReturnType(p.config, typ[0]):
+    if isInvalidReturnType(p.module, typ[0]):
       if numArgs(ri) > 0: pl.add(~", ")
       # the destination is guaranteed to be either a temporary or an lvalue
       # that can be modified in-place

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -206,7 +206,7 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
     else:
       lineF(p, cpsStmts, PatProc & ";$n", [rdLoc(op), pl, pl.addComma, rawProc])
 
-  let rawProc = getClosureType(p.module, typ, clHalf)
+  let rawProc = getClosureType(p.module, ri[0].typ, clHalf)
   if typ[0] != nil:
     if isInvalidReturnType(p.module, typ[0]):
       if numArgs(ri) > 0: pl.add(~", ")

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -129,6 +129,7 @@ proc genOpenArrayConv(p: BProc; d: TLoc; a: TLoc) =
       linefmt(p, cpsStmts, "$1.Field0 = $2; $1.Field1 = $2Len_0;$n",
         [rdLoc(d), a.rdLoc])
   of tySequence, tyString:
+    requestFullDesc(p.module, a.t)
     linefmt(p, cpsStmts, "$1.Field0 = ($2.p != NIM_NIL ? $2$3 : NIM_NIL); $1.Field1 = $4;$n",
       [rdLoc(d), a.rdLoc, dataField(p), lenExpr(p, a)])
   of tyArray:
@@ -563,6 +564,7 @@ proc genSeqElem(p: BProc, n, x, y: CgNode, d: var TLoc) =
   var a, b: TLoc
   initLocExpr(p, x, a)
   initLocExpr(p, y, b)
+  requestFullDesc(p.module, a.t)
   var ty = skipTypes(a.t, abstractVarRange)
   if ty.kind in {tyRef, tyPtr}:
     ty = skipTypes(ty.lastSon, abstractVarRange)
@@ -1270,6 +1272,7 @@ proc genDestroy(p: BProc; n: CgNode) =
     let t = arg.typ.skipTypes(abstractInst)
     case t.kind
     of tyString:
+      requestFullDesc(p.module, arg.typ)
       var a: TLoc
       initLocExpr(p, arg, a)
       if optThreads in p.config.globalOptions:
@@ -1281,6 +1284,7 @@ proc genDestroy(p: BProc; n: CgNode) =
           " #dealloc($1.p);$n" &
           "}$n", [rdLoc(a)])
     of tySequence:
+      requestFullDesc(p.module, arg.typ)
       var a: TLoc
       initLocExpr(p, arg, a)
       linefmt(p, cpsStmts, "if ($1.p && !($1.p->cap & NIM_STRLIT_FLAG)) {$n" &

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -494,7 +494,6 @@ proc genRecordField(p: BProc, e: CgNode, d: var TLoc) =
   if true:
     var rtyp: PType
     let field = lookupFieldAgain(p, ty, f, r, addr rtyp)
-    ensureObjectFields(p.module, field, rtyp)
     r.addf(".$1", [p.fieldName(field)])
     putIntoDest(p, d, e, r, a.storage)
 
@@ -742,7 +741,6 @@ proc specializeInitObjectN(p: BProc, accessor: Rope, n: PNode, typ: PType) =
     p.config.internalAssert(n[0].kind == nkSym, n.info,
                             "specializeInitObjectN")
     let disc = n[0].sym
-    ensureObjectFields(p.module, disc, typ)
     lineF(p, cpsStmts, "switch ($1.$2) {$n", [accessor, p.fieldName(disc)])
     for i in 1..<n.len:
       let branch = n[i]
@@ -757,7 +755,6 @@ proc specializeInitObjectN(p: BProc, accessor: Rope, n: PNode, typ: PType) =
   of nkSym:
     let field = n.sym
     if field.typ.kind == tyVoid: return
-    ensureObjectFields(p.module, field, typ)
     specializeInitObject(p, "$1.$2" % [accessor, p.fieldName(field)],
                          field.typ, n.info)
   else: internalError(p.config, n.info, "specializeInitObjectN()")
@@ -855,7 +852,6 @@ proc genObjConstr(p: BProc, e: CgNode, d: var TLoc) =
     var tmp2: TLoc
     tmp2.r = r
     let field = lookupFieldAgain(p, ty, it[0].field, tmp2.r)
-    ensureObjectFields(p.module, field, ty)
     tmp2.r.add(".")
     tmp2.r.add(p.fieldName(field))
     tmp2.k = d.k

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -305,7 +305,7 @@ proc genExcept(p: BProc, n: CgNode) =
   # setup the handler frame:
   var tmp: TLoc
   getTemp(p, p.module.g.graph.getCompilerProc("ExceptionFrame").typ, tmp)
-  lineCg(p, cpsStmts, "#nimCatchException($1);$n", [addrLoc(p.config, tmp)])
+  lineCg(p, cpsStmts, "#nimCatchException($1);$n", [addrLoc(p.module, tmp)])
 
 proc genAsmOrEmitStmt(p: BProc, t: CgNode, isAsmStmt=false): Rope =
   var res = ""

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -317,9 +317,10 @@ proc genAsmOrEmitStmt(p: BProc, t: CgNode, isAsmStmt=false): Rope =
         let sym = it.astLit.sym
         # special support for raw field symbols
         discard getTypeDesc(p.module, skipTypes(sym.typ, abstractPtrs))
-        p.config.internalAssert(sym.locId != 0, it.info):
-          "field's surrounding type not setup"
-        res.add(p.fieldName(sym))
+        # make sure the owner was generated, so that the field's mangled name
+        # is available
+        discard getTypeDesc(p.module, sym.owner.typ)
+        res.add(p.fieldName(sym.owner.typ, sym))
     of cnkLocal:
       # make sure the C type description is available:
       discard getTypeDesc(p.module, skipTypes(it.typ, abstractPtrs))

--- a/compiler/backend/ccgthreadvars.nim
+++ b/compiler/backend/ccgthreadvars.nim
@@ -44,7 +44,6 @@ proc declareThreadVar*(m: BModule, id: GlobalId, isExtern: bool) =
 proc generateThreadLocalStorage(m: BModule) =
   if m.g.nimtv != "" and (usesThreadVars in m.flags or sfMainModule in m.module.flags):
     for t in items(m.g.nimtvDeps): discard getTypeDesc(m, t)
-    finishTypeDescriptions(m)
     m.s[cfsSeqTypes].addf("typedef struct {$1} NimThreadVars;$n", [m.g.nimtv])
 
 proc generateThreadVarsSize(m: BModule) =

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -833,18 +833,6 @@ proc getClosureType(m: BModule, t: PType, kind: TClosureTypeKind): Rope =
           "void* ClE_0;$n} $1;$n",
            [result, rettype, desc])
 
-proc finishTypeDescriptions(m: BModule) =
-  var i = 0
-  var check = initIntSet()
-  while i < m.typeStack.len:
-    let t = m.typeStack[i]
-    if t.skipTypes(abstractInst).kind == tySequence:
-      seqV2ContentType(m, t, check)
-    else:
-      discard getTypeDescAux(m, t, check)
-    inc(i)
-  m.typeStack.setLen 0
-
 proc genProcHeader(m: BModule, prc: PSym, locs: openArray[TLoc]): Rope =
   ## Generates the C function header for `prc`, with `locs` being the locs
   ## of the formal parameters.

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -314,6 +314,15 @@ proc payloadType(m: BModule, typ: TypeId): TypeId =
   # the second field is a pointer to the payload type
   m.types.headerFor(m.types[lookupField(m.types, typ, 1)].typ, Lowered).elem
 
+proc requestFullDesc(m: BModule, typ: PType) =
+  ## Requests the full type description for the seq/string type and its
+  ## payload.
+  ## This procedure is a temporary workaround; it becomes obsolete once seq
+  ## and string operations are lowered during the MIR phase.
+  let id = m.addLate(typ)
+  discard useType(m, id) # pull in the seq/string type
+  discard useType(m, payloadType(m, id)) # pull in the payload type
+
 proc getSeqPayloadType(m: BModule; t: PType): Rope =
   let typ = m.addLate(t)
   result = useType(m, payloadType(m, typ))

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -245,32 +245,8 @@ proc addAbiCheck(m: BModule, t: PType, name: Rope) =
     m.s[cfsTypeInfo].addf("NIM_STATIC_ASSERT(sizeof($1) == $2, $3);$n", [name, rope(size), msg2.rope])
     # see `testCodegenABICheck` for example error message it generates
 
-proc ccgIntroducedPtr(conf: ConfigRef; s: PSym, retType: PType): bool =
-  var pt = skipTypes(s.typ, typedescInst)
-  assert skResult != s.kind
-
-  if tfByRef in pt.flags: return true
-  elif tfByCopy in pt.flags: return false
-  case pt.kind
-  of tyObject:
-    if s.typ.sym != nil and sfForward in s.typ.sym.flags:
-      # forwarded objects are *always* passed by pointers for consistency!
-      result = true
-    elif (optByRef in s.options) or (getSize(conf, pt) > conf.target.floatSize * 3):
-      result = true           # requested anyway
-    elif (tfFinal in pt.flags) and (pt[0] == nil):
-      result = false          # no need, because no subtyping possible
-    else:
-      result = true           # ordinary objects are always passed by reference,
-                              # otherwise casting doesn't work
-  of tyTuple:
-    result = (getSize(conf, pt) > conf.target.floatSize*3) or (optByRef in s.options)
-  else:
-    result = false
-  # first parameter and return type is 'lent T'? --> use pass by pointer
-  if s.position == 0 and retType != nil and retType.kind == tyLent:
-    result = not (pt.kind in {tyVar, tyArray, tyOpenArray, tyVarargs, tyRef, tyPtr, tyPointer} or
-      pt.kind == tySet and mapSetType(conf, pt) == ctArray)
+proc ccgIntroducedPtr(m: BModule; s: PSym, retType: PType): bool =
+  isPassByRef(m.config, s, retType) and mapType(m, s.typ) != ctArray
 
 proc initResultParamLoc(m: BModule; param: CgNode): TLoc =
   result = initLoc(locParam, param, "Result", OnStack)
@@ -356,7 +332,7 @@ proc prepareParameters(m: BModule, t: PType): seq[TLoc] =
     result[i] = initLoc(locParam, newLocalRef(LocalId(i), param.info, param.typ),
                         mangleParamName(m.config, param), storage)
 
-    if ccgIntroducedPtr(m.config, param, t[0]):
+    if ccgIntroducedPtr(m, param, t[0]):
       # the parameter is passed by address; mark it as indirect
       incl(result[i].flags, lfIndirect)
       result[i].storage = OnUnknown

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -22,6 +22,11 @@ proc isKeyword(w: PIdent): bool =
      ord(wInline): return true
   else: return false
 
+proc mangleField(m: BModule; name: string): string =
+  result = mangle(name)
+  if isKeyword(m.g.graph.cache.getIdent(name)):
+    result.add "_0"
+
 proc mangleField(m: BModule; name: PIdent): string =
   result = mangle(name.s)
   # fields are tricky to get right and thanks to generic types producing
@@ -79,27 +84,6 @@ const
   irrelevantForBackend = {tyGenericBody, tyGenericInst, tyGenericInvocation,
                           tyDistinct, tyRange, tyStatic, tyAlias, tySink,
                           tyInferred}
-
-proc typeName(typ: PType): Rope =
-  let typ = typ.skipTypes(irrelevantForBackend)
-  result =
-    if typ.sym != nil and typ.kind in {tyObject, tyEnum}:
-      rope($typ.kind & '_' & typ.sym.name.s.mangle)
-    else:
-      rope($typ.kind)
-
-proc getTypeName(m: BModule; typ: PType; sig: SigHash): Rope =
-  var t = typ
-  while true:
-    if t.sym != nil and {sfImportc, sfExportc} * t.sym.flags != {}:
-      return t.sym.extname
-
-    if t.kind in irrelevantForBackend:
-      t = t.lastSon
-    else:
-      break
-  let typ = if typ.kind in {tyAlias, tySink}: typ.lastSon else: typ
-  result = typ.typeName & $sig
 
 proc mapSetType(conf: ConfigRef; typ: PType): TCTypeKind =
   ## Legacy procedure.
@@ -182,10 +166,8 @@ proc mapReturnType(m: BModule; typ: PType): TCTypeKind =
   #else:
   result = mapType(m, typ)
 
-proc isImportedType(t: PType): bool =
-  result = t.sym != nil and sfImportc in t.sym.flags
-
-proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope
+proc getTypeDesc(m: BModule, typ: PType): Rope
+proc useType(m: BModule, typ: TypeId, desc: TypeHeader; onlyName = false): Rope
 
 proc containsGarbageCollectedRef(env: TypeEnv, typ: TypeId): bool =
   ## Computes whether `typ` is or contains a garbage-collected type.
@@ -254,12 +236,6 @@ const
                  # but one can #define it to what one wants
     "N_INLINE", "N_NOINLINE", "N_FASTCALL", "N_CLOSURE", "N_NOCONV"]
 
-proc cacheGetType(tab: TypeCache; sig: SigHash): Rope =
-  # returns nil if we need to declare this type
-  # since types are now unique via the ``getUniqueType`` mechanism, this slow
-  # linear search is not necessary anymore:
-  result = tab.getOrDefault(sig)
-
 proc addAbiCheck(m: BModule, t: PType, name: Rope) =
   if isDefined(m.config, "checkAbi") and (let size = getSize(m.config, t); size != szUnknownSize):
     var msg = "backend & Nim disagree on size for: "
@@ -303,111 +279,44 @@ proc initResultParamLoc(m: BModule; param: CgNode): TLoc =
     incl(result.flags, lfIndirect)
     result.storage = OnUnknown
 
-proc typeNameOrLiteral(m: BModule; t: PType, literal: string): Rope =
-  if t.sym != nil and sfImportc in t.sym.flags and t.sym.magic == mNone:
-    useHeader(m, t.sym)
-    result = t.sym.extname
-  else:
-    result = rope(literal)
+proc useType(m: BModule, typ: TypeId; onlyName = false): Rope =
+  useType(m, typ, m.types.headerFor(typ, Lowered), onlyName)
 
 proc getSimpleTypeDesc(m: BModule, typ: PType): Rope =
-  const
-    NumericalTypeToStr: array[tyInt..tyUInt64, string] = [
-      "NI", "NI8", "NI16", "NI32", "NI64",
-      "NF", "NF32", "NF64",
-      "NU", "NU8", "NU16", "NU32", "NU64"]
-  case typ.kind
-  of tyPointer:
-    result = typeNameOrLiteral(m, typ, "void*")
-  of tyString:
-    discard cgsym(m, "NimStrPayload")
-    discard cgsym(m, "NimStringV2")
-    result = typeNameOrLiteral(m, typ, "NimStringV2")
-  of tyCstring: result = typeNameOrLiteral(m, typ, "NCSTRING")
-  of tyBool: result = typeNameOrLiteral(m, typ, "NIM_BOOL")
-  of tyChar: result = typeNameOrLiteral(m, typ, "NIM_CHAR")
-  of tyNil: result = typeNameOrLiteral(m, typ, "void*")
-  of tyInt..tyUInt64:
-    result = typeNameOrLiteral(m, typ, NumericalTypeToStr[typ.kind])
-  of tyDistinct, tyRange, tyOrdinal: result = getSimpleTypeDesc(m, typ[0])
-  of tyStatic:
-    m.config.internalAssert(typ.n != nil, "tyStatic for getSimpleTypeDesc")
-    result = getSimpleTypeDesc(m, lastSon typ)
-  of tyGenericInst, tyAlias, tySink, tyEnum:
-    result = getSimpleTypeDesc(m, lastSon typ)
-  else: result = ""
+  useType(m, m.addLate(typ))
 
-  if result != "" and typ.isImportedType():
-    let sig = hashType typ
-    if cacheGetType(m.typeCache, sig) == "":
-      m.typeCache[sig] = result
-
-proc pushType(m: BModule, typ: PType) =
-  for i in 0..high(m.typeStack):
-    # pointer equality is good enough here:
-    if m.typeStack[i] == typ: return
-  m.typeStack.add(typ)
-
-proc getTypePre(m: BModule, typ: PType; sig: SigHash): Rope =
-  if typ == nil: result = rope("void")
-  else:
-    result = getSimpleTypeDesc(m, typ)
-    if result == "": result = cacheGetType(m.typeCache, sig)
-
-proc structOrUnion(t: PType): Rope =
-  let cachedUnion = rope("union")
-  let cachedStruct = rope("struct")
-  let t = t.skipTypes({tyAlias, tySink})
-  if tfUnion in t.flags: cachedUnion
-  else: cachedStruct
+proc structOrUnion(kind: TypeKind): Rope =
+  case kind
+  of tkRecord: "struct"
+  of tkUnion:  "union"
+  else:        unreachable(kind)
 
 proc addForwardStructFormat(m: BModule, structOrUnion: Rope, typename: Rope) =
   m.s[cfsForwardTypes].addf "typedef $1 $2 $2;$n", [structOrUnion, typename]
 
-proc getTypeForward(m: BModule, typ: PType; sig: SigHash): Rope =
-  result = cacheGetType(m.forwTypeCache, sig)
+proc getTypeForward(m: BModule, typ: TypeId, desc: TypeHeader): Rope =
+  result = m.forwTypeCache.getOrDefault(typ)
   if result != "": return
-  result = getTypePre(m, typ, sig)
+  result = m.typeCache.getOrDefault(typ)
   if result != "": return
-  let concrete = typ.skipTypes(abstractInst)
-  case concrete.kind
-  of tySequence, tyTuple, tyObject:
-    result = getTypeName(m, typ, sig)
-    m.forwTypeCache[sig] = result
-    if not isImportedType(concrete):
-      addForwardStructFormat(m, structOrUnion(typ), result)
-    else:
-      pushType(m, concrete)
-    doAssert m.forwTypeCache[sig] == result
-  else: internalError(m.config, "getTypeForward(" & $typ.kind & ')')
 
-proc getTypeDescWeak(m: BModule; t: PType; check: var IntSet): Rope =
-  ## like getTypeDescAux but creates only a *weak* dependency. In other words
-  ## we know we only need a pointer to it so we only generate a struct forward
-  ## declaration:
-  let etB = t.skipTypes(abstractInst)
-  case etB.kind
-  of tyObject, tyTuple:
-    result = getTypeForward(m, t, hashType(t))
-    pushType(m, t)
+  case desc.kind
+  of tkRecord, tkUnion:
+    result = computeTypeName(m.g.graph, m.types, typ)
+    addForwardStructFormat(m, structOrUnion(desc.kind), result)
+    m.forwTypeCache[typ] = result
+  of tkImported:
+    result = useType(m, typ, desc)
   else:
-    result = getTypeDescAux(m, t, check)
+    unreachable(desc.kind)
+
+proc payloadType(m: BModule, typ: TypeId): TypeId =
+  # the second field is a pointer to the payload type
+  m.types.headerFor(m.types[lookupField(m.types, typ, 1)].typ, Lowered).elem
 
 proc getSeqPayloadType(m: BModule; t: PType): Rope =
-  var check = initIntSet()
-  result = getTypeDescWeak(m, t, check) & "_Content"
-  #result = getTypeForward(m, t, hashType(t)) & "_Content"
-
-proc seqV2ContentType(m: BModule; t: PType; check: var IntSet) =
-  let sig = hashType(t)
-  let result = cacheGetType(m.typeCache, sig)
-  if result == "":
-    # the struct definition hasn't been emitted yet
-    discard getTypeDescAux(m, t, check)
-  else:
-    # emit the payload type:
-    appcg(m, m.s[cfsTypes], "struct $2_Content { NI cap; $1 data[SEQ_DECL_SIZE];};$N",
-          [getTypeDescAux(m, t.skipTypes(abstractInst)[0], check), result])
+  let typ = m.addLate(t)
+  result = useType(m, payloadType(m, typ))
 
 proc prepareParameters(m: BModule, t: PType): seq[TLoc] =
   ## Sets up and returns the locs of the parameter symbols for procedure
@@ -443,63 +352,118 @@ proc prepareParameters(m: BModule, t: PType): seq[TLoc] =
       incl(result[i].flags, lfIndirect)
       result[i].storage = OnUnknown
 
-proc genProcParams(m: BModule, t: PType, rettype, params: var Rope,
-                   check: var IntSet, locs: openArray[TLoc],
-                   declareEnvironment=true; weakDep=false) =
-  params = ""
-  if t[0] == nil or isInvalidReturnType(m.config, t[0]):
-    rettype = ~"void"
+proc prepareParameters(m: BModule, desc: TypeHeader): seq[TLoc] =
+  assert desc.kind == tkProc
+  result.newSeq(desc.numParams + 1)
+
+  for i, it, flags in params(m.types, desc):
+    let i = i + 1
+    if it == VoidType:
+      # ignore compile-time only parameters
+      # XXX: the parameter needs to be eliminated during to-MIR translation
+      #      already
+      continue
+
+    # the loc sequence is only used for procedure type emission, so using nil
+    # as the node is fine
+    result[i] = initLoc(locParam, nil, "_" & $i, OnUnknown)
+
+    if pfByRef in flags and mapType(m.types, it) != ctArray:
+      # the parameter is passed by address; mark it as indirect
+      incl(result[i].flags, lfIndirect)
+      result[i].storage = OnUnknown
+
+proc genParamDecl(m: BModule, id: TypeId, params: var Rope, name: string,
+                  indirect, noAlias, weakDep: bool) =
+  ## Emits the declaration for a parameter.
+  case mapType(m.types, id)
+  of ctNimOpenArray:
+    # an openArray tuple is "unpacked" into the parameter list (it takes up
+    # two parameters)
+    params.add useType(m, m.types[m.types.lookupField(id, 0)].typ)
+    params.add " "
+    if noAlias:
+      params.add("NIM_NOALIAS ")
+    params.add(name)
+    params.addf(", NI $1Len_0", [name])
+  elif indirect:
+    params.add useType(m, id, onlyName=true)
+    params.add("* ")
+    if noAlias:
+      params.add("NIM_NOALIAS ")
+    params.add(name)
   else:
-    rettype = getTypeDescAux(m, t[0], check)
-  for i in 1..<t.n.len:
-    m.config.internalAssert(t.n[i].kind == nkSym, t.n.info, "genProcParams")
-    var param = t.n[i].sym
-    if locs[i].k == locNone: continue
-    if params != "": params.add(~", ")
+    params.add useType(m, id, onlyName=weakDep)
+    if noAlias:
+      params.add(" NIM_NOALIAS")
+    params.add(" ")
+    params.add(name)
 
-    var arr = param.typ.skipTypes({tyGenericInst})
-    if arr.kind in {tyVar, tyLent, tySink}:
-      arr = arr.lastSon
-    let isOpenArray = arr.kind in {tyOpenArray, tyVarargs}
-
-    if isOpenArray:
-      # declare the pointer field for openArray:
-      params.add(getTypeDescWeak(m, arr.base, check))
-      params.add("*")
-    elif lfIndirect in locs[i].flags:
-      params.add(getTypeDescWeak(m, param.typ, check))
-      params.add(~"*")
-    elif weakDep:
-      params.add(getTypeDescWeak(m, param.typ, check))
+proc finishProcType(m: BModule, ret: TypeId, withEnv, withVarargs: bool,
+                    params: var string) =
+  ## Appends the return type as a parameter, and wraps `params` in parenthesis.
+  if isInvalidReturnType(m.types, ret):
+    if params != "":
+      params.add ", "
+    if mapType(m.g.env.types, ret) == ctArray:
+      params.add useType(m, ret)
     else:
-      params.add(getTypeDescAux(m, param.typ, check))
-    params.add(~" ")
-    if sfNoalias in param.flags:
-      params.add(~"NIM_NOALIAS ")
-    params.add(locs[i].r)
-    # declare the len field for open arrays:
-    if isOpenArray:
-      # need to pass hidden parameter:
-      params.addf(", NI $1Len_$2", [locs[i].r, 0.rope])
+      params.add useType(m, ret, onlyName=true)
+      params.add "*"
+    params.add " Result"
 
-  if t[0] != nil and isInvalidReturnType(m.config, t[0]):
-    var arr = t[0]
-    if params != "": params.add(", ")
-    if mapReturnType(m.config, t[0]) != ctArray:
-      params.add(getTypeDescWeak(m, arr, check))
-      params.add("*")
-    else:
-      params.add(getTypeDescAux(m, arr, check))
-    params.addf(" Result", [])
-  if t.callConv == ccClosure and declareEnvironment:
-    if params != "": params.add(", ")
-    params.add("void* ClE_0")
-  if tfVarargs in t.flags:
-    if params != "": params.add(", ")
-    params.add("...")
+  if withEnv:
+    if params != "":
+      params.add ", "
+    params.add "void* ClE_0"
+
+  if withVarargs:
+    if params != "":
+      params.add ", "
+    params.add "..."
+
   if params == "": params.add("void)")
   else: params.add(")")
   params = "(" & params
+
+proc genProcParams(m: BModule, desc: TypeHeader, ret, params: var Rope,
+                   locs: openArray[TLoc], weakDep: bool) =
+  assert desc.kind == tkProc
+  params = ""
+  let rt = desc.retType(m.types)
+  if isInvalidReturnType(m.types, rt):
+    ret = ~"void"
+  else:
+    ret = useType(m, rt, weakDep)
+
+  for i, typ, flags in params(m.types, desc):
+    let i = i + 1
+    if locs[i].k == locNone: continue
+    if params != "": params.add(~", ")
+    genParamDecl(m, typ, params, locs[i].r, lfIndirect in locs[i].flags,
+                 noAlias=false, weakDep)
+
+  finishProcType(m, rt, desc.callConv(m.types) == ccClosure,
+                 desc.hasVarargs(m.types), params)
+
+proc genProcParams(m: BModule, t: PType, rettype, params: var string,
+                   locs: openArray[TLoc]) =
+  ## Legacy procedure for contexts where type IDs aren't yet used.
+  params = ""
+  let rty = m.addLate(t[0])
+  if isInvalidReturnType(m.g.env.types, rty):
+    rettype = ~"void"
+  else:
+    rettype = useType(m, rty)
+
+  for i in 1..<t.len:
+    if locs[i].k == locNone: continue
+    if params != "": params.add(~", ")
+    let ty = m.addLate(t[i])
+    genParamDecl(m, ty, params, locs[i].r, lfIndirect in locs[i].flags,
+                 sfNoalias in t.n[i].sym.flags, weakDep=false)
+
+  finishProcType(m, rty, t.callConv == ccClosure, tfVarargs in t.flags, params)
 
 proc mangleRecFieldName(m: BModule; field: PSym): Rope =
   if {sfImportc, sfExportc} * field.flags != {}:
@@ -508,297 +472,253 @@ proc mangleRecFieldName(m: BModule; field: PSym): Rope =
     result = rope(mangleField(m, field.name))
   m.config.internalAssert(result != "", field.info, "mangleRecFieldName")
 
-proc genRecordFieldsAux(m: BModule, n: PNode,
-                        rectype: PType,
-                        check: var IntSet, unionPrefix = ""): Rope =
-  result = ""
-  case n.kind
-  of nkRecList:
-    for i in 0..<n.len:
-      result.add(genRecordFieldsAux(m, n[i], rectype, check, unionPrefix))
-  of nkRecCase:
-    m.config.internalAssert(n[0].kind == nkSym, n.info, "genRecordFieldsAux")
-    result.add(genRecordFieldsAux(m, n[0], rectype, check, unionPrefix))
-    # prefix mangled name with "_U" to avoid clashes with other field names,
-    # since identifiers are not allowed to start with '_'
-    var unionBody = ""
-    for i in 1..<n.len:
-      case n[i].kind
-      of nkOfBranch, nkElse:
-        let k = lastSon(n[i])
-        if k.kind != nkSym:
-          let structName = "_" & mangleRecFieldName(m, n[0].sym) & "_" & $i
-          let a = genRecordFieldsAux(m, k, rectype, check, unionPrefix & $structName & ".")
-          if a != "":
-            if tfPacked notin rectype.flags:
-              unionBody.add("struct {")
-            else:
-              if hasAttribute in CC[m.config.cCompiler].props:
-                unionBody.add("struct __attribute__((__packed__)){")
-              else:
-                unionBody.addf("#pragma pack(push, 1)$nstruct{", [])
-            unionBody.add(a)
-            unionBody.addf("} $1;$n", [structName])
-            if tfPacked in rectype.flags and hasAttribute notin CC[m.config.cCompiler].props:
-              unionBody.addf("#pragma pack(pop)$n", [])
-        else:
-          unionBody.add(genRecordFieldsAux(m, k, rectype, check, unionPrefix))
-      else: internalError(m.config, "genRecordFieldsAux(record case branch)")
-    if unionBody != "":
-      result.addf("union{$n$1};$n", [unionBody])
-  of nkSym:
-    let field = n.sym
-    if field.typ.kind == tyVoid: return
-    #assert(field.ast == nil)
-    let sname = mangleRecFieldName(m, field)
-    if field.locId == 0:
-      # XXX: the C struct definition for the type is re-generated in every C
-      #      file the type is used in, so the field might have an associated
-      #      loc. Eventually, each C type will only be generated once, and then
-      #      the guard can be removed
-      m.fields.put(field): unionPrefix & sname
-
-    if field.alignment > 0:
-      result.addf "NIM_ALIGN($1) ", [rope(field.alignment)]
-    let noAlias = if sfNoalias in field.flags: " NIM_NOALIAS" else: ""
-
-    let fieldType = field.typ.skipTypes(abstractInst)
-    if fieldType.kind == tyUncheckedArray:
-      result.addf("$1 $2[SEQ_DECL_SIZE];$n",
-          [getTypeDescAux(m, fieldType.elemType, check), sname])
-    elif field.bitsize != 0:
-      result.addf("$1$4 $2:$3;$n", [getTypeDescAux(m, field.typ, check), sname, rope($field.bitsize), noAlias])
-    else:
-      # TODO: C++ remove
-      # don't use fieldType here because we need the
-      # tyGenericInst for C++ template support
-      result.addf("$1$3 $2;$n", [getTypeDescAux(m, field.typ, check), sname, noAlias])
-  else: internalError(m.config, n.info, "genRecordFieldsAux()")
-
-proc getRecordFields(m: BModule, typ: PType, check: var IntSet): Rope =
-  result = genRecordFieldsAux(m, typ.n, typ, check)
-
 proc mangleDynLibProc(sym: PSym): Rope
 
-proc getRecordDesc(m: BModule, typ: PType, name: Rope,
-                   check: var IntSet): Rope =
-  # declare the record:
-  var hasField = false
+proc genDecl(m: BModule, result: var Rope, typ: TypeId, name: Rope,
+             align, bitsize: int, noAlias: bool) =
+  let desc = m.types.headerFor(typ, Lowered)
+  if align != 0 and align != desc.align:
+    result.addf("NIM_ALIGN($1) ", [$align])
 
-  if tfPacked in typ.flags:
-    if hasAttribute in CC[m.config.cCompiler].props:
-      result = structOrUnion(typ) & " __attribute__((__packed__))"
-    else:
-      result = "#pragma pack(push, 1)\L" & structOrUnion(typ)
+  case desc.kind
+  of tkVoid:
+    # XXX: void fields need to be eliminated during PType->MIR translation
+    #      instead
+    discard "drop"
+  of tkUncheckedArray:
+    result.add useType(m, desc.elem)
+    result.addf(" $1[SEQ_DECL_SIZE]", [name])
+  of tkArray:
+    result.add useType(m, desc.elem)
+    result.addf(" $1[$2]", [name, $desc.arrayLen(m.types)])
   else:
-    result = structOrUnion(typ)
+    result.add useType(m, typ)
+    if noAlias:
+      result.add " NIM_NOALIAS"
+    result.add " " & name
+    if bitsize != 0:
+      result.add ":" & $bitsize
 
-  result.add " "
+proc genFieldDesc(m: BModule, id: FieldId, field: RecField, pos: int,
+                  result: var Rope, accessor: string) =
+  var mangled: string
+  if not field.isNamed:
+    # use a name derived from the position for anonymous fields. The name can
+    # easily be reconstructed from anywhere, so it's not cached
+    mangled = "Field" & $pos
+  elif field.isNoMangle:
+    mangled = m.types.name(field)
+    m.g.fields[id] = accessor & mangled
+  else:
+    mangled = mangleField(m, m.types.name(field))
+    # for efficiency, cache the name combined with the accessor
+    m.g.fields[id] = accessor & mangled
+
+  genDecl(m, result, field.typ, mangled, field.align, field.bitsize,
+          field.isNoAlias)
+  result.add ";\n"
+
+proc getTaggedUnionDesc(m: BModule, desc: TypeHeader, result: var Rope,
+                        accessor: string)
+
+proc genRecordDesc(m: BModule, desc: TypeHeader, result: var Rope,
+                   accessor: string) =
+  if desc.isPacked(m.types) and hasAttribute in CC[m.config.cCompiler].props:
+    # if only push/pop are supported, the outer struct is already wrapped in a
+    # pair of those
+    result.add "struct __attribute__((__packed__)) {\n"
+  else:
+    result.add "struct {\n"
+
+  var pos = 0
+  for (id, it) in m.types.fields(desc):
+    if m.types.isEmbedded(it.typ):
+      # embedded tagged union
+      getTaggedUnionDesc(m, m.types.headerFor(it.typ, Lowered), result,
+                         accessor)
+    else:
+      genFieldDesc(m, id, it, pos, result, accessor)
+    inc pos
+
+  result.add "}"
+
+proc getTaggedUnionDesc(m: BModule, desc: TypeHeader, result: var Rope,
+                        accessor: string) =
+  # the discriminator is directly embedded into the surrounding struct
+  let
+    id    = desc.discr(m.types)
+    discr = m.types[id]
+  genFieldDesc(m, id, discr, 0, result, accessor)
+
+  let
+    name = m.types.name(discr)
+    # all ``struct`` union fields use the mangled discriminator field name
+    # as the prefix
+    unionPrefix =
+      if discr.isNoMangle:
+        "_" & name & "_"
+      else:
+        "_" & mangleField(m, name) & "_"
+
+  result.add "union {\n"
+  var i = 1
+  for (id, it) in m.types.fields(desc, 1):
+    if m.types.isEmbedded(it.typ):
+      # embedded record description. The accessor combined with the union
+      # field name is passed along
+      genRecordDesc(m, m.types.headerFor(it.typ, Lowered), result,
+                    accessor & unionPrefix & $i & ".")
+      result.addf(" $1$2;$n", [unionPrefix, $i])
+    else:
+      genFieldDesc(m, id, it, i, result, accessor)
+      result.add ";\n"
+
+    inc i
+
+  result.add "};\n"
+
+proc genUnionDesc(m: BModule, desc: TypeHeader, name: Rope, result: var Rope) =
+  result.add "union "
+  result.add name
+  result.add " {\n"
+  for (id, it) in m.types.fields(desc):
+    genFieldDesc(m, id, it, 0, result, "")
+  result.add "}"
+
+proc genRecordDesc(m: BModule, desc: TypeHeader, name: Rope, result: var Rope) =
+  let isPacked = desc.isPacked(m.types)
+
+  if isPacked:
+    if hasAttribute in CC[m.config.cCompiler].props:
+      result.add "struct __attribute__((__packed__)) "
+    else:
+      result.add "#pragma pack(push, 1)\nstruct "
+  else:
+    result.add "struct "
   result.add name
 
-  if typ.kind == tyObject:
-    if typ[0] == nil:
-      if lacksMTypeField(typ):
-        appcg(m, result, " {$n", [])
-      else:
-        appcg(m, result, " {$n#TNimTypeV2* m_type;$n", [])
-        hasField = true
+  result.add " {\n"
+  # the base type (if any) is added as the first field:
+  if desc.base(m.types) != VoidType:
+    result.add useType(m, desc.base(m.types))
+    result.add " Sup;\n"
+
+  var pos = 0
+  for (id, it) in m.g.env.types.fields(desc):
+    if m.types.isEmbedded(it.typ):
+      # embedded tagged union
+      getTaggedUnionDesc(m, m.types.headerFor(it.typ, Lowered), result, "")
     else:
-      appcg(m, result, " {$n  $1 Sup;$n",
-                      [getTypeDescAux(m, typ[0].skipTypes(skipPtrs), check)])
-      hasField = true
-  else:
-    result.addf(" {$n", [name])
+      genFieldDesc(m, id, it, pos, result, "")
+    inc pos
 
-  let desc = getRecordFields(m, typ, check)
-  if desc == "" and not hasField:
-    result.addf("char dummy;$n", [])
-  else:
-    result.add(desc)
-  result.add("};\L")
-  if tfPacked in typ.flags and hasAttribute notin CC[m.config.cCompiler].props:
-    result.add "#pragma pack(pop)\L"
+  result.add "}"
+  # pop the packed pragma again:
+  if isPacked and
+     hasAttribute notin CC[m.config.cCompiler].props:
+    result.add "#pragma pack(pop)\n"
 
-proc getTupleDesc(m: BModule, typ: PType, name: Rope,
-                  check: var IntSet): Rope =
-  result = "$1 $2 {$n" % [structOrUnion(typ), name]
-  var desc = ""
-  for i in 0..<typ.len:
-    desc.addf("$1 Field$2;$n",
-         [getTypeDescAux(m, typ[i], check), rope(i)])
-  if desc == "": result.add("char dummy;\L")
-  else: result.add(desc)
-  result.add("};\L")
+proc isImportedType(t: PType): bool =
+  t.sym != nil and sfImportc in t.sym.flags
 
-proc getOpenArrayDesc(m: BModule, t: PType, check: var IntSet): Rope =
-  let sig = hashType(t)
-  if true:
-    result = cacheGetType(m.typeCache, sig)
-    if result == "":
-      result = getTypeName(m, t, sig)
-      m.typeCache[sig] = result
-      let elemType = getTypeDescWeak(m, t[0], check)
-      m.s[cfsTypes].addf("typedef struct {$n$2* Field0;$nNI Field1;$n} $1;$n",
-                         [result, elemType])
-
-proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
-  # returns only the type's name
-
-  var t = origTyp.skipTypes(irrelevantForBackend)
-  m.config.internalAssert(not containsOrIncl(check, t.id),
-                          "cannot generate C type for: " & typeToString(origTyp))
-  # XXX: this BUG is hard to fix -> we need to introduce helper structs,
-  # but determining when this needs to be done is hard. We should split
-  # C type generation into an analysis and a code generation phase somehow.
-  if t.sym != nil: useHeader(m, t.sym)
-  if t != origTyp and origTyp.sym != nil: useHeader(m, origTyp.sym)
-  let sig = hashType(origTyp)
-
-  defer: # defer is the simplest in this case
-    if isImportedType(t) and not m.typeABICache.containsOrIncl(sig):
-      addAbiCheck(m, t, result)
-
-  result = getTypePre(m, t, sig)
-  if result != "":
-    excl(check, t.id)
+proc emitTypeDef(m: BModule, id: TypeId, desc: TypeHeader) =
+  ## Emits the full definition for the type.
+  if id in m.typeCache:
     return
-  case t.kind
-  of tyRef, tyPtr, tyVar, tyLent:
-    let star = "*"
-    var et = origTyp.skipTypes(abstractInst).lastSon
-    var etB = et.skipTypes(abstractInst)
-    if mapType(m.config, t) == ctPtrToArray:
-      if etB.kind == tySet:
-        et = getSysType(m.g.graph, unknownLineInfo, tyUInt8)
-      else:
-        et = elemType(etB)
-      etB = et.skipTypes(abstractInst)
-    case etB.kind
-    of tyObject, tyTuple, tySequence:
-      # no restriction! We have a forward declaration for structs
-      let name = getTypeForward(m, et, hashType et)
-      result = name & star
-    of tyOpenArray:
-      result = getTypeDescAux(m, etB, check)
+
+  let name = computeTypeName(m.g.graph, m.types, id)
+  assert name != ""
+  # remember that the type was emitted. Doing it before producing the type
+  # body ensures that cyclic types don't result in infinite recursion:
+  m.typeCache[id] = name
+
+  case desc.kind
+  of tkArray:
+    let elem = useType(m, desc.elem)
+    m.s[cfsTypes].addf("typedef $1 $2[$3];$n",
+                       [elem, name, $desc.arrayLen(m.types)])
+  of tkUncheckedArray:
+    let elem = useType(m, desc.elem)
+    m.s[cfsTypes].addf("typedef $1 $2[1];$n",
+                       [elem, name])
+  of tkProc:
+    let locs = prepareParameters(m, desc)
+    var rettype, params: string
+    genProcParams(m, desc, rettype, params, locs, weakDep=true)
+    m.s[cfsTypes].addf("typedef $1_PTR($2, $3)$4;$n",
+                       [rope(CallingConvToStr[desc.callConv(m.types)]),
+                        rettype, name, params])
+  of tkRecord, tkUnion:
+    if id notin m.forwTypeCache:
+      m.forwTypeCache[id] = name
+      addForwardStructFormat(m, structOrUnion(desc.kind), name)
+
+    var recdesc: Rope
+    if desc.kind == tkRecord:
+      genRecordDesc(m, desc, name, recdesc)
     else:
-      # else we have a strong dependency  :-(
-      result = getTypeDescAux(m, et, check) & star
+      genUnionDesc(m, desc, name, recdesc)
+    m.s[cfsTypes].addf("$1;$n", [recdesc])
+  of tkImported:
+    let t = m.types[id]
+    useHeader(m, t.sym)
+    addAbiCheck(m, t, name)
 
-    m.typeCache[sig] = result
-  of tyOpenArray, tyVarargs:
-    result = getOpenArrayDesc(m, t, check)
-  of tyEnum:
-    result = cacheGetType(m.typeCache, sig)
-    if result == "":
-      result = getTypeName(m, origTyp, sig)
-      if not (sfImportc in t.sym.flags and t.sym.magic == mNone):
-        m.typeCache[sig] = result
-        m.s[cfsTypes].addf("typedef $1 $2;$n",
-          [getTypeDescAux(m, t.lastSon, check), result])
-        when false:
-          let owner = hashOwner(t.sym)
-          if not gDebugInfo.hasEnum(t.sym.name.s, t.sym.info.line, owner):
-            var vals: seq[(string, int)] = @[]
-            for i in 0..<t.n.len:
-              assert(t.n[i].kind == nkSym)
-              let field = t.n[i].sym
-              vals.add((field.name.s, field.position.int))
-            gDebugInfo.registerEnum(EnumDesc(size: size, owner: owner, id: t.sym.id,
-              name: t.sym.name.s, values: vals))
-  of tyProc:
-    result = getTypeName(m, origTyp, sig)
-    m.typeCache[sig] = result
-    var rettype, desc: Rope
-    let params = prepareParameters(m, t)
-    genProcParams(m, t, rettype, desc, check, params, true, true)
-    if not isImportedType(t):
-      if t.callConv != ccClosure: # procedure vars may need a closure!
-        m.s[cfsTypes].addf("typedef $1_PTR($2, $3) $4;$n",
-             [rope(CallingConvToStr[t.callConv]), rettype, result, desc])
-      else:
-        m.s[cfsTypes].addf("typedef struct {$n" &
-            "N_NIMCALL_PTR($2, ClP_0) $3;$n" &
-            "void* ClE_0;$n} $1;$n",
-             [result, rettype, desc])
-  of tySequence:
-    # a sequence type is two structs underneath: one for the seq itself, and
-    # one for its payload
-    m.config.internalAssert(skipTypes(t[0], typedescInst).kind != tyEmpty,
-                            "cannot map the empty seq type to a C type")
-
-    result = cacheGetType(m.forwTypeCache, sig)
-    if result == "":
-      result = getTypeName(m, origTyp, sig)
-      if not isImportedType(t):
-        m.forwTypeCache[sig] = result
-        addForwardStructFormat(m, structOrUnion(t), result)
-
-    # it's possible that the element type cannot be emitted yet because it
-    # depends on the sequence type (a cyclic type). For this reason, the
-    # payload type is only forward-declared here, and the actual definition
-    # is emitted later
-    addForwardStructFormat(m, structOrUnion(t), result & "_Content")
-    # note: force push the type (by not using ``pushType``)
-    m.typeStack.add origTyp
-
-    m.typeCache[sig] = result
-    appcg(m, m.s[cfsTypes],
-      "struct $1 {$N" &
-      "  NI len; $1_Content* p;$N" &
-      "};$N", [result])
-  of tyUncheckedArray:
-    result = getTypeName(m, origTyp, sig)
-    m.typeCache[sig] = result
-    if not isImportedType(t):
-      let foo = getTypeDescAux(m, t[0], check)
-      m.s[cfsTypes].addf("typedef $1 $2[1];$n", [foo, result])
-  of tyArray:
-    var n: BiggestInt = toInt64(lengthOrd(m.config, t))
-    if n <= 0: n = 1   # make an array of at least one element
-    result = getTypeName(m, origTyp, sig)
-    m.typeCache[sig] = result
-    if not isImportedType(t):
-      let foo = getTypeDescAux(m, t[1], check)
-      m.s[cfsTypes].addf("typedef $1 $2[$3];$n",
-           [foo, result, rope(n)])
-  of tyObject, tyTuple:
-    result = cacheGetType(m.forwTypeCache, sig)
-    if result == "":
-      result = getTypeName(m, origTyp, sig)
-      m.forwTypeCache[sig] = result
-      if not isImportedType(t):
-        addForwardStructFormat(m, structOrUnion(t), result)
-      assert m.forwTypeCache[sig] == result
-    m.typeCache[sig] = result # always call for sideeffects:
-    if not incompleteType(t):
-      let recdesc = if t.kind != tyTuple: getRecordDesc(m, t, result, check)
-                    else: getTupleDesc(m, t, result, check)
-      if not isImportedType(t):
-        m.s[cfsTypes].add(recdesc)
-      elif tfIncompleteStruct notin t.flags:
-        discard # addAbiCheck(m, t, result) # already handled elsewhere
-  of tySet:
-    # Don't use the imported name as it may be scoped: 'Foo::SomeKind'
-    result = $t.kind & '_' & t.lastSon.typeName & $t.lastSon.hashType
-    m.typeCache[sig] = result
-    if not isImportedType(t):
-      let s = int(getSize(m.config, t))
-      case s
-      of 1, 2, 4, 8: m.s[cfsTypes].addf("typedef NU$2 $1;$n", [result, rope(s*8)])
-      else: m.s[cfsTypes].addf("typedef NU8 $1[$2];$n",
-             [result, rope(getSize(m.config, t))])
-  of tyGenericInst, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias, tySink,
-     tyUserTypeClass, tyUserTypeClassInst, tyInferred:
-    result = getTypeDescAux(m, lastSon(t), check)
+    # fill in the field names for records:
+    let h = m.types.headerFor(desc.elem, Lowered)
+    case h.kind
+    of tkRecord:
+      var tmp: Rope; genRecordDesc(m, h, "", tmp)
+    of tkUnion:
+      var tmp: Rope; genUnionDesc(m, h, "", tmp)
+    else:
+      discard "nothing to do"
   else:
-    internalError(m.config, "getTypeDescAux(" & $t.kind & ')')
-    result = ""
-  # fixes bug #145:
-  excl(check, t.id)
+    unreachable("doesn't need a full definition")
+
+proc useType(m: BModule, typ: TypeId, desc: TypeHeader; onlyName = false): Rope =
+  case desc.kind
+  of tkVoid:
+    result = "void"
+  of tkPointer:
+    result = "void*"
+  of tkCstring:
+    result = "NCSTRING"
+  of tkBool:
+    result = "NIM_BOOL"
+  of tkChar:
+    result = "NIM_CHAR"
+  of tkInt:
+    result = "NI" & $(desc.size(m.types) * 8)
+  of tkUInt:
+    result = "NU" & $(desc.size(m.types) * 8)
+  of tkFloat:
+    result = "NF" & $(desc.size(m.types) * 8)
+  of tkRef, tkPtr, tkVar, tkLent:
+    if mapType(m.types, desc) == ctPtrToArray:
+      # use ``T*``, where `T` is the array's element type
+      result = useType(m, m.types.headerFor(desc.elem, Lowered).elem,
+                       onlyName=true)
+    else:
+      # only the pointee's name is required, not its full definition
+      result = useType(m, desc.elem, onlyName=true)
+    result.add "*"
+  of tkImported, tkProc, tkArray, tkUncheckedArray:
+    # definition is the same as only a forward declaration
+    emitTypeDef(m, typ, desc)
+    result = m.typeCache[typ]
+  of tkRecord, tkUnion:
+    if onlyName:
+      # a forward declaration suffices
+      result = getTypeForward(m, typ, desc)
+    else:
+      emitTypeDef(m, typ, desc)
+      result = m.typeCache[typ]
+  else:
+    unreachable(desc.kind)
 
 proc getTypeDesc(m: BModule, typ: PType): Rope =
-  var check = initIntSet()
-  result = getTypeDescAux(m, typ, check)
+  result = useType(m, m.addLate(typ))
 
 type
   TClosureTypeKind = enum ## In C closures are mapped to 3 different things.
@@ -807,21 +727,23 @@ type
     clFull            ## struct {fn(args, void* env), env}
 
 proc getClosureType(m: BModule, t: PType, kind: TClosureTypeKind): Rope =
-  assert t.kind == tyProc
-  var check = initIntSet()
-  result = getTempName(m)
-  let params = prepareParameters(m, t)
-  var rettype, desc: Rope
-  genProcParams(m, t, rettype, desc, check, params, declareEnvironment=kind != clHalf)
-  if not isImportedType(t):
-    if t.callConv != ccClosure or kind != clFull:
-      m.s[cfsTypes].addf("typedef $1_PTR($2, $3) $4;$n",
-           [rope(CallingConvToStr[t.callConv]), rettype, result, desc])
-    else:
-      m.s[cfsTypes].addf("typedef struct {$n" &
-          "N_NIMCALL_PTR($2, ClP_0) $3;$n" &
-          "void* ClE_0;$n} $1;$n",
-           [result, rettype, desc])
+  case kind
+  of clHalf:
+    # create a proc type with all of `t`'s parameters, except for the
+    # environment pointer
+    let canon {.cursor.} =
+      m.types.headerFor(m.types.canonical(m.types[t]), Canonical)
+
+    let pt = m.types.buildProc(tkProc, ccNimCall, canon.retType(m.types), bu):
+      for (_, typ, flags) in params(m.types, canon):
+        bu.addParam(flags, typ)
+
+    result = useType(m, pt)
+  of clHalfWithEnv:
+    let c = m.types.canonical(m.types[t])
+    result = useType(m, m.types[m.types.lookupField(c, 0)].typ)
+  of clFull:
+    result = getTypeDesc(m, t)
 
 proc genProcHeader(m: BModule, prc: PSym, locs: openArray[TLoc]): Rope =
   ## Generates the C function header for `prc`, with `locs` being the locs
@@ -838,8 +760,7 @@ proc genProcHeader(m: BModule, prc: PSym, locs: openArray[TLoc]): Rope =
     result.add "static "
   elif sfImportc notin prc.flags:
     result.add "N_LIB_PRIVATE "
-  var check = initIntSet()
-  genProcParams(m, prc.typ, rettype, params, check, locs)
+  genProcParams(m, prc.typ, rettype, params, locs)
 
   # careful here! don't access ``prc.ast`` as that could reload large parts of
   # the object graph!
@@ -943,11 +864,12 @@ proc genObjectFields(m: BModule, typ, origType: PType, n: PNode, expr: Rope;
     var tmp = discriminatorTableName(m, typ, field)
     var L = lengthOrd(m.config, field.typ)
     assert L > 0
+    let id = m.g.env.types.lookupField(m.types[origType], field.position.int32)
     m.s[cfsTypeInit3].addf("$1.kind = 3;$n" &
         "$1.offset = offsetof($2, $3);$n" & "$1.typ = $4;$n" &
         "$1.name = $5;$n" & "$1.sons = &$6[0];$n" &
         "$1.len = $7;$n", [expr, getTypeDesc(m, origType),
-                           m.fields[field],
+                           m.fields[id],
                            genTypeInfoV1(m, field.typ, info),
                            makeCString(field.name.s),
                            tmp, rope(L)])
@@ -978,10 +900,11 @@ proc genObjectFields(m: BModule, typ, origType: PType, n: PNode, expr: Rope;
     # Do not produce code for void types
     if isEmptyType(field.typ): return
     if field.bitsize == 0:
+      let id = m.g.env.types.lookupField(m.types[origType], field.position.int32)
       m.s[cfsTypeInit3].addf("$1.kind = 1;$n" &
           "$1.offset = offsetof($2, $3);$n" & "$1.typ = $4;$n" &
           "$1.name = $5;$n", [expr, getTypeDesc(m, origType),
-          m.fields[field], genTypeInfoV1(m, field.typ, info),
+          m.fields[id], genTypeInfoV1(m, field.typ, info),
           makeCString(field.name.s)])
   else: internalError(m.config, n.info, "genObjectFields")
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -726,7 +726,7 @@ proc startProc*(m: BModule, id: ProcedureId; procBody: sink Body): BProc =
     let
       res = resultId
       resNode = newLocalRef(res, prc.info, prc.typ[0])
-    if not isInvalidReturnType(m.config, prc.typ[0]):
+    if not isInvalidReturnType(m, prc.typ[0]):
       # declare the result symbol:
       assignLocalVar(p, resNode)
     else:
@@ -778,7 +778,7 @@ proc finishProc*(p: BProc, id: ProcedureId): string =
     header = genProcHeader(p.module, prc, p.params)
     returnStmt = ""
 
-  if sfPure notin prc.flags and not isInvalidReturnType(p.config, prc.typ[0]):
+  if sfPure notin prc.flags and not isInvalidReturnType(p.module, prc.typ[0]):
     returnStmt = ropecg(p.module, "\treturn $1;$n",
                         [rdLoc(p.locals[resultId])])
 

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -65,7 +65,8 @@ import
     ccgutils,
     ccgflow,
     cgendata,
-    cgir
+    cgir,
+    mangling
   ],
   compiler/plugins/[
   ]
@@ -111,6 +112,13 @@ template getString(p: BProc, n: CgNode): string =
 proc findPendingModule(m: BModule, s: PSym): BModule =
   let ms = s.itemId.module  #getModule(s)
   result = m.g.modules[ms]
+
+proc fieldName(p: BProc, typ: PType, field: PSym): string =
+  ## Returns the C name for the given `field`.
+  # the type the field is part of must have been emitted into the module
+  # already
+  p.module.fields[lookupField(p.module.types, p.module.types[typ],
+                              field.position.int32)]
 
 proc initLoc(result: var TLoc, k: TLocKind, lode: CgNode, s: TStorageLoc) =
   result.k = k
@@ -1119,8 +1127,8 @@ proc rawNewModule*(g: BModuleList; module: PSym, filename: AbsoluteFile): BModul
   result.declaredProtos = initIntSet()
   result.cfilename = filename
   result.filename = filename
-  result.typeCache = initTable[SigHash, Rope]()
-  result.forwTypeCache = initTable[SigHash, Rope]()
+  result.typeCache = initTable[TypeId, Rope]()
+  result.forwTypeCache = initTable[TypeId, Rope]()
   result.module = module
   result.typeInfoMarker = initTable[SigHash, Rope]()
   result.sigConflicts = initCountTable[SigHash]()

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -1124,7 +1124,6 @@ proc rawNewModule*(g: BModuleList; module: PSym, filename: AbsoluteFile): BModul
   result.module = module
   result.typeInfoMarker = initTable[SigHash, Rope]()
   result.sigConflicts = initCountTable[SigHash]()
-  result.typeStack = @[]
   result.typeNodesName = getTempName(result)
   # no line tracing for the init sections of the system module so that we
   # don't generate a TFrame which can confuse the stack bottom initialization:
@@ -1194,7 +1193,7 @@ proc shouldRecompile(m: BModule; code: Rope, cfile: Cfile): bool =
     result = true
 
 proc finalizeModule*(m: BModule) =
-  finishTypeDescriptions(m)
+  discard
 
 proc finalizeMainModule*(m: BModule) =
   generateThreadVarsSize(m) # TODO: not the job of the code generator

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -241,7 +241,6 @@ type
     headerFiles*: seq[string] ## needed headers to include
     typeInfoMarker*: TypeCache ## needed for generating type information
     typeInfoMarkerV2*: TypeCache
-    typeStack*: TTypeSeq      ## used for type generation
     defaultCache*: Table[SigHash, int]
       ## maps a type hash to the name of a C constant storing the type's
       ## default value

--- a/compiler/backend/cgendata.nim
+++ b/compiler/backend/cgendata.nim
@@ -25,7 +25,8 @@ import
   ],
   compiler/mir/[
     mirenv,
-    mirtrees
+    mirtrees,
+    mirtypes
   ],
   compiler/modules/[
     modulegraphs
@@ -207,7 +208,7 @@ type
       ## the locs for all alive constants of the program
     procs*: SeqMap[ProcedureId, ProcLoc]
       ## the locs for all alive procedure of the program
-    fields*: SymbolMap[string]
+    fields*: Table[FieldId, string]
       ## stores the C name for each field
 
     hooks*: seq[(BModule, ProcedureId)]
@@ -230,12 +231,8 @@ type
     cfilename*: AbsoluteFile  ## filename of the module (including path,
                               ## without extension)
     tmpBase*: Rope            ## base for temp identifier generation
-    typeCache*: TypeCache     ## cache the generated types
-    typeABICache*: HashSet[SigHash] ## cache for ABI checks; reusing typeCache
-                              ## would be ideal but for some reason enums
-                              ## don't seem to get cached so it'd generate
-                              ## 1 ABI check per occurence in code
-    forwTypeCache*: TypeCache ## cache for forward declarations of types
+    typeCache*: Table[TypeId, Rope] ## cache the generated types
+    forwTypeCache*: Table[TypeId, Rope] ## cache for forward declarations of types
     declaredThings*: IntSet   ## things we have declared in this .c file
     declaredProtos*: IntSet   ## prototypes we have declared in this .c file
     headerFiles*: seq[string] ## needed headers to include
@@ -275,10 +272,6 @@ template globals*(m: BModule): untyped = m.g.globals
 template consts*(m: BModule): untyped  = m.g.consts
 
 template env*(p: BProc): untyped = p.module.g.env
-
-template fieldName*(p: BProc, field: PSym): string =
-  ## Returns the C name for the given `field`.
-  p.module.fields[field]
 
 template params*(p: BProc): seq[TLoc] =
   ## Returns the mutable list with the locs of `p`'s

--- a/compiler/backend/mangling.nim
+++ b/compiler/backend/mangling.nim
@@ -63,7 +63,7 @@ proc mangle(g: ModuleGraph, typ: PType): string =
       # use the local ID as the name. "H" stands for "hidden"
       result = "H" & $s.itemId.item & "_M" & withLen(m)
     else:
-      # non-exported objec type's don't necessarily have unique names within a
+      # non-exported object types don't necessarily have unique names within a
       # module; the ID is included to produced a unique name
       result = "L" & mangleWithLen(s.name.s) & "_" & $s.itemId.item & "_M" &
                withLen(m)

--- a/compiler/backend/mangling.nim
+++ b/compiler/backend/mangling.nim
@@ -1,0 +1,199 @@
+## Implements the "name mangling" used by the code generators. Name mangling
+## needs to make sure that:
+## * the resulting identifier is valid according to the target's rules
+## * different entities get different names
+
+import
+  compiler/ast/[
+    ast_types,
+    ast_query
+  ],
+  compiler/mir/[
+    mirtypes,
+    mirtrees
+  ],
+  compiler/modules/[
+    modulegraphs
+  ],
+  compiler/utils/[
+    idioms
+  ]
+
+from compiler/backend/ccgutils import mangle
+
+const
+  CallConvToShort: array[TCallingConvention, string] = [
+    "ni", "st", "cd", "sa", "sy", "in", "ni", "fa", "cl", "nc"
+  ] ## every name must be unique and composed out of the same number of
+    ## letters
+
+proc mangle(g: ModuleGraph, env: TypeEnv, desc: TypeHeader): string
+proc mangle(g: ModuleGraph, env: TypeEnv, id: TypeId): string
+
+proc mangle(g: ModuleGraph, typ: PType): string =
+  ## For object types, returns a unique name based on the original symbol.
+  ## An empty string otherwise.
+  if typ.isNil:
+    return ""
+
+  proc withLen(s: string): string {.inline.} =
+    result = $s.len
+    result.add s
+
+  template mangleWithLen(s: string): string =
+    withLen(mangle(s))
+
+  if typ.kind == tyObject and typ.typeInst != nil:
+    # XXX: not very stable, but guaranteed to be unique and it also works
+    #      with the current IC mechanism
+    result = "I" & mangleWithLen(typ.typeInst[0].sym.name.s) & "_" & $typ.id
+  elif typ.kind == tyObject or (typ.sym != nil and sfImportc in typ.sym.flags):
+    # imported types are nominal types from the perspective of name mangling
+    let
+      s = typ.sym
+      m {.cursor.} = g.ifaces[typ.itemId.module].uniqueName
+
+    # the underscores are not strictly necessary; they're only added for
+    # better readability
+    if sfExported in s.flags:
+      # exported object types have unique name within their defining module.
+      # "G" stands for "global"
+      result = "G" & mangleWithLen(s.name.s) & "_M" & withLen(m)
+    elif sfAnon in s.flags:
+      # use the local ID as the name. "H" stands for "hidden"
+      result = "H" & $s.itemId.item & "_M" & withLen(m)
+    else:
+      # non-exported objec type's don't necessarily have unique names within a
+      # module; the ID is included to produced a unique name
+      result = "L" & mangleWithLen(s.name.s) & "_" & $s.itemId.item & "_M" &
+               withLen(m)
+  else:
+    result = "" # needs a structure-derived name
+
+proc mangleStruct(g: ModuleGraph, env: TypeEnv, prefix: string,
+                  desc: TypeHeader): string =
+  result = prefix
+  result.addInt desc.numFields
+  # bitsize, offset, custom alignment, etc. can only be used in records that
+  # don't use structure-basd mangling, and can thus be ignored here
+  for (_, f) in fields(env, desc):
+    result.add mangle(g, env, f.typ)
+
+proc mangleProc(result: var string, g: ModuleGraph, env: TypeEnv,
+                desc: TypeHeader) =
+  ## (return type)(parameter count)(parameters)*(E)?
+  let hasVarargs = desc.hasVarargs(env)
+  result.add mangle(g, env, desc.retType(env))
+  result.addInt desc.numParams + ord(hasVarargs)
+  for _, it, flags in env.params(desc):
+    result.add mangle(g, env, it)
+    # the flags are also part of the procedural type
+    if pfByRef in flags:
+      result.add "_R"
+
+  if hasVarargs:
+    result.add "E" # E for ellipsis
+
+proc mangle(g: ModuleGraph, env: TypeEnv, desc: TypeHeader): string =
+  ## Produces a mangled name from the *content* of the type `desc`.
+  template recurse(id: TypeId): string =
+    mangle(g, env, id)
+
+  case desc.kind
+  of tkRecord:
+    # no name specified, derive one from the structure
+    result = mangleStruct(g, env, "T", desc)
+  of tkUnion:
+    # no name specified, derive one from the structure
+    result = mangleStruct(g, env, "U", desc)
+  of tkImported, tkTaggedUnion:
+    # requires the original type name
+    unreachable()
+  of tkInt:
+    result = "i"
+    result.addInt desc.size(env) * 8
+  of tkUInt:
+    result = "u"
+    result.addInt desc.size(env) * 8
+  of tkFloat:
+    result = "f"
+    result.addInt desc.size(env) * 8
+  of tkChar:
+    result = "c"
+  of tkBool:
+    result = "b"
+  of tkArray:
+    result = "A"
+    result.addInt desc.arrayLen(env)
+    result.add mangle(g, env, desc.elem)
+  of tkProc:
+    result = "P"
+    result.add CallConvToShort[desc.callConv(env)]
+    mangleProc(result, g, env, desc)
+  of tkClosure:
+    result = "C"
+    mangleProc(result, g, env, desc)
+  of tkUncheckedArray:
+    result = "a"
+    result.add recurse(desc.elem)
+  of tkSeq:
+    result = "s"
+    result.add recurse(desc.elem)
+  of tkCstring:
+    result = "x"
+  of tkOpenArray:
+    result = "o"
+    result.add recurse(desc.elem)
+  of tkRef:
+    result = "r"
+    result.add recurse(desc.elem)
+  of tkPtr:
+    result = "p"
+    result.add recurse(desc.elem)
+  of tkPointer:
+    result = "pV" # mangle as ``ptr void``
+  of tkVar:
+    result = "v"
+    result.add recurse(desc.elem)
+  of tkLent:
+    result = "l"
+    result.add recurse(desc.elem)
+  of tkVoid:
+    result = "V"
+  of tkString:
+    result = "S"
+  of tkSet:
+    result = "e"
+    result.addInt desc.count
+  of tkIndirect:
+    unreachable("cannot mangle")
+
+proc mangle(g: ModuleGraph, env: TypeEnv, id: TypeId): string =
+  result = mangle(g, env[id])
+  if result.len == 0:
+    # derive the mangled name from the canonical representation
+    result = mangle(g, env, env.headerFor(id, Canonical))
+
+  assert result.len > 0
+
+proc computeTypeName*(g: ModuleGraph, env: TypeEnv, typ: TypeId): string =
+  ## Computes the name to address the type with in the generated code. Mangled
+  ## names are always prefixed with an underscore.
+  let n = env.get(env.canonical(typ)).desc[Canonical]
+
+  case env[n].kind
+  of tkRecord, tkUnion:
+    let inst = env.get(typ).inst
+    if inst != nil and inst.sym != nil and sfExportc in inst.sym.flags:
+      # the type has an external name, use that verbatim
+      inst.sym.extname
+    else:
+      # use the mangled/decorated name
+      "_" & mangle(g, env, typ)
+  of tkImported:
+    # use the specified external name as-is
+    env.get(typ).inst.sym.extname
+  of tkString:
+    "NimStringV2"
+  else:
+    "_" & mangle(g, env, env[n])

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -234,7 +234,7 @@ template useSource(bu: var MirBuilder, sp: var SourceProvider,
 
 # -------------- Symbol translation --------------
 
-func localToMir(c: var TCtx, s: PSym): Local =
+proc localToMir(c: var TCtx, s: PSym): Local =
   Local(typ: c.env.types.add(s.typ),
         flags: s.flags,
         isImmutable: s.kind in {skLet, skForVar},
@@ -290,7 +290,7 @@ template emitByName(c: var TCtx, eff: EffectKind, body: untyped) =
 template addLocal(c: var TCtx, local: Local): LocalId =
   c.builder.addLocal(local)
 
-func addLocal(c: var TCtx, s: PSym): LocalId =
+proc addLocal(c: var TCtx, s: PSym): LocalId =
   ## Translates `s` to its MIR representation, registers it with body, and
   ## establishes a mapping.
   assert s.id notin c.localsMap
@@ -309,7 +309,7 @@ func uintLiteral(env: var MirEnv, val: BiggestUInt, typ: TypeId): Value =
 func floatLiteral(env: var MirEnv, val: BiggestFloat, typ: TypeId): Value =
   literal(mnkFloatLit, env.getOrIncl(val), typ)
 
-func astLiteral(env: var MirEnv, val: PNode, typ: PType): Value =
+proc astLiteral(env: var MirEnv, val: PNode, typ: PType): Value =
   literal(env.asts.add(val), env.types.add(typ))
 
 proc toIntLiteral(env: var MirEnv, val: Int128, typ: PType): Value =
@@ -359,7 +359,7 @@ template labelNode(lbl: LabelId): MirNode =
 template newLabelNode(c: var TCtx): MirNode =
   labelNode(c.builder.allocLabel())
 
-func nameNode(c: var TCtx, s: PSym): MirNode =
+proc nameNode(c: var TCtx, s: PSym): MirNode =
   let t = c.typeToMir(s.typ)
   case s.kind
   of skTemp:
@@ -380,7 +380,7 @@ func nameNode(c: var TCtx, s: PSym): MirNode =
   else:
     unreachable(s.kind)
 
-func genLocation(c: var TCtx, n: PNode): Value =
+proc genLocation(c: var TCtx, n: PNode): Value =
   let f = c.builder.push: c.builder.add(nameNode(c, n.sym))
   c.builder.popSingle(f)
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1824,7 +1824,7 @@ proc genAsmOrEmitStmt(c: var TCtx, kind: range[mnkAsm..mnkEmit], n: PNode) =
       # both asm and emit statements support arbitrary expressions
       # (including type expressions) ...
       if it.typ != nil and it.typ.kind == tyTypeDesc:
-        c.use genTypeExpr(c, it)
+        c.use typeLit(c.typeToMir(it.typ.base))
       elif it.kind == nkSym and it.sym.kind == skField:
         # emit and asm support using raw field symbols. For pushing them
         # through to the code generators, they're quoted (i.e., boxed into

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -191,7 +191,7 @@ func hash(env: TypeEnv, t: TypeHeader): Hash =
   result = hash(t.kind)
   case t.kind
   of tkVoid, tkBool, tkChar, tkPointer, tkString, tkCstring:
-    discard "no content to hash"
+    discard "no additional content to hash"
   of tkInt, tkUInt, tkFloat, tkPtr, tkRef, tkVar, tkLent, tkSeq,
      tkUncheckedArray, tkOpenArray, tkSet, tkIndirect, tkImported:
     result = result !& hash(t.a)

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -135,7 +135,7 @@ type
 
     instances: Table[(int, HeaderId), TypeId]
       ## associates a generic type ID + instance body with a type symbol. This
-      ## is used for eliminating  same-shaped instantiations of a generic
+      ## is used for eliminating same-shaped instantiations of a generic
       ## object type
 
     idents: BiTable[string]

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -1033,7 +1033,7 @@ proc typeSymToMir(env: var TypeEnv, t: PType): TypeId =
 
     let
       orig  = typeToMir(env, t, canon=false)
-      canon = typeToMir(env, t, canon=true, unique=(t.typeInst == nil))
+      canon = typeToMir(env, t, canon=true, unique=(tfFromGeneric notin t.flags))
 
     # there's nothing to lower for object types
     env.symbols[result].desc = [orig, canon, canon]
@@ -1041,10 +1041,10 @@ proc typeSymToMir(env: var TypeEnv, t: PType): TypeId =
     # generic types support covariance for tuples. Pick an instance as the
     # "canonical" one, so that - for example - ``Generic[(int,)]`` and
     # ``Generic[tuple[x: int]]`` map to the same MIR type in the end
-    if t.typeInst != nil and
-       (let orig = env.instances.mgetOrPut((t.owner.typ.id, canon), result);
-        orig != result):
-      env.symbols[result].canon = orig
+    if tfFromGeneric in t.flags and
+       (let c = env.instances.mgetOrPut((t.owner.typ.id, canon), result);
+        c != result):
+      env.symbols[result].canon = c
   else:
     # create the type description preserving the original type symbols:
     let

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -220,6 +220,9 @@ func isEqual(env: TypeEnv, a, b: TypeHeader): bool =
         return false
     result = true
 
+  template fieldCount(t: TypeHeader): uint32 =
+    t.b - t.a # also valid for procedure types
+
   case a.kind
   of tkVoid, tkBool, tkChar, tkPointer, tkString, tkCstring:
     true
@@ -229,13 +232,13 @@ func isEqual(env: TypeEnv, a, b: TypeHeader): bool =
   of tkArray:
     a.a == b.a and a.b == b.b
   of tkRecord, tkUnion, tkTaggedUnion:
-    if a.b - a.a == b.b - b.a: # same number of fields?
-      isEqual(env.fields, a.a, b.a, a.b - a.a)
+    if fieldCount(a) == fieldCount(b): # same number of fields?
+      isEqual(env.fields, a.a, b.a, fieldCount(a))
     else:
       false
   of tkProc, tkClosure:
-    if a.b - a.a == b.b - b.a: # same number of params?
-      isEqual(env.params, a.a, b.a, a.b - a.a)
+    if fieldCount(a) == fieldCount(b): # same number of params?
+      isEqual(env.params, a.a, b.a, fieldCount(a))
     else:
       false
 

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -2,7 +2,16 @@
 ## `TypeEnv <#TypeEnv>`_, which stores the data for all types.
 ##
 ## All types are addressed via ``TypeId``, with the built-in types using
-## static IDs.
+## static IDs. Every ``TypeId`` is associated with a `TypeSym <#TypeSym>`_,
+## linking together the type's various representations. If multiple equal
+## structural types are added to the environment, the one added first is
+## designated as the "canonical" one.
+##
+## At the MIR level, a type representation has three different levels
+## (`Level <#Level>`_). On the `Original` level, all type references are
+## exactly as they appear in the ``PType`` form, the `Canonical` level only
+## uses references to canonical types, and the `Lowered` level is the type as
+## the code generator sees it.
 
 import
   std/[
@@ -10,8 +19,11 @@ import
     tables
   ],
   compiler/ast/[
+    ast,
     ast_types,
-    lineinfos
+    lineinfos,
+    idents,
+    types
   ],
   compiler/front/[
     options
@@ -24,25 +36,122 @@ import
     mirtrees,
     typemaps
   ],
+  compiler/ic/[
+    bitabs
+  ],
   compiler/utils/[
     containers,
     idioms
   ]
 
 type
-  TypeEnv* {.requiresInit.} = object
+  TypeKind* = enum
+    tkVoid
+    tkBool, tkChar
+    tkInt, tkUInt, tkFloat
+
+    tkPointer
+    tkPtr, tkRef, tkVar, tkLent
+
+    tkProc
+    tkClosure ## proc + environment
+
+    tkArray
+    tkUncheckedArray
+    tkOpenArray
+    tkSet
+    tkSeq
+    tkString
+    tkCstring
+
+    tkImported
+    tkIndirect # not a real type
+
+    # record-like types:
+    tkRecord
+    tkUnion
+    tkTaggedUnion
+
+  ParamFlag* = enum
+    pfByRef
+
+  IntVal = distinct uint32
+    ## If the MSB is not set, the lower 31 bit represent an unsigned integer
+    ## value. Otherwise, they represent a ``LitId``.
+
+  FieldId* = distinct uint32
+  HeaderId* = uint32
+
+  RecField* = object
+    ## Record field description.
+    ident: LitId
+    offset: IntVal
+    align*: int16
+    extra: uint16
+    typ*: TypeId
+
+  TypeHeader* = object
+    ## Type description header.
+    kind*: TypeKind
+    align*: int16   ## required alignment
+    size: IntVal    ## size in bytes
+    a: uint32       ## meaning depends on the type
+    b: uint32       ## meaning depends on the type
+
+  Level* = enum
+    Original  ## contains the original type symbols
+    Canonical ## same as `Original`, but with only canonical types symbols
+    Lowered   ## fully lowered version of the type
+
+  TypeSym* = object
+    ## A *type symbol* links together the various representations of a type.
+    inst*: PType
+      ## the original type instance
+    canon*: TypeId
+      ## if a type symbol is the canonical one, canon points to itself
+    desc*: array[Level, HeaderId]
+
+  TypeEnv* = object
     ## Stores the data associated with types. Has no valid default value, and
     ## must be explicitly initialized first.
     map: TypeTable[TypeId]
-      ## maps the hash of a type. Since the hash is not guaranteed to be
-      ## unique, hash collisions are possible!
-      # XXX: ^^ the collision needs to be addressed at some point. A proper,
-      #      non-sighash-based comparision needs to be used
-    types: Store[TypeId, PType]
+    symbols {.requiresInit.}: Store[TypeId, TypeSym]
+
+    headers: Store[HeaderId, TypeHeader]
+      ## all type headers
+    fields: seq[RecField]
+      ## all record fields referenced from `headers`
+    params: seq[tuple[x: uint32, typ: TypeId]]
+      ## all parameters referenced from `headers`
+
+    structs: seq[uint32]
+      ## an open-addressing using hash table. Indexed by ``hash(desc)``. The
+      ## items are indices (biased by 1) into the `headers` sequence
+    numStructs: int
+      ## the number of occupied slots in `structs`
+
+    canon: Table[HeaderId, TypeId]
+      ## maps headers of canonical type descriptions to their type symbol
+
+    idents: BiTable[string]
+    numbers: BiTable[BiggestInt]
+
+    config: ConfigRef
+    graph: ModuleGraph
+
     sizeType: TypeId
       ## the target-dependent integer type to use for size values
     usizeType: TypeId
       ## the target-dependent unsigned integer type to use for size values
+
+  RecordBuilder = object
+    header: TypeHeader
+    start: int
+    fields: seq[RecField]
+
+  ProcBuilder* = object
+    header: TypeHeader
+    params: seq[tuple[x: uint32, typ: TypeId]]
 
 const
   VoidType*    = TypeId 0
@@ -62,42 +171,734 @@ const
   CstringType* = TypeId 14
   PointerType* = TypeId 15
 
+  Skip = {tyAlias, tyDistinct, tySink, tyGenericInst, tyEnum, tyOrdinal,
+          tyRange} + tyUserTypeClasses
+    ## types not relevant to the MIR type description
+
+  MangleFlag = 0x4000'u16
+  NoAliasFlag = 0x8000'u16
+
+func `==`*(a, b: FieldId): bool {.borrow, inline.}
+func `==`(a, b: IntVal): bool {.borrow, inline.}
+
+func hash(env: TypeEnv, t: TypeHeader): Hash =
+  ## Computes the structural hash for the type `t`.
+  result = hash(t.kind)
+  case t.kind
+  of tkVoid, tkBool, tkChar, tkPointer, tkString, tkCstring:
+    discard "no content to hash"
+  of tkInt, tkUInt, tkFloat, tkPtr, tkRef, tkVar, tkLent, tkSeq,
+     tkUncheckedArray, tkOpenArray, tkSet, tkIndirect, tkImported:
+    result = result !& hash(t.a)
+  of tkArray:
+    result = result !& hash(t.a) !& hash(t.b)
+  of tkRecord, tkUnion, tkTaggedUnion:
+    # size and alignment doesn't need to be part of the hash. Two structural
+    # types with the same content cannot have different size or alignment,
+    # and two nominal types are always distinct
+    for it in t.a..<t.b:
+      result = result !& hash(env.fields[it])
+  of tkProc, tkClosure:
+    for it in t.a..<t.b:
+      result = result !& hash(env.params[it])
+
+  result = !$(result)
+
+func isEqual(env: TypeEnv, a, b: TypeHeader): bool =
+  ## Compares `a` and `b` for structural equality.
+  if a.kind != b.kind:
+    return false
+
+  func isEqual(s: seq, a, b, len: uint32): bool {.nimcall.} =
+    for i in 0..<len:
+      if s[a + i] != s[b + i]:
+        return false
+    result = true
+
+  case a.kind
+  of tkVoid, tkBool, tkChar, tkPointer, tkString, tkCstring:
+    true
+  of tkInt, tkUInt, tkFloat, tkPtr, tkRef, tkVar, tkLent, tkSeq,
+     tkUncheckedArray, tkOpenArray, tkSet, tkIndirect, tkImported:
+    a.a == b.a
+  of tkArray:
+    a.a == b.a and a.b == b.b
+  of tkRecord, tkUnion, tkTaggedUnion:
+    if a.b - a.a == b.b - b.a: # same number of fields?
+      isEqual(env.fields, a.a, b.a, a.b - a.a)
+    else:
+      false
+  of tkProc, tkClosure:
+    if a.b - a.a == b.b - b.a: # same number of params?
+      isEqual(env.params, a.a, b.a, a.b - a.a)
+    else:
+      false
+
+# -------------------------
+# Hash-table implementation
+
+template maxHash(t: seq): int =
+  t.high
+
+template isFilled(m: uint32): bool =
+  m != 0
+
+template nextTry(i, max: int): int =
+  (i + 1) and max
+
+func enlarge(env: var TypeEnv) =
+  ## Grows and re-hashes the `env.structs` hash-table.
+  template tbl: untyped = env.structs
+  var n = newSeq[uint32](tbl.len * 2)
+  swap(n, tbl)
+  for old in n.items:
+    if old.isFilled:
+      var j = hash(env, env.headers[old-1]) and maxHash(tbl)
+      while tbl[j].isFilled:
+        j = nextTry(j, maxHash(tbl))
+      tbl[j] = old
+
+func deduplicate(env: var TypeEnv, header: TypeHeader): (bool, HeaderId) =
+  ## Adds `header` to env, but only if the type wasn't added already. Only
+  ## types previously passed to `deduplicate` are considered. Returns the
+  ## ID to address the added header with and whether it existed already.
+  let hash = hash(env, header) ## hash of the tree
+  var i = hash and maxHash(env.structs)
+  # note: the items in the table are offset by 1, so that '0' means
+  # "empty slot"
+  if env.structs.len > 0:
+    while (let slot = env.structs[i]; slot.isFilled):
+      let h = uint32(slot - 1) # header index
+      if isEqual(env, header, env.headers[h]): # same types?
+        return (true, h) # already exists
+      i = nextTry(i, maxHash(env.structs))
+
+    # not a duplicate. Before adding a new entry, first enlarge the table, if
+    # necessary
+    template mustRehash(len, counter: int): bool =
+      (len * 2 < counter * 3) or (len - counter < 4)
+
+    if mustRehash(env.structs.len, env.numStructs):
+      enlarge(env)
+      i = hash and maxHash(env.structs)
+      # find the first empty slot:
+      while isFilled(env.structs[i]):
+        i = nextTry(i, maxHash(env.structs))
+
+  else:
+    # the table is empty, initialize it
+    env.structs.setLen(16) # must to be a power-of-two
+    i = hash and maxHash(env.structs)
+
+  let id = env.headers.add header
+  # remember the description in the list:
+  env.structs[i] = id + 1
+  inc env.numStructs
+
+  result = (false, id)
+
+proc toIntVal(env: var TypeEnv, val: BiggestInt): IntVal =
+  ## Turns `val` into an ``IntVal``.
+  if val in 0..0x7FFF_FFFF:
+    IntVal(val)
+  else:
+    IntVal(uint32(env.numbers.getOrIncl(val)) or 0x8000_0000'u32)
+
+proc getInt(env: TypeEnv, val: IntVal): BiggestInt =
+  ## Turns `val` back into an integer value.
+  if (val.uint32 and 0x8000_0000'u32) == 0:
+    BiggestInt(val.uint32 and 0x7FFF_FFFF'u32)
+  else:
+    env.numbers[LitId(val.uint32 and 0x7FFF_FFFF'u32)]
+
+# Type inspection/query routines
+# ------------------------------
+
+# the querie routines are simple enough to warrant inlining
+{.push inline.}
+
+func headerFor*(env: TypeEnv, id: TypeId, phase: Level): lent TypeHeader =
+  env.headers[env.symbols[id].desc[phase]]
+
+func `[]`*(env: TypeEnv, id: HeaderId): lent TypeHeader {.inline.} =
+  env.headers[id]
+
+func size*(desc: TypeHeader, env: TypeEnv): BiggestInt {.inline.} =
+  ## Returns the size-in-bytes for the given type.
+  env.getInt(desc.size)
+
+proc elem*(desc: TypeHeader): TypeId {.inline.} =
+  ## Returns the element type for `h`.
+  assert desc.kind in {tkArray, tkSeq, tkUncheckedArray, tkIndirect,
+                       tkImported, tkOpenArray, tkLent, tkVar, tkPtr, tkRef}
+  desc.a.TypeId
+
+proc count*(desc: TypeHeader): uint32 {.inline.} =
+  ## Returns the number of elements the ``set`` type can contain.
+  assert desc.kind == tkSet
+  desc.a
+
+proc arrayLen*(desc: TypeHeader, env: TypeEnv): BiggestInt {.inline.} =
+  assert desc.kind == tkArray
+  env.getInt(IntVal desc.b)
+
+func discr*(desc: TypeHeader, env: TypeEnv): FieldId =
+  ## Returns the discriminator field for the given tagged union.
+  assert desc.kind == tkTaggedUnion
+  FieldId desc.a
+
+func numParams*(desc: TypeHeader): int =
+  int(desc.b - desc.a) - 1
+
+func callConv*(desc: TypeHeader, env: TypeEnv): TCallingConvention =
+  TCallingConvention env.params[desc.a].x
+
+func hasVarargs*(desc: TypeHeader, env: TypeEnv): bool =
+  (env.params[desc.a].x and 0x8000_0000'u32) != 0
+
+func retType*(desc: TypeHeader, env: TypeEnv): TypeId =
+  assert desc.kind in {tkProc, tkClosure}
+  env.params[desc.a].typ
+
+iterator params*(env: TypeEnv, desc: TypeHeader
+                ): tuple[i: int, typ: TypeId, flags: set[ParamFlag]] =
+  ## Returns the typ and flags for all parameters of type t
+  for i in (desc.a + 1)..<desc.b:
+    yield (int(i - desc.a - 1), env.params[i].typ,
+           cast[set[ParamFlag]](env.params[i].x))
+
+func base*(desc: TypeHeader, env: TypeEnv): TypeId =
+  ## Returns the node storing the base type (i.e., the parent type) for a
+  ## record type.
+  assert desc.kind == tkRecord
+  env.fields[desc.a].typ
+
+func fieldOffset*(desc: TypeHeader, env: TypeEnv): int32 =
+  ## Returns the first field's position in the object.
+  assert desc.kind == tkRecord
+  env.fields[desc.a].align.int32
+
+func isPacked*(desc: TypeHeader, env: TypeEnv): bool =
+  ## Whether the record type is
+  assert desc.kind == tkRecord
+  env.fields[desc.a].extra == 1
+
+func numFields*(desc: TypeHeader): int =
+  ## Returns the number of fields in the record-like type, ignoring parent
+  ## types.
+  int(desc.b - desc.a) - ord(desc.kind == tkRecord)
+
+func isNamed*(f: RecField): bool =
+  f.ident != LitId(0)
+
+func name*(env: TypeEnv, f: RecField): lent string =
+  assert f.ident != LitId(0)
+  result = env.idents[f.ident]
+
+func isNoMangle*(f: RecField): bool =
+  ## Whether the field's name must not be mangled.
+  (f.extra and MangleFlag) == 0
+
+func isNoAlias*(f: RecField): bool =
+  (f.extra and NoAliasFlag) != 0
+
+func bitsize*(f: RecField): int =
+  int(f.extra and 0x00FF)
+
+{.pop.} # inline
+
+iterator fields*(env: TypeEnv, desc: TypeHeader;
+                 offset = 0): (FieldId, RecField) =
+  ## Returns all fields directly part of `desc`. Super types are not
+  ## considered.
+  assert desc.kind in {tkRecord, tkUnion, tkTaggedUnion}
+  # note: the field storing the super type is not included
+  let offset = ord(desc.kind == tkRecord) + offset
+  for it in (desc.a + uint32(offset))..<desc.b:
+    yield (FieldId(it), env.fields[it])
+
+proc computeDepth*(env: TypeEnv, desc: TypeHeader, pos: int32): int =
+  ## Computes the depth at which the field with position `pos` is located.
+  ## 0 means it's part of `desc`, 1 means it's part of the first parent type,
+  ## etc.
+  case desc.kind
+  of tkRecord:
+    result = 0
+    var h {.cursor.} = desc
+    while h.fieldOffset(env) > pos:
+      h = env.headerFor(h.base(env), Lowered)
+      inc result
+  of tkUnion:
+    result = 0
+  of tkImported, tkIndirect:
+    result = computeDepth(env, env.headerFor(desc.elem, Lowered), pos)
+  else:
+    unreachable(desc.kind)
+
+proc canonical*(env: TypeEnv, typ: TypeId): TypeId =
+  ## Returns the canonical symbol for `typ`. All indirections are skipped.
+  result = env.symbols[typ].canon
+  # skip indirections:
+  while env.headerFor(result, Canonical).kind == tkIndirect:
+    result = env.headerFor(result, Canonical).elem
+
+proc isEmbedded*(env: TypeEnv, typ: TypeId): bool =
+  ## Whether the `typ` is a record that's directly embedded where it's used.
+  env.symbols[typ].inst.isNil and
+    env.headerFor(typ, Lowered).kind in {tkRecord, tkTaggedUnion}
+
+proc lookupField*(env: TypeEnv, typ: TypeId, pos: int32): FieldId =
+  ## Returns the ID of the field with position `pos`. Said field *must* exist
+  ## in record-like type `typ`. Imported types and indirection are skipped.
+
+  # skip indirections and imported types:
+  var typ = env.symbols[typ].canon
+  while env.headerFor(typ, Canonical).kind in {tkIndirect, tkImported}:
+    typ = env.headerFor(typ, Canonical).elem
+
+  var curr = 0'i32
+  # seek to the type in the inheritance hierarchy that contains the field
+  if env.headerFor(typ, Lowered).kind == tkRecord:
+    curr = env.headerFor(typ, Lowered).fieldOffset(env)
+    while curr > pos: # part of the current record?
+      # it's not, try the parent type
+      typ = env.headerFor(typ, Lowered).base(env)
+      curr = env.headerFor(typ, Lowered).fieldOffset(env)
+
+    assert typ != VoidType, "field not in record"
+
+  proc searchRecord(env: TypeEnv, desc: TypeHeader, pos: int32,
+                    curr: var int32): (bool, FieldId) =
+    # look for the field whose position matches `pos`. Anonymous record-like
+    # types are always embedded at the moment, so they are transparently
+    # recursed into
+    for (id, it) in fields(env, desc):
+      if isEmbedded(env, it.typ):
+        result = searchRecord(env, env.headerFor(it.typ, Lowered), pos, curr)
+        if result[0]:
+          return
+      elif curr == pos:
+        return (true, id)
+      else:
+        inc curr
+
+    result = (false, default(FieldId))
+
+  let r = searchRecord(env, env.headerFor(typ, Lowered), pos, curr)
+  assert r[0], "field not in type"
+  result = r[1]
+
+# Record/proc builder API
+# -----------------------
+
+proc newType*(env: var TypeEnv, desc: HeaderId): TypeId =
+  ## If none exists already, creates a new type symbol for `desc`.
+  result = env.canon.mgetOrPut(desc, env.symbols.nextId())
+  if result == env.symbols.nextId():
+    # no type symbol exists yet
+    result = env.symbols.add(TypeSym(canon: result, desc: [desc, desc, desc]))
+
+proc openRecord(size: IntVal, align: int16; offset = 0;
+                base = VoidType): RecordBuilder =
+  result.header = TypeHeader(kind: tkRecord, size: size, align: align, b: 1)
+  result.fields.add RecField(typ: base, align: offset.int16)
+
+proc open(kind: TypeKind; size: IntVal, align: int16): RecordBuilder =
+  result.header = TypeHeader(kind: kind, size: size, align: align)
+
+proc openProc(env: TypeEnv, kind: TypeKind, conv: TCallingConvention,
+              ret: TypeId, isVarargs: bool): ProcBuilder =
+  ## Opens a builder for a procedure-like type.
+  result.header = TypeHeader(kind: kind, b: 1,
+                             align: env.config.target.ptrSize.int16)
+  if kind == tkProc:
+    result.header.size = IntVal(env.config.target.ptrSize)
+  else:
+    # a closure is two pointers
+    result.header.size = IntVal(env.config.target.ptrSize * 2)
+  result.params.add (uint32(conv) or (uint32(ord(isVarargs)) shl 31), ret)
+
+proc openRecord(b: var RecordBuilder): RecordBuilder =
+  result = RecordBuilder(start: b.fields.len)
+  swap(result.fields, b.fields) # temporarily take over the buffer
+  result.header = TypeHeader(kind: tkRecord, b: 1)
+  result.fields.add RecField(typ: VoidType, align: 0)
+
+proc open(b: var RecordBuilder, kind: TypeKind): RecordBuilder =
+  result = RecordBuilder(start: b.fields.len)
+  swap(result.fields, b.fields) # temporarily take over the buffer
+  result.header = TypeHeader(kind: kind)
+
+proc addField(b: var RecordBuilder, env: var TypeEnv, offset: IntVal,
+              typ: TypeId; name = ""; mangle = true) =
+  ## Adds a field declaration. `typ` is the type, `name` the name, and `mangle`
+  ## indicates whether the name should be mangled.
+  inc b.header.b
+  if name.len > 0:
+    b.fields.add RecField(typ: typ, offset: offset,
+                          ident: env.idents.getOrIncl(name),
+                          extra: (if mangle: MangleFlag else: 0))
+  else:
+    b.fields.add RecField(typ: typ, offset: offset)
+
+proc addField(b: var RecordBuilder, offset: IntVal, typ: TypeId) =
+  inc b.header.b
+  b.fields.add RecField(typ: typ, offset: offset)
+
+proc addField(b: var RecordBuilder, env: var TypeEnv, s: PSym, typ: TypeId) =
+  var field = RecField(typ: typ, offset: env.toIntVal(s.offset),
+                       align: s.alignment.int16)
+  if {sfImportc, sfExportc} * s.flags == {}:
+    field.ident = env.idents.getOrIncl(s.name.s)
+    field.extra = MangleFlag
+  else:
+    # use the external name and disable mangling
+    field.ident = env.idents.getOrIncl(s.extname)
+
+  if sfNoalias in s.flags:
+    field.extra = field.extra or NoAliasFlag
+
+  # the bitsize value can only be in the range 0..64, so it fits well into the
+  # lower 8 bit of `extra`
+  field.extra = field.extra or uint16(s.bitsize)
+
+  inc b.header.b
+  b.fields.add field
+
+proc addParam*(b: var ProcBuilder, s: set[ParamFlag], typ: TypeId) =
+  ## Adds a parameter to the proc type.
+  inc b.header.b
+  b.params.add (cast[uint32](s), typ)
+
+proc close(prev: var RecordBuilder, env: var TypeEnv,
+           other: sink RecordBuilder): HeaderId =
+  ## Closes `other`, commiting the type description to `env`. `prev` must be
+  ## the builder `other` was previously spawned from.
+  var header = other.header
+  header.a += env.fields.len.uint32
+  header.b += env.fields.len.uint32
+  # move the fields to the environment:
+  env.fields.add other.fields.toOpenArray(other.start, other.fields.high)
+  other.fields.setLen(other.start)
+  # hand the buffer back to the parent builder:
+  swap(prev.fields, other.fields)
+
+  # nested records are currently always anonymous and never de-duplicated:
+  result = env.headers.add header
+
+proc close(b: sink RecordBuilder, env: var TypeEnv; unique = false): HeaderId =
+  ## Finalizes the record description and commits it to `env`. De-duplication
+  ## is only performed if `unique` is false.
+  var header = b.header
+  header.a += env.fields.len.uint32
+  header.b += env.fields.len.uint32
+  var start = env.fields.len
+  env.fields.add b.fields
+
+  if unique:
+    result = env.headers.add(header)
+  else:
+    # register the type description in the deduplication table
+    var existed: bool
+    (existed, result) = deduplicate(env, header)
+    if existed:
+      env.fields.setLen(start)
+
+proc close(env: var TypeEnv, b: sink ProcBuilder): uint32 =
+  ## Finished the type description, and returns its root node. If the type
+  ## description already existed previously, no new one is added.
+  var header = b.header
+  header.a += env.params.len.uint32
+  header.b += env.params.len.uint32
+  var start = env.params.len
+  env.params.add b.params
+
+  # register the type description in the deduplication table
+  var existed: bool
+  (existed, result) = deduplicate(env, header)
+  if existed:
+    env.params.setLen(start)
+
+# Type translation/lowering
+# -------------------------
+
+proc add*(env: var TypeEnv, t: PType): TypeId
+
+proc recordToMir(env: var TypeEnv, rec: var RecordBuilder, n: PNode,
+                 packed, canon: bool) =
+  ## Translates record node/AST `n` to the corresponding MIR type description.
+  template recurse(rec: var RecordBuilder, n: PNode) =
+    recordToMir(env, rec, n, packed, canon)
+
+  case n.kind
+  of nkSym:
+    var t = env.add(n.sym.typ)
+    if canon:
+      t = canonical(env, t)
+
+    rec.addField(env, n.sym, t)
+  of nkRecList:
+    for it in n.items:
+      recurse(rec, it)
+  of nkRecCase:
+    # at the moment, tagged union description are directly embedded into
+    # their parent record
+    var tu = rec.open(tkTaggedUnion)
+    recurse(tu, n[0]) # discriminator
+    for i in 1..<n.len:
+      let child = n[i][^1]
+      if child.kind == nkSym:
+        recurse(tu, child)
+      else:
+        # start a new record
+        var sub = tu.openRecord()
+        if packed:
+          sub.fields[^1].extra = 1 # mark as packed
+        recurse(sub, child)
+        let x = tu.close(env, sub)
+        # add as field to the tagged union:
+        tu.addField(IntVal(0), env.newType(x))
+
+    let x = rec.close(env, tu)
+    rec.addField(env.toIntVal(n[0].sym.offset), env.newType(x))
+  else:
+    unreachable(n.kind)
+
+proc nextFieldPosition(t: PType): int =
+  ## Computes the position of the would-be next field added to object-type `t`.
+  let t = t.skipTypes(skipPtrs)
+  if t.n.len > 0:
+    var n = t.n
+    # seek to the record's very last field:
+    while n.kind != nkSym:
+      n = n[^1]
+    result = n.sym.position + 1
+  elif t[0].isNil:
+    # no super type and no body
+    result = 0
+  else:
+    # no body, but there's a super type to inspect
+    result = nextFieldPosition(t[0])
+
+proc skipIrrelevant(t: sink PType): PType =
+  ## Skips all types that don't contribute to the MIR type description.
+  while t.kind in Skip and (t.sym.isNil or sfImportc notin t.sym.flags):
+    t = t.lastSon
+  result = t
+
+proc add(env: var TypeEnv, desc: sink TypeHeader): HeaderId =
+  ## Adds `desc` to `env`, but only if it doesn't exist there already.
+  var existed: bool
+  (existed, result) = deduplicate(env, desc)
+
+proc objectBase(t: PType): PType =
+  # skip ref/ptr types, but make sure to not skip instance types
+  # wrapping the immediate object type
+  result = t.base
+  while result.kind notin {tyRef, tyPtr, tyObject}:
+    result = result.lastSon
+
+  case result.kind
+  of tyRef, tyPtr:
+    result = result.lastSon
+  else:
+    result = t.base # use the original base type
+
+proc makeDesc(kind: TypeKind, size: IntVal, align: int16,
+              typ: TypeId; other = 0'u32): TypeHeader {.inline.} =
+  TypeHeader(kind: kind, size: size, align: align, a: typ.uint32, b: other)
+
+proc typeToMir(env: var TypeEnv, t: PType; canon = false): uint32 =
+  template typeref(typ: PType): TypeId =
+    let t = env.add(typ)
+    if canon: canonical(env, t)
+    else:     t
+
+  template single(k: TypeKind, elem: PType): uint32 =
+    env.add makeDesc(k, env.toIntVal(t.size), t.align, typeref elem)
+
+  template simple(id: TypeId): uint32 = env.symbols[id].desc[Original]
+
+  case t.kind
+  of tyVoid:    simple(VoidType)
+  of tyBool:    simple(BoolType)
+  of tyChar:    simple(CharType)
+  of tyInt8:    simple(Int8Type)
+  of tyInt16:   simple(Int16Type)
+  of tyInt32:   simple(Int32Type)
+  of tyInt64:   simple(Int64Type)
+  of tyInt:     simple(env.sizeType)
+  of tyUInt8:   simple(UInt8Type)
+  of tyUInt16:  simple(UInt16Type)
+  of tyUInt32:  simple(UInt32Type)
+  of tyUInt64:  simple(UInt64Type)
+  of tyUInt:    simple(env.usizeType)
+  of tyFloat32: simple(Float32Type)
+  of tyFloat:   simple(Float64Type)
+  of tyFloat64: simple(Float64Type)
+  of tyString:  simple(StringType)
+  of tyCstring: simple(CstringType)
+  of tyPointer, tyNil: simple(PointerType)
+  of tyTuple:
+    var tup = openRecord(env.toIntVal(t.size), t.align)
+    if t.len == 0:
+      tup.addField(IntVal 0, CharType)
+    elif t.size < 0:
+      # the size contains some incomplete imported types; no offsets can be
+      # computed
+      for i in 0..<t.len:
+        tup.addField(env, IntVal 0, typeref t[i])
+    else:
+      var offset: BiggestInt = 0
+      for i in 0..<t.len:
+        let mask = t[i].align - 1
+        offset = (offset + mask) and not(mask) # align the offset
+        tup.addField(env, env.toIntVal(offset), typeref t[i])
+        offset += t[i].size
+
+    tup.close(env)
+  of tyObject:
+    let
+      size = env.toIntVal(t.size)
+    var
+      rec: RecordBuilder
+      isEmpty = false
+
+    if tfUnion in t.flags:
+      rec = open(tkUnion, size, t.align)
+      isEmpty = t.n.len == 0
+    elif t[0] != nil:
+      # object has a super type
+      let b = objectBase(t)
+      rec = openRecord(size, t.align, b.nextFieldPosition, typeref(b))
+    elif lacksMTypeField(t):
+      # no super type and no type header
+      rec = openRecord(size, t.align)
+      isEmpty = t.n.len == 0
+    elif (let rtti = env.graph.getCompilerProc("TNimTypeV2"); rtti != nil):
+      # the object has a field for the RTTI
+      let ptrTyp = env.newType(single(tkPtr, rtti.typ))
+      # the type field is at position -1
+      rec = openRecord(size, t.align, -1)
+      rec.addField(env, IntVal 0, ptrTyp, "m_type")
+    else:
+      # legacy support for backends not yet using RTTI fields
+      rec = openRecord(size, t.align)
+
+    if rec.header.kind == tkRecord and tfPacked in t.flags:
+      rec.fields[0].extra = 1 # mark as packed
+
+    recordToMir(env, rec, t.n, tfPacked in t.flags, canon)
+
+    if isEmpty:
+      # record-like types must always have at least *one* field
+      rec.addField(IntVal 0, CharType)
+
+    # object/union types are not de-duplicated
+    rec.close(env, unique=true)
+  of tyProc:
+    var prc: ProcBuilder
+    let ret = if t[0].isNil: VoidType else: typeref(t[0])
+    if t.callConv == ccClosure:
+      prc = env.openProc(tkClosure, t.callConv, ret, tfVarargs in t.flags)
+    else:
+      prc = env.openProc(tkProc, t.callConv, ret, tfVarargs in t.flags)
+
+    # future direction: static parameters need to be filtered out here.
+    # Typedesc parameters only need to be removed in non-compile-time
+    # execution contexts
+    for i in 1..<t.len:
+      var s: set[ParamFlag]
+      if isPassByRef(env.config, t.n[i].sym, t[0]):
+        s.incl pfByRef
+
+      prc.addParam(s, typeref t[i])
+
+    env.close(prc)
+  of tyVar:
+    # a ``var openArray`` is just an ``openArray``
+    if classifyBackendView(t) == bvcSequence:
+      typeToMir(env, t[0], canon)
+    else:
+      single(tkVar, t[0])
+  of tyLent:
+    if classifyBackendView(t) == bvcSequence:
+      typeToMir(env, t[0], canon)
+    else:
+      single(tkLent, t[0])
+  of tyRef:
+    single(tkRef, t[^1])
+  of tyPtr:
+    single(tkPtr, t[^1])
+  of tyOpenArray, tyVarargs:
+    single(tkOpenArray, t[0])
+  of tyArray:
+    # in terms of in-memory representation, array always have a length of at
+    # least 1
+    let len = max(lengthOrd(env.config, t), One)
+    env.add makeDesc(tkArray, env.toIntVal(t.size), t.align,
+                     typeref elemType(t), uint32 env.toIntVal(toInt len))
+  of tySequence:
+    single(tkSeq, t[0])
+  of tySet:
+    # sets always have a length <= 2^16
+    let len = toUInt32 lengthOrd(env.config, t)
+    env.add TypeHeader(kind: tkSet, size: env.toIntVal(t.size), align: t.align,
+                       a: len)
+  of tyUncheckedArray:
+    single(tkUncheckedArray, t[0])
+  of tyTypeDesc, tyStatic, tyUntyped, tyTyped:
+    # have no relevance in the MIR's type syste, beyond taking up slots
+    # XXX: untyped/typed shouldn't reach here, but currently they do
+    simple(VoidType)
+  of tyEnum, tyOrdinal, tyRange:
+    # the underlying type is usually a simple, single-node type, so
+    # translate it directly
+    typeToMir(env, t.lastSon, canon)
+  of tyUserTypeClasses, tyGenericInst, tyInferred, tySink, tyAlias, tyDistinct:
+    # use a type-reference instead of in-place translation. This prevents
+    # unnecessary de-duplication work for, e.g., object types
+    single(tkIndirect, t.lastSon)
+  else:
+    unreachable(t.kind)
+
 proc initTypeEnv*(graph: ModuleGraph): TypeEnv =
   ## Returns a fully initialized type environment instance.
-  result = TypeEnv(map: default(TypeTable[TypeId]),
-                   types: default(Store[TypeId, PType]),
-                   sizeType: VoidType,
-                   usizeType: VoidType)
+  result = TypeEnv(symbols: default(Store[TypeId, TypeSym]))
+  result.graph = graph
+  result.config = graph.config
 
-  template add(kind: TTypeKind, expect: TypeId) =
-    let
-      typ = graph.getSysType(unknownLineInfo, kind)
-      id  = result.types.add(typ)
-    assert id == expect
-    # the type needs to be mapped too
-    result.map[typ] = id
+  template add(ttk: TTypeKind, expect: TypeId, tk: TypeKind) =
+    block:
+      let
+        typ = graph.getSysType(unknownLineInfo, ttk)
+        desc = result.headers.add:
+          TypeHeader(kind: tk, size: IntVal(typ.size), align: typ.align)
+        id  = result.symbols.add:
+          TypeSym(inst: typ, canon: expect, desc: [desc, desc, desc])
 
-  add(tyVoid, VoidType)
-  add(tyBool, BoolType)
-  add(tyChar, CharType)
-  add(tyInt8, Int8Type)
-  add(tyInt16, Int16Type)
-  add(tyInt32, Int32Type)
-  add(tyInt64, Int64Type)
-  add(tyUInt8, UInt8Type)
-  add(tyUInt16, UInt16Type)
-  add(tyUInt32, UInt32Type)
-  add(tyUInt64, UInt64Type)
-  add(tyFloat32, Float32Type)
-  add(tyFloat64, Float64Type)
-  add(tyString, StringType)
-  add(tyCstring, CstringType)
-  add(tyPointer, PointerType)
+      assert id == expect
+      # register a mapping:
+      result.map[typ] = id
+      result.canon[desc] = id
 
-  # also register the built-in unspecified-width types. This prevents int/float
-  # literal types from being added to the environment
-  add(tyInt,   TypeId(ord(PointerType) + 1))
-  add(tyFloat, TypeId(ord(PointerType) + 2))
+  # setup the built-in types:
+  add tyVoid,    VoidType,    tkVoid
+  add tyBool,    BoolType,    tkBool
+  add tyChar,    CharType,    tkChar
+  add tyInt8,    Int8Type,    tkInt
+  add tyInt16,   Int16Type,   tkInt
+  add tyInt32,   Int32Type,   tkInt
+  add tyInt64,   Int64Type,   tkInt
+  add tyUInt8,   UInt8Type,   tkUInt
+  add tyUInt16,  UInt16Type,  tkUInt
+  add tyUInt32,  UInt32Type,  tkUInt
+  add tyUInt64,  UInt64Type,  tkUInt
+  add tyFloat32, Float32Type, tkFloat
+  add tyFloat64, Float64Type, tkFloat
+  add tyString,  StringType,  tkString
+  add tyCstring, CstringType, tkCstring
+  add tyPointer, PointerType, tkPointer
 
   (result.sizeType, result.usizeType) =
     case graph.config.target.intSize
@@ -105,15 +906,189 @@ proc initTypeEnv*(graph: ModuleGraph): TypeEnv =
     of 8:       (Int64Type, UInt64Type)
     else:       unreachable()
 
+  # also register the built-in unspecified-width types. This prevents int/float
+  # literal types from being added to the environment
+  discard result.add(graph.getSysType(unknownLineInfo, tyInt))
+  discard result.add(graph.getSysType(unknownLineInfo, tyFloat))
+
+  # setup the lowered representation of the string type
+  let str = graph.getCompilerProc("NimStringV2")
+  if str != nil: # not all code generators use the lowered type yet
+    let base = result.add(str.typ)
+    # redirect NimStringV2 in a way such that the code generators will
+    # treat it as being the same as ``string``
+    # XXX: this is an interim solution. Ultimately, the definition of
+    #      ``string`` in the system module should express this directly
+    result.symbols[StringType].desc[Lowered] =
+      result.symbols[base].desc[Lowered]
+    result.symbols[base].canon = StringType
+
+proc newPtrTy(env: var TypeEnv, elem: TypeId): TypeId =
+  # inherit size and alignment information from the base pointer type
+  var h = env.headerFor(PointerType, Original)
+  h.kind = tkPtr
+  h.a = elem.uint32
+  env.newType(env.add h)
+
+proc newUncheckedArrayTy(env: var TypeEnv, elem: TypeId): TypeId =
+  let desc = makeDesc(tkUncheckedArray, IntVal(0),
+                      env.headerFor(elem, Original).align, elem)
+  env.newType(env.add desc)
+
+template buildProc*(env: var TypeEnv, kind: TypeKind, conv: TCallingConvention,
+                    ret: TypeId, builder, body: untyped): TypeId =
+  ## Convenience template for a structured way of producing type descriptions.
+  block:
+    var builder = openProc(env, kind, conv, ret, false)
+    body
+    env.newType(env.close(builder))
+
+template buildRecord(env: var TypeEnv, size: IntVal, align: int16,
+                     builder, body: untyped): HeaderId =
+  block:
+    var builder = openRecord(size, align)
+    body
+    builder.close(env)
+
+proc lowerType(env: var TypeEnv, graph: ModuleGraph, id: HeaderId): HeaderId =
+  let h = env.headers[id]
+  case h.kind
+  of tkSet:
+    # either an array or integer, depending on the number of elements
+    case env.getInt(h.size)
+    of 1: env.symbols[UInt8Type].desc[Lowered]
+    of 2: env.symbols[UInt16Type].desc[Lowered]
+    of 4: env.symbols[UInt32Type].desc[Lowered]
+    of 8: env.symbols[UInt64Type].desc[Lowered]
+    else:
+      # -> array[size, uint8]
+      env.add makeDesc(tkArray, h.size, h.align, UInt8Type, h.size.uint32)
+  of tkClosure:
+    # -> (ClP_0: proc, ClE_0: pointer)
+    # the proc pointer uses the nimcall calling convention
+    let prc = env.buildProc(tkProc, ccNimCall, h.retType(env), bu):
+      for _, typ, flags in params(env, h):
+        bu.addParam(flags, typ)
+
+      # add the environment parameter:
+      bu.addParam({}, PointerType)
+
+    env.buildRecord(h.size, h.align, bu):
+      bu.addField(env, IntVal 0, prc, "ClP_0", mangle=false)
+      # XXX: the type of the environment pointer should be a ``RootRef``
+      bu.addField(env, IntVal graph.config.target.ptrSize,
+                  PointerType, "ClE_0", mangle=false)
+  of tkOpenArray:
+    # -> (ptr UncheckedArray[T], int)
+    let ptrTyp = env.newPtrTy(env.newUncheckedArrayTy(h.elem))
+
+    env.buildRecord(h.size, h.align, bu):
+      bu.addField(env, IntVal 0, ptrTyp)
+      bu.addField(env, IntVal graph.config.target.ptrSize, env.sizeType)
+  of tkSeq:
+    # -> (cap: int, data: ptr (int, UncheckedArray[T]))
+    let
+      dataType = env.newUncheckedArrayTy(h.elem)
+      # the payload type's name is inferred from the body
+      payload = env.buildRecord(h.size, h.align, bu):
+        bu.addField(env, IntVal 0, env.sizeType, "cap")
+        bu.addField(env, IntVal graph.config.target.intSize, dataType, "data")
+      ppTyp = env.newPtrTy(env.newType(payload))
+
+    env.buildRecord(h.size, h.align, bu):
+      bu.addField(env, IntVal 0, env.sizeType, "len")
+      bu.addField(env, IntVal graph.config.target.intSize, ppTyp, "p")
+  else:
+    id
+
+proc typeSymToMir(env: var TypeEnv, t: PType): TypeId =
+  discard getSize(env.config, t) # compute size, alignment, and field offsets
+
+  if t.kind == tyObject:
+    # register the type symbol *first*. This prevents infinite recursion for
+    # cyclic types
+    result = env.symbols.add TypeSym(inst: t, canon: env.symbols.nextId())
+    env.map[t] = result
+
+    let
+      orig  = typeToMir(env, t, canon=false)
+      canon = typeToMir(env, t, canon=true)
+
+    # there's nothing to lower for object types
+    env.symbols[result].desc = [orig, canon, canon]
+  else:
+    # create the type description preserving the original type symbols:
+    let
+      orig  = typeToMir(env, t, canon=false)
+      canon = typeToMir(env, t, canon=true)
+    var lowered: uint32
+
+    var prev = env.canon.getOrDefault(canon, env.symbols.nextId())
+    if prev == env.symbols.nextId():
+      # the new type symbol is the *canonical* one. Create the lowered
+      # representation
+      lowered = lowerType(env, env.graph, canon)
+      # lowering could have added new type symbols
+      prev = env.symbols.nextId()
+      env.canon[canon] = prev
+    else:
+      # a canonical type symbol already exists. Inherit its lowered
+      # representation
+      lowered = env.symbols[prev].desc[Lowered]
+
+    # now add the symbol and mapping:
+    result = env.symbols.add TypeSym(inst: t, canon: prev,
+                                     desc: [orig, canon, lowered])
+    env.map[t] = result
+
+proc handleImported(env: var TypeEnv, t: PType): TypeId =
+  if t.sym != nil and sfImportc in t.sym.flags:
+    # an imported type. It's wrapped in a ``tkImported``, referencing the
+    # underlying type
+    let base = typeSymToMir(env):
+      if t.kind in Skip:
+        t.lastSon.skipIrrelevant()
+      else:
+        t
+
+    discard getSize(env.config, t) # compute the sizes, alignments, and offsets
+
+    let
+      size  = env.toIntVal(t.size)
+      orig  = env.add makeDesc(tkImported, size, t.align, base)
+      canon = env.add makeDesc(tkImported, size, t.align,
+                               env.canonical(base))
+    result = env.symbols.add TypeSym(inst: t, canon: env.symbols.nextId(),
+                                     desc: [orig, canon, canon])
+
+    # doesn't matter if a symbol mapping already exists (happens when
+    # `base` == `t`); override it
+    env.map[t] = result
+  else:
+    result = typeSymToMir(env, t)
+
 proc add*(env: var TypeEnv, t: PType): TypeId =
   ## If not registered yet, adds `t` to `env` and returns the ID to later
-  ## look it up with. Basic structural type unification is performed.
-  result = env.map.mgetOrPut(t, env.types.nextId())
-  if result == env.types.nextId():
-    result = env.types.add(t)
+  ## look it up with.
+  result = env.map.getOrDefault(t, env.symbols.nextId())
+  if result == env.symbols.nextId(): # not seen yet?
+    result = handleImported(env, t)
+    # translation of the type registered the mapping for us
+
+func get*(env: TypeEnv, id: TypeId): lent TypeSym =
+  ## Returns the symbol for `id`.
+  env.symbols[id]
+
+template `[]`*(env: TypeEnv, id: FieldId): RecField =
+  env.fields[ord(id)]
+
+template `[]`*(env: TypeEnv, t: PType): TypeId =
+  env.map[t]
 
 func `[]`*(env: TypeEnv, id: TypeId): lent PType {.inline.} =
-  env.types[id]
+  # XXX: this procedure needs to eventually start returning the ``TypeSym``
+  #      instead
+  env.symbols[id].inst
 
 func sizeType*(env: TypeEnv): TypeId {.inline.} =
   ## Returns the type to use for values representing some size. This is a

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -1042,7 +1042,7 @@ proc typeSymToMir(env: var TypeEnv, t: PType): TypeId =
     # "canonical" one, so that - for example - ``Generic[(int,)]`` and
     # ``Generic[tuple[x: int]]`` map to the same MIR type in the end
     if tfFromGeneric in t.flags and
-       (let c = env.instances.mgetOrPut((t.owner.typ.id, canon), result);
+       (let c = env.instances.mgetOrPut((t.sym.owner.typ.id, canon), result);
         c != result):
       env.symbols[result].canon = c
   else:

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -717,16 +717,16 @@ proc makeDesc(kind: TypeKind, size: IntVal, align: int16,
               typ: TypeId; other = 0'u32): TypeHeader {.inline.} =
   TypeHeader(kind: kind, size: size, align: align, a: typ.uint32, b: other)
 
-proc typeToMir(env: var TypeEnv, t: PType; canon = false): uint32 =
+proc typeToMir(env: var TypeEnv, t: PType; canon = false): HeaderId =
   template typeref(typ: PType): TypeId =
     let t = env.add(typ)
     if canon: canonical(env, t)
     else:     t
 
-  template single(k: TypeKind, elem: PType): uint32 =
+  template single(k: TypeKind, elem: PType): HeaderId =
     env.add makeDesc(k, env.toIntVal(t.size), t.align, typeref elem)
 
-  template simple(id: TypeId): uint32 = env.symbols[id].desc[Original]
+  template simple(id: TypeId): HeaderId = env.symbols[id].desc[Original]
 
   case t.kind
   of tyVoid:    simple(VoidType)
@@ -1050,7 +1050,7 @@ proc typeSymToMir(env: var TypeEnv, t: PType): TypeId =
     let
       orig  = typeToMir(env, t, canon=false)
       canon = typeToMir(env, t, canon=true)
-    var lowered: uint32
+    var lowered: HeaderId
 
     var prev = env.canon.getOrDefault(canon, env.symbols.nextId())
     if prev == env.symbols.nextId():

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -509,11 +509,13 @@ proc openRecord(size: IntVal, align: int16; offset = 0;
   result.fields.add RecField(typ: base, align: offset.int16)
 
 proc open(kind: TypeKind; size: IntVal, align: int16): RecordBuilder =
+  assert kind in {tkUnion, tkTaggedUnion}
   result.header = TypeHeader(kind: kind, size: size, align: align)
 
 proc openProc(env: TypeEnv, kind: TypeKind, conv: TCallingConvention,
               ret: TypeId, isVarargs: bool): ProcBuilder =
   ## Opens a builder for a procedure-like type.
+  assert kind in {tkProc, tkClosure}
   result.header = TypeHeader(kind: kind, b: 1,
                              align: env.config.target.ptrSize.int16)
   if kind == tkProc:
@@ -530,6 +532,7 @@ proc openRecord(b: var RecordBuilder): RecordBuilder =
   result.fields.add RecField(typ: VoidType, align: 0)
 
 proc open(b: var RecordBuilder, kind: TypeKind): RecordBuilder =
+  assert kind in {tkUnion, tkTaggedUnion}
   result = RecordBuilder(start: b.fields.len)
   swap(result.fields, b.fields) # temporarily take over the buffer
   result.header = TypeHeader(kind: kind)

--- a/compiler/mir/typemaps.nim
+++ b/compiler/mir/typemaps.nim
@@ -175,7 +175,7 @@ func hash*(x: Type): Hash {.inline.} =
   ## Leaked implementation detail -- do not use.
   hash(PType x)
 
-proc `[]`*[T](t: TypeTable[T], key: PType): lent T {.inline.} =
+proc `[]`*[T](t: TypeTable[T], key: PType): T {.inline.} =
   ## Looks up the item for `key`.
   t.inner[Type key]
 

--- a/compiler/mir/typemaps.nim
+++ b/compiler/mir/typemaps.nim
@@ -186,3 +186,7 @@ proc `[]=`*[T](t: var TypeTable[T], key: PType, val: sink T) {.inline.} =
 proc mgetOrPut*[T](t: var TypeTable, key: PType, val: T): var T =
   ## If `key` has no mapping in `t`, adds one with `val` as the value first.
   t.inner.mgetOrPut(Type(key), val)
+
+proc getOrDefault*[T](t: TypeTable[T], key: PType, def: T): T =
+  ## If there's a value for `key` in `t`, returns it, `def` otherwise.
+  t.inner.getOrDefault(Type(key), def)

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -524,7 +524,7 @@ proc findEh(c: TCtx, t: VmThread, at: PrgCtr, frame: int
     # search for the instruction's asscoiated exception handler:
     for i in handlers.items:
       if c.ehTable[i].offset == offset:
-        return some (frame: frame, ehInstr: c.ehTable[i].instr)
+        return some (frame, c.ehTable[i].instr)
 
     # no handler was found, try the above frame
     pc = t.sframes[frame].comesFrom

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -524,7 +524,7 @@ proc findEh(c: TCtx, t: VmThread, at: PrgCtr, frame: int
     # search for the instruction's asscoiated exception handler:
     for i in handlers.items:
       if c.ehTable[i].offset == offset:
-        return some (frame, c.ehTable[i].instr)
+        return some (frame: frame, ehInstr: c.ehTable[i].instr)
 
     # no handler was found, try the above frame
     pc = t.sframes[frame].comesFrom

--- a/tests/align/talign.nim
+++ b/tests/align/talign.nim
@@ -1,5 +1,5 @@
 discard """
-ccodeCheck: "\\i @'NIM_ALIGN(128) NI mylocal1' .*"
+ccodeCheck: "\\i @'NIM_ALIGN(128) NI64 mylocal1' .*"
 labels: "pragma alignment generic"
 description: '''
   . First one is is for Azure. The keyword ``alignof`` only exists in ``c++11``
@@ -36,9 +36,9 @@ proc foobar() =
   doAssert (cast[uint](addr(toplevel3)) and 31) == 0
 
   # test multiple align expressions
-  var mylocal1 {.align(128), align(32).}: int = 123
-  var mylocal2 {.align(128), align(32).}: int = 123
-  var mylocal3 {.align(32), align(128).}: int = 123
+  var mylocal1 {.align(128), align(32).}: int64 = 123
+  var mylocal2 {.align(128), align(32).}: int64 = 123
+  var mylocal3 {.align(32), align(128).}: int64 = 123
 
   doAssert (cast[uint](addr(mylocal1)) and 127) == 0
   doAssert (cast[uint](addr(mylocal2)) and 127) == 0

--- a/tests/ccgbugs/tnoalias.nim
+++ b/tests/ccgbugs/tnoalias.nim
@@ -1,10 +1,10 @@
 discard """
-  ccodecheck: "\\i@'NI* NIM_NOALIAS field;' @'NIM_CHAR* NIM_NOALIAS x,' @'void* NIM_NOALIAS q'"
+  ccodecheck: "\\i@'NI64* NIM_NOALIAS field;' @'NIM_CHAR* NIM_NOALIAS x,' @'void* NIM_NOALIAS q'"
 """
 
 type
   BigNum = object
-    field {.noalias.}: ptr UncheckedArray[int]
+    field {.noalias.}: ptr UncheckedArray[int64]
 
 proc p(x {.noalias.}: openArray[char]) =
   var q {.noalias.}: pointer = addr(x[0])

--- a/tests/lang_exprs/tempty_typed_expressions_issues.nim
+++ b/tests/lang_exprs/tempty_typed_expressions_issues.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c js vm"
-  knownIssue.c vm: '''
+  knownIssue.c js vm: '''
     `typeRel` treats an empty array matching against a concrete type as a
     generic match, resulting in no implicit conversion being injected (the
     conversion is required for the proper typing of statement-list
@@ -9,8 +9,6 @@ discard """
 """
 
 # XXX: merge into ``tempty_typed_expressions.nim`` once the issue is fixed
-# XXX: doesn't fail for the JS backend due to the code generator being more
-#      lenient
 
 proc get(x: array[0, int]): array[0, int] = x
 


### PR DESCRIPTION
## Summary

* implement a dedicated type IR for the MIR and back-end phase
* use the new IR in parts of the C code generator
* use a new name mangling scheme for types that doesn't rely on
  signature hashes

## Details

The idea behind introducing a dedicated type IR for the MIR and back-
end phase is to:
* have a simpler and more regular IR during lowering and code
  generation
* decouple type lowering from code generation 
* make `PType` solely used by `sem` and `transf`

The key ideas for the type IR are that:
* same ID (`HeaderId`) means same type; there are no duplicates like
  with `PType`
* transformations and code generation have easy access to the various
  stages of a type's representation (including the `PType`)
* lineage to `PType`s is kept track of

The current design likely covers more ground than it ultimately needs
to, but this was a deliberate choice in order to ease the transition to
the new IR.

### Translation

The lowering and or fixes performed by `mirtypes` during the
translation of types intends to exactly match what was previously
implemented in `ccgtypes`.

So that the IR is well-tested, all `PType`s entering `mirgen` are
translated to the IR representation.

### Code generation

Most of the existing is still oblivious to the new type IR, with only
the type emission in the C code generation. Some analysis that was
previously performed on `PType`s is ported to operate on MIR type
descriptions.

The `mangling` module implements a semi-stable, reversible name
mangling for types. It's necessary since not all MIR types have an
originating-from `PType` (such as the internal payload type for `seq`s
and `string`s), meaning that the `sighash`-based mangling cannot be
used there.

### AST

Associating fields with names in the C code generator is now done via
the new type IR, meaning that the `locId` field on `TSym` is obsolete;
it's removed.

### Tests

* multiple `ccodecheck` test are adjusted to `int` now translating to a
  sized integer instead of `NI`
* due to usage of the to-MIR-type-translation,
  `tempty_typed_expressions_issues.nim` now also fails for JS