### PR TITLE
ci: bump ubuntu image to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           [
             {
               "name": "Linux",
-              "runner": "ubuntu-20.04"
+              "runner": "ubuntu-22.04"
             },
             {
               "name": "macOS",


### PR DESCRIPTION
## Summary
Updated x86 Ubuntu images to 22.04.

## Details
GitHub will begin brown-outs of Ubuntu 20 images in March. Migrating to
the newer image to avoid disruption to our CI.

Ref:
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/