### PR TITLE
mir: turn tail-call elimination into a standalone pass

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -853,9 +853,6 @@ type
     mStoreParams
       ## storeParams(p, tup): savely stores the tuple in the storage pointed
       ## to by `p`
-    mEnsureNoCleanup
-      ## destructor calls following an ensureNoCleanup call result in a
-      ## compiler error
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -435,8 +435,7 @@ proc generateCode*(graph: ModuleGraph, g: BModuleList, mlist: sink ModuleList) =
   let
     config = BackendConfig(
       tconfig: TranslationConfig(
-        magicsToKeep: NonMagics,
-        options: {goTailCallElim}
+        magicsToKeep: NonMagics
       )
     )
 

--- a/compiler/backend/ccgcalls.nim
+++ b/compiler/backend/ccgcalls.nim
@@ -238,16 +238,6 @@ proc genClosureCall(p: BProc, le, ri: CgNode, d: var TLoc) =
 proc genAsgnCall(p: BProc, le, ri: CgNode, d: var TLoc) =
   if ri[0].typ.skipTypes({tyGenericInst, tyAlias, tySink}).callConv == ccClosure:
     genClosureCall(p, le, ri, d)
-  elif ri[0].typ.skipTypes(abstractInst).callConv == ccTailcall and
-       ri[0].kind != cnkProc:
-    # an indirect tailcall call. The real signature doesn't match the `tyProc`,
-    # so we manually emit the call
-    # XXX: this is fundamentally a hack see https://github.com/nim-works/nimskull/pull/1504
-    assert numArgs(ri) == 1
-    var callee, arg: TLoc
-    initLocExpr(p, ri[0], callee)
-    initLocExpr(p, ri[1], arg)
-    fixupCall(p, le, ri, d, rdLoc(callee), rdLoc(arg))
   else:
     genPrefixCall(p, le, ri, d)
 

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -126,8 +126,7 @@ proc generateCode*(graph: ModuleGraph, mlist: sink ModuleList) =
     globals = newGlobals(graph)
     bconf = BackendConfig(
       tconfig: TranslationConfig(
-        magicsToKeep: NonMagics,
-        options: {goTailCallElim}
+        magicsToKeep: NonMagics
       )
     )
 

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1318,16 +1318,7 @@ proc genInfixCall(p: PProc, n: CgNode, r: var TCompRes) =
 
 proc genCall(p: PProc, n: CgNode, r: var TCompRes) =
   gen(p, n[0], r)
-  if n[0].kind != cnkProc and
-     n[0].typ.skipTypes(abstractInst).callConv == ccTailcall:
-    # an indirect tailcall call. The signature doesn't match reality, so we
-    # manually handle the argument
-    # XXX: this is fundamentally a hack see https://github.com/nim-works/nimskull/pull/1504
-    r.res.add "("
-    genArg(p, n[1], p.module.graph.getSysType(n[1].info, tyPointer), r, nil)
-    r.res.add ")"
-  else:
-    genArgs(p, n, r)
+  genArgs(p, n, r)
   if n.typ != nil:
     let t = mapType(n.typ)
     if t == etyBaseIndex:

--- a/compiler/mir/injecthooks.nim
+++ b/compiler/mir/injecthooks.nim
@@ -288,19 +288,15 @@ proc injectHooks*(body: MirBody, graph: ModuleGraph, env: var MirEnv,
           bu.emitByName ekMutate:
             bu.emitFrom(tree, tree.child(i, 0))
 
-    of mnkMagic:
-      if n.magic == mEnsureNoCleanup:
-        # make sure there's no destroy operation following the marker
-        let
-          stmt = tree.parent(tree.parent(i))
-          next = tree.sibling(stmt)
-        if tree[next].kind == mnkDestroy:
-          diags.add LocalDiag(pos: stmt,
-                              entity: tree.child(next, 0),
-                              kind: ldkCleanupPreventsTailCall)
-
-        # remove the marker:
-        changes.remove(tree, stmt)
+    of mnkTailCall:
+      # make sure there's no destroy operation following the tailcall
+      let
+        stmt = tree.parent(i)
+        next = tree.sibling(stmt)
+      if tree[next].kind == mnkDestroy:
+        diags.add LocalDiag(pos: stmt,
+                            entity: tree.child(next, 0),
+                            kind: ldkCleanupPreventsTailCall)
     else:
       discard "nothing to do"
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -733,7 +733,7 @@ proc genArg(c: var TCtx, formal: PType, n: PNode) =
   else:
     c.emitOperandTree n, false
 
-proc genArgs(c: var TCtx, n: PNode) =
+proc genArgs(c: var TCtx, n: PNode, isTailcall=false) =
   ## Emits the MIR code for the argument expressions (including the
   ## argument node), but without a wrapping ``mnkArgBlock``.
   let fntyp = skipTypes(n[0].typ, abstractInst)
@@ -780,6 +780,11 @@ proc genArgs(c: var TCtx, n: PNode) =
         var e = exprToPmir(c, n[i], false, false)
         wantStable(e)
         genx(c, e, e.high)
+    elif isTailcall and
+         t.kind notin {tySink, tyVar} and
+         isPassByRef(c.graph.config, fntyp.n[i].sym, fntyp):
+      # use explicit pass-by-name for all by-ref parameters
+      c.emitByName ekNone, genLvalueOperand(c, n[i], false)
     elif fntyp.callConv == ccTailcall and
          t.kind notin {tySink, tyVar} and
          i < fntyp.len and # ignore the env argument
@@ -1356,7 +1361,7 @@ proc genReturn(c: var TCtx, n: PNode) =
     c.buildStmt mnkVoid:
       c.builder.rawBuildCall mnkTailCall, VoidType, false:
         genCallee(c, n[0][0])
-        genArgs(c, n[0])
+        genArgs(c, n[0], isTailcall=true)
     tailExit(c.blocks, c.builder)
   else:
     gen(c, n[0])
@@ -2470,8 +2475,10 @@ proc addParams(c: var TCtx, prc: PSym, signature: PType) =
   for i in 1..<params.len:
     add c.paramToMir(params[i].sym)
 
-  if signature.callConv == ccClosure:
+  if signature.callConv in {ccClosure, ccTailcall}:
     # environment parameter
+    # note: for .tailcall routines, the local for the environment parameter is
+    # always added, even when portable tail-call elimination is not used
     add c.paramToMir(prc.ast[paramsPos][^1].sym)
 
 proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -138,7 +138,6 @@ type
     goGenTypeExpr ## don't omit type expressions
     goIsCompileTime ## whether the code is meant to be run at compile-time.
                     ## Affects handling of ``.compileTime`` globals
-    goTailCallElim  ## enables elimination of eligible `.tailcall` calls
 
   TranslationConfig* = object
      ## Extra configuration for the AST -> MIR translation.
@@ -181,12 +180,6 @@ const
   ComplexExprs = {nkIfExpr, nkCaseStmt, nkBlockExpr, nkTryStmt}
     ## The expression that are treated as complex and which are transformed
     ## into assignments-to-temporaries
-
-func tailCallElimActive(c: TCtx): bool =
-  ## Whether tail-call elimination is enabled in the current context.
-  c.owner != nil and c.owner.kind in routineKinds and
-    c.owner.typ.callConv == ccTailcall and
-    goTailCallElim in c.config.options
 
 func isHandleLike(t: PType): bool =
   t.skipTypes(abstractInst).kind in {tyPtr, tyRef, tyLent, tyVar, tyOpenArray}
@@ -1234,122 +1227,9 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
     # no special transformation for the other magics:
     genCall(c, n)
 
-proc genParamContainerSetup(c: var TCtx, n: PNode, dst: Value) =
-  ## Given call `n`, generates and emits the parameter container setup for the
-  ## tail-call elimination, plus the store into the storage identified by
-  ## `dst`.
-  assert n.len > 1, "no arguments"
-  let fntype = n[0].typ.skipTypes(abstractInst)
-  # creating a parameter tuple using the graph's IdGenerator yields types
-  # with degenerate IDs. Let's hope these types don't end up anywhere
-  # problematic...
-  let typ = c.typeToMir(newParamTuple(c.graph.config, c.graph.idgen,
-                                      c.owner, fntype))
-  let tup = c.wrapTemp typ:
-    c.buildTree mnkTupleConstr, typ:
-      for i in 1..<n.len:
-        case fntype[i].kind
-        of tySink, tyVar:
-          c.emitOperandTree n[i], sink=true
-        elif isPassByRef(c.graph.config, fntype.n[i].sym, fntype[0]):
-          let pt = c.env.types[c.env.types.lookupField(typ, int32(i - 1))].typ
-          c.subTree mnkConsume:
-            c.wrapAndUse pt:
-              c.buildTree mnkAddr, pt:
-                genLvalueOperand(c, n[i], false)
-        else:
-          c.emitOperandTree n[i], sink=false
-
-  c.buildStmt mnkVoid:
-    c.buildMagicCall mStoreParams, VoidType:
-      c.emitByVal dst
-      c.subTree mnkConsume:
-        c.use tup
-
 proc genCallOrMagic(c: var TCtx, n: PNode) =
   if n[0].kind == nkSym and (let s = n[0].sym; s.magic != mNone):
     genMagic(c, n, s.magic)
-  elif n[0].typ.skipTypes(abstractInst).callConv == ccTailcall and
-       (c.owner.isNil or sfGeneratedOp notin c.owner.flags) and
-       goTailCallElim in c.config.options:
-    # a call to a ``.tailcall`` routine from outside a ``.tailcall`` routine.
-    # Emit:
-    #   var params: ParamBlob
-    #   var cont = callee(..., addr params)
-    #   while not cont.done:
-    #     cont = cont.next(addr params)
-    #   cont.val
-    let
-      contTyp = c.typeToMir(n[0].typ.skipTypes(abstractInst).n[0][3].typ)
-      nextTyp = c.env.types[c.env.types.lookupField(contTyp, 1)].typ
-      blobTyp = c.graph.systemModuleType(c.graph.cache.getIdent("ParamBlob"))
-      blob = c.allocTemp(c.typeToMir(blobTyp))
-    c.buildStmt mnkDef:
-      c.use blob
-      c.add MirNode(kind: mnkNone)
-    let addrTmp = c.wrapTemp PointerType:
-      c.buildTree mnkAddr, PointerType:
-        c.use blob
-
-    var cont: Value
-    if n[0].kind == nkSym and n[0].sym.kind in routineKinds:
-      # it's a static call
-      cont = c.wrapTemp contTyp:
-        c.builder.rawBuildCall callKind(c, n[0]), contTyp, true:
-          genCallee(c, n[0])
-          genArgs(c, n)
-          c.emitByVal addrTmp
-          if callKind(c, n[0]) == mnkCheckedCall:
-            raiseExit(c)
-    else:
-      # it's a dynamic call. `.tailcall` procedure pointers point to the apply
-      # procedure, not the actual procedure. Therefore, the parameters need to
-      # be passed via the blob
-      if n.len > 1:
-        genParamContainerSetup(c, n, addrTmp)
-
-      cont = c.wrapTemp contTyp:
-        c.builder.rawBuildCall callKind(c, n[0]), contTyp, true:
-          c.genArgExpression(n[0], sink=false)
-          c.emitByVal addrTmp
-          if callKind(c, n[0]) == mnkCheckedCall:
-            raiseExit(c)
-
-    let loop = c.allocLabel()
-    let exit = c.allocLabel()
-    c.buildStmt mnkLoopJoin:
-      c.add labelNode(loop)
-    let cond = c.wrapTemp BoolType:
-      c.buildTree mnkCopy, BoolType:
-        c.builder.pathNamed(BoolType, 0):
-          c.use cont
-    c.buildIf (c.use cond;):
-      c.buildStmt mnkGoto:
-        c.add labelNode(exit)
-
-    let tmp = c.wrapTemp contTyp:
-      c.builder.rawBuildCall mnkCheckedCall, contTyp, true:
-        c.builder.pathNamed nextTyp, 1:
-          c.builder.pathVariant contTyp, 0:
-            c.use cont
-        c.emitByVal addrTmp
-        raiseExit(c)
-    c.buildStmt mnkAsgn:
-      c.use cont
-      c.buildTree mnkMove, contTyp:
-        c.use tmp
-    c.buildStmt mnkLoop:
-      c.add labelNode(loop)
-    c.buildStmt mnkJoin:
-      c.add labelNode(exit)
-
-    let ret = n[0].typ.skipTypes(abstractInst)[0]
-    if not ret.isEmptyType():
-      # it's not a void call; extract the result from the continuation
-      c.buildTree mnkMove, c.typeToMir(ret):
-        c.builder.pathNamed(c.typeToMir(ret), 2):
-          c.builder.pathVariant(contTyp, 0):
-            c.use cont
   else:
     genCall(c, n)
 
@@ -1464,50 +1344,23 @@ proc genRaise(c: var TCtx, n: PNode) =
   c.buildStmt mnkRaise:
     raiseExit(c)
 
-proc genSiblingCall(c: var TCtx, n: PNode) =
-  ## Generates a non-native sibling call for call `n`.
-  let typ = c.typeToMir(c.owner.ast[miscPos][1].typ)
-  c.builder.useSource(c.sp, n)
-  # initialize the continuation:
-  c.buildStmt mnkInit:
-    c.add MirNode(kind: mnkLocal, local: resultId, typ: typ)
-    c.buildTree mnkObjConstr, typ:
-      c.subTree mnkBinding:
-        c.add MirNode(kind: mnkField, field: 0)
-        c.subTree mnkConsume:
-          c.use intLiteral(c.env, 0, BoolType)
-      c.subTree mnkBinding:
-        c.add MirNode(kind: mnkField, field: 1)
-        c.emitOperandTree n[0], sink=true
-
-  # set up and store the parameter container
-  if n.len > 1:
-    genParamContainerSetup(c, n, c.genLocation(c.owner.ast[paramsPos].lastSon))
-
-  tailExit(c.blocks, c.builder)
-
 proc genReturn(c: var TCtx, n: PNode) =
   assert n.kind == nkReturnStmt
   # when eliminating tail calls, normal returns jump to the pre-exit
   # continuation setup label
-  let target = if tailCallElimActive(c): 2 else: 0
-
   if n[0].kind == nkEmpty:
-    blockExit(c.blocks, c.graph, c.env, c.builder, target)
+    blockExit(c.blocks, c.graph, c.env, c.builder, 0)
   elif n[0].kind in nkCallKinds:
-    # it's a tail call that must be turned into a sibling call
-    if goTailCallElim in c.config.options:
-      genSiblingCall(c, n[0])
-    else:
-      c.builder.useSource(c.sp, n[0])
-      c.buildStmt mnkVoid:
-        c.builder.rawBuildCall mnkTailCall, VoidType, false:
-          genCallee(c, n[0][0])
-          genArgs(c, n[0])
-      tailExit(c.blocks, c.builder)
+    # it's a tail call
+    c.builder.useSource(c.sp, n[0])
+    c.buildStmt mnkVoid:
+      c.builder.rawBuildCall mnkTailCall, VoidType, false:
+        genCallee(c, n[0][0])
+        genArgs(c, n[0])
+    tailExit(c.blocks, c.builder)
   else:
     gen(c, n[0])
-    blockExit(c.blocks, c.graph, c.env, c.builder, target)
+    blockExit(c.blocks, c.graph, c.env, c.builder, 0)
 
 proc genAsgnSource(c: var TCtx, e: PNode, status: set[DestFlag]) =
   ## Generates the MIR code for the right-hand side of an assignment.
@@ -2200,10 +2053,7 @@ proc genx(c: var TCtx, e: PMirExpr, i: int; fromMove = false) =
   let typ = c.typeToMir(n.typ)
   case n.kind
   of pirProc:
-    if goTailCallElim in c.config.options and n.typ.callConv == ccTailcall:
-      c.use toValue(c.env.procedures.add(n.sym.ast[miscPos][0].sym), typ)
-    else:
-      c.use toValue(c.env.procedures.add(n.sym), typ)
+    c.use toValue(c.env.procedures.add(n.sym), typ)
   of pirLiteral:
     case n.orig.kind
     of nkNilLit:
@@ -2608,11 +2458,7 @@ proc addParams(c: var TCtx, prc: PSym, signature: PType) =
     discard c.addLocal(x)
 
   # result variable:
-  if tailCallElimActive(c):
-    # create a new result variable using the continuation type
-    add Local(name: c.graph.cache.getIdent("result"),
-              typ: c.typeToMir(signature.n[0][3].typ))
-  elif signature[0].isEmptyType():
+  if signature[0].isEmptyType():
     # always reserve a slot for the result variable, even if the latter is
     # not present
     add Local()
@@ -2624,7 +2470,7 @@ proc addParams(c: var TCtx, prc: PSym, signature: PType) =
   for i in 1..<params.len:
     add c.paramToMir(params[i].sym)
 
-  if signature.callConv in {ccClosure} or tailCallElimActive(c):
+  if signature.callConv == ccClosure:
     # environment parameter
     add c.paramToMir(prc.ast[paramsPos][^1].sym)
 
@@ -2652,9 +2498,7 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
 
   let
     needsTerminate = sfNeverRaises in owner.flags
-    needsContConstr = tailCallElimActive(c)
     needsCleanup = (c.injectDestructors and
-                    not needsContConstr and
                     owner.kind in routineKinds and
                     owner.typ[0] != nil and
                     hasDestructor(owner.typ[0]))
@@ -2664,22 +2508,6 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
   if owner.kind in routineKinds:
     # before emitting anything else, register the paramters and result
     addParams(c, owner, signature(owner))
-
-  if needsContConstr:
-    c.blocks.add Block(kind: bkBlock)
-    # use a dedicated scope for the result var, so that it can be cleaned
-    # up separately. For ease of processing, a logical scope is always opened,
-    # even when there's no result variable
-    discard c.blocks.startScope()
-    if owner.typ.callConv == ccTailcall and not owner.typ[0].isEmptyType():
-      c.subTree mnkScope: discard
-      # add the user-visible result variable as a proper variable:
-      let r = owner.ast[resultPos]
-      discard c.addLocal(r.sym)
-      c.subTree mnkDef:
-        c.add nameNode(c, r.sym)
-        c.add MirNode(kind: mnkNone)
-      c.register(genLocation(c, r))
 
   block:
     c.blocks.add Block(kind: bkBlock) # the target for return statements
@@ -2754,39 +2582,10 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
 
     # a procedure must end in a terminator
     if b.id.isSome or doesReturn:
-      if needsContConstr:
-        let typ = c.typeToMir(owner.ast[miscPos][1].typ)
-        c.buildStmt mnkInit:
-          c.add MirNode(kind: mnkLocal, local: resultId, typ: typ)
-          c.buildTree mnkObjConstr, typ:
-            c.subTree mnkBinding:
-              c.add MirNode(kind: mnkField, field: 0)
-              c.subTree mnkConsume:
-                c.use intLiteral(c.env, 1, BoolType)
-            if not owner.typ[0].isEmptyType():
-              c.subTree mnkBinding:
-                c.add MirNode(kind: mnkField, field: 2)
-                # the result variable can be moved out of unconditionally,
-                # since we know there'll be no further use
-                c.subTree mnkConsume:
-                  c.add nameNode(c, owner.ast[resultPos].sym)
-        leaveBlock(c)
-      else:
-        c.subTree mnkReturn:
-          if c.owner.kind in routineKinds and
-            not isEmptyType(signature(c.owner)[0]):
-            c.use genLocation(c, c.owner.ast[resultPos])
-
-  if needsContConstr:
-    c.blocks.closeScope(c.builder, 0, true)
-    if owner.typ.callConv == ccTailcall and not owner.typ[0].isEmptyType():
-      c.subTree mnkEndScope: discard
-    if (let b = c.blocks.pop(); b.id.isSome):
-      c.subTree mnkJoin:
-        c.add labelNode(b.id.unsafeGet)
-      let typ = c.typeToMir(owner.ast[miscPos][1].typ)
       c.subTree mnkReturn:
-        c.add MirNode(kind: mnkLocal, local: resultId, typ: typ)
+        if c.owner.kind in routineKinds and
+           not isEmptyType(signature(c.owner)[0]):
+          c.use genLocation(c, c.owner.ast[resultPos])
 
   env = c.env
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1354,7 +1354,7 @@ proc genReturn(c: var TCtx, n: PNode) =
   # when eliminating tail calls, normal returns jump to the pre-exit
   # continuation setup label
   if n[0].kind == nkEmpty:
-    blockExit(c.blocks, c.graph, c.env, c.builder, 0)
+    blockExit(c.blocks, c.graph, c.env, c.builder, 1)
   elif n[0].kind in nkCallKinds:
     # it's a tail call
     c.builder.useSource(c.sp, n[0])
@@ -1365,7 +1365,7 @@ proc genReturn(c: var TCtx, n: PNode) =
     tailExit(c.blocks, c.builder)
   else:
     gen(c, n[0])
-    blockExit(c.blocks, c.graph, c.env, c.builder, 0)
+    blockExit(c.blocks, c.graph, c.env, c.builder, 1)
 
 proc genAsgnSource(c: var TCtx, e: PNode, status: set[DestFlag]) =
   ## Generates the MIR code for the right-hand side of an assignment.
@@ -2505,10 +2505,6 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
 
   let
     needsTerminate = sfNeverRaises in owner.flags
-    needsCleanup = (c.injectDestructors and
-                    owner.kind in routineKinds and
-                    owner.typ[0] != nil and
-                    hasDestructor(owner.typ[0]))
     doesReturn = doesReturn(body)
       ## whether the body "falls through"
 
@@ -2517,13 +2513,15 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
     addParams(c, owner, signature(owner))
 
   block:
+    c.blocks.add Block(kind: bkScope)
+    # ^^ the hidden scope for the 'result' variable. It's always added, so
+    # that the "return" block always has the same index
+    if owner.kind in routineKinds and not isEmptyType(signature(owner)[0]):
+      c.register(c.genLocation(owner.ast[resultPos]))
+
     c.blocks.add Block(kind: bkBlock) # the target for return statements
     if needsTerminate:
       # it needs to be ensured that no exceptions leave the body
-      c.blocks.add Block(kind: bkTryExcept)
-    if needsCleanup:
-      # the result variable only needs to be cleaned up when the procedure
-      # exits via an exception
       c.blocks.add Block(kind: bkTryExcept)
 
     c.scope(doesReturn):
@@ -2550,26 +2548,8 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
 
       gen(c, body)
 
-    var isFirst = true
-
-    if needsCleanup and (let b = c.blocks.pop(); b.id.isSome):
-      if doesReturn:
-        leaveBlock(c) # jump over the handler
-        isFirst = false
-
-      # emit the finally section for cleaning up the result variable:
-      c.subTree mnkFinally:
-        c.add labelNode(b.id.unsafeGet)
-      c.subTree mnkDestroy:
-        c.use genLocation(c, owner.ast[resultPos])
-      # note: we don't need to reset the location. Per the MIR semantics, it's
-      # guaranteed that no one can observe the result location when the
-      # procedure raises
-      c.subTree mnkContinue:
-        raiseExit(c)
-
     if needsTerminate and (let b = c.blocks.pop(); b.id.isSome):
-      if doesReturn and isFirst:
+      if doesReturn:
         leaveBlock(c)
 
       # emit the handler for panicking on escaping exceptions:
@@ -2593,6 +2573,9 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
         if c.owner.kind in routineKinds and
            not isEmptyType(signature(c.owner)[0]):
           c.use genLocation(c, c.owner.ast[resultPos])
+
+    # close the hidden 'result' variable scope:
+    c.blocks.closeScope(c.builder, 0, false)
 
   env = c.env
 

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -165,6 +165,8 @@ type
       ## > 0 if the current statement/expression is part of a loop
     injectDestructors: bool
       ## whether injection of destroy operations is enabled
+    returnBlock: int
+      ## index of the block to target with return statements
 
     # input:
     userOptions: set[TOption]
@@ -1355,7 +1357,7 @@ proc genReturn(c: var TCtx, n: PNode) =
   # when eliminating tail calls, normal returns jump to the pre-exit
   # continuation setup label
   if n[0].kind == nkEmpty:
-    blockExit(c.blocks, c.graph, c.env, c.builder, 1)
+    blockExit(c.blocks, c.graph, c.env, c.builder, c.returnBlock)
   elif n[0].kind in nkCallKinds:
     # it's a tail call
     c.builder.useSource(c.sp, n[0])
@@ -1366,7 +1368,7 @@ proc genReturn(c: var TCtx, n: PNode) =
     tailExit(c.blocks, c.builder)
   else:
     gen(c, n[0])
-    blockExit(c.blocks, c.graph, c.env, c.builder, 1)
+    blockExit(c.blocks, c.graph, c.env, c.builder, c.returnBlock)
 
 proc genAsgnSource(c: var TCtx, e: PNode, status: set[DestFlag]) =
   ## Generates the MIR code for the right-hand side of an assignment.
@@ -2515,11 +2517,11 @@ proc generateCode*(graph: ModuleGraph, env: var MirEnv, owner: PSym,
 
   block:
     c.blocks.add Block(kind: bkScope)
-    # ^^ the hidden scope for the 'result' variable. It's always added, so
-    # that the "return" block always has the same index
+    # ^^ the hidden scope for the 'result' variable
     if owner.kind in routineKinds and not isEmptyType(signature(owner)[0]):
       c.register(c.genLocation(owner.ast[resultPos]))
 
+    c.returnBlock = 1
     c.blocks.add Block(kind: bkBlock) # the target for return statements
     if needsTerminate:
       # it needs to be ensured that no exceptions leave the body

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -387,6 +387,7 @@ proc nameNode(c: var TCtx, s: PSym): MirNode =
     unreachable(s.kind)
 
 proc genLocation(c: var TCtx, n: PNode): Value =
+  c.builder.useSource(c.sp, n)
   let f = c.builder.push: c.builder.add(nameNode(c, n.sym))
   c.builder.popSingle(f)
 

--- a/compiler/mir/mirgen_blocks.nim
+++ b/compiler/mir/mirgen_blocks.nim
@@ -156,12 +156,6 @@ proc tailExit*(c; bu) =
   ## Emits the tentative cleanup logic after a tail call. The caller has to
   ## guarantee that there are no enclosing except, finally, or try clauses.
   var last = c.toDestroy.high
-  if last >= 0:
-    # add a marker for the later "no trailing cleanup" pass
-    bu.subTree mnkVoid:
-      bu.buildMagicCall mEnsureNoCleanup, VoidType:
-        discard
-
   for i in countdown(c.blocks.high, 0):
     let b {.cursor.} = c.blocks[i]
     case b.kind

--- a/compiler/mir/mirgen_blocks.nim
+++ b/compiler/mir/mirgen_blocks.nim
@@ -172,8 +172,8 @@ proc tailExit*(c; bu) =
     of bkTryFinally, bkExcept, bkFinally:
       unreachable()
 
-  bu.subTree mnkGoto:
-    bu.add labelNode(bu.requestLabel(c.blocks[0]))
+  bu.subTree mnkReturn:
+    discard
 
 template add*(c: var BlockCtx; b: Block) =
   c.blocks.add b

--- a/compiler/mir/mirpasses.nim
+++ b/compiler/mir/mirpasses.nim
@@ -24,7 +24,8 @@ import
     mirtrees,
     mirtypes,
     rtchecks,
-    sourcemaps
+    sourcemaps,
+    tailcall_elim
   ],
   compiler/modules/[
     modulegraphs,
@@ -826,6 +827,17 @@ proc applyPasses*(body: var MirBody, prc: PSym, env: var MirEnv,
       var c {.inject.} = initChangeset(body)
       b
       apply(body, c)
+
+  if target in {targetC, targetJs} and sfGeneratedOp notin prc.flags:
+    # portable tail-call elimination
+    batch:
+      lowerProcvals(body.code, env, c)
+    batch:
+      insertTrampolines(body.code, graph, prc, env, c)
+    if prc.typ.callConv == ccTailcall:
+      insertNewResult(body, graph, prc, env)
+      batch:
+        lowerTailcallBody(body, graph, prc, env, c)
 
   if target == targetC:
     batch:

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -818,17 +818,6 @@ proc typeToMir(env: var TypeEnv, t: PType; canon = false, unique=true): HeaderId
     # object/union types are not de-duplicated
     rec.close(env, unique)
   of tyProc:
-    # special case: .tailcall procedure type's are lowered early. Their
-    # original shape does not exist at and past the MIR stage
-    if t.callConv == ccTailcall:
-      # the correct return type is stored hidden in the the effects list. A
-      # .tailcall proc type becomes:
-      #   `proc(pointer): Continuation[...] {.nimcall.}`
-      let ret = typeref(t.n[0][3].typ)
-      var prc = env.openProc(tkProc, ccNimCall, ret, false)
-      prc.addParam({}, PointerType)
-      return env.close(prc)
-
     var prc: ProcBuilder
     let ret = if t[0].isNil: VoidType else: typeref(t[0])
     if t.callConv == ccClosure:

--- a/compiler/mir/tailcall_elim.nim
+++ b/compiler/mir/tailcall_elim.nim
@@ -189,12 +189,23 @@ proc lowerProcvals*(tree: MirTree, env: var MirEnv, changes: var Changeset) =
       let canon = env.types.canonical(it.typ)
       if env.types.headerFor(canon, Canonical).callConv(env.types) ==
           ccTailcall:
-        # taking the address of a .tailcall procedure yields the address of
-        # the application procedure
+        # the type of the expression must stay the same; the application
+        # procedure procval is bitcast to the correct type
+        var stmt = pos
+        while tree[stmt].kind notin StmtNodes:
+          stmt = tree.parent(stmt)
+
         let np = env[it.prc].ast[miscPos][0].sym
-        changes.replace(tree, pos):
-          MirNode(kind: mnkProcVal, prc: env.procedures.add(np),
-                  typ: env.types.add(np.typ))
+        var tmp: Value
+        changes.insert(tree, stmt, pos, bu):
+          tmp = bu.allocTemp(it.typ)
+          bu.subTree mnkDef:
+            bu.use tmp
+            bu.subTree mnkCast, it.typ:
+              bu.use toValue(env.procedures.add(np), env.types.add(np.typ))
+
+        changes.replaceMulti(tree, pos, bu):
+          bu.use tmp
 
 proc insertTrampolines*(tree: MirTree, g: ModuleGraph, owner: PSym,
                         env: var MirEnv, changes: var Changeset) =

--- a/compiler/mir/tailcall_elim.nim
+++ b/compiler/mir/tailcall_elim.nim
@@ -1,0 +1,296 @@
+## Implements the MIR passes making up the portable tail-call elimination (a
+## high-level description of how this works can be found `here <tailcallelim.html>`_).
+
+import
+  std/private/[
+    containers
+  ],
+  compiler/ast/[
+    ast_types,
+    ast_query,
+    idents,
+    types
+  ],
+  compiler/mir/[
+    mirbodies,
+    mirchangesets,
+    mirconstr,
+    mirenv,
+    mirtrees,
+    mirtypes
+  ],
+  compiler/modules/[
+    modulegraphs
+  ]
+
+template subTree(bu: var MirBuilder, k: MirNodeKind, t: TypeId,
+                 body: untyped) =
+  bu.subTree MirNode(kind: k, typ: t):
+    body
+
+proc getCalleeType(tree: MirTree, pos: NodePosition, env: MirEnv): PType =
+  if tree[pos].kind == mnkProc:
+    env[tree[pos].prc].typ
+  else:
+    env.types[env.types.canonical(tree[pos].typ)]
+
+proc emitParamBlobInit(bu: var MirBuilder, tree: MirTree, call: NodePosition,
+                       to: Value, g: ModuleGraph, owner: PSym,
+                       env: var MirEnv) =
+  ## Emits the parameter blob initialization, using the arguments from the
+  ## call at `call`. `to` provides the destination.
+  if tree.numArgs(call) == 0:
+    # nothing to store
+    return
+
+  let fntype = getCalleeType(tree, tree.callee(call), env)
+  # creating a parameter tuple using the graph's IdGenerator yields types
+  # with degenerate IDs. Let's hope these types don't end up anywhere
+  # problematic...
+  let typ = env.types.add(newParamTuple(g.config, g.idgen, owner, fntype))
+  var tup = bu.allocTemp(typ)
+  bu.buildStmt mnkDef:
+    bu.use tup
+    bu.subTree mnkTupleConstr, typ:
+      var i = 0'i32
+      for (mode, _, arg) in tree.arguments(call):
+        case mode
+        of mnkArg:
+          bu.subTree mnkArg:
+            bu.emitFrom(tree, NodePosition arg)
+        of mnkConsume:
+          bu.subTree mnkConsume:
+            bu.emitFrom(tree, NodePosition arg)
+        of mnkName:
+          let pt = env.types[env.types.lookupField(typ, i)].typ
+          bu.subTree mnkConsume:
+            var tmp: Value
+            bu.withFront:
+              tmp = bu.wrapTemp pt:
+                bu.subTree mnkAddr, pt:
+                  bu.emitFrom(tree, NodePosition arg)
+            bu.use tmp
+        inc i
+
+  bu.subTree mnkVoid:
+    bu.buildMagicCall mStoreParams, VoidType:
+      bu.emitByVal to
+      bu.subTree mnkConsume:
+        bu.use tup
+
+proc insertNewResult*(body: var MirBody, g: ModuleGraph, owner: PSym,
+                      env: var MirEnv) =
+  ## First part of the .tailcall lowering. Changes the 'result' type to
+  ## a ``Continuation`` type and turns the previous 'result' variable
+  ## (if any) into a normal local.
+  let contType = env.types.add(owner.typ.n[0][effectListLen].typ)
+  if body[resultId].typ == VoidType:
+    body.locals[resultId] =
+      Local(name: g.cache.getIdent("result"), typ: contType)
+  else:
+    var res = body[resultId]
+    let newId = body.locals.add(res)
+    # patch the result type:
+    res.typ = contType
+    body.locals[resultId] = res
+
+    # patch the result variable usages in the body:
+    for n in body.code.mitems:
+      if n.kind == mnkLocal and n.local == resultId:
+        n.local = newId
+    # note: this pass leaves the body in a state where invariants for
+    # return statements don't hold. This is not a problem, however, as
+    # the second pass, which has to be run immediately afterwards, makes
+    # them hold again
+
+    # wrap the body in a scope containing the 'def' for the new local:
+    var c = initChangeset(body)
+    c.insert(body.code, NodePosition(0), NodePosition(0), bu):
+      bu.subTree mnkScope: discard
+      bu.subTree mnkDef:
+        bu.use toValue(mnkLocal, newId, body[newId].typ)
+        bu.add MirNode(kind: mnkNone)
+    c.insert(body.code, NodePosition(body.code.len), NodePosition(0), bu):
+      bu.subTree mnkEndScope: discard
+    body.apply(c)
+
+proc lowerTailcallBody*(body: MirBody, g: ModuleGraph, owner: PSym,
+                        env: var MirEnv, changes: var Changeset) =
+  ## Second part of the .tailcall lowering. Lowers all 'tailcall' statements
+  ## into constructing and returning a ``Continuation`` object.
+  template tree: MirTree = body.code
+  let
+    contType = env.types.add(owner.typ.n[0][effectListLen].typ)
+    nextType = env.types[env.types.lookupField(contType, 1)].typ
+
+  var pos = NodePosition(0)
+  while pos < NodePosition(tree.len):
+    if tree[pos].kind == mnkVoid and tree[pos, 0].kind == mnkTailCall:
+      let
+        call = tree.child(pos, 0)
+        callee = tree.callee(call)
+      changes.replaceMulti(tree, pos, bu):
+        bu.buildStmt mnkInit:
+          bu.use toValue(mnkLocal, resultId, contType)
+          bu.subTree mnkObjConstr, contType:
+            bu.subTree mnkBinding:
+              bu.add MirNode(kind: mnkField, field: 0)
+              bu.subTree mnkConsume:
+                bu.use literal(mnkUIntLit, env.getOrIncl(0), BoolType)
+            bu.subTree mnkBinding:
+              bu.add MirNode(kind: mnkField, field: 1)
+              bu.subTree mnkConsume:
+                if tree[callee].kind == mnkProc:
+                  let prc = env[tree[callee].prc].ast[miscPos][0].sym
+                  bu.use toValue(env.procedures.add(prc), env.types.add(prc.typ))
+                else:
+                  # the static type doesn't match the dyanmic type; cast it
+                  var tmp: Value
+                  bu.withFront:
+                    tmp = bu.wrapTemp nextType:
+                      bu.subTree mnkCast, nextType:
+                        bu.emitFrom(tree, callee)
+                  bu.use tmp
+
+        # set up and store the parameter container
+        let dest = toValue(mnkLocal, LocalId(owner.typ.len), PointerType)
+        emitParamBlobInit(bu, tree, call, dest, g, owner, env)
+        bu.subTree mnkReturn:
+          bu.add MirNode(kind: mnkLocal, local: resultId, typ: contType)
+
+      # drop the following return statement:
+      pos = tree.sibling(pos)
+      changes.remove(tree, pos)
+    elif tree[pos].kind == mnkReturn:
+      # replace with a Continuation construction + return
+      changes.replaceMulti(tree, pos, bu):
+        bu.subTree mnkInit:
+          bu.use toValue(mnkLocal, resultId, contType)
+          bu.subTree mnkObjConstr, contType:
+            bu.subTree mnkBinding:
+              bu.add MirNode(kind: mnkField, field: 0)
+              bu.subTree mnkConsume:
+                bu.use literal(mnkUIntLit, env.getOrIncl(1), BoolType)
+            if tree[pos].len == 1:
+              bu.subTree mnkBinding:
+                bu.add MirNode(kind: mnkField, field: 2)
+                bu.subTree mnkConsume:
+                  bu.add tree[pos, 0]
+        bu.subTree mnkReturn:
+          bu.use toValue(mnkLocal, resultId, contType)
+
+    pos = tree.sibling(pos)
+
+proc lowerProcvals*(tree: MirTree, env: var MirEnv, changes: var Changeset) =
+  ## Turns all procval creation for .tailcall procedures into procval
+  ## creation of the associated application procedure.
+  for pos, it in tree.pairs:
+    if it.kind == mnkProcVal:
+      let canon = env.types.canonical(it.typ)
+      if env.types.headerFor(canon, Canonical).callConv(env.types) ==
+          ccTailcall:
+        # taking the address of a .tailcall procedure yields the address of
+        # the application procedure
+        let np = env[it.prc].ast[miscPos][0].sym
+        changes.replace(tree, pos):
+          MirNode(kind: mnkProcVal, prc: env.procedures.add(np),
+                  typ: env.types.add(np.typ))
+
+proc insertTrampolines*(tree: MirTree, g: ModuleGraph, owner: PSym,
+                        env: var MirEnv, changes: var Changeset) =
+  ## Turns all non-tailcall invocations of ``.tailcall`` procedures into
+  ## trampolines.
+  for pos, n in tree.pairs:
+    case n.kind
+    of mnkCall, mnkCheckedCall:
+      let fntype = getCalleeType(tree, tree.callee(pos), env)
+      if fntype.callConv == ccTailcall:
+        let
+          contType = env.types.add(fntype.n[0][effectListLen].typ)
+          nextType = env.types[env.types.lookupField(contType, 1)].typ
+          mutatesGlobal = tree.mutatesGlobal(pos)
+
+        var cont: Value
+        changes.insert(tree, tree.parent(pos), pos, bu):
+          cont = bu.allocTemp(contType)
+          let
+            blobType = g.systemModuleType(g.cache.getIdent("ParamBlob"))
+            storage = bu.allocTemp(env.types.add(blobType))
+            addrTmp = bu.allocTemp(PointerType)
+          bu.subTree mnkDef:
+            bu.use storage
+            bu.add MirNode(kind: mnkNone)
+          bu.subTree mnkDef:
+            bu.use addrTmp
+            bu.subTree mnkAddr, PointerType:
+              bu.use storage
+          if tree[tree.callee(pos)].kind == mnkProc:
+            # a static call
+            bu.subTree mnkDef:
+              bu.use cont
+              bu.subTree n.kind, contType:
+                # insert the the paramtere blob address as a new parameter
+                if n.kind == mnkCheckedCall:
+                  for i in 0..<(n.len - 1):
+                    bu.emitFrom(tree, tree.child(pos, i))
+                  bu.emitByVal(addrTmp)
+                  bu.add tree[tree.last(pos)] # add the resumption target
+                else:
+                  for i in 0..<(n.len - 1):
+                    bu.emitFrom(tree, tree.child(pos, i))
+                  bu.emitByVal(addrTmp)
+          else:
+            # a dynamic call. The address points to the application procedure,
+            # not the .tailcall procedure, and thus, the parameters need to be
+            # passed via the blob
+            emitParamBlobInit(bu, tree, pos, addrTmp, g, owner, env)
+
+            # the address has wrong type, it needs to be cast first
+            let tmp = bu.wrapTemp nextType:
+              bu.subTree mnkCast, nextType:
+                bu.emitFrom(tree, tree.callee(pos))
+            bu.subTree mnkDef:
+              bu.use cont
+              bu.rawBuildCall n.kind, contType, mutatesGlobal:
+                bu.use tmp
+                bu.emitByVal(addrTmp)
+                if n.kind == mnkCheckedCall:
+                  bu.add tree[tree.last(pos)]
+
+          let
+            loop = bu.allocLabel()
+            exit = bu.allocLabel()
+          bu.subTree mnkLoopJoin:
+            bu.add MirNode(kind: mnkLabel, label: loop)
+          bu.buildIf:
+            bu.pathNamed BoolType, 0:
+              bu.use cont
+          do:
+            bu.goto(exit)
+
+          bu.subTree mnkAsgn:
+            bu.use cont
+            bu.rawBuildCall n.kind, contType, mutatesGlobal:
+              bu.pathNamed nextType, 1:
+                bu.pathVariant contType, 0:
+                  bu.use cont
+              bu.emitByVal addrTmp
+              if n.kind == mnkCheckedCall:
+                bu.add tree[tree.last(pos)]
+          bu.subTree mnkLoop:
+            bu.add MirNode(kind: mnkLabel, label: loop)
+          bu.join(exit)
+
+        if n.typ == VoidType:
+          changes.remove(tree, tree.parent(pos))
+        else:
+          # it's not a void call; extract the result from the
+          # Continuation object
+          changes.replaceMulti(tree, pos, bu):
+            bu.subTree mnkMove, n.typ:
+              bu.pathNamed n.typ, 2:
+                bu.pathVariant contType, 0:
+                  bu.use cont
+
+    else:
+      discard "nothing to do"

--- a/doc/mir.rst
+++ b/doc/mir.rst
@@ -177,12 +177,8 @@ Semantics
             | Goto TARGET
             | Loop <Label>              # unconditional jump back to the start
                                         # of a loop
-            | Return                    # return from procedure; only allowed in
-                                        # procedure with a void return type
-            | Return LVALUE             # return from procedure; only allowed in
-                                        # procedure with a non-void return type.
-                                        # The operand must be the
-                                        # result variable 
+            | Return                    # return from procedure
+            | Return LVALUE             # return from procedure
             | Destroy LVALUE
             | Raise EX_TARGET
             | Join <Label>              # join point for non-exceptional
@@ -301,6 +297,16 @@ target for exceptional control-flow.
 
 At the end of `Finally` section must be a `Continue` statement, which specifies
 where raising the exception continues.
+
+Returns
+-------
+
+For procedures with a non-void return type, all `Return`s must have the result
+variable as the singular operand, except when it follows after a tailcall, in
+which case the `Return` must use the zero-operand form.
+
+For procedures with a void return type, all `Return` statements must use the
+zero-operand form.
 
 Storage
 =======

--- a/tests/arc/topt_no_cursor.nim
+++ b/tests/arc/topt_no_cursor.nim
@@ -26,11 +26,9 @@ scope:
   def _6: Target = (consume _3, consume _4, consume _5)
   result := move _6
   =destroy(name splat)
-  goto [L1]
+return result
 finally (L0):
   continue [Unwind]
-L1:
-return result
 -- end of expandArc ------------------------
 --expandArc: delete
 
@@ -216,11 +214,10 @@ scope:
     =destroy(name x)
     continue [L5]
   L4:
-goto [L1]
-finally (L5):
-  continue [Unwind]
 L1:
 return result
+finally (L5):
+  continue [Unwind]
 
 -- end of expandArc ------------------------
 --expandArc: check

--- a/tests/lang/s99_tailcall/t06_cleanup_of_result_prevents_tail_call_error.nim
+++ b/tests/lang/s99_tailcall/t06_cleanup_of_result_prevents_tail_call_error.nim
@@ -1,0 +1,18 @@
+discard """
+  action: reject
+"""
+
+type Object = object
+
+proc `=destroy`(x: var Object) =
+  discard
+
+proc p(): Object {.tailcall.} = Object()
+
+proc test(): Object {.tailcall.} =
+  result = Object()
+  # `result` has to be destroyed at the end of the scope, preventing the call
+  # from being a tail call
+  return p()
+
+discard test()

--- a/tests/optimization/tno_destroy_for_empty_result.nim
+++ b/tests/optimization/tno_destroy_for_empty_result.nim
@@ -13,11 +13,9 @@ scope:
         doRaise() -> [L1]
   def _2: Object = ()
   result := move _2
-goto [L2]
+return result
 finally (L1):
   continue [Unwind]
-L2:
-return result
 
 -- end of expandArc ------------------------
 '''


### PR DESCRIPTION
## Summary

* turn the portable tail-call elimination into a standalone MIR pass
* fix a compiler crash when a tail-call is prevented from happening due
  to `result` variable cleanup

## Details

* remove the tail-call elimination from `mirgen`, including the
  `goTailCallElim` option. `mirgen` always emits `mnkTailCall`
  statements for tail calls now

* remove the now-obsolete `mEnsureNoDestroy` magic. Detecting tail-
  call-preventing cleanup is anchored on `mnkTailCall` instead

* change the MIR rules to allow the zero-form `return` following a
  tail-call. A MIR tail-call is always followed by a `return` now,
  making tail-call elimination a bit simpler

* add the `tailcall_elim` module implementing the portable tail-call
  elimination. The transformation produces the same code as the
  previous implementation, except for:

  * translate `.tailcall` proc types the same as other non-`.closure`
     proc types

  * register the 'result' variable in a hidden scope during MIR
     translation, so that emitting the cleanup logic is handled
     automatically

  * remove the indirect .tailcall call workarounds from `ccgcalls`
     and `jsgen`

  * use precise source/origin information for all references to
locations
     created with `mirgen.genLocation`, fixing a crash in `injecthooks`
     due to the origin of `destroy` statements not pointing to
     symbol nodes

* add a test for tail calls being prevented due to the `result`
  variable requiring cleanup

The tail-call elimination passes happens after the `injectdestructors`
passes. It's only enabled for the C and JS code generators, same as
before.