### PR TITLE
fix: crash when passing NimNode to static parameter

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2490,6 +2490,8 @@ proc constDataToMir*(env: var MirEnv, n: PNode): MirTree =
       bu.use toFloatLiteral(env, n)
     of nkStrLiterals:
       bu.use strLiteral(env, n.strVal, typ)
+    of nkNimNodeLit:
+      bu.use astLiteral(env, n[0], n.typ)
     of nkHiddenStdConv, nkHiddenSubConv:
       # doesn't translate to a MIR node itself, but the type overrides
       # that of the sub-expression

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -500,7 +500,11 @@ proc regToNode*(c: TCtx, x: TFullReg; typ: PType, info: TLineInfo): PNode =
       # TODO: validate the address
       result = c.deserialize(c.allocator.makeLocHandle(x.addrVal, x.addrTyp), typ, info)
   of rkHandle, rkLocation: result = c.deserialize(x.handle, typ, info)
-  of rkNimNode: result = x.nimNode
+  of rkNimNode:
+    if typ.sym != nil and typ.sym.magic == mPNimrodNode:
+      result = c.deserializeNimNode(x.nimNode, typ, info)
+    else:
+      result = x.nimNode
 
 # ---- exception handling ----
 

--- a/tests/lang_callable/macros/tstatic_nim_node_parameter.nim
+++ b/tests/lang_callable/macros/tstatic_nim_node_parameter.nim
@@ -1,0 +1,14 @@
+discard """
+  description: '''
+    Ensure that a NimNode can be passed as a static parameter to a macro.
+  '''
+  action: compile
+"""
+
+import std/macros
+
+macro m(n: static NimNode) =
+  doAssert n.kind == nnkStmtList
+  doAssert n.len == 0
+
+m(newStmtList())


### PR DESCRIPTION
## Summary

* fix a compiler crash when passing a NimNode to a `static` parameter
* fix a compiler crash when evaluating a `NimNode`-returning constant
  expression

## Details

There were two problems:
* `nkNimNodeLit` wasn't handled in constant data expression by `mirgen`
* `NimNode` values returned directly from a VM invocation weren't
  wrapped in `nkNimNodeLit` trees

For handling `NimNode` values in `vm.regToNode`, the existing
deserialization logic for `NimNode` values in `vmcompilerserdes` is
moved to a separate procedure, so that it can be used by `regToNode`.

The `opcRepr` implementation relied on `regToNode` always returning
an unwrapped `PNode` -- it is adjusted to manually handle `NimNode`
values.

A test covering both issues is added.

Fixes https://github.com/nim-works/nimskull/issues/1448.