### PR TITLE
fix compiler crashing for some `.tailcall` bodies

### DIFF
--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -779,7 +779,8 @@ proc finishProc*(p: BProc, id: ProcedureId): string =
     header = genProcHeader(p.module, prc, p.params)
     returnStmt = ""
 
-  if sfPure notin prc.flags and not isInvalidReturnType(p.module, prc.typ[0]):
+  if sfPure notin prc.flags and
+     not isInvalidReturnType(p.env.types, p.body[resultId].typ):
     returnStmt = ropecg(p.module, "\treturn $1;$n",
                         [rdLoc(p.locals[resultId])])
 

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1480,6 +1480,14 @@ proc forwardReturn(g: ModuleGraph, owner: PSym, n: var PNode, active: bool) =
     for i in 0..<n.len:
       recurse(n[i], false)
     wrap(n)
+  of nkObjConstr:
+    for i in 1..<n.len:
+      recurse(n[i], false)
+    wrap(n)
+  of nkBracket, nkCurly, nkTupleConstr:
+    for i in 0..<n.len:
+      recurse(n[i], false)
+    wrap(n)
   of nkNimNodeLit, nkLambdaKinds:
     # values, but the pass doesn't enter them
     wrap(n)

--- a/tests/lang_callable/proc/ttailcall_return.nim
+++ b/tests/lang_callable/proc/ttailcall_return.nim
@@ -1,0 +1,28 @@
+discard """
+  description: '''
+    Tests for expressions used directly as a tailcall's return operand.
+  '''
+"""
+
+proc tup(): (int, int) {.tailcall.} =
+  (1, 2)
+
+doAssert tup() == (1, 2)
+
+proc arr(): array[2, int] {.tailcall.} =
+  [1, 2]
+
+doAssert arr() == [1, 2]
+
+proc bitset(): set[uint8] {.tailcall.} =
+  {1'u8, 2}
+
+doAssert bitset() == {1'u8, 2}
+
+type Obj = object
+  a: int
+
+proc obj(): Obj {.tailcall.} =
+  Obj(a: 1)
+
+doAssert obj() == Obj(a: 1)


### PR DESCRIPTION
## Summary

* fix the compiler crashing when using array, tuple, set, or object
  constructions as the return operand in `.tailcall` routines
* fix `.tailcall` routines with `array` or `set` return types returning
  clobbered values when using the C backend

## Details

There were two separate bugs:
1. the `forwardReturn` pass didn't consider aggregate constructions,
   resulting in illformed AST that didn't pass `mirgen`
2. `cgen` used the *original* (not the real) return type of `.tailcall`
   routines to decide whether the result variable uses a parameter,
   and thus erroneously omitted the C `return` in some cases

They're fixed by:
1. handling the aggregate constructions in `forwardReturn`
2. using the routine's real return type for the "is valid return type"
   analysis

A test is added that covers both bugs.