### PR TITLE
fix: import current dir relative modules

### DIFF
--- a/compiler/modules/importer.nim
+++ b/compiler/modules/importer.nim
@@ -378,25 +378,15 @@ proc evalImport*(c: PContext, n: PNode): PNode =
 
   for it in n.sons:
     if it.kind == nkPrefix and it.len == 2 and it[1].kind == nkBracket:
-      let
-        sep = it[0]
-        impTmpl =
-          block:
-            let t = newNodeI(nkPrefix, it.info, 2)
-            t[0] = sep
-            t
-          ## `impTmpl` is copied/instanced in a loop below including setting
-          ## the second child
-
-      for x in it[1]:
-        let imp = copyTree(impTmpl)
-
-        # transform `./[a as b] to `./a as b`
-        imp[1] =
+      for x in it[1].items:
+        let imp = newTreeI(nkPrefix, it.info,
+          it[0],
+          # transform `./[a as b] to `./a as b`
           if x.kind == nkInfix and x[0].ident.s == "as":
             x[1]
           else:
             x
+        )
 
         hasError = impMod(c, imp, x.info, result).kind == nkError or hasError
     elif it.kind == nkInfix and it.len == 3 and it[2].kind == nkBracket:

--- a/tests/lang_stmts/importstmt/timport_relative.nim
+++ b/tests/lang_stmts/importstmt/timport_relative.nim
@@ -1,0 +1,7 @@
+discard """
+  description: "Regression test for relative imports"
+"""
+
+import ./[mbar]
+import ./[mbaz, mfoo]
+import ./[mqux1 as mqux]

--- a/tests/lang_stmts/importstmt/timport_relative.nim
+++ b/tests/lang_stmts/importstmt/timport_relative.nim
@@ -2,6 +2,8 @@ discard """
   description: "Regression test for relative imports"
 """
 
+# relative to current directory
 import ./[mbar]
 import ./[mbaz, mfoo]
 import ./[mqux1 as mqux]
+import ./mqux2

--- a/tests/lang_stmts/importstmt/ttyped_import_nimskull757.nim
+++ b/tests/lang_stmts/importstmt/ttyped_import_nimskull757.nim
@@ -40,22 +40,3 @@ outputTyped:
   import mqux4 except bar4, baz4
   # import as output might have issues, see below
   import mqux5 as mqux6
-
-when false: # knownIssue: `import except` doesn't preserve exclusion info
-  # test should check for output:
-  #   ImportExceptStmt
-  #     Sym "mqux3"
-  #     Sym "bar3"
-  #   ImportExceptStmt
-  #     Sym "mqux4"
-  #     Sym "bar4"
-  #     Sym "baz4"
-  outputTyped:
-    import mqux3 except bar3
-    import mqux4 except bar4, baz4
-
-when false: # knownIssue: `Import as` doesn't preserve original identifier info
-  # not quite sure what the test should be yet, current behaviour might be
-  # acceptable, because the symbol decl can be introspected?
-  outputTyped:
-    import mqux5 as mqux6

--- a/tests/lang_stmts/importstmt/ttyped_import_nimskull757_knownissues.nim
+++ b/tests/lang_stmts/importstmt/ttyped_import_nimskull757_knownissues.nim
@@ -1,0 +1,31 @@
+discard """
+  description: "Test import statements are properly analysed"
+  knownissue: "`import except` doesn't preserve exclusion info"
+  output: '''
+StmtList
+  ImportExceptStmt
+    Sym "mqux3"
+    Sym "bar3"
+  ImportExceptStmt
+    Sym "mqux4"
+    Sym "bar4"
+    Sym "baz4"
+'''
+"""
+
+import std/macros
+
+macro outputTyped(n: typed) =
+  let output = treeRepr n
+  quote:
+    echo `output`
+
+outputTyped:
+  import mqux3 except bar3
+  import mqux4 except bar4, baz4
+
+when false: # knownIssue: `Import as` doesn't preserve original identifier info
+  # not quite sure what the test should be yet, current behaviour might be
+  # acceptable, because the symbol decl can be introspected?
+  outputTyped:
+    import mqux5 as mqux6


### PR DESCRIPTION
## Summary

Attempts to import modules using relative import with multiple module
syntax like  `import ./[foo, bar]`  no longer result in an error.

Fixes: https://github.com/nim-works/nimskull/issues/1430

## Details

`./some_dir/[foo]`  worked because the AST resulted in an  `infix`  node
for the second directory separator  `/` , but a  `prefix`  node when
using  `./[foo]` ,  `importEval`  now takes this into account. A test
has been included along with the fix.

Along with this change some preexisting import statement tests were
adjusted away from using  `when false`  to flag known issues to the
builtin testament functionality of the  `knownissue`  field.