### PR TITLE
sem: fix error propagation for tuple construction

### DIFF
--- a/tests/errmsgs/tmixed_tuple.nim
+++ b/tests/errmsgs/tmixed_tuple.nim
@@ -1,0 +1,7 @@
+discard """
+  errormsg: "named expression not allowed here"
+  line: 7
+"""
+
+var x = 0
+discard (x, a: x)


### PR DESCRIPTION
## Summary

* fix errors in anonymous tuple constructions not being propagated
* fix the error for colon expressions in anonymous tuple constructions
  being "invalid expression" instead of "named expression not allowed
  here"

## Details

* properly propagate errors from element expressions
* don't analyze `nkExprColonExpr` as a normal expression
* don't modify input AST
* skip tuple type constructor analysis if any of the element
  expressions is erroneous