### PR TITLE
stdlib: enumutils len calculates enum length

### DIFF
--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -175,3 +175,7 @@ func symbolName*[T: enum](a: T): string =
     assert c1.symbolName == "c1"
   const names = enumNames(T)
   names[a.symbolRank]
+
+func len*[T: enum](E: typedesc[T]): int =
+  for e in E.items:
+    inc result

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -176,6 +176,6 @@ func symbolName*[T: enum](a: T): string =
   const names = enumNames(T)
   names[a.symbolRank]
 
-func len*[T: enum](E: typedesc[T]): uint16 =
+func len*[T: enum](E: typedesc[T]): int =
   for e in E.items:
     inc result

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -176,6 +176,6 @@ func symbolName*[T: enum](a: T): string =
   const names = enumNames(T)
   names[a.symbolRank]
 
-func len*[T: enum](E: typedesc[T]): int =
+func len*[T: enum](E: typedesc[T]): uint16 =
   for e in E.items:
     inc result

--- a/tests/stdlib/algorithm/tenumutils.nim
+++ b/tests/stdlib/algorithm/tenumutils.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c js"
+  targets: "c js vm"
 """
 
 import std/enumutils
@@ -11,6 +11,12 @@ template main =
     type B[T] = enum b0 = 2, b1 = 4
     doAssert A.toSeq == [a0, a1, a2]
     doAssert B[float].toSeq == [B[float].b0, B[float].b1]
+  
+  block: # len
+    type A3 = enum a0, a1, a2
+    type B3 = enum b0 = 2, b1 = 4, b2 = 8, b3 = 16
+    doAssert len(A3) == 3
+    doAssert B3.len == 4
 
   block: # symbolName
     block:


### PR DESCRIPTION
## Summary

Add a `len` routine to the `enumutils` module, which calculates the number of entries in an enum.

## Details

Besides adding the procedure, a corresponding test was also added to the existing `tenumutils`, and that test now also runs for the `vm` target instead of just `c` and `js`.

---

## Notes for Reviewers
* I'm tired so there might be a much better way to do this or preexisting functionality that I'm forgetting
* required for property based testing