### PR TITLE
fix a compiler crash with `.varargs` proc types

### DIFF
--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -183,6 +183,8 @@ const
   MangleFlag = 0x4000'u16
   NoAliasFlag = 0x8000'u16
 
+  VarargsFlag = 0x8000_0000'u32
+
 func `==`*(a, b: FieldId): bool {.borrow, inline.}
 func `==`(a, b: IntVal): bool {.borrow, inline.}
 
@@ -359,10 +361,11 @@ func numParams*(desc: TypeHeader): int =
   int(desc.b - desc.a) - 1
 
 func callConv*(desc: TypeHeader, env: TypeEnv): TCallingConvention =
-  TCallingConvention env.params[desc.a].x
+  # mask away the varargs flag
+  TCallingConvention(env.params[desc.a].x and not(VarargsFlag))
 
 func hasVarargs*(desc: TypeHeader, env: TypeEnv): bool =
-  (env.params[desc.a].x and 0x8000_0000'u32) != 0
+  (env.params[desc.a].x and VarargsFlag) != 0
 
 func retType*(desc: TypeHeader, env: TypeEnv): TypeId =
   assert desc.kind in {tkProc, tkClosure}

--- a/tests/ccgbugs/tvarargs_proc_type.nim
+++ b/tests/ccgbugs/tvarargs_proc_type.nim
@@ -1,0 +1,10 @@
+discard """
+  description: '''
+    Regression test for a bug with querying the calling convention of a MIR
+    type. Derived from https://github.com/nim-works/nimskull/issues/1394.
+  '''
+"""
+
+# calling convention doesn't matter, as long as the proc type is not a closure
+# type
+var p: proc(x: int) {.nimcall, varargs.}


### PR DESCRIPTION
## Summary

Fix the compiler crashing when a non-closure `proc` type with C-style
varargs is used somewhere. Only the C backend was affected.

Fixes https://github.com/nim-works/nimskull/issues/1394.

## Details

* `mirtypes.callConv` didn't consider the `x` field storing a boolean
  value in the most-significant bit, resulting in range defect
* the integer value is now properly masked before converting it to a
  `TCallingConvention` enum value