### PR TITLE
lexopt: remove bundle special case in `remaining()`

### DIFF
--- a/lib/experimental/lexopt.nim
+++ b/lib/experimental/lexopt.nim
@@ -233,22 +233,17 @@ iterator remaining*(l: var CmdLexer): string =
   ##
   ## If the previous option returned from `next()` have a value that was not
   ## consumed by `value()`, `UnexpectedValueError` will be raised.
-  ##
-  ## As a special case, any short options within a bundle (ie. `-abcde`) that
-  ## have not been processed by `next()` is considered the value of the last
-  ## short option returned and will raise `UnexpectedValueError`.
   if l.valueIdx > 0:
     if l.current.isLongOpt:
       raise newUnexpectedValueError(l.current[0..<l.valueIdx],
                                     l.current[l.valueIdx + 1..^1])
+    elif l.current[l.valueIdx] in ValueSeparators:
+      raise newUnexpectedValueError("-" & $l.current[l.valueIdx - 1],
+                                    l.current[l.valueIdx + 1..^1])
     else:
-      let value =
-        if l.current[l.valueIdx] in ValueSeparators:
-          l.current[l.valueIdx + 1..^1]
-        else:
-          l.current[l.valueIdx..^1]
-
-      raise newUnexpectedValueError("-" & $l.current[l.valueIdx - 1], value)
+      yield "-" & l.current[l.valueIdx..^1]
+      l.valueIdx = 0
+      inc l.index
 
   while l.index < l.cmdline.len:
     yield move l.current

--- a/tests/stdlib/experimental/tlexopt.nim
+++ b/tests/stdlib/experimental/tlexopt.nim
@@ -443,14 +443,19 @@ block opts:
 
     block afterOpts:
       ## Use `remaining()` after stepping
-      const values = ["-it-s", "free", "--real", "estate"]
-      var lexer = initCmdLexer(@["-1", "--second"] & @values)
+      const values = ["-undle", "-it-s", "free", "--real", "estate"]
+      var lexer = initCmdLexer(
+        @["-1", "--second", "-bundle", "-it-s", "free", "--real", "estate"]
+      )
 
       var (kind, option) = lexer.next()
       doAssert (kind, option) == (cmdShort, "1"):
         "Unexpected value: " & $(kind, option)
       (kind, option) = lexer.next()
       doAssert (kind, option) == (cmdLong, "second"):
+        "Unexpected value: " & $(kind, option)
+      (kind, option) = lexer.next()
+      doAssert (kind, option) == (cmdShort, "b"):
         "Unexpected value: " & $(kind, option)
 
       let collected = toSeq(lexer.remaining())
@@ -459,7 +464,7 @@ block opts:
 
     block unexpected:
       ## UnexpectedValueError when remaining() is called where inline values exist
-      var lexer = initCmdLexer(@["-d:useMalloc", "--run:false", "-bundle"])
+      var lexer = initCmdLexer(@["-d:useMalloc", "--run:false"])
 
       var (kind, option) = lexer.next()
       doAssert (kind, option) == (cmdShort, "d"):
@@ -484,23 +489,3 @@ block opts:
       except UnexpectedValueError as e:
         doAssert e.opt == "--run"
         doAssert e.value == "false"
-
-      discard lexer.value()
-
-      # Special case: unconsumed bundle is treated as inline value
-      (kind, option) = lexer.next()
-      doAssert (kind, option) == (cmdShort, "b"):
-        "Unexpected value: " & $(kind, option)
-      (kind, option) = lexer.next()
-      doAssert (kind, option) == (cmdShort, "u"):
-        "Unexpected value: " & $(kind, option)
-      (kind, option) = lexer.next()
-      doAssert (kind, option) == (cmdShort, "n"):
-        "Unexpected value: " & $(kind, option)
-      try:
-        for _ in lexer.remaining():
-          doAssert false, "unreachable"
-        doAssert false, "the previous call should've failed"
-      except UnexpectedValueError as e:
-        doAssert e.opt == "-n"
-        doAssert e.value == "dle"


### PR DESCRIPTION
## Summary
The  `remaining()`  iterator no longer considers the remainder of a
partially processed bundle as a value that has to be handled, and
instead produces a set of short options bundle.

## Details
The idea I had when this "feature" was implemented is to avoid value
synthesis in  `remaining()` , making sure that only the original input
is yielded. That way, you can distinguish between  `-pstuff`  from 
`-p -stuff`  when  `remaining()`  is used.

However,  `lexopt`  was designed with the premise that an user would
never have to distinguish between different kinds of inline value
representation, since "delimited" is the only supported type of inline
parameter. As such this feature is just an error that you cannot avoid.

This commit removes the special case, and synthesize a short option
bundle from the unprocessed portions of the active bundle instead.