### PR TITLE
mirgen: use better shape for `mOffsetOf`

### DIFF
--- a/compiler/backend/ccgexprs.nim
+++ b/compiler/backend/ccgexprs.nim
@@ -1324,19 +1324,15 @@ proc genMagicExpr(p: BProc, e: CgNode, d: var TLoc, op: TMagic) =
     let t = e[1].typ.skipTypes({tyTypeDesc})
     putIntoDest(p, d, e, "((NI)NIM_ALIGNOF($1))" % [getTypeDesc(p.module, t)])
   of mOffsetOf:
-    var dotExpr: CgNode
-    case e[1].kind
-    of cnkFieldAccess, cnkTupleAccess:
-      dotExpr = e[1]
+    let tname = getTypeDesc(p.module, e[1].typ)
+    let field = lookupField(p.module.types, p.module.types[e[1].typ],
+                            e[2].intVal.int32)
+    if field in p.module.fields:
+      putIntoDest(p, d, e, "((NI)offsetof($1, $2))" %
+                  [tname, p.module.fields[field]])
     else:
-      internalError(p.config, e.info, "unknown ast")
-    let t = dotExpr[0].typ.skipTypes({tyTypeDesc})
-    let tname = getTypeDesc(p.module, t)
-    let member =
-      if dotExpr.kind == cnkTupleAccess:
-        "Field" & rope(dotExpr[1].intVal)
-      else: p.fieldName(dotExpr[0].typ, dotExpr[1].field)
-    putIntoDest(p,d,e, "((NI)offsetof($1, $2))" % [tname, member])
+      putIntoDest(p, d, e, "((NI)offsetof($1, Field$2))" %
+                  [tname, $e[2].intVal])
   of mChr: genSomeCast(p, e, d)
   of mOrd: genOrd(p, e, d)
   of mLengthArray, mHigh, mLengthStr, mLengthSeq, mLengthOpenArray:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1007,16 +1007,15 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
         arg it
   of mOffsetOf:
     # an offsetOf call that has to be evaluated by the backend
+    let dotExpr =
+      case n[1].kind
+      of nkDotExpr:          n[1]
+      of nkCheckedFieldExpr: n[1][0]
+      else:                  unreachable()
+
     c.buildMagicCall mOffsetOf, rtyp:
-      c.builder.emitByName ekNone:
-        # prevent all checks and make sure that the original lvalue
-        # expression reaches the code generators
-        # XXX: this is a brittle and problematic hack. The type plus field
-        #      index should be passed as the arguments instead
-        let orig = c.userOptions
-        c.userOptions = {}
-        genx(c, n[1])
-        c.userOptions = orig
+      c.emitByVal typeLit(c.typeToMir(dotExpr[0].typ))
+      c.emitByVal intLiteral(c.env, dotExpr[1].sym.position, Int32Type)
   of mHigh:
     # custom translation in order to skip both explicit and implicit to-slice
     # conversions; those are unnecessary


### PR DESCRIPTION
## Summary

In `mirgen`, translate `mOffsetOf` to magic calls with a shape that's
easier to process for code generators.

## Details

* translate `offsetof(x.y)` to `offsetof(<type>, <field-position>)`
  * doesn't need the awkward disabling of checks the previous
    approach did
  * doesn't need a temporary variable
  * simpler to process for code generators, as they can use the field
    position to lookup the field directly
* update `mOffsetOf` handling in `cgen`