### PR TITLE
sem: make taking the address of `sink` parameter work

### DIFF
--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3826,7 +3826,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
     result = n
     checkSonsLen(n, 1, c.config)
     result[0] = semAddrArg(c, n[0])
-    result.typ = makePtrType(c, result[0].typ)
+    result.typ = makePtrType(c, result[0].typ.skipTypes({tySink}))
   of nkHiddenAddr, nkHiddenDeref:
     checkSonsLen(n, 1, c.config)
     n[0] = semExpr(c, n[0], flags)

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -31,7 +31,7 @@ proc semAddrCall(c: PContext, n: PNode): PNode =
   if result[0].kind == nkError:
     result = c.config.wrapError(result)
   else:
-    result.typ = makePtrType(c, result[0].typ)
+    result.typ = makePtrType(c, result[0].typ.skipTypes({tySink}))
 
 proc semTypeOf(c: PContext; n: PNode): PNode =
   addInNimDebugUtils(c.config, "semTypeOf", n, result)

--- a/tests/lang_types/sink/taddr_of_sink_parameter.nim
+++ b/tests/lang_types/sink/taddr_of_sink_parameter.nim
@@ -1,0 +1,19 @@
+discard """
+  description: '''
+    Ensure that it's possible to take the address of a sink parameter.
+  '''
+  targets: "c js vm"
+  knownIssue.js: '''
+    Changes through a ptr-to-sink-parameter don't reflect on the parameter's
+    value.
+  '''
+"""
+
+proc f_sink(p: sink int) =
+  let x = addr p
+  doAssert x[] == 1
+  x[] = 2
+  doAssert x[] == 2
+  doAssert p == 2
+
+f_sink(1)


### PR DESCRIPTION
## Summary

Fix taking the address of a `sink` parameter erroneously resulting in a
static error.

## Details

Analysis of `system.addr` and `nkAddr` used the operand's type
verbatim, which led to the creation of a `ptr(sink(...))` type for
`sink` parameter operands. Depending on usage of this type, this either
caused `typeAllowed` to report an error, or it caused some other
internal failure downstream.

The analysis of `system.addr` and `nkAddr` now skips `tySink` prior to
creating the pointer type, fixing the issue.

Fixes https://github.com/nim-works/nimskull/issues/1532 .