### PR TITLE
fix fields with names containing backticks being inaccessible

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -63,7 +63,8 @@ const
   PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
   
   PersistentNodeFlags*: TNodeFlags = {nfDotSetter, nfDotField, nfLL,
-                                      nfFromTemplate, nfDefaultRefsParam}
+                                      nfFromTemplate, nfDefaultRefsParam,
+                                      nfWasGensym}
   
   namePos*          = 0 ## Name of the type/proc-like node
   patternPos*       = 1 ## empty except for term rewriting macros

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -612,6 +612,8 @@ type
     nfDefaultRefsParam ## a default param value references another parameter
                        ## the flag is applied to proc default values and to calls
     nfHasComment ## node has a comment
+    nfWasGensym  ## the identifier node was a gensym prior to template
+                 ## evaluation
 
   TNodeFlags* = set[TNodeFlag]
   TTypeFlag* = enum   ## keep below 32 for efficiency reasons (now: 43)

--- a/compiler/sem/evaltempl.nim
+++ b/compiler/sem/evaltempl.nim
@@ -88,6 +88,7 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
         if sfGenSym in s.flags:
           result.add newIdentNode(getIdent(c.ic, x.name.s & "`gensym" & $c.instID),
             if c.instLines: actual.info else: templ.info)
+          result.flags.incl nfWasGensym
         else:
           result.add newSymNode(x, if c.instLines: actual.info else: templ.info)
     else:

--- a/tests/lang_callable/macros/tmacros_issues.nim
+++ b/tests/lang_callable/macros/tmacros_issues.nim
@@ -539,3 +539,19 @@ block orginal_parameter_types:
     doAssert y.intVal == 2
 
   m(1, 2)
+
+block field_names_with_backticks:
+  # field names containing backticks (only possible with macro-generated
+  # code) couldn't be accessed with dot expressions
+  macro test() =
+    let name = ident"a`b"
+
+    result = quote do:
+      type Object = object
+        `name`: int
+
+      # test accessing the field with both constructors and a dot expression
+      let o = Object(`name`: 1)
+      doAssert o.`name` == 1
+
+  test()


### PR DESCRIPTION
## Summary

Fix a regression where field names with backticks in them couldn't be
accessed with a field access.

Fixes https://github.com/nim-works/nimskull/issues/1379.

## Details

* identifier nodes resulting from gensyms are now tagged with a new
  node flag (`nfWasGensym`)
* `originalName` only strips the `gensym` suffix from identifiers
  marked with the flag
* the node flag is persistent, so that it stays on the node across tree
  copies

Looking for the full "`gensym" suffix wouldn't work, because it would
also trigger the stripping for user-created names containing the
suffix.