### PR TITLE
fix(sem): crash with procedure with error used as argument

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3561,6 +3561,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
       result = symChoice(c, n, s, scClosed)
       if result.kind == nkSym:
         markIndirect(c, result.sym)
+        result = semSym(c, n, result.sym, flags)
     of skEnumField:
       if overloadableEnums in c.features:
         result = enumFieldSymChoice(c, n, s)

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3561,7 +3561,10 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
       result = symChoice(c, n, s, scClosed)
       if result.kind == nkSym:
         markIndirect(c, result.sym)
-        result = semSym(c, n, result.sym, flags)
+        # the symbol was alrady marked as used, don't mark it as such again
+        # (via ``semSym``)
+        if result.sym.ast.isError:
+          result = c.config.newError(result, PAstDiag(kind: adWrappedSymError))
     of skEnumField:
       if overloadableEnums in c.features:
         result = enumFieldSymChoice(c, n, s)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2602,9 +2602,9 @@ proc paramTypesMatch*(
 
     else:
       # only one valid interpretation found, executing argument match
-      markUsed(candidate.c, arg.info, arg[bestArg].sym)
+      let realArg = candidate.c.semExpr(c, arg[bestArg], {})
       result = paramTypesMatchAux(
-        candidate, formal, arg[bestArg].typ, arg[bestArg])
+        candidate, formal, realArg.typ, realArg)
 
   when false:
     if candidate.calleeSym != nil and

--- a/tests/error_propagation/tgeneric_proc_sym_as_argument.nim
+++ b/tests/error_propagation/tgeneric_proc_sym_as_argument.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    Ensure that generic procedure symbols are wrapped in an error, when used
+    in an argument context
+  '''
+  action: reject
+  matrix: "--errorMax:100"
+"""
+
+proc call(p: proc(x: int)) = discard
+
+proc withError[T](x: T) =
+  missing
+
+call(withError) # <- this crashed the compiler

--- a/tests/error_propagation/toverloaded_proc_sym_as_argument.nim
+++ b/tests/error_propagation/toverloaded_proc_sym_as_argument.nim
@@ -1,0 +1,18 @@
+discard """
+  description: '''
+    Ensure that overloaded procedure symbols are wrapped in an error, when
+    used in an argument context
+  '''
+  action: reject
+  matrix: "--errorMax:100"
+"""
+
+proc call(p: proc()) = discard
+
+proc withError() =
+  missing
+
+proc withError(a: int) = # <- this overload is not picked below
+  discard
+
+call(withError) # <- this crashed the compiler

--- a/tests/error_propagation/tproc_sym_as_argument.nim
+++ b/tests/error_propagation/tproc_sym_as_argument.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    Ensure that procedure symbols are wrapped in an error, when used in an
+    argument context
+  '''
+  action: reject
+  matrix: "--errorMax:100"
+"""
+
+proc call(p: proc()) = discard
+
+proc withError() =
+  missing
+
+call(withError) # <- this crashed the compiler


### PR DESCRIPTION
## Summary

Fix a compiler crash when passing the name of a procedure with an error
as an argument to another routine.

## Details

Overloadable and overloaded procedure symbols forewent the `nkError`
wrapping done by `semSym`, thus not preventing instantiation or later
inspection by `sempass2`, crashing the compiler with an `IndexDefect`
on attempting to access the symbol's AST.

Non-overloaded procedure symbols can be passed to `semSym` directly,
which takes care of the wrapping. To handle overloaded symbols,
`sigmatch.paramTypesMatch` passes the picked symbol to `semExpr` first,
which subsequently calls `semSym`, also marking the symbols as used.

The problem with using `semExpr` in `paramTypesMatch` is that the
returned `nkError` currently dismisses the overload, resulting in an
unnecessary "type mismatch" compiler error (with `nimsuggest`, `check`,
etc.).

Fixes https://github.com/nim-works/nimskull/issues/1384.
Fixes https://github.com/nim-works/nimskull/issues/1442.