### PR TITLE
transf: fix the compiler crashing on valid conversions

### DIFF
--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -193,9 +193,10 @@ proc handleSpecialConv(c: ConfigRef, n: CgNode, info: TLineInfo,
   ## between the source type (i.e. that of `n`) and the destination type.
   ## If it is, generates the conversion operation IR and returns it -- nil
   ## otherwise
-  if dest.skipTypes(skipPtrs - {tyDistinct}).kind == tyObject:
-    # if the destination is an object (or ptr/ref object), it must be an
-    # object conversion
+  if dest.skipTypes(skipPtrs - {tyDistinct}).kind == tyObject and
+     n.typ.skipTypes(skipPtrs - {tyDistinct}).kind == tyObject:
+    # if the destination and source are an object (or ptr/ref object), it must
+    # be an object conversion
     genObjConv(n, dest, info)
   else:
     nil

--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -627,8 +627,10 @@ proc transformConv(c: PTransf, n: PNode): PNode =
     of tyObject:
       let diff = inheritanceDiff(dest, source)
       if diff == 0 or diff == high(int):
-        result = transform(c, n[1])
-        result.typ = n.typ
+        if sameType(n.typ, n[1].typ):
+          result = transform(c, n[1])
+        else:
+          result = transformSons(c, n)
       else:
         result = newTreeIT(
           if diff < 0: nkObjUpConv else: nkObjDownConv,
@@ -638,8 +640,11 @@ proc transformConv(c: PTransf, n: PNode): PNode =
   of tyObject:
     let diff = inheritanceDiff(dest, source)
     if diff == 0 or diff == high(int):
-      result = transform(c, n[1])
-      result.typ = n.typ
+      if sameType(n.typ, n[1].typ):
+        # the conversion doesn't modify the type, drop it
+        result = transform(c, n[1])
+      else:
+        result = transformSons(c, n)
     else:
       result = newTreeIT(
         if diff < 0: nkObjUpConv else: nkObjDownConv,

--- a/tests/arc/t14383.nim
+++ b/tests/arc/t14383.nim
@@ -114,48 +114,6 @@ main()
 
 
 #------------------------------------------------------------------------------
-# Issue #16722, ref on distinct type, wrong destructors called
-#------------------------------------------------------------------------------
-
-type
-  Obj = object of RootObj
-  ObjFinal = object
-  ObjRef = ref Obj
-  ObjFinalRef = ref ObjFinal
-  D = distinct Obj
-  DFinal = distinct ObjFinal
-  DRef = ref D
-  DFinalRef = ref DFinal
-
-proc `=destroy`(o: var Obj) =
-  doAssert false, "no Obj is constructed in this sample"
-
-proc `=destroy`(o: var ObjFinal) =
-  doAssert false, "no ObjFinal is constructed in this sample"
-
-var dDestroyed: int
-proc `=destroy`(d: var D) =
-  dDestroyed.inc
-
-proc `=destroy`(d: var DFinal) =
-  dDestroyed.inc
-
-func newD(): DRef =
-  DRef ObjRef()
-
-func newDFinal(): DFinalRef =
-  DFinalRef ObjFinalRef()
-
-proc testRefs() =
-  discard newD()
-  discard newDFinal()
-
-testRefs()
-
-doAssert(dDestroyed == 2)
-
-
-#------------------------------------------------------------------------------
 # Issue #16185, complex self-assingment elimination
 #------------------------------------------------------------------------------
 

--- a/tests/types/tmulti_step_conversion.nim
+++ b/tests/types/tmulti_step_conversion.nim
@@ -1,0 +1,13 @@
+discard """
+  description: '''
+    Ensure immediately converting a to-distinct-base conversion to the
+    distinct type works.
+  '''
+"""
+
+type
+  Base     = ref object of RootObj
+  Derived  = ref object of Base
+  Distinct = distinct Base
+
+discard Distinct(Base(Derived()))


### PR DESCRIPTION
## Summary

Fix the compiler crashing for certain distinct type conversions
involving `object` or `ref object` types.

## Details

`mirgen` expects conversions to be "single-step" conversion, where the
conversion is either coercion from or to a distinct type, a numeric
conversion, or an object up- or down-conversion, triggering an
assertion for conversions involving object types if this is not the
case.

`transf` folded away distinct conversions involving object types,
modifying the operand's type, which led to "multi-step" conversions
when the folded conversion's operand was a conversion itself.

Conversion transformation is changed to only elide same-type object
conversions, keeping the distinct coercion intact. This breaks a test
case relying on distinct conversions that should be disallowed (which
now changed behaviour) -- it's removed.