### PR TITLE
ci(dependabot-pr-body): use webpage PR URL instead of API URL

### DIFF
--- a/.github/workflows/dependabot-pr-body.yml
+++ b/.github/workflows/dependabot-pr-body.yml
@@ -22,5 +22,5 @@ jobs:
           gh pr view "$PR_URL" --json body --jq '"---\n\n" + .body' \
           | gh pr edit "$PR_URL" --body-file -
         env:
-          PR_URL: ${{ github.event.pull_request.url }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
`gh` CLI tool can only handle URL to a PR page, not the PR's API URL.

## Details
The  `url`  element in  `pull_request`  payload links to the API URL for
the associated PR. It appears that  `gh`  CLI will not interpret this as
an usable URL and will attempt to obtain the repository from the current
directory, which is not available since we don't perform cloning,
breaking the automation.

This PR swaps the URL over to the  `html_url`  element, which points to
the same link one will find in a browser when a PR page is opened. Local
testing confirmed that this URL would work with a non-git working
directory.