### PR TITLE
cgirgen: instrument with `frameMsg`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1638,7 +1638,7 @@ proc useData(p: BProc, x: ConstId, typ: PType): string =
 
 proc expr(p: BProc, n: CgNode, d: var TLoc) =
   when defined(nimCompilerStacktraceHints):
-    frameMsg(p.config, n)
+    frameMsg(p.config, n.info)
   p.currLineInfo = n.info
 
   case n.kind

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -47,6 +47,9 @@ import std/options as std_options
 from compiler/ast/ast import newSym, newType, rawAddSon
 from compiler/sem/semdata import makeVarType
 
+when defined(nimCompilerStacktraceHints):
+  import compiler/utils/debugutils
+
 type
   TranslateCl = object
     graph: ModuleGraph
@@ -557,6 +560,9 @@ proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
   let n {.cursor.} = tree.get(cr)
   let info = cr.info ## the source information of `n`
 
+  when defined(nimCompilerStacktraceHints):
+    frameMsg(cl.graph.config, info)
+
   template to(kind: CgNodeKind, args: varargs[untyped]) =
     stmts.add newStmt(kind, info, args)
 
@@ -682,6 +688,9 @@ proc exprToIr(tree: MirBody, cl: var TranslateCl,
   ## Moves the cursor to the next tree item.
   let n {.cursor.} = get(tree, cr)
   let info = cr.info
+
+  when defined(nimCompilerStacktraceHints):
+    frameMsg(cl.graph.config, info)
 
   template op(kind: CgNodeKind, e: CgNode): CgNode =
     newOp(kind, info, cl.map(n.typ), e)

--- a/compiler/utils/debugutils.nim
+++ b/compiler/utils/debugutils.nim
@@ -636,13 +636,13 @@ template frameMsg*(c: ConfigRef, n: PNode) =
       $n.info.line,
       $n.info.col]
 
-template frameMsg*(c: ConfigRef, n: CgNode) =
+template frameMsg*(c: ConfigRef, info: TLineInfo) =
   {.line.}:
     setFrameMsg "$1 $2($3, $4)" % [
       $n.kind,
-      c.toFullPath(n.info.fileIndex),
-      $n.info.line,
-      $n.info.col]
+      c.toFullPath(info.fileIndex),
+      $info.line,
+      $info.col]
 
 const locOffset = -2
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2998,7 +2998,7 @@ proc binaryArith(c: var TCtx, e, x, y: CgNode, dest: var TDest,
 
 proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
   when defined(nimCompilerStacktraceHints):
-    frameMsg c.config, n
+    frameMsg c.config, n.info
 
   case n.kind
   of cnkProc:


### PR DESCRIPTION
## Summary

Instrument `cgirgen` with stack-frame annotations in order to aid
debugging with `nim_dbg`.

## Details

* to keep overhead reasonably low, only the `exprToIr` and `stmtToIr`
  procedures are instrumented
* `debugutils.frameMsg` is generalized to accept a `TLineInfo`; the
  callsites are adjusted accordingly