### PR TITLE
fix compiler crashing for captured unpacked tuples

### DIFF
--- a/compiler/sem/varpartitions.nim
+++ b/compiler/sem/varpartitions.nim
@@ -807,7 +807,7 @@ proc computeLiveRanges(c: var Partitions; n: PNode) =
       else:
         for i in 0..<child.len-2:
           registerVariable(c, child[i])
-          if child.kind == nkVarTuple:
+          if child.kind == nkVarTuple and child[i].kind == nkSym:
             # an unpacking definition where the rhs is not a literal tuple
             # construction. The vars are always owning
             pretendOwnsData(c, child[i].sym)


### PR DESCRIPTION
## Summary

Fix the compiler crashing for captured locals introduced by an
unpacking `let` or `var` statement.

## Details

`nkVarTuple` processing in `varpartitions.computeLiveRange` didn't
consider the form for lifted locals (where the nodes in the definition
positions are `nkDotExpr`s), thus causing a field defect when the local
has been lifted into the local closure environment.

No new test is added, since `tlift_local_in_loop.nim` already covers
this case.

Fixes https://github.com/nim-works/nimskull/issues/1589.