### PR TITLE
net: add support for Windows certificate store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,13 +140,6 @@ jobs:
         if: runner.os == 'Windows'
         run: vcpkg install pcre sqlite3
 
-      - name: Download CA certificates (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          $binPath = Join-Path $PWD "vcpkg" "installed" "x64-mingw-dynamic-release" "bin"
-          Invoke-WebRequest https://curl.se/ca/cacert.pem -OutFile (Join-Path $binPath "cacert.pem")
-        shell: pwsh
-
       - name: Set Xcode version (macOS M1)
         if: runner.os == 'macOS' && runner.arch == 'ARM64'
         uses: maxim-lobanov/setup-xcode@v1

--- a/lib/pure/ssl_certs.nim
+++ b/lib/pure/ssl_certs.nim
@@ -140,27 +140,3 @@ iterator scanSSLCertificates*(useEnvVars = false): string =
         defer: free(paths)
         for i in 0 ..< size:
           yield $paths[i]
-
-# Certificates management on windows
-# when defined(windows) or defined(nimdoc):
-#
-#   import std/openssl
-#
-#   type
-#     PCCertContext {.final, pure.} = pointer
-#     X509 {.final, pure.} = pointer
-#     CertStore {.final, pure.} = pointer
-#
-#   # OpenSSL cert store
-#
-#   {.push stdcall, dynlib: "kernel32", importc.}
-#
-#   proc CertOpenSystemStore*(hprov: pointer=nil, szSubsystemProtocol: cstring): CertStore
-#
-#   proc CertEnumCertificatesInStore*(hCertStore: CertStore, pPrevCertContext: PCCertContext): pointer
-#
-#   proc CertFreeCertificateContext*(pContext: PCCertContext): bool
-#
-#   proc CertCloseStore*(hCertStore:CertStore, flags:cint): bool
-#
-#   {.pop.}

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -245,6 +245,8 @@ const
 when compileOption("dynlibOverride", "ssl") or defined(noOpenSSLHacks):
   when not defined(openssl111):
     proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 {.cdecl, dynlib: DLLSSLName, importc: "SSL_get1_peer_certificate".}
+
+    proc SSL_CTX_load_verify_store*(ssl: SslCtx, CAstore: cstring): cint {.cdecl, dynlib: DLLSSLName, importc.}
   else:
     proc SSL_get_peer_certificate*(ssl: SslCtx): PX509 {.cdecl, dynlib: DLLSSLName, importc: "SSL_get_peer_certificate".}
 else:
@@ -289,6 +291,13 @@ else:
           sslSymThrows("SSL_get1_peer_certificate", "SSL_get_peer_certificate")
         )
         if not thisProc.isNil: result = thisProc(ssl)
+
+    proc SSL_CTX_load_verify_store*(ssl: SslCtx, CAstore: cstring): cint {.gcsafe, tags: [].} =
+      {.cast(tags: []), cast(gcsafe).}:
+        var thisProc {.global.}: proc (ssl: SslCtx, CAstore: cstring): cint {.cdecl.}
+        if thisProc.isNil:
+          thisProc = cast[typeof(thisProc)](sslSymThrows("SSL_CTX_load_verify_store"))
+        result = thisProc(ssl, CAstore)
 
 proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
 proc OpenSSL_version_num*(): culong {.cdecl, dynlib: DLLUtilName, importc.}


### PR DESCRIPTION
## Summary
When applicable, load the Windows Root Certificate store into OpenSSL
verification store. This allows  `cacert.pem`  requirement to become
optional and provide support for custom certificates within the root
store (ie. in corporate environments).

## Details
* On OpenSSL >= 3.2.0, load the Windows Root Certificate store and don't
require  `cacert.pem`  to be present.
* Removed `cacert.pem` from CI as we use a recent OpenSSL there.