### PR TITLE
openssl, net: remove openssl pre-1.1.1 and libressl support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,10 @@ jobs:
         run: |
           brew update
 
+      - name: Add Homebrew libraries to search path (macOS M1)
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        run: echo "DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib" >> "$GITHUB_ENV"
+
       - name: Install MinGW (Windows)
         if: runner.os == 'Windows'
         uses: ./.github/actions/setup-mingw


### PR DESCRIPTION
## Summary
Remove support for OpenSSL older than 3.0, as it has reached EoL and
should no longer be used in production.

Since version 1.1.1 is still widely used in LTS distributions such as
RHEL 8 or Ubuntu 20.04, support for it is retained, however.

## Details
* LibreSSL support is also removed from the wrapper, as it has not been
tested and likely no longer works with the latest versions of LibreSSL.
* Removed shims for older OpenSSL from the wrapper. This is a breaking
change although the impacts should be light to non-existent.
* Removed unnecessary initialization functions from  `net` , since
OpenSSL now automatically initializes the necessary components.
*  `protTLSv1`  is now deprecated as TLSv1.0 is no longer safe, and
OpenSSL has deprecated the related procedures.
*  `openssl111`  define has been added to handle statically linking with
OpenSSL 1.1.1, since the symbol  `SSL_get_peer_certificate`  depended on
it.
* CI for M1 macOS has been configured to always use Homebrew-supplied
OpenSSL.