### PR TITLE
liftdestructors: fix ill-formed code

### DIFF
--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -600,13 +600,17 @@ proc atomicRefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
       body.add genIf(c, cond, actions)
       body.add newAsgnStmt(x, y)
   of attachedAsgn:
+    var nilCheck = genBuiltin(c, mIsNil, "isNil", y)
+    nilCheck.typ = cond.typ
+    nilCheck = genBuiltin(c, mNot, "not", nilCheck)
+    nilCheck.typ = cond.typ
     if isCyclic:
-      body.add genIf(c, y, callCodegenProc(c.g,
+      body.add genIf(c, nilCheck, callCodegenProc(c.g,
           "nimIncRefCyclic", c.info, y, getCycleParam(c)))
       body.add newAsgnStmt(x, y)
       body.add genIf(c, cond, actions)
     else:
-      body.add genIf(c, y, callCodegenProc(c.g, "nimIncRef", c.info, y))
+      body.add genIf(c, nilCheck, callCodegenProc(c.g, "nimIncRef", c.info, y))
       body.add genIf(c, cond, actions)
       body.add newAsgnStmt(x, y)
   of attachedDestructor:


### PR DESCRIPTION
## Summary

Fix a latent issue with the AST `liftdestructors` produces for `ref`
assignment hooks.

## Details

AST was created that uses a `ref` value directly as the condition of an
`if`. The hook is only generated when using the C backend, and since
the code compiled down to CGIR AST without error (even though it's
wrong), the code worked correctly, as C allows pointer values being
used as conditions.

Beyond being plain wrong, this will also cease to work as soon as:
* some MIR pass relies on all `mnkIf` conditions being a boolean value
* the hook is used with the other backends