### PR TITLE
ci: makes sure dependabot PR don't litter commit log

### DIFF
--- a/.github/workflows/dependabot-pr-body.yml
+++ b/.github/workflows/dependabot-pr-body.yml
@@ -1,0 +1,26 @@
+name: Edit dependabot PR body for merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  edit:
+    if: github.event.pull_request.user.login == 'app/dependabot'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Edit PR body
+        run: |
+          # Modifies the PR body to prepend a horizontal ruler.
+          # This makes sure /merge trims the entire PR body, preventing
+          # dependabot fancy formatting from littering the commit message
+          gh pr view "$PR_URL" --json body --jq '"---\n\n" + .body' \
+          | gh pr edit "$PR_URL" --body-file -
+        env:
+          PR_URL: ${{ github.event.pull_request.url }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
When a PR is opened by dependabot, prepend its body with a horizontal
ruler, allowing merge command to trim it away.

## Details
Dependabot PR body is filled with HTML formatting and unnecessary
auxiliary information on controlling the bot. This would just bloat up
the commit message, making them awful to look at.

This PR adds a new workflow to automatically prepend such PR bodies with 
`---` , making sure  `/merge`  trims them when triggered, emptying the
commit message body.