### PR TITLE
fix regression with imported `distinct` types

### DIFF
--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -1085,11 +1085,13 @@ proc handleImported(env: var TypeEnv, t: PType): TypeId =
   if t.sym != nil and sfImportc in t.sym.flags:
     # an imported type. It's wrapped in a ``tkImported``, referencing the
     # underlying type
-    let base = typeSymToMir(env):
+    let base =
       if t.kind in Skip:
-        t.lastSon.skipIrrelevant()
+        env.add t.lastSon.skipIrrelevant()
       else:
-        t
+        # create a type symbol without going through the cache or ``.importc``
+        # handling
+        typeSymToMir(env, t)
 
     discard getSize(env.config, t) # compute the sizes, alignments, and offsets
 

--- a/tests/ccgbugs/timport_distinct.nim
+++ b/tests/ccgbugs/timport_distinct.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    Regression test for importing ``distinct`` types resulting in duplicate C
+    type definitions
+  '''
+"""
+
+type
+  Object = object
+  Imported {.importc: "int", nodecl.} = distinct Object
+
+var x: Object
+var y: Imported
+
+# two type definitions for `Object` were emitted


### PR DESCRIPTION
## Summary

Marking a `distinct T` type as imported resulted in multiple C
definitions for `T`, if `T` is a non-numeric, non-pointer type. This is
now fixed.

Fixes https://github.com/nim-works/nimskull/issues/1417.

## Details

When translating imported types, `mirtypes` always created a new type
symbol for the imported type's underlying type. For `tyAlias` and
`tyDistinct` types (or any other type kind in the `Skip` set), this
resulted in a duplicate of the underlying type symbol being created.
Since MIR types are identified by ID, both look separate to `cgen`, and
thus a C definition is emitted for each.

`handleImportedTypes` now goes through the caching mechanism for the
underlying type if its not the type marked with `.importc`, fixing the
issue.