### PR TITLE
fix compiler crash when converting `nil` to `distinct pointer` 

### DIFF
--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -518,8 +518,15 @@ proc foldConv(n, a: PNode; idgen: IdGenerator; g: ModuleGraph): PNode =
       result = newFloatNodeT(val, n, g)
     else:
       result = rangeError(n, a, g)
-  of tyOpenArray, tyVarargs, tyProc, tyPointer:
+  of tyOpenArray, tyVarargs:
     discard
+  of tyProc, tyPointer, tyPtr:
+    if a.kind == nkNilLit:
+      # apply the type directly to the 'nil' expression
+      result = a
+      result.typ = n.typ
+    else:
+      result = nil # cannot fold
   else:
     # FIXME: conversion-to-enum is missing checks
     result = a

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -910,7 +910,7 @@ proc foldConstExprAux(m: PSym, n: PNode, idgen: IdGenerator, g: ModuleGraph): Fo
   # in the back-end (e.g. ``cast[pointer](someProc)``). In addition, so as to
   # not interfere with the documentation generator, statement-list expressions
   # are not folded if they have a comment in the first position
-  let exprIsPointerCast = n.kind in {nkCast, nkConv, nkHiddenStdConv} and
+  let exprIsPointerCast = n.kind == nkCast and
                           n.typ != nil and
                           n.typ.kind in {tyPointer, tyProc}
   if not exprIsPointerCast and

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -636,12 +636,6 @@ proc transformConv(c: PTransf, n: PNode): PNode =
         result = newTreeIT(
           if diff < 0: nkObjUpConv else: nkObjDownConv,
           n.info, n.typ): transform(c, n[1])
-    of tyNil:
-      # a ``T(nil)`` expression
-      # XXX: it might be a better idea to eliminate the conversion during
-      #      semantic analysis instead
-      result = transform(c, n[1])
-      result.typ = n.typ
     else:
       result = transformSons(c, n)
   of tyObject:
@@ -653,13 +647,6 @@ proc transformConv(c: PTransf, n: PNode): PNode =
       result = newTreeIT(
         if diff < 0: nkObjUpConv else: nkObjDownConv,
         n.info, n.typ): transform(c, n[1])
-  of tyPointer:
-    case source.kind
-    of tyNil:
-      result = transform(c, n[1])
-      result.typ = n.typ
-    else:
-      result = transformSons(c, n)
   of tyGenericParam, tyOrdinal:
     result = transform(c, n[1])
     # happens sometimes for generated assignments, etc.

--- a/tests/lang_exprs/tnil_to_distinct_conversion.nim
+++ b/tests/lang_exprs/tnil_to_distinct_conversion.nim
@@ -1,0 +1,23 @@
+discard """
+  description: '''
+    Ensure that converting 'nil' literals to ``distinct pointer`` works
+  '''
+  matrix: "--hints:off --showir:mir_in:test"
+  nimoutFull: true
+  nimout: '''
+-- MIR: test
+scope:
+  def a: Ptr = nil
+  def b: Ptr = nil
+
+-- end
+'''
+"""
+
+type Ptr = distinct pointer
+
+proc test() =
+  var a = Ptr(nil) # direct conversions
+  var b = Ptr(pointer(nil)) # with intermediate conversion
+
+test()


### PR DESCRIPTION
## Summary

Expressions such as `A(pointer(nil))` crashed the compiler when `A` is
a `distinct pointer` type. This is now fixed.

## Details

Said expression reached cgirgen as `(LvalueConv (Type "A") (NilLit))`,
and since `NilLit` is not expected as the operand of an lvalue
conversion, the compiler crashed. `distinct ptr` types weren't
affected, due to `semfold` unconditionally folding `ptr` conversions
away. `A(nil)` was not affected due to `transf` folding the expression
into just a `nil` literal as part of its `tyNil` fixup.

In order to make pointer conversion behaviour consistent, `semfold` now
folds all nil-to-pointer-like conversions into a properly typed `nil`
literal. The `tyNil` fixup logic in `transf` thus becomes obsolete, and
is removed.

Beyond fixing the crash, this also means that `pointer(nil)` is now
detected as a constant expression without having to evaluate it with
the VM.