### PR TITLE
transf: fix internal error with `.noreturn` calls

### DIFF
--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1479,7 +1479,9 @@ proc forwardReturn(g: ModuleGraph, owner: PSym, n: var PNode, active: bool) =
   of nkCallKinds:
     for i in 0..<n.len:
       recurse(n[i], false)
-    wrap(n)
+    # don't wrap noreturn calls, they don't return a value
+    if n.typ != g.noreturnType:
+      wrap(n)
   of nkObjConstr:
     for i in 1..<n.len:
       recurse(n[i], false)

--- a/tests/lang_callable/proc/ttailing_noreturn_in_tailcall.nim
+++ b/tests/lang_callable/proc/ttailing_noreturn_in_tailcall.nim
@@ -1,0 +1,26 @@
+discard """
+  description: '''
+    Ensures that noreturn calls work when appearing as a tailing expression of
+    a .tailcall body
+  '''
+"""
+
+proc noreturn() {.noreturn.} =
+  raise ValueError.newException("")
+
+# simple case: no implicit cleanup
+proc test(cond: bool): int {.tailcall.} =
+  if cond: 1
+  else:    noreturn()
+
+discard test(true)
+
+# more complex: with implicit cleanup
+type Obj = object
+proc `=copy`(x: var Obj, y: Obj) = discard
+
+proc test(cond: bool, x: sink Obj): int {.tailcall.} =
+  if cond: 1
+  else:    noreturn()
+
+discard test(true, Obj())


### PR DESCRIPTION
## Summary

Fix using `.noreturn` calls as a tailing expression in `.tailcall`
bodies leading to backend compiler or internal compiler errors,
depending on the used backend.

## Details

The `forwardReturn` pass didn't account for `.noreturn` calls, also
wrapping them in a `return`, which led to semantically incorrect MIR
code being generated, showing up as erroneous C code when using the C
backend.

Since the return forwarding pass is run after local dead-code
elimination, noreturn calls can be detected by comparing the call
expression's type against the special `ModuleGraph.noreturnType`
instance.