### PR TITLE
ci: pin CMake to 3.31.6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,6 +62,15 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/setup-mingw
 
+      # the mingw PCRE library requires CMake 2.8.5 to built, and the last
+      # CMake version to have compatibility with the old version is 3.31.6,
+      # so make sure that version is installed
+      - name: Pin CMake
+        if: runner.os == 'Windows'
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
+
       - name: Setup vcpkg (Windows)
         if: runner.os == 'Windows'
         uses: ./.github/actions/setup-vcpkg

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,6 +79,15 @@ jobs:
           # Pipe from zstd to tar because macOS' tar does not support unpacking zstd
           zstd -c -d "$archive" | tar -xf - --strip-components 1
 
+      # the mingw PCRE library requires CMake 2.8.5 to built, and the last
+      # CMake version to have compatibility with the old version is 3.31.6,
+      # so make sure that version is installed
+      - name: Pin CMake
+        if: runner.os == 'Windows'
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
+
       - name: Setup vcpkg (Windows)
         if: runner.os == 'Windows'
         uses: ./git-src/.github/actions/setup-vcpkg


### PR DESCRIPTION
## Summary

Pin CMake version to 3.31.6 for the Windows CI runner, as it's the last
version with compatibility for the CMake version PCRE needs to be
built.

## Details

GitHub updated the Windows 2022 runner image to include CMake 4.0.0,
which breaks backwards compatibility and thus makes the Windows CI jobs
depending on PCRE fail.

The problematic release:
https://github.com/actions/runner-images/releases/tag/win22%2F20250330.1