### PR TITLE
ci(macos): update Intel macOS to version 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             },
             {
               "name": "macOS",
-              "runner": "macos-13"
+              "runner": "macos-15-intel"
             },
             {
               "name": "macOS (M1)",


### PR DESCRIPTION
## Summary
Update macOS x86 to version 15 to unbreak CI.

## Details
GitHub has begun deprecation of macOS 13 images and offered version 15
as the replacement. Furthermore, the Homebrew project has started
targeting macOS 14+, and as such certain formulaes we use like openssl
are no longer working.

Upgrade Intel images to avoid brownouts and keep CI working.

Ref: https://github.com/actions/runner-images/issues/13046