### PR TITLE
fix(sem): avoid no-return false positives

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1216,13 +1216,15 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
       result = "illegal discard"
 
     of rsemUseOrDiscardExpr:
-      let n = r.wrongNode
+      let
+        n = r.wrongNode
+        typStr = if n.typ.isNil: "void" else: n.typ.skipTypes({tyVar}).render
 
       result.add(
         "expression '",
         n.render,
         "' is of type '",
-        n.typ.skipTypes({tyVar}).render,
+        typStr,
         "' and has to be used (or discarded)"
       )
 

--- a/tests/lang_exprs/tnoreturn_nested_reject.nim
+++ b/tests/lang_exprs/tnoreturn_nested_reject.nim
@@ -1,0 +1,14 @@
+discard """
+  description: '''
+    Ensure nested non-noreturn statements aren't treated as such
+  '''
+"""
+
+let x =
+  if true:
+    10
+  else:
+    try:
+      discard
+    except:
+      discard

--- a/tests/lang_exprs/tnoreturn_nested_reject.nim
+++ b/tests/lang_exprs/tnoreturn_nested_reject.nim
@@ -2,6 +2,8 @@ discard """
   description: '''
     Ensure nested non-noreturn statements aren't treated as such
   '''
+  errormsg: "expression '10' is of type 'int literal(10)' and has to be used (or discarded)"
+  line: 11
 """
 
 let x =


### PR DESCRIPTION
## Summary
no-return analysis now no longer confuses  `void`  branches for true
no-returns.

## Details

No-return analysis now dives into the trees of  `if/try/block/case` 
statements in order to determine if they are in fact no-return
scenarios. This is only done for the statement variety.

The updated analysis besides being more correct, in that it avoids false
positive no-return identification, it still allows for a number of false
negatives. Chiefly that unstructured exits ( `return/break/raise` ) are
only considered in the trailing position of statement lists and not part
way through. This is considered acceptable as there is an overall
improvement in accuracy and it should cover most code.

This includes a fix for an NPE crash in discard-or-use error reporting.