### PR TITLE
testament: fix missing error reporting

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -319,7 +319,7 @@ proc isJoinableSpec(spec: TSpec, targets: set[TTarget], early: TResultEnum): boo
     not fileExists(spec.file.changeFileExt("nim.cfg")) and
     not fileExists(parentDir(spec.file) / "nim.cfg") and
     spec.cmd.len == 0 and
-    early notin {reDisabled} and
+    early notin {reDisabled, reInvalidSpec} and
     not spec.unjoinable and
     spec.exitCode == 0 and
     spec.input.len == 0 and

--- a/tests/lang_callable/converter/tconverter_for_static_param.nim
+++ b/tests/lang_callable/converter/tconverter_for_static_param.nim
@@ -1,7 +1,7 @@
 discard """
   description: '''
     Ensure that converters are considered for arguments to static parameters
-  "
+  '''
 """
 
 converter toInt(x: float): int = int(x)

--- a/tests/lang_callable/macros/tmodify_result_assignment.nim
+++ b/tests/lang_callable/macros/tmodify_result_assignment.nim
@@ -3,7 +3,7 @@ discard """
     Partially typed ``nkReturnStmt`` AST is properly re-analyzed after macro
     invocation
   '''
-  errmsg: "got <string> but expected 'int'"
+  errormsg: "got <string> but expected 'int'"
   line: 26
 """
 

--- a/tests/lang_callable/macros/tmodify_result_assignment.nim
+++ b/tests/lang_callable/macros/tmodify_result_assignment.nim
@@ -19,7 +19,7 @@ macro modify(input: typed) =
   # replace the right side of the assignment with an expression of different,
   # incompatible type
   result.body[0][1] = newStrLitNode("") # wrong type: int vs. string
-  result.body.copyLineInfo(input.body[0][1])
+  result.body[0][1].copyLineInfo(input.body[0][1])
 
 modify:
   proc p(): int =

--- a/tests/lang_stmts/for_stmt/tfor_ill_formed_sym.nim
+++ b/tests/lang_stmts/for_stmt/tfor_ill_formed_sym.nim
@@ -1,6 +1,6 @@
 discard """
   description: "Ensure that ill-formed AST generates a well formed error"
-  errmsg: "identifier expected, but found '123'"
+  errormsg: "identifier expected, but found '123'"
 """
 
 # This test covers a regression where an error with the symbol outside a pragma

--- a/tests/lang_stmts/for_stmt/tfor_ill_formed_sym.nim
+++ b/tests/lang_stmts/for_stmt/tfor_ill_formed_sym.nim
@@ -1,6 +1,6 @@
 discard """
   description: "Ensure that ill-formed AST generates a well formed error"
-  errormsg: "identifier expected, but found '123'"
+  errormsg: "identifier expected, but found: 123"
 """
 
 # This test covers a regression where an error with the symbol outside a pragma

--- a/tests/vm/tconst_seq_crash.nim
+++ b/tests/vm/tconst_seq_crash.nim
@@ -4,7 +4,7 @@ discard """
     be code evaluated with the compile-time VM
   '''
   target: native
-  action: compiles
+  action: compile
 """
 
 type Obj = object


### PR DESCRIPTION
## Summary

Fix tests with invalid specs being silently ignored (they were neither
compiled nor run) when using `all` or `cat megatest`.

## Details

The `isJoinableSpec` procedure didn't prevent tests with an invalid
spec (`reInvalidSpec`) from being joined, which overrode the failure
with `reJoined`. Since the specs then had no target enabled, they were
also not included in the megatest.

A few invalid test specifications went by unnoticed due to this bug --
they're now fixed.