### PR TITLE
ci: don't run on dependabot branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - staging-squash-merge.tmp
       # Github Merge Queue temporary branches
       - gh-readonly-queue/**
+      # Dependabot branches
+      - dependabot/**
 
   pull_request:
     # Only take PRs to devel

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,6 +5,8 @@ on:
       - devel
       # Github Merge Queue temporary branches
       - gh-readonly-queue/**
+      # Dependabot branches
+      - dependabot/**
 
   pull_request:
     # Only consider PRs to devel


### PR DESCRIPTION
## Summary
Turn `push` CI off for dependabot branches

## Details
As dependabot creates new PRs, it also pushes into a branch in our
repository. This causes both PR and push CI to run at the same time,
saturating our CI capacity.

This PR disables the redundant push CI for branches created by
dependabot.