### PR TITLE
ci(reproducible): add workaround for reprotest usage of sudo

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -56,6 +56,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # XXX: Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1108550
+      - name: Configure sudo for reprotest
+        run: |
+          umask 0200
+          echo 'Defaults !fqdn' | sudo tee /etc/sudoers.d/10-no-fqdn
+
       - name: Install reprotest
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
## Summary
Configures sudo to workaround a bug in `reprotest`.

## Details
`sudo`  recent security fixes exposed a bug where reprotest was using
the program improperly, causing reproducible build tests to fail.

This commit configures  `sudo`  to allow  `reprotest`  to continue
working as before, as described in
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1108550