### PR TITLE
sem: wrap expression routine bodies in `return`

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2370,7 +2370,17 @@ proc semProcBody(c: PContext, n: PNode): PNode =
       # are not expressions:
       fixNilType(c, result)
     else:
-      result = semReturn(c, newTreeI(nkReturnStmt, n.info, result))
+      if result.kind == nkStmtListExpr:
+        # in order to preserve doc comments, apply the return to the last
+        # statement in the list, not to the whole list
+        result.transitionSonsKind(nkStmtList)
+        result.typ = nil
+        let last = semReturn(c, newTreeI(nkReturnStmt, n.info, result[^1]))
+        result[^1] = last
+        if last.kind == nkError:
+          result = c.config.wrapError(result)
+      else:
+        result = semReturn(c, newTreeI(nkReturnStmt, n.info, result))
   else:
     result = discardCheck(c, result, {})
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2370,10 +2370,7 @@ proc semProcBody(c: PContext, n: PNode): PNode =
       # are not expressions:
       fixNilType(c, result)
     else:
-      var a = newNodeI(nkAsgn, n.info, 2)
-      a[0] = newSymNode(c.p.resultSym)
-      a[1] = result
-      result = semAsgn(c, a)
+      result = semReturn(c, newTreeI(nkReturnStmt, n.info, result))
   else:
     result = discardCheck(c, result, {})
 

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -2369,18 +2369,17 @@ proc semProcBody(c: PContext, n: PNode): PNode =
       #   # comment
       # are not expressions:
       fixNilType(c, result)
+    elif result.kind == nkStmtListExpr:
+      # in order to preserve doc comments, apply the return to the last
+      # statement in the list, not to the whole list
+      result.transitionSonsKind(nkStmtList)
+      result.typ = nil
+      let last = semReturn(c, newTreeI(nkReturnStmt, n.info, result[^1]))
+      result[^1] = last
+      if last.kind == nkError:
+        result = c.config.wrapError(result)
     else:
-      if result.kind == nkStmtListExpr:
-        # in order to preserve doc comments, apply the return to the last
-        # statement in the list, not to the whole list
-        result.transitionSonsKind(nkStmtList)
-        result.typ = nil
-        let last = semReturn(c, newTreeI(nkReturnStmt, n.info, result[^1]))
-        result[^1] = last
-        if last.kind == nkError:
-          result = c.config.wrapError(result)
-      else:
-        result = semReturn(c, newTreeI(nkReturnStmt, n.info, result))
+      result = semReturn(c, newTreeI(nkReturnStmt, n.info, result))
   else:
     result = discardCheck(c, result, {})
 

--- a/compiler/tools/docgen.nim
+++ b/compiler/tools/docgen.nim
@@ -701,36 +701,6 @@ proc getAllRunnableExamplesImpl(d: PDoc; n: PNode, dest: var ItemPre,
     # change this to `rsStart` if you want to keep generating doc comments
     # and runnableExamples that occur after some code in routine
 
-proc getRoutineBody(n: PNode): PNode =
-  ##[
-  nim transforms these quite differently:
-
-  proc someType*(): int =
-    ## foo
-    result = 3
-=>
-  result =
-    ## foo
-    3;
-
-  proc someType*(): int =
-    ## foo
-    3
-=>
-  ## foo
-  result = 3;
-
-  so we normalize the results to get to the statement list containing the
-  (0 or more) doc comments and runnableExamples.
-  ]##
-  result = n[bodyPos]
-
-  # This won't be transformed: result.id = 10. Namely result[0].kind != nkSym.
-  if result.kind == nkAsgn and result[0].kind == nkSym and
-                               n.len > bodyPos+1 and n[bodyPos+1].kind == nkSym:
-    doAssert result.len == 2
-    result = result[1]
-
 proc getAllRunnableExamples(d: PDoc, n: PNode, dest: var ItemPre) =
   var n = n
   var state = rsStart
@@ -739,7 +709,7 @@ proc getAllRunnableExamples(d: PDoc, n: PNode, dest: var ItemPre) =
   dest.add genComment(d, n)
   case n.kind
   of routineDefs:
-    n = n.getRoutineBody
+    n = n[bodyPos]
     case n.kind
     of nkCommentStmt, nkCallKinds: fn(n, topLevel = false)
     else:

--- a/compiler/tools/suggest.nim
+++ b/compiler/tools/suggest.nim
@@ -81,8 +81,6 @@ proc findDocComment(n: PNode): PNode =
     if result != nil: return
     if n.len > 1:
       result = findDocComment(n[1])
-  elif n.kind in {nkAsgn, nkFastAsgn} and n.len == 2:
-    result = findDocComment(n[1])
 
 proc extractDocComment(g: ModuleGraph; s: PSym): string =
   var n = findDocComment(s.ast)

--- a/tests/lang_callable/macros/tmacrostmt.nim
+++ b/tests/lang_callable/macros/tmacrostmt.nim
@@ -116,9 +116,9 @@ proc fn6() =
 # bug #10807
 
 static:
-  let fn1s = "proc fn1(x, y: int): int =\n  result = 2 * (x + y)\n"
-  let fn2s = "proc fn2(x, y: float): float =\n  result = (y + 2.0 * x) / (x - y)\n"
-  let fn3s = "proc fn3(x, y: int): bool =\n  result = ((x and 3) div 4 or x mod (y xor -1)) == 0 or not contains([1, 2], y)\n"
+  let fn1s = "proc fn1(x, y: int): int =\n  return 2 * (x + y)\n"
+  let fn2s = "proc fn2(x, y: float): float =\n  return (y + 2.0 * x) / (x - y)\n"
+  let fn3s = "proc fn3(x, y: int): bool =\n  return ((x and 3) div 4 or x mod (y xor -1)) == 0 or not contains([1, 2], y)\n"
   let fn4s = "proc fn4(x: int): int =\n  if x mod 2 == 0:\n    return x + 2\n  else:\n    return 0\n"
   let fn5s = "proc fn5(a, b: float): float =\n  result = -a * a / (b * b)\n"
   let fn6s = "proc fn6() =\n  var a = @[1.0, 2.0]\n  let z = a{0, 1}\n  a{2} = 5.0\n"

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -224,9 +224,9 @@ doAssert: xx == false
 
 macro checkSym(s: typed{nkSym}): untyped =
   let body = s.getImpl.body
-  doAssert body[1].kind == nnkPragmaBlock
-  doAssert body[1][0].kind == nnkPragma
-  doAssert body[1][0][0] == bindSym"thingy"
+  doAssert body[0][1].kind == nnkPragmaBlock
+  doAssert body[0][1][0].kind == nnkPragma
+  doAssert body[0][1][0][0] == bindSym"thingy"
 
 checkSym(myproc)
 

--- a/tests/stdlib/algorithm/trepr.nim
+++ b/tests/stdlib/algorithm/trepr.nim
@@ -275,11 +275,11 @@ func fn2(): int =
     doAssert a2 == """
 func fn1(): int =
   ## comment
-  result = 1
+  return 1
 
 func fn2(): int =
   ## comment
-  result = 1"""
+  return 1"""
 
 static: main()
 main()


### PR DESCRIPTION
## Summary

Wrap expression routine bodies in `return` statements instead of
`result` assignments. This preserves the information that the
expression is returned directly.

## Details

The information that the expression is returned directly gets lost when
lowering it to a `result = body` statement, as those assignments cannot
be distinguished from the ones written directly by the programmer.

In addition, compared to the previous transform, the `return` is
applied to the last expression in the list (if the body is an
expression list), not the whole list.

Both `docgen` and `suggest` previously had to look for doc comments and
examples within trailing top-level assignment due to the whole body
expression being used as the assignment RHS -- these workarounds are no
longer necessary and thus removed.