### PR TITLE
 utils: make MIR pretty-printing output more stable

### DIFF
--- a/compiler/mir/utils.nim
+++ b/compiler/mir/utils.nim
@@ -189,6 +189,8 @@ func add(result: var string, id: LabelId) =
   result.add 'L'
   result.addInt id.uint32
 
+proc constToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx)
+
 proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
   case n.kind
   of mnkParam:
@@ -197,7 +199,12 @@ proc singleToStr(n: MirNode, result: var string, c: RenderCtx) =
     result.addLocalName(n.local, "<L", c)
   of mnkConst:
     if isAnon(n.cnst):
-      idToStr(result, extract(n.cnst), "<D") # "D" for "Data"
+      if c.env.isNil:
+        idToStr(result, extract(n.cnst), "<D") # "D" for "Data"
+      else:
+        result.add "<const> "
+        var i = 0
+        constToStr(c.env[][extract(n.cnst)], i, result, c)
     else:
       result.addName(n.cnst, "<C", c)
   of mnkGlobal:
@@ -482,6 +489,62 @@ proc exprToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
 
 template exprToStr() =
   exprToStr(nodes, i, result, c)
+
+proc constToStr(nodes: MirTree, i: var int, result: var string, c: RenderCtx) =
+  template arg() =
+    inc i # skip the operand descriptor
+    constToStr(nodes, i, result, c)
+
+  template tree(start: string, body: untyped) =
+    result.add start
+    body
+
+  let n {.cursor.} = next(nodes, i)
+  case n.kind
+  of mnkNilLit, mnkIntLit, mnkUIntLit, mnkFloatLit, mnkStrLit, mnkProcVal,
+     mnkAstLit:
+    singleToStr(n, result, c)
+  of mnkObjConstr, mnkRefConstr:
+    let typ = n.typ
+    tree "(":
+      commaSeparated n.len:
+        tree "":
+          fieldToStr(next(nodes, i).field, typ, result, c)
+          result.add ": "
+          constToStr(nodes, i, result, c)
+      result.add ")"
+  of mnkArrayConstr:
+    tree "[":
+      commaSeparated n.len:
+        arg()
+      result.add "]"
+  of mnkSeqConstr:
+    tree "@[":
+      commaSeparated n.len:
+        arg()
+      result.add "]"
+  of mnkTupleConstr:
+    tree "(":
+      commaSeparated n.len:
+        arg()
+      result.add ")"
+  of mnkClosureConstr:
+    tree "closure (":
+      commaSeparated n.len:
+        arg()
+      result.add ")"
+  of mnkSetConstr:
+    tree "{":
+      commaSeparated n.len:
+        constToStr(nodes, i, result, c)
+      result.add "}"
+  of mnkRange:
+    tree "":
+      constToStr(nodes, i, result, c)
+      result.add " .. "
+      constToStr(nodes, i, result, c)
+  else:
+    result.error(n)
 
 proc renderNameWithType(tree: MirTree, i: var int, result: var string,
                         c: RenderCtx) =

--- a/tests/arc/topt_cursor.nim
+++ b/tests/arc/topt_cursor.nim
@@ -4,14 +4,14 @@ discard """
   nimout: '''--expandArc: main
 
 scope:
-  def_cursor x: (string, int) = <D0>
+  def_cursor x: (string, int) = <const> ("hi", 5)
   scope:
     if cond:
       scope:
-        x = <D1>
+        x = <const> ("different", 54)
         goto [L1]
   scope:
-    x = <D2>
+    x = <const> ("string here", 80)
   L1:
   def_cursor _3: (string, int) = x
   def _4: string = $(arg _3) -> [Unwind]

--- a/tests/exception/truntime_check_panics.nim
+++ b/tests/exception/truntime_check_panics.nim
@@ -16,7 +16,7 @@ scope:
   def _7: int = addI(arg i, arg i)
   def _8: int = unaryMinusI(arg i)
   def _9: range 0..1(int) = chckRange(arg i, arg 0, arg 1)
-  chckField(arg <D0>, arg o.kind, arg false, arg "field \'x\' is not accessible for type \'Object\' using \'kind = ")
+  chckField(arg <const> {true}, arg o.kind, arg false, arg "field \'x\' is not accessible for type \'Object\' using \'kind = ")
   discard o.kind.x
   def _11: bool = isNil(arg r)
   def _10: bool = not(arg _11)

--- a/tests/optimization/tno_unnecessary_bound_check_for_contains.nim
+++ b/tests/optimization/tno_unnecessary_bound_check_for_contains.nim
@@ -6,7 +6,7 @@ scope:
   def _2: bool
   def _3: bool = leI(arg 0'i8, arg x)
   if _3:
-    _2 := inSet(arg <D0>, arg x)
+    _2 := inSet(arg <const> {1, 2, 3}, arg x)
   result = _2
   goto [L1]
 L1:


### PR DESCRIPTION
## Summary

Pretty-print the anonymous constants as their value in `--expandArc`
and `--showir` output.

## Details

When the MIR environment is available, anonymous constants are now
rendered as their value, not as their raw ID (which is dependent on
externalities unrelated to the body of the procedure).

The goal is to keep tests inspecting `--expandArc` and `--showir`
output from starting to fail when unrelated processing changes in
the future -- the tests affected by the change in rendering are
updated.