### PR TITLE
cmdline/parsers: fixed float edge cases and enums

### DIFF
--- a/lib/experimental/cmdline/parsers.nim
+++ b/lib/experimental/cmdline/parsers.nim
@@ -78,7 +78,7 @@ proc parseCli*(T: typedesc[SomeInteger], value: string): T =
 
 proc parseCli*(T: typedesc[SomeFloat], value: string): T =
   ## Implements `parseCli` for all floats.
-  parseFloat(value)
+  T(parseFloat(value))
 
 proc parseCli*(T: typedesc[string], value: string): T =
   ## Implements `parseCli` for `string`.

--- a/lib/experimental/cmdline/parsers.nim
+++ b/lib/experimental/cmdline/parsers.nim
@@ -61,6 +61,7 @@ runnableExamples:
 
 import std/strutils
 import std/typetraits
+import std/math
 
 proc parseCli*(T: typedesc[SomeInteger], value: string): T =
   ## Implements `parseCli` for all integers.
@@ -80,7 +81,7 @@ proc parseCli*(T: typedesc[SomeFloat], value: string): T =
   ## Implements `parseCli` for all floats.
   let parsed = parseFloat(value)
 
-  if parsed notin low(T)..high(T):
+  if not (parsed in low(T)..high(T) or parsed.isNaN):
     raise newException(ValueError):
       $parsed & " is not in the range of " & $low(T) & ".." & $high(T)
 
@@ -96,7 +97,7 @@ proc parseCli*(T: typedesc[bool], value: string): T =
 
 proc parseCli*(T: typedesc[enum], value: string): T =
   ## Implements `parseCli` for enum types.
-  parseEnum(value)
+  parseEnum[T](value)
 
 proc parseCli*(T: typedesc[range], value: string): T =
   ## Implements `parseCli` for range types.

--- a/lib/experimental/cmdline/parsers.nim
+++ b/lib/experimental/cmdline/parsers.nim
@@ -61,7 +61,6 @@ runnableExamples:
 
 import std/strutils
 import std/typetraits
-import std/math
 
 proc parseCli*(T: typedesc[SomeInteger], value: string): T =
   ## Implements `parseCli` for all integers.
@@ -79,13 +78,7 @@ proc parseCli*(T: typedesc[SomeInteger], value: string): T =
 
 proc parseCli*(T: typedesc[SomeFloat], value: string): T =
   ## Implements `parseCli` for all floats.
-  let parsed = parseFloat(value)
-
-  if not (parsed in low(T)..high(T) or parsed.isNaN):
-    raise newException(ValueError):
-      $parsed & " is not in the range of " & $low(T) & ".." & $high(T)
-
-  result = T(parsed)
+  parseFloat(value)
 
 proc parseCli*(T: typedesc[string], value: string): T =
   ## Implements `parseCli` for `string`.

--- a/tests/stdlib/experimental/tcmdline.nim
+++ b/tests/stdlib/experimental/tcmdline.nim
@@ -45,16 +45,6 @@ block typicalUsage:
       .parser(bool, (k, v, var c) => (c.opts[ShowNonPrinting] = v))
       .describe("display non-printing characters")
       .addTo(cli)
-      cli.parse(parsed, @["10", "--format", "--separator=;"])
-      doAssert parsed.format == some("--separator=;")
-      doAssert parsed.separator == "\\n"
-      doAssert not parsed.equalizeWidth
-      doAssert parsed.numbers == [10]
-
-    block multiple:
-      var parsed = baseConfig
-      cli.parse(parsed, @["10", "--separator", ";", "100"])
-      doAssert parsed.format == n
     cli.flagBuilder
       .name("squeeze-blank")
       .alias("s")

--- a/tests/stdlib/experimental/tcmdline.nim
+++ b/tests/stdlib/experimental/tcmdline.nim
@@ -45,6 +45,16 @@ block typicalUsage:
       .parser(bool, (k, v, var c) => (c.opts[ShowNonPrinting] = v))
       .describe("display non-printing characters")
       .addTo(cli)
+      cli.parse(parsed, @["10", "--format", "--separator=;"])
+      doAssert parsed.format == some("--separator=;")
+      doAssert parsed.separator == "\\n"
+      doAssert not parsed.equalizeWidth
+      doAssert parsed.numbers == [10]
+
+    block multiple:
+      var parsed = baseConfig
+      cli.parse(parsed, @["10", "--separator", ";", "100"])
+      doAssert parsed.format == n
     cli.flagBuilder
       .name("squeeze-blank")
       .alias("s")

--- a/tests/stdlib/experimental/tcmdline_parsers.nim
+++ b/tests/stdlib/experimental/tcmdline_parsers.nim
@@ -1,0 +1,44 @@
+discard """
+  description: "Tests for the cmdline parsers module"
+  targets: "c js vm"
+"""
+
+import std/math
+import experimental/cmdline/parsers
+
+block intParser:
+  doAssert parseCli(int, "99") == 99
+  doAssert parseCli(int, "-99") == -99
+  doAssert parseCli(uint8, "255") == 255
+  doAssertRaises(ValueError):
+    discard parseCli(int8, "255")
+  doAssertRaises(ValueError):
+    discard parseCli(uint8, "256")
+  doAssertRaises(ValueError):
+    discard parseCli(uint8, "-1")
+
+block stringParser:
+  doAssert parseCli(string, "foo bar") == "foo bar"
+
+block boolParser:
+  doAssert parseCli(bool, "true") == true
+  doAssert parseCli(bool, "false") == false
+  doAssertRaises(ValueError):
+    discard parseCli(bool, "fool")
+
+block enumParser:
+  type
+    Colour = enum
+      Red, Green
+
+  doAssert parseCli(Colour, "Red") == Red
+  doAssert parseCli(Colour, "Green") == Green
+  doAssertRaises(ValueError):
+    discard parseCli(Colour, "Blue")
+
+block rangeParser:
+  doAssert parseCli(range[0..99], "99") == 99
+  doAssert parseCli(range[0..99], "0") == 0
+  doAssert parseCli(range[0..99], "50") == 50
+  doAssertRaises(ValueError):
+    discard parseCli(range[0..99], "100")

--- a/tests/stdlib/experimental/tcmdline_parsers_float.nim
+++ b/tests/stdlib/experimental/tcmdline_parsers_float.nim
@@ -1,0 +1,17 @@
+discard """
+  description: "Tests for the cmdline float parser"
+  targets: "c js vm"
+  knownIssue.vm: '''
+    Error: undeclared identifier: 'c_isnan'
+  '''
+"""
+import std/math
+import experimental/cmdline/parsers
+# TODO: Merge into tcmdline_parsers.nim once `math.isNaN` is implemented for VM
+
+block floatParser:
+  doAssert parseCli(float64, "3.14") == 3.14
+  doAssert parseCli(float64, "-3.14") == -3.14
+  doAssert parseCli(float32, "nan").isNaN
+  doAssert parseCli(float32, "inf") == Inf
+  doAssert parseCli(float32, "-inf") == -Inf


### PR DESCRIPTION
## Summary
* fixed `parseCli` raising an error on NaN inputs
* fixed `parseCli` for enum values not compiling

## Details
* Added tests for cmdline/parsers.nim
* The float parser test was split into a separate file since  `isNaN` 
doesn't work on the VM.