### PR TITLE
fix alignment computation for large sets

### DIFF
--- a/compiler/sem/sizealignoffsetimpl.nim
+++ b/compiler/sem/sizealignoffsetimpl.nim
@@ -301,12 +301,9 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
       elif length <= 64:
         typ.size = 8
         typ.align = int16(conf.floatInt64Align)
-      elif align(length, 8) mod 8 == 0:
-        typ.size = align(length, 8) div 8
-        typ.align = int16(conf.floatInt64Align)
       else:
-        typ.size = align(length, 8) div 8 + 1
-        typ.align = int16(conf.floatInt64Align)
+        typ.size = align(length, 8) div 8
+        typ.align = 1 # it's an array of uint8
   of tyRange:
     computeSizeAlign(conf, typ[0])
     typ.size = typ[0].size

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -392,6 +392,7 @@ testinstance:
     var issue15516: MyObject
     var issue12636_1: Stack[5, MyObject]
     var issue12636_2: Stack2[MyObject]
+    var seLarge: set[0..64] # only needs more than 64 elements
 
     var
       e1: Enum1
@@ -410,7 +411,8 @@ testinstance:
     else:
       doAssert sizeof(SimpleAlignment) > 10
 
-    testSizeAlignOf(t,a,b,c,d,e,f,g,ro,go,po, e1, e2, e4, e8, eoa, eob, capo, issue15516, issue12636_1, issue12636_2)
+    testSizeAlignOf(t,a,b,c,d,e,f,g,ro,go,po, e1, e2, e4, e8, eoa, eob, capo,
+                    issue15516, issue12636_1, issue12636_2, seLarge)
 
     type
       WithBitsize {.objectconfig.} = object


### PR DESCRIPTION
## Summary

Fix the alignment computation for large sets not matching the physical
alignment when using the C backend, which could cause heap/stack
corruption due to incorrectly computed aggregate type sizes.

## Details

Large sets (i.e., sets with more than 64 elements) are implemented as
arrays of `uint8` by the C code generator, which have an alignment of 1
byte, but `sizealignoffsetimpl` considered the sets to be aligned
the same as `int`.

Since the computed alignment is used when computing internal field
offsets and aggregate type sizes, it was possible for `offsetof` and
`sizeof` to report *larger* sizes and offsets than what the actual
values are, thus being able to cause out-of-bound reads/writes when
used in conjunction with low-level memory operations (e.g., `copyMem`).