### PR TITLE
sem: fix `.tailcall` proc types with generic return type

### DIFF
--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -308,11 +308,16 @@ proc instantiateProcType(c: PContext, pt: TIdTable,
     propagateToOwner(result, result[i])
     addDecl(c, param)
 
+  result.n[0] = originalParams[0].copyTree
+  if originalParams[0].len > effectListLen:
+    # instantiate the hidden ``Continuation`` type
+    result.n[0][effectListLen] =
+      replaceTypeVarsN(cl, originalParams[0][effectListLen])
+
   resetIdTable(cl.symMap)
   cl.isReturnType = true
   result[0] = replaceTypeVarsT(cl, result[0])
   cl.isReturnType = false
-  result.n[0] = originalParams[0].copyTree
   if result[0] != nil:
     propagateToOwner(result, result[0])
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1916,7 +1916,11 @@ proc prepareTailcallProc(c: PContext, info: TLineInfo, typ: PType) =
   else:
     invoc.rawAddSon(typ[0])
 
-  let inst = instGenericContainer(c, info, invoc)
+  # if the return type is generic, delay instantiation of the ``Continuation``
+  # until the proc type is instantiated
+  let inst =
+    if containsGenericType(typ[0]): invoc
+    else: instGenericContainer(c, info, invoc)
   # we cannot override the return type right away, since that'd leak the
   # Continuation implementation detail. Therefore the type is hidden away
   # in the effect list...

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -136,7 +136,7 @@ type
 
 proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType
 proc replaceTypeVarsS(cl: var TReplTypeVars, s: PSym): PSym
-proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode
+proc replaceTypeVarsN*(cl: var TReplTypeVars, n: PNode): PNode
 proc replaceTypeVarsInBody*(c: PContext, pt: TIdTable, n: PNode): PNode
 
 proc initLayeredTypeMap*(pt: TIdTable): LayeredIdTable =
@@ -294,7 +294,7 @@ proc reResolveCallsWithTypedescParams(c: PContext, n: PNode): PNode =
 
   return n
 
-proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
+proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode): PNode =
   ## Replaces references to unresolved types in AST associated with types (i.e.:
   ## the AST that is stored in the ``TType.n`` field).
   ##
@@ -325,9 +325,7 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
   else:
     if n.len > 0:
       newSons(result, n.len)
-      if start > 0:
-        result[0] = n[0]
-      for i in start..<n.len:
+      for i in 0..<n.len:
         result[i] = replaceTypeVarsN(cl, n[i])
 
 proc replaceTypeVarsS(cl: var TReplTypeVars, s: PSym): PSym =
@@ -829,13 +827,24 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
         eraseVoidTypes(result)
 
       of tyProc:
-        # bug #4677: Do not instantiate effect lists
-        result.n = replaceTypeVarsN(cl, result.n, 1)
+        let orig = result.n
+        result.n = shallowCopy(result.n)
+        # the effects list is ignored
+        result.n[0] = copyTree(orig[0])
+        if orig[0].len > effectListLen:
+          # instantiate the hidden ``Continuation`` type
+          result.n[0][effectListLen] =
+            replaceTypeVarsN(cl, orig[0][effectListLen])
+
+        # instantiate types in the parameter symbol list:
+        for i in 1..<orig.len:
+          result.n[i] = replaceTypeVarsN(cl, orig[i])
+
         eraseVoidParams(result)
         skipIntLiteralParams(result, cl.c.idgen)
 
       of tyRange:
-        result.n = replaceTypeVarsN(cl, result.n, 0)
+        result.n = replaceTypeVarsN(cl, result.n)
         result[0] = result[0].skipTypes({tyStatic, tyDistinct})
 
       else: discard

--- a/tests/lang/s99_tailcall/t03_generic_return_type.nim
+++ b/tests/lang/s99_tailcall/t03_generic_return_type.nim
@@ -1,0 +1,7 @@
+discard """
+  description: "The return type of a .tailcall routine may be generic."
+"""
+
+proc test[T](x: T): T {.tailcall.} = x
+
+doAssert test(1) == 1

--- a/tests/lang/s99_tailcall/t05_tailcall_proc_values_generic_return_type.nim
+++ b/tests/lang/s99_tailcall/t05_tailcall_proc_values_generic_return_type.nim
@@ -1,0 +1,11 @@
+discard """
+  description: "The return type of a .tailcall proc type may be generic."
+"""
+
+type Generic[T] = proc(x: T): T {.tailcall.}
+
+proc test(x: int): int {.tailcall.} = x
+
+var x: Generic[int]
+x = test
+doAssert x(1) == 1


### PR DESCRIPTION
## Summary

Fix `.tailcall` routine definitions and proc types where the return
type is or contains an unresolved type variable always causing an
instantiation error.

## Details

The internal  `Continuation`  type was instantiated eagerly, even when
the
return type was an unresolved type variable or contained one,
triggering an instantiation error.

Instantiation of the type is now delayed until the routine or proc type
is instantiated. To implement this, handling the `nkFormalParams` tree
stored in `tyProc` types is moved out of `replaceTypeVarsN`, as not
all `nkFormalParams` trees processed by `replaceTypeVarsN` belong to
`tyProc`s.