### PR TITLE
colordiff: improve `formatDiffed` performance

### DIFF
--- a/lib/experimental/colordiff.nim
+++ b/lib/experimental/colordiff.nim
@@ -704,6 +704,10 @@ proc formatDiffed*(
     text1, text2: string,
     conf: DiffFormatConf = diffFormatter()
   ): ColText =
-  ## Format diff of two text blocks via newline split and default
-  ## `formatDiffed` implementation
-  formatDiffed(text1.split("\n"), text2.split("\n"), conf)
+  ## Formats diff of two text blocks via newline split and default
+  ## `formatDiffed` implementation.
+  let text1 = text1.split("\n")
+  let text2 = text2.split("\n")
+  formatDiffed(
+    myersDiff(text1, text2).shiftDiffed(text1, text2),
+    text1, text2, conf)


### PR DESCRIPTION
## Summary

Improve the performance of `colordiff.formatDiffed` where the inputs
are strings and no custom line comparison operator is used.

## Details

The string-taking overload dispatched to the generic sequence
`formatDiffed` overload that converts the sequence to a sequence of
strings first.

While a no-op for sequence-of-string inputs, it still incurs extra
allocations, so the string-taking `formatDiffed` overload is changed to
call the internal diff formatting directly, getting rid of the
unnecessary allocations.