### PR TITLE
ci(reproducible): disable sudo usage for reprotest

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -81,21 +81,22 @@ jobs:
       - id: reprotest
         name: Run reproducibility build
         run: |
+          set -euxo pipefail
+
           # Add a guest user for reprotest
           sudo useradd -m guest-builder
 
           # The path to output diffoscope HTML to
           output_html=$RUNNER_TEMP/diffoscope.html
           run_reprotest() {
-            # Disabled kernel variation as it messes with csources architecture
-            # detection.
+            # XXX: user_group and domain_host variation are disabled due to
+            # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1108550
             #
-            # Can be re-enabled once reprotest is >= 0.7.18, where a fix is added
-            # to prevent 32-bit architectures from being selected.
+            # Remove this once the bug is fixed.
             reprotest \
               --vary=domain_host.use_sudo=1 \
               --vary=user_group.available+=guest-builder:guest-builder \
-              --vary=-kernel \
+              --vary=-user_group,-domain_host \
               --diffoscope-arg="--html=$output_html" \
               'export XDG_CACHE_HOME=$PWD/build/nimcache \
                 && ${{ matrix.test.command }}' \


### PR DESCRIPTION
## Summary
Disables environment variations requiring `sudo` in `reprotest`.

## Details
`sudo` recent security fixes exposed a bug where reprotest was using
the program improperly, causing reproducible build tests to fail.

This commit disables all variations requiring `sudo` to workaround
the issue. This includes:

- `user_group`: Variations in build user/group. This can detect
  issues with non-normalized tar-archives, which we faced in the past.
  It's unfortunate, but for now we just have to be vigilant with
  changes to `niminst`.
- `domain_host`: Variations in build hostname. While it is possible to
  disable the use of `sudo`, this has always failed in CI. Since we
  don't use this information at all, it is rather safe to disable.

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1108550