### PR TITLE
vm: implement partial support for `toOpenArray`

### DIFF
--- a/compiler/vm/packed_env.nim
+++ b/compiler/vm/packed_env.nim
@@ -490,7 +490,8 @@ proc loadSliceList*[T: SliceListType](p: PackedEnv, id: uint32): seq[Slice[T]] =
 func numFields(t: PVmType): int =
   case t.kind
   of akInt, akFloat, akPNode: 0
-  of akPtr, akRef, akSeq, akString, akSet, akDiscriminator, akCallable: 1
+  of akPtr, akRef, akSeq, akString, akOpenArray, akSet, akDiscriminator,
+     akCallable: 1
   of akArray: 1
   of akObject: 1 + t.objFields.len
 
@@ -511,7 +512,7 @@ func storeVmType(enc: var PackedEncoder, dst: var PackedEnv, t: PVmType): Packed
   dst.tfields[fieldStart] =
     case t.kind
     of akPtr, akRef:          (0'u32, enc.typeMap[t.targetType])
-    of akSeq, akString:
+    of akSeq, akString, akOpenArray:
       # it's not strictly necessary to store the stride (since it can
       # currently be computed from the element type)
       (t.seqElemStride.uint32, enc.typeMap[t.seqElemType])
@@ -555,7 +556,7 @@ func loadVmType(s: PackedEnv, types: seq[PVmType],
     unreachable()
   of akPtr, akRef:
     t.targetType = types[firstField.typId]
-  of akSeq, akString:
+  of akSeq, akString, akOpenArray:
     t.seqElemStride = firstField.offset.int
     t.seqElemType = types[firstField.typId]
   of akSet:

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -634,6 +634,15 @@ template `strVal=`*(r: TFullReg, s: string) =
     assert r.handle.typ.kind == akString
   newVmString(deref(r.handle).strVal, s, c.allocator)
 
+proc toSlice(h: LocHandle, a: VmAllocator): VmSlice =
+  let typ = h.typ
+  case typ.kind
+  of akString:   toSlice(deref(h).strVal.VmSeq, typ.seqElemType, a)
+  of akSeq:      toSlice(deref(h).seqVal,       typ.seqElemType, a)
+  of akOpenArray:toSlice(deref(h).oaVal,        typ.seqElemType, a)
+  of akArray:    toSlice(h)
+  else:          unreachable(typ.kind)
+
 proc opConv(c: var TCtx; dest: var TFullReg, src: TFullReg, dt, st: (PType, PVmType)): bool =
   ## Convert the value in register `src` from `st` to `dt` and write the result
   ## to register `dest`
@@ -1873,15 +1882,6 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
     of opcArrCopy:
       let rb = instr.regB
       let rc = instr.regC
-
-      proc toSlice(h: LocHandle, a: VmAllocator): VmSlice =
-        let typ = h.typ
-        case typ.kind
-        of akString: toSlice(deref(h).strVal.VmSeq, typ.seqElemType, a)
-        of akSeq:    toSlice(deref(h).seqVal,       typ.seqElemType, a)
-        of akArray:  toSlice(h)
-        else:        unreachable(typ.kind)
-
       checkHandle(regs[ra])
       checkHandle(regs[rb])
 
@@ -1905,6 +1905,25 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         raiseVmError(reportVmIdx(L, src.len - 1))
 
       c.memory.arrayCopy(byteView(dest), byteView(src), L, src.typ, true)
+    of opcSlice:
+      decodeBC(akOpenArray)
+      checkHandle(regs[ra])
+      checkHandle(regs[rb])
+      inc pc
+      let
+        lo = regs[rc].intVal
+        hi = regs[c.code[pc].regB].intVal
+        # the user ought to know what they're doing, so prevent the length from
+        # going below zero and don't report any run-time error
+        len = max(hi - lo + 1, 0)
+        slice = toSlice(regs[rb].handle, c.allocator)
+      if lo < 0 or hi >= slice.len or len == 0:
+        # out of bounds or empty; create an openArray for which an access
+        # will error
+        regs[ra].atomVal.oaVal = VmOpenArray(data: nil, length: len.int)
+      else:
+        # the data pointer points to the start of the first element
+        regs[ra].atomVal.oaVal = VmOpenArray(data: slice[lo].p, length: len.int)
     of opcIndCall, opcIndCallAsgn:
       # dest = call regStart, n; where regStart = fn, arg1, ...
       let rb = instr.regB

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -1010,7 +1010,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         # TODO: Remove this case once openArray handling is reworked
         regs[ra].setHandle:
           getItemHandle(regs[rb].strVal.VmSeq, srcTyp, idx, c.allocator)
-      of akSeq, akArray:
+      of akSeq, akArray, akOpenArray:
         regs[ra].setHandle(getItemHandle(regs[rb].handle, idx, c.allocator))
       else:
         unreachable(srcTyp.kind)
@@ -1031,7 +1031,8 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         regs[ra].setAddress(
           regs[rb].strVal.data.applyOffset(idx.uint * t.sizeInBytes),
           t)
-      of akSeq, akArray:
+      of akSeq, akArray, akOpenArray:
+        # only the address is computed, no openArray check is necessary
         let h = getItemHandle(src, idx, c.allocator)
         regs[ra].setAddress(h.p, h.typ)
       else:
@@ -1068,6 +1069,12 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
           toSlice(deref(dest).strVal.VmSeq, dTyp.seqElemType, c.allocator)
         of akSeq:
           toSlice(deref(dest).seqVal, dTyp.seqElemType, c.allocator)
+        of akOpenArray:
+          let tmp = toSlice(deref(dest).oaVal, dTyp.seqElemType, c.allocator)
+          # an openArray is non-owning, meaning that the pointed-to-sequence is
+          # not guaranteed to still exist
+          checkHandle(c.allocator, tmp[idx])
+          tmp
         of akArray:
           toSlice(dest)
         of akInt, akFloat, akSet, akPtr, akRef, akObject, akPNode, akCallable,
@@ -2286,7 +2293,8 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
           res = atom.ptrVal == nil
         of akCallable:
           res = atom.callableVal.isNil
-        of akInt, akFloat, akSet, akObject, akArray, akPNode, akDiscriminator:
+        of akInt, akFloat, akSet, akObject, akArray, akPNode, akDiscriminator,
+           akOpenArray:
           unreachable(regs[rb].kind)
       of rkNimNode:
         res = regs[rb].nimNode.kind == nkNilLit
@@ -2335,7 +2343,7 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       decodeBC(rkNimNode)
       checkHandle(regs[rc])
       let typ = regs[rc].handle.typ
-      assert typ.kind in {akSeq, akArray} # varargs
+      assert typ.kind in {akSeq, akArray, akOpenArray} # varargs
       assert typ.elemType().kind == akPNode
       let x = regs[rc].handle
       var u = regs[rb].nimNode

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -89,6 +89,7 @@ type
     opcIndexChck, ## abort execution if the index is not in bounds
 
     opcArrCopy,
+    opcSlice,
 
     # NimNode manipulation opcodes
 

--- a/compiler/vm/vmcompilerserdes.nim
+++ b/compiler/vm/vmcompilerserdes.nim
@@ -12,6 +12,7 @@ import
   ],
   compiler/vm/[
     vmaux,
+    vmchecks,
     vmdef,
     vmmemory,
     vmobjects,
@@ -338,6 +339,40 @@ proc deserialize(c: TCtx, m: VmMemoryRegion, vt: PVmType, formal, t: PType, info
         vt.seqElemType,
         t.elemType(),
         info)
+    of akOpenArray:
+      # openArray stores an unsafe host pointer, requiring manual access
+      # validation in order to not access host memory
+      let
+        len        = atom.oaVal.length
+        elem       = vt.seqElemType
+        slice      = toSlice(atom.oaVal, elem, c.allocator)
+        formalElem = t.elemType()
+      var hasError = false
+
+      proc error(c: TCtx, kind: AstDiagVmKind, formal: PType,
+                 info: TLineInfo): PNode =
+        c.config.newError(
+          wrongNode(),
+          PAstDiag(kind: adVmError, vmErr: AstDiagVmError(kind: kind)))
+
+      result = newNodeIT(nkBracket, info, formal, len)
+      for i in 0..<len:
+        case checkValid(c.allocator, slice[i])
+        of avrNoError:
+          result[i] =
+            deserialize(c, byteView(slice[i]), elem, formalElem, info)
+        of avrNoLocation:
+          result[i] = error(c, adVmAccessNoLocation, formal, info)
+          hasError = true
+        of avrOutOfBounds:
+          result[i] = error(c, adVmAccessOutOfBounds, formal, info)
+          hasError = true
+        of avrTypeMismatch:
+          result[i] = error(c, adVmAccessTypeMismatch, formal, info)
+          hasError = true
+
+      if hasError:
+        result = c.config.wrapError(result)
     else:
       unreachable($vt.kind)
 

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -112,6 +112,7 @@ type
 
     akString
     akSeq
+    akOpenArray
     akRef
     akCallable # TODO: rename to akProcedural or akFuncHandle
 
@@ -186,7 +187,7 @@ type
       targetType*: PVmType
     of akSet:
       setLength*: int ## The number of elements in the set
-    of akSeq, akString:
+    of akSeq, akString, akOpenArray:
       # TODO: remove stride information and merge this branch with
       #       `akPtr`/`akRef`
       seqElemStride*: int
@@ -288,6 +289,11 @@ type
     length*: int
     data*: CellPtr
 
+  VmOpenArray* = object
+    ## An openArray as stored in VM memory.
+    data*: VmMemPointer
+    length*: int
+
   VmString* = distinct VmSeq
 
   Atom* {.union.} = object
@@ -297,6 +303,7 @@ type
     ptrVal*: pointer ## akPtr
     strVal*: VmString ## akString
     seqVal*: VmSeq ## akSeq
+    oaVal*: VmOpenArray
     refVal*: HeapSlotHandle ## akRef
     callableVal*: VmFunctionPtr ## akCallable
 
@@ -830,6 +837,7 @@ proc init*(cache: var TypeInfoCache) =
 
   setInfo(akSeq, VmSeq)
   setInfo(akString, VmString)
+  setInfo(akOpenArray, VmOpenArray)
   setInfo(akPtr, ptr Atom)
   setInfo(akRef, HeapSlotHandle)
   setInfo(akCallable, VmFunctionPtr)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1381,11 +1381,15 @@ proc asgnOpenArray(c: var TCtx, n: CgNode, dest: TRegister) =
   ## ``openArray``.
   let
     val = genx(c, n)
-    L = c.getTemp(c.graph.getSysType(n.info, tyInt))
-  c.gABC(n, opcLenSeq, L, val) # fetch the length of the input array
-  c.gABC(n, opcSetLenSeq, dest, L) # resize the destination
-  c.gABC(n, opcArrCopy, dest, val, L) # copy the contents
+    lo = c.getTemp(slotTempInt)
+    hi = c.getTemp(slotTempInt)
+  c.gABx(n, opcLdImmInt, lo, 0)
+  c.gABI(n, opcLenSeq, hi, val, 1) # arr.high
+  c.gABC(n, opcSlice, dest, val, lo)
+  c.gABC(n, opcSlice, dest, hi)
   c.freeTemp(val)
+  c.freeTemp(lo)
+  c.freeTemp(hi)
 
 proc genToSlice(c: var TCtx, n: CgNode, dest: TRegister, reified: bool) =
   if n.len == 1:
@@ -1404,8 +1408,22 @@ proc genToSlice(c: var TCtx, n: CgNode, dest: TRegister, reified: bool) =
         c.gABx(n, opcLdNull, dest, c.genType(n.typ))
       gen(c, n[0], dest)
   else:
-    # not yet supported
-    fail(n.info, vmGenDiagCodeGenUnhandledMagic, mSlice)
+    # a proper slice is always created, even if the receiver doesn't require
+    # a reified openArray
+    if not reified:
+      # the destination is a local register, not a location; allocate a
+      # proper location
+      c.gABx(n, opcLdNull, dest, c.genType(n.typ))
+
+    let
+      val = genx(c, n[0])
+      lo  = genIndex(c, n[1], n[0].typ)
+      hi  = genIndex(c, n[2], n[0].typ)
+    c.gABC(n, opcSlice, dest, val, lo)
+    c.gABC(n, opcSlice, dest, hi)
+    c.freeTemp(val)
+    c.freeTemp(lo)
+    c.freeTemp(hi)
 
 proc genObjConv(c: var TCtx, n: CgNode, dest: var TDest) =
   prepare(c, dest, n.typ)
@@ -2090,6 +2108,16 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
     c.gABC(n, opcIndexChck, 0, arr, idx)
     c.freeTemp(idx)
     c.freeTemp(arr)
+  of mChckBounds:
+    let
+      arr = c.genx(n[1])
+      lo = c.genx(n[2])
+      hi = c.genx(n[3])
+    # TODO: implement. The magic is necessary for correctness, but it's not
+    #       necessary for VM runtime safety
+    c.freeTemp(hi)
+    c.freeTemp(lo)
+    c.freeTemp(arr)
   of mChckField:
     genFieldCheck(c, n)
   of mChckObj:
@@ -2277,7 +2305,7 @@ proc putIntoLoc(c: var TCtx, e: CgNode, dest: TDest, idx: TRegister,
     if e.kind == cnkToSlice:
       genToSlice(c, e, dest, reified=true)
     else:
-      # the value must be converted to the fixed openArray
+      # the value must be converted to the reified openArray
       # representation first
       write(asgnOpenArray)
   elif e.kind in LvalueExprKinds:

--- a/compiler/vm/vmmemory.nim
+++ b/compiler/vm/vmmemory.nim
@@ -118,6 +118,11 @@ func mapInteriorPointerToCell(a: VmAllocator, p: pointer): CellId =
 
   result = -1
 
+func mapInteriorPointerToCell*(a: VmAllocator, p: VmMemPointer): CellId {.
+    inline.} =
+  ## Maps an interior ponter to a cell ID.
+  mapInteriorPointerToCell(a, cast[pointer](p))
+
 func mapToCell*(a: VmAllocator, p: CellPtr): lent VmCell =
   let id = mapPointerToCell(a, p)
   assert id != -1, "pointer wasn't checked"

--- a/compiler/vm/vmobjects.nim
+++ b/compiler/vm/vmobjects.nim
@@ -357,6 +357,8 @@ func arrayLen*(loc: LocHandle): int =
   case loc.typ.kind
   of akSeq:
     deref(loc).seqVal.length
+  of akOpenArray:
+    deref(loc).oaVal.length
   of akArray:
     loc.typ.elementCount
   of akString:
@@ -504,22 +506,15 @@ func add*(s: var string, str: VmString) =
   safeCopyMem(s.toOpenArray(i, s.high), str.data.slice(str.len), str.len)
 
 
-func getItemHandle*(loc: LocHandle, index: Natural, a: VmAllocator): LocHandle =
-  ## Creates a handle to the item at `index` for the array-like at `loc`
-  let typ = loc.typ
-  case typ.kind
-  of akSeq:
-    makeLocHandle(a, deref(loc).seqVal.data, typ.seqElemStride * index, typ.seqElemType)
-  of akArray:
-    subLocation(loc, typ.elementStride * index, typ.elementType)
-  else:
-    # Not an array like type
-    unreachable(typ.kind)
-
 func `[]`*(s: VmSlice, i: Natural): LocHandle =
   ## Creates a ``LocHandle`` to the `i`-th element of the slice `s`
-  LocHandle(cell: s.cell, p: applyOffset(s.start, uint(i) * s.typ.alignedSize),
-            typ: s.typ)
+  if s.cell == -1:
+    # don't use pointer arithmetic on `s.p`, which might be a nil pointer
+    LocHandle(cell: -1, typ: s.typ)
+  else:
+    LocHandle(cell: s.cell,
+              p: applyOffset(s.start, uint(i) * s.typ.alignedSize),
+              typ: s.typ)
 
 func toSlice*(loc: LocHandle): VmSlice =
   ## Creates a ``VmSlice`` view for the array location `loc`
@@ -534,6 +529,28 @@ func toSlice*(s: VmSeq, elemTyp: PVmType, a: VmAllocator): VmSlice =
   # cell
   VmSlice(cell: id, start: cast[VmMemPointer](s.data), len: s.length,
           typ: elemTyp)
+
+func toSlice*(oa: VmOpenArray, elemTyp: PVmType, a: VmAllocator): VmSlice =
+  ## Creates a ``VmSlice`` view for all elements in the slice `oa`.
+  let id = a.mapInteriorPointerToCell(oa.data)
+  # set the `start` and `len` even if data pointer doesn't point to a
+  # cell
+  VmSlice(cell: id, start: oa.data, len: oa.length, typ: elemTyp)
+
+func getItemHandle*(loc: LocHandle, index: Natural, a: VmAllocator): LocHandle =
+  ## Creates a handle to the item at `index` for the array-like at `loc`.
+  let typ = loc.typ
+  case typ.kind
+  of akSeq:
+    makeLocHandle(a, deref(loc).seqVal.data, typ.seqElemStride * index,
+                  typ.seqElemType)
+  of akOpenArray:
+    toSlice(deref(loc).oaVal, typ.seqElemType, a)[index]
+  of akArray:
+    subLocation(loc, typ.elementStride * index, typ.elementType)
+  else:
+    # Not an array like type
+    unreachable(typ.kind)
 
 proc arrayCopy*(mm: var VmMemoryManager, dest: var VmMemoryRegion, src: VmMemoryRegion, count: Natural, elemTyp: PVmType, reset: static[bool]) =
   ## Copies (via assignment) all items from `src[0..count-1]` to
@@ -664,7 +681,7 @@ func resetLocation*(mm: var VmMemoryManager, loc: var VmMemoryRegion, typ: PVmTy
   let a = cast[ptr Atom](addr loc[0])
 
   case typ.kind
-  of akInt, akFloat, akPtr, akSet, akCallable: discard
+  of akInt, akFloat, akPtr, akSet, akCallable, akOpenArray: discard
   of akString:
     if not a.strVal.data.isNil:
       mm.allocator.dealloc(a.strVal.data)
@@ -722,7 +739,7 @@ proc copyToLocation*(mm: var VmMemoryManager, dest: var VmMemoryRegion, src: VmM
         doAssert false
 
   case typ.kind
-  of akInt, akFloat, akPtr, akSet:
+  of akInt, akFloat, akPtr, akSet, akOpenArray:
     safeCopyMem(dest, src.subView(0, size), size)
   of akString:
     asgnVmString(dstAtom.strVal, srcAtom.strVal, mm.allocator)

--- a/compiler/vm/vmrunner.nim
+++ b/compiler/vm/vmrunner.nim
@@ -94,6 +94,33 @@ proc loadConst(s: PackedEnv, idx: int, dst: LocHandle,
     while i < L:
       result += loadConst(s, idx+1+result, getItemHandle(dst, i, mem.allocator), mem)
       inc i
+  of akOpenArray:
+    var
+      len: int
+      data: CellPtr
+    case n.kind
+    of pdkString:
+      let str {.cursor.} = s.strings[n.pos.LitId]
+      len = str.len
+      data = mem.allocator.allocTypedLocations(
+        dst.typ.seqElemType,
+        len,
+        len * dst.typ.seqElemStride)
+      let slice = loadFullSlice(mem.allocator, data, dst.typ.seqElemType)
+      safeCopyMem(byteView(slice), toOpenArray(str, 0, str.high), str.len)
+    of pdkArray:
+      len = n.pos.int
+      data = mem.allocator.allocTypedLocations(
+        dst.typ.seqElemType,
+        len,
+        len * dst.typ.seqElemStride)
+      let slice = loadFullSlice(mem.allocator, data, dst.typ.seqElemType)
+      for i in 0..<len:
+        result += loadConst(s, idx + i + 1, slice[i], mem)
+    else:
+      unreachable()
+
+    deref(dst).oaVal = VmOpenArray(data: cast[VmMemPointer](data), length: len)
 
   of akString:
     assert n.kind == pdkString

--- a/compiler/vm/vmserialize.nim
+++ b/compiler/vm/vmserialize.nim
@@ -75,6 +75,40 @@ proc initFromExpr(dest: LocHandle, tree: MirTree, n: var int, env: MirEnv,
                               dest.typ.seqElemType)
     iterTree(j):
       arg recurse(slice[j])
+  of akOpenArray:
+    # the input is some container construction. The container is constructed
+    # into its own location, to which the openArray value then points
+    var len: int
+    var data: CellPtr = nil
+    case tree[n].kind
+    of mnkStrLit:
+      let str {.cursor.} = env[next().strVal]
+      len = str.len
+      if len > 0:
+        # allocate a payload and copy the character array:
+        data = c.allocator.allocTypedLocations(
+          dest.typ.seqElemType,
+          len,
+          len * dest.typ.seqElemStride)
+        let slice = loadFullSlice(c.allocator, data, dest.typ.seqElemType)
+        safeCopyMem(byteView(slice), str.toOpenArray(0, str.high), str.len)
+    of mnkArrayConstr, mnkSeqConstr:
+      len = tree[n].len.int
+      if len > 0:
+        # allocate a payload and put the elements into it:
+        data = c.allocator.allocTypedLocations(
+          dest.typ.seqElemType,
+          len,
+          len * dest.typ.seqElemStride)
+        let slice = loadFullSlice(c.allocator, data, dest.typ.seqElemType)
+        iterTree(j):
+          arg recurse(slice[j])
+    else:
+      unreachable(tree[n].kind)
+
+    # the openArray value refers to the whole sequence
+    deref(dest).oaVal =
+      VmOpenArray(data: cast[VmMemPointer](data), length: len)
   of akPtr:
     # nothing to do, only nil literals are allowed here
     discard next()

--- a/compiler/vm/vmtypegen.nim
+++ b/compiler/vm/vmtypegen.nim
@@ -48,7 +48,7 @@ func hash(t: VmType): Hash =
   let h = hash(t.kind)
   let body =
     case t.kind
-    of akSeq:                 hash(t.seqElemType)
+    of akSeq, akOpenArray:    hash(t.seqElemType)
     of akPtr, akRef:          hash(t.targetType)
     of akSet:                 hash(t.setLength)
     of akCallable:            hash(t.routineSig.int)
@@ -74,7 +74,7 @@ func `==`(a, b: VmType): bool =
   template cmpField(n): untyped = a.n == b.n
 
   case a.kind
-  of akSeq:                 cmpField(seqElemType)
+  of akSeq, akOpenArray:    cmpField(seqElemType)
   of akPtr, akRef:          cmpField(targetType)
   of akSet:                 cmpField(setLength)
   of akCallable:            cmpField(routineSig)
@@ -254,7 +254,14 @@ func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure;
   #       type was just created
 
   case t.kind
-  of tyVar, tyLent, tyPtr:
+  of tyVar, tyLent:
+    if t.base.skipTypes(abstractInst).kind == tyOpenArray:
+      return genType(c, t.base, cl)
+    else:
+      res.typ = VmType(kind: akPtr,
+                       targetType: genType(c, t[0], cl).typ)
+
+  of tyPtr:
     res.typ = VmType(kind: akPtr,
                      targetType: genType(c, t[0], cl).typ)
 
@@ -262,8 +269,12 @@ func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure;
     res.typ = VmType(kind: akRef,
                      targetType: genType(c, t[0], cl).typ)
 
-  of tySequence, tyOpenArray:
+  of tySequence:
     res.typ = VmType(kind: akSeq,
+                     seqElemType: genType(c, t[0], cl).typ)
+
+  of tyOpenArray:
+    res.typ = VmType(kind: akOpenArray,
                      seqElemType: genType(c, t[0], cl).typ)
 
   of tyProc:
@@ -386,7 +397,7 @@ func genType(c: var TypeInfoCache, t: PType, cl: var GenClosure;
 
       # tuples and arrays use deferred size computation; seqs use
       # deferred stride computation
-      if typ.kind in {akObject, akArray, akSeq}:
+      if typ.kind in {akObject, akArray, akSeq, akOpenArray}:
         cl.sizeQueue.add(result.typ)
 
   # add a lookup entry from the `PType` ID to the `VmType`
@@ -729,7 +740,7 @@ func genAllTypes(c: var TypeInfoCache, cl: var GenClosure) =
     case ty.kind:
     of akObject, akArray:
       discard calcSizeAndAlign(ty[])
-    of akSeq:
+    of akSeq, akOpenArray:
       # seqs are added after their element type, so the element type has it's
       # size calcualated by now
       ty.seqElemStride = int paddedSize(ty.seqElemType[])

--- a/compiler/vm/vmutils.nim
+++ b/compiler/vm/vmutils.nim
@@ -33,6 +33,8 @@ type
     case opc*: TOpcode:
       of opcConv, opcCast:
         types*: tuple[tfrom, tto: PType]
+      of opcSlice:
+        rd*: int
       of opcLdConst:
         ast*: PNode
       else:
@@ -86,6 +88,9 @@ proc codeListing*(c: TCtx; start = 0; last = -1): seq[DebugVmCodeEntry] =
       code.types = (c.rtti[c.code[i + 0].regBx-wordExcess].nimType,
                     c.rtti[c.code[i + 1].regBx-wordExcess].nimType)
       inc i, 1
+    of opcSlice:
+      code.rd = c.code[i + 1].regB
+      inc i, 1
     of opcLdConst:
       let cnst = c.constants[code.idx]
       code.ast =
@@ -135,6 +140,9 @@ proc renderCodeListing*(config: ConfigRef, sym: PSym,
                 $<e.opc, $<e.ra, $<e.rb,
                 $<e.types[0].typeToString(),
                 $<e.types[1].typeToString())
+    of opcSlice:
+      line.addf("  $# r$# r$# r$# r$#",
+                $<e.opc, $<e.ra, $<e.rb, $<e.rc, $<e.rd)
     of opcSetEh:
       line.addf("  $# $# $#", $<e.opc, $<e.ra, $e.rb)
     elif e.opc < firstABxInstr:

--- a/tests/lang/s06_experimental/s01_views/s00_bugs/t01_var_openarray.nim
+++ b/tests/lang/s06_experimental/s01_views/s00_bugs/t01_var_openarray.nim
@@ -3,7 +3,6 @@ description: '''
 `var openarray` is allowed as the type of a `var` binding, but it's unclear
 whether this is going to stay
 '''
-knownIssue.vm: "`toOpenArray` is not yet supported"
 """
 
 {.experimental: "views".}

--- a/tests/lang_objects/destructor/tconsider_var_openarray.nim
+++ b/tests/lang_objects/destructor/tconsider_var_openarray.nim
@@ -5,7 +5,6 @@ discard """
     underlying array is treated as alive afterwards
   '''
   targets: "c js vm"
-  knownIssue.vm: "`toOpenArray` is not yet supported"
 """
 
 import mhelper

--- a/tests/lang_types/openarray/topenarray.nim
+++ b/tests/lang_types/openarray/topenarray.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c js"
+  targets: "c js vm"
 """
 
 proc fn1[T](a: openArray[T]): seq[T] =

--- a/tests/magics/ttoopenarray.nim
+++ b/tests/magics/ttoopenarray.nim
@@ -3,7 +3,6 @@ discard """
     Specify the behaviour of the ``toOpenArray`` built-in procedure
   '''
   targets: "c js vm"
-  knownIssue.vm: "The magic is not yet supported by the VM backend"
 """
 
 template test(a, b: untyped) =
@@ -20,10 +19,6 @@ proc toSeq(a: openArray[int]): seq[int] {.noinline.} =
   for x in a.items:
     result.add x
 
-proc toSeqByte(a: openArray[byte]): seq[byte] {.noinline.} =
-  for x in a.items:
-    result.add x
-
 block from_array_construction:
   # test with an array construction as the array operand
   doAssert toSeq(toOpenArray([1, 2, 3], 0, 0)) == [1]
@@ -35,21 +30,12 @@ block from_postive_range_based_array:
   # knownIssue: the bounds are not properly offset
   test toSeq(toOpenArray(arr, 8, 12)), [11, 12, 13, 14, 15]
 
-  doAssertRaises(IndexDefect):
-    discard toOpenArray(arr, 10, 8)
-
 block from_negative_range_based_array:
   var arr: array[-3 .. -1, int] = [1, 2, 3]
   # knownIssue: the bounds are not properly offset
   test toSeq(toOpenArray(arr, -3, -1)), [1, 2, 3]
   doAssert toSeq(toOpenArray(arr, 0, -1)) == []
   doAssert toSeq(toOpenArray(arr, -3, -4)) == []
-  doAssertRaises(IndexDefect):
-    discard toOpenArray(arr, -4, -1)
-  doAssertRaises(IndexDefect):
-    discard toOpenArray(arr, -1, 0)
-  doAssertRaises(IndexDefect):
-    discard toOpenArray(arr, -1, -3)
 
 block from_seq:
   var s = @[1, 2, 3, 4, 5]
@@ -59,8 +45,6 @@ block from_seq:
   # https://github.com/nim-lang/nim/issues/7904
   doAssert toSeq(toOpenArray(s, 0, -1)) == []
   doAssert toSeq(toOpenArray(s, 1, 0)) == []
-  doAssertRaises(IndexDefect):
-    discard toOpenArray(s, 0, -2)
 
   doAssert toSeq(toOpenArray(s, 9, 8)) == []
   doAssert toSeq(toOpenArray(s, 0, -1)) == []
@@ -82,21 +66,3 @@ block from_openArray:
   # create empty openArray from non-empty openArray
   testEmpty(toOpenArray(s, 1, 2))
   doAssert first(toOpenArray(s, 1, s.len-1)) == 2
-
-block from_unchecked_array:
-  let
-    s = @[1, 2, 3, 4, 5]
-    p = cast[ptr UncheckedArray[int]](addr s[0])
-
-  when defined(js):
-    # knownIssue: the ``UncheckedArray`` overload is not yet
-    #             supported by the JS backend
-    doAssert not compiles(toOpenArray(p, 1, 3)), "it works now"
-  else:
-    doAssert first(toOpenArray(p, 1, 3)) == 2
-
-block from_string:
-  # test the byte-casting overload
-  let str = "0123456789"
-  doAssert toSeqByte(toOpenArrayByte(str, 0, str.high)) ==
-           [0x30'u8, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39]

--- a/tests/magics/ttoopenarray_index_error.nim
+++ b/tests/magics/ttoopenarray_index_error.nim
@@ -1,0 +1,26 @@
+discard """
+  description: '''
+    Ensure that the bound checks for `toOpenArray` work correctly.
+  '''
+  targets: "c js vm"
+  knownIssue.vm: "Bound checks for `toOpenArray` are not implemented"
+"""
+
+block from_postive_range_based_array:
+  var arr: array[8..12, int] = [11, 12, 13, 14, 15]
+  doAssertRaises(IndexDefect):
+    discard toOpenArray(arr, 10, 8)
+
+block from_negative_range_based_array:
+  var arr: array[-3 .. -1, int] = [1, 2, 3]
+  doAssertRaises(IndexDefect):
+    discard toOpenArray(arr, -4, -1)
+  doAssertRaises(IndexDefect):
+    discard toOpenArray(arr, -1, 0)
+  doAssertRaises(IndexDefect):
+    discard toOpenArray(arr, -1, -3)
+
+block from_seq:
+  var s = @[1, 2, 3, 4, 5]
+  doAssertRaises(IndexDefect):
+    discard toOpenArray(s, 0, -2)

--- a/tests/magics/ttoopenarray_unchecked_array.nim
+++ b/tests/magics/ttoopenarray_unchecked_array.nim
@@ -1,0 +1,22 @@
+discard """
+  description: '''
+    Ensure that `toOpenArray` works for a pointer-to-UncheckedArray operand.
+  '''
+  targets: "c js vm"
+  knownIssue.js: "the overload is not available"
+  knownIssue.vm: "UncheckedArray is not supported"
+"""
+
+proc toSeq(a: openArray[int]): seq[int] {.noinline.} =
+  ## Intended to prevent comparisons being folded away by the compiler.
+  for x in a.items:
+    result.add x
+
+proc first(a: openArray[int]): int =
+  toSeq(toOpenArray(a, 0, 0))[0]
+
+let
+  s = @[1, 2, 3, 4, 5]
+  p = cast[ptr UncheckedArray[int]](addr s[0])
+
+doAssert first(toOpenArray(p, 1, 3)) == 2

--- a/tests/magics/ttoopenarraybyte.nim
+++ b/tests/magics/ttoopenarraybyte.nim
@@ -1,0 +1,15 @@
+discard """
+  targets: "c js vm"
+  knownIssue.vm: '''
+    toOpenArrayByte returns an openArray[char] internally, causing a run-time
+    type error
+  '''
+"""
+
+proc toSeqByte(a: openArray[byte]): seq[byte] {.noinline.} =
+  for x in a.items:
+    result.add x
+
+let str = "0123456789"
+doAssert toSeqByte(toOpenArrayByte(str, 0, str.high)) ==
+         [0x30'u8, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39]

--- a/tests/misc/ttoopenarray_array_bound_checks.nim
+++ b/tests/misc/ttoopenarray_array_bound_checks.nim
@@ -4,7 +4,7 @@ discard """
     Regression test for ``toOpenArray`` calls not bound-checking dereferenced
     pointer-to-array values
   '''
-  knownIssue.vm: "`toOpenArray` is not yet supported"
+  knownIssue.vm: "`toOpenArray` bound checking is not implemented"
 """
 
 template check(x: untyped) =


### PR DESCRIPTION
## Summary

Add support for all `toOpenArray` overloads except the
`ptr UncheckedArray` one for code running in the VM (both compile-time
and standalone).

## Details

To support slices, the new built-in VM type `akOpenArray` is added,
which is implemented as a pointer + length pair and represents a
*non-owning* slice.

Adding the type means:
* handling it in type translation (`vmtypegen`)
* handling it in constant data initialization (`vmserialize` for
  compile-time code; `vmrunner` for standalone code)
* handling it in to-AST deserialization (`vmcompilerserdes`)

Compared to the other VM built-in container types (string, array, seq,
etc.), `akOpenArray` is non-owning, which means that the location
storing the openArray value being accessible doesn't imply the data
pointer being safely accessible. Read and write access has to account
for this by validating the `LocHandle` returned for a slice element.

Since the extra validation has overhead compared to seq/string/array
access, seq/string/array locations are still passed as-is to
`openArray` parameters and locals -- an `akOpenArray` value is only
constructed when storing into a field/element of `openArray` type, or
when using `toOpenArray`.

For implementing `toOpenArray`, the `opcSlice` opcode is added. The
`mChckBounds`  magic is not yet implemented, meaning that no bound
checks
are performed for `toOpenArray` for code running in the VM. Since
`opcSlice` creates an empty slice for out-of-bounds operands, the
sandbox is not compromised by the missing bound checks. 

Finally, the `knownIssue` tag is removed from various tests. The
`tests/magic/toopenarray.nim` tests is split into multiple tests in
order to be able to mark the not-yet-working parts of `toOpenArray` as
known issues, without reducing test coverage for the working parts.

Fixes https://github.com/nim-works/nimskull/issues/1541