### PR TITLE
mir: enable move analysis for `result`

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -65,6 +65,9 @@ type
       ## the list of all locals in the body, taken from the ``MirBody``.
       ## Only needed for updating the type for alias locals
 
+    returns: seq[CgNode]
+      ## goto statements to which the return label needs to be added
+
     inUnscoped: int
       ## whether the currently proceesed statement/expression is part of an
       ## unscoped control-flow context. Used to move definitions to the start
@@ -569,6 +572,12 @@ proc stmtToIr(tree: MirBody, env: MirEnv, cl: var TranslateCl,
     to cnkGotoStmt, targetToIr(tree, cr)
   of mnkLoop:
     to cnkLoopStmt, targetToIr(tree, cr)
+  of mnkReturn:
+    if n.len == 1:
+      skip(tree, cr) # skip the operand
+    let goto = newStmt(cnkGotoStmt, info)
+    cl.returns.add goto
+    stmts.add goto
   of mnkLoopJoin:
     to cnkLoopJoinStmt, targetToIr(tree, cr)
   of mnkJoin:
@@ -777,6 +786,24 @@ proc tb(tree: MirBody, env: MirEnv, cl: var TranslateCl,
   var cr = TreeCursor(pos: start.uint32)
   var stmts: seq[CgNode]
   scopeToIr(tree, env, cl, cr, stmts)
+
+  # remove all trailing return gotos:
+  while stmts.len > 0 and stmts[^1].kind == cnkGotoStmt:
+    assert stmts[^1].len == 0
+    cl.returns.del(cl.returns.find(stmts[^1]))
+    stmts.shrink(stmts.len - 1)
+
+  # complete all return goto's such that they jump to the end of the body
+  if cl.returns.len > 0:
+    if stmts[^1].kind == cnkJoinStmt:
+      # re-use the trailing join's label
+      for it in cl.returns.items:
+        it.add newLabelNode(LabelId(stmts[^1][0].label))
+    else:
+      for it in cl.returns.items:
+        it.add newLabelNode(tree.nextLabel)
+      stmts.add newTree(cnkJoinStmt, unknownLineInfo,
+                        newLabelNode(tree.nextLabel))
 
   # XXX: the list of statements is still wrapped in a node for now, but
   #      this needs to change once all code generators use the new CGIR

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -2681,7 +2681,8 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
         c.add MirNode(kind: mnkNone)
       c.register(genLocation(c, r))
 
-  c.withBlock bkBlock: # the target for return statements
+  block:
+    c.blocks.add Block(kind: bkBlock) # the target for return statements
     if needsTerminate:
       # it needs to be ensured that no exceptions leave the body
       c.blocks.add Block(kind: bkTryExcept)
@@ -2746,29 +2747,46 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
       c.subTree mnkEndStruct:
         c.add labelNode(b.id.unsafeGet)
 
-  if needsContConstr:
-    # TODO: only emit the construction when there are normal exits
-    let typ = c.typeToMir(owner.ast[miscPos][1].typ)
-    c.buildStmt mnkInit:
-      c.add MirNode(kind: mnkLocal, local: resultId, typ: typ)
-      c.buildTree mnkObjConstr, typ:
-        c.subTree mnkBinding:
-          c.add MirNode(kind: mnkField, field: 0)
-          c.subTree mnkConsume:
-            c.use intLiteral(c.env, 1, BoolType)
-        if not owner.typ[0].isEmptyType():
-          c.subTree mnkBinding:
-            c.add MirNode(kind: mnkField, field: 2)
-            # the result variable can be moved out of unconditionally, since
-            # we know there'll be no further use
-            c.subTree mnkConsume:
-              c.add nameNode(c, owner.ast[resultPos].sym)
+    let b = c.blocks.pop()
+    if b.id.isSome:
+      c.subTree mnkJoin:
+        c.add labelNode(b.id.unsafeGet)
 
+    # a procedure must end in a terminator
+    if b.id.isSome or doesReturn:
+      if needsContConstr:
+        let typ = c.typeToMir(owner.ast[miscPos][1].typ)
+        c.buildStmt mnkInit:
+          c.add MirNode(kind: mnkLocal, local: resultId, typ: typ)
+          c.buildTree mnkObjConstr, typ:
+            c.subTree mnkBinding:
+              c.add MirNode(kind: mnkField, field: 0)
+              c.subTree mnkConsume:
+                c.use intLiteral(c.env, 1, BoolType)
+            if not owner.typ[0].isEmptyType():
+              c.subTree mnkBinding:
+                c.add MirNode(kind: mnkField, field: 2)
+                # the result variable can be moved out of unconditionally,
+                # since we know there'll be no further use
+                c.subTree mnkConsume:
+                  c.add nameNode(c, owner.ast[resultPos].sym)
+        leaveBlock(c)
+      else:
+        c.subTree mnkReturn:
+          if c.owner.kind in routineKinds and
+            not isEmptyType(signature(c.owner)[0]):
+            c.use genLocation(c, c.owner.ast[resultPos])
+
+  if needsContConstr:
     c.blocks.closeScope(c.builder, 0, true)
     if owner.typ.callConv == ccTailcall and not owner.typ[0].isEmptyType():
-      # close the physical the result scope
       c.subTree mnkEndScope: discard
-    c.closeBlock()
+    if (let b = c.blocks.pop(); b.id.isSome):
+      c.subTree mnkJoin:
+        c.add labelNode(b.id.unsafeGet)
+      let typ = c.typeToMir(owner.ast[miscPos][1].typ)
+      c.subTree mnkReturn:
+        c.add MirNode(kind: mnkLocal, local: resultId, typ: typ)
 
   env = c.env
 
@@ -2801,6 +2819,9 @@ proc exprToMir*(graph: ModuleGraph, env: var MirEnv,
           c.use genTypeExpr(c, e)
         else:
           c.genAsgnSource(e, {dfOwns, dfEmpty})
+
+  c.buildStmt mnkReturn:
+    c.use toValue(mnkLocal, res, rtyp)
 
   env = move c.env
 

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -430,11 +430,9 @@ proc injectResultInit(tree: MirTree, resultTyp: TypeId, changes: var Changeset) 
       of opMutateGlobal:
         discard "not relevant"
 
-    # the exit flag indicates that traversal reached the end of the body
-    # (without ``result`` being an initialized). The a > b check makes sure
-    # an empty procedure body also requires initialization of the result
-    # var
-    result = s.exit or all.a > all.b
+    # the result variable is not used before its value is set -> no default
+    # initialization is required
+    result = false
 
   if requiresInit(tree):
     assert tree[0].kind == mnkScope

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -226,6 +226,8 @@ type
               ## value of the operand
     mnkBranch ## a branch in a ``mnkCase`` dispatcher
     mnkLoop   ## unconditional jump to the associated-with loop start
+    mnkReturn ## exits the procedure, returning the value stored in the
+              ## result local
 
     mnkJoin   ## join point for gotos and branches
     mnkLoopJoin## join point for loops. Represents the start of a loop
@@ -342,7 +344,7 @@ const
   StmtNodes* = {mnkScope, mnkGoto, mnkIf, mnkCase, mnkLoop, mnkJoin,
                 mnkLoopJoin, mnkExcept, mnkFinally, mnkContinue, mnkEndStruct,
                 mnkInit, mnkAsgn, mnkSwitch, mnkVoid, mnkRaise, mnkDestroy,
-                mnkEmit, mnkAsm, mnkEndScope} + DefNodes
+                mnkEmit, mnkAsm, mnkEndScope, mnkReturn} + DefNodes
     ## Nodes that are treated like statements, in terms of syntax.
 
   # --- semantics-focused sets:

--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -622,6 +622,12 @@ proc stmtToStr(nodes: MirTree, i: var int, indent: var int, result: var string,
     tree "goto ":
       targetToStr()
       result.add "\n"
+  of mnkReturn:
+    tree "return":
+      if n.len == 1:
+        result.add " "
+        valueToStr()
+      result.add "\n"
   of mnkLoopJoin:
     tree "while true:\n":
       inc i # skip the label node

--- a/compiler/sem/injectdestructors.nim
+++ b/compiler/sem/injectdestructors.nim
@@ -258,7 +258,15 @@ func initEntityDict(tree: MirTree, dfg: DataFlowGraph, env: MirEnv): EntityDict 
         result.mgetOrPut(toName(entity), @[]).add:
           # don't include the data-flow operations preceding the def
           EntityInfo(def: i, scope: subgraphFor(dfg, i .. scope.b))
-
+    of mnkLocal:
+      # there's no def for the result variable
+      if n.local == resultId and hasDestructor(env[n.typ]):
+        let name = toName(n)
+        if name notin result:
+          # the result variable's location exists for the full duration
+          # of the procedure
+          let scope = subgraphFor(dfg, NodePosition(0)..NodePosition(tree.high))
+          result[name] = @[EntityInfo(scope: scope)]
     else:
       discard
 
@@ -272,12 +280,6 @@ func computeOwnership(tree: MirTree, cfg: DataFlowGraph, entities: EntityDict,
     # `entities`. Those that don't also can't be consumed (because we either
     # can't reason about them or they're non-owning locations), so values
     # derived from them are treated as non-owning
-    # TODO: this currently also includes the ``result`` variable. It's possible
-    #       to analyse it too -- we just need to make sure to treat an
-    #       otherwise last-read as not a last-read if it is connected to a
-    #       procedure exit. A slightly different approach would be to add a
-    #       pseudo-use at the end of the body and make all procedure exits
-    #       visit it first
     var exists = false
     let info = entities.findScope(toName(tree[lval.root]), start, exists)
     exists and isLastRead(tree, cfg, info.scope, lval, start)
@@ -324,16 +326,11 @@ func isAlive(tree: MirTree, cfg: DataFlowGraph,
 
   case tree[root].kind
   of mnkLocal, mnkParam, mnkGlobal, mnkTemp:
-    let scope =
-      # XXX: the way the ``result`` variable is detected here is a hack. It
-      #      should be treated as any other local in the context of the MIR
-      if tree[root].kind == mnkLocal and tree[root].local == resultId:
-        cfg.subgraphFor(NodePosition(0) .. NodePosition(tree.high))
-      else:
-        var exists: bool
-        let info = entities.findScope(toName(tree[root]), at, exists)
-        if exists: info.scope
-        else:      return true # not something we can analyse -> assume alive
+    let scope = block:
+      var exists: bool
+      let info = entities.findScope(toName(tree[root]), at, exists)
+      if exists: info.scope
+      else:      return true # not something we can analyse -> assume alive
 
     # if the location is not assigned an initial value on definition, `start`
     # may come before the alive subgraph
@@ -360,18 +357,8 @@ func needsReset(tree: MirTree, cfg: DataFlowGraph, ar: AnalysisResults,
   ## If it can't be proven that the unowned value is observed (which could
   ## cause problems like, for example, double-frees), the location is
   ## explicitly reset (i.e. the value removed from it).
-  let root = src.root
-  # XXX: the way the ``result`` variable is detected here is a hack. It
-  #      should be treated as any other local in the context of MIR. The
-  #      fact that the result variable is potentially used outside the
-  #      procedure's body should be encoded by inserting a special 'use'
-  #      operation that has a control-flow dependency on *all* other
-  #      operations
-  if tree[root].kind == mnkLocal and tree[root].local == resultId:
-    return true
-
   var exists: bool
-  let info = findScope(ar.entities[], toName(tree[root]), at, exists)
+  let info = findScope(ar.entities[], toName(tree[src.root]), at, exists)
 
   if not exists:
     # the location is not local to the current context -> assume that it needs

--- a/compiler/sem/mirexec.nim
+++ b/compiler/sem/mirexec.nim
@@ -439,6 +439,11 @@ func computeDfg*(tree: MirTree): DataFlowGraph =
       # emit a join at the end of an 'if'
       if ifs.len > 0 and tree[i, 0].label == ifs[^1]:
         join i, ifs.pop()
+    of mnkReturn:
+      if tree[i].len == 1:
+        emitLvalueOp(env, opUse, tree, i, OpValue tree.child(i, 0))
+
+      env.instrs.add Instr(op: opGoto, node: i, dest: getUnwindLabel(env))
 
     of mnkDef, mnkDefCursor, mnkAsgn, mnkInit:
       emitForDef(env, tree, i)

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -177,6 +177,12 @@ Semantics
             | Goto TARGET
             | Loop <Label>              # unconditional jump back to the start
                                         # of a loop
+            | Return                    # return from procedure; only allowed in
+                                        # procedure with a void return type
+            | Return LVALUE             # return from procedure; only allowed in
+                                        # procedure with a non-void return type.
+                                        # The operand must be the
+                                        # result variable 
             | Destroy LVALUE
             | Raise EX_TARGET
             | Join <Label>              # join point for non-exceptional
@@ -236,13 +242,15 @@ Terminology:
 * *terminator*: marks the end of a basic block
 
 A basic block is started by `Finally` and `Except`. Terminators are: `Case`,
-`Goto`, `Raise`, `Continue`, and `Loop`. `If`, `Join`, and `LoopJoin` act as
-both the start and end of a basic block. The nature of `End` depends on the
-associated construct:
+`Goto`, `Return`, `Raise`, `Continue`, and `Loop`. `If`, `Join`, and `LoopJoin`
+act as both the start and end of a basic block. The nature of `End` depends
+on the associated construct:
 * for `If`, it acts as both a terminator and start of a basic block
 * for `Except`, it only marks the end of the section
 
 Except for `Loop`, all terminators only allow forward control-flow.
+
+Ignoring end-of-scope markers, a MIR body must end with a terminator.
 
 Structured Constructs
 ---------------------

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -22,6 +22,7 @@ scope:
     =destroy(name _4)
     continue [Unwind]
   L3:
+return
 -- end of expandArc ------------------------
 --expandArc: sio
 
@@ -76,6 +77,7 @@ scope:
     L10:
     raise -> [Unwind]
     L11:
+return
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -30,6 +30,7 @@ scope:
 finally (L0):
   continue [Unwind]
 L1:
+return result
 -- end of expandArc ------------------------
 --expandArc: delete
 
@@ -48,6 +49,7 @@ scope:
   def_cursor _9: Node = sibling
   =sink(name _9[].parent, arg saved)
   =destroy(name sibling)
+return
 -- end of expandArc ------------------------
 --expandArc: p1
 
@@ -68,6 +70,7 @@ scope:
   =destroy(name _)
   =destroy(name lnext)
   =destroy(name lvalue)
+return result
 -- end of expandArc ------------------------
 --expandArc: tt
 
@@ -91,6 +94,7 @@ scope:
     =destroy(name a)
     continue [Unwind]
   L2:
+return
 -- end of expandArc ------------------------
 --expandArc: extractConfig
 
@@ -142,6 +146,7 @@ scope:
     =destroy(name lan_ip)
     continue [Unwind]
   L7:
+return
 --expandArc: mergeShadowScope
 
 scope:
@@ -183,6 +188,7 @@ scope:
     =destroy(name shadowScope)
     continue [Unwind]
   L6:
+return
 -- end of expandArc ------------------------
 --expandArc: treturn
 
@@ -214,6 +220,7 @@ goto [L1]
 finally (L5):
   continue [Unwind]
 L1:
+return result
 
 -- end of expandArc ------------------------
 --expandArc: check
@@ -269,6 +276,7 @@ scope:
     =destroy(name par)
     continue [Unwind]
   L7:
+return
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/arc/topt_no_loop_cursor.nim
+++ b/tests/arc/topt_no_loop_cursor.nim
@@ -34,6 +34,7 @@ scope:
     destroy x
     continue [Unwind]
   L6:
+return
 
 -- end
 '''

--- a/tests/arc/topt_refcursors.nim
+++ b/tests/arc/topt_refcursors.nim
@@ -56,6 +56,7 @@ scope:
     =destroy(name jt)
     continue [Unwind]
   L9:
+return
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/arc/topt_unpacking_no_cursor.nim
+++ b/tests/arc/topt_unpacking_no_cursor.nim
@@ -11,6 +11,7 @@ scope:
   b := move _2.1
   =destroy(name b)
   =destroy(name a)
+return
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/arc/topt_wasmoved_destroy_pairs.nim
+++ b/tests/arc/topt_wasmoved_destroy_pairs.nim
@@ -23,6 +23,7 @@ scope:
   finally (L0):
     continue [Unwind]
   L3:
+return
 -- end of expandArc ------------------------
 --expandArc: tfor
 
@@ -80,6 +81,7 @@ scope:
     continue [Unwind]
   L9:
 L5:
+return
 -- end of expandArc ------------------------
 --expandArc: texit
 scope:
@@ -102,6 +104,7 @@ scope:
   =destroy(name x)
   =destroy(name str)
 L1:
+return result
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/exception/truntime_check_panics.nim
+++ b/tests/exception/truntime_check_panics.nim
@@ -27,6 +27,7 @@ scope:
   discard r.(Sub)
   def _12: float = mulF64(arg f, arg f)
   chckNaN(arg _12)
+return
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/lang_exprs/tnil_to_distinct_conversion.nim
+++ b/tests/lang_exprs/tnil_to_distinct_conversion.nim
@@ -9,6 +9,7 @@ discard """
 scope:
   def a: Ptr = nil
   def b: Ptr = nil
+return
 
 -- end
 '''

--- a/tests/lang_objects/destructor/tv2_cast.nim
+++ b/tests/lang_objects/destructor/tv2_cast.nim
@@ -21,6 +21,7 @@ scope:
     =destroy(name _2)
     continue [Unwind]
   L1:
+return
 -- end of expandArc ------------------------
 --expandArc: main1
 scope:
@@ -42,6 +43,7 @@ scope:
     =destroy(name s)
     continue [Unwind]
   L1:
+return
 -- end of expandArc ------------------------
 --expandArc: main2
 scope:
@@ -59,6 +61,7 @@ scope:
     =destroy(name s)
     continue [Unwind]
   L1:
+return
 -- end of expandArc ------------------------
 --expandArc: main3
 scope:
@@ -76,6 +79,7 @@ scope:
     =destroy(name _2)
     continue [Unwind]
   L1:
+return
 -- end of expandArc ------------------------'''
 """
 

--- a/tests/lang_types/tuples/tsink_generic_tuple_assignment.nim
+++ b/tests/lang_types/tuples/tsink_generic_tuple_assignment.nim
@@ -10,6 +10,7 @@ scope:
   def x: sink Tuple[system.int]
   def v: Tuple[system.int]
   v = sink x
+return
 
 -- end
 '''

--- a/tests/misc/tdont_fold_procedure_cast.nim
+++ b/tests/misc/tdont_fold_procedure_cast.nim
@@ -12,6 +12,7 @@ scope:
   def p: proc (x: float){.nimcall.} = copy _2
   def_cursor _3: proc (x: int){.nimcall.} = cast p
   _3(arg 1) -> [Unwind]
+return
 -- end of expandArc ------------------------
   '''
   output: "1"

--- a/tests/optimization/tmove_from_non_variant_field.nim
+++ b/tests/optimization/tmove_from_non_variant_field.nim
@@ -20,6 +20,7 @@ scope:
     =destroy(name x)
   _5 = _6
   =destroy(name x)
+return result
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/optimization/tno_conv_for_seq_high.nim
+++ b/tests/optimization/tno_conv_for_seq_high.nim
@@ -8,6 +8,7 @@ discard """
   nimout: '''--expandArc: test
 scope:
   result = high(arg x)
+return result
 
 -- end of expandArc ------------------------'''
 """

--- a/tests/optimization/tno_destroy_for_empty_result.nim
+++ b/tests/optimization/tno_destroy_for_empty_result.nim
@@ -17,6 +17,7 @@ goto [L2]
 finally (L1):
   continue [Unwind]
 L2:
+return result
 
 -- end of expandArc ------------------------
 '''

--- a/tests/optimization/tno_unnecessary_bound_check_for_contains.nim
+++ b/tests/optimization/tno_unnecessary_bound_check_for_contains.nim
@@ -10,6 +10,7 @@ scope:
   result = _2
   goto [L1]
 L1:
+return result
 
 -- end'''
 """


### PR DESCRIPTION
## Summary

* support automatic moves from the high-level `result` variable
* omit implicit `result` variable initialization in some more cases
* add the MIR-level `return` statement, making all `result`
  usages explicit at that stage

## Details

The main motivation is to add a dedicated return statement to the
MIR -- the improved `result` variable analysis is a side-effect.

* add and document the `mnkReturn` MIR node kind (a statement)
* change `mirgen` to emit a MIR `return` statement at all
  procedure exits
* translate `mnkReturn` statements into CGIR gotos in `cgirgen`,
  instead of introducing a `cnkReturn` node kind. This allows CGIR body
  merging to continue working without change
* handle `mnkReturn` when computing an MIR data-flow graph

In procedures that return something, the `return` statement is required
to have the result local as the singular operand. The reason is that it
makes all result variable usage explicit in MIR code, which allows for
some follow-up simplifications/improvements:
* in `injectdestructors`, remove most of the special handling for the
  result. This enables move analysis for the result local

* remove the "leaves control-flow graph" condition for deciding whether
  the result local needs to be default initialized, which results in
  the initialization being omitted in procedures where the result local
  is only uninitialized when unwinding due to an exception

Tests inspecting `--showir` and `--expandArc` output are updated.