### PR TITLE
fix(sem): analysis considers nested noreturn

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -690,6 +690,16 @@ iterator genericParamsInMacroCall*(macroSym: PSym, call: PNode): (PSym, PNode) =
     if posInCall < call.len:
       yield (genericParam, call[posInCall])
 
+proc endsInNoReturn*(n: PNode): bool =
+  ## checks if expression `n` ends in an unstructured exit (raise, return,
+  ## etc), calls of noreturn proc, or
+  var it = n
+  while it.kind in {nkStmtList, nkStmtListExpr} and it.len > 0:
+    it = it.lastSon
+  result = it.kind in nkLastBlockStmts or
+    it.kind in {nkIfStmt, nkIfExpr, nkTryStmt, nkCaseStmt, nkTryStmt, nkBlockExpr} and it.typ.isNil or
+    it.kind in nkCallKinds and it[0].kind == nkSym and sfNoReturn in it[0].sym.flags
+
 type
   NodePosName* = enum
     ## Named node position accessor

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -692,7 +692,7 @@ iterator genericParamsInMacroCall*(macroSym: PSym, call: PNode): (PSym, PNode) =
 
 proc endsInNoReturn*(n: PNode): bool =
   ## checks if expression `n` ends in an unstructured exit (raise, return,
-  ## etc), calls of noreturn proc, or
+  ## etc) or calls of noreturn proc. This is meant to be called on an semmed `n`.
   var it = n
   while it.kind in {nkStmtList, nkStmtListExpr} and it.len > 0:
     it = it.lastSon

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -691,13 +691,15 @@ iterator genericParamsInMacroCall*(macroSym: PSym, call: PNode): (PSym, PNode) =
       yield (genericParam, call[posInCall])
 
 proc endsInNoReturn*(n: PNode): bool =
-  ## checks if expression `n` ends in an unstructured exit (raise, return,
-  ## etc) or calls of noreturn proc. This is meant to be called on an semmed `n`.
+  ## Checks if expression `n` ends in an unstructured exit (raise, return,
+  ## etc.) or a call of a noreturn proc. This is meant to be called on a
+  ## semmed `n`.
   var it = n
   while it.kind in {nkStmtList, nkStmtListExpr} and it.len > 0:
     it = it.lastSon
   result = it.kind in nkLastBlockStmts or
-    it.kind in {nkIfStmt, nkIfExpr, nkTryStmt, nkCaseStmt, nkTryStmt, nkBlockExpr} and it.typ.isNil or
+    (it.kind in {nkIfStmt, nkTryStmt, nkCaseStmt, nkBlockStmt} and
+     it.typ.isEmptyType()) or
     it.kind in nkCallKinds and it[0].kind == nkSym and sfNoReturn in it[0].sym.flags
 
 type

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -390,14 +390,6 @@ proc commonType*(c: PContext; x, y: PType): PType =
         result = newType(k, nextTypeId(c.idgen), r.owner)
         result.addSonSkipIntLit(r, c.idgen)
 
-proc endsInNoReturn(n: PNode): bool =
-  # check if expr ends in raise exception or call of noreturn proc
-  var it = n
-  while it.kind in {nkStmtList, nkStmtListExpr} and it.len > 0:
-    it = it.lastSon
-  result = it.kind in nkLastBlockStmts or
-    it.kind in nkCallKinds and it[0].kind == nkSym and sfNoReturn in it[0].sym.flags
-
 proc commonType*(c: PContext; x: PType, y: PNode): PType =
   # ignore exception raising branches in case/if expressions
   addInNimDebugUtils(c.config, "commonType", y, x, result)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -1705,7 +1705,6 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
       localReport(c.config, result, SemReport(
         kind: rsemMissingCaseBranches,
         nodes: formatMissingBranches(c, result)))
-
     else:
       localReport(c.config, result, reportSem rsemMissingCaseBranches)
 

--- a/tests/lang_exprs/tnoreturn_nested.nim
+++ b/tests/lang_exprs/tnoreturn_nested.nim
@@ -1,0 +1,53 @@
+discard """
+  description: "
+    Ensure nested noreturn statements are considererd in noreturn analysis
+  "
+"""
+
+block nested_in_if:
+  let x =
+    if true:
+      0
+    else:
+      if true:
+        raise newException(CatchableError, "error")
+      else:
+        raise newException(CatchableError, "another error")
+
+  doAssert x is int
+
+block nested_in_try:
+  let x =
+    if true:
+      0
+    else:
+      try:
+        raise newException(CatchableError, "error")
+      finally:
+        discard
+
+  doAssert x is int
+
+block nested_in_case:
+  let x =
+    if true:
+      0
+    else:
+      let s = false
+      case
+      of true:
+        raise newException(CatchableError, "error")
+      of false:
+        raise newException(CatchableError, "another error")
+
+  doAssert x is int
+
+block nested_in_block:
+  let x =
+    if true:
+      0
+    else:
+      block:
+        raise newException(CatchableError, "error")
+
+  doAssert x is int

--- a/tests/lang_exprs/tnoreturn_nested.nim
+++ b/tests/lang_exprs/tnoreturn_nested.nim
@@ -1,7 +1,7 @@
 discard """
-  description: """
+  description: '''
     Ensure nested noreturn statements are considererd in noreturn analysis
-  """
+  '''
 """
 
 block nested_in_if:

--- a/tests/lang_exprs/tnoreturn_nested.nim
+++ b/tests/lang_exprs/tnoreturn_nested.nim
@@ -1,7 +1,7 @@
 discard """
-  description: "
+  description: """
     Ensure nested noreturn statements are considererd in noreturn analysis
-  "
+  """
 """
 
 block nested_in_if:
@@ -34,7 +34,7 @@ block nested_in_case:
       0
     else:
       let s = false
-      case
+      case s
       of true:
         raise newException(CatchableError, "error")
       of false:


### PR DESCRIPTION
## Summary
No-return analysis ensures that nested final expressions (
`block/case/if/try` ) are accounted for no-return itself.

## Details
Prior to this change if the last expression within a greater expression
was a no-return expression it would not be deemed as such if it was a 
`block/case/if/try` , instead errors would be raised related to discard
checks or that path not resulting in the correct type.

For example, the following would result in an error where  `0`  must be
used or discarded:
```nim
proc foo() =
  let x =
    if false: 10
    else:
      block:
        return
```

Fixes https://github.com/nim-works/nimskull/issues/1440