### PR TITLE
fix(typeinfo): expanding seq doesn't clear locations

### DIFF
--- a/tests/stdlib/metaprogramming/ttypeinfo.nim
+++ b/tests/stdlib/metaprogramming/ttypeinfo.nim
@@ -69,3 +69,17 @@ block:
 
   doAssert getEnumOrdinal(y, "Hello") == 0
   doAssert getEnumOrdinal(y, "hello") == 1
+
+block seq_extension_zeroes:
+  # make sure ``invokeNewSeq`` and ``extendSeq`` zero the new locations
+  var s: seq[int]
+  toAny(s).invokeNewSeq(100)
+
+  # check that the values are all zero and change them to something else
+  for it in s.mitems:
+    doAssert it == 0
+    it = 1
+
+  s.setLen(0) # clear the seq, which should leave the memory untouched
+  toAny(s).extendSeq() # grow by one
+  doAssert s[0] == 0


### PR DESCRIPTION
## Summary

New seq slots are now zeroed when expanding the seq via `invokeNewSeq`
or `extendSeq`, making the behaviour consistent with `setLen` and
`newSeq`, and also fixing crashes with `marshal` caused by the
uninitialized memory.

## Details

Zeroing the memory is not correct for types that don't have a zero-
default, but those cannot be detected with just RTTI. Zeroing the
memory is usually still better then leaving it as is.

For the JavaScript and VM backends, the `zeroMem` call is excluded
from compilation. Using `invokeNewSeq` and `extendSeq` is already
not possible on these backends.

Fixes https://github.com/nim-works/nimskull/issues/1462