### PR TITLE
system: add the `unreachable` routine

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -22,7 +22,6 @@ import
     in_options
   ],
   compiler/utils/[
-    idioms,
     int128 # Values for integer nodes
   ],
   std/[

--- a/compiler/ast/ast_parsed_types.nim
+++ b/compiler/ast/ast_parsed_types.nim
@@ -5,9 +5,6 @@ import
     lineinfos,  # For TLineInfo
     idents,     # For `PIdent`
     numericbase
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 from compiler/ast/lexer import Token, TokType

--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -12,7 +12,6 @@ import
   ],
   compiler/utils/[
     int128,    # Values for integer nodes
-    idioms,    # `unreachable`
   ]
 
 const

--- a/compiler/ast/astalgo.nim
+++ b/compiler/ast/astalgo.nim
@@ -17,9 +17,6 @@ import
     idents,
     renderer
   ],
-  compiler/utils/[
-    idioms
-  ],
   std/[
     hashes,
     intsets,

--- a/compiler/ast/lexer.nim
+++ b/compiler/ast/lexer.nim
@@ -19,8 +19,7 @@
 import
   compiler/utils/[
     platform,
-    pathutils,
-    idioms
+    pathutils
   ],
   compiler/ast/[
     numericbase,

--- a/compiler/ast/linter.nim
+++ b/compiler/ast/linter.nim
@@ -35,9 +35,6 @@ import
   compiler/front/[
     options,
     msgs
-  ],
-  compiler/utils/[
-    idioms,
   ]
 
 # TODO: linter should have its own diag/event/telemetry types

--- a/compiler/ast/parser.nim
+++ b/compiler/ast/parser.nim
@@ -47,7 +47,6 @@ import
   compiler/utils/[
     pathutils,
     astrepr,
-    idioms,
     tracer
   ]
 

--- a/compiler/ast/reports.nim
+++ b/compiler/ast/reports.nim
@@ -35,9 +35,6 @@ import
     reports_internal,
     reports_external,
     reports_cmd,
-  ],
-  compiler/utils/[
-    idioms,
   ]
 
 from compiler/utils/int128 import toInt128

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -14,9 +14,6 @@ import
     ast,
     wordrecg,
     idents,
-  ],
-  compiler/utils/[
-    idioms,
   ]
 
 proc cyclicTreeAux(n: PNode, visited: var seq[PNode]): bool =

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -28,7 +28,6 @@ import
   ],
   compiler/utils/[
     platform,
-    idioms,
     int128,
   ],
   compiler/modules/[

--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -50,7 +50,6 @@ import
     varpartitions
   ],
   compiler/utils/[
-    idioms,
     tracer
   ]
 

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -67,7 +67,6 @@ import
     modulelowering
   ],
   compiler/utils/[
-    idioms,
     pathutils,
     platform,
     ropes,

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -54,7 +54,6 @@ import
     bitsets,
     ropes,
     pathutils,
-    idioms,
     int128,
     tracer
   ],

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -40,7 +40,6 @@ import
     modulegraphs
   ],
   compiler/utils/[
-    idioms,
     int128
   ]
 

--- a/compiler/backend/compat.nim
+++ b/compiler/backend/compat.nim
@@ -29,7 +29,6 @@ import
   ],
   compiler/utils/[
     bitsets,
-    idioms,
     int128
   ]
 

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -35,7 +35,6 @@ import
     sourcemap
   ],
   compiler/utils/[
-    idioms,
     ropes
   ]
 

--- a/compiler/backend/jsflow.nim
+++ b/compiler/backend/jsflow.nim
@@ -14,9 +14,6 @@ import
   ],
   compiler/backend/[
     cgir
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -56,7 +56,6 @@ import
     msgs
   ],
   compiler/utils/[
-    idioms,
     int128,
     nversion,
     ropes,

--- a/compiler/backend/mangling.nim
+++ b/compiler/backend/mangling.nim
@@ -14,9 +14,6 @@ import
   ],
   compiler/modules/[
     modulegraphs
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 from compiler/backend/ccgutils import mangle

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -47,8 +47,7 @@ import
   ],
   compiler/utils/[
     nversion,
-    astrepr,
-    idioms
+    astrepr
   ],
   compiler/front/[
     msgs

--- a/compiler/front/commands.nim
+++ b/compiler/front/commands.nim
@@ -51,7 +51,6 @@ import
   ],
   compiler/utils/[
     nversion,
-    idioms,
   ]
 
 # xxx: legacy reports cruft

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -51,7 +51,6 @@ import
     nversion,
     pathutils,   # Input file handling
     astrepr,     # Output parsed data, for compiler development
-    idioms,
     tracer,
     trace_dump
   ],

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -15,7 +15,7 @@ import
   std/options as std_options
 
 import
-  compiler/utils/[ropes, pathutils, idioms],
+  compiler/utils/[ropes, pathutils],
   compiler/ast/[report_enums, reports, lineinfos, reports_internal],
   compiler/front/[options]
 

--- a/compiler/front/optionsprocessor.nim
+++ b/compiler/front/optionsprocessor.nim
@@ -29,7 +29,6 @@ import
   compiler/utils/[
     pathutils,
     platform,
-    idioms,
   ]
 
 from compiler/ast/ast import setUseIc

--- a/compiler/mir/datatables.nim
+++ b/compiler/mir/datatables.nim
@@ -10,9 +10,6 @@ import
   ],
   compiler/mir/[
     mirtrees
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -30,9 +30,6 @@ import
   ],
   compiler/sem/[
     sighashes
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 # XXX: reports are a code smell meaning data types are misplaced

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -96,7 +96,6 @@ import
     ast_analysis
   ],
   compiler/utils/[
-    idioms,
     tracer
   ]
 

--- a/compiler/mir/mirgen_blocks.nim
+++ b/compiler/mir/mirgen_blocks.nim
@@ -19,9 +19,6 @@ import
   compiler/modules/[
     magicsys,
     modulegraphs
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -33,9 +33,6 @@ import
   compiler/sem/[
     aliasanalysis,
     mirexec
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 from std/math import nextPowerOfTwo

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -5,9 +5,6 @@
 import
   compiler/ast/[
     ast_types
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -41,9 +41,6 @@ import
   ],
   compiler/ic/[
     bitabs
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 # XXX: sighashes are currently needed for merging generic instantiations, but

--- a/compiler/mir/proto_mir.nim
+++ b/compiler/mir/proto_mir.nim
@@ -19,9 +19,6 @@ import
   ],
   compiler/sem/[
     ast_analysis
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/mir/rtchecks.nim
+++ b/compiler/mir/rtchecks.nim
@@ -27,7 +27,6 @@ import
   ],
   compiler/utils/[
     int128,
-    idioms
   ]
 
 import compiler/front/options as comp_options

--- a/compiler/mir/typemaps.nim
+++ b/compiler/mir/typemaps.nim
@@ -14,9 +14,6 @@ import
   compiler/ast/[
     ast_types,
     ast_query
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/modules/magicsys.nim
+++ b/compiler/modules/magicsys.nim
@@ -11,7 +11,6 @@
 
 import
   compiler/utils/[
-    idioms,
     platform,
   ],
   compiler/ast/[

--- a/compiler/sem/aliasanalysis.nim
+++ b/compiler/sem/aliasanalysis.nim
@@ -22,9 +22,6 @@ import
   ],
   compiler/mir/[
     mirtrees
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/sem/ast_analysis.nim
+++ b/compiler/sem/ast_analysis.nim
@@ -10,7 +10,6 @@ import
     options
   ],
   compiler/utils/[
-    idioms,
     int128
   ]
 

--- a/compiler/sem/closureiters.nim
+++ b/compiler/sem/closureiters.nim
@@ -169,9 +169,6 @@ import
   compiler/sem/[
     lowerings,
     lambdalifting
-  ],
-  compiler/utils/[
-    idioms,
   ]
 
 type

--- a/compiler/sem/guards.nim
+++ b/compiler/sem/guards.nim
@@ -23,7 +23,6 @@ import
   compiler/utils/[
     saturate,
     int128,
-    idioms,
   ],
   compiler/modules/[
     magicsys,

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -109,8 +109,7 @@ import
     mirexec,
   ],
   compiler/utils/[
-    cursors,
-    idioms
+    cursors
   ]
 
 type

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -30,9 +30,6 @@ import
     options,
     msgs
   ],
-  compiler/utils/[
-    idioms
-  ],
   compiler/sem/[
     semdata,
     sighashes,

--- a/compiler/sem/lookups.nim
+++ b/compiler/sem/lookups.nim
@@ -28,7 +28,6 @@ import
     modulegraphs
   ],
   compiler/utils/[
-    idioms,
     debugutils
   ],
   compiler/front/[

--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -33,9 +33,6 @@ import
   ],
   compiler/sem/[
     passes
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 from compiler/mir/injecthooks import getOp

--- a/compiler/sem/patterns.nim
+++ b/compiler/sem/patterns.nim
@@ -21,9 +21,6 @@ import
     sigmatch,
     aliases,
     parampatterns
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -36,8 +36,7 @@ import
   ],
   compiler/utils/[
     pathutils,
-    debugutils,
-    idioms
+    debugutils
   ],
   compiler/sem/[
     semdata,

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -53,7 +53,6 @@ import
     debugutils,
     int128,
     astrepr,
-    idioms,
     tracer
   ],
   compiler/sem/[

--- a/compiler/sem/semfold.nim
+++ b/compiler/sem/semfold.nim
@@ -35,7 +35,6 @@ import
   ],
   compiler/utils/[
     platform,
-    idioms,
   ]
 
 # xxx: legacy reports cruft

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -35,7 +35,6 @@ import
   ],
   compiler/utils/[
     debugutils,
-    idioms
   ],
   compiler/sem/[
     varpartitions,

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -34,7 +34,6 @@ import
   compiler/utils/[
     astrepr,
     debugutils,
-    idioms
   ]
 
 # xxx: reports are a code smell meaning data types are misplaced

--- a/compiler/sem/sighashes.nim
+++ b/compiler/sem/sighashes.nim
@@ -23,7 +23,6 @@ import
   ],
   compiler/utils/[
     ropes,
-    idioms
   ]
 
 proc `&=`(c: var MD5Context, s: string) = md5Update(c, s, s.len)

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -41,7 +41,6 @@ import
   ],
   compiler/utils/[
     debugutils,
-    idioms
   ]
 
 # xxx: reports are a code smell meaning data types are misplaced

--- a/compiler/sem/tailcall_analysis.nim
+++ b/compiler/sem/tailcall_analysis.nim
@@ -27,9 +27,6 @@ import
   ],
   compiler/front/[
     msgs
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 from compiler/ast/report_enums import ReportKind

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -50,7 +50,6 @@ import
     cgmeth
   ],
   compiler/utils/[
-    idioms,
     tracer
   ]
 

--- a/compiler/sem/unreachable_elim.nim
+++ b/compiler/sem/unreachable_elim.nim
@@ -26,9 +26,6 @@ import
   ],
   compiler/modules/[
     modulegraphs
-  ],
-  compiler/utils/[
-    idioms
   ]
 
 type

--- a/compiler/utils/astrepr.nim
+++ b/compiler/utils/astrepr.nim
@@ -59,9 +59,6 @@ import
     options,
     msgs
   ],
-  compiler/utils/[
-    idioms
-  ],
   experimental/colortext,
   std/[
     tables,

--- a/compiler/utils/idioms.nim
+++ b/compiler/utils/idioms.nim
@@ -2,11 +2,7 @@
 ## the compiler. Dependencies on other modules should be kept as minimal as
 ## possible
 
-from std/private/miscdollars import toLocation
-
 type
-  IInfo = typeof(instantiationInfo())
-
   HOslice*[T] = object
     ## A half-open slice, that is, a slice where the end is excluded. These
     ## are useful for use with unsigned integers, as, compared to ``Slice``,
@@ -23,37 +19,3 @@ iterator items*[T](s: HOslice[T]): T =
   ## Returns all items in the slice
   for i in s.a..<s.b:
     yield i
-
-# ----------------- unreachable -----------------
-
-func unreachableImpl(str: string, loc: IInfo) {.noinline, noreturn.} =
-  var msg: string
-  msg.toLocation(loc.filename, loc.line, loc.column + 1)
-  msg.add:
-    if str.len > 0: " unreachable: "
-    else:           " unreachable"
-  msg.add str
-  raiseAssert(msg)
-
-func unreachableImpl(e: enum, loc: IInfo) {.noinline, noreturn.} =
-  ## A bit more efficient than ``unreachable($e)``, due to the stringication
-  ## logic being located inside a separate procedure instead of at the
-  ## callsite
-  unreachableImpl($e, loc)
-
-template unreachable*() =
-  ## Use ``unreachable`` to mark a point in the program as unreachable. That
-  ## is, execution must never reach said point and if it does, the event is
-  ## treated as an unrecoverable fatal error.
-  ## As the intent is clearer, it's preferred to use ``unreachable`` is
-  ## over ``doAssert false``
-  unreachableImpl("", instantiationInfo(-1))
-
-template unreachable*(msg: string) =
-  ## Similar to `#unreachable <#unreachable>`_, but reports an additional
-  ## `msg` when reached
-  unreachableImpl(msg, instantiationInfo(-1))
-
-template unreachable*(e: enum) =
-  ## More efficient than using ``unreachable($e)``
-  unreachableImpl(e, instantiationInfo(-1))

--- a/compiler/vm/compilerbridge.nim
+++ b/compiler/vm/compilerbridge.nim
@@ -41,7 +41,6 @@ import
   ],
   compiler/utils/[
     debugutils,
-    idioms,
     tracer
   ],
   compiler/vm/[

--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -36,7 +36,6 @@ import
     mirtypes
   ],
   compiler/utils/[
-    idioms,
     int128,
     pathutils # for `AbsoluteFile`
   ],

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -42,7 +42,6 @@ import
     magicsys
   ],
   compiler/utils/[
-    idioms,
     tracer
   ],
   compiler/vm/[

--- a/compiler/vm/vmchecks.nim
+++ b/compiler/vm/vmchecks.nim
@@ -10,9 +10,6 @@
 ## disciminator(s) there.
 
 import
-  compiler/utils/[
-    idioms
-  ],
   compiler/vm/[
     vmdef,
     vmtypes

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -10,9 +10,6 @@ import
     nimsets,
     types
   ],
-  compiler/utils/[
-    idioms
-  ],
   compiler/vm/[
     vmaux,
     vmdef,

--- a/compiler/vm/vmdeps.nim
+++ b/compiler/vm/vmdeps.nim
@@ -25,7 +25,6 @@ import
   ],
   compiler/utils/[
     pathutils,
-    idioms
   ],
   experimental/[
     results

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -62,9 +62,6 @@ import
     msgs,
     options
   ],
-  compiler/utils/[
-    idioms
-  ],
   compiler/vm/[
     identpatterns,
     vmaux,

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -11,9 +11,6 @@ import
   compiler/front/[
     options
   ],
-  compiler/utils/[
-    idioms
-  ],
   compiler/vm/[
     vmdef,
     vmmemory,

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -32,7 +32,6 @@ import
     bitabs
   ],
   compiler/utils/[
-    idioms,
     pathutils,
     bitsets
   ],

--- a/compiler/vm/vmserialize.nim
+++ b/compiler/vm/vmserialize.nim
@@ -24,7 +24,6 @@ import
   ],
   compiler/utils/[
     bitsets,
-    idioms,
     int128
   ]
 

--- a/compiler/vm/vmtypegen.nim
+++ b/compiler/vm/vmtypegen.nim
@@ -15,9 +15,6 @@ import
   compiler/front/[
     options
   ],
-  compiler/utils/[
-    idioms
-  ],
   compiler/vm/[
     vmdef
   ],

--- a/compiler/vm/vmtypes.nim
+++ b/compiler/vm/vmtypes.nim
@@ -2,9 +2,6 @@
 ## `VmType`s and working with them in general.
 
 import
-  compiler/utils/[
-    idioms
-  ],
   compiler/vm/[
     vmdef
   ]

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -141,6 +141,15 @@ template unreachable*() =
   ##
   ## but the intention is clearer and the call marks the execution path as not
   ## returning anything.
+  runnableExamples:
+    for i in 1..5:
+      if i mod 2 == 0:
+        echo:
+          case i
+          of 2: "two"
+          of 4: "four"
+          else: unreachable()
+
   unreachableImpl("", instantiationInfo(-1))
 
 template unreachable*(msg: string) =

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -113,3 +113,42 @@ template doAssertRaises*(exception: typedesc, code: untyped) =
     except: raisedForeign()
   if wrong:
     raiseAssert(begin & " nothing was raised" & msgEnd)
+
+# ------------- unreachable -------------
+
+func unreachableImpl(str: string, loc: InstantiationInfo) {.
+    noinline, noreturn.} =
+  var msg: string
+  msg.toLocation(loc.filename, loc.line, loc.column + 1)
+  msg.add:
+    if str.len > 0: " unreachable: "
+    else:           " unreachable"
+  msg.add str
+  raiseAssert(msg)
+
+func unreachableImpl(e: enum, loc: InstantiationInfo) {.noinline, noreturn.} =
+  ## A bit more efficient than ``unreachable($e)``, as the stringification
+  ## code is not part of the callsite (less I-cache pressure).
+  unreachableImpl($e, loc)
+
+template unreachable*() =
+  ## Marks a point in the program as being unreachable. At run-time, behaves
+  ## the same as:
+  ##
+  ## .. code-block:: nim
+  ##
+  ##   doAssert false, "unreachable"
+  ##
+  ## but the intention is clearer and the call marks the execution path as not
+  ## returning anything.
+  unreachableImpl("", instantiationInfo(-1))
+
+template unreachable*(msg: string) =
+  ## Same as `unreachable <#unreachable>`_, but with the error message
+  ## including the extra `msg`.
+  unreachableImpl(msg, instantiationInfo(-1))
+
+template unreachable*(e: enum) =
+  ## Same as `unreachable <#unreachable>`_, but reports `e` as the message.
+  ## Prefer this routine over using ``unreachable($e)``.
+  unreachableImpl(e, instantiationInfo(-1))


### PR DESCRIPTION
## Summary

Add the `unreachable` routine, plus some convenience overloads, to the
`assertions`  module.  `unreachable`  behaves the same as 
`doAssert false` ,
but it also marks the control-flow path as `.noreturn`.

## Details

Most if not all projects using `case` expressions a lot tend to require
some sort of  `unreachable` , and giving its foundational nature, it
makes
sense to have `unreachable` be part of `system`.

The implementation from `compiler/utils/idioms` is moved into the
`system/assertions` module, with some improvements made to the doc
comments. All now-unused imports of the `idioms` module in the
compiler's codebase are removed.