### PR TITLE
ci: add Linux arm64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
               "runner": "macos-14"
             },
             {
+              "name": "Linux (AArch64)",
+              "runner": "ubuntu-22.04-arm"
+            },
+            {
               "name": "Windows",
               "runner": "windows-2022",
               "batch-count": 3


### PR DESCRIPTION
## Summary

Add arm64 linux builds.

## Details

GitHub recently opened up arm64 Linux machines for free, so taking this
opportunity to start offering arm64 Linux builds.

All that was being done here was adding a new entry to the CI matrix.
The output is based on an Ubuntu 22.04 runtime, and as such will /not/
run on Android or non-GNU systems.

Ref:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/