### PR TITLE
lang: add "generated" symbol kind

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -719,6 +719,8 @@ type
                           ## file (it is loaded on demand, which may
                           ## mean: never)
     skPackage             ## symbol is a package (used for canonicalization)
+    skGenerated           ## symbol is generated and requires specialization in
+                          ## a definition context
 
   TSymKinds* = set[TSymKind]
 
@@ -1245,6 +1247,7 @@ type
     adSemCannotMixTypesAndValuesInTuple
     adSemNoReturnTypeDeclared
     adSemReturnNotAllowed
+    adSemGeneratedSymUsed
     # semmagics
     adSemExprHasNoAddress
     adSemExpectedOrdinal
@@ -1396,7 +1399,8 @@ type
         adSemContinueCannotHaveLabel,
         adSemUnavailableLocation,
         adSemForExpectedIterator,
-        adSemExternalLocalNotAllowed:
+        adSemExternalLocalNotAllowed,
+        adSemGeneratedSymUsed:
       discard
     of adSemExpectedIdentifierInExpr:
       notIdent*: PNode

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -718,9 +718,9 @@ type
     skStub                ## symbol is a stub and not yet loaded from the ROD
                           ## file (it is loaded on demand, which may
                           ## mean: never)
-    skPackage             ## symbol is a package (used for canonicalization)
     skGenerated           ## symbol is generated and requires specialization in
                           ## a definition context
+    skPackage             ## symbol is a package (used for canonicalization)
 
   TSymKinds* = set[TSymKind]
 

--- a/compiler/ast/astmsgs.nim
+++ b/compiler/ast/astmsgs.nim
@@ -15,7 +15,11 @@ proc typSym*(t: PType): PSym =
     result = t.skipTypes({tyGenericInst}).sym
 
 proc addDeclaredLoc*(result: var string, conf: ConfigRef; sym: PSym) =
-  result.add " [$1 declared in $2]" % [sym.kind.toHumanStr, toFileLineCol(conf, sym.info)]
+  case sym.kind
+  of skGenerated:
+    result.add " [generated in $1]" % [toFileLineCol(conf, sym.info)]
+  else:
+    result.add " [$1 declared in $2]" % [sym.kind.toHumanStr, toFileLineCol(conf, sym.info)]
 
 proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =
   if optDeclaredLocs in conf.globalOptions and sym != nil:

--- a/compiler/ast/linter.nim
+++ b/compiler/ast/linter.nim
@@ -53,7 +53,7 @@ const
   skLiteralValue = {skEnumField, skLabel}
   skOverloadableDef = routineKinds
   skLocals = {skLet, skVar, skParam, skForVar, skField}
-  skIgnore = {skUnknown, skConditional, skDynLib, skStub, skTemp}
+  skIgnore = {skUnknown, skConditional, skDynLib, skStub, skTemp, skGenerated}
   # skResult needs to be accounted for here
 
 type

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -702,6 +702,7 @@ type
     rsemPragmaRecursiveDependency
     rsemMisplacedDeprecation
     rsemNoUnionForJs
+    rsemUndeclaredSymUsed
 
     rsemThisPragmaRequires01Args
     rsemMismatchedPopPush

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -577,6 +577,10 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemNoUnionForJs:
       result = "`{.union.}` is not implemented for js backend."
 
+    of rsemUndeclaredSymUsed:
+      result = "symbol used before declaration: "
+      result.add conf.getSymRepr r.sym
+
     of rsemBitsizeRequiresPositive:
       result = "bitsize needs to be positive"
 
@@ -3335,7 +3339,8 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         kind: kind,
         ast: diag.wrongNode)
   of adSemDotOperatorsNotEnabled,
-     adSemCallOperatorsNotEnabled:
+     adSemCallOperatorsNotEnabled,
+     adSemGeneratedSymUsed:
     semRep = SemReport(
         location: some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,

--- a/compiler/front/condsyms.nim
+++ b/compiler/front/condsyms.nim
@@ -79,3 +79,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimskullNoNkNone")
   defineSymbol("nimskullHasSupportsZeroMem")
   defineSymbol("nimskullHasNoParseFloatMagic")
+  defineSymbol("nimskullHasUnaryGenSym")

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -580,6 +580,7 @@ func astDiagToLegacyReportKind*(
   of adSemCannotMixTypesAndValuesInTuple: rsemCannotMixTypesAndValuesInTuple
   of adSemNoReturnTypeDeclared: rsemNoReturnTypeDeclared
   of adSemReturnNotAllowed: rsemReturnNotAllowed
+  of adSemGeneratedSymUsed: rsemUndeclaredSymUsed
   of adSemFieldAssignmentInvalid: rsemFieldAssignmentInvalid
   of adSemFieldNotAccessible: rsemFieldNotAccessible
   of adSemObjectRequiresFieldInit: rsemObjectRequiresFieldInit

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -466,7 +466,10 @@ proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
       # xxx: we really should guard on `sfGenSym`; but macros can transplant
       #      symbols from pretty much anywhere, so we don't know where gensym
       #      really came from.
-      if n.sym.kind in {kind, skTemp}:
+      if n.sym.kind in {kind, skTemp, skGenerated}:
+        # declaration position converts generated sym to the correct type
+        if n.sym.kind == skGenerated:
+          n.sym.kind = kind
         n.sym.owner = currOwner # xxx: modifying the sym owner is suss
         n
       else:

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1660,6 +1660,11 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
       # the owner should have been set by now by addParamOrResult
       c.config.internalAssert s.owner != nil
     result = newSymNode(s, n.info)
+  of skGenerated:
+    let info = getCallLineInfo(n)
+    markUsed(c, info, s)
+    result = c.config.newError(newSymNode(s, info),
+                               PAstDiag(kind: adSemGeneratedSymUsed))
   else:
     let info = getCallLineInfo(n)
     markUsed(c, info, s)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3039,7 +3039,8 @@ proc semRoutineDef(c: PContext, n: PNode): PNode =
   result[namePos] =
     semRoutineName(c, n[namePos], kind, allowAnon = kind in AllowAnon)
 
-  c.config.timeTracer.traceSym(tikSem, result[namePos].sym)
+  if result[namePos].kind != nkError:
+    c.config.timeTracer.traceSym(tikSem, result[namePos].sym)
 
   if result[namePos].kind == nkError:
     if result[namePos].diag.kind == adSemDefNameSym:

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -252,7 +252,7 @@ proc getIdentNode(c: var TemplCtx, n: PNode): PNode =
 
 func isTemplParam(c: TemplCtx, s: PSym): bool {.inline.} =
   ## True if `s` is a parameter symbol of the current template.
-  s.kind == skParam and s.owner == c.owner and sfTemplateParam in s.flags
+  s.kind in {skParam, skGenerated} and s.owner == c.owner and sfTemplateParam in s.flags
 
 func isTemplParam(c: TemplCtx, n: PNode): bool {.inline.} =
   ## True if `n` is a parameter symbol of the current template.

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -252,7 +252,7 @@ proc getIdentNode(c: var TemplCtx, n: PNode): PNode =
 
 func isTemplParam(c: TemplCtx, s: PSym): bool {.inline.} =
   ## True if `s` is a parameter symbol of the current template.
-  s.kind in {skParam, skGenerated} and s.owner == c.owner and sfTemplateParam in s.flags
+  s.kind == skParam and s.owner == c.owner and sfTemplateParam in s.flags
 
 func isTemplParam(c: TemplCtx, n: PNode): bool {.inline.} =
   ## True if `n` is a parameter symbol of the current template.
@@ -304,10 +304,10 @@ proc onlyReplaceParams(c: var TemplCtx, n: PNode): PNode =
     if hasError:
       result = c.c.config.wrapError(result)
 
-proc newGenSym(n: PNode, c: var TemplCtx): PSym =
+proc newGenSym(kind: TSymKind, n: PNode, c: var TemplCtx): PSym =
   let (ident, err) = considerQuotedIdent(c.c, n)
   if err.isNil:
-    result = newSym(skGenerated, ident, nextSymId c.c.idgen, c.owner, n.info)
+    result = newSym(kind, ident, nextSymId c.c.idgen, c.owner, n.info)
     result.flags.incl {sfGenSym, sfShadowed}
   else:
     result = newSym(skError, ident, nextSymId c.c.idgen, c.owner, n.info)
@@ -384,7 +384,7 @@ proc addLocalDecl(c: var TemplCtx, n: var PNode, k: TSymKind) =
         replaceIdentBySym(c.c, n, ident)
       else:
         if n.kind != nkSym:
-          let local = newGenSym(ident, c)
+          let local = newGenSym(k, ident, c)
 
           addPrelimDecl(c.c, local)
           styleCheckDef(c.c.config, n.info, local)
@@ -497,7 +497,7 @@ proc semRoutineInTemplBody(c: var TemplCtx, n: PNode, k: TSymKind): PNode =
     elif definitionTemplParam(c, ident):
       n[namePos] = ident
     else:
-      var s = newGenSym(ident, c)
+      var s = newGenSym(k, ident, c)
       s.ast = n
       addPrelimDecl(c.c, s)
       styleCheckDef(c.c.config, n.info, s)

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -304,10 +304,10 @@ proc onlyReplaceParams(c: var TemplCtx, n: PNode): PNode =
     if hasError:
       result = c.c.config.wrapError(result)
 
-proc newGenSym(kind: TSymKind, n: PNode, c: var TemplCtx): PSym =
+proc newGenSym(n: PNode, c: var TemplCtx): PSym =
   let (ident, err) = considerQuotedIdent(c.c, n)
   if err.isNil:
-    result = newSym(kind, ident, nextSymId c.c.idgen, c.owner, n.info)
+    result = newSym(skGenerated, ident, nextSymId c.c.idgen, c.owner, n.info)
     result.flags.incl {sfGenSym, sfShadowed}
   else:
     result = newSym(skError, ident, nextSymId c.c.idgen, c.owner, n.info)
@@ -384,7 +384,7 @@ proc addLocalDecl(c: var TemplCtx, n: var PNode, k: TSymKind) =
         replaceIdentBySym(c.c, n, ident)
       else:
         if n.kind != nkSym:
-          let local = newGenSym(k, ident, c)
+          let local = newGenSym(ident, c)
 
           addPrelimDecl(c.c, local)
           styleCheckDef(c.c.config, n.info, local)
@@ -497,7 +497,7 @@ proc semRoutineInTemplBody(c: var TemplCtx, n: PNode, k: TSymKind): PNode =
     elif definitionTemplParam(c, ident):
       n[namePos] = ident
     else:
-      var s = newGenSym(k, ident, c)
+      var s = newGenSym(ident, c)
       s.ast = n
       addPrelimDecl(c.c, s)
       styleCheckDef(c.c.config, n.info, s)

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2707,15 +2707,19 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
         delSon(regs[ra].nimNode, bb)
     of opcGenSym:
       decodeBC(rkNimNode)
-      let k = regs[rb].intVal
-      checkHandle(regs[rc])
-      assert regs[rc].handle.typ.kind == akString
+      let rh =
+        if regs[rb].kind == rkInt:
+          # Called from compatibility symbol
+          rc
+        else:
+          rb
+
+      checkHandle(regs[rh])
+      assert regs[rh].handle.typ.kind == akString
       # XXX: costly stringify of strVal... `getIdent` doesn't use openArray :(
-      let name = if regs[rc].strVal.len == 0: ":tmp"
-                 else: $regs[rc].strVal
-      guestValidate(k in 0..ord(high(TSymKind)),
-        "request to create symbol of invalid kind")
-      var sym = newSym(k.TSymKind, getIdent(c.cache, name), nextSymId c.idgen, c.module.owner, c.debug[pc])
+      let name = if regs[rh].strVal.len == 0: ":tmp"
+                 else: $regs[rh].strVal
+      var sym = newSym(skGenerated, getIdent(c.cache, name), nextSymId c.idgen, nil, c.debug[pc])
       incl(sym.flags, sfGenSym)
       regs[ra].nimNode = newSymNode(sym)
     of opcNccValue:

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2706,19 +2706,12 @@ proc rawExecute(c: var TCtx, t: var VmThread, pc: var int): YieldReason =
       for i in 0..<regs[rc].intVal.int:
         delSon(regs[ra].nimNode, bb)
     of opcGenSym:
-      decodeBC(rkNimNode)
-      let rh =
-        if regs[rb].kind == rkInt:
-          # Called from compatibility symbol
-          rc
-        else:
-          rb
-
-      checkHandle(regs[rh])
-      assert regs[rh].handle.typ.kind == akString
+      decodeB(rkNimNode)
+      checkHandle(regs[rb])
+      assert regs[rb].handle.typ.kind == akString
       # XXX: costly stringify of strVal... `getIdent` doesn't use openArray :(
-      let name = if regs[rh].strVal.len == 0: ":tmp"
-                 else: $regs[rh].strVal
+      let name = if regs[rb].strVal.len == 0: ":tmp"
+                 else: $regs[rb].strVal
       var sym = newSym(skGenerated, getIdent(c.cache, name), nextSymId c.idgen, nil, c.debug[pc])
       incl(sym.flags, sfGenSym)
       regs[ra].nimNode = newSymNode(sym)

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2003,7 +2003,13 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mNCallSite:
     if dest.isUnset: dest = c.getTemp(n.typ)
     c.gABC(n, opcCallSite, dest)
-  of mNGenSym: genBinaryABC(c, n, dest, opcGenSym)
+  of mNGenSym:
+    if n.len == 2:
+      # Unary genSym
+      genUnaryABC(c, n, dest, opcGenSym)
+    else:
+      # Deprecated binary form
+      genBinaryABC(c, n, dest, opcGenSym)
   of mMinI, mMaxI, mAbsI, mDotDot:
     c.genCall(n, dest)
   of mExpandToAst:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -2003,13 +2003,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mNCallSite:
     if dest.isUnset: dest = c.getTemp(n.typ)
     c.gABC(n, opcCallSite, dest)
-  of mNGenSym:
-    if n.len == 2:
-      # Unary genSym
-      genUnaryABC(c, n, dest, opcGenSym)
-    else:
-      # Deprecated binary form
-      genBinaryABC(c, n, dest, opcGenSym)
+  of mNGenSym: genUnaryABC(c, n, dest, opcGenSym)
   of mMinI, mMaxI, mAbsI, mDotDot:
     c.genCall(n, dest)
   of mExpandToAst:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -438,13 +438,17 @@ when defined(nimskullHasUnaryGenSym):
     ## Generates a fresh symbol that is guaranteed to be unique. The symbol
     ## needs to occur in a declaration context.
 
-proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
-  magic: "NGenSym", noSideEffect, deprecated: "genSym no longer takes a `kind` parameter".}
-  ## Generates a fresh symbol that is guaranteed to be unique. The symbol
-  ## needs to occur in a declaration context.
-  ##
-  ## This is a compatibility alias for `genSym`, the `kind` parameter is
-  ## ignored.
+  proc genSym*(kind: NimSymKind = nskGenerated; ident: string): NimNode {.
+    magic: "NGenSym", noSideEffect, deprecated: "genSym no longer takes a `kind` parameter".}
+    ## Generates a fresh symbol that is guaranteed to be unique. The symbol
+    ## needs to occur in a declaration context.
+    ##
+    ## This is a compatibility alias for `genSym`, the `kind` parameter is
+    ## ignored.
+else:
+  # Old prototype for bootstrapping
+  proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
+    magic: "NGenSym", noSideEffect.}
 
 proc callsite*(): NimNode {.magic: "NCallSite", benign, deprecated:
   "Deprecated since v0.18.1; use `varargs[untyped]` in the macro prototype instead".}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -145,8 +145,7 @@ type
     nskProc, nskFunc, nskMethod, nskIterator,
     nskConverter, nskMacro, nskTemplate, nskField,
     nskEnumField, nskForVar, nskLabel,
-    nskStub,
-    nskGenerated = ord(nskStub) + 2
+    nskStub, nskGenerated
 
 const
   nnkLiterals* = {nnkCharLit..nnkNilLit}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -437,13 +437,24 @@ when defined(nimskullHasUnaryGenSym):
     ## Generates a fresh symbol that is guaranteed to be unique. The symbol
     ## needs to occur in a declaration context.
 
-  proc genSym*(kind: NimSymKind = nskGenerated; ident: string): NimNode {.
-    magic: "NGenSym", noSideEffect, deprecated: "genSym no longer takes a `kind` parameter".}
+  template genSym*(kind: NimSymKind = nskGenerated; ident: string): NimNode {.
+    deprecated: "genSym no longer takes a `kind` parameter".} =
     ## Generates a fresh symbol that is guaranteed to be unique. The symbol
     ## needs to occur in a declaration context.
     ##
-    ## This is a compatibility alias for `genSym`, the `kind` parameter is
-    ## ignored.
+    ## This is a compatibility alias for `genSym <#genSym,string>`_, the `kind`
+    ## parameter is ignored.
+    genSym(ident)
+
+  template genSym*(kind: NimSymKind): NimNode {.
+    deprecated: "genSym no longer takes a `kind` parameter".} =
+    ## Generates a fresh symbol that is guaranteed to be unique. The symbol
+    ## needs to occur in a declaration context.
+    ##
+    ## This is a compatibility alias for `genSym <#genSym,string>`_, the `kind`
+    ## parameter is ignored.
+    genSym()
+
 else:
   # Old prototype for bootstrapping
   proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -444,7 +444,9 @@ when defined(nimskullHasUnaryGenSym):
     ##
     ## This is a compatibility alias for `genSym <#genSym,string>`_, the `kind`
     ## parameter is ignored.
-    genSym(ident)
+    {.line.}:
+      discard kind 
+      genSym(ident)
 
   template genSym*(kind: NimSymKind): NimNode {.
     deprecated: "genSym no longer takes a `kind` parameter".} =
@@ -453,7 +455,9 @@ when defined(nimskullHasUnaryGenSym):
     ##
     ## This is a compatibility alias for `genSym <#genSym,string>`_, the `kind`
     ## parameter is ignored.
-    genSym()
+    {.line.}:
+      discard kind
+      genSym()
 
 else:
   # Old prototype for bootstrapping

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -145,7 +145,8 @@ type
     nskProc, nskFunc, nskMethod, nskIterator,
     nskConverter, nskMacro, nskTemplate, nskField,
     nskEnumField, nskForVar, nskLabel,
-    nskStub
+    nskStub,
+    nskGenerated = ord(nskStub) + 2
 
 const
   nnkLiterals* = {nnkCharLit..nnkNilLit}
@@ -432,10 +433,18 @@ proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
   ##
   ## See the `manual <manual.html#macros-bindsym>`_ for more details.
 
+when defined(nimskullHasUnaryGenSym):
+  proc genSym*(ident = ""): NimNode {.magic: "NGenSym", noSideEffect.}
+    ## Generates a fresh symbol that is guaranteed to be unique. The symbol
+    ## needs to occur in a declaration context.
+
 proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
-  magic: "NGenSym", noSideEffect.}
+  magic: "NGenSym", noSideEffect, deprecated: "genSym no longer takes a `kind` parameter".}
   ## Generates a fresh symbol that is guaranteed to be unique. The symbol
   ## needs to occur in a declaration context.
+  ##
+  ## This is a compatibility alias for `genSym`, the `kind` parameter is
+  ## ignored.
 
 proc callsite*(): NimNode {.magic: "NCallSite", benign, deprecated:
   "Deprecated since v0.18.1; use `varargs[untyped]` in the macro prototype instead".}

--- a/lib/std/tasks.nim
+++ b/lib/std/tasks.nim
@@ -84,7 +84,7 @@ template checkIsolate(scratchAssignList: seq[NimNode], procParam, scratchDotExpr
   #   scratch.a = extract(isolateA)
   #   var isoTempB = isolate(literal)
   #   scratch.b = extract(isolateB)
-  let isolatedTemp = genSym(nskTemp, "isoTemp")
+  let isolatedTemp = genSym("isoTemp")
   scratchAssignList.add newVarStmt(isolatedTemp, newCall(newidentNode("isolate"), procParam))
   scratchAssignList.add newAssignment(scratchDotExpr,
       newcall(newIdentNode("extract"), isolatedTemp))
@@ -94,7 +94,7 @@ template addAllNode(assignParam: NimNode, procParam: NimNode) =
 
   checkIsolate(scratchAssignList, procParam, scratchDotExpr)
 
-  let tempNode = genSym(kind = nskTemp, ident = formalParams[i][0].strVal)
+  let tempNode = genSym(formalParams[i][0].strVal)
   callNode.add nnkExprEqExpr.newTree(formalParams[i][0], tempNode)
   tempAssignList.add newLetStmt(tempNode, newDotExpr(objTemp, formalParams[i][0]))
   scratchRecList.add newIdentDefs(newIdentNode(formalParams[i][0].strVal), assignParam)
@@ -117,7 +117,7 @@ macro toTask*(e: typed{nkCall | nkInfix | nkPrefix | nkPostfix | nkCommand | nkC
     error("closure call is not allowed")
 
   if e.len > 1:
-    let scratchIdent = genSym(kind = nskTemp, ident = "scratch")
+    let scratchIdent = genSym("scratch")
     let impl = e[0].getTypeInst
 
     when defined(nimTasksDebug):
@@ -132,7 +132,7 @@ macro toTask*(e: typed{nkCall | nkInfix | nkPrefix | nkPostfix | nkCommand | nkC
       callNode: seq[NimNode]
 
     let
-      objTemp = genSym(nskTemp, ident = "objTemp")
+      objTemp = genSym("objTemp")
 
     for i in 1 ..< formalParams.len:
       var param = formalParams[i][1]
@@ -169,7 +169,7 @@ macro toTask*(e: typed{nkCall | nkInfix | nkPrefix | nkPostfix | nkCommand | nkC
       else:
         error("not supported type kinds")
 
-    let scratchObjType = genSym(kind = nskType, ident = "ScratchObj")
+    let scratchObjType = genSym("ScratchObj")
     let scratchObj = nnkTypeSection.newTree(
                       nnkTypeDef.newTree(
                         scratchObjType,
@@ -207,9 +207,9 @@ macro toTask*(e: typed{nkCall | nkInfix | nkPrefix | nkPostfix | nkCommand | nkC
     functionStmtList.add tempAssignList
     functionStmtList.add funcCall
 
-    let funcName = genSym(nskProc, e[0].strVal)
-    let destroyName = genSym(nskProc, "destroyScratch")
-    let objTemp2 = genSym(ident = "obj")
+    let funcName = genSym(e[0].strVal)
+    let destroyName = genSym("destroyScratch")
+    let objTemp2 = genSym("obj")
     let tempNode = quote("@") do:
         `=destroy`(@objTemp2[])
 
@@ -227,7 +227,7 @@ macro toTask*(e: typed{nkCall | nkInfix | nkPrefix | nkPostfix | nkCommand | nkC
       Task(callback: `funcName`, args: `scratchIdent`, destroy: `destroyName`)
   else:
     let funcCall = newCall(e[0])
-    let funcName = genSym(nskProc, e[0].strVal)
+    let funcName = genSym(e[0].strVal)
 
     result = quote do:
       proc `funcName`(args: pointer) {.gcsafe, nimcall.} =

--- a/tests/errmsgs/tundeclared_symbol.nim
+++ b/tests/errmsgs/tundeclared_symbol.nim
@@ -1,0 +1,14 @@
+discard """
+  cmd: '''nim check --msgFormat:sexp --filenames:canonical --hints:off $file'''
+  action: reject
+  nimoutFormat: sexp
+"""
+
+import std/macros
+
+macro useBeforeDecl(): untyped =
+  let c = genSym("c")#[tt.Error
+               ^ (SemUndeclaredSymUsed)]#
+  result = c
+
+useBeforeDecl()

--- a/tests/errmsgs/tundeclared_symbol.nim
+++ b/tests/errmsgs/tundeclared_symbol.nim
@@ -1,9 +1,6 @@
 discard """
-  cmd: '''nim check --hints:off $file'''
-  action: reject
-  nimout: '''
-tundeclared_symbol.nim(12, 17) Error: symbol used before declaration: 'c' [generated in tundeclared_symbol.nim(12, 17)]
-'''
+  errormsg: "symbol used before declaration: 'c' [generated in tundeclared_symbol.nim(9, 17)]"
+  line: 9
 """
 
 import std/macros

--- a/tests/errmsgs/tundeclared_symbol.nim
+++ b/tests/errmsgs/tundeclared_symbol.nim
@@ -1,14 +1,15 @@
 discard """
-  cmd: '''nim check --msgFormat:sexp --filenames:canonical --hints:off $file'''
+  cmd: '''nim check --hints:off $file'''
   action: reject
-  nimoutFormat: sexp
+  nimout: '''
+tundeclared_symbol.nim(12, 17) Error: symbol used before declaration: 'c' [generated in tundeclared_symbol.nim(12, 17)]
+'''
 """
 
 import std/macros
 
 macro useBeforeDecl(): untyped =
-  let c = genSym("c")#[tt.Error
-               ^ (SemUndeclaredSymUsed)]#
+  let c = genSym("c")
   result = c
 
 useBeforeDecl()

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -1,5 +1,5 @@
 discard """
-  description: "Generated symbols not matching the definition must be rejected"
+  description: "Symbols not matching the definition must be rejected"
   action: reject
   cmd: "nim check --msgFormat:sexp --filenames:canonical $options $file"
   nimoutFormat: sexp
@@ -7,62 +7,114 @@ discard """
 
 import std/macros
 
-macro replaceName(kind: static[NimSymKind], def: untyped): untyped =
-  ## Replaces the identifier in the name slot of `def` with a generated symbol
-  ## of the given `kind`.
+proc nameExpr(n: NimNode): NimNode =
+  # Extracts the expression containing the replacement name
+  case n.kind
+  of nnkStmtList, nnkStmtListExpr, nnkForStmt:
+    nameExpr n[^1]
+  of nnkConstSection, nnkConstDef:
+    nameExpr n[0]
+  of nnkDiscardStmt:
+    nameExpr n[0]
+  of RoutineNodes:
+    n.name
+  of AtomicNodes:
+    n
+  else:
+    unreachable("unsupported kind: " & $n.kind)
+
+macro replaceName(sym: typed, def: untyped): untyped =
+  ## Replaces the identifier in the name slot of `def` with the symbol in the
+  ## last expression of `sym`.
   let def = if def.kind == nnkStmtList: def[0] else: def
+  let sym = nameExpr sym
 
-  def.expectKind(RoutineNodes)
-
-  proc genSym(kind: NimSymKind, ident: NimNode): NimNode =
-    result = genSym(kind, ident.strVal)
-    copyLineInfo(result, ident)
-
-  def.name = genSym(kind, def.name)
-  result = def
+  case def.kind
+  of RoutineNodes:
+    copyLineInfo(sym, def.name)
+    def.name = sym
+    def
+  of nnkVarSection, nnkLetSection, nnkConstSection, nnkTypeSection:
+    if def.len != 1 or def[0].len != 3:
+      error "there should only be one identifier in a var/let/const/type section", def
+    # Replace the name in the first IdentDef
+    copyLineInfo(sym, def[0][0])
+    def[0][0] = sym
+    def
+  else:
+    unreachable()
 
 # test each routine definition
 
-replaceName(nskConst):
+replaceName:
+  const p = 10
+do:
   proc p() = #[tt.Error
       ^ (SemSymbolKindMismatch)]#
     discard
 
-replaceName(nskProc):
+replaceName:
+  proc f() = discard
+do:
   func f() = #[tt.Error
       ^ (SemSymbolKindMismatch)]#
     discard
 
-replaceName(nskVar):
+replaceName:
+  for iter in [0]:
+    discard iter
+do:
   iterator iter() = #[tt.Error
           ^ (SemSymbolKindMismatch)]#
     discard
 
-replaceName(nskForVar):
+replaceName:
+  for conv in [0]:
+    discard conv
+do:
   converter conv() = #[tt.Error
            ^ (SemSymbolKindMismatch)]#
     discard
 
-replaceName(nskForVar):
-  method meth() = #[tt.Error
+replaceName:
+  for meth in [0]:
+    discard meth
+do:
+  method meth(x: RootObj) {.base.} = #[tt.Error
         ^ (SemSymbolKindMismatch)]#
     discard
 
-replaceName(nskTemplate):
+replaceName:
+  template m() = discard
+do:
   macro m() = #[tt.Error
        ^ (SemSymbolKindMismatch)]#
     discard
 
-replaceName(nskMacro):
+replaceName:
+  macro t() = discard
+do:
   template t() = #[tt.Error
           ^ (SemSymbolKindMismatch)]#
     discard
 
-macro t1(): untyped =
-  # test that an error is correctly reported when inserting the wrong symbol
-  # into a non-routine definition
-  let b = genSym(nskLet, ident = "a")#[tt.Error
-               ^ (SemSymbolKindMismatch)]#
-  result = newVarStmt(b, newLit 1)
+replaceName:
+  let a = 0
+  a
+do:
+  var a: int #[tt.Error
+     ^ (SemSymbolKindMismatch)]#
 
-t1()
+replaceName:
+  proc c = discard
+  c
+do:
+  const c = 10 #[tt.Error
+       ^ (SemSymbolKindMismatch)]#
+
+replaceName:
+  func T = discard
+  T
+do:
+  type T = int #[tt.Error
+      ^ (SemSymbolKindMismatch)]#

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -10,16 +10,12 @@ import std/macros
 proc nameExpr(n: NimNode): NimNode =
   # Extracts the expression containing the replacement name
   case n.kind
-  of nnkStmtList, nnkStmtListExpr, nnkForStmt:
+  of nnkStmtList:
     nameExpr n[^1]
-  of nnkConstSection, nnkConstDef:
-    nameExpr n[0]
-  of nnkDiscardStmt:
-    nameExpr n[0]
+  of nkLetSection, nkVarSection, nkConstSection:
+    n[0][0]
   of RoutineNodes:
     n.name
-  of AtomicNodes:
-    n
   else:
     unreachable("unsupported kind: " & $n.kind)
 
@@ -61,24 +57,21 @@ do:
     discard
 
 replaceName:
-  for iter in [0]:
-    discard iter
+  var iter = 0
 do:
   iterator iter() = #[tt.Error
           ^ (SemSymbolKindMismatch)]#
     discard
 
 replaceName:
-  for conv in [0]:
-    discard conv
+  proc conv() = discard
 do:
   converter conv() = #[tt.Error
            ^ (SemSymbolKindMismatch)]#
     discard
 
 replaceName:
-  for meth in [0]:
-    discard meth
+  proc meth() = discard
 do:
   method meth(x: RootObj) {.base.} = #[tt.Error
         ^ (SemSymbolKindMismatch)]#
@@ -100,21 +93,18 @@ do:
 
 replaceName:
   let a = 0
-  a
 do:
   var a: int #[tt.Error
      ^ (SemSymbolKindMismatch)]#
 
 replaceName:
-  proc c = discard
-  c
+  proc c() = discard
 do:
   const c = 10 #[tt.Error
        ^ (SemSymbolKindMismatch)]#
 
 replaceName:
-  func T = discard
-  T
+  func T() = discard
 do:
   type T = int #[tt.Error
       ^ (SemSymbolKindMismatch)]#

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -12,7 +12,7 @@ proc nameExpr(n: NimNode): NimNode =
   case n.kind
   of nnkStmtList:
     nameExpr n[^1]
-  of nkLetSection, nkVarSection, nkConstSection:
+  of nnkLetSection, nnkVarSection, nnkConstSection:
     n[0][0]
   of RoutineNodes:
     n.name

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -2,7 +2,7 @@ discard """
   description: "`defer` must have exactly one child node (macro input)."
   errormsg: "illformed AST"
   file: "macros.nim"
-  line: 670
+  line: 674
 """
 
 import std/macros

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -2,7 +2,7 @@ discard """
   description: "`defer` must have exactly one child node (macro input)."
   errormsg: "illformed AST"
   file: "macros.nim"
-  line: 647
+  line: 659
 """
 
 import std/macros

--- a/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
+++ b/tests/lang_stmts/defer/tdefer_malformed_many_children.nim
@@ -2,7 +2,7 @@ discard """
   description: "`defer` must have exactly one child node (macro input)."
   errormsg: "illformed AST"
   file: "macros.nim"
-  line: 659
+  line: 670
 """
 
 import std/macros

--- a/tests/lang_syntax/astspec/tastspec.nim
+++ b/tests/lang_syntax/astspec/tastspec.nim
@@ -48,7 +48,7 @@ macro myquote*(args: varargs[untyped]): untyped =
       sym, ident"untyped", newEmptyNode()
     )
 
-  let templateSym = genSym(nskTemplate)
+  let templateSym = genSym()
   let templateDef = nnkTemplateDef.newTree(
     templateSym,
     newEmptyNode(),
@@ -144,7 +144,7 @@ static:
 
 # this should be just `block` but it doesn't work that way anymore because of VM.
 macro scope(arg: untyped): untyped =
-  let procSym = genSym(nskProc)
+  let procSym = genSym()
   result = quote do:
     proc `procSym`() {.compileTime.} =
       `arg`


### PR DESCRIPTION
## Summary
* Adds  `skGenerated`  symbol kind and diagnostics for
used-but-undeclared symbols.
*  `macros.genSym`  no longer takes a  `kind`  parameter and instead
will convert to the correct type on declaration.

## Details
Previously, generated symbols are specialized directly into their target
kind at generation site. This however throws a wrench into the
compiler's assumption, where specialized symbols are considered to be
well-formed and can be used as is.

This PR introduces a new  `skGenerated`  symbol type, which is used by
all generated symbols until their specialization (i.e. a declaration
statement happened for the symbol). This allows symbol usage sites
within the compiler to catch use-before-declaration errors and emit
appropriate diagnostics.

The automatic specialization also provided a UX improvement for macros
users, where  `genSym`  no longer requires a  `kind`  to be specified
and can automatically morph to the correct type once appropriate ASTs
are emitted. The old form of  `genSym`  has been marked as deprecated.

Fixes https://github.com/nim-works/nimskull/issues/1539