### PR TITLE
lexopt: lexer for command line

### DIFF
--- a/lib/experimental/lexopt.nim
+++ b/lib/experimental/lexopt.nim
@@ -6,9 +6,7 @@
 # See the file "copying.txt", included in this distribution, for
 # details about copyright.
 
-import std/[strutils, options]
-
-## This module provides an user-driven command line lexer.
+## This module provides a user-driven command line lexer.
 ##
 ## Unlike `std/parseopt`, this lexer parses command line tokens as requested
 ## by the caller.
@@ -41,42 +39,44 @@ runnableExamples:
   doAssert opts.color == true
   doAssert opts.output == "outfile.txt"
 
-const ValueDelims* = {':', '='}
-  ## Characters that delimit between the option and its value
+import std/[strutils, options]
+
+const ValueSeparators* = {':', '='}
+  ## Characters that separate an option's name from its value
 
 type
   CmdlineKind* = enum
     cmdEnd ## End of command line
-    cmdLong ## A long option (ie. `--opt`)
-    cmdShort ## A short option (ie. `-o`)
+    cmdLong ## A long option (i.e. `--opt`)
+    cmdShort ## A short option (i.e. `-o`)
     cmdValue ## A value that is not an option
 
   CmdLexer* = object
     cmdline: seq[string] ## The command line to parse
     index: int ## The index of `cmdline` to be processed
-    valueIdx: int ## \
-      ## For long options, the index of `ValueDelims`.
+    valueIdx: int
+      ## For long options, the index of `ValueSeparators`.
       ##
       ## For short options, the index of the next flag to be processed.
       ##
       ## Otherwise, it is unused.
 
   LexError* = object of CatchableError
-    ## Errors occurred while lexing
+    ## Errors occurring during lexing.
 
   UnexpectedValueError* = object of LexError
-    ## A value was provided but was not consumed
+    ## A value was provided but not consumed.
     opt*: string ## The option that a value was provided to
     value*: string ## The provided value
 
 proc initCmdLexer*(args: sink seq[string]): CmdLexer =
   ## Creates a new `CmdLexer`. `args` should be the command line parameters as
-  ## returned by `os.commandLineArgs()`.
+  ## returned by `commandLineParams <os.html#commandLineParams>`_.
   CmdLexer(cmdline: args)
 
 proc initCmdLexer*(args: openArray[string]): CmdLexer =
   ## Creates a new `CmdLexer`. `args` should be the command line parameters as
-  ## returned by `os.commandLineArgs()`.
+  ## returned by `commandLineParams <os.html#commandLineParams>`_.
   CmdLexer(cmdline: @args)
 
 template current(l: CmdLexer): string =
@@ -90,7 +90,7 @@ proc isDash(s: string): bool = s == "-"
 proc isDashDash(s: string): bool = s == "--"
 
 proc prefix*(kind: CmdlineKind): string =
-  ## Return the prefix string for a given command line parameter kind
+  ## Returns the prefix string for a given command line parameter kind.
   case kind
   of cmdLong:
     "--"
@@ -99,7 +99,7 @@ proc prefix*(kind: CmdlineKind): string =
   else:
     ""
 
-func newUnexpectedValueError(opt, value: string): ref UnexpectedValueError =
+func newUnexpectedValueError(opt, value: sink string): ref UnexpectedValueError =
   (ref UnexpectedValueError)(
     msg: "unexpected value '" & value & "' for '" & opt & "'",
     opt: opt,
@@ -118,19 +118,22 @@ proc next*(l: var CmdLexer): (CmdlineKind, string) =
   ##    If this value is not consumed before the next call to `next()`, an error
   ##    will be raised. See below for more details.
   ## 3. `--foo` is treated as a long option with key `foo`.
-  ## 4. `-abco` is treated as into `a`, `b`, `c`, `o` short options, returned
-  ##    one per `next()` call.
-  ## 5. `-abco:foo` and `-abco=foo` are treated as `a`, `b`, `c`, `o` short
-  ##    options, with `foo` being the value of option `o`.
+  ## 4. `-a:foo` and `-a=foo` are treated as short options with key `a` and
+  ##    value `foo`.
+  ## 5. `-a` is treated as a short option with key `a`.
+  ## 6. `-abco` is equivalent to `-a`, `-b`, `-c`, `-o` appearing in sequence.
+  ##    Four calls to `next()` are required to consume `-abco`.
+  ## 7. `-abco:foo` and `-abco=foo` are equivalent to `-a`, `-b`, `-c`,
+  ##    `-o:foo` appearing in sequence.
   ##
   ##    If this value is not consumed before the next call to `next()`, an error
   ##    will be raised. See below for more details
-  ## 6. Everything else is considered values.
+  ## 8. Everything else is considered values.
   ##
-  ## If the previous option have an unconsumed value (eg. `value()` was not
+  ## If the previous option have an unconsumed value (e.g. `value()` was not
   ## called for `--opt:foo`), `UnexpectedValueError` will be raised.
   type
-    LexState {.pure.} = enum
+    LexState = enum
       ## Current lexer state
       Value ## A value that is not an option
       ShortOpt ## A short option
@@ -150,7 +153,7 @@ proc next*(l: var CmdLexer): (CmdlineKind, string) =
       else:
         LexState.Value
     elif l.current.isShortOpt:
-      if l.valueIdx > 0 and l.current[l.valueIdx] in ValueDelims:
+      if l.valueIdx > 0 and l.current[l.valueIdx] in ValueSeparators:
         LexState.ShortValue
       elif not l.current.isDash:
         LexState.ShortOpt
@@ -161,10 +164,13 @@ proc next*(l: var CmdLexer): (CmdlineKind, string) =
 
   case currentState
   of LongOpt:
-    let delimIdx = l.current.find(ValueDelims)
-    if delimIdx > 2:
-      l.valueIdx = delimIdx
-      result = (cmdLong, l.current[2..<delimIdx])
+    let sepIdx = l.current.find(ValueSeparators)
+    if sepIdx > 2:
+      # XXX: It is intentional that `--:` and `--=` is not rejected
+      # and falls into the alternative branch to avoid introducing syntax
+      # errors as a concept. However, this is open to change.
+      l.valueIdx = sepIdx
+      result = (cmdLong, l.current[2..<sepIdx])
     else:
       result = (cmdLong, l.current[2..^1])
       inc l.index
@@ -204,24 +210,21 @@ proc value*(l: var CmdLexer, delimitedOnly = false): Option[string] =
   if l.index < l.cmdline.len:
     # The current index is parsed and contains a value
     if l.valueIdx > 0:
-      # valueIdx is ValueDelims for either `--foo:bar` or `-o:bar`
-      if l.current[l.valueIdx] in ValueDelims:
-        result = some(l.current[l.valueIdx + 1..^1])
-
-      # This is a short option being parsed, return the remainder
-      # as a value if it is valid
+      # valueIdx is ValueSeparators for either `--foo:bar` or `-o:bar`
+      if l.current[l.valueIdx] in ValueSeparators:
+        result = some(l.current[(l.valueIdx + 1)..^1])
       elif not delimitedOnly:
+         # This is a short option being parsed, return the remainder
+         # as a value if it is valid
         result = some(l.current[l.valueIdx..^1])
-
-      # Do nothing otherwise
       else:
+        # Do nothing otherwise
         return
 
       l.valueIdx = 0
       inc l.index
-
-    # The current index is not parsed, treat it as a value if valid
     elif not delimitedOnly:
+      # The current index is not parsed, treat it as a value if valid
       result = some(l.current)
       inc l.index
 
@@ -236,10 +239,11 @@ iterator remaining*(l: var CmdLexer): string =
   ## short option returned and will raise `UnexpectedValueError`.
   if l.valueIdx > 0:
     if l.current.isLongOpt:
-      raise newUnexpectedValueError(l.current[0..<l.valueIdx], l.current[l.valueIdx + 1..^1])
+      raise newUnexpectedValueError(l.current[0..<l.valueIdx],
+                                    l.current[l.valueIdx + 1..^1])
     else:
       let value =
-        if l.current[l.valueIdx] in ValueDelims:
+        if l.current[l.valueIdx] in ValueSeparators:
           l.current[l.valueIdx + 1..^1]
         else:
           l.current[l.valueIdx..^1]

--- a/lib/experimental/lexopt.nim
+++ b/lib/experimental/lexopt.nim
@@ -1,0 +1,251 @@
+#
+#
+#                 NimSkull's runtime library
+#     (c) Copyright 2024 Leorize <leorize+oss@disroot.org>
+#
+# See the file "copying.txt", included in this distribution, for
+# details about copyright.
+
+import std/[strutils, options]
+
+## This module provides an user-driven command line lexer.
+##
+## Unlike `std/parseopt`, this lexer parses command line tokens as requested
+## by the caller.
+runnableExamples:
+  import std/options
+
+  type
+    Opts = object
+      paths: seq[string]
+      color: bool
+      output: string
+
+  var lexer = initCmdLexer(["--color", "/", "-o", "outfile.txt"])
+  var (kind, option) = lexer.next()
+  var opts = Opts()
+  while kind != cmdEnd:
+    if (kind == cmdLong and option == "color") or (kind == cmdShort and option == "c"):
+      opts.color = true
+    elif (kind == cmdLong and option == "output") or (kind == cmdShort and option == "o"):
+      let value = lexer.value()
+      if value.isNone:
+        quit "error: '--output' must be followed by a value"
+      opts.output = value.get()
+    elif kind == cmdValue:
+      opts.paths.add option
+
+    (kind, option) = lexer.next()
+
+  doAssert opts.paths == ["/"]
+  doAssert opts.color == true
+  doAssert opts.output == "outfile.txt"
+
+const ValueDelims* = {':', '='}
+  ## Characters that delimit between the option and its value
+
+type
+  CmdlineKind* = enum
+    cmdEnd ## End of command line
+    cmdLong ## A long option (ie. `--opt`)
+    cmdShort ## A short option (ie. `-o`)
+    cmdValue ## A value that is not an option
+
+  CmdLexer* = object
+    cmdline: seq[string] ## The command line to parse
+    index: int ## The index of `cmdline` to be processed
+    valueIdx: int ## \
+      ## For long options, the index of `ValueDelims`.
+      ##
+      ## For short options, the index of the next flag to be processed.
+      ##
+      ## Otherwise, it is unused.
+
+  LexError* = object of CatchableError
+    ## Errors occurred while lexing
+
+  UnexpectedValueError* = object of LexError
+    ## A value was provided but was not consumed
+    opt*: string ## The option that a value was provided to
+    value*: string ## The provided value
+
+proc initCmdLexer*(args: sink seq[string]): CmdLexer =
+  ## Creates a new `CmdLexer`. `args` should be the command line parameters as
+  ## returned by `os.commandLineArgs()`.
+  CmdLexer(cmdline: args)
+
+proc initCmdLexer*(args: openArray[string]): CmdLexer =
+  ## Creates a new `CmdLexer`. `args` should be the command line parameters as
+  ## returned by `os.commandLineArgs()`.
+  CmdLexer(cmdline: @args)
+
+template current(l: CmdLexer): string =
+  l.cmdline[l.index]
+
+proc isLongOpt*(s: string): bool = s.startsWith("--")
+  ## Returns whether `s` can be parsed as a long option.
+proc isShortOpt*(s: string): bool = s.startsWith('-')
+  ## Returns whether `s` can be parsed as a short option.
+proc isDash(s: string): bool = s == "-"
+proc isDashDash(s: string): bool = s == "--"
+
+proc prefix*(kind: CmdlineKind): string =
+  ## Return the prefix string for a given command line parameter kind
+  case kind
+  of cmdLong:
+    "--"
+  of cmdShort:
+    "-"
+  else:
+    ""
+
+func newUnexpectedValueError(opt, value: string): ref UnexpectedValueError =
+  (ref UnexpectedValueError)(
+    msg: "unexpected value '" & value & "' for '" & opt & "'",
+    opt: opt,
+    value: value
+  )
+
+proc next*(l: var CmdLexer): (CmdlineKind, string) =
+  ## Consume the next option.
+  ##
+  ## The following section describes how various syntaxes are handled:
+  ##
+  ## 1. `--` and `-` are considered values.
+  ## 2. `--foo:bar` and `--foo=bar` are treated as long options with key `foo`
+  ##    and `bar` is considered the value of `foo`.
+  ##
+  ##    If this value is not consumed before the next call to `next()`, an error
+  ##    will be raised. See below for more details.
+  ## 3. `--foo` is treated as a long option with key `foo`.
+  ## 4. `-abco` is treated as into `a`, `b`, `c`, `o` short options, returned
+  ##    one per `next()` call.
+  ## 5. `-abco:foo` and `-abco=foo` are treated as `a`, `b`, `c`, `o` short
+  ##    options, with `foo` being the value of option `o`.
+  ##
+  ##    If this value is not consumed before the next call to `next()`, an error
+  ##    will be raised. See below for more details
+  ## 6. Everything else is considered values.
+  ##
+  ## If the previous option have an unconsumed value (eg. `value()` was not
+  ## called for `--opt:foo`), `UnexpectedValueError` will be raised.
+  type
+    LexState {.pure.} = enum
+      ## Current lexer state
+      Value ## A value that is not an option
+      ShortOpt ## A short option
+      LongOpt ## A long option
+      LongValue ## Value of a long option
+      ShortValue ## Value of a short option
+      Ended ## Nothing left
+
+  let currentState =
+    if l.index >= l.cmdline.len:
+      LexState.Ended
+    elif l.current.isLongOpt:
+      if l.valueIdx > 0:
+        LexState.LongValue
+      elif not l.current.isDashDash:
+        LexState.LongOpt
+      else:
+        LexState.Value
+    elif l.current.isShortOpt:
+      if l.valueIdx > 0 and l.current[l.valueIdx] in ValueDelims:
+        LexState.ShortValue
+      elif not l.current.isDash:
+        LexState.ShortOpt
+      else:
+        LexState.Value
+    else:
+      LexState.Value
+
+  case currentState
+  of LongOpt:
+    let delimIdx = l.current.find(ValueDelims)
+    if delimIdx > 2:
+      l.valueIdx = delimIdx
+      result = (cmdLong, l.current[2..<delimIdx])
+    else:
+      result = (cmdLong, l.current[2..^1])
+      inc l.index
+  of ShortOpt:
+    l.valueIdx = if l.valueIdx == 0: 1 else: l.valueIdx
+    result = (cmdShort, $l.current[l.valueIdx])
+
+    inc l.valueIdx
+    if l.valueIdx >= l.current.len:
+      l.valueIdx = 0
+      inc l.index
+  of Value:
+    result = (cmdValue, l.current)
+    inc l.index
+  of LongValue:
+    raise newUnexpectedValueError(l.current[0..<l.valueIdx], l.current[l.valueIdx + 1..^1])
+  of ShortValue:
+    raise newUnexpectedValueError("-" & $l.current[l.valueIdx - 1], l.current[l.valueIdx + 1..^1])
+  of Ended:
+    result = (cmdEnd, "")
+
+proc value*(l: var CmdLexer, delimitedOnly = false): Option[string] =
+  ## Consume the value for the current option, if any.
+  ##
+  ## The following section describes how various syntaxes are handled:
+  ##
+  ## 1. `--foo:bar` or `--foo=bar` yields `bar` if called after `next()`
+  ##    returns `foo`.
+  ## 2. `-abco:foo` or `-abco=foo` yields foo if called after `next()` returns
+  ##    `o`.
+  ## 3. If `delimitedOnly` is true, syntaxes below will not be considered.
+  ## 4. `-abcooutput.txt` yields `output.txt` if called after `next()` returns
+  ##    `o`.
+  ## 5. The current parameter is treated as a value, regardless of whether it
+  ##    can be considered as an option (ie. `--foo --bar` will yield `--bar` if
+  ##    this procedure is called after `--foo`).
+  if l.index < l.cmdline.len:
+    # The current index is parsed and contains a value
+    if l.valueIdx > 0:
+      # valueIdx is ValueDelims for either `--foo:bar` or `-o:bar`
+      if l.current[l.valueIdx] in ValueDelims:
+        result = some(l.current[l.valueIdx + 1..^1])
+
+      # This is a short option being parsed, return the remainder
+      # as a value if it is valid
+      elif not delimitedOnly:
+        result = some(l.current[l.valueIdx..^1])
+
+      # Do nothing otherwise
+      else:
+        return
+
+      l.valueIdx = 0
+      inc l.index
+
+    # The current index is not parsed, treat it as a value if valid
+    elif not delimitedOnly:
+      result = some(l.current)
+      inc l.index
+
+iterator remaining*(l: var CmdLexer): string =
+  ## Consume the remaining unprocessed parameters.
+  ##
+  ## If the previous option returned from `next()` have a value that was not
+  ## consumed by `value()`, `UnexpectedValueError` will be raised.
+  ##
+  ## As a special case, any short options within a bundle (ie. `-abcde`) that
+  ## have not been processed by `next()` is considered the value of the last
+  ## short option returned and will raise `UnexpectedValueError`.
+  if l.valueIdx > 0:
+    if l.current.isLongOpt:
+      raise newUnexpectedValueError(l.current[0..<l.valueIdx], l.current[l.valueIdx + 1..^1])
+    else:
+      let value =
+        if l.current[l.valueIdx] in ValueDelims:
+          l.current[l.valueIdx + 1..^1]
+        else:
+          l.current[l.valueIdx..^1]
+
+      raise newUnexpectedValueError("-" & $l.current[l.valueIdx - 1], value)
+
+  while l.index < l.cmdline.len:
+    yield move l.current
+    inc l.index

--- a/tests/stdlib/experimental/tlexopt.nim
+++ b/tests/stdlib/experimental/tlexopt.nim
@@ -1,5 +1,6 @@
 discard """
-description: "Tests for the lexopt module"
+  description: "Tests for the lexopt module"
+  targets: "c js vm"
 """
 
 import experimental/lexopt

--- a/tests/stdlib/experimental/tlexopt.nim
+++ b/tests/stdlib/experimental/tlexopt.nim
@@ -1,0 +1,505 @@
+discard """
+description: "Tests for the lexopt module"
+"""
+
+import experimental/lexopt
+import std/[options, sequtils, strutils]
+
+block typicalUsage:
+  ## Samples of typical command lines
+
+  block catLike:
+    ## Unix's cat clone
+    type
+      Option = enum
+        optSqueeze
+        optNonPrinting
+
+    proc parseCmd(cmd: openArray[string]): (set[Option], seq[string]) =
+      var files: seq[string]
+      var opts: set[Option]
+      var lexer = initCmdLexer(cmd)
+      var (kind, option) = lexer.next()
+      while kind != cmdEnd:
+        if (cmdShort, "v") == (kind, option) or (cmdLong, "show-nonprinting") == (kind, option):
+          opts.incl optNonPrinting
+        elif (cmdShort, "s") == (kind, option) or (cmdLong, "squeeze-blank") == (kind, option):
+          opts.incl optSqueeze
+        elif (cmdValue, "--") == (kind, option):
+          for file in lexer.remaining():
+            files.add file
+        elif kind == cmdValue:
+          files.add option
+        else:
+          raise newException(ValueError):
+            "unknown option '" & kind.prefix & option & "'"
+
+        (kind, option) = lexer.next()
+
+      result = (opts, files)
+
+    var (opts, files) = parseCmd(["-v", "-", "--", "--squeeze-blank"])
+    doAssert opts == {optNonPrinting}:
+      "Unexpected value: " & $opts
+    doAssert files == ["-", "--squeeze-blank"]:
+      "Unexpected value: " & $files
+
+    (opts, files) = parseCmd(["-sv", "-"])
+    doAssert opts == {optNonPrinting, optSqueeze}:
+      "Unexpected value: " & $opts
+    doAssert files == ["-"]:
+      "Unexpected value: " & $files
+
+    doAssertRaises(ValueError):
+      discard parseCmd(["-c", "-"])
+
+    doAssertRaises(UnexpectedValueError):
+      discard parseCmd(["--squeeze-blank=no"])
+
+  block seqLike:
+    ## Unix's seq clone
+    type
+      Opts = object
+        format: Option[string]
+        separator: Option[string]
+        sequence: seq[int]
+
+    proc parseCmd(cmd: openArray[string]): Opts =
+      var lexer = initCmdLexer(cmd)
+      var (kind, option) = lexer.next()
+      while kind != cmdEnd:
+        if (kind, option) == (cmdLong, "format") or (kind, option) == (cmdShort, "f"):
+          let value = lexer.value()
+          if value.isNone:
+            raise newException(ValueError):
+              "option requires an argument: " & kind.prefix & option
+          result.format = value
+        elif (kind, option) == (cmdLong, "separator") or (kind, option) == (cmdShort, "s"):
+          let value = lexer.value()
+          if value.isNone:
+            raise newException(ValueError):
+              "option requires an argument: " & kind.prefix & option
+          result.separator = value
+        elif kind == cmdValue:
+          if result.sequence.len < 3:
+            result.sequence.add parseInt(option)
+          else:
+            raise newException(ValueError):
+              "extra operand: " & option
+        else:
+          raise newException(ValueError):
+            "invalid option: " & kind.prefix & option
+
+        (kind, option) = lexer.next()
+
+      if result.sequence.len == 0:
+        raise newException(ValueError):
+          "missing operand"
+
+    var opts = parseCmd(["1"])
+    doAssert opts.format.isNone
+    doAssert opts.separator.isNone
+    doAssert opts.sequence == [1]
+
+    opts = parseCmd(["10", "-f:%02d"])
+    doAssert opts.format == some("%02d"):
+      "Unexpected value: " & $opts.format
+    doAssert opts.separator.isNone
+    doAssert opts.sequence == [10]
+
+    opts = parseCmd(["10", "-f", "-s;"])
+    doAssert opts.format == some("-s;"):
+      "Unexpected value: " & $opts.format
+    doAssert opts.separator.isNone
+    doAssert opts.sequence == [10]
+
+    opts = parseCmd(["10", "-s;", "100"])
+    doAssert opts.format.isNone
+    doAssert opts.separator == some(";"):
+      "Unexpected value: " & $opts.separator
+    doAssert opts.sequence == [10, 100]
+
+block opts:
+  ## Unit tests for the option parser
+  block long:
+    ## Long options
+    block dashdash:
+      ## `--` special case
+      var lexer = initCmdLexer(["--"])
+      let (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdValue, "--")
+      doAssert kind.prefix & option == "--"
+
+    block basic:
+      ## Long option of varying sizes and characters
+      var lexer = initCmdLexer(["--foo", "--yes-i-am-sure", "--d;", "--plus+"])
+      var (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "foo"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--foo"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "yes-i-am-sure"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--yes-i-am-sure"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "d;"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--d;"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "plus+"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--plus+"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdEnd, ""):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == ""
+
+    block values:
+      ## Long options with values and some edge cases
+      var lexer = initCmdLexer([
+        "--foo=bar", "--foo:bar", "--d", "--this-is-value",
+        "--bar=:foobar", "--bar::barfoo", "--=smt", "--:bar"
+      ])
+
+      var (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "foo"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--foo"
+      # inline values are unskippable
+      doAssertRaises(UnexpectedValueError):
+        discard lexer.next()
+      var value = lexer.value()
+      doAssert value == some("bar"):
+        "Unexpected value: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "foo"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--foo"
+      # inline values are unskippable
+      doAssertRaises(UnexpectedValueError):
+        discard lexer.next()
+      value = lexer.value(delimitedOnly = true)
+      doAssert value == some("bar"):
+        "Unexpected value: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "d"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--d"
+      # This option does not have any inline values
+      value = lexer.value(delimitedOnly = true)
+      doAssert value.isNone:
+        "Unexpected values: " & $value
+      value = lexer.value()
+      doAssert value == some("--this-is-value")
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "bar"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--bar"
+      value = lexer.value(delimitedOnly = true)
+      doAssert value == some(":foobar"):
+        "Unexpected values: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "bar"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "--bar"
+      value = lexer.value()
+      doAssert value == some(":barfoo"):
+        "Unexpected values: " & $value
+
+      block edgecases:
+        ## Edge cases, might be subjected to changes in interpretation
+        (kind, option) = lexer.next()
+        doAssert (kind, option) == (cmdLong, "=smt"):
+          "Unexpected values: " & $(kind, option)
+        doAssert kind.prefix & option == "--=smt"
+        value = lexer.value(delimitedOnly = true)
+        doAssert value.isNone
+
+        (kind, option) = lexer.next()
+        doAssert (kind, option) == (cmdLong, ":bar"):
+          "Unexpected values: " & $(kind, option)
+        doAssert kind.prefix & option == "--:bar"
+        value = lexer.value()
+        doAssert value.isNone
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdEnd, ""):
+        "Unexpected values: " & $(kind, option)
+      value = lexer.value()
+      doAssert value.isNone
+
+  block short:
+    # Short options
+    block dash:
+      ## `-` special case
+      var lexer = initCmdLexer(["-"])
+      let (kind, option) = lexer.next()
+      doAssert kind == cmdValue
+      doAssert option == "-"
+      doAssert kind.prefix & option == "-"
+
+    block basic:
+      ## Short options without values
+      var lexer = initCmdLexer(["-a", "-Acd", "-0@-"])
+
+      var (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "a"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "-a"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "A"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "-A"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "c"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "-c"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "d"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "-d"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "0"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "-0"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "@"):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == "-@"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "-"):
+        "Unexpected values: " & $(kind, option)
+      # A bit of an edge case because `--` does not parse as (cmdShort, "-").
+      doAssert kind.prefix & option == "--"
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdEnd, ""):
+        "Unexpected values: " & $(kind, option)
+      doAssert kind.prefix & option == ""
+
+    block values:
+      ## Short options with values
+      var lexer = initCmdLexer([
+        "-o", "out", "-O-", "-d:val", "-abcdef", "-f=false", "-:o", "-="
+      ])
+
+      var (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "o")
+      doAssert kind.prefix & option == "-o"
+      # No inline value for this one
+      var value = lexer.value(delimitedOnly = true)
+      doAssert value.isNone:
+        "Unexpected value: " & $value
+      value = lexer.value()
+      doAssert value == some("out"):
+        "Unexpected value: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "O")
+      doAssert kind.prefix & option == "-O"
+      # Inline values are not considered delimited
+      value = lexer.value(delimitedOnly = true)
+      doAssert value.isNone:
+        "Unexpected value: " & $value
+
+      value = lexer.value()
+      doAssert value == some("-"):
+        "Unexpected value: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "d")
+      doAssert kind.prefix & option == "-d"
+      # Delimited values are unskippable
+      doAssertRaises(UnexpectedValueError):
+        discard lexer.next()
+
+      value = lexer.value()
+      doAssert value == some("val"):
+        "Unexpected value: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "a")
+      doAssert kind.prefix & option == "-a"
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "b")
+      doAssert kind.prefix & option == "-b"
+      # No delimited value here
+      value = lexer.value(delimitedOnly = true)
+      doAssert value.isNone:
+        "Unexpected value: " & $value
+      # Value collects the remaining short ops
+      value = lexer.value()
+      doAssert value == some("cdef"):
+        "Unexpected value: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "f")
+      doAssert kind.prefix & option == "-f"
+      # Delimited values are unskippable
+      doAssertRaises(UnexpectedValueError):
+        discard lexer.next()
+
+      value = lexer.value()
+      doAssert value == some("false"):
+        "Unexpected value: " & $value
+
+      block edgecases:
+        ## Edge cases, interpretation might change
+        (kind, option) = lexer.next()
+        doAssert (kind, option) == (cmdShort, ":")
+        doAssert kind.prefix & option == "-:"
+        # What comes after is not considered to be delimited
+        value = lexer.value(delimitedOnly = true)
+        doAssert value.isNone:
+          "Unexpected value: " & $value
+
+        value = lexer.value()
+        doAssert value == some("o"):
+          "Unexpected value: " & $value
+
+        (kind, option) = lexer.next()
+        doAssert (kind, option) == (cmdShort, "=")
+        doAssert kind.prefix & option == "-="
+        value = lexer.value()
+        doAssert value.isNone:
+          "Unexpected value: " & $value
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdEnd, "")
+      doAssert kind.prefix & option == ""
+      value = lexer.value()
+      doAssert value.isNone:
+        "Unexpected value: " & $value
+
+  block unexpected:
+    ## Tests for UnexpectedValueError exception
+    var lexer = initCmdLexer(["--foo=bar", "-d:foo", "-ab=cdef"])
+    var (kind, option) = lexer.next()
+    doAssert (kind, option) == (cmdLong, "foo")
+
+    try:
+      discard lexer.next()
+      doAssert false, "the previous statement should've raised"
+    except UnexpectedValueError as e:
+      doAssert e.opt == "--foo"
+      doAssert e.value == "bar"
+
+    discard lexer.value()
+
+    (kind, option) = lexer.next()
+    doAssert (kind, option) == (cmdShort, "d")
+    try:
+      discard lexer.next()
+      doAssert false, "the previous statement should've raised"
+    except UnexpectedValueError as e:
+      doAssert e.opt == "-d"
+      doAssert e.value == "foo"
+
+    discard lexer.value()
+
+    # Test that the option value is correct even for opts within a bundle
+    (kind, option) = lexer.next()
+    doAssert (kind, option) == (cmdShort, "a")
+    (kind, option) = lexer.next()
+    doAssert (kind, option) == (cmdShort, "b")
+    try:
+      discard lexer.next()
+      doAssert false, "the previous statement should've raised"
+    except UnexpectedValueError as e:
+      doAssert e.opt == "-b"
+      doAssert e.value == "cdef"
+
+    discard lexer.value()
+    (kind, option) = lexer.next()
+    doAssert (kind, option) == (cmdEnd, "")
+
+  block remaining:
+    ## Tests for the `remaining()` iterator
+    block allRemaining:
+      ## Use `remaining()` immediately
+      const values = ["-FAl", "--define:x=y", "fun", "--not", "fun", "-cool"]
+      var lexer = initCmdLexer(@values)
+      let collected = toSeq(lexer.remaining())
+      doAssert collected == values:
+        "Unexpected value: " & $collected
+
+      let (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdEnd, "")
+
+    block afterOpts:
+      ## Use `remaining()` after stepping
+      const values = ["-it-s", "free", "--real", "estate"]
+      var lexer = initCmdLexer(@["-1", "--second"] & @values)
+
+      var (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "1"):
+        "Unexpected value: " & $(kind, option)
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "second"):
+        "Unexpected value: " & $(kind, option)
+
+      let collected = toSeq(lexer.remaining())
+      doAssert collected == values:
+        "Unexpected value: " & $collected
+
+    block unexpected:
+      ## UnexpectedValueError when remaining() is called where inline values exist
+      var lexer = initCmdLexer(@["-d:useMalloc", "--run:false", "-bundle"])
+
+      var (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "d"):
+        "Unexpected value: " & $(kind, option)
+      try:
+        for _ in lexer.remaining():
+          doAssert false, "unreachable"
+        doAssert false, "the previous call should've failed"
+      except UnexpectedValueError as e:
+        doAssert e.opt == "-d"
+        doAssert e.value == "useMalloc"
+
+      discard lexer.value()
+
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdLong, "run"):
+        "Unexpected value: " & $(kind, option)
+      try:
+        for _ in lexer.remaining():
+          doAssert false, "unreachable"
+        doAssert false, "the previous call should've failed"
+      except UnexpectedValueError as e:
+        doAssert e.opt == "--run"
+        doAssert e.value == "false"
+
+      discard lexer.value()
+
+      # Special case: unconsumed bundle is treated as inline value
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "b"):
+        "Unexpected value: " & $(kind, option)
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "u"):
+        "Unexpected value: " & $(kind, option)
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "n"):
+        "Unexpected value: " & $(kind, option)
+      try:
+        for _ in lexer.remaining():
+          doAssert false, "unreachable"
+        doAssert false, "the previous call should've failed"
+      except UnexpectedValueError as e:
+        doAssert e.opt == "-n"
+        doAssert e.value == "dle"


### PR DESCRIPTION
## Summary
Introduce an experimental command line lexer  `lexopt` , meant to
replace  `parseopt`  in all use cases.

## Details

`lexopt`  is an user-driven lexer, where the next token interpretation
is decided by the user at runtime. This was originally designed to
supplement a command line parser implementation, but I've found that
this design is easier to work with for almost all use cases compared to 
`parseopt` .

### Improvements over `parseopt`

#### Support for  `--input in.txt`  and  `-ooutput.txt`  syntax without
explicit declaration

Unlike  `parseopt` , where  `shortNoVal`  and  `longNoVal`  must be
declared ahead of time to support such syntax,  `lexopt`  can handle
these cases dynamically through  `value()` . This removes the burden of
maintaining multiple sources of truth, and allow command line parsers to
dictate the parsing strategy dynamically.

Example:

```nim
import std/parseopt
import std/options
import experimental/lexopt

const TestCmd = @["-j4", "-b", "not_an_arg"]

type Opts = object
  j: string
  arg: string
  b: bool

proc popt(): Opts =
  var parser = initOptParser(
    TestCmd,
    shortNoVal = {'b'} # -b has to be declared as "not having a value"
  )
  while (parser.next(); parser.kind != parseopt.cmdEnd):
    if (parseopt.cmdShortOption, "j") == (parser.kind, parser.key):
      result.j = parser.val
    elif (parseopt.cmdShortOption, "b") == (parser.kind, parser.key):
      result.b = true
    elif parser.kind == cmdArgument:
      result.arg = parser.key

proc lopt(): Opts =
  var lex = initCmdLexer(TestCmd)
  while (let (kind, option) = lex.next(); kind != lexopt.cmdEnd):
    if (lexopt.cmdShort, "j") == (kind, option):
      result.j = lex.value().get() # .value() returns Option[string]
    elif (lexopt.cmdShort, "b") == (kind, option):
      result.b = true
    elif kind == lexopt.cmdValue:
      result.arg = option

doAssert popt() == lopt()
```

#### Option values can be tested for "empty" vs "unspecified"

`lexopt` 's  `value()`  function returns  `Option[string]` , allowing
programs to distinguish between having a value and not having one. 
`parseopt`  has no equivalence.

Example:

```nim
import std/parseopt
import std/options
import experimental/lexopt

const TestCmdNoVal = @["--separator"]
const TestCmdVal = @["--separator="]

type Opts = object
  separator: Option[string]

proc popt(args: openArray[string]): Opts =
  var parser = initOptParser(args)
  while (parser.next(); parser.kind != parseopt.cmdEnd):
    if (parseopt.cmdLongOption, "separator") == (parser.kind, parser.key):
      result.separator = some parser.val # not possible to yield None

proc lopt(args: openArray[string]): Opts =
  var lex = initCmdLexer(args)
  while (let (kind, option) = lex.next(); kind != lexopt.cmdEnd):
    if (lexopt.cmdLong, "separator") == (kind, option):
      result.separator = lex.value()

doAssert popt(TestCmdVal) == lopt(TestCmdVal)

doAssert lopt(TestCmdNoVal).separator == none(string)
# doAssert popt(TestCmdNoVal).separator == none(string) # This will fail
```

#### Forced handling of unexpected option values

Unlike  `parseopt` , where all flags are "assumed" to take a value and
require explicit code to check for unexpected values,  `lexopt` 
requires values to be handled should it exists.  `UnexpectedValueError` 
will be raised for any option with values that were not handled.

This mainly benefits handwritten command line parsers, where the
alternative is to add value existence checking code to all options not
expecting one.

Example:

```nim
import experimental/lexopt

const TestCmd = @["--dont-take-val="]

proc main() =
  var lex = initCmdLexer(TestCmd)
  while (let (kind, _) = lex.next(); kind != lexopt.cmdEnd):
    discard

doAssertRaises(UnexpectedValueError):
  main()
```

#### Miscellaneous improvements

- Support for zero-copy ownership takeover:  `initCmdLexer()`  can
consume a  `seq[string]`  directly.
-  `-`  and  `--`  are treated as  `cmdValue` s directly and not as
special cases (ie.  `(parseopt.cmdLongOption, "")`  or 
`(parseopt.cmdShortOption, "")` ).
-  `remaining()`  consuming iterator allows for iterating through
not-yet-parsed arguments without allocating any  `seq` s. The iterator
will prioritize moving values where applicable.