### PR TITLE
strs_v2: improve performance of string operations

### DIFF
--- a/lib/system/strs_v2.nim
+++ b/lib/system/strs_v2.nim
@@ -45,9 +45,9 @@ proc prepareAdd(s: var NimStringV2; addlen: int) {.compilerRtl.} =
     let oldP = s.p
     # can't mutate a literal, so we need a fresh copy here:
     when compileOption("threads"):
-      s.p = cast[ptr NimStrPayload](allocShared0(contentSize(newLen)))
+      s.p = cast[ptr NimStrPayload](allocShared(contentSize(newLen)))
     else:
-      s.p = cast[ptr NimStrPayload](alloc0(contentSize(newLen)))
+      s.p = cast[ptr NimStrPayload](alloc(contentSize(newLen)))
     s.p.cap = newLen
     if s.len > 0:
       # we are about to append, so there is no need to copy the \0 terminator:
@@ -57,9 +57,9 @@ proc prepareAdd(s: var NimStringV2; addlen: int) {.compilerRtl.} =
     if newLen > oldCap:
       let newCap = max(newLen, resize(oldCap))
       when compileOption("threads"):
-        s.p = cast[ptr NimStrPayload](reallocShared0(s.p, contentSize(oldCap), contentSize(newCap)))
+        s.p = cast[ptr NimStrPayload](reallocShared(s.p, contentSize(newCap)))
       else:
-        s.p = cast[ptr NimStrPayload](realloc0(s.p, contentSize(oldCap), contentSize(newCap)))
+        s.p = cast[ptr NimStrPayload](realloc(s.p, contentSize(newCap)))
       s.p.cap = newCap
 
 proc nimAddCharV1(s: var NimStringV2; c: char) {.compilerRtl, inline.} =
@@ -74,13 +74,12 @@ proc toNimStr(str: cstring, len: int): NimStringV2 {.compilerproc.} =
     result = NimStringV2(len: 0, p: nil)
   else:
     when compileOption("threads"):
-      var p = cast[ptr NimStrPayload](allocShared0(contentSize(len)))
+      var p = cast[ptr NimStrPayload](allocShared(contentSize(len)))
     else:
-      var p = cast[ptr NimStrPayload](alloc0(contentSize(len)))
+      var p = cast[ptr NimStrPayload](alloc(contentSize(len)))
     p.cap = len
-    if len > 0:
-      # we are about to append, so there is no need to copy the \0 terminator:
-      copyMem(unsafeAddr p.data[0], str, len)
+    copyMem(unsafeAddr p.data[0], str, len)
+    p.data[len] = '\0'
     result = NimStringV2(len: len, p: p)
 
 proc cstrToNimstr(str: cstring): NimStringV2 {.compilerRtl.} =
@@ -108,9 +107,9 @@ proc rawNewString(space: int): NimStringV2 {.compilerproc.} =
     result = NimStringV2(len: 0, p: nil)
   else:
     when compileOption("threads"):
-      var p = cast[ptr NimStrPayload](allocShared0(contentSize(space)))
+      var p = cast[ptr NimStrPayload](allocShared(contentSize(space)))
     else:
-      var p = cast[ptr NimStrPayload](alloc0(contentSize(space)))
+      var p = cast[ptr NimStrPayload](alloc(contentSize(space)))
     p.cap = space
     result = NimStringV2(len: 0, p: p)
 
@@ -131,6 +130,8 @@ proc setLengthStrV2(s: var NimStringV2, newLen: int) {.compilerRtl.} =
   else:
     if newLen > s.len or isLiteral(s):
       prepareAdd(s, newLen - s.len)
+    if newLen > s.len:
+      zeroMem(addr s.p.data[s.len], newLen - s.len)
     s.p.data[newLen] = '\0'
   s.len = newLen
 
@@ -148,9 +149,9 @@ proc nimAsgnStrV2(a: var NimStringV2, b: NimStringV2) {.compilerRtl.} =
       # on the other hand... These get turned into moves now.
       frees(a)
       when compileOption("threads"):
-        a.p = cast[ptr NimStrPayload](allocShared0(contentSize(b.len)))
+        a.p = cast[ptr NimStrPayload](allocShared(contentSize(b.len)))
       else:
-        a.p = cast[ptr NimStrPayload](alloc0(contentSize(b.len)))
+        a.p = cast[ptr NimStrPayload](alloc(contentSize(b.len)))
       a.p.cap = b.len
     a.len = b.len
     copyMem(unsafeAddr a.p.data[0], unsafeAddr b.p.data[0], b.len+1)
@@ -159,9 +160,9 @@ proc nimPrepareStrMutationImpl(s: var NimStringV2) =
   let oldP = s.p
   # can't mutate a literal, so we need a fresh copy here:
   when compileOption("threads"):
-    s.p = cast[ptr NimStrPayload](allocShared0(contentSize(s.len)))
+    s.p = cast[ptr NimStrPayload](allocShared(contentSize(s.len)))
   else:
-    s.p = cast[ptr NimStrPayload](alloc0(contentSize(s.len)))
+    s.p = cast[ptr NimStrPayload](alloc(contentSize(s.len)))
   s.p.cap = s.len
   copyMem(unsafeAddr s.p.data[0], unsafeAddr oldP.data[0], s.len+1)
 

--- a/tests/stdlib/strings/tstring_grow_zeroes_memory.nim
+++ b/tests/stdlib/strings/tstring_grow_zeroes_memory.nim
@@ -1,0 +1,24 @@
+discard """
+  targets: c js vm
+  knownIssue.js: "The new characters are not set to NUL"
+"""
+
+var a: string
+a.setLen(3)
+doAssert a == "\0\0\0"
+
+# start from a constant string
+var b = "abcdef"
+b.setLen(3)
+doAssert b == "abc"
+b.setLen(6) # grow to previous size
+doAssert b == "abc\0\0\0"
+
+# start from a manually constructed string
+var c: string
+for _ in 0..<4:
+  c.add 'c'
+c.setLen(2)
+doAssert c == "cc"
+c.setLen(4) # grow to previous size
+doAssert c == "cc\0\0"


### PR DESCRIPTION
## Summary

Make growing a string always initialize new characters to NUL (`'\0'`) 
and improve performance of string operations that resize the internal
buffer.

## Details

So far, string payloads were always allocated with `alloc0`, filling
the whole allocation with zero. In most cases, this is unnecessary,
as either parts of or the whole buffer is overwritten immediately
afterwards.

The payload is now generally allocated without zeroing it, with
memory regions only being filled with zero when they become active
without explicit initialization (i.e., `newString`, or when growing
a string via `setLen`).

This also makes the behaviour of growing strings via `setLen`
consistent across backends and with `seq` (where new elements are
default initialized). A test is added to codify this.