### PR TITLE
fix(sem): fix crash routine pragma redefinition

### DIFF
--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -1057,11 +1057,11 @@ const
     rsemRedefinitionOf,
     rsemInvalidMethodDeclarationOrder, # [s, witness]
     rsemIllegalCallconvCapture, # [symbol, owner]
-    rsemDeprecated # [symbol, use-instead]
+    rsemDeprecated, # [symbol, use-instead]
+    rsemUnexpectedPragmaInDefinitionOf,
   }
 
   rsemReportOneSym* = {
-    rsemUnexpectedPragmaInDefinitionOf,
     rsemDoubleCompletionOf,
 
     rsemOverrideSafetyMismatch,

--- a/compiler/ast/reports_sem.nim
+++ b/compiler/ast/reports_sem.nim
@@ -220,9 +220,7 @@ proc reportSymbols*(
     ast: PNode = nil
   ): SemReport =
   case kind
-  of rsemReportTwoSym: assert symbols.len == 2
-  of rsemReportOneSym: assert symbols.len == 1
-  of rsemReportListSym: discard
+  of rsemReportTwoSym, rsemReportOneSym, rsemReportListSym: discard
   else: assert false, $kind
 
   result = SemReport(kind: kind, ast: ast)

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1581,8 +1581,8 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       let
         proto = r.symbols[0]
         s = r.symbols[1]
-      result = "pragmas are only allowed in the header of a routine; '$1' " &
-               "header at $2 redefined at $3" %
+      result = ("pragmas are only allowed in the header of a routine; '$1' " &
+                "header at $2 redefined at $3") %
                [proto.name.s, conf $ proto.info, conf $ s.info]
 
     of rsemDisjointFields:

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1578,11 +1578,12 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "'method' needs a parameter that has an object type"
 
     of rsemUnexpectedPragmaInDefinitionOf:
-      let proto = r.symbols[0]
-      let s = r.symbols[1]
-      result = "pragmas are only allowed in the header of a proc; redefinition of $1" %
-        ("'" & proto.name.s & "' from " & conf $ proto.info &
-        " '" & s.name.s & "' from " & conf $ s.info)
+      let
+        proto = r.symbols[0]
+        s = r.symbols[1]
+      result = "pragmas are only allowed in the header of a routine; '$1' " &
+               "header at $2 redefined at $3" %
+               [proto.name.s, conf $ proto.info, conf $ s.info]
 
     of rsemDisjointFields:
       result = ("The fields '$1' and '$2' cannot be initialized together, " &

--- a/tests/lang_callable/tpragma_redefinition_on_routine_def_err.nim
+++ b/tests/lang_callable/tpragma_redefinition_on_routine_def_err.nim
@@ -1,0 +1,8 @@
+discard """
+  description: "Error when routine def has pragma not in prototype"
+  errormsg: "pragmas are only allowed in the header of a proc; redefinition of 'a' from"
+  line: 8
+"""
+
+proc a()
+proc a() {.gcsafe.} = discard

--- a/tests/lang_callable/tpragma_redefinition_on_routine_def_err.nim
+++ b/tests/lang_callable/tpragma_redefinition_on_routine_def_err.nim
@@ -1,6 +1,6 @@
 discard """
   description: "Error when routine def has pragma not in prototype"
-  errormsg: "pragmas are only allowed in the header of a proc; redefinition of 'a' from"
+  errormsg: "pragmas are only allowed in the header of a routine; 'a'"
   line: 8
 """
 


### PR DESCRIPTION
## Summary

The compiler no longer crashes when encountering a pragma redefinition
error on a routine. This was due to unnecessary asserts in error message
code

## Details
* dropped the asserts that added no value
* dropped the redundancy in the error message itself, no need to repeat
the symbol for the definition, as they will be the same
* error message generation now properly uses string format ( `%` )
instead of concatenation

Fixes https://github.com/nim-works/nimskull/issues/1444