### PR TITLE
dependabot: manage custom actions and group artifact-related updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,17 @@ version: 2
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # XXX: Workaround https://github.com/dependabot/dependabot-core/issues/6345
+    directories:
+      - /
+      - /.github/actions/download-compiler
+      - /.github/actions/upload-compiler
+      - /.github/actions/setup-mingw
+      - /.github/actions/setup-vcpkg
     schedule:
       interval: "weekly"
+    groups:
+      # Group download/upload artifact action updates
+      actions-artifacts:
+        patterns:
+          - actions/*-artifact


### PR DESCRIPTION
## Summary
Add custom actions to dependabot to have their dependencies updated, and
group artifact-related updates together.

## Details
Dependabot does not manage updates for actions in  `.github/actions` 
automatically. This PR populates the configuration with our custom
actions locations to get them monitored.

Also, groups the updates of download-artifact and upload-artifact
actions, since they usually requires updating in lockstep.

Ref: https://github.com/dependabot/dependabot-core/issues/6345