### PR TITLE
ci: update x86 macOS to version 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             },
             {
               "name": "macOS",
-              "runner": "macos-12"
+              "runner": "macos-13"
             },
             {
               "name": "macOS (M1)",
@@ -221,9 +221,14 @@ jobs:
         run: |
           brew update
 
-      - name: Add Homebrew libraries to search path (macOS M1)
-        if: runner.os == 'macOS' && runner.arch == 'ARM64'
-        run: echo "DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib" >> "$GITHUB_ENV"
+          # Downgrade to OpenSSL 3.0
+          brew unlink openssl
+          brew install openssl@3.0
+          brew link --overwrite openssl@3.0
+
+      - name: Add Homebrew libraries to search path
+        if: runner.os == 'macOS'
+        run: echo "DYLD_FALLBACK_LIBRARY_PATH=$(brew --prefix)/lib" >> "$GITHUB_ENV"
 
       - name: Install MinGW (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
macOS-12 has been deprecated by GHA and runners requesting those images
no longer run. As such, upgrade our macOS 12 runners to 13.

## Details
* Starting from macOS-13, binaries no longer have default 
`/usr/local/lib`  fallback search path. As such, the brew prefix now has
to be installed as  `DYLD_FALLBACK_LIBRARY_PATH`  for both ARM and x86
runners.

* There are compatibility issues with OpenSSL 3.4.0 installed within the
current macOS images, as such this PR pin version 3.0 instead.