### PR TITLE
fix `or`, `and`, and `|` type operators

### DIFF
--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -205,10 +205,6 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
 
   let s = trait.sym.name.s
   case s
-  of "or", "|":
-    return typeWithSonsResult(tyOr, @[operand, operand2])
-  of "and":
-    return typeWithSonsResult(tyAnd, @[operand, operand2])
   of "not":
     if traitCall.len == 3:
       c.config.internalAssert traitCall[2].kind == nkNilLit

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -123,11 +123,20 @@ proc compileOption*(option, arg: string): bool {.
 {.push warning[GcMem]: off, warning[Uninit]: off.}
 # {.push hints: off.}
 
-proc `or`*(a, b: typedesc): typedesc {.magic: "TypeTrait", noSideEffect.}
+template `or`*(a, b: typedesc): typedesc =
   ## Constructs an `or` meta class.
+  mixin `or`
+  a or b
 
-proc `and`*(a, b: typedesc): typedesc {.magic: "TypeTrait", noSideEffect.}
+template `|`*(a, b: typedesc): typedesc =
+  ## An alias for `or <#or,typedesc,typdesc>`_. Constructs an `or` meta class.
+  mixin `or`
+  a or b
+
+template `and`*(a, b: typedesc): typedesc =
   ## Constructs an `and` meta class.
+  mixin `and`
+  a and b
 
 proc `not`*(a: typedesc): typedesc {.magic: "TypeTrait", noSideEffect.}
   ## Constructs an `not` meta class.
@@ -1478,10 +1487,6 @@ const
 
 
 include "system/memalloc"
-
-
-proc `|`*(a, b: typedesc): typedesc = discard
-
 include "system/iterators_1"
 
 

--- a/tests/lang_objects/metatype/tmetatype_issues.nim
+++ b/tests/lang_objects/metatype/tmetatype_issues.nim
@@ -157,3 +157,24 @@ block t3338:
   var t2 = Bar[int32]()
   t2.add()
   doAssert t2.x == 5
+
+block or_result_not_usable:
+  # regression test for the result of `or` (in expression context) not being
+  # usable as typedesc argument
+  proc test(T: typedesc) =
+    assert $T == "int or string"
+
+  test(int or string)
+
+block and_result_not_usable:
+  # regression test for the result of `and` (in expression context) not being
+  # usable as typedesc argument
+  proc test(T: typedesc) =
+    assert $T == "int and string"
+
+  test(int and string)
+
+block invalid_vdash_result:
+  # regression test for the result of `|` (in expression context) not being
+  # an `or` meta type
+  assert $(int | string) == "int or string"


### PR DESCRIPTION
## Summary

* fix `and` and `or` not returning `typedesc` in expression context
* fix `|` not creating an `or` meta type

Fixes https://github.com/nim-works/nimskull/issues/1516
Fixes https://github.com/nim-works/nimskull/issues/1517

## Details

* turn the `and` and `or` system routines into `typedesc` templates
  that use the language built-in `and` and `or` type operators, which
  requires no special support from the compiler, and it also yields a
  proper `typedesc`
* remove the `and`, `or`, and `|` typetraits, as they're no longer used
* turn into `|` system procedure into a `typedesc` template that
  works the same as the `or` template. Previously, the `|` procedure
  returned a `typedesc[None]`

The templates have to use `mixin or` and `mixin and`, as otherwise
the identifiers would bind the already defined `and` and `or` boolean
operators.