### PR TITLE
varpartitions: fix memory leak with tuple unpacking

### DIFF
--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -807,6 +807,10 @@ proc computeLiveRanges(c: var Partitions; n: PNode) =
       else:
         for i in 0..<child.len-2:
           registerVariable(c, child[i])
+          if child.kind == nkVarTuple:
+            # an unpacking definition where the rhs is not a literal tuple
+            # construction. The vars are always owning
+            pretendOwnsData(c, child[i].sym)
           #deps(c, child[i], last)
 
   of nkAsgn, nkFastAsgn:

--- a/tests/arc/topt_unpacking_no_cursor.nim
+++ b/tests/arc/topt_unpacking_no_cursor.nim
@@ -1,0 +1,31 @@
+discard """
+  matrix: "--expandArc:test --hints:off"
+  nimout: '''--expandArc: test
+
+scope:
+  def x: (Obj, Obj) = init() -> [Resume]
+  def _2: (Obj, Obj) = move x
+  def a: Obj
+  a := move _2.0
+  def b: Obj
+  b := move _2.1
+  =destroy(name b)
+  =destroy(name a)
+
+-- end of expandArc ------------------------'''
+"""
+
+type Obj = object
+
+proc `=copy`(a: var Obj, b: Obj) =
+  discard
+
+proc init(): (Obj, Obj) =
+  discard
+
+proc test() =
+  let x = init()
+  let (a, b) = x
+  # ^^ the rhs is not something that *requires* taking ownership of
+
+test()


### PR DESCRIPTION
## Summary

Fix a compiler bug that led to destructors not being called for some
local tuple-unpacking definitions.

## Details

Locals introduced via tuple-unpacking `let`/`var` statements were
allowed to be inferred as cursors. Since `mirgen` assumes that
unpacked-into locals are always owning, values are moved into inferred-
as-cursor unpack locals, causing memory leaks due to missing
destruction.

To fix the issue, locals introduced via tuple-unpacking are prevented
from ever being cursors. Alternatively, `mirgen` could be changed to
not assume unpacked-into locals always being owning, but this is more
complex to implement.