### PR TITLE
ci: update minimum x86 macOS version to 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             },
             {
               "name": "macOS",
-              "runner": "macos-12"
+              "runner": "macos-13"
             },
             {
               "name": "macOS (M1)",


### PR DESCRIPTION
## Summary

Change the minimum officially supported x86 macOS version for the
compiler and tooling to 13, as GitHub Actions no longer support version
12.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
* all merging is blocked by the `macos-12` runner image being EOL

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
