### PR TITLE
liftdestructors: generate proper `isNil` check

### DIFF
--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -657,13 +657,16 @@ proc atomicClosureOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   of attachedAsgn:
     let yenv = genBuiltin(c, mAccessEnv, "accessEnv", y)
     yenv.typ = getSysType(c.g, c.info, tyPointer)
+    var nilCheck = genBuiltin(c, mIsNil, "isNil", yenv)
+    nilCheck.typ = cond.typ
+    nilCheck = genBuiltin(c, mNot, "not", nilCheck)
+    nilCheck.typ = cond.typ
     if isCyclic:
-      body.add genIf(c, yenv, callCodegenProc(c.g, "nimIncRefCyclic", c.info, yenv, getCycleParam(c)))
+      body.add genIf(c, nilCheck, callCodegenProc(c.g, "nimIncRefCyclic", c.info, yenv, getCycleParam(c)))
       body.add newAsgnStmt(x, y)
       body.add genIf(c, cond, actions)
     else:
-      body.add genIf(c, yenv, callCodegenProc(c.g, "nimIncRef", c.info, yenv))
-
+      body.add genIf(c, nilCheck, callCodegenProc(c.g, "nimIncRef", c.info, yenv))
       body.add genIf(c, cond, actions)
       body.add newAsgnStmt(x, y)
   of attachedDestructor:


### PR DESCRIPTION
## Summary

Fix an internal issue with type-bound operator lifting for closure
types.

## Details

Instead of a proper  `isNil`  check, generation of the "not nil" check
for
closure environments used the pointer expression itself as the
condition expression of an `if`.

Since the expression was translated as is and a pointer value is valid
in an `if` condition position in C, this worked, but it's not correct
according to NimSkull's type system. A proper "not nil" check is
generated now.