### PR TITLE
fix C codegen regression with closures

### DIFF
--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -980,13 +980,9 @@ proc lowerType(env: var TypeEnv, graph: ModuleGraph, id: HeaderId): HeaderId =
       env.add makeDesc(tkArray, h.size, h.align, UInt8Type, h.size.uint32)
   of tkClosure:
     # -> (ClP_0: proc, ClE_0: pointer)
-    # the proc pointer uses the nimcall calling convention
-    let prc = env.buildProc(tkProc, ccNimCall, h.retType(env), bu):
+    let prc = env.buildProc(tkProc, ccClosure, h.retType(env), bu):
       for _, typ, flags in params(env, h):
         bu.addParam(flags, typ)
-
-      # add the environment parameter:
-      bu.addParam({}, PointerType)
 
     env.buildRecord(h.size, h.align, bu):
       bu.addField(env, IntVal 0, prc, "ClP_0", mangle=false)


### PR DESCRIPTION
## Summary

Fix explicit or implicit creation of a closure leading to C
compiler errors when using strict(er) C compilers.

## Details

* when lowering closure types, use a `tkProc` type with `ccClosure`
  calling convention
* using a `ccNimCall` type with an additional `void` parameter meant
  that `cgen` placed the result type (in case of RVO) *after* the
  environment type, which is incorrect and doesn't match the signature
  of closure procedures
* C compilers that require compatible types when implicitly casting
  rightfully reported an error in this case