### PR TITLE
ci: build and test the compiler with GCC 14

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -93,3 +93,12 @@ jobs:
       - name: Print all test errors
         if: failure()
         run: bin/nim r tools/ci_testresults
+
+  passed:
+    name: All C compatibility tests passed
+    needs: [test]
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: exit 1

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,95 @@
+name: Test C compiler compatibility
+on:
+  push:
+    branches-ignore:
+      - devel
+      # Github Merge Queue temporary branches
+      - gh-readonly-queue/**
+
+  pull_request:
+    # Only consider PRs to devel
+    branches:
+      - devel
+
+    # Type of events to run CI on
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+  merge_group:
+    # Test all additions to the merge queue
+
+# Run every script action in bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  binaries:
+    name: Build binaries with most recent GCC version
+    runs-on: ubuntu-24.04
+    # Don't run for draft PRs
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == 'false'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Enable annotations
+        run: echo "::add-matcher::.github/nim-problem-matcher.json"
+
+      - name: Make GCC 14 the default
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 10
+          sudo update-alternatives --set gcc /usr/bin/gcc-14
+
+      - name: Build compiler and tools
+        run: ./koch.py all-strict
+
+      - name: Upload workspace to artifacts
+        uses: ./.github/actions/upload-compiler
+
+  test:
+    needs: [binaries]
+
+    strategy:
+      fail-fast: false
+
+      # Parallelize testing. Refer to ``ci.yml`` for how and why this works.
+      matrix:
+        batch: [0, 1]
+        total_batch: [2]
+
+    name: "Test the compiler and standard library (Batch ${{ matrix.batch }})"
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - uses: ./.github/actions/download-compiler
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libc6-dbg valgrind libpcre3
+
+      - name: Make GCC 14 the default
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 10
+          sudo update-alternatives --set gcc /usr/bin/gcc-14
+
+      - name: Run tester
+        run: ./koch.py test --batch:"$TEST_BATCH" --tryFailing --targets:c all
+        env:
+          TEST_BATCH: ${{ matrix.batch }}_${{ matrix.total_batch }}
+
+      - name: Print all test errors
+        if: failure()
+        run: bin/nim r tools/ci_testresults

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build binaries with most recent GCC version
     runs-on: ubuntu-24.04
     # Don't run for draft PRs
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: ${{ !github.event.pull_request.draft }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build binaries with most recent GCC version
     runs-on: ubuntu-24.04
     # Don't run for draft PRs
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == 'false'
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/lang/s02_core/s02_procedures/t02_argument_passing.nim
+++ b/tests/lang/s02_core/s02_procedures/t02_argument_passing.nim
@@ -241,10 +241,6 @@ block varargs_arguments_no_converter:
 
     doAssert impl(1) == (@[1], newSeq[bool]())
 
-    if false:
-      # Right nor results in `(@[1, 2, 0], @[true, false, false])`
-      doAssert impl(1, 2, false) == (@[1, 2], @[false])
-
     ## It is not possible to entirely omit leading varargs arguments; however, it
     ## is possible to explicitly pass values to the other varargs (if present)
     doAssert impl(va2 = true) == (newSeq[int](), @[true])

--- a/tests/lang/s02_core/s02_procedures/t02_argument_passing_bug.nim
+++ b/tests/lang/s02_core/s02_procedures/t02_argument_passing_bug.nim
@@ -1,0 +1,9 @@
+discard """
+  description: "A separate test for a bug with varargs handling"
+  knownIssue: "https://github.com/nim-works/nimskull/issues/1375"
+"""
+
+# XXX: merge back into ``t02_argument_passing`` once the below succeeds
+
+# right now results in `(@[1, 2, 0], @[true, false, false])`
+doAssert impl(1, 2, false) == (@[1, 2], @[false])

--- a/tests/lang_experimental/views/tprocedural_views.nim
+++ b/tests/lang_experimental/views/tprocedural_views.nim
@@ -4,10 +4,6 @@ discard """
     Tests for indirect calls where the callee is an expression evaluating to a
     view
   '''
-  knownIssue.vm: '''
-    Semantic analysis produces incorrect AST for tuple initialization, causing
-    VM access violation errors at run-time
-  '''
 """
 
 {.experimental: "views".}
@@ -24,19 +20,13 @@ block direct_view:
 block complex_view_callee:
   # the callee expression evaluate to a view is a:
   # - dot expression
-  # - a bracket expression
   # - a parenthesized expression
   type Obj = object
     x: lent Proc
-    tup: (lent Proc,)
 
   let
     p = proc (x: int): int = x
-    o = Obj(x: p, tup: (p,))
+    o = Obj(x: p)
 
   doAssert o.x(2) == 2
   doAssert (o.x)(3) == 3
-  # XXX: semantic analysis currently generates invalid code tuple or array
-  #      constructors where an element is a view, so the below would crash at
-  #      run-time
-  doAssert compiles(o.tup[0](4) == 4)

--- a/tests/lang_experimental/views/tprocedural_views_in_tuple.nim
+++ b/tests/lang_experimental/views/tprocedural_views_in_tuple.nim
@@ -1,0 +1,29 @@
+discard """
+  description: '''
+    Ensure views of procedural values can be stored in and called from tuples
+    via the bracket syntax
+  '''
+  targets: "c js vm"
+  knownIssue.c vm: '''
+    Semantic analysis produces incorrect AST for tuple initialization
+  '''
+"""
+
+# tracked by https://github.com/nim-works/nimskull/issues/1376
+
+# note: the JavaScript target is affected too, but the bug doesn't lead to any
+# compile or run-time errors
+
+{.experimental: "views".}
+
+type Proc = proc(x: int): int {.nimcall.}
+
+proc test() =
+  # wrap the test in a procedure to make sure that local variables are used
+  let
+    p = proc (x: int): int = x
+    tup: (lent Proc,) = (p,)
+
+  doAssert tup[0](2) == 2
+
+test()


### PR DESCRIPTION
## Summary

Add a CI workflow for making sure the most recent version of common C
compilers work. Only GCC 14 is tested at the moment.

## Details

* the in-beta 24.04 Ubuntu runner image is used, since it comes with
  GCC 14 installed
* the compatibility job builds the compiler, tools, and tests with GCC
  14
* two test cases that currently fail to compile (due to
  `-Werror=incompatible-pointer-types`) are split into standalone test
  files and marked as known issues
* the workflow is configured to run for push and PR events (except for
  in-draft PRs)