### PR TITLE
transf: fix indirect tail calls not being detected as such

### DIFF
--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -1134,7 +1134,8 @@ proc transformCall(c: PTransf, n: PNode): PNode =
     else:
       result = s
 
-    if result[0].typ != nil and result[0].typ.callConv == ccTailcall and
+    if result[0].typ != nil and
+       result[0].typ.skipTypes(abstractInst).callConv == ccTailcall and
        sfGeneratedOp notin getCurrOwner(c).flags and
        getCurrOwner(c).typ != nil and
        getCurrOwner(c).typ.callConv == ccTailcall and
@@ -1442,7 +1443,8 @@ proc forwardReturn(g: ModuleGraph, owner: PSym, n: var PNode, active: bool) =
   proc wrap(g: ModuleGraph, owner: PSym, n: var PNode, active: bool) =
     if active:
       if n.kind in nkCallKinds and
-         n[0].typ != nil and n[0].typ.callConv == ccTailcall:
+         n[0].typ != nil and
+         n[0].typ.skipTypes(abstractInst).callConv == ccTailcall:
         n = newTreeI(nkReturnStmt, n.info, n)
       else:
         n = newTreeI(nkReturnStmt, n.info,

--- a/tests/lang_callable/proc/ttailcall_generic_callee.nim
+++ b/tests/lang_callable/proc/ttailcall_generic_callee.nim
@@ -1,0 +1,41 @@
+discard """
+  description: '''
+    Ensures that calls where the callee is a .tailcall procval whose type
+    comes from a generic instantiation work.
+  '''
+  matrix: "--hints:off --showir:mir_in:test_expression --showir:mir_in:test_statement"
+  targets: "c"
+  nimoutFull: true
+  nimout: '''
+-- MIR: test_expression
+scope:
+  def callee: Proc[system.int] = other1
+  tail callee(arg 1)
+  return
+
+-- end
+-- MIR: test_statement
+scope:
+  def callee: Proc[system.void] = other2
+  tail callee()
+  return
+
+-- end
+'''
+"""
+
+type Proc[T] = proc(x: T): T {.tailcall.}
+
+proc other1(x: int): int {.tailcall.} = x
+proc other2() {.tailcall.} = discard
+
+proc test_expression(): int {.tailcall.} =
+  let callee: Proc[int] = other1
+  callee(1)
+
+proc test_statement() {.tailcall.} =
+  let callee: Proc[void] = other2
+  callee()
+
+doAssert test_expression() == 1
+test_statement()


### PR DESCRIPTION
## Summary

Fix calls where the callee is a `.tailcall` procval not being
considered a tail call when the callee type is a generic type
instantiation.

## Details

Type skipping in `transf` was missing for the relevant "is callee a
`.tailcall` proc type" checks, leaving such calls as normal calls.

A MIR-output-based test is added to ensure the calls in question being
tail calls.