### PR TITLE
macros: add `stamp` for unquoting a template body

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1813,7 +1813,7 @@ macro stamp*(body: untyped): NimNode =
       log("hi!") # this will error!
 
   var args: seq[NimNode]
-  proc extract(n: NimNode): NimNode =
+  proc extract(n: NimNode, args: var seq[NimNode]): NimNode =
     ## Extract backticks-delimited expressions.
     case n.kind
     of nnkAccQuoted:
@@ -1821,10 +1821,10 @@ macro stamp*(body: untyped): NimNode =
       args.add n[0]
     else:
       for i in 0..<n.len:
-        n[i] = extract(n[i])
+        n[i] = extract(n[i], args)
       result = n
 
-  let body = extract(body)
+  let body = extract(body, args)
 
   var params = @[bindSym"untyped"]
   for i in 0..<args.len:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1724,7 +1724,7 @@ proc extractDocCommentsAndRunnables*(n: NimNode): NimNode =
     else: break
 
 macro stamp*(body: untyped): NimNode =
-  ## Accepts a template body and returns the AST that represents it.
+  ## Accepts a template body, immediately applies it, and returns the resulting AST.
   ##
   ## Identifiers within `body` are bound to symbols from the caller's scope in
   ## the same fashion as a template. As a special case, `result` is excluded

--- a/tests/stdlib/macros/tstamp.nim
+++ b/tests/stdlib/macros/tstamp.nim
@@ -1,0 +1,20 @@
+discard """
+  description: Tests for macros.stamp
+"""
+
+import std/macros
+
+block binder:
+  ## Test automatic binding behavior
+  macro simple() =
+    let ast = stamp(echo "hello")
+    doAssert ast[0] == bindSym"echo"
+
+  simple()
+
+  macro noResult() =
+    let ast = stamp(result)
+    doAssert ast.kind == nnkIdent
+    doAssert eqIdent(ast, "result")
+
+  noResult()


### PR DESCRIPTION
## Summary

Add  `stamp`  to  `std/macros` , which takes a template body and applies
it immediately. This is the same behaviour as the previous  `quote` 
that was changed after https://github.com/nim-works/nimskull/pull/1393.


## Details

After https://github.com/nim-works/nimskull/pull/1393 we have a hole in
the stdlib for  `quote` -like interpolation but with automatic binding
of symbols to reduce boilerplate. Various libraries within the ecosystem
such as  `criterion`  and  `npeg`  have found the feature useful and
extensively employ it.

Reintroduces old  `quote`  behavior as  `stamp` , without support for
custom operators and explicitly document the template-like nature of 
`stamp` 's body as well as its pitfalls.

This macro was originally written and shared to Matrix by @zerbina.