### PR TITLE
compiler: add the `--timetrace` switch

### DIFF
--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -48,6 +48,7 @@ import
     pathutils,
     astrepr,
     idioms,
+    tracer
   ]
 
 type
@@ -2318,6 +2319,7 @@ proc parseAll(p: var Parser): ParsedNode =
 proc parseTopLevelStmt(p: var Parser): ParsedNode =
   ## Implements an iterator which, when called repeatedly, returns the next
   ## top-level statement or emptyNode if end of stream.
+  p.lex.config.timeTracer.traceLoc(tikParser, p.lex.getLineInfo(p.tok))
   result = p.emptyNode
   # progress guaranteed
   while true:

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -48,7 +48,8 @@ import
   ],
   compiler/utils/[
     containers,
-    idioms
+    idioms,
+    tracer
   ]
 
 export TranslationConfig
@@ -350,7 +351,8 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
   if shouldInjectDestructorCalls(prc):
     block:
       var c = initChangeset(body)
-      injectDestructorCalls(body.code, graph, env, c)
+      graph.config.timeTracer.traceSym(tikInjectDestr, prc):
+        injectDestructorCalls(body.code, graph, env, c)
       # XXX: ``vmgen`` doesn't support the code resulting from the switch
       #      lowering, so branch destructors are disabled for the VM target
       #      at the moment
@@ -360,7 +362,8 @@ proc process(body: var MirBody, prc: PSym, graph: ModuleGraph,
 
     # hook injection needs to happen *after* move analysis and destroy
     # injection
-    injectHooks(body, graph, env, prc)
+    graph.config.timeTracer.traceSym(tikInjectDestr, prc):
+      injectHooks(body, graph, env, prc)
 
     if graph.config.arcToExpand.hasKey(prc.name.s):
       graph.config.msgWrite("--expandArc: " & prc.name.s & "\n")
@@ -386,14 +389,17 @@ proc translate*(id: ProcedureId, body: PNode, graph: ModuleGraph,
   if optCursorInference in graph.config.options and
       shouldInjectDestructorCalls(prc):
     # TODO: turn cursor inference into a MIR pass and remove this part
+    graph.config.timeTracer.traceStr("cursors")
     computeCursors(prc, body, graph)
 
   echoInput(graph.config, prc, body)
-  result = generateCode(graph, env, prc, config.tconfig, body)
+  graph.config.timeTracer.traceSym(tikMirgen, prc):
+    result = generateCode(graph, env, prc, config.tconfig, body)
   echoMir(graph.config, prc, result, env)
 
   # now apply the passes:
-  process(result, prc, graph, idgen, env)
+  graph.config.timeTracer.traceSym(tikPasses, prc):
+    process(result, prc, graph, idgen, env)
 
 proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
                  owner: PSym, body: sink MirBody): Body =

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -393,8 +393,7 @@ proc translate*(id: ProcedureId, body: PNode, graph: ModuleGraph,
     computeCursors(prc, body, graph)
 
   echoInput(graph.config, prc, body)
-  graph.config.timeTracer.traceSym(tikMirgen, prc):
-    result = generateCode(graph, env, prc, config.tconfig, body)
+  result = generateCode(graph, env, prc, config.tconfig, body)
   echoMir(graph.config, prc, result, env)
 
   # now apply the passes:

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -68,7 +68,8 @@ import
     idioms,
     pathutils,
     platform,
-    ropes
+    ropes,
+    tracer
   ]
 
 import std/options as std_options
@@ -254,6 +255,7 @@ proc processEvent(g: BModuleList, inl: var InliningData,
       body = generateIR(g.graph, bmod.idgen, g.env, evt.sym, evt.body)
       p    = startProc(bmod, evt.id, body)
 
+    g.graph.config.timeTracer.traceSym(tikCodegen, evt.sym)
     # we can't generate with ``genProc`` because we still need to output
     # the mangled names
     genStmts(p, p.body.code)

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -53,7 +53,8 @@ import
     ropes,
     pathutils,
     idioms,
-    int128
+    int128,
+    tracer
   ],
   compiler/sem/[
     rodutils,
@@ -819,6 +820,7 @@ proc finishProc*(p: BProc, id: ProcedureId): string =
 proc genProc*(m: BModule, id: ProcedureId, procBody: sink Body): Rope =
   ## Generates the code for the procedure `id`, where `procBody` is the code
   ## of the body with all applicable lowerings and transformation applied.
+  m.config.timeTracer.traceSym(tikCodegen, m.g.env[id])
   let p = startProc(m, id, procBody)
   genStmts(p, p.body.code)
   result = finishProc(p, id)
@@ -1218,6 +1220,8 @@ proc writeModule(m: BModule) =
   onExit()
 
 proc cgenWriteModules*(backend: RootRef, config: ConfigRef) =
+  config.timeTracer.traceStr("cgenWriteModules")
+
   let g = BModuleList(backend)
   g.config = config
 

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -16,7 +16,8 @@ import
   compiler/utils/[
     ropes,
     platform,
-    pathutils
+    pathutils,
+    tracer
   ],
   compiler/ast/[
     lineinfos,
@@ -752,6 +753,7 @@ proc getExtraCmds(conf: ConfigRef; output: AbsoluteFile): seq[string] =
       result.add "dsymutil " & $(output).quoteShell
 
 proc execLinkCmd(conf: ConfigRef; linkCmd: string) =
+  conf.timeTracer.traceStr(tikBackend, "link")
   tryExceptOSErrorMessage(conf, "invocation of external linker program failed."):
     execExternalProgram(conf, linkCmd, rcmdLinking)
 
@@ -845,6 +847,7 @@ proc callCCompiler*(conf: ConfigRef) =
       script.add("\n")
 
   if optCompileOnly notin conf.globalOptions:
+    conf.timeTracer.traceStr(tikBackend, "compile C")
     execCmdsInParallel(conf, cmds, prettyCb)
   if optNoLinking notin conf.globalOptions:
     # call the linker:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -56,7 +56,8 @@ import
     idioms,
     int128,
     nversion,
-    ropes
+    ropes,
+    tracer
   ],
   compiler/backend/[
     cgir,
@@ -2309,6 +2310,7 @@ proc handleRequestArrayConstr(g: PGlobals, graph: ModuleGraph) =
 
 proc genProc*(g: PGlobals, module: BModule, id: ProcedureId,
               body: sink Body): Rope =
+  module.graph.config.timeTracer.traceSym(tikCodegen, g.env[id])
   handleRequestArrayConstr(g, module.graph)
   var p = startProc(g, module, id, body)
   p.nested: genStmts(p, p.fullBody.code.kids)

--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -58,6 +58,8 @@ type
     optProfileVM              ## enable VM profiler
     optEnableDeepCopy         ## ORC specific: enable 'deepcopy' for all types
     optCmdExitGcStats         ## print gc stats as part of command exit
+    optTimeTrace              ## create a trace of where the compiler spends
+                              ## its time
 
   TGlobalOptions* = set[TGlobalOption]
 

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -13,7 +13,7 @@ when not defined(nimcore):
   {.error: "nimcore MUST be defined for Nim's core tooling".}
 
 import
-  std/[sequtils, strutils, os, times, tables, sha1, with, json],
+  std/[sequtils, strutils, streams, os, times, tables, sha1, with, json],
   compiler/ast/[
     llstream,    # Input data stream
     ast,
@@ -53,6 +53,7 @@ import
     astrepr,     # Output parsed data, for compiler development
     idioms,
     tracer,
+    trace_dump
   ],
   compiler/vm/[
     compilerbridge, # Configuration file evaluation, `nim e`
@@ -705,6 +706,14 @@ proc mainCommand*(graph: ModuleGraph) =
 
   if optProfileVM in conf.globalOptions:
     conf.writeln cmdOutUserProf, dumpVmProfilerData(graph)
+
+  if optTimeTrace in conf.globalOptions:
+    conf.timeTracer.finish()
+    let suffix = now().format("YYYY-MM-dd'T'HH-mm-ss")
+    let name = RelativeFile(conf.projectName & "_trace" & suffix & ".json")
+    let f = newFileStream(string(conf.projectPath / name), fmWrite)
+    writeToStream(conf.timeTracer, f)
+    f.close()
 
   if conf.errorCounter == 0 and conf.cmd notin {cmdTcc, cmdDump, cmdNop}:
     if conf.isEnabled(rintSuccessX):

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -52,6 +52,7 @@ import
     pathutils,   # Input file handling
     astrepr,     # Output parsed data, for compiler development
     idioms,
+    tracer,
   ],
   compiler/vm/[
     compilerbridge, # Configuration file evaluation, `nim e`
@@ -211,7 +212,8 @@ proc commandCompileToC(graph: ModuleGraph) =
   if not extccomp.ccHasSaneOverflow(conf):
     conf.defineSymbol("nimEmulateOverflowChecks")
 
-  compileProject(graph)
+  graph.config.timeTracer.traceStr("compile"):
+    compileProject(graph)
   prepareForCodegen(graph)
   if conf.symbolFiles == disabledSf:
     cbackend2.generateCode(graph, graph.takeModuleList())

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -9,7 +9,7 @@
 
 import
   std/[os, strutils, strtabs, sets, tables, packedsets],
-  compiler/utils/[prefixmatches, pathutils, platform],
+  compiler/utils/[prefixmatches, pathutils, platform, tracer],
   compiler/ast/[lineinfos],
   compiler/modules/nimpaths
 
@@ -324,6 +324,9 @@ type
     toDebugIr*: set[IrName]
       ## the IRs which should always be always printed to the standard
       ## output
+    timeTracer*: Tracer
+      ## global instance of the time tracer, for creating an execution time
+      ## trace
 
     when defined(nimDebugUnreportedErrors):
       unreportedErrors*: OrderedTable[NodeId, PNode]

--- a/compiler/front/optionsprocessor.nim
+++ b/compiler/front/optionsprocessor.nim
@@ -154,7 +154,6 @@ type
     cmdSwitchExperimental
     cmdSwitchExceptions
     cmdSwitchCppdefine
-    cmdSwitchSeqsv2
     cmdSwitchStylecheck
     cmdSwitchShowallmismatches
     cmdSwitchDocinternal
@@ -171,6 +170,7 @@ type
     cmdSwitchProjStdin
     cmdSwitchCmdexitgcstats
     cmdSwitchShowIr
+    cmdSwitchTimeTrace
     cmdSwitchConfigVar
 
   # Full list of all the command line options.
@@ -284,7 +284,6 @@ type
     fullSwitchTxtExperimental        = "experimental"
     fullSwitchTxtExceptions          = "exceptions"
     fullSwitchTxtCppdefine           = "cppdefine"
-    fullSwitchTxtSeqsv2              = "seqsv2"
     fullSwitchTxtStylecheck          = "stylecheck"
     fullSwitchTxtShowallmismatches   = "showallmismatches"
     fullSwitchTxtDocinternal         = "docinternal"
@@ -300,6 +299,7 @@ type
     fullSwitchTxtDeepcopy            = "deepcopy"
     fullSwitchTxtCmdexitgcstats      = "cmdexitgcstats"
     fullSwitchShowIr                 = "showir"
+    fullSwitchTxtTimeTrace           = "timetrace"
     smolSwitchTxtProjStdin           = ""               # `nim c -r -`, the `-` gets stripped
     fullSwitchTxtConfigVar           = "*.*"            # cfg var dummy entry
     fullSwitchTxtInvalid             = "!ERROR!"
@@ -412,7 +412,6 @@ const
       cmdSwitchExperimental       : {fullSwitchTxtExperimental},
       cmdSwitchExceptions         : {fullSwitchTxtExceptions},
       cmdSwitchCppdefine          : {fullSwitchTxtCppdefine},
-      cmdSwitchSeqsv2             : {fullSwitchTxtSeqsv2},
       cmdSwitchStylecheck         : {fullSwitchTxtStylecheck},
       cmdSwitchShowallmismatches  : {fullSwitchTxtShowallmismatches},
       cmdSwitchDocinternal        : {fullSwitchTxtDocinternal},
@@ -429,6 +428,7 @@ const
       cmdSwitchProjStdin          : {smolSwitchTxtProjStdin},
       cmdSwitchCmdexitgcstats     : {fullSwitchTxtCmdexitgcstats},
       cmdSwitchShowIr             : {fullSwitchShowIr},
+      cmdSwitchTimeTrace          : {fullSwitchTxtTimeTrace},
       cmdSwitchConfigVar          : {fullSwitchTxtConfigVar},
     ]
 
@@ -1650,6 +1650,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass,
     else:
       # IR debugging is enabled only for the specific procedure
       conf.toDebugProc[name] = $ir # use the canonical name
+  of "timetrace":
+    setSwitchAndSrc cmdSwitchTimeTrace
+    processOnOffSwitchG(conf, {optTimeTrace}, arg, switch)
   else:
     if strutils.find(switch, '.') >= 0:
       setSwitchAndSrc cmdSwitchConfigVar

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -93,7 +93,8 @@ import
   ],
   compiler/utils/[
     containers,
-    idioms
+    idioms,
+    tracer
   ]
 
 import std/options as std_options
@@ -2439,6 +2440,7 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
   # XXX: this assertion can currently not be used, as the ``nfTransf`` flag
   #      might no longer be present after the lambdalifting pass
   #assert nfTransf in body.flags, "transformed AST is expected as input"
+  graph.config.timeTracer.traceSym(tikMirgen, owner)
 
   var c = initCtx(graph, config, owner, move env)
   c.sp.active = (body, c.sp.map.add(body))
@@ -2530,6 +2532,7 @@ proc exprToMir*(graph: ModuleGraph, env: var MirEnv,
   ## Only meant to be used by `vmjit <#vmjit>`_. Produces a MIR body for a
   ## standalone expression. The result of the expression is assigned to the
   ## special local with ID 0.
+  graph.config.timeTracer.traceLoc(tikMirgen, e.info)
   var c = initCtx(graph, config, nil, move env)
   c.sp.active = (e, c.sp.map.add(e))
 

--- a/compiler/modules/modules.nim
+++ b/compiler/modules/modules.nim
@@ -34,7 +34,8 @@ import
     magicsys,
   ],
   compiler/utils/[
-    pathutils
+    pathutils,
+    tracer
   ],
   compiler/ic/[
     replayer
@@ -137,6 +138,7 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags, fr
     let filename = AbsoluteFile toFullPath(graph.config, fileIdx)
     if result == nil:
       result = newModule(graph, fileIdx)
+      graph.config.timeTracer.traceSym(tikModule, result)
       result.flags.incl flags
       registerModule(graph, result)
       processModuleAux("import")

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -31,7 +31,8 @@ import
     modulegraphs
   ],
   compiler/utils/[
-    pathutils
+    pathutils,
+    tracer
   ],
   compiler/ast/[
     idents,
@@ -69,6 +70,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef, argv: openArray[string]):
   ## Main entry point to the compiler - dispatches command-line commands
   ## into different subsystems, sets up configuration options for the
   ## `conf`:arg: and so on.
+  conf.timeTracer = startTracer()
   let self = NimProg(
     supportsStdinFile: true,
     processCmdLine: processCmdLine

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -53,7 +53,8 @@ import
     debugutils,
     int128,
     astrepr,
-    idioms
+    idioms,
+    tracer
   ],
   compiler/sem/[
     semfold,
@@ -858,6 +859,7 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   ## accumulator across the various top level statements, modules, and overall
   ## program compilation.
   addInNimDebugUtils(c.config, "semStmtAndGenerateGenerics", n, result)
+  c.config.timeTracer.traceSem(n.kind, n.info)
 
   proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool {.nimcall.} =
     ## true if `n` is an import statement referring to the system module

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3029,6 +3029,8 @@ proc semRoutineDef(c: PContext, n: PNode): PNode =
   result[namePos] =
     semRoutineName(c, n[namePos], kind, allowAnon = kind in AllowAnon)
 
+  c.config.timeTracer.traceSym(tikSem, result[namePos].sym)
+
   if result[namePos].kind == nkError:
     if result[namePos].diag.kind == adSemDefNameSym:
       discard "don't leave early, we can still make progress"
@@ -3048,6 +3050,7 @@ proc semRoutineDef(c: PContext, n: PNode): PNode =
 
 proc evalInclude(c: PContext, n: PNode): PNode =
   proc incMod(c: PContext, n, it, includeStmtResult: PNode) {.nimcall.} =
+    c.config.timeTracer.traceStr(tikInclude, getModuleName(c.config, it))
     let f = checkModuleName(c.config, it)
     if f != InvalidFileIdx:
       addIncludeFileDep(c, f)

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -49,7 +49,8 @@ import
     cgmeth
   ],
   compiler/utils/[
-    idioms
+    idioms,
+    tracer
   ]
 
 from compiler/sem/semdata import makeVarType
@@ -1425,6 +1426,7 @@ proc transformBody*(g: ModuleGraph, idgen: IdGenerator, prc: PSym, body: PNode):
   ## 3. the ``closureiters`` transformation
   ##
   ## Application always happens in that exact order.
+  g.config.timeTracer.traceSym(tikTransform, prc)
   var c = PTransf(graph: g, module: prc.getModule, idgen: idgen)
   (result, c.env) = liftLambdas(g, prc, body, c.idgen)
   result = processTransf(c, result, prc)
@@ -1473,6 +1475,7 @@ proc transformStmt*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode):
   if nfTransf in n.flags:
     result = n
   else:
+    g.config.timeTracer.traceLoc(tikTransform, n.info)
     var c = PTransf(graph: g, module: module, idgen: idgen)
     result = processTransf(c, n, module)
     liftDefer(c, result)
@@ -1484,6 +1487,7 @@ proc transformExpr*(g: ModuleGraph; idgen: IdGenerator; module: PSym, n: PNode):
   if nfTransf in n.flags:
     result = n
   else:
+    g.config.timeTracer.traceLoc(tikTransform, n.info)
     var c = PTransf(graph: g, module: module, idgen: idgen)
     result = processTransf(c, n, module)
     liftDefer(c, result)

--- a/compiler/utils/trace_dump.nim
+++ b/compiler/utils/trace_dump.nim
@@ -40,22 +40,22 @@ proc writeFloat(stream: Stream, val: float) =
 template fieldPart(name: untyped): untyped {.dirty.} =
   '"' & astToStr(name) & "\":"
 
-template intField(name: untyped, val: SomeInteger) =
+template intField(name, val: untyped) =
   mixin stream
   stream.write fieldPart(name)
   stream.write $val
 
-template floatField(name: untyped, val: float) =
+template floatField(name, val: untyped) =
   mixin stream
   stream.write fieldPart(name)
   stream.writeFloat val
 
-template stringField(name: untyped, val: string) =
+template stringField(name, val: untyped) =
   mixin stream
   stream.write fieldPart(name)
   stream.write escapeJson(val)
 
-template rawField(name: untyped, raw: string) =
+template rawField(name, raw: untyped) =
   mixin name
   stream.write fieldPart(name)
   stream.write raw

--- a/compiler/utils/trace_dump.nim
+++ b/compiler/utils/trace_dump.nim
@@ -74,7 +74,7 @@ proc writePayload(stream: Stream, pl: EventPayload) =
     stringField(kind, $pl.nk)
     next()
     intField(line, pl.loc.line)
-  of tikCodegen, tikVmCodegen:
+  of tikCodegen, tikVmCodegen, tikMirgen, tikPasses:
     if pl.sym != nil:
       stringField(name, pl.sym.name.s)
     else:

--- a/compiler/utils/trace_dump.nim
+++ b/compiler/utils/trace_dump.nim
@@ -72,10 +72,13 @@ proc writePayload(stream: Stream, pl: EventPayload) =
   of tikInclude:
     stringField(name, pl.str)
   of tikSem:
-    stringField(kind, $pl.nk)
-    next()
-    intField(line, pl.loc.line)
-  of tikCodegen, tikVmCodegen, tikMirgen, tikPasses:
+    if pl.sym != nil:
+      stringField(name, pl.sym.name.s)
+    else:
+      stringField(kind, $pl.nk)
+      next()
+      intField(line, pl.loc.line)
+  of tikCodegen, tikVmCodegen, tikMirgen, tikPasses, tikTransform, tikVm:
     if pl.sym != nil:
       stringField(name, pl.sym.name.s)
     else:

--- a/compiler/utils/trace_dump.nim
+++ b/compiler/utils/trace_dump.nim
@@ -20,12 +20,13 @@ import
   std/[
     monotimes,
     times,
-    strutils,
     streams
   ],
   compiler/utils/[
     tracer
   ]
+
+from std/json import escapeJson
 
 const
   BeginPhase = "\"B\""
@@ -52,7 +53,7 @@ template floatField(name: untyped, val: float) =
 template stringField(name: untyped, val: string) =
   mixin stream
   stream.write fieldPart(name)
-  stream.write escape(val)
+  stream.write escapeJson(val)
 
 template rawField(name: untyped, raw: string) =
   mixin name

--- a/compiler/utils/trace_dump.nim
+++ b/compiler/utils/trace_dump.nim
@@ -74,8 +74,6 @@ proc writePayload(stream: Stream, pl: EventPayload) =
     stringField(kind, $pl.nk)
     next()
     intField(line, pl.loc.line)
-  of tikNimScript:
-    stringField(file, pl.str)
   of tikCodegen, tikVmCodegen:
     if pl.sym != nil:
       stringField(name, pl.sym.name.s)

--- a/compiler/utils/tracer.nim
+++ b/compiler/utils/tracer.nim
@@ -130,6 +130,13 @@ template traceLoc*(t: var Tracer, k: TracedItemKind, l: TLineInfo) =
   t.record(true, p)
   defer: t.record(false, p)
 
+template traceLoc*(t: var Tracer, k: TracedItemKind, l: TLineInfo, body) =
+  bind addPayload, record
+  let p = t.addPayload EventPayload(kind: k, loc: l)
+  t.record(true, p)
+  body
+  t.record(false, p)
+
 template traceSym*(t: var Tracer, k: TracedItemKind, s: PSym) =
   bind addPayload, record
   let p = t.addPayload EventPayload(kind: k, sym: s)

--- a/compiler/utils/tracer.nim
+++ b/compiler/utils/tracer.nim
@@ -30,6 +30,8 @@ type
     tikTransform   = "Transform" # ``transf`` is invoked
     tikCodegen     = "Codegen" # an event related to code-generation for the
                                # target language
+    tikMirgen      = "Mir"     # mirgen is invoked
+    tikPasses      = "Passes"  # all MIR passes are run for a procedure
     tikInjectDestr = "InjectDestructors"
     tikBackend     = "Backend" # the backend is invoked (e.g. the C compiler or
                                # linker)

--- a/compiler/utils/tracer.nim
+++ b/compiler/utils/tracer.nim
@@ -19,7 +19,6 @@ type
     ## Used to loosely group events together (the kind is used as the event name
     ## in the output). This likely needs a complete redesign - the only goal so
     ## far was to make the output readable
-    tikNimScript   = "NimScript" # an event related to NimScript processing
     tikParser      = "Parser"
     tikModule      = "Module"  # a module is imported
     tikInclude     = "Include" # a module is included

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -41,7 +41,8 @@ import
   ],
   compiler/utils/[
     debugutils,
-    idioms
+    idioms,
+    tracer
   ],
   compiler/vm/[
     vmcompilerserdes,
@@ -407,6 +408,7 @@ proc evalStmt(jit: var JitState, c: var TCtx, n: PNode): PNode =
   let n = transformExpr(c.graph, c.idgen, c.module, n)
   let info = genStmt(jit, c, n).returnOnErr(c.config, n)
 
+  c.config.timeTracer.traceLoc(tikVm, n.info)
   # execute new instructions; this redundant opcEof check saves us lots
   # of allocations in 'execute':
   if c.code[info.start].opcode != opcEof:
@@ -495,6 +497,7 @@ proc eval(jit: var JitState, c: var TCtx; prc: PSym, n: PNode): PNode =
     else:
       mkCallback(c, r): newNodeI(nkEmpty, n.info)
 
+  c.config.timeTracer.traceLoc(tikVm, n.info)
   let thread = initVmThread(c, start, regCount, prc)
   result = execute(jit, c, thread, cb).unpackResult(c.config, n)
 
@@ -589,7 +592,8 @@ proc evalMacroCall*(jit: var JitState, c: var TCtx, call, args: PNode,
       setupMacroParam(thread.regs[idx], jit, c, args[idx - 1], gp[i].sym.typ)
 
   let cb = mkCallback(c, r): r.nimNode
-  result = execute(jit, c, thread, cb).unpackResult(c.config, call)
+  c.config.timeTracer.traceSym(tikVm, sym):
+    result = execute(jit, c, thread, cb).unpackResult(c.config, call)
 
   if result.kind != nkError and cyclicTree(result):
     result = c.config.newError(call, PAstDiag(kind: adCyclicTree))

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -40,7 +40,8 @@ import
   ],
   compiler/utils/[
     containers,
-    idioms
+    idioms,
+    tracer
   ],
   compiler/vm/[
     identpatterns,
@@ -126,9 +127,9 @@ proc generateCodeForProc(c: var CodeGenCtx, idgen: IdGenerator, s: PSym,
                          body: sink MirBody): CodeInfo =
   ## Generates and the bytecode for the procedure `s` with body `body`. The
   ## resulting bytecode is emitted into the global bytecode section.
-  let
-    body = generateIR(c.graph, idgen, c.env, s, body)
-    r    = genProc(c, s, body)
+  let body = generateIR(c.graph, idgen, c.env, s, body)
+  c.graph.config.timeTracer.traceSym(tikCodegen, s):
+    let r = genProc(c, s, body)
 
   if r.isOk:
     result = r.unsafeGet

--- a/compiler/vm/vmjit.nim
+++ b/compiler/vm/vmjit.nim
@@ -55,6 +55,9 @@ import
     vmmemory,
     vmtypegen
   ],
+  compiler/utils/[
+    tracer
+  ],
   experimental/[
     results
   ]
@@ -222,8 +225,9 @@ proc gen(jit: var JitState, c: var TCtx, n: PNode, isStmt: bool): VmGenResult =
     body = generateIR(c, jit.gen.env, mirBody)
     start = c.code.len
 
-  # generate the bytecode:
-  let r = runCodeGen(c, jit.gen, body): genStmt(jit.gen, body)
+  c.config.timeTracer.traceLoc(tikVmCodegen, n.info):
+    # generate the bytecode:
+    let r = runCodeGen(c, jit.gen, body): genStmt(jit.gen, body)
 
   if unlikely(r.isErr):
     rewind(jit.gen.env, cp)
@@ -269,12 +273,9 @@ proc genProc(jit: var JitState, c: var TCtx, s: PSym): VmGenResult =
   let outBody = generateIR(c.graph, c.idgen, jit.gen.env, s, mirBody)
   echoOutput(c.config, s, outBody)
 
-  try:
+  c.config.timeTracer.traceSym(tikVmCodegen, s):
     # generate the bytecode:
     result = runCodeGen(c, jit.gen, outBody): genProc(jit.gen, s, outBody)
-  except:
-    # echo render(tree)
-    raise
 
   if unlikely(result.isErr):
     rewind(jit.gen.env, cp)

--- a/tests/compilerfeatures/ttimetrace.nim
+++ b/tests/compilerfeatures/ttimetrace.nim
@@ -1,0 +1,9 @@
+discard """
+  description: "Make sure some code can be compiled with time-tracing enabled"
+  targets: "c js vm"
+  matrix: "--timetrace:on"
+"""
+
+# import some modules so that there's some processing for the compiler
+# to trace
+import std/[strutils, macros]


### PR DESCRIPTION
## Summary

Add the `--timetrace` (`off` by default) switch for enabling or
disabling time tracing in the compiler. When enabled, a `.json`
trace (using the Chrome Trace Event format) of what the compiler did
and when is dumped next to the compiled module.

## Details

The feature is intended to aid compiler development and help users
analyze compile times. It is built upon the existing `tracer` module.

Instrumented are:
* top-level statement parsing
* semantic analysis of top-level statements and routines
* whole module processing
* `transf`
* compile-time code generation and execution
* cursor inference, MIR generation, and MIR processing
* final C, JS, and VM code generation
* backend C compiler and linker invocation

If tracing is disabled, the events are still recorded, but no dump of
them is created. The JSON file name is made up of the project's name
plus the current time and date, so that traces aren't overwritten.

Due to a csources compiler bug, enums used at compile-time as an
array's index type enum can only have 128 elements, and thus the
(unused) `seqsv2` switch had to be removed in order to add the
`timetrace` switch (`CmdSwitchTextKind` is the problematic enum).

### Tracer Adjustments

* the obsolete `tikNimScript` event group is removed
* the `tikMirgen` and `tikPasses` event groups are added
* a `traceLoc` overload accepting a statement to trace is added
* `trace_dump` uses `escapeJson` instead of `escape` to escape strings