### PR TITLE
sempass2: fix bug with `.closure` inference

### DIFF
--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1642,23 +1642,28 @@ proc detectCapture(owner, top: PSym, n: PNode, marker: var IntSet): PNode =
     of skProc, skFunc, skIterator:
       # NOTE: a routine using the closure calling convention means that it
       # *may* captures something (it might not). A routine not using the
-      # closure calling convention means that it *can't* capture anything,
+      # closure calling convention means that it *cannot* capture anything,
       # so we don't need to analyse the latter
-      if s.typ != nil and s.typ.callConv == ccClosure and
-         s.owner.kind != skModule: # don't analyse top-level closure iterators
-        if s.owner.id == owner.id:
-          # a procedure that's defined directly inside the currently analysed
-          # procedure is used as a value. Recurse into it to see if it captures
-          # an entity outside of `top`
-          result = detectCapture(s, top, s.ast[bodyPos], marker)
+      if s.typ != nil and s.skipGenericOwner.kind != skModule:
+        # top-level routines cannot capture anything and are thus not relevant
+        if s.isOwnedBy(top) or sfForward notin s.flags:
+          # an inner routine is used, scan it if hasn't been already
+          if s.typ.callConv == ccClosure and not containsOrIncl(marker, s.id):
+            if s.isOwnedBy(top):
+              result = detectCapture(s, top, s.ast[bodyPos], marker)
+            else:
+              # treat as capturing, even if `s` doesn't close over anything
+              # in practice
+              # TODO: fix lambdalifting such that not all .closure routines are
+              #       considered capturing and remove this workaround
+              result = n
         else:
-          # procedure A that uses the closure calling convention is used in
-          # procedure B, but A is not an inner procedure of B. Because of a
-          # limitation of the lambda-lifting implementation, B needs to be
-          # treated as capturing something
-          # XXX: fixing this requires two things: 1) tracking which routine
-          #      really captures something, and 2) fixing ``lambdalifting``
-          result = detect(s)
+          # an outer (relative to `top`), still forwarded routine is used
+          if s.typ.callConv == ccClosure or
+             tfExplicitCallConv notin s.typ.flags:
+            # conservatively assume that the routine will capture something
+            result = n
+
     else:
       discard "not relevant"
   of nkWithoutSons - {nkSym, nkCommentStmt}:

--- a/tests/lang_callable/closure/tclosure_inference.nim
+++ b/tests/lang_callable/closure/tclosure_inference.nim
@@ -13,7 +13,7 @@ proc test1() =
 
   var x = 0
   proc inner() =
-    echo x
+    doAssert x == 0
 
   inner2()
 
@@ -66,8 +66,8 @@ proc test4() =
 
   var x = 0
   proc inner() =
-    # ... and does
-    echo x
+    # ... and it does close over something
+    doAssert x == 0
 
   inner2()
 
@@ -93,7 +93,7 @@ proc test6() =
   proc inner() =
     # `inner` doesn't close over anything *directly*
     proc innerInner[T]() =
-      echo x # generic routine closes over something
+      doAssert x == 0 # generic routine closes over something
     innerInner[int]()
     # `inner` still closes over something indirectly, by using `innerInner`
 

--- a/tests/lang_callable/closure/tclosure_inference.nim
+++ b/tests/lang_callable/closure/tclosure_inference.nim
@@ -1,0 +1,102 @@
+discard """
+  description: '''
+    Ensures inner routines are properly detected as closing over something.
+  '''
+"""
+
+# forwarded .closure routine used in inner routine
+proc test1() =
+  proc inner() {.closure.}
+  proc inner2() =
+    # ^^ inferred as a closure, because `inner` might close over something
+    inner()
+
+  var x = 0
+  proc inner() =
+    echo x
+
+  inner2()
+
+test1()
+
+# forwarded .closure routine that doesn't actually close over something
+proc test2() =
+  proc inner() {.closure.}
+  proc inner2() =
+    # ^^ inferred as a closure, because `inner` might close over something
+    inner()
+
+  static:
+    doAssert inner2 isnot (proc() {.nimcall.})
+
+  proc inner() =
+    discard
+
+  inner2()
+
+test2()
+
+# forwarded inner routine with unspecified calling convention
+proc test3() =
+  proc inner()
+  proc inner2() =
+    # inferred as .closure because `inner` might close over something
+    inner()
+
+  static:
+    doAssert inner2 isnot (proc() {.nimcall.})
+
+  proc inner() =
+    # ... but doesn't in reality
+    discard
+
+  inner2()
+
+test3()
+
+# forwarded inner routine with unspecified calling convention (2)
+proc test4() =
+  proc inner()
+  proc inner2() =
+    # inferred as .closure because `inner` might close over something
+    inner()
+
+  static:
+    doAssert inner2 isnot (proc() {.nimcall.})
+
+  var x = 0
+  proc inner() =
+    # ... and does
+    echo x
+
+  inner2()
+
+test4()
+
+# forwarded inner routine with explicit, non-.closure calling convention
+proc test5() =
+  proc inner() {.nimcall.}
+  proc inner2() {.nimcall.} =
+    inner()
+
+  proc inner() =
+    discard
+
+  inner2()
+
+test5()
+
+# generic inner routine defined and used in other inner routine
+proc test6() =
+  var x = 0
+
+  proc inner() =
+    # `inner` doesn't close over anything *directly*
+    proc innerInner[T]() =
+      echo x # generic routine closes over something
+    innerInner[int]()
+    # `inner` still closes over something indirectly, by using `innerInner`
+
+  inner()
+
+test6()

--- a/tests/lang_callable/closure/tclosure_proc_doesnt_require_capture.nim
+++ b/tests/lang_callable/closure/tclosure_proc_doesnt_require_capture.nim
@@ -1,0 +1,23 @@
+discard """
+  description: '''
+    An inner procedure using the .closure calling convention may be used in
+    a separate, non-.closure inner routine.
+  '''
+  knownIssue: '''
+    Lambda-lifting assumes .closure means "closes over something", requiring
+    sempass2 to enforce the .closure calling covention on the callee/using
+    routine
+  '''
+"""
+
+proc test() =
+  proc inner() {.closure.} =
+    # uses closure calling convention, but doesn't close over anything
+    discard
+
+  proc inner2() {.nimcall.} =
+    inner()
+
+  inner2()
+
+test()


### PR DESCRIPTION
## Summary

Fix inference failure and the compiler subsequently crashing for
forwarded inner procedures and generic inner routines.

## Details

`.closure` inference for didn't consider forwarded routines properly
and generic owners were also not ignored, leading to some the affected
inner routines not being inferred as requiring the `.closure` calling
convention, which then led to an internal assertion failure during
lambda-lifting.

Still-forwarded routines don't have a body to analyze at the time of
usage, and thus have to be assumed to capture, unless an explicit
calling convention is specified that's not `.closure`.