### PR TITLE
fix double-free and compiler crash

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -202,10 +202,11 @@ proc applyConversion(c: PContext, conv, n: PNode): tuple[n: PNode, keep: bool] =
     else:
       (n, tmp.keep)
   else:
-    if conv.typ.kind in {tySet, tyTuple}:
+    let styp = conv.typ.skipTypes({tyAlias, tyGenericInst})
+    if styp.kind in {tySet, tyTuple}:
       # apply the type directly and drop the conversion
       n.typ = conv.typ
-    elif conv.typ.kind in {tyOpenArray, tyVarargs, tySequence, tyArray} and
+    elif styp.kind in {tyOpenArray, tyVarargs, tySequence, tyArray} and
          n.typ.isEmptyContainer:
       # fixup empty container types
       let
@@ -221,7 +222,7 @@ proc applyConversion(c: PContext, conv, n: PNode): tuple[n: PNode, keep: bool] =
       n.typ = typ
 
     # keep to-openArray conversions, later processing still needs them
-    (n, conv.typ.kind notin {tySequence, tyArray, tyTuple, tySet})
+    (n, styp.kind notin {tySequence, tyArray, tyTuple, tySet})
 
 proc fitNodePostMatch(c: PContext, n: PNode): PNode =
   ## Performs post-processing on the result of a ``paramTypesMatch``

--- a/tests/lang_exprs/tempty_typed_expressions.nim
+++ b/tests/lang_exprs/tempty_typed_expressions.nim
@@ -6,6 +6,8 @@ discard """
   '''
 """
 
+type Generic[T] = seq[T]
+
 proc get(x: pointer): pointer = x
 proc get(x: array[0, int]): array[0, int] = x
 proc get(x: seq[int]): seq[int] = x
@@ -17,6 +19,10 @@ proc get2(x: openArray[int]): int =
   # parameter was passed correctly
   x.len
 
+proc get3(x: Generic[int]): Generic[int] =
+  # test with a generic receiver type
+  x
+
 # simple case: empty-container typed expression is passed directly
 discard get(nil)
 discard get([])
@@ -25,6 +31,8 @@ discard get({})
 
 doAssert get2([]) == 0
 doAssert get2(@[]) == 0
+
+discard get3(@[])
 
 # more complex case: statement-list expressions
 discard get((discard; nil))
@@ -35,3 +43,5 @@ discard get((discard; {}))
 
 doAssert get2((discard; [])) == 0
 doAssert get2((discard; @[])) == 0
+
+discard get3((discard; @[]))

--- a/tests/lang_types/tuples/tsink_generic_tuple_assignment.nim
+++ b/tests/lang_types/tuples/tsink_generic_tuple_assignment.nim
@@ -1,0 +1,24 @@
+discard """
+  description: '''
+    Regression test for a bug where assigning a ``sink`` generic tuple type
+    to a variable of non-``sink`` type led to the value being shallow copied.
+  '''
+  matrix: "--showir:mir_in:test --hints:off"
+  nimout: '''
+-- MIR: test
+scope:
+  def x: sink Tuple[system.int]
+  def v: Tuple[system.int]
+  v = sink x
+
+-- end
+'''
+"""
+
+type Tuple[T] = (T, T)
+
+proc test(x: sink Tuple[int]) =
+  var v: Tuple[int]
+  v = x # this assignment was considered to involve a conversion
+
+test default(Tuple[int])


### PR DESCRIPTION
## Summary

* fix a double-free issue when assigning to `sink` parameters of
  instantiated generic tuple type
* fix a compiler crash when passing an empty `seq`, `array`, or `set`
  construction to a generic instantiation receiver type

Fixes https://github.com/nim-works/nimskull/issues/1415.

## Details

Post-match fitting didn't consider generic tuple instantiations when
applying implicit conversions, meaning that the `nkHiddenSubConv` or
`nkHiddenStdConv` inserted earlier by `sigmatch` stayed.

This led to two issues:
* `nkStmtListExpr`s of empty container type didn't have their types
  fixed properly, causing crashes when the empty type reached into the
  MIR phase
* a conversion between `sink T` and `T` is considered an rvalue
  conversion by `proto_mir`, which resulted in assignments involving
  these implicit conversions effectively being *shallow* assignments
  (and thus double frees)

Skipping `tyGenericInst` and `tyAlias` (for good measure) makes sure
the implicit conversion is collapsed when the destination type is a
generic instantiation, fixing both issues. A test is added for both.