### PR TITLE
transf: fix self-conversion creating improper copy

### DIFF
--- a/compiler/sem/transf.nim
+++ b/compiler/sem/transf.nim
@@ -571,6 +571,10 @@ proc generateThunk(c: PTransf; prc: PNode, dest: PType): PNode =
     [conv, newNodeIT(nkNilLit, prc.info, getSysType(c.graph, prc.info, tyNil))]
 
 proc transformConv(c: PTransf, n: PNode): PNode =
+  if sameType(n.typ.skipTypes({tySink}), n[1].typ.skipTypes({tySink})):
+    # the conversion doesn't modify the type, drop it
+    return transform(c, n[1])
+
   # numeric types need range checks:
   var dest = skipTypes(n.typ, abstractVarRange)
   var source = skipTypes(n[1].typ, abstractVarRange)
@@ -627,10 +631,7 @@ proc transformConv(c: PTransf, n: PNode): PNode =
     of tyObject:
       let diff = inheritanceDiff(dest, source)
       if diff == 0 or diff == high(int):
-        if sameType(n.typ, n[1].typ):
-          result = transform(c, n[1])
-        else:
-          result = transformSons(c, n)
+        result = transformSons(c, n)
       else:
         result = newTreeIT(
           if diff < 0: nkObjUpConv else: nkObjDownConv,
@@ -640,11 +641,8 @@ proc transformConv(c: PTransf, n: PNode): PNode =
   of tyObject:
     let diff = inheritanceDiff(dest, source)
     if diff == 0 or diff == high(int):
-      if sameType(n.typ, n[1].typ):
-        # the conversion doesn't modify the type, drop it
-        result = transform(c, n[1])
-      else:
-        result = transformSons(c, n)
+      # must be some distinct type conversion; keep
+      result = transformSons(c, n)
     else:
       result = newTreeIT(
         if diff < 0: nkObjUpConv else: nkObjDownConv,

--- a/tests/lang_objects/destructor/tself_conversion_sink_bug.nim
+++ b/tests/lang_objects/destructor/tself_conversion_sink_bug.nim
@@ -1,0 +1,24 @@
+discard """
+  description: '''
+    Regression test for self-conversion where the source type is `sink`-
+    modified causing a double-free.
+  '''
+"""
+
+type Object = object
+  val: int
+
+var wasDestroyed = false
+
+proc `=destroy`(x: var Object) =
+  if x.val == 1:
+    doAssert not wasDestroyed
+    wasDestroyed = true
+
+proc get(x: sink Object): Object =
+  return Object(x) # pointless conversion to self
+
+block:
+  discard get(Object(val: 1))
+
+doAssert wasDestroyed


### PR DESCRIPTION
## Summary

Fix self-conversion where the source operand is a `sink` parameter
creating an improper copy, potentially leading to use-after-free
or double-free issues afterwards.

## Details

Conversions where the types are equals modulo `sink` were treated as
owned r-value producing conversions during to-MIR translation, which
are expected to not exist for resource-like types by `proto_mir`/
`mirgen`. As a consequence, no proper copy of the value was created
when the conversion appeared in a sink context.

Since these conversions do nothing anyway (the compiler also reports
a warning for them), `transf` now always elides them, regardless of
type kind and ignoring sink parameters, preventing them from ever
reaching `mirgen`.