### PR TITLE
treat no return type as meaning `void` in type inference

### DIFF
--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -626,17 +626,16 @@ proc procTypeRel(c: var TCandidate, f, a: PType): TTypeRelation =
     for i in 1..<f.len:
       checkParam(f[i], a[i])
 
-    if f[0] != nil and a[0] != nil:
-      # both have return types
-      if a[0].kind == tyUntyped:
-        # special handling for the return type: if `a` is 'auto' we first
-        # instantiate the procedure passed as the argument
-        result = isBothMetaConvertible
-      else:
-        checkParam(f[0], a[0])
-    elif a[0] != f[0]:
-      # one has a void return type while the other doesn't
-      return isNone
+    let
+      aret = if a[0] == nil: c.c.voidType else: a[0]
+      fret = if f[0] == nil: c.c.voidType else: f[0]
+
+    if aret.kind == tyUntyped:
+      # special handling for the return type: if `a` is 'auto' we first
+      # instantiate the procedure passed as the argument
+      result = isBothMetaConvertible
+    else:
+      checkParam(fret, aret)
 
     result = getProcConvMismatch(c.c.config, f, a, result)[1]
 

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -212,7 +212,8 @@ proc map*[T](self: Option[T], callback: proc (input: T)) {.inline.} =
   if self.isSome:
     callback(self.val)
 
-proc map*[T, R](self: Option[T], callback: proc (input: T): R): Option[R] {.inline.} =
+proc map*[T; R: not void](self: Option[T], callback: proc (input: T): R
+                         ): Option[R] {.inline.} =
   ## Applies a `callback` function to the value of the `Option` and returns an
   ## `Option` containing the new value.
   ##

--- a/tests/typerel/tproc_type_inference_3.nim
+++ b/tests/typerel/tproc_type_inference_3.nim
@@ -6,7 +6,7 @@ discard """
 """
 
 proc generic[T](x: T): auto =
-  echo x
+  discard
 
 proc test(x: proc(x: int)) =
   x(1)

--- a/tests/typerel/tproc_type_inference_3.nim
+++ b/tests/typerel/tproc_type_inference_3.nim
@@ -1,0 +1,15 @@
+discard """
+  description: '''
+    A generic procedure expression with an `auto` return type can match against
+    a procedure type with no return type
+  '''
+"""
+
+proc generic[T](x: T): auto =
+  echo x
+
+proc test(x: proc(x: int)) =
+  x(1)
+
+# the return type is inferred as void (read, none/empty)
+test generic

--- a/tests/typerel/tproc_type_inference_4.nim
+++ b/tests/typerel/tproc_type_inference_4.nim
@@ -1,0 +1,17 @@
+discard """
+  description: '''
+    A generic parameter can be inferred as `void` from procedure type's return
+    type
+  '''
+"""
+
+proc test[T](x: proc(): T) =
+  doAssert T is void
+  x()
+
+proc voidProc() = discard
+
+# type parameter inference works
+test(voidProc)
+# also works with an explicit type
+test[void](voidProc)


### PR DESCRIPTION
## Summary

During type inference part of overload resolution, a procedure type
with no return type (e.g., `proc()`) is now treated as having return
type `void`.

## Details

### Previous Behaviour

A parameter with procedure type could only match an argument with
procedure if both either have an absent return type (including an
explicit `void`) prior to inference, or not.

A parameter type such as `proc(x: int)` would never match
`proc(x: auto): auto` (where the return type is later inferred as
`void`).

### New Behavior

An absent return type is treated as meaning `void` (for both the
parameter and argument types), meaning that in the aforementioned case,
a match is possible.

### Implementation

The "are both types nil or not nil" guard in `sigmatch.procTypeRel` is
removed. Prior to relating the types, no return types are turned into
`void`, with a cached instance of the void type retrieved from the
module context.

In the `options` module, the `map` procedure accepting a non-`void`
procedure argument now needs to constrain the return type as having to
be non-`void`, otherwise the `map` overload is ambiguous with the one
having a `proc(x: T)` parameter.