### PR TITLE
docs: mark tutorial docs as legacy

### DIFF
--- a/doc/docs.rst
+++ b/doc/docs.rst
@@ -58,6 +58,11 @@ For Users
 For Users (Legacy)
 ==================
 
+.. warning::
+   These documents are not maintained and might not correspond to the
+   current language semantics. Consult the `manual <manual.html>`_ and
+   `standard library <lib.html>`_ for the most up-to-date information.
+
 - | `Tutorial (part I) <tut1.html>`_
   | The Nim tutorial part one deals with the basics.
 

--- a/doc/docs.rst
+++ b/doc/docs.rst
@@ -1,6 +1,6 @@
 The documentation consists of several documents:
 
-For developers and contributors
+For Developers and Contributors
 ===============================
 
 - | `Internal documentation <intern.html>`_
@@ -25,20 +25,11 @@ For developers and contributors
 - | `Continuous integration internals <ci.html>`_
   | Describes how CI is implemented and steps for troubleshooting common failures. Required reading for those looking to work on the CI infrastructure.
 
-For users
+For Users
 =========
 
 - | `Language specification <spec.html>`_
   | Description of the language specification purpose and structure.
-
-- | `Tutorial (part I) <tut1.html>`_
-  | The Nim tutorial part one deals with the basics.
-
-- | `Tutorial (part II) <tut2.html>`_
-  | The Nim tutorial part two deals with the advanced language constructs.
-
-- | `Tutorial (part III) <tut3.html>`_
-  | The Nim tutorial part three about Nim's macro system.
 
 - | `Language Manual <manual.html>`_
   | The Nim manual is a draft that will evolve into a proper specification.
@@ -63,3 +54,15 @@ For users
 
 - | `Index <theindex.html>`_
   | The generated index.
+
+For Users (Legacy)
+==================
+
+- | `Tutorial (part I) <tut1.html>`_
+  | The Nim tutorial part one deals with the basics.
+
+- | `Tutorial (part II) <tut2.html>`_
+  | The Nim tutorial part two deals with the advanced language constructs.
+
+- | `Tutorial (part III) <tut3.html>`_
+  | The Nim tutorial part three about Nim's macro system.


### PR DESCRIPTION
## Summary

Move all three tutorials into a legacy section on the documentation home
page

## Details

Move all three tutorials further down the docs page in under a legacy
title. This is to indicate that they're no longer really maintained, and
they shouldn't supersede the spec, reference, standard library docs,
etc.