### PR TITLE
sempass2: lift capture restriction

### DIFF
--- a/tests/lang_callable/closure/tclosure.nim
+++ b/tests/lang_callable/closure/tclosure.nim
@@ -457,6 +457,24 @@ block close_over_compile_time_loc:
   static:
     p()
 
+block close_over_compile_time_loc_2:
+  # nested non-compile-time-only procedures can close over locals of compile-
+  # time-only procedures
+  proc p() {.compileTime.} =
+    var x = 0
+    proc inner(cmp: int) = # `inner` is explicitly not compile-time-only
+      proc innerInner(cmp: int) =
+        inc x
+        doAssert x == cmp
+
+      innerInner(cmp)
+
+    inner(1)
+    inner(2)
+
+  static:
+    p()
+
 template test(body: untyped) {.dirty.} =
   ## Tests that `body` works when placed in:
   ## - a normal procedure


### PR DESCRIPTION
## Summary

Procedures useable in both compile- and run-time contexts can now close
over compile-time-only locals even if nested in another procedure
usable in both contexts.

Fixes https://github.com/nim-works/nimskull/issues/1425.

## Details

Given the nested procedures `a: b: c:`, where `c` closes over a local
of `a`, `c` effectively captures from `b` and `b` captures from `a`.

A procedure usable in both a compile- and run-time context may capture
from a compile-time-only procedure, so the aforementioned should work
when `a` is a compile-time-only procedure and the others are not, since
`c` can legally borrow from `b` and `b` from `a`, but it was disallowed
in practice.

The arbitrary restriction is now lifted, and the code implementing the
test restructured to be easier to understand.