### PR TITLE
Revert "build(deps): Bump softprops/action-gh-release from 2.1.0 to 2.2.0"

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -103,7 +103,7 @@ jobs:
 
       - id: release
         name: Create pre-release
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           prerelease: true
           files: ${{ steps.release-files.outputs.result }}
@@ -120,7 +120,7 @@ jobs:
           failOnError: true
 
       - name: Push changelog
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           tag_name: ${{ steps.release-files.outputs.version }}
           body: ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
This is currently broken, see:
https://github.com/softprops/action-gh-release/issues/556

Reverts https://github.com/nim-works/nimskull#1476