### PR TITLE
sem: replace `addr` calls with `nkAddr`

### DIFF
--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -599,13 +599,8 @@ proc iiTablePut(t: var TIITable, key, val: int) =
     iiTableRawInsert(t.data, key, val)
     inc(t.counter)
 
-proc isAddrNode*(n: PNode): bool =
-  case n.kind
-    of nkAddr, nkHiddenAddr: true
-    of nkCallKinds:
-      if n[0].kind == nkSym and n[0].sym.magic == mAddr: true
-      else: false
-    else: false
+func isAddrNode*(n: PNode): bool =
+  n.kind in {nkAddr, nkHiddenAddr}
 
 proc listSymbolNames*(symbols: openArray[PSym]): string =
   for sym in symbols:

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2814,9 +2814,7 @@ proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
   of mAddr:
     markUsed(c, n.info, s)
     checkSonsLen(n, 2, c.config)
-    result[0] = newSymNode(s, n[0].info)
-    result[1] = semAddrArg(c, n[1])
-    result.typ = makePtrType(c, result[1].typ)
+    result = semAddrCall(c, n)
   of mTypeOf:
     markUsed(c, n.info, s)
     result = semTypeOf(c, n)

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1143,8 +1143,6 @@ proc allowCStringConv(n: PNode): bool =
   of nkStrLiterals: result = true
   of nkSym: result = n.sym.kind in {skConst, skParam}
   of nkAddr: result = isCharArrayPtr(n.typ, true)
-  of nkCallKinds:
-    result = isCharArrayPtr(n.typ, n[0].kind == nkSym and n[0].sym.magic == mAddr)
   else: result = isCharArrayPtr(n.typ, false)
 
 proc reportErrors(c: ConfigRef, n: PNode) =

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1110,9 +1110,6 @@ proc transformCall(c: PTransf, n: PNode): PNode =
           inc(j)
       result.add(a)
     if result.len == 2: result = result[1]
-  elif magic == mAddr:
-    result = newTreeIT(nkAddr, n.info, n.typ): n[1]
-    result = transformAddr(c, result)
   elif magic == mTypeOf:
     result = n
   elif magic == mRunnableExamples:

--- a/tests/effects/teffects11.nim
+++ b/tests/effects/teffects11.nim
@@ -1,0 +1,11 @@
+discard """
+  description: '''
+    Taking the address of a location storing a procedural value does not
+    incur the procedure's effects.
+  '''
+  action: compile
+"""
+
+proc p() {.raises: [].} =
+  var a: proc() {.raises: ValueError.}
+  discard addr(a)

--- a/tests/lang_callable/macros/tmacrostmt.nim
+++ b/tests/lang_callable/macros/tmacrostmt.nim
@@ -114,8 +114,6 @@ proc fn6() =
 
 #------------------------------------
 # bug #10807
-proc fn_unsafeaddr(x: int): int =
-  cast[int](unsafeAddr(x))
 
 static:
   let fn1s = "proc fn1(x, y: int): int =\n  result = 2 * (x + y)\n"
@@ -124,7 +122,6 @@ static:
   let fn4s = "proc fn4(x: int): int =\n  if x mod 2 == 0:\n    return x + 2\n  else:\n    return 0\n"
   let fn5s = "proc fn5(a, b: float): float =\n  result = -a * a / (b * b)\n"
   let fn6s = "proc fn6() =\n  var a = @[1.0, 2.0]\n  let z = a{0, 1}\n  a{2} = 5.0\n"
-  let fnAddr = "proc fn_unsafeaddr(x: int): int =\n  result = cast[int](unsafeAddr(x))\n"
 
   doAssert fn1.repr_to_string == fn1s
   doAssert fn2.repr_to_string == fn2s
@@ -132,7 +129,6 @@ static:
   doAssert fn4.repr_to_string == fn4s
   doAssert fn5.repr_to_string == fn5s
   doAssert fn6.repr_to_string == fn6s
-  doAssert fn_unsafeaddr.repr_to_string == fnAddr
 
 #------------------------------------
 # bug #8763


### PR DESCRIPTION
## Summary

In typed AST, address-of operations are now *always* represented by
`nkAddr` trees. This simplifies some compiler logic, makes processing
for typed macros easier, and fixes an effect tracking bug with `addr`.

## Details

This is effectively a revert of
https://github.com/nim-lang/nim/pull/10814.
Not turning calls to `mAddr` into `nkAddr` was done to prevent the
unsafe address semantics from being lost, but those no longer exist.

Lowering the call into an `nkAddr` tree has the benefit that it
simplifies AST analysis and processing, as address-of operation can now
always be detected by `PNode.kind == nkAddr`. Old code for detecting
`mAddr` magic calls is removed.

The effect tracking in `sempass2` had no special case for `mAddr`
calls, thus treating them as normal calls, which led to `addr(x)` being
treated as an indirect invocation of `x`, when `x` is of procedural
type. With the `mAddr` call now being lowered earlier, this is no
longer the case.