### PR TITLE
sigmatch: fix missing conversion for varargs containers

### DIFF
--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2986,8 +2986,10 @@ proc matchesAux(c: PContext, n, nOrig: PNode, diags: DiagContext,
       if m.baseTypeMatch or (arg.isError and container.isNil):
         #assert(container.isNil())
         container = newNodeIT(nkBracket, n[a].info, arrayConstr(c, arg))
+        container.typ.flags.incl tfVarargs
         container.add arg
-        setSon(m.call, formal.position + 1, container)
+        setSon(m.call, formal.position + 1,
+          implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
 
         if f != formalLen - 1: # not the last formal param
           container = nil      # xxx: is this more vararg stuff?


### PR DESCRIPTION
## Summary

Fix an internal-only problem with `sigmatch` handling of named
parameters in conjunction with `varargs`.

## Details

Unlike for unnamed parameters, the implicit array construction created
when using named parameters for passing a single value to a `varargs`
parameter was not wrapped in a to-varargs conversion, nor was the type
marked as being a varargs container (via the `tfVarargs` flag).

This caused no downstream issues so far, as all three code generators
handle the necessary run-time conversion themselves, but it's
still incorrect.