### PR TITLE
std: remove deprecation for `macros.callsite`

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -464,10 +464,8 @@ else:
   proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
     magic: "NGenSym", noSideEffect.}
 
-proc callsite*(): NimNode {.magic: "NCallSite", benign, deprecated:
-  "Deprecated since v0.18.1; use `varargs[untyped]` in the macro prototype instead".}
+proc callsite*(): NimNode {.magic: "NCallSite", benign.}
   ## Returns the AST of the invocation expression that invoked this macro.
-  # see https://github.com/nim-lang/RFCs/issues/387 as candidate replacement.
 
 proc toStrLit*(n: NimNode): NimNode =
   ## Converts the AST `n` to the concrete Nim code and wraps that


### PR DESCRIPTION
## Summary

`macros.callsite` was marked deprecated and is no longer deprecated, because it's still very useful.

## Details

It was initially thought that the main use case for `macros.callsite` was fetching arbitrary arguments to a macro call. That use case was taken over by `varargs[untyped]`, but this is obvious short sighted. The routine still has utility and is no longer marked deprecated.

---

## Notes for Reviewers

* came up in a discussion in matrix chat with Robyn ([link](https://matrix.to/#/!alsWvZtOfWkQlHwcHC:envs.net/$LP5UYOriZEEAZOEml2hHF6JWktlrQhU0Jb48CjDM7Rk?via=matrix.org&via=nim.works&via=envs.net))