### PR TITLE
reject overloads that require conversion in `var` position

### DIFF
--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2818,7 +2818,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         if argConverter.typ.kind notin {tyVar}:
           m.error.firstMismatch.kind = kVarNeeded
           noMatch()
-      elif not isLValue(c, n):
+      elif not isLValue(c, arg):
         m.error.firstMismatch.kind = kVarNeeded
         noMatch()
 

--- a/tests/errmsgs/timplicit_conversion_var_parameter.nim
+++ b/tests/errmsgs/timplicit_conversion_var_parameter.nim
@@ -1,0 +1,18 @@
+discard """
+  action: reject
+  nimout: '''
+timplicit_conversion_var_parameter.nim(18, 2) Error: type mismatch: got <uint16>
+but expected one of:
+proc p(x: var uint32)
+  first type mismatch at position: 1
+  required type for x: var uint32
+  but expression 'arg' is immutable, not 'var'
+
+expression: p(arg)
+'''
+"""
+
+proc p(x: var uint32) = discard
+
+var arg: uint16 # requires widening conversion
+p(arg)


### PR DESCRIPTION
## Summary

* overloads where an argument passed to a `var` parameter requires an
  implicit conversion are now rejected
* this results in clearer error messages

## Details

The `checkConstraint` template is only called with `operand`, which is
the operand before fixup (e.g., introduction of implicit conversions),
hence the `isLValue` test not failing.

`arg` (the operand after fixup) is now passed to `isLValue`, so that
implicit conversions are taken into account.