### PR TITLE
ci(dependabot-pr-body): fix dependabot login name

### DIFF
--- a/.github/workflows/dependabot-pr-body.yml
+++ b/.github/workflows/dependabot-pr-body.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   edit:
-    if: github.event.pull_request.user.login == 'app/dependabot'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
Update dependabot login name in workflow condition to the correct one.

## Details
I originally filled in the login name based on the output of 
`gh pr view <a dependabot pr> --json author` . However it turns out that
GitHub uses a different format when sending a webhook (which is what
triggers GH Actions).

I collected the correct name from the webhook trigger log for our GitHub
bot on Matrix and updated the workflow accordingly to make sure it will
trigger.