### PR TITLE
fix(ci): make package-git respect skip signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
 
   package-git:
     needs: [pre_run]
+    if: needs.pre_run.outputs.skip != 'true'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Add missing skip check to package-git job. This makes sure that draft
PRs don't activate CI.