### PR TITLE
use a `-d:release` compiler during CI

### DIFF
--- a/tools/koch/koch.nim
+++ b/tools/koch/koch.nim
@@ -366,7 +366,7 @@ type
 proc buildReleaseBinaries(args = "") =
   ## Build binaries needed for creating a release
   # Boot the compiler
-  boot("-d:danger " & args)
+  boot("-d:release " & args)
   # Build the tools
   buildTools(args)
 


### PR DESCRIPTION
## Summary

* use a `-d:release` compiler during CI testing (instead of a
  `-d:danger` one) to be able to catch more issues 
* package a `-d:release` compiler into release bundles

## Details

A `-d:danger` compiler has both assertions and run-time checks
disabled, meaning that some compiler issues (e.g., access of inactive
field) cannot be detected with it.

To be able to catch these issues with CI, a `-d:release` compiler is
used now, which has both run-time checks and assertions enabled. Since
the compiler shipped in a release bundle should be the same as was
tested, release bundles now ship a `-d:release` compiler.

As a consequence, the compiler from release bundles becomes *slower*;
the same goes for CI test runs.