### PR TITLE
parseutils: make `parseBiggestFloat` non-magic

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -787,7 +787,7 @@ type
     mSetLengthStr, mSetLengthSeq,
     mIsPartOf, mAstToStr,
     mSwap, mIsNil, mArrToSeq,
-    mNewString, mNewStringOfCap, mParseBiggestFloat,
+    mNewString, mNewStringOfCap,
     mMove, mWasMoved, mDestroy, mTrace,
     mDefault, mFinished, mIsolate, mAccessEnv, mAccessTypeField, mReset,
     mArray, mOpenArray, mRange, mSet, mSeq, mVarargs,

--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1379,7 +1379,7 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
   of mIncl, mExcl, mCard, mLtSet, mLeSet, mEqSet, mMulSet, mPlusSet, mMinusSet,
      mInSet:
     genSetOp(p, e, d, op)
-  of mNewString, mNewStringOfCap, mExit, mParseBiggestFloat:
+  of mNewString, mNewStringOfCap, mExit:
     var opr = p.env[e[0].prc]
     # Why would anyone want to set nodecl to one of these hardcoded magics?
     # - not sure, and it wouldn't work if the symbol behind the magic isn't

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -95,7 +95,7 @@ when options.hasTinyCBackend:
   import backend/tccgen
 
 const NonMagics* = {mNewString, mNewStringOfCap, mNewSeq, mSetLengthSeq,
-                    mAppendSeqElem, mEnumToStr, mExit, mParseBiggestFloat,
+                    mAppendSeqElem, mEnumToStr, mExit,
                     mAbsI, mDotDot, mEqCString, mIsolate}
   ## magics that are treated like normal procedures by the code generator.
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -188,7 +188,7 @@ const
   sfModuleInit* = sfMainModule
     ## the procedure is the 'init' procedure of a module
 
-  NonMagics* = { mAbsI, mDotDot, mParseBiggestFloat, mExit }
+  NonMagics* = { mAbsI, mDotDot, mExit }
     ## magics that are treated like normal procedures by the code
     ## generator
 
@@ -1847,9 +1847,6 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
   of mNewStringOfCap:
     unaryExpr(p, n, r, "mnewString", "mnewString(0)")
   of mAbsI, mDotDot:
-    genCall(p, n, r)
-  of mParseBiggestFloat:
-    useMagic(p, "nimParseBiggestFloat")
     genCall(p, n, r)
   # of mAccessEnv:
   #   unaryExpr(p, n, r, "accessEnv", "accessEnv($1)")

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -78,3 +78,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimskullNoNkStmtListTypeAndNkBlockType")
   defineSymbol("nimskullNoNkNone")
   defineSymbol("nimskullHasSupportsZeroMem")
+  defineSymbol("nimskullHasNoParseFloatMagic")

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -20,8 +20,7 @@
 import
   std/[
     strutils,
-    tables,
-    parseutils
+    tables
   ],
   compiler/ast/[
     ast,
@@ -1782,31 +1781,6 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
 
       checkHandle(regs[rb])
       regs[ra].intVal = ord(bitSetIn(bitSet(regs[rb].handle), regs[rc].intVal))
-    of opcParseFloat:
-      # TODO: this op has really unusual semantics. Turn it into a callback?
-
-      # a = number of chars read
-      # c[] = parseFloat(rb, rd)
-      decodeBC(rkInt)
-      inc pc
-      assert c.code[pc].opcode == opcParseFloat
-      let rd = c.code[pc].regA
-
-      checkHandle(regs[rb])
-      checkHandle(regs[rc])
-      assert regs[rc].handle.typ.kind == akFloat
-
-      # because the ``number`` parameter of ``parseBiggestFloat`` is an out
-      # parameter, no valid input value needs to be provided
-      var number: BiggestFloat
-      # TODO: don't do a string copy here
-      let r = parseBiggestFloat($regs[rb].strVal, number, regs[rd].intVal.int)
-      if r != 0:
-        # only write back the number if parsing succeeded (matching the
-        # behaviour of ``parseBiggestFloat``)
-        writeFloat(regs[rc].handle, number)
-
-      regs[ra].intVal = r
     of opcRangeChck:
       # Checks if a is in range [b, c], aborts execution otherwise
       let rb = instr.regB

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -77,7 +77,7 @@ type
     opcMulSet, opcPlusSet, opcMinusSet, opcConcatStr,
     opcContainsSet, opcRepr, opcSetLenStr, opcSetLenSeq,
     opcIsNil, opcOf,
-    opcParseFloat, opcConv, opcNumConv, opcObjConv, opcCast
+    opcConv, opcNumConv, opcObjConv, opcCast
     opcQuit, opcInvalidField,
     opcNarrowS, opcNarrowU,
     opcSignExtend,

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1859,17 +1859,6 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
       c.freeTemp(tmp)
     else:
       genUnaryABC(c, n, dest, opcIsNil)
-  of mParseBiggestFloat:
-    if dest.isUnset: dest = c.getTemp(n.typ)
-    var
-      tmp1 = c.genx(n[1])
-      tmp2 = c.genx(n[2])
-      tmp3 = c.genx(n[3])
-    c.gABC(n, opcParseFloat, dest, tmp1, tmp2)
-    c.gABC(n, opcParseFloat, tmp3)
-    c.freeTemp(tmp1)
-    c.freeTemp(tmp2)
-    c.freeTemp(tmp3)
   of mDefault:
     if fitsRegister(n.typ):
       prepare(c, dest, n.typ)

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -65,6 +65,7 @@ from std/times import getTime
 from std/hashes import hash
 from std/osproc import nil
 from system/formatfloat import writeFloatToBufferSprintf
+from std/parseutils import parseBiggestFloat
 
 from compiler/modules/modulegraphs import `$`
 
@@ -352,6 +353,13 @@ iterator basicOps*(): Override =
     of 1: setResult(a, round(getFloat(a, 0)))
     of 2: setResult(a, round(getFloat(a, 0), getInt(a, 1).int))
     else: doAssert false, $n
+
+  override "stdlib.parseutils.parseBiggestFloat", proc(a: VmArgs) {.nimcall.} =
+    var num: BiggestFloat
+    copyMem(num.addr, a.getHandle(1).rawPointer, sizeof(num))
+    let parsed = a.getString(0).parseBiggestFloat(num, int a.getInt(2))
+    copyMem(a.getHandle(1).rawPointer, num.addr, sizeof(num))
+    a.setResult(parsed)
 
   wrap1s(getMD5, md5op)
 

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -569,11 +569,233 @@ proc parseUInt*(s: string, number: var uint, start = 0): int {.
   if result != 0:
     number = uint(res)
 
-proc parseBiggestFloat*(s: string, number: var BiggestFloat, start = 0): int {.
-  magic: "ParseBiggestFloat", importc: "nimParseBiggestFloat", noSideEffect.}
-  ## Parses a float starting at `start` and stores the value into `number`.
-  ## Result is the number of processed chars or 0 if a parsing error
-  ## occurred.
+
+when not defined(nimskullHasNoParseFloatMagic):
+  proc parseBiggestFloat*(s: string, number: var BiggestFloat, start = 0): int {.
+    magic: "ParseBiggestFloat", importc: "nimParseBiggestFloat", noSideEffect.}
+elif defined(js):
+  proc parseFloatNative(a: string): float =
+    let a2 = a.cstring
+    asm """
+    `result` = Number(`a2`);
+    """
+
+  proc parseBiggestFloat*(s: string, number: var BiggestFloat, start: int): int {.noSideEffect.} =
+    var sign: bool
+    var i = start
+    if s[i] == '+': inc(i)
+    elif s[i] == '-':
+      sign = true
+      inc(i)
+    if s[i] == 'N' or s[i] == 'n':
+      if s[i+1] == 'A' or s[i+1] == 'a':
+        if s[i+2] == 'N' or s[i+2] == 'n':
+          if s[i+3] notin IdentChars:
+            number = NaN
+            return i+3 - start
+      return 0
+    if s[i] == 'I' or s[i] == 'i':
+      if s[i+1] == 'N' or s[i+1] == 'n':
+        if s[i+2] == 'F' or s[i+2] == 'f':
+          if s[i+3] notin IdentChars:
+            number = if sign: -Inf else: Inf
+            return i+3 - start
+      return 0
+
+    var buf: string
+      # we could also use an `array[char, N]` buffer to avoid reallocs, or
+      # use a 2-pass algorithm that first computes the length.
+    if sign: buf.add '-'
+    template addInc =
+      buf.add s[i]
+      inc(i)
+    template eatUnderscores =
+      while i in 0..s.high and s[i] == '_': inc(i)
+    while i in 0..s.high and s[i] in {'0'..'9'}: # Read integer part
+      buf.add s[i]
+      inc(i)
+      eatUnderscores()
+    if i in 0..s.high and s[i] == '.': # Decimal?
+      addInc()
+      while i in 0..s.high and s[i] in {'0'..'9'}: # Read fractional part
+        addInc()
+        eatUnderscores()
+    # Again, read integer and fractional part
+    if buf.len == ord(sign): return 0
+    if i in 0..s.high and s[i] in {'e', 'E'}: # Exponent?
+      addInc()
+      if s[i] == '+': inc(i)
+      elif s[i] == '-': addInc()
+      if s[i] notin {'0'..'9'}: return 0
+      while s[i] in {'0'..'9'}:
+        addInc()
+        eatUnderscores()
+    number = parseFloatNative(buf)
+    result = i - start
+else:
+  proc c_strtod(buf: cstring, endptr: ptr cstring): float64 {.importc: "strtod", header: "<stdlib.h>", noSideEffect.}
+  const powtens = [1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
+              1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+              1e20, 1e21, 1e22]
+
+  proc parseBiggestFloat*(s: string, number: var BiggestFloat,
+                          start = 0): int {.noSideEffect.} =
+    ## Parses a float starting at `start` and stores the value into `number`.
+    ## Result is the number of processed chars or 0 if a parsing error
+    ## occurred.
+    # This routine attempt to parse float that can parsed quickly.
+    # i.e. whose integer part can fit inside a 53bits integer.
+    # their real exponent must also be <= 22. If the float doesn't follow
+    # these restrictions, transform the float into this form:
+    #  INTEGER * 10 ^ exponent and leave the work to standard `strtod()`.
+    # This avoid the problems of decimal character portability.
+    # see: http://www.exploringbinary.com/fast-path-decimal-to-floating-point-conversion/
+    var
+      i = start
+      sign = 1.0
+      kdigits, fdigits = 0
+      exponent = 0
+      integer = uint64(0)
+      fracExponent = 0
+      expSign = 1
+      firstDigit = -1
+      hasSign = false
+
+    # Sign?
+    if i < s.len and (s[i] == '+' or s[i] == '-'):
+      hasSign = true
+      if s[i] == '-':
+        sign = -1.0
+      inc(i)
+
+    # NaN?
+    if i+2 < s.len and (s[i] == 'N' or s[i] == 'n'):
+      if s[i+1] == 'A' or s[i+1] == 'a':
+        if s[i+2] == 'N' or s[i+2] == 'n':
+          if i+3 >= s.len or s[i+3] notin IdentChars:
+            number = NaN
+            return i+3 - start
+      return 0
+
+    # Inf?
+    if i+2 < s.len and (s[i] == 'I' or s[i] == 'i'):
+      if s[i+1] == 'N' or s[i+1] == 'n':
+        if s[i+2] == 'F' or s[i+2] == 'f':
+          if i+3 >= s.len or s[i+3] notin IdentChars:
+            number = Inf*sign
+            return i+3 - start
+      return 0
+
+    if i < s.len and s[i] in {'0'..'9'}:
+      firstDigit = (s[i].ord - '0'.ord)
+    # Integer part?
+    while i < s.len and s[i] in {'0'..'9'}:
+      inc(kdigits)
+      integer = integer * 10'u64 + (s[i].ord - '0'.ord).uint64
+      inc(i)
+      while i < s.len and s[i] == '_': inc(i)
+
+    # Fractional part?
+    if i < s.len and s[i] == '.':
+      inc(i)
+      # if no integer part, Skip leading zeros
+      if kdigits <= 0:
+        while i < s.len and s[i] == '0':
+          inc(fracExponent)
+          inc(i)
+          while i < s.len and s[i] == '_': inc(i)
+
+      if firstDigit == -1 and i < s.len and s[i] in {'0'..'9'}:
+        firstDigit = (s[i].ord - '0'.ord)
+      # get fractional part
+      while i < s.len and s[i] in {'0'..'9'}:
+        inc(fdigits)
+        inc(fracExponent)
+        integer = integer * 10'u64 + (s[i].ord - '0'.ord).uint64
+        inc(i)
+        while i < s.len and s[i] == '_': inc(i)
+
+    # if has no digits: return error
+    if kdigits + fdigits <= 0 and
+      (i == start or # no char consumed (empty string).
+      (i == start + 1 and hasSign)): # or only '+' or '-
+      return 0
+
+    if i+1 < s.len and s[i] in {'e', 'E'}:
+      inc(i)
+      if s[i] == '+' or s[i] == '-':
+        if s[i] == '-':
+          expSign = -1
+
+        inc(i)
+      if s[i] notin {'0'..'9'}:
+        return 0
+      while i < s.len and s[i] in {'0'..'9'}:
+        exponent = exponent * 10 + (ord(s[i]) - ord('0'))
+        inc(i)
+        while i < s.len and s[i] == '_': inc(i) # underscores are allowed and ignored
+
+    var realExponent = expSign*exponent - fracExponent
+    let expNegative = realExponent < 0
+    var absExponent = abs(realExponent)
+
+    # if exponent greater than can be represented: +/- zero or infinity
+    if absExponent > 999:
+      if expNegative:
+        number = 0.0*sign
+      else:
+        number = Inf*sign
+      return i - start
+
+    # if integer is representable in 53 bits:  fast path
+    # max fast path integer is  1<<53 - 1 or  8999999999999999 (16 digits)
+    let digits = kdigits + fdigits
+    if digits <= 15 or (digits <= 16 and firstDigit <= 8):
+      # max float power of ten with set bits above the 53th bit is 10^22
+      if absExponent <= 22:
+        if expNegative:
+          number = sign * integer.float / powtens[absExponent]
+        else:
+          number = sign * integer.float * powtens[absExponent]
+        return i - start
+
+      # if exponent is greater try to fit extra exponent above 22 by multiplying
+      # integer part is there is space left.
+      let slop = 15 - kdigits - fdigits
+      if absExponent <= 22 + slop and not expNegative:
+        number = sign * integer.float * powtens[slop] * powtens[absExponent-slop]
+        return i - start
+
+    # if failed: slow path with strtod.
+    var t: array[500, char] # flaviu says: 325 is the longest reasonable literal
+    var ti = 0
+    let maxlen = t.high - "e+000".len # reserve enough space for exponent
+
+    let endPos = i
+    result = endPos - start
+    i = start
+    # re-parse without error checking, any error should be handled by the code above.
+    if i < endPos and s[i] == '.': i.inc
+    while i < endPos and s[i] in {'0'..'9','+','-'}:
+      if ti < maxlen:
+        t[ti] = s[i]; inc(ti)
+      inc(i)
+      while i < endPos and s[i] in {'.', '_'}: # skip underscore and decimal point
+        inc(i)
+
+    # insert exponent
+    t[ti] = 'E'
+    inc(ti)
+    t[ti] = if expNegative: '-' else: '+'
+    inc(ti, 4)
+
+    # insert adjusted exponent
+    t[ti-1] = ('0'.ord + absExponent mod 10).char
+    absExponent = absExponent div 10
+    t[ti-2] = ('0'.ord + absExponent mod 10).char
+    absExponent = absExponent div 10
+    t[ti-3] = ('0'.ord + absExponent mod 10).char
+    number = c_strtod(addr t, nil)
 
 proc parseFloat*(s: string, number: var float, start = 0): int {.
   rtl, extern: "npuParseFloat", noSideEffect.} =

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -580,7 +580,9 @@ elif defined(js):
     `result` = Number(`a2`);
     """
 
-  proc parseBiggestFloat*(s: string, number: var BiggestFloat, start: int): int {.noSideEffect.} =
+  {.checks: off.} # TODO: Make the parsing work with checks enabled
+  proc parseBiggestFloat*(s: string, number: var BiggestFloat,
+                          start: int = 0): int {.noSideEffect.} =
     var sign: bool
     var i = start
     if s[i] == '+': inc(i)
@@ -610,19 +612,19 @@ elif defined(js):
       buf.add s[i]
       inc(i)
     template eatUnderscores =
-      while i in 0..s.high and s[i] == '_': inc(i)
-    while i in 0..s.high and s[i] in {'0'..'9'}: # Read integer part
+      while s[i] == '_': inc(i)
+    while s[i] in {'0'..'9'}: # Read integer part
       buf.add s[i]
       inc(i)
       eatUnderscores()
-    if i in 0..s.high and s[i] == '.': # Decimal?
+    if s[i] == '.': # Decimal?
       addInc()
-      while i in 0..s.high and s[i] in {'0'..'9'}: # Read fractional part
+      while s[i] in {'0'..'9'}: # Read fractional part
         addInc()
         eatUnderscores()
     # Again, read integer and fractional part
     if buf.len == ord(sign): return 0
-    if i in 0..s.high and s[i] in {'e', 'E'}: # Exponent?
+    if s[i] in {'e', 'E'}: # Exponent?
       addInc()
       if s[i] == '+': inc(i)
       elif s[i] == '-': addInc()
@@ -632,11 +634,13 @@ elif defined(js):
         eatUnderscores()
     number = parseFloatNative(buf)
     result = i - start
+  {.checks: on.}
 else:
-  proc c_strtod(buf: cstring, endptr: ptr cstring): float64 {.importc: "strtod", header: "<stdlib.h>", noSideEffect.}
+  proc c_strtod(buf: cstring, endptr: ptr cstring): float64 {.
+    importc: "strtod", header:"<stdlib.h>", noSideEffect.}
   const powtens = [1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
-              1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
-              1e20, 1e21, 1e22]
+                   1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+                   1e20, 1e21, 1e22]
 
   proc parseBiggestFloat*(s: string, number: var BiggestFloat,
                           start = 0): int {.noSideEffect.} =

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -580,7 +580,7 @@ elif defined(js):
     `result` = Number(`a2`);
     """
 
-  {.checks: off.} # TODO: Make the parsing work with checks enabled
+  {.push checks: off.} # TODO: Make the parsing work with checks enabled
   proc parseBiggestFloat*(s: string, number: var BiggestFloat,
                           start: int = 0): int {.noSideEffect.} =
     var sign: bool
@@ -634,7 +634,7 @@ elif defined(js):
         eatUnderscores()
     number = parseFloatNative(buf)
     result = i - start
-  {.checks: on.}
+  {.pop.}
 else:
   proc c_strtod(buf: cstring, endptr: ptr cstring): float64 {.
     importc: "strtod", header:"<stdlib.h>", noSideEffect.}


### PR DESCRIPTION
## Summary

Make  `parseutils.parseBiggestFloat`  not rely on compiler magic,
enabling changing  `std/parseutils`  to use  `openArray[char]`  in the
future. Behaviour and interface stay the same.

## Details

There's no need for  `parseBiggestFloat`  to use compiler magic, so it's
changed to be a normal procedure, making it possible to change its
implementation and interface without touching the compiler.

The implementation is part of  `parseutils`  and dependent on the
backend:
* for the C backend, the implementation is copied verbatim from 
`strmantle.nimParseBiggestFloat` 
* for the JS backend, the implementation is copied verbatim from 
`jssys.nimParseBiggestFloat` 
* the VM implements the procedure via a VM hook

The now obsolete  `mParseBiggestFloat`  magic and the  `opcParseFloat` 
VM operation are removed.

For csources compatibility, the old magic procedure is still used when
the new   `nimskullHasNoParseFloatMagic`  conditional symbol is absent.
The related  `.compilerprocs`  in  `strmantle`  and  `jssys`  also have
to be kept.