### PR TITLE
mirgen: fix internal type error

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -874,37 +874,47 @@ proc genInSetOp(c: var TCtx, n: PNode) =
     let
       se = n[1]
       x  = n[2]
-      elemTyp = x.typ.skipTypes(abstractRange)
+      elemTyp = x[0].typ.skipTypes(abstractRange)
       leOp = getMagicLeForType(elemTyp) # less-equal op
       res = getTemp(c, BoolType) # the temporary to write the result to
 
     # the evaluation order is reversed here: the second operand comes
     # first
-    let
-      val = genRd(c, x[0])
-      a   = genRd(c, x[1])
-      b   = genRd(c, x[2])
+    let val = genRd(c, x[0])
 
     c.builder.buildStmt:
+      # only emit the comparison for the upper or lower bound if it cannot
+      # statically be proven that the dynamic value will be below (or above)
+      # the limit
       let
-        label1 = c.allocLabel()
-        label2 = c.allocLabel()
+        label1 =
+          if firstOrd(c.graph.config, elemTyp) < x[1].intVal:
+            some c.allocLabel()
+          else:
+            none LabelId
+        label2 =
+          if lastOrd(c.graph.config, elemTyp) > x[2].intVal:
+            some c.allocLabel()
+          else:
+            none LabelId
 
-      c.subTree mnkIf:
-        # condition: ``a <= x:``
-        c.wrapAndUse(BoolType):
-          c.buildMagicCall leOp, BoolType:
-            c.emitByVal a
-            c.emitByVal val
-        c.add labelNode(label1)
+      if label1.isSome:
+        c.subTree mnkIf:
+          # condition: ``a <= x:``
+          c.wrapAndUse(BoolType):
+            c.buildMagicCall leOp, BoolType:
+              c.emitByVal toIntLiteral(c.env, x[1].intVal.toInt128, elemTyp)
+              c.emitByVal val
+          c.add labelNode(label1.unsafeGet)
 
-      c.subTree mnkIf:
-        # condition: ``x <= b:``
-        c.wrapAndUse(BoolType):
-          c.buildMagicCall leOp, BoolType:
-            c.emitByVal val
-            c.emitByVal b
-        c.add labelNode(label2)
+      if label2.isSome:
+        c.subTree mnkIf:
+          # condition: ``x <= b:``
+          c.wrapAndUse(BoolType):
+            c.buildMagicCall leOp, BoolType:
+              c.emitByVal val
+              c.emitByVal toIntLiteral(c.env, x[2].intVal.toInt128, elemTyp)
+          c.add labelNode(label2.unsafeGet)
 
       var sv: Value
       if se.kind == nkCurly and not isDeepConstExpr(se):
@@ -922,10 +932,12 @@ proc genInSetOp(c: var TCtx, n: PNode) =
           c.emitByVal val
 
       # close the if statements:
-      c.subTree mnkEndStruct:
-        c.add labelNode(label2)
-      c.subTree mnkEndStruct:
-        c.add labelNode(label1)
+      if label2.isSome:
+        c.subTree mnkEndStruct:
+          c.add labelNode(label2.unsafeGet)
+      if label1.isSome:
+        c.subTree mnkEndStruct:
+          c.add labelNode(label1.unsafeGet)
 
     c.use res
   else:

--- a/tests/optimization/tno_unnecessary_bound_check_for_contains.nim
+++ b/tests/optimization/tno_unnecessary_bound_check_for_contains.nim
@@ -1,0 +1,18 @@
+discard """
+  action: compile
+  matrix: "--showir:mir_in:test --checks:off"
+  nimout: '''-- MIR: test
+scope:
+  def _2: bool
+  def _3: bool = leI(arg 0'i8, arg x)
+  if _3:
+    _2 := inSet(arg <D0>, arg x)
+  result = _2
+  goto [L1]
+L1:
+
+-- end'''
+"""
+
+proc test(x: int8): bool {.exportc.} =
+  x in {1, 2, 3}


### PR DESCRIPTION
## Summary

Fix a type error in the `mirgen`-produced MIR code. Observable program
and compiler behaviour doesn't change.

## Details

For `var x; x in {1, 2, 3}` where `x` has a type other than `int`,
`mirgen` produced less-equal operations where the operands had a
different types, which is disallowed according to the MIR's semantics.

Nothing enforces these semantics, nor does anything rely on the
operand's types being equal, so this went by unnoticed.

To fix the issue, the upper or lower bound check is omitted if
unnecessary, and the integer constant operand is changed to always use
the same type as the to-be-range-checked value (`x` in the above
example).