### PR TITLE
ci: install `libpcre3` for leak job

### DIFF
--- a/.github/workflows/leak.yml
+++ b/.github/workflows/leak.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Enable annotations
         run: echo "::add-matcher::.github/nim-problem-matcher.json"
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpcre3
+
       - name: Build release binaries with LeakSanitizer
         run: |
           ./koch.py all-strict \


### PR DESCRIPTION
## Summary

The latest Ubuntu image doesn't seem to ship with `pcre3` anymore,
which the `nimsuggest` tester needs, so the library is now installed
manually.