### PR TITLE
improve the "cleanup prevents tail call" error message

### DIFF
--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1373,8 +1373,12 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
                " except, with no finally in-between"
 
     of rsemCleanupPreventsTailCall:
-      result = "'$1' requires cleanup that prevents a tail call" %
-               [r.ast.render]
+      if r.sym != nil:
+        result = "cannot tail call; local '$1' requires cleanup" %
+                 [r.symstr]
+      else:
+        result = ("cannot tail call; temporary requires cleanup (comes " &
+                 "from $1)") % [conf $ r.ast.info]
 
     of rsemDeferPreventsTailCall:
       result = "cannot tail call because of 'defer' (at $1)" %

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1377,8 +1377,8 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
         result = "cannot tail call; local '$1' requires cleanup" %
                  [r.symstr]
       else:
-        result = ("cannot tail call; temporary requires cleanup (comes " &
-                 "from $1)") % [conf $ r.ast.info]
+        result = ("cannot tail call; temporary requires cleanup [comes " &
+                 "from: $1]") % [conf $ r.ast.info]
 
     of rsemDeferPreventsTailCall:
       result = "cannot tail call because of 'defer' (at $1)" %

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -134,10 +134,10 @@ proc reportDiagnostics(g: ModuleGraph, types: TypeEnv, body: MirBody,
         SemReport(kind: rsemCopiesToSink, ast: ast)
       of ldkCleanupPreventsTailCall:
         let ent = body.sourceFor(diag.entity)
-        if body.code[diag.entity].kind == mnkLocal:
-          SemReport(kind: rsemCleanupPreventsTailCall, sym: ent.sym)
-        else:
+        if body.code[diag.entity].kind == mnkTemp:
           SemReport(kind: rsemCleanupPreventsTailCall, ast: ent)
+        else:
+          SemReport(kind: rsemCleanupPreventsTailCall, sym: ent.sym)
 
     localReport(g.config, ast.info, rep)
 

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -58,7 +58,9 @@ type
     case kind: LocalDiagKind
     of ldkUnavailableTypeBound:
       op: TTypeAttachedOp
-    of ldkPassCopyToSink, ldkCleanupPreventsTailCall:
+    of ldkCleanupPreventsTailCall:
+      entity: NodePosition
+    of ldkPassCopyToSink:
       discard
 
 const
@@ -131,7 +133,11 @@ proc reportDiagnostics(g: ModuleGraph, types: TypeEnv, body: MirBody,
       of ldkPassCopyToSink:
         SemReport(kind: rsemCopiesToSink, ast: ast)
       of ldkCleanupPreventsTailCall:
-        SemReport(kind: rsemCleanupPreventsTailCall, ast: ast)
+        let ent = body.sourceFor(diag.entity)
+        if body.code[diag.entity].kind == mnkLocal:
+          SemReport(kind: rsemCleanupPreventsTailCall, sym: ent.sym)
+        else:
+          SemReport(kind: rsemCleanupPreventsTailCall, ast: ent)
 
     localReport(g.config, ast.info, rep)
 
@@ -292,7 +298,8 @@ proc injectHooks*(body: MirBody, graph: ModuleGraph, env: var MirEnv,
           stmt = tree.parent(tree.parent(i))
           next = tree.sibling(stmt)
         if tree[next].kind == mnkDestroy:
-          diags.add LocalDiag(pos: tree.child(next, 0),
+          diags.add LocalDiag(pos: stmt,
+                              entity: tree.child(next, 0),
                               kind: ldkCleanupPreventsTailCall)
 
         # remove the marker:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1454,6 +1454,7 @@ proc genRaise(c: var TCtx, n: PNode) =
 proc genSiblingCall(c: var TCtx, n: PNode) =
   ## Generates a non-native sibling call for call `n`.
   let typ = c.typeToMir(c.owner.ast[miscPos][1].typ)
+  c.builder.useSource(c.sp, n)
   # initialize the continuation:
   c.buildStmt mnkInit:
     c.add MirNode(kind: mnkLocal, local: resultId, typ: typ)
@@ -1485,6 +1486,7 @@ proc genReturn(c: var TCtx, n: PNode) =
     if goTailCallElim in c.config.options:
       genSiblingCall(c, n[0])
     else:
+      c.builder.useSource(c.sp, n[0])
       c.buildStmt mnkVoid:
         c.builder.rawBuildCall mnkTailCall, VoidType, false:
           genCallee(c, n[0][0])
@@ -2687,6 +2689,7 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
         for i in 1..<params.len:
           let s = params[i].sym
           if s.typ.isSinkTypeForParam():
+            c.builder.useSource(c.sp, params[i])
             c.subTree mnkDef:
               c.add nameNode(c, s)
               c.add MirNode(kind: mnkNone)

--- a/tests/errmsgs/tmissing_cleanup_1.nim
+++ b/tests/errmsgs/tmissing_cleanup_1.nim
@@ -1,0 +1,10 @@
+discard """
+  errormsg: "cannot tail call; local 'x' requires cleanup"
+  line: 8
+"""
+
+proc test(i: int) {.tailcall.} =
+  var x = $i
+  test(i)
+
+test(1)

--- a/tests/errmsgs/tmissing_cleanup_2.nim
+++ b/tests/errmsgs/tmissing_cleanup_2.nim
@@ -1,0 +1,9 @@
+discard """
+  errormsg: "cannot tail call; local 'x' requires cleanup"
+  line: 7
+"""
+
+proc test(x: sink string) {.tailcall.} =
+  test("")
+
+test("")

--- a/tests/errmsgs/tmissing_cleanup_3.nim
+++ b/tests/errmsgs/tmissing_cleanup_3.nim
@@ -1,0 +1,10 @@
+discard """
+  errormsg: "cannot tail call; temporary requires cleanup [comes from: tmissing_cleanup_3.nim(7, 8)]"
+  line: 8
+"""
+
+proc test(x: int) {.tailcall.} =
+  echo x
+  test(x)
+
+test(1)


### PR DESCRIPTION
## Summary

Improve the error message reported when a cleanup of some local
prevents a tail call from taking place, making it easier for the
user to fix the problem.

## Details

* the error now points to the call, not the local/temporary that
  prevents the tail call 
* when a named local prevents a tail call, the message provides the
  name
* when a temporary prevents a tail call, the message points to where
  the temporary comes from 

`mirgen` is updated to use more precise origin information, so that
the errors point to where one would expect.