### PR TITLE
change how top-level emit/asm statements work

### DIFF
--- a/compiler/backend/backends.nim
+++ b/compiler/backend/backends.nim
@@ -4,6 +4,7 @@ import
   std/[
     deques,
     dynlib, # for computing possible candidate names
+    strutils,
     strtabs,
     tables
   ],
@@ -66,6 +67,14 @@ type
       ## if ``true``, indicates that a procedure with a body should not be
       ## treated as imported, even if it's marked as such
 
+  EmitSection* = enum
+    ## The code-generator-specific section where top-level emit/asm statements
+    ## should be placed.
+    secIncludes
+    secTypes
+    secVars
+    secProcedures
+
   DiscoveryData* = object
     ## Bundles all data needed during the disovery of alive, backend-relevant
     ## entities.
@@ -93,6 +102,7 @@ type
                  ## became available
     bekProcedure ## a complete procedure was processed and transformed
     bekImported  ## an alive runtime-imported procedure finished processing
+    bekEmit      ## a top-level emit or asm statement was discovered
 
   BackendEvent* = object
     ## Progress event returned by the ``process`` iterator.
@@ -117,6 +127,10 @@ type
         ## the symbol of the procedure the event is about
         ## XXX: only here for convenience, remove it once feasible
       body*: MirBody
+    of bekEmit:
+      stmt*: MirBody
+        ## a single emit or asm statement
+      section*: EmitSection
 
   WorkItemKind = enum
     wikPreprocess
@@ -180,6 +194,24 @@ func moduleId*(o: PIdObj): int32 {.inline.} =
   ## case of generic instantiations, this is not the necessarily the same
   ## module as the one indicated via the owner.
   o.itemId.module
+
+func determineSection(n: PNode): EmitSection =
+  ## Determines the section a top-level emit/asm statement belongs to.
+  if n.kind == nkPragma:
+    let it = n[0][1]
+    if it.len >= 1 and it[0].kind in nkStrKinds:
+      if it[0].strVal.startsWith("/*TYPESECTION*/"):
+        secTypes
+      elif it[0].strVal.startsWith("/*VARSECTION*/"):
+        secVars
+      elif it[0].strVal.startsWith("/*INCLUDESECTION*/"):
+        secIncludes
+      else:
+        secProcedures
+    else:
+      secProcedures
+  else:
+    secProcedures
 
 # ---- main procedure generation -----
 
@@ -772,6 +804,12 @@ iterator process*(graph: ModuleGraph, modules: var ModuleList,
       yield evt
     yield BackendEvent(module: id, kind: bekModule)
     postActions(queue, discovery, env, id)
+
+    # translate and report the emit sections:
+    for it in m.emit:
+      yield BackendEvent(kind: bekEmit, module: id,
+                         stmt: topLevelEmitToMir(graph, env, it),
+                         section: determineSection(it))
 
   template reportBody(prc: ProcedureId, m: FileIndex, evt: BackendEventKind,
                       frag: MirBody) =

--- a/compiler/backend/cbackend.nim
+++ b/compiler/backend/cbackend.nim
@@ -75,6 +75,8 @@ import
 
 import std/options as std_options
 
+from compiler/backend/cgirgen import topLevelEmitToIr
+
 from compiler/ast/ast import id, newNode, newTree, newSymNode
 
 # XXX: reports are a legacy facility that is going to be phased out. A
@@ -227,7 +229,15 @@ proc processEvent(g: BModuleList, inl: var InliningData,
        emulatedThreadVars(g.config):
       dependOnCompilerProc(inl, g.env, evt.module, g.graph,
                            "initThreadVarsEmulation")
-
+  of bekEmit:
+    let section = [
+        secIncludes: cfsHeaders,
+        secTypes: cfsTypes,
+        secVars: cfsVars,
+        secProcedures: cfsProcHeaders
+      ][evt.section]
+    genTopLevelEmit(bmod, section,
+      topLevelEmitToIr(g.graph, bmod.idgen, g.env, bmod.module, evt.stmt))
   of bekConstant:
     # emit the definition now that the body is available
     let s = g.env[evt.cnst]

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -332,33 +332,12 @@ proc genAsmStmt(p: BProc, t: CgNode) =
   assert(t.kind == cnkAsmStmt)
   genLineDir(p, t)
   var s = genAsmOrEmitStmt(p, t, isAsmStmt=true)
-  # see bug #2362, "top level asm statements" seem to be a mis-feature
-  # but even if we don't do this, the example in #2362 cannot possibly
-  # work:
-  if sfTopLevel in p.prc.flags:
-    # top level asm statement?
-    p.module.s[cfsProcHeaders].add runtimeFormat(CC[p.config.cCompiler].asmStmtFrmt, [s])
-  else:
-    p.s(cpsStmts).add indentLine(p, runtimeFormat(CC[p.config.cCompiler].asmStmtFrmt, [s]))
-
-proc determineSection(env: MirEnv, n: CgNode): TCFileSection =
-  result = cfsProcHeaders
-  if n.len >= 1 and n[0].kind == cnkStrLit:
-    let sec = env[n[0].strVal]
-    if sec.startsWith("/*TYPESECTION*/"): result = cfsTypes
-    elif sec.startsWith("/*VARSECTION*/"): result = cfsVars
-    elif sec.startsWith("/*INCLUDESECTION*/"): result = cfsHeaders
+  p.s(cpsStmts).add indentLine(p, runtimeFormat(CC[p.config.cCompiler].asmStmtFrmt, [s]))
 
 proc genEmit(p: BProc, t: CgNode) =
-  var s = genAsmOrEmitStmt(p, t)
-  if sfTopLevel in p.prc.flags:
-    # top level emit pragma?
-    let section = determineSection(p.env, t)
-    genCLineDir(p.module.s[section], t.info, p.config)
-    p.module.s[section].add(s)
-  else:
-    genLineDir(p, t)
-    line(p, cpsStmts, s)
+  let s = genAsmOrEmitStmt(p, t)
+  genLineDir(p, t)
+  line(p, cpsStmts, s)
 
 proc genTopLevelEmit*(m: BModule, section: TCFileSection, n: CgNode) =
   # the emit/asm statements cannot refer to any routine-local entities, so

--- a/compiler/backend/ccgstmts.nim
+++ b/compiler/backend/ccgstmts.nim
@@ -360,6 +360,25 @@ proc genEmit(p: BProc, t: CgNode) =
     genLineDir(p, t)
     line(p, cpsStmts, s)
 
+proc genTopLevelEmit*(m: BModule, section: TCFileSection, n: CgNode) =
+  # the emit/asm statements cannot refer to any routine-local entities, so
+  # using a pseudo-proc context is fine
+  let p = newProc(nil, m)
+  case n.kind
+  of cnkEmitStmt:
+    let s = genAsmOrEmitStmt(p, n)
+    genCLineDir(m.s[section], n.info, m.config)
+    m.s[section].add s
+  of cnkAsmStmt:
+    # @Araq: see bug #2362, "top level asm statements" seem to be a mis-feature
+    # but even if we don't do this, the example in #2362 cannot possibly
+    # work:
+    let s = genAsmOrEmitStmt(p, n, isAsmStmt=true)
+    genCLineDir(m.s[section], n.info, m.config)
+    m.s[section].add runtimeFormat(CC[m.config.cCompiler].asmStmtFrmt, [s])
+  else:
+    unreachable()
+
 when false:
   proc genCaseObjDiscMapping(p: BProc, e: PNode, t: PType, field: PSym; d: var TLoc) =
     const ObjDiscMappingProcSlot = -5

--- a/compiler/backend/cgen.nim
+++ b/compiler/backend/cgen.nim
@@ -99,7 +99,7 @@ const NonMagics* = {mNewString, mNewStringOfCap, mNewSeq, mSetLengthSeq,
 const
   sfTopLevel* = sfMainModule
     ## the procedure contains top-level code, which currently affects how
-    ## emit, asm, and error handling works
+    ## error handling works
 
 template types(m: BModule): TypeEnv =
   m.g.env.types

--- a/compiler/backend/cgirgen.nim
+++ b/compiler/backend/cgirgen.nim
@@ -822,3 +822,15 @@ proc generateIR*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
   result = Body()
   result.code = tb(body, env, cl, NodePosition 0)
   result.locals = cl.locals
+
+proc topLevelEmitToIr*(graph: ModuleGraph, idgen: IdGenerator, env: var MirEnv,
+                       owner: PSym, stmt: sink MirBody): CgNode =
+  ## Translates a MIR top-level emit/asm statement to its CGIR analogue.
+  assert stmt.code.len > 0 and stmt.code[0].kind in {mnkEmit, mnkAsm}
+  var
+    cl = TranslateCl(graph: graph, idgen: idgen, env: addr env, owner: owner)
+    cr = TreeCursor(pos: 0)
+  var tmp: seq[CgNode]
+  stmtToIr(stmt, env, cl, cr, tmp)
+  assert tmp.len == 1
+  result = tmp[0]

--- a/compiler/backend/jsbackend.nim
+++ b/compiler/backend/jsbackend.nim
@@ -92,6 +92,8 @@ proc processEvent(g: PGlobals, graph: ModuleGraph, modules: BModuleList,
 
   of bekImported:
     discard "ignored for now"
+  of bekEmit:
+    unreachable()
 
 proc writeModules(graph: ModuleGraph, globals: PGlobals) =
   let

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -104,7 +104,7 @@ import std/options as std_options
 when defined(nimCompilerStacktraceHints):
   import compiler/utils/debugutils
 
-from compiler/front/msgs import unquotedFilename, toLinenumber
+from compiler/front/msgs import unquotedFilename, toLinenumber, internalAssert
 
 type
   DestFlag = enum
@@ -2695,3 +2695,28 @@ proc constDataToMir*(env: var MirEnv, n: PNode): MirTree =
   # the staging buffer, which is necessary for after-the-fact type patching
   bu.pop(bu.push(constToMirAux(bu, env, n)))
   bu.finish()[0]
+
+proc topLevelEmitToMir*(graph: ModuleGraph, env: var MirEnv, n: PNode): MirBody =
+  ## Translate a top-level emit or asm statement to a MIR tree.
+  # create a pseudo context that's enough to do the translation with
+  var c = initCtx(graph, TranslationConfig(), nil, move env)
+  c.sp.active = (n, c.sp.map.add(n))
+
+  case n.kind
+  of nkAsmStmt:
+    c.genAsmOrEmitStmt(mnkAsm, n)
+  of nkPragma:
+    assert n.len == 1 and whichPragma(n[0]) == wEmit
+    c.genAsmOrEmitStmt(mnkEmit, n[0][1])
+  else:
+    unreachable()
+
+  let body = createBody(move c.builder, move c.sp.map)
+
+  # report at least some error when the emit/asm statement is nonsense (e.g.,
+  # interpolating complex expressions)
+  graph.config.internalAssert(body.locals.nextId == LocalId(0), n.info)
+  graph.config.internalAssert(body.code[0].kind in {mnkEmit, mnkAsm}, n.info)
+
+  env = move c.env
+  result = body

--- a/compiler/sem/modulelowering.nim
+++ b/compiler/sem/modulelowering.nim
@@ -23,7 +23,9 @@ import
     ast_types,
     ast_query,
     lineinfos,
-    idents
+    idents,
+    trees,
+    wordrecg
   ],
   compiler/front/[
     options
@@ -58,6 +60,8 @@ type
     decls*: PNode
       ## all declarative statements (type, routine, and constant
       ## definitions)
+    emit*: seq[PNode]
+      ## all top-level emit and asm statements
     structs*: ModuleStructs
       ## the contents of the module's structs
 
@@ -166,6 +170,41 @@ proc group(n: PNode, decl, imperative: var seq[PNode]) =
     # what to do with them, this also includes declarative statements part
     # of nested scopes (those inside ``if``, ``block``, etc. statements)
     imperative.add(n)
+
+proc extractEmitAndAsm(stmts: var seq[PNode]): seq[PNode] =
+  ## Extracts all top-level emit and emit statements from `n` into a separate
+  ## list.
+  var i = 0
+  while i < stmts.len:
+    let s = stmts[i]
+    case s.kind
+    of nkAsmStmt:
+      result.add(s)
+      stmts.delete(i)
+    of nkPragma:
+      # a pragma statement may contain multiple emit pragmas
+      var modified = s
+      for at, it in s.pairs:
+        if whichPragma(it) == wEmit:
+          if modified == s:
+            # copy on write
+            modified = newNodeI(nkPragma, s.info)
+            for j in 0..<at:
+              modified.add s[j]
+
+          result.add newTreeI(nkPragma, it.info, it)
+        elif modified != s:
+          modified.add it
+
+      if modified == s:
+        inc i # nothing changed
+      elif modified.len > 0:
+        stmts[i] = modified
+        inc i
+      else:
+        stmts.delete(i)
+    else:
+      inc i # keep the statement
 
 proc createModuleOp(graph: ModuleGraph, idgen: IdGenerator, postfix: string,
                     module: PSym, body: PNode, options: TOptions): PSym =
@@ -377,12 +416,12 @@ proc changeOwner(n: PNode, newOwner: PSym) =
       changeOwner(it, newOwner)
 
 proc setupModule*(graph: ModuleGraph, idgen: IdGenerator, m: PSym,
-                  decls, imperative: seq[PNode]): Module =
+                  decls, imperative, emit: seq[PNode]): Module =
   ## Creates a ``Module`` instance from `decls` and `imperative`. The module
   ## structs are populated with the initial items (top-level globals defined
   ## in the outermost scope, and threadvars) and the module-bound operators
   ## are set up.
-  result = Module(sym: m, idgen: idgen)
+  result = Module(sym: m, idgen: idgen, emit: emit)
 
   result.decls =
     if decls.len == 0: newNodeI(nkEmpty, m.info)
@@ -464,8 +503,13 @@ proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
     c = CollectPassCtx(b)
     pos = c.module.position.FileIndex
 
+  var emit: seq[PNode]
+  if graph.config.backend == backendC:
+    # only the C code generator supports top-level emit/asm statements
+    emit = extractEmitAndAsm(c.imperative)
+
   list.modules[pos] = setupModule(graph, c.idgen, c.module, c.decls,
-                                  c.imperative)
+                                  c.imperative, emit)
   list.modulesClosed.add(pos)
 
   # remember the positions of important modules:

--- a/compiler/vm/vmbackend.nim
+++ b/compiler/vm/vmbackend.nim
@@ -193,6 +193,8 @@ proc processEvent(c: var GenCtx, mlist: ModuleList, discovery: var DiscoveryData
     # not supported at the moment; ``vmgen`` is going to raise an
     # error when generating a call to a dynlib procedure
     discard "ignore"
+  of bekEmit:
+    unreachable()
 
 proc generateAliveProcs(c: var GenCtx, config: BackendConfig,
                         discovery: var DiscoveryData, mlist: var ModuleList) =

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7045,9 +7045,17 @@ Example:
   is a single string literal, Nim symbols can be referred to via backticks.
   This usage is however deprecated.
 
-For a top-level emit statement, the section where in the generated C file
-the code should be emitted can be influenced via the prefixes
-`/*TYPESECTION*/`:c: or `/*VARSECTION*/`:c: or `/*INCLUDESECTION*/`:c:\:
+
+Top-Level Emit
+~~~~~~~~~~~~~~
+
+When using the C backend, emit statements appearing at module scope (after
+expansion of templates, macros, and `when` statements) and outside of any
+expression are *top-level emit statements*.
+
+By default, they're emitted into the *procedure* section of the generated
+C file, but the section can be influenced via the prefixes `/*TYPESECTION*/`:c:
+or `/*VARSECTION*/`:c: or `/*INCLUDESECTION*/`:c:\:
 
 .. code-block:: Nim
   # TODO: Complete this example

--- a/tests/lang/s05_pragmas/s01_interop/t02_emit_c.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t02_emit_c.nim
@@ -5,11 +5,13 @@ Emit pragma outputs code directly through the back, these are C examples.
 '''
 """
 
-block emit_type:
-  {.emit: """/*TYPESECTION*/
+## emitting into a top-level section requires to be at the module's top-level
+## scope, outside of any expression
+{.emit: """/*TYPESECTION*/
 struct CStruct { int field; };
 """.}
 
+block emit_type:
   type
     CStruct {.importc: "struct CStruct".} = object
       field: cint

--- a/tests/lang_callable/overload/tstatic_with_converter.nim
+++ b/tests/lang_callable/overload/tstatic_with_converter.nim
@@ -8,7 +8,7 @@ output: '''
 
 ### bug #6773
 
-{.emit: """ /*INCLUDESECTION*/
+{.emit: """/*INCLUDESECTION*/
 typedef double cimported;
  
 cimported set1_imported(double x) {


### PR DESCRIPTION
## Summary

Only treat `emit` and `asm` statements at the module-scope *and*
outside of any complex expression as top-level emit/asm statements.

## Details

The main goal is to move top-level emit/asm handling largely out of the
code generator and into the orchestrator; the user-facing behaviour
changing is a side effect.

When creating the module lifecycle routines from module AST, emit/asm
statements that are at the top-level are now extracted and put into a
separate section. They're then translated from AST to MIR and
emitted as the new `bekEmit` event by the `backends.process` iterator.

For the C backend, they're passed onto the code generator; they're not
possible for the other two backends. Section determination is removed
from `cgen`.

While the section modifiers are translated to the same C file section
as before, all top-level emit/asm statements are now processed *before*
other top-level code. Tests for top-level emit statements and those
using them are updated (where needed).