### PR TITLE
Fix `sysrand` for Android (and some other POSIX platforms)

### DIFF
--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -189,8 +189,8 @@ elif defined(linux) and not defined(emscripten):
       elif readBytes > 0:
         inc(result, readBytes)
       else:
-        case osLastError().int
-        of EINTR, EAGAIN:
+        let err = osLastError().int
+        if err == EINTR or err == EAGAIN:
           discard
         else:
           result = -1


### PR DESCRIPTION
## Summary
Fixes a bug that caused the compiler to fail to compile anything with
e.g.  `--os:android`  (and some uncommon POSIX platforms) when it uses 
`sysrand`  in any way, such as when importing  `random` .  `koch`  was
affected so one couldn't bootstrap nimskull in android as the host
platform.

## Details
There's two POSIX constants used in  `sysrand.nim`  that are not
actually constants for some platforms like Android.  `EINTR`  and 
`EAGAIN`  are required to be constants at compile time because they're
used in a  `case of`  but the condition is so simple that we can replace
it by an  `if`  statement.

They're technically constants in all platforms, but on the C side (taken
from  `errno.h` ), not in nimskull, and the latter is oblivious to the
content of those header files.