### PR TITLE
sempass2: fix crash with generic .closure routine

### DIFF
--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1753,7 +1753,7 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
   if cap != nil:
     # the procedure captures something and thus requires a hidden environment
     # parameter
-    if not canCaptureFrom(s, cap.sym.owner):
+    if not canCaptureFrom(s, cap.sym.skipGenericOwner):
       # attempting to capture an entity that only exists at run-time in a
       # compile-time context
       localReport(g.config, cap.info, reportSym(

--- a/tests/lang_callable/closure/tclosure_inference.nim
+++ b/tests/lang_callable/closure/tclosure_inference.nim
@@ -100,3 +100,15 @@ proc test6() =
   inner()
 
 test6()
+
+# generic inner routine that's used inside a sibling inner routine
+proc test7() =
+  var x = 0
+  proc inner[T]() =
+    x = 1 # `inner` is a closure
+
+  proc other() =
+    inner[int]()
+  other()
+
+test7()


### PR DESCRIPTION
## Summary

Fix the compiler crashing when using the instance of an inner generic
.closure routine in a routine that's not a parent of the generic
routine.

## Details

Detection in `sempass2` of whether a capture is used the `owner` of the
first-appearing outer symbol as the traversal target. If the outer
symbol is that of a generic instantiation, the owner is the
originating-from generic routine, and since the traversal in
`canCaptureFrom` skips generic owners (as it should), this meant that
traversal skipped over the target and ended up fetching the owner of
the top-level `skPackage` symbol (which is `nil`), causing a nil
pointer access.

The generic owner is now skipped properly.