### PR TITLE
sem, pragmas: fix fatal pragma

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1324,7 +1324,6 @@ type
         adSemAlignRequiresPowerOfTwo,
         adSemNoReturnHasReturn,
         adSemMisplacedDeprecation,
-        adSemFatalError,
         adSemNoUnionForJs,
         adSemBitsizeRequiresPositive,
         adSemExperimentalRequiresToplevel,
@@ -1421,7 +1420,7 @@ type
       externName*: string
     of adSemPragmaRecursiveDependency:
       userPragma*: PSym
-    of adSemCustomUserError:
+    of adSemCustomUserError, adSemFatalError:
       errmsg*: string
     of adSemImplicitPragmaError:
       implicitPragma*: PSym

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -224,6 +224,13 @@ func severity*(
       of repDebug:    report.debugReport.severity()
       of repExternal: report.externalReport.severity()
 
+func isCompilerFatal*(report: Report): bool =
+  ## Check if report stores fatal compilation error
+  case report.category:
+    of repSem:      report.semReport.severity() == rsevFatal
+    of repInternal: report.internalReport.severity() == rsevFatal
+    else: false # only sem and internal can be fatal
+
 func toReportLineInfo*(iinfo: InstantiationInfo): ReportLineInfo =
   ReportLineInfo(file: iinfo[0], line: uint16(iinfo[1]), col: int16(iinfo[2]))
 

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -224,13 +224,6 @@ func severity*(
       of repDebug:    report.debugReport.severity()
       of repExternal: report.externalReport.severity()
 
-func isFatalSeverity*(report: Report): bool =
-  ## Returns whether the report severity is rsevFatal
-  case report.category:
-    of repSem:      report.semReport.severity() == rsevFatal
-    of repInternal: report.internalReport.severity() == rsevFatal
-    else: false # only sem and internal can be fatal
-
 func toReportLineInfo*(iinfo: InstantiationInfo): ReportLineInfo =
   ReportLineInfo(file: iinfo[0], line: uint16(iinfo[1]), col: int16(iinfo[2]))
 

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -224,8 +224,8 @@ func severity*(
       of repDebug:    report.debugReport.severity()
       of repExternal: report.externalReport.severity()
 
-func isCompilerFatal*(report: Report): bool =
-  ## Check if report stores fatal compilation error
+func isFatalSeverity*(report: Report): bool =
+  ## Returns whether the report severity is rsevFatal
   case report.category:
     of repSem:      report.semReport.severity() == rsevFatal
     of repInternal: report.internalReport.severity() == rsevFatal

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3211,7 +3211,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       adSemAlignRequiresPowerOfTwo,
       adSemNoReturnHasReturn,
       adSemMisplacedDeprecation,
-      adSemFatalError,
       adSemNoUnionForJs,
       adSemBitsizeRequiresPositive,
       adSemExperimentalRequiresToplevel,
@@ -3427,6 +3426,13 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         reportInst: diag.instLoc.toReportLineInfo,
         kind: rsemPragmaRecursiveDependency,
         sym: diag.userPragma,
+        ast: diag.wrongNode)
+  of adSemFatalError:
+    semRep = SemReport(
+        location: some diag.location,
+        reportInst: diag.instLoc.toReportLineInfo,
+        kind: rsemFatalError,
+        str: diag.errmsg,
         ast: diag.wrongNode)
   of adSemCustomUserError:
     semRep = SemReport(

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3427,18 +3427,11 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         kind: rsemPragmaRecursiveDependency,
         sym: diag.userPragma,
         ast: diag.wrongNode)
-  of adSemFatalError:
+  of adSemFatalError, adSemCustomUserError:
     semRep = SemReport(
         location: some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,
-        kind: rsemFatalError,
-        str: diag.errmsg,
-        ast: diag.wrongNode)
-  of adSemCustomUserError:
-    semRep = SemReport(
-        location: some diag.location,
-        reportInst: diag.instLoc.toReportLineInfo,
-        kind: rsemCustomUserError,
+        kind: kind,
         str: diag.errmsg,
         ast: diag.wrongNode)
   of adSemImplicitPragmaError:

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -294,7 +294,7 @@ proc errorActions(
     eh: TErrorHandling
   ): tuple[action: TErrorHandling, withTrace: bool] =
   result = (doNothing, false)
-  if report.isFatalSeverity:
+  if report.severity == rsevFatal:
     # Fatal message such as ICE (internal compiler), errFatal,
     result = (doAbort, true)
   elif conf.isCodeError(report):

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -36,7 +36,7 @@ from compiler/ast/reports_base_sem import ReportContext, ReportContextKind
 
 # when you have data where it belongs, it's easy to see this stuff... should
 # `msgs` really depend upon `SemReport`?
-from compiler/ast/reports_sem import SemReport, severity
+from compiler/ast/reports_sem import SemReport
 
 export InstantiationInfo
 export TErrorHandling

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -294,7 +294,7 @@ proc errorActions(
     eh: TErrorHandling
   ): tuple[action: TErrorHandling, withTrace: bool] =
   result = (doNothing, false)
-  if report.isCompilerFatal:
+  if report.isFatalSeverity:
     # Fatal message such as ICE (internal compiler), errFatal,
     result = (doAbort, true)
   elif conf.isCodeError(report):

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -294,8 +294,7 @@ proc errorActions(
     eh: TErrorHandling
   ): tuple[action: TErrorHandling, withTrace: bool] =
   result = (doNothing, false)
-  if conf.isCompilerFatal(report) or
-      (report.category == repSem and report.semReport.severity == rsevFatal):
+  if report.isCompilerFatal:
     # Fatal message such as ICE (internal compiler), errFatal,
     result = (doAbort, true)
   elif conf.isCodeError(report):

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -36,7 +36,7 @@ from compiler/ast/reports_base_sem import ReportContext, ReportContextKind
 
 # when you have data where it belongs, it's easy to see this stuff... should
 # `msgs` really depend upon `SemReport`?
-from compiler/ast/reports_sem import SemReport
+from compiler/ast/reports_sem import SemReport, severity
 
 export InstantiationInfo
 export TErrorHandling
@@ -294,7 +294,8 @@ proc errorActions(
     eh: TErrorHandling
   ): tuple[action: TErrorHandling, withTrace: bool] =
   result = (doNothing, false)
-  if conf.isCompilerFatal(report):
+  if conf.isCompilerFatal(report) or
+      (report.category == repSem and report.semReport.severity == rsevFatal):
     # Fatal message such as ICE (internal compiler), errFatal,
     result = (doAbort, true)
   elif conf.isCodeError(report):

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -615,16 +615,6 @@ template report*[R: ReportTypes](
   ## it's instantiation info with `instantiationInfo()` of the template.
   report(conf, wrap(inReport, instLoc(), tinfo))
 
-# REFACTOR: we shouldn't need to dig into the internalReport and query severity
-#           directly
-from compiler/ast/reports_internal import severity
-
-func isCompilerFatal*(conf: ConfigRef, report: Report): bool =
-  ## Check if report stores fatal compilation error
-  report.category == repInternal and
-  report.internalReport.severity() == rsevFatal or
-  report.kind == rextCmdRequiresFile
-
 func severity*(conf: ConfigRef, report: ReportTypes | Report): ReportSeverity =
   # style checking is a hint by default, but can be globally overriden to
   # be treated as error via `--styleCheck:error`, and this is handled in

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1556,7 +1556,12 @@ proc applyStmtPragma(c: PContext, owner: PSym, it: PNode, k: TSpecialWord): PNod
           result = c.config.newError(
             it, PAstDiag(kind: adSemCustomUserError, errmsg: s.strVal))
   of wFatal:
-    result = c.config.newError(it, PAstDiag(kind: adSemFatalError))
+    let (s, err) = strLitToStrOrErr(c, it)
+    result =
+      if err.isNil:
+        c.config.newError(it, PAstDiag(kind: adSemFatalError, errmsg: s))
+      else:
+        err
   of wDefine:
     result = processDefine(c, it)
   of wUndef:

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -316,7 +316,7 @@ proc verboseCmd(cmd: string) =
 
 let
   pegLineError =
-    peg"{[^(]*} '(' {\d+} ', ' {\d+} ') ' ('Error') ':' \s* {.*}"
+    peg"{[^(]*} '(' {\d+} ', ' {\d+} ') ' ('Error' / 'Fatal') ':' \s* {.*}"
   pegOtherError = peg"'Error:' \s* {.*}"
   pegOfInterest = pegLineError / pegOtherError
 

--- a/tests/pragmas/tfatal.nim
+++ b/tests/pragmas/tfatal.nim
@@ -1,0 +1,4 @@
+discard """
+  errormsg: "user message"
+"""
+{.fatal:"user message".}


### PR DESCRIPTION
## Summary

Using  `{.fatal:"...".}`  did not show any message to the user and it
didn't stop compilation.
This commit fixes both issues.

## Details

-  `adSemFatalError`  now carries a message just like 
`adSemCustomUserError` .
- All reports of `fatal` severity abort compilation.
- Testament now also consider fatal errors to be errors.
- A simple test case has been included.
-  `isCompilerFatal`  has been removed as it seems it lost its purpose.
The check for  `rextCmdRequiresFile`  seems to be unnecessary. A fatal
report is produced elsewhere (the only place where 
`rextCmdRequiresFile`  is used) before this function is ever called, so
it was redundant and it doesn't break existing code.