### PR TITLE
fix missing destruction when discarding complex expression

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2185,15 +2185,14 @@ proc gen(c: var TCtx, n: PNode) =
           c.builder.pop(f)
   of nkDiscardStmt:
     if n[0].kind != nkEmpty:
-      let e = exprToPmir(c, n[0], false, false)
+      var e = exprToPmir(c, n[0], false, false)
       case classify(e)
-      of Rvalue:
-        discard toValue(c, e, e.high, mnkDefCursor)
-      of OwnedRvalue:
+      of Rvalue, OwnedRvalue:
         # extend the lifetime of the value
         # XXX: while not possible at the moment, in the future, the
         #      discard statement could destroy the temporary right away
-        discard toValue(c, e, e.high, mnkDef)
+        wantValue(e) # forces materialization
+        discard toValue(c, e, e.high)
       of Lvalue:
         c.buildStmt mnkVoid:
           genx(c, e, e.high)

--- a/tests/lang_objects/destructor/tdestroy_discarded_complex.nim
+++ b/tests/lang_objects/destructor/tdestroy_discarded_complex.nim
@@ -1,0 +1,49 @@
+discard """
+  description: '''
+    Ensure that the result of complex expressions is properly destroyed when
+    the full expression is discarded
+  '''
+  targets: "c js vm"
+"""
+
+type Object = object
+  has: bool
+
+var destroyed = 0
+
+proc `=destroy`(x: var Object) =
+  if x.has:
+    inc destroyed
+
+proc make(): Object = Object(has: true)
+
+# ---------------
+# test procedures
+
+proc test_block() =
+  discard (block: make())
+
+proc test_if(cond: bool) =
+  discard (if cond: make() else: make())
+
+proc test_case(cond: bool) =
+  discard (
+    case cond
+    of true:  make()
+    of false: make()
+  )
+
+proc test_try() =
+  discard (
+    try:    make()
+    except: make()
+  )
+
+test_block()
+doAssert destroyed == 1
+test_if(true)
+doAssert destroyed == 2
+test_case(true)
+doAssert destroyed == 3
+test_try()
+doAssert destroyed == 4


### PR DESCRIPTION
## Summary

Fix the result of `if`, `case`, `block`, and `try` expression not being
destroyed when `discard`ing the expression.

Fixes https://github.com/nim-works/nimskull/issues/1421.

## Details

* in `mirgen`, a value-like PMIR expression is now requested for the
  discarded expression
* `toValue` expects a properly value-like PMIR expression, which a
  complex expression is not, hence the missing destructor
* the expression is now properly materialized, which means that the a
  destructor call is registered for the temporary