### PR TITLE
ci: fail on cancellation and update CI to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,12 +290,14 @@ jobs:
     needs:
       - test
       - test-package
-    if: cancelled() || failure()
+      - source
+      - package-git
+      - package-source
+    if: cancelled() || failure() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
 
     steps:
       - name: Raise failure
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "::error::There are failing required jobs"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     outputs:
       skip: ${{ steps.skip_result.outputs.result }}
       target_matrix: ${{ steps.matrix.outputs.result }}
-      shared_builder: ${{ steps.matrix.outputs.shared }}
+      linux_runner: ${{ steps.matrix.outputs.linux_runner }}
 
     steps:
       - id: skip_result
@@ -99,6 +99,7 @@ jobs:
 
           # Use jq to compact the matrix into one line to be used as the result
           echo "result=$(jq -c . matrix.json)" >> $GITHUB_OUTPUT
+          echo "linux_runner=$(jq -r '.[] | select(.name == "Linux") | .runner' matrix.json)" >> $GITHUB_OUTPUT
 
   test:
     needs: [pre_run]
@@ -121,7 +122,7 @@ jobs:
     if: needs.pre_run.outputs.skip != 'true'
 
     name: Build source archive
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.pre_run.outputs.linux_runner }}
 
     steps:
       - uses: actions/checkout@v4
@@ -197,7 +198,7 @@ jobs:
     needs: [pre_run, package-git, package-source]
 
     name: Test release artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Makes sure that CI will fail if any jobs are cancelled, and update CI to
Ubuntu 22.04 to avoid brownouts.

## Details
Cancellation would cause our required check "All check passed" to be
skipped, causing GitHub to consider the check cleared and allowing
merges (https://github.com/actions/runner/issues/2566). This is
troubling as events like runner brownouts would allow PRs to skip CI and
be merged.

This PR updated the conditions for "All check passed" to ensure that a
failure is raised if any individual jobs were to be cancelled. This
change has been tested in my fork and confirmed to be working:
https://github.com/alaviss/nimskull/actions/runs/14339979291

Furthermore, while the main test runners were updated in
https://github.com/nim-works/nimskull/pull/1489 to Ubuntu 22.04, we
overlooked supporting jobs which now hits us in the form of brownouts as
GitHub phases out 20.04 runners. To avoid this in the future, this PR
makes sure that any job requiring versioned Ubuntu would follow the test
matrix, and jobs that don't will use the latest image.