### PR TITLE
lambdalifting: omit unnecessary env creation

### DIFF
--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -642,12 +642,7 @@ proc liftCapturedVars(n: PNode, graph: ModuleGraph, idgen: IdGenerator,
   ## environment field access, and usages of closure routines (except for
   ## iterators) are transformed into closure construction expressions.
   ##
-  ## In addition, the current enivornment (which can either be the root
-  ## routines local environment or some outer environment) is added as the
-  ## hidden parameter to each closure routine defined in the root
-  ## routine.
-  ##
-  ## `n` is assumed to be owned, and is thus modified in-place.
+  ## `n` is expected to be a production and is modified in-place.
   result = n
   case n.kind
   of nkSym:
@@ -724,7 +719,7 @@ proc liftIterToProc*(g: ModuleGraph; fn: PSym; body: PNode; ptrType: PType;
 proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode;
                   idgen: IdGenerator): tuple[body: PNode, env: PSym] =
   ## Performs multiple things:
-  ## * produce an object type that contains all local variables and
+  ## * produces an object type that contains all local variables and
   ##   parameters of `fn` (with body `body`) that inner routines close
   ##   over
   ## * injects the AST for setting up an instance of the environment

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -782,24 +782,23 @@ proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode;
     var d = initDetectionPass(g, fn, idgen)
     detectCapturedVars(body, fn, d)
 
-    if d.requireUp or d.accessOuter or d.closureProcCalled or
-       d.capturedVars.len > 0:
+    if d.capturedVars.len > 0 or
+       (not d.requireUp and not d.accessOuter and d.closureProcCalled):
+      # TODO: an unnecessary env is currently when there are only inner
+      #       .closure procedures that don't close over anything. Find a good
+      #       way to mark all real closures as such and then ignore all other
+      #       .closure routines during lambda lifting
       let t = produceEnvType(d, idgen, fn, fn.info)
       prepareInnerRoutines(d, idgen, t, fn.info)
-
-      let
-        c = initLiftingPass(d, newEnvVar(g.cache, fn, t, fn.info, idgen))
-        transformed = liftCapturedVars(body, g, idgen, c)
-
-      # XXX: if only the outer environment needs to be passed to inner
-      #      routines and nothing in `fn` itself needs to be lifted,
-      #      then we don't need a dedicated environment that stores just
-      #      the up reference
-      if d.requireUp or d.closureProcCalled or d.capturedVars.len > 0:
-        result = rawClosureCreation(g, idgen, c, body.info)
-        result.add transformed
-      else:
-        result = transformed
+      let c = initLiftingPass(d, newEnvVar(g.cache, fn, t, fn.info, idgen))
+      result = rawClosureCreation(g, idgen, c, body.info)
+      result.add liftCapturedVars(body, g, idgen, c)
+    elif d.requireUp or d.accessOuter:
+      # the procedure only access the env parameter, without creating its
+      # own environment
+      let param = getHiddenParam(g, fn)
+      prepareInnerRoutines(d, idgen, param.typ, fn.info)
+      result = liftCapturedVars(body, g, idgen, initLiftingPass(d, param))
     else:
       # nothing to do
       result = body

--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -617,10 +617,14 @@ proc symToClosure(n: PNode; graph: ModuleGraph; idgen: IdGenerator;
 proc transformedAccess(n: PNode, graph: ModuleGraph, idgen: IdGenerator, c: LiftingPass): PNode =
   let s = n.sym
   if isInnerProc(s):
-    # don't transform closure iterator usages yet; we don't know the
-    # proper environment types at this point
-    if s.typ.callConv == ccClosure and not s.isIterator:
-      result = symToClosure(n, graph, idgen, c)
+    if s.typ.callConv == ccClosure:
+      if s.isIterator:
+        # only create a preliminary construction using the local env.
+        # A proper construction is created once the iterator's environment
+        # type is known
+        result = makeClosure(graph, idgen, s, newSymNode(c.envSym), n.info)
+      else:
+        result = symToClosure(n, graph, idgen, c)
     else:
       result = n
   elif s.id in c.capturedVars:
@@ -639,8 +643,8 @@ proc liftCapturedVars(n: PNode, graph: ModuleGraph, idgen: IdGenerator,
                       c: LiftingPass): PNode =
   ## Recursively transforms the AST `n` according to the context provided
   ## with `c`. Usages and definitions of locals are transformed into an
-  ## environment field access, and usages of closure routines (except for
-  ## iterators) are transformed into closure construction expressions.
+  ## environment field access, and usages of closure routines are transformed
+  ## into closure construction expressions.
   ##
   ## `n` is expected to be a production and is modified in-place.
   result = n
@@ -717,7 +721,7 @@ proc liftIterToProc*(g: ModuleGraph; fn: PSym; body: PNode; ptrType: PType;
   result = liftCapturedVars(body, g, idgen, c)
 
 proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode;
-                  idgen: IdGenerator): tuple[body: PNode, env: PSym] =
+                  idgen: IdGenerator): PNode =
   ## Performs multiple things:
   ## * produces an object type that contains all local variables and
   ##   parameters of `fn` (with body `body`) that inner routines close
@@ -770,8 +774,7 @@ proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode;
     prepareInnerRoutines(d, idgen, t, fn.info)
     # the environment instance is not setup here; that's done at the iterator's
     # callsite
-    result.body = liftCapturedVars(body, g, idgen, initLiftingPass(d, param))
-    result.env = param
+    result = liftCapturedVars(body, g, idgen, initLiftingPass(d, param))
   elif body.kind != nkEmpty:
     assert fn.typ.callConv != ccClosure or getEnvParam(fn) != nil,
       "missing environment parameter"
@@ -793,40 +796,48 @@ proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode;
       #      then we don't need a dedicated environment that stores just
       #      the up reference
       if d.requireUp or d.closureProcCalled or d.capturedVars.len > 0:
-        result.body = rawClosureCreation(g, idgen, c, body.info)
-        result.body.add transformed
+        result = rawClosureCreation(g, idgen, c, body.info)
+        result.add transformed
       else:
-        result.body = transformed
-
-      result.env = c.envSym
+        result = transformed
     else:
       # nothing to do
-      result = (body, nil)
+      result = body
   else:
     # a routine prototype or otherwise empty routine -> nothing to do
-    result = (body, nil)
+    result = body
 
 proc liftLambdasForTopLevel*(module: PSym, body: PNode): PNode =
   # XXX implement it properly
   result = body
 
-proc liftIterSym*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner, currEnv: PSym): PNode =
-  ## Transforms  ``(iter)``  to  ``(iter, newClosure[iter]())``.
-  ## This cannot happen as part of ``liftCapturedVars``, as the iterator's
-  ## environment type is not available at that point.
+proc liftIterSym*(g: ModuleGraph; n: PNode; idgen: IdGenerator; owner: PSym): PNode =
+  ## Transforms  ``(iter)`` into a closure iterator value construction
+  ## ``(iter, newClosure[iter]())``.
   let iter = n.sym
   assert iter.isIterator
+  let constr = newObjConstr(getHiddenParam(g, iter).typ, n.info)
+  result = makeClosure(g, idgen, iter, constr, n.info)
 
+proc transformIterConstr*(g: ModuleGraph; n: PNode, idgen: IdGenerator,
+                          owner: PSym): PNode =
+  ## Transforms a preliminary closure iterator value construction generated
+  ## during lambda lifting into a proper construction, now that the iterator's
+  ## environment type is known.
+  assert n.kind == nkClosure
+  let iter = n[0].sym
+  assert iter.isIterator
   let
-    hp = getHiddenParam(g, iter)
-    envTyp = hp.typ # the environment's ``ref`` type
+    envTyp = getHiddenParam(g, iter).typ
     constr = newObjConstr(envTyp, n.info)
 
   let upField = lookupInRecord(envTyp.base.n, getIdent(g.cache, upName))
   if upField != nil:
-    # the iterator has an 'up' field, and we have to initialize it here
-    let access = accessEnv(currEnv, upField.typ, n.info, g)
-    constr.add newTree(nkExprColonExpr, [newSymNode(upField), access])
+    g.config.internalAssert(n[1].kind == nkSym,
+      "iterator construction is missing the up value")
+    constr.add nkExprColonExpr.newTree(
+      newSymNode(upField),
+      accessEnv(n[1].sym, upField.typ, n.info, g))
 
   result = makeClosure(g, idgen, iter, constr, n.info)
 

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -90,10 +90,6 @@ type
     graph: ModuleGraph
     idgen: IdGenerator
 
-    env: PSym ## the symbol of the local (or parameter) through which
-              ## the lifted local environment is accessed. 'nil', if
-              ## none exists.
-
 proc transformBody*(g: ModuleGraph; idgen: IdGenerator, prc: PSym, cache: bool): PNode
 
 proc pushTransCon(c: PTransf, t: PTransCon) =
@@ -135,7 +131,7 @@ proc transformSymAux(c: PTransf, n: PNode): PNode =
       # which is only available after transforming the routine...
       discard transformBody(c.graph, c.idgen, s, true)
 
-      return liftIterSym(c.graph, n, c.idgen, getCurrOwner(c), c.env)
+      return liftIterSym(c.graph, n, c.idgen, getCurrOwner(c))
     elif s.kind in {skProc, skFunc, skConverter, skMethod}:
       # top level .closure procs are still somewhat supported for 'Nake':
       ensureEnvParam(c.graph, c.idgen, s)
@@ -1335,10 +1331,15 @@ proc transform(c: PTransf, n: PNode): PNode =
     # it can happen that for-loop-inlining produced a fresh
     # set of variables, including some computed environment
     # (bug #2604). We need to patch this environment here too:
-    let a = n[1]
-    if a.kind == nkSym:
+    if c.inlining > 0:
       result = copyTree(n)
-      result[1] = transformSymAux(c, a)
+      result[1] = transform(c, n[1])
+    elif n[0].kind == nkSym and n[0].sym.isIterator:
+      # must be a preliminary construction created by lambda lifting; complete
+      # it, but first transform the iterator so that it has a proper
+      # environment type
+      discard transformBody(c.graph, c.idgen, n[0].sym, true)
+      result = transformIterConstr(c.graph, n, c.idgen, getCurrOwner(c))
     else:
       result = n
   of nkOfBranch:
@@ -1566,7 +1567,7 @@ proc transformBody*(g: ModuleGraph, idgen: IdGenerator, prc: PSym, body: PNode):
   ## Application always happens in that exact order.
   g.config.timeTracer.traceSym(tikTransform, prc)
   var c = PTransf(graph: g, module: prc.getModule, idgen: idgen)
-  (result, c.env) = liftLambdas(g, prc, body, c.idgen)
+  result = liftLambdas(g, prc, body, c.idgen)
   result = processTransf(c, result, prc)
   liftDefer(c, result)
   result = eliminateUnreachable(g, result)


### PR DESCRIPTION
## Summary

* improve call performance for inner routines that call closure
  routines but don't have closed-over locals themselves
* improve performance in general for closures where some parent
  routine(s) don't have closed-over locals

## Details

Previously, a local closure environment was always allocated on entry
of a routine A that called routines closing over some locals outside of
A. If such routine doesn't have closed-over locals itself, the closure
environment only stored an up-pointer, thus being unnecessary.

An example of such a case:
```nim
proc top() =
  var x = 0
  proc inner() = # <- an closure environment was allocate here
    proc inner2() =
      x = 1
    inner2()
  ...
```

Lambda-lifting is changed to never create a local closure environment
for closure procedures that have no closed-over locals. Instead, the
environment parameter is passed to the inner closures directly.

To make the above change easier, the lambda-lifting pass is changed to
not return the env variable symbol anymore, instead creating a
preliminary `nkClosure` construction with the env symbol that the main
`transf` pass then completes.