### PR TITLE
vmgen: respect overflow checks for 64-bit negation

### DIFF
--- a/tests/overflw/tunchecked_negation_32.nim
+++ b/tests/overflw/tunchecked_negation_32.nim
@@ -1,0 +1,10 @@
+discard """
+  description: '''
+    Ensure that disabling overflow checks works for 32-bit integer negations
+  '''
+  targets: "c js vm"
+  matrix: "--overflowChecks:off"
+"""
+
+var x = low(int32)
+discard -x

--- a/tests/overflw/tunchecked_negation_64.nim
+++ b/tests/overflw/tunchecked_negation_64.nim
@@ -1,0 +1,10 @@
+discard """
+  description: '''
+    Ensure that disabling overflow checks works for 64-bit integer negations
+  '''
+  targets: "c js vm"
+  matrix: "--overflowChecks:off"
+"""
+
+var x = low(int64)
+discard -x


### PR DESCRIPTION
## Summary

Negation of 64-bit integers didn't respect the overflow check setting,
resulting in overflow defects even when the checks are disabled. This
is now fixed.

Fixes https://github.com/nim-works/nimskull/issues/1406.

## Details

The VM presently doesn't support unchecked negation. For ease of
implementation, unchecked negation is emulated in bytecode as
`not(x) + 1`.