### PR TITLE
mirtypes: fix regression with cyclic generic object types

### DIFF
--- a/tests/lang_callable/generics/tequal_instantiation_with_tuple.nim
+++ b/tests/lang_callable/generics/tequal_instantiation_with_tuple.nim
@@ -5,6 +5,7 @@ discard """
     one of them is instantiated with a named tuple and the other with an
     unnamed one
   '''
+  knownIssue.vm: "``vmtypegen`` considers the two types distinct"
 """
 
 type Recursive[T] = object

--- a/tests/lang_callable/generics/tequal_instantiation_with_tuple.nim
+++ b/tests/lang_callable/generics/tequal_instantiation_with_tuple.nim
@@ -1,0 +1,18 @@
+discard """
+  description: '''
+    Ensure that two instantiations of a cyclic generic object type are
+    considered equal at every level (type system, backend, run-time) when
+    one of them is instantiated with a named tuple and the other with an
+    unnamed one
+  '''
+"""
+
+type Recursive[T] = object
+  # the same problem occurred when a ``ref`` type is used
+  self: ptr Recursive[T]
+  val: T
+
+# it's important that both tuples are comprised of the exact same types
+var x: Recursive[(int, int)]
+var y: Recursive[tuple[a, b: int]]
+x = y


### PR DESCRIPTION
## Summary

Fix cyclic generic object types instantiated with tuple types as one
of the arguments causing C compiler errors under some circumstances.

## Details

* the type merging logic in `mirtypes` now uses `sighashes`, which is
  able to handle cyclic types
* previously, `Obj[(int,)]` and `Obj[tuple[x: int]]` were not being
  merged into one when `Obj` is cyclic
* this led to C compiler errors when assigning between such types, or
  when the type has hooks (explicit or synthesized) that are called