### PR TITLE
ci(windows): bump vcpkg revision to 2025.07.25

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           triplet: x64-mingw-dynamic-release
           host-triplet: x64-mingw-dynamic-release
-          revision: 2024.01.12
+          revision: 2025.07.25
           overlay-triplets: ${{ github.workspace }}/tools/vcpkg/triplets
 
       - name: Install dependencies (Windows)

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           triplet: x64-mingw-dynamic-release
           host-triplet: x64-mingw-dynamic-release
-          revision: 2024.01.12
+          revision: 2025.07.25
           overlay-triplets: ${{ github.workspace }}/tools/vcpkg/triplets
 
       - name: Install dependencies (Windows)


### PR DESCRIPTION
## Summary
Bump the vcpkg revision used to supply Windows libraries.

## Details
The current revision no longer compiles in CI due to external sources no
longer hosting the required binaries. Bump the revision to the latest to
fix the problem.