### PR TITLE
allow multiple parameters using an underscore as name

### DIFF
--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -207,8 +207,8 @@ proc getNamedParamFromList*(list: PNode, ident: PIdent): PSym =
   ##            if c.instLines: actual.info else: templ.info)
   for i in 1..<list.len:
     let it = list[i].sym
-    if it.name.id == ident.id or
-        sameIgnoreBacktickGensymInfo(it.name.s, ident.s): return it
+    if it.name.s != "_" and (it.name.id == ident.id or
+        sameIgnoreBacktickGensymInfo(it.name.s, ident.s)): return it
 
 proc hashNode(p: RootRef): Hash =
   result = hash(cast[pointer](p))

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -51,7 +51,11 @@ proc mangleParamName(c: ConfigRef; s: PSym): Rope =
   ## we cannot use 'sigConflicts' here since we don't have access to a BProc.
   ## Fortunately C's scoping rules are sane enough so that that doesn't
   ## cause any trouble.
-  if true:
+  if s.name.s == "_":
+    # multiple parameters can use an underscore as the name. Construct a
+    # locally unique C name by appending the parameter position
+    result = "_p" & $s.position
+  else:
     var res = s.name.s.mangle
     if isKeyword(s.name) or c.cppDefines.contains(res):
       res.add "_0"

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -843,6 +843,7 @@ proc semConstBoolExpr(c: PContext, n: PNode): PNode =
 
 proc semGenericStmt(c: PContext, n: PNode): PNode
 proc semConceptBody(c: PContext, n: PNode): PNode
+proc isDiscardUnderscore(v: PSym): bool
 
 include semtypes, semtempl, semgnrc, semstmts, semexprs
 

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -104,9 +104,7 @@ proc addParamOrResult(c: PContext, param: PSym)
 
 proc instantiateBody(c: PContext, n, params: PNode, result, orig: PSym) =
   if n[bodyPos].kind != nkEmpty:
-    let procParams = result.typ.n
-    for i in 1..<procParams.len:
-      addDecl(c, procParams[i].sym)
+    addParams(c, result.typ.n)
     maybeAddResult(c, result, result.ast)
 
     inc c.inGenericInst

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1589,6 +1589,9 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       if argNode.kind == nkError:
         localReport(c.config, argNode)
 
+      # mark underscore parameters as gensyms:
+      discard isDiscardUnderscore(arg)
+
       if a[j].kind == nkPragmaExpr:
         a[j][1] = pragmaDecl(c, arg, a[j][1], paramPragmas)
         # check if we got any errors and if so report them
@@ -1614,7 +1617,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       inc(counter)
       if def != nil and def.kind != nkEmpty:
         arg.ast = copyTree(def)
-      if containsOrIncl(check, arg.name.id):
+      if arg.name.s != "_" and containsOrIncl(check, arg.name.id):
         localReport(c.config, a[j], reportSym(
           rsemParameterRedefinition, arg))
 

--- a/tests/lang/s02_core/s02_procedures/t99_underscore_parameter.nim
+++ b/tests/lang/s02_core/s02_procedures/t99_underscore_parameter.nim
@@ -1,0 +1,19 @@
+discard """
+  description: '''
+    Multiple parameters can use an underscore as the name, making the
+    parameters inaccessible
+  '''
+"""
+
+proc test1(_: int) = discard
+test1(1)
+
+proc test2(_: int, _: int) = discard
+test2(1, 2)
+
+proc mixed(a: int, _: int) = discard
+mixed(1, 2)
+
+## The same is true for parameters of anonymous procedures.
+let anon = proc(_, _, _: int) = discard
+anon(1, 2, 3)

--- a/tests/lang/s02_core/s02_procedures/t99_underscore_parameter_cannot_reference.nim
+++ b/tests/lang/s02_core/s02_procedures/t99_underscore_parameter_cannot_reference.nim
@@ -1,0 +1,9 @@
+discard """
+  description: '''
+    An underscore parameter cannot be reference in named parameter passing.
+  '''
+  action: reject
+"""
+
+proc test(_: int) = discard
+test(_ = 1)


### PR DESCRIPTION
## Summary

Using an underscore as a parameter's name now makes the symbol
anonymous, allowing multiple parameters to use a single underscore.
This affects all routine definitions as well procedure type.

## Details

The motivation is to not require one to give a name to unused
parameters, which is often the case for procedure type parameters and
sometimes for lambda expression parameters. It also makes the meaning
of a single underscore used in a definition context more consistent. 

In `semProcTypeNode` (which is called for all parameter lists),
`isDiscardUnderscore` is called on the parameter symbol, marking it as
a gensym in case it's an underscore, thus preventing it from later
being added to the symbol table. The manual name check ignores
underscore parameters.

So that underscore parameters cannot be referenced in named parameter
passing, `getNamedParamFromList` ignores underscore parameters.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
* longer term, I think underscores should be handled the same in all
  definition positions (i.e., creating an anonymous entity)

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
