### PR TITLE
mir: rename `mnkResume` to `mnkUnwind`

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -348,7 +348,7 @@ proc targetToIr(tree: MirBody, cr: var TreeCursor): CgNode =
   case n.kind
   of mnkLabel:
     result = newLabelNode(n.label)
-  of mnkResume:
+  of mnkUnwind:
     result = CgNode(kind: cnkResume, info: cr.info)
   else:
     unreachable(n.kind)

--- a/compiler/mir/mirgen_blocks.nim
+++ b/compiler/mir/mirgen_blocks.nim
@@ -227,7 +227,7 @@ proc raiseExit*(c; bu) =
       return
 
   # no local exception handler exists
-  bu.add MirNode(kind: mnkResume)
+  bu.add MirNode(kind: mnkUnwind)
 
 proc closeBlock*(c; bu): bool =
   ## Finishes the current block. If required for the block (because it is a

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -806,7 +806,7 @@ proc splitAssignments(tree: MirTree, changes: var Changeset) =
       # * if the destination is a local, does the exceptional path enter a
       #   local exception handler?
       if tree[tree.getRoot(tree.operand(p, 0))].kind notin Locals or
-         tree[target].kind != mnkResume:
+         tree[target].kind != mnkUnwind:
         # future direction: this can be optimized. The assignment only needs to
         # be split if the assignment destination's value is observed on the
         # exceptional control-flow path

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -85,8 +85,7 @@ type
     mnkMagic  ## only allowed in a callee position. Refers to a magic
               ## procedure
 
-    mnkResume    ## special action in a target list that means "resume
-                 ## exception handling in caller"
+    mnkUnwind    ## special target for exceptional control-flow
 
     mnkDef       ## marks the start of existence of a local, global, procedure,
                  ## or temporary. Supports an optional intial value (except for
@@ -281,9 +280,9 @@ type
       imm*: uint32 ## meaning depends on the context
     of mnkMagic:
       magic*: TMagic
-    of mnkNone, mnkNilLit, mnkType, mnkResume:
+    of mnkNone, mnkNilLit, mnkType, mnkUnwind:
       discard
-    of {low(MirNodeKind)..high(MirNodeKind)} - {mnkNone..mnkResume}:
+    of {low(MirNodeKind)..high(MirNodeKind)} - {mnkNone..mnkUnwind}:
       len*: uint32
 
   MirTree* = seq[MirNode]
@@ -308,7 +307,7 @@ const
     ## Node kinds that represent definition statements (i.e. something that
     ## introduces a named entity)
 
-  AtomNodes* = {mnkNone..mnkResume}
+  AtomNodes* = {mnkNone..mnkUnwind}
     ## Nodes that don't support sub nodes.
 
   SubTreeNodes* = AllNodeKinds - AtomNodes
@@ -420,7 +419,7 @@ template `[]`*(tree: MirTree, i: NodePosition | OpValue): untyped =
 
 template isAtom(kind: MirNodeKind): bool =
   # much faster than an `in SubTreeNodes` test
-  ord(kind) <= ord(mnkResume)
+  ord(kind) <= ord(mnkUnwind)
 
 func parent*(tree: MirTree, n: NodePosition): NodePosition =
   result = n

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -59,7 +59,7 @@ func `$`(n: MirNode): string =
   of mnkImmediate:
     result.add " imm: "
     result.addInt n.imm
-  of mnkNone, mnkNilLit, mnkType, mnkResume:
+  of mnkNone, mnkNilLit, mnkType, mnkUnwind:
     discard
   of SubTreeNodes:
     result.add " len: "
@@ -241,7 +241,7 @@ proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
     result.add "type("
     typeToStr(result, n.typ, c.env)
     result.add ")"
-  of AllNodeKinds - Atoms - mnkProc + {mnkResume}:
+  of AllNodeKinds - Atoms - mnkProc + {mnkUnwind}:
     result.error(n)
 
 proc singleToStr(tree: MirTree, i: var int, result: var string, c: RenderCtx) =
@@ -351,8 +351,8 @@ proc targetToStr(nodes: MirTree, i: var int, result: var string) =
     result.add "["
     result.add n.label
     result.add "]"
-  of mnkResume:
-    result.add "[Resume]"
+  of mnkUnwind:
+    result.add "[Unwind]"
   else:
     result.error(n)
 

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -144,7 +144,7 @@ type
       ## the ``JoinId`` -> instruction position mappings
     labelToJoin: Table[LabelId, JoinId]
       ## maps the label ID to the corresponding join ID
-    resumeLabel: Option[JoinId]
+    unwindLabel: Option[JoinId]
       ## only setup when used
 
 func incl[T](s: var seq[T], v: sink T) =
@@ -188,22 +188,22 @@ func dfaOp(env: var ClosureEnv, opc: Opcode, tree: MirTree, n: NodePosition,
   if tree[v].kind in LvalueExprKinds:
     dfaOp(env, opc, n, v)
 
-func getResumeLabel(env: var ClosureEnv): JoinId =
+func getUnwindLabel(env: var ClosureEnv): JoinId =
   # the join point is allocated when first used
-  if env.resumeLabel.isNone:
-    env.resumeLabel = some env.joins.len.JoinId
+  if env.unwindLabel.isNone:
+    env.unwindLabel = some env.joins.len.JoinId
     env.joins.add 0 # will be patched later
-  env.resumeLabel.unsafeGet
+  env.unwindLabel.unsafeGet
 
 func raiseExit(env: var ClosureEnv, opc: Opcode, tree: MirTree,
                at, target: NodePosition) =
-  # compute the join ID to use, accounting for the special 'resume' action:
+  # compute the join ID to use, accounting for the special 'unwind' action:
   let join =
     case tree[target].kind
     of mnkLabel:
       map(env, tree[target].label)
-    of mnkResume:
-      env.getResumeLabel()
+    of mnkUnwind:
+      env.getUnwindLabel()
     else:
       unreachable()
 
@@ -248,7 +248,7 @@ func emitForArgs(env: var ClosureEnv, tree: MirTree, at, source: NodePosition) =
     case tree[it].kind
     of mnkArg, mnkConsume, mnkName:
       emitForArg(env, tree, at, it)
-    of mnkMagic, mnkProc, mnkLabel, mnkImmediate, mnkResume:
+    of mnkMagic, mnkProc, mnkLabel, mnkImmediate, mnkUnwind:
       discard
     else:
       emitLvalueOp(env, opUse, tree, at, OpValue it)
@@ -463,9 +463,9 @@ func computeDfg*(tree: MirTree): DataFlowGraph =
     else:
       discard "not relevant"
 
-  # patch the resume label, if used:
-  if env.resumeLabel.isSome:
-    let id = env.resumeLabel.unsafeGet
+  # patch the unwind label, if used:
+  if env.unwindLabel.isSome:
+    let id = env.unwindLabel.unsafeGet
     env.joins[id] = env.instrs.len.InstrPos
     env.instrs.add Instr(op: opJoin, node: tree.len.NodePosition, id: id)
 

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -49,7 +49,7 @@ Semantics
         | LVALUE
 
   TARGET = <Label>
-  EX_TARGET = <Label> | Resume
+  EX_TARGET = <Label> | Unwind
 
   UNARY_OP = NegI VALUE
 
@@ -262,10 +262,10 @@ that:
 is not allowed. However, much like in the high-level language, structured
 constructs can be nested.
 
-Resume
+Unwind
 ------
 
-`Resume` is a special jump target that may only appear as the target of
+`Unwind` is a special jump target that may only appear as the target of
 `Raise`, `Continue`, `CheckedCall`, and `Except`. It specifies that
 unwinding/exception-handling *resumes* in the caller procedure.
 

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -14,13 +14,13 @@ scope:
     x = <D2>
   L1:
   def_cursor _3: (string, int) = x
-  def _4: string = $(arg _3) -> [Resume]
+  def _4: string = $(arg _3) -> [Unwind]
   echo(arg type(array[0..0, string]), arg _4) -> [L2]
   =destroy(name _4)
   goto [L3]
   finally (L2):
     =destroy(name _4)
-    continue [Resume]
+    continue [Unwind]
   L3:
 -- end of expandArc ------------------------
 --expandArc: sio
@@ -29,7 +29,7 @@ scope:
   scope:
     def_cursor filename: string = "debug.txt"
     def_cursor _3: string = filename
-    def f: File = open(arg _3, arg fmRead, arg 8000) -> [Resume]
+    def f: File = open(arg _3, arg fmRead, arg 8000) -> [Unwind]
     def _4: uint32
     scope:
       def res: string = newStringOfCap(arg 80)
@@ -66,7 +66,7 @@ scope:
       def _13: bool = eqI(arg _4, arg 1'u32)
       if _13:
         nimAbortException(arg true)
-      continue [Resume]
+      continue [Unwind]
     L7:
     case _4
     of 0'u32: goto L9
@@ -74,7 +74,7 @@ scope:
     L9:
     goto [L11]
     L10:
-    raise -> [Resume]
+    raise -> [Unwind]
     L11:
 
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -28,7 +28,7 @@ scope:
   =destroy(name splat)
   goto [L1]
 finally (L0):
-  continue [Resume]
+  continue [Unwind]
 L1:
 -- end of expandArc ------------------------
 --expandArc: delete
@@ -89,7 +89,7 @@ scope:
     continue [L0]
   finally (L0):
     =destroy(name a)
-    continue [Resume]
+    continue [Unwind]
   L2:
 -- end of expandArc ------------------------
 --expandArc: extractConfig
@@ -140,7 +140,7 @@ scope:
   goto [L7]
   finally (L3):
     =destroy(name lan_ip)
-    continue [Resume]
+    continue [Unwind]
   L7:
 --expandArc: mergeShadowScope
 
@@ -181,7 +181,7 @@ scope:
   goto [L6]
   finally (L0):
     =destroy(name shadowScope)
-    continue [Resume]
+    continue [Unwind]
   L6:
 -- end of expandArc ------------------------
 --expandArc: treturn
@@ -212,7 +212,7 @@ scope:
   L4:
 goto [L1]
 finally (L5):
-  continue [Resume]
+  continue [Unwind]
 L1:
 
 -- end of expandArc ------------------------
@@ -220,11 +220,11 @@ L1:
 
 scope:
   def_cursor _2: string = this[].value
-  this[].isValid = fileExists(arg _2) -> [Resume]
+  this[].isValid = fileExists(arg _2) -> [Unwind]
   def _4: tuple[dir: string, front: string]
   scope:
     def_cursor _5: string = this[].value
-    def _6: bool = dirExists(arg _5) -> [Resume]
+    def _6: bool = dirExists(arg _5) -> [Unwind]
     if _6:
       scope:
         def _7: string
@@ -233,7 +233,7 @@ scope:
         goto [L1]
   scope:
     def_cursor _8: string = this[].value
-    def _9: string = parentDir(arg _8) -> [Resume]
+    def _9: string = parentDir(arg _8) -> [Unwind]
     def _10: string
     =copy(name _10, arg this[].value)
     def _11: tuple[head: string, tail: string] = splitPath(consume _10) -> [L2]
@@ -245,7 +245,7 @@ scope:
     goto [L3]
     finally (L2):
       =destroy(name _9)
-      continue [Resume]
+      continue [Unwind]
     L3:
   L1:
   def par: tuple[dir: string, front: string] = move _4
@@ -267,7 +267,7 @@ scope:
   goto [L7]
   finally (L4):
     =destroy(name par)
-    continue [Resume]
+    continue [Unwind]
   L7:
 
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_no_loop_cursor.nim
+++ b/tests/arc/topt_no_loop_cursor.nim
@@ -32,7 +32,7 @@ scope:
   goto [L6]
   finally (L5):
     destroy x
-    continue [Resume]
+    continue [Unwind]
   L6:
 
 -- end

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -19,7 +19,7 @@ scope:
               goto [L2]
         def_cursor _8: Node = it
         def_cursor _9: string = _8[].s
-        echo(arg type(array[0..0, string]), arg _9) -> [Resume]
+        echo(arg type(array[0..0, string]), arg _9) -> [Unwind]
         def_cursor _10: Node = it
         it = _10[].ri
   L2:
@@ -54,7 +54,7 @@ scope:
   goto [L9]
   finally (L8):
     =destroy(name jt)
-    continue [Resume]
+    continue [Unwind]
   L9:
 
 -- end of expandArc ------------------------'''

--- a/tests/arc/topt_unpacking_no_cursor.nim
+++ b/tests/arc/topt_unpacking_no_cursor.nim
@@ -3,7 +3,7 @@ discard """
   nimout: '''--expandArc: test
 
 scope:
-  def x: (Obj, Obj) = init() -> [Resume]
+  def x: (Obj, Obj) = init() -> [Unwind]
   def _2: (Obj, Obj) = move x
   def a: Obj
   a := move _2.0

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -21,7 +21,7 @@ scope:
   =destroy(name a)
   goto [L3]
   finally (L0):
-    continue [Resume]
+    continue [Unwind]
   L3:
 -- end of expandArc ------------------------
 --expandArc: tfor
@@ -77,7 +77,7 @@ scope:
     continue [L0]
   finally (L0):
     =destroy(name a)
-    continue [Resume]
+    continue [Unwind]
   L9:
 L5:
 -- end of expandArc ------------------------

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -19,7 +19,7 @@ scope:
   goto [L1]
   finally (L0):
     =destroy(name _2)
-    continue [Resume]
+    continue [Unwind]
   L1:
 -- end of expandArc ------------------------
 --expandArc: main1
@@ -40,12 +40,12 @@ scope:
   goto [L1]
   finally (L0):
     =destroy(name s)
-    continue [Resume]
+    continue [Unwind]
   L1:
 -- end of expandArc ------------------------
 --expandArc: main2
 scope:
-  def s: seq[byte] = newSeq(arg 100) -> [Resume]
+  def s: seq[byte] = newSeq(arg 100) -> [Unwind]
   def _3: openArray[byte] = toOpenArray s
   def _4: seq[byte] = encode(arg _3) -> [L0]
   def_cursor _5: string = cast _4
@@ -57,12 +57,12 @@ scope:
   goto [L1]
   finally (L0):
     =destroy(name s)
-    continue [Resume]
+    continue [Unwind]
   L1:
 -- end of expandArc ------------------------
 --expandArc: main3
 scope:
-  def _2: seq[byte] = newSeq(arg 100) -> [Resume]
+  def _2: seq[byte] = newSeq(arg 100) -> [Unwind]
   def _3: openArray[byte] = toOpenArray _2
   def _4: seq[byte] = encode(arg _3) -> [L0]
   def_cursor _5: string = cast _4
@@ -74,7 +74,7 @@ scope:
   goto [L1]
   finally (L0):
     =destroy(name _2)
-    continue [Resume]
+    continue [Unwind]
   L1:
 -- end of expandArc ------------------------'''
 """

--- a/tests/misc/tdont_fold_procedure_cast.nim
+++ b/tests/misc/tdont_fold_procedure_cast.nim
@@ -11,7 +11,7 @@ scope:
   def_cursor _2: proc (x: float){.nimcall.} = cast other
   def p: proc (x: float){.nimcall.} = copy _2
   def_cursor _3: proc (x: int){.nimcall.} = cast p
-  _3(arg 1) -> [Resume]
+  _3(arg 1) -> [Unwind]
 -- end of expandArc ------------------------
   '''
   output: "1"

--- a/tests/optimization/tno_destroy_for_empty_result.nim
+++ b/tests/optimization/tno_destroy_for_empty_result.nim
@@ -15,7 +15,7 @@ scope:
   result := move _2
 goto [L2]
 finally (L1):
-  continue [Resume]
+  continue [Unwind]
 L2:
 
 -- end of expandArc ------------------------


### PR DESCRIPTION
## Summary

Rename the MIR node kind `mnkResume` to `mnkUnwind`; behaviour doesn't
change.

## Details

The name "resume" is a good fit for a control-flow primitive needed by
delimited continuation support (for resuming after suspending/forking),
so `mnkResume` is renamed to `mnkUnwind` in order to make the name
"resume" available again.

Both the node kind as well as some routines related to it are renamed.
The pretty-printer also renders the unwind target as `Unwind`, and the
tests comparing textual MIR fragments are adjusted accordingly.