### PR TITLE
tssl: ignore SslError in "close during write" test

### DIFF
--- a/tests/stdlib/web/tssl.nim
+++ b/tests/stdlib/web/tssl.nim
@@ -69,7 +69,7 @@ proc main() =
       while true:
         # Send data until we get EPIPE.
         peer.send(DummyData, {})
-    except OSError:
+    except OSError, SslError:
       discard
     finally:
       peer.close()


### PR DESCRIPTION
## Summary
Fix intermittent Windows CI failures from an unhandled  `SslError` 
being raised due to abrupt peer disconnection in  `tssl` .

## Details
The goal of the test is to verify that closing an SSL socket after a
fatal error happens will not cause the action to raise an error.
Sometimes this fatal error manifests as  `SslError` , which was not
handled, causing intermittent failures (on Windows).

This commit modifies the test to also ignore  `SslError`  should that
happen, since we are only interested in the  `close`  statement not
raising an error.