### PR TITLE
fix(sem): non-boolean `when` conditions being ignored

### DIFF
--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -561,7 +561,7 @@ proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
         allowedFlags: {})))
 
 proc semDirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode
-proc semWhen(c: PContext, n: PNode, semCheck: bool = true): PNode
+proc semWhen(c: PContext, n: PNode, flags: TExprFlags): PNode
 proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
                      flags: TExprFlags = {}): PNode
 proc semMacroExpr(c: PContext, n: PNode, sym: PSym,

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -2188,7 +2188,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         else:
           result = semTypeExpr(c, n, prev)
   of nkWhenStmt:
-    var whenResult = semWhen(c, n, false)
+    var whenResult = semWhen(c, n, {efNoSemCheck})
     if whenResult.kind == nkStmtList:
       whenResult.transitionSonsKind(nkStmtListExpr)
     result = semTypeNode(c, whenResult, prev)

--- a/tests/lang_stmts/whenstmt/twhen_condition_must_be_bool.nim
+++ b/tests/lang_stmts/whenstmt/twhen_condition_must_be_bool.nim
@@ -1,0 +1,11 @@
+discard """
+  description: '''
+    Ensure that an error is reported for a non-boolean expression used as the
+    condition of a `when`
+  '''
+  errormsg: "type mismatch: got <int literal(2)> but expected 'bool'"
+  line: 10
+"""
+
+when 1 + 1:
+  discard


### PR DESCRIPTION
## Summary

Fix `when` branches where the condition has an incorrect type being
silently ignored without an error.

## Details

* a type mismatch error was already created, but not properly
  propagated; now it is
* fix error propagation for `when nimvm` statements
* simplify the control-flow in `semWhen` by handling `when nimvm`
  separately
* refactor `semWhen` to not modify the input AST
* pass the analysis flags along to `semWhen`, and integrate the
  `semCheck` parameter into the flags (now indicated by `efNoSemCheck`)