### PR TITLE
io: only define stdmsg when stdout/err are defined

### DIFF
--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -58,12 +58,12 @@ when not isNimVmTarget and not defined(js):
     stderr* {.importc: stderrName, header: "<stdio.h>".}: File
       ## The standard error stream.
 
-when defined(useStdoutAsStdmsg):
-  template stdmsg*: File = stdout
-else:
-  template stdmsg*: File = stderr
-    ## Template which expands to either stdout or stderr depending on
-    ## `useStdoutAsStdmsg` compile-time switch.
+  when defined(useStdoutAsStdmsg):
+    template stdmsg*: File = stdout
+  else:
+    template stdmsg*: File = stderr
+      ## Template which expands to either stdout or stderr depending on
+      ## `useStdoutAsStdmsg` compile-time switch.
 
 when defined(windows):
   proc c_fileno(f: File): cint {.


### PR DESCRIPTION
## Summary
Makes sure that  `stdmsg`  is only defined when  `stdout`  and  `stderr` 
are defined.

## Details
For JS/VM backends,  `stderr`  and  `stdout`  don't exist, making 
`stdmsg`  unusable. However, feature detection via 
`when declared(stdmsg)`  would not be able to recognize this as 
`stdmsg`  remains defined even in those scenarios.

This PR moves  `stdmsg`  definition to be under the same conditionals
that defines  `stdout` / `stderr` , making sure that it is only defined
when it can be used.