### PR TITLE
remove some unused `Report`-related things

### DIFF
--- a/compiler/ast/errorreporting.nim
+++ b/compiler/ast/errorreporting.nim
@@ -37,7 +37,6 @@ proc errorHandling*(err: PNode): TErrorHandling =
   ## `msg.liMessage` when reporting errors.
   assert err.isError, "err can't be nil and must be an nkError"
   case err.diag.astDiagToLegacyReportKind:
-    of rsemCustomGlobalError: doRaise
     of rsemFatalError: doAbort
     else: doNothing
 

--- a/compiler/ast/report_enums.nim
+++ b/compiler/ast/report_enums.nim
@@ -297,12 +297,6 @@ type
     # nimsuggest
     rsemSugNoSymbolAtPosition
 
-    # Global Errors
-    rsemCustomGlobalError
-      ## just like custom error, but treat it like a "raise" and fast track the
-      ## "graceful" abort of this compilation run, used by `errorreporting` to
-      ## bridge into the existing `msgs.liMessage` and `msgs.handleError`.
-
     # Module errors
     rsemSystemNeeds
     rsemInvalidModulePath

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -1746,9 +1746,6 @@ proc reportBody*(conf: ConfigRef, r: SemReport): string =
     of rsemNodeNotAllowed:
       result = "'$1' not allowed here" % r.ast.render
 
-    of rsemCustomGlobalError:
-      result = r.str
-
     of rsemCannotImportItself:
       result = "module '$1' cannot import itself" % r.symstr
 

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -690,15 +690,6 @@ proc handleReport*(
   of doDefault: unreachable(
     "Default error handing action must be turned into ignore/raise/abort")
 
-template globalAssert*(
-    conf: ConfigRef;
-    cond: untyped, info: TLineInfo = unknownLineInfo, arg = "") =
-  ## avoids boilerplate
-  if not cond:
-    var arg2 = "'$1' failed" % [astToStr(cond)]
-    if arg.len > 0: arg2.add "; " & astToStr(arg) & ": " & arg
-    handleReport(conf, info, errGenerated, arg2, doRaise, instLoc())
-
 template fatalReport*(conf: ConfigRef, info: TLineInfo, report: ReportTypes) =
   # this works around legacy reports stupidity
   handleReport(conf, wrap(report, instLoc(), info), instLoc(), doAbort)


### PR DESCRIPTION
## Summary

* remove the unused `msgs.globalAssert`
* remove the unused `rsemCustomGlobalError` enum field