### PR TITLE
fix(ci): always raise error after printing error logs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,12 +171,11 @@ jobs:
       - name: Run tester
         run: |
           if ! ./koch.py test --batch:"$TEST_BATCH" --tryFailing all; then
-            oldExitCode=$?
             # XXX: Move this to either koch or testament since it's useful.
             echo ===
             echo Errors occured during tests:
             bin/nim r tools/ci_testresults
-            exit $oldExitCode
+            exit 1
           fi
         env:
           TEST_BATCH: ${{ matrix.batch.idx }}_${{ matrix.num-batch }}


### PR DESCRIPTION
## Summary
Fixes a regression from #1475 where failing test runs are still marked
as passing.

Issue was reported by @zerbina on Matrix.

## Details
Due to some bash shenanigans,

    if ! ./koch tests; then
      exitCode=$? # yields 0!
      ...
      exit $exitCode # ends up being "successful"
    fi

while there are ways to workaround this, it doesn't really matter since
GitHub Actions is only looking for a non-zero result, so hard-code 
`exit 1`  instead to force failing the step.