### PR TITLE
fix wrong cursor inference in the context of loops

### DIFF
--- a/tests/arc/topt_no_loop_cursor.nim
+++ b/tests/arc/topt_no_loop_cursor.nim
@@ -1,0 +1,58 @@
+discard """
+  description: '''
+    Ensure that outer variables don't borrow from locals within loops, when not
+    safe
+  '''
+  matrix: "--showir:mir_in:test --hints:off"
+  action: compile
+  nimoutFull: true
+  nimout: '''-- MIR: test
+scope:
+  def x: Object
+  scope:
+    while true:
+      scope:
+        scope:
+          def _3: bool = not(arg cond)
+          if _3:
+            scope:
+              goto [L2]
+        def y: Object = ()
+        def_cursor _5: Object = x
+        use(arg _5) -> [L3, L4, Resume]
+        x = sink y
+        goto [L3, L5]
+        finally (L3):
+          destroy y
+          continue {L4, L5}
+        L5:
+  L2:
+  goto [L4, L6]
+  finally (L4):
+    destroy x
+    continue {L6}
+  L6:
+
+-- end
+'''
+"""
+
+type Object = object
+
+# make Object a type that's eligible for cursor inference
+proc `=destroy`(x: var Object) =
+  discard
+
+proc use(x: Object) =
+  discard
+
+proc test(cond: bool) =
+  var x: Object
+  while cond:
+    var y = Object()
+    use x
+    # if `x` were a cursor, the above usage would observe a stale value,
+    # as the value assigned below went out of scope already
+    x = y
+
+test(false)

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -23,7 +23,8 @@ scope:
         def_cursor _10: Node = it
         it = _10[].ri
   L2:
-  def_cursor jt: Node = root
+  def jt: Node
+  =copy(name jt, arg root)
   scope:
     while true:
       scope:
@@ -37,12 +38,25 @@ scope:
             scope:
               goto [L5]
         def_cursor _18: Node = jt
-        def_cursor ri: Node = _18[].ri
+        def ri: Node
+        =copy(name ri, arg _18[].ri)
         def_cursor _19: Node = jt
         def_cursor _20: string = _19[].s
-        echo(arg type(array[0..0, string]), arg _20) -> [Resume]
-        jt = ri
+        echo(arg type(array[0..0, string]), arg _20) -> [L6, L7, Resume]
+        =sink(name jt, arg ri)
+        wasMoved(name ri)
+        goto [L6, L8]
+        finally (L6):
+          =destroy(name ri)
+          continue {L7, L8}
+        L8:
   L5:
+  goto [L7, L9]
+  finally (L7):
+    =destroy(name jt)
+    continue {L9}
+  L9:
+
 -- end of expandArc ------------------------'''
 """
 
@@ -64,5 +78,3 @@ proc traverse(root: Node) =
     jt = ri
 
 traverse(nil)
-
-# XXX: This optimization is not sound


### PR DESCRIPTION
## Summary

* fix cursor inference bug where variables were erroneously inferred as
  cursors, leading to use-after-free issues
* improve cursor inference. `var`/`let` bindings are now inferred to be
  cursors more reliably

Fixes https://github.com/nim-works/nimskull/issues/1385

## Details

For `var`/`let` bindings defined in loops, the `aliveEnd` is now only
updated during the first analysis of the loop. This ensures that
variables defined outside the loop, but only assigned to within the
loop, always have longer alive times than variables defined within
loops, thus preventing outer variables borrowing from inner variables
(cursorfication cannot happen when a variable outlives its assignment
source).

This fix also renders the `isConditionallyReassigned` heuristic
obsolete, which was used to fix a more specific case of the same bug.
The heuristic disabled cursorfication for all variables of which
re-assignments are enclosed by a loop and `if`/`else`/`elif`/`of`,
which also applied to, e.g.:

```nim
while cond:
  if cond:
    var a = newString(...)
    var b = newString(...)
    var x: string
    x = a
    x = b # this assignment disabled `x` being turned into a cursor
    discard a
```

With the heuristic removed, in the above example, `x` is now turned
into a cursor, matching what would happen when there is no enclosing
loop or `if`.