### PR TITLE
mir: distinguish between procedure and pointer-to-procedure

### DIFF
--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -653,9 +653,13 @@ proc emitTypeDef(m: BModule, id: TypeId, desc: TypeHeader) =
   of tkProc:
     let locs = prepareParameters(m, desc)
     var rettype, params: string
+    var cc = desc.callConv(m.types)
+    if cc in {ccInline, ccNoInline}:
+      # inline and noinline are not calling conventions in C
+      cc = ccNoConvention
     genProcParams(m, desc, rettype, params, locs, weakDep=true)
-    m.s[cfsTypes].addf("typedef $1_PTR($2, $3)$4;$n",
-                       [rope(CallingConvToStr[desc.callConv(m.types)]),
+    m.s[cfsTypes].addf("typedef $1($2, $3)$4;$n",
+                       [rope(CallingConvToStr[cc]),
                         rettype, name, params])
   of tkStruct, tkUnion:
     if id notin m.forwTypeCache:

--- a/compiler/backend/ccgtypes.nim
+++ b/compiler/backend/ccgtypes.nim
@@ -747,9 +747,10 @@ proc getClosureType(m: BModule, t: PType, kind: TClosureTypeKind): Rope =
     let canon {.cursor.} =
       m.types.headerFor(m.types.canonical(m.types[t]), Canonical)
 
-    let pt = m.types.buildProc(tkProc, ccNimCall, canon.retType(m.types), bu):
+    var pt = m.types.buildProc(tkProc, ccNimCall, canon.retType(m.types), bu):
       for (_, typ, flags) in params(m.types, canon):
         bu.addParam(flags, typ)
+    pt = m.types.newPtr(pt)
 
     result = useType(m, pt)
   of clHalfWithEnv:

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -1170,3 +1170,10 @@ func usizeType*(env: TypeEnv): TypeId {.inline.} =
   ## Returns the type to use for values representing some size. This is an
   ## unsigned integer type of target-dependent bit-width.
   env.usizeType
+
+# type creation routines
+# ----------------------
+
+func newPtr*(env: var TypeEnv, target: TypeId): TypeId =
+  ## Creates and returns a pointer type with target type `target`.
+  env.newPtrTy(target)

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -118,6 +118,9 @@ type
     map: TypeTable[TypeId]
     symbols {.requiresInit.}: Store[TypeId, TypeSym]
 
+    signatures: TypeTable[TypeId]
+      ## maps `tyProc` (treated as a signature) to MIR signature types
+
     headers: Store[HeaderId, TypeHeader]
       ## all type headers
     fields: seq[StructField]
@@ -635,6 +638,7 @@ proc close(env: var TypeEnv, b: sink ProcBuilder): uint32 =
 # -------------------------
 
 proc add*(env: var TypeEnv, t: PType): TypeId
+proc addSignature*(env: var TypeEnv, t: PType): TypeId
 
 proc recordToMir(env: var TypeEnv, str: var StructBuilder, n: PNode,
                  packed, canon: bool) =
@@ -720,6 +724,34 @@ proc makeDesc(kind: TypeKind, size: IntVal, align: int16,
               typ: TypeId; other = 0'u32): TypeHeader {.inline.} =
   TypeHeader(kind: kind, size: size, align: align, a: typ.uint32, b: other)
 
+proc procTypeToMir(env: var TypeEnv, kind: TypeKind, t: PType,
+                   canon=false): HeaderId =
+  ## Translates the ``tyProc`` type `t` to a MIR signature type.
+  template typeref(typ: PType): TypeId =
+    let t = env.add(typ)
+    if canon: canonical(env, t)
+    else:     t
+
+  var prc: ProcBuilder
+  let ret =
+    if isEmptyType(t[0]):
+      VoidType
+    else:
+      typeref(t[0])
+  prc = env.openProc(kind, t.callConv, ret, tfVarargs in t.flags)
+
+  # future direction: static parameters need to be filtered out here.
+  # Typedesc parameters only need to be removed in non-compile-time
+  # execution contexts
+  for i in 1..<t.len:
+    var s: set[ParamFlag]
+    if isPassByRef(env.config, t.n[i].sym, t[0]):
+      s.incl pfByRef
+
+    prc.addParam(s, typeref t[i])
+
+  env.close(prc)
+
 proc typeToMir(env: var TypeEnv, t: PType; canon = false, unique=true): HeaderId =
   ## Translates `t` to its MIR representation. All structural types are
   ## deduplicated, meaning that two structural types with the same structure
@@ -804,24 +836,15 @@ proc typeToMir(env: var TypeEnv, t: PType; canon = false, unique=true): HeaderId
     # object/union types are not de-duplicated
     rec.close(env, unique)
   of tyProc:
-    var prc: ProcBuilder
-    let ret = if t[0].isNil: VoidType else: typeref(t[0])
+    # important: a `tyProc` type used as the type for values refers to a
+    # *pointer-to-procedure* (or closure), not a mere *procedure signature*
     if t.callConv == ccClosure:
-      prc = env.openProc(tkClosure, t.callConv, ret, tfVarargs in t.flags)
+      procTypeToMir(env, tkClosure, t, canon)
     else:
-      prc = env.openProc(tkProc, t.callConv, ret, tfVarargs in t.flags)
-
-    # future direction: static parameters need to be filtered out here.
-    # Typedesc parameters only need to be removed in non-compile-time
-    # execution contexts
-    for i in 1..<t.len:
-      var s: set[ParamFlag]
-      if isPassByRef(env.config, t.n[i].sym, t[0]):
-        s.incl pfByRef
-
-      prc.addParam(s, typeref t[i])
-
-    env.close(prc)
+      var sig = env.addSignature(t)
+      if canon:
+        sig = env.canonical(sig)
+      env.add makeDesc(tkPtr, env.toIntVal(t.size), t.align, sig)
   of tyVar:
     # a ``var openArray`` is just an ``openArray``
     if classifyBackendView(t) == bvcSequence:
@@ -964,9 +987,10 @@ proc lowerType(env: var TypeEnv, graph: ModuleGraph, id: HeaderId): HeaderId =
       env.add makeDesc(tkArray, h.size, h.align, UInt8Type, h.size.uint32)
   of tkClosure:
     # -> (ClP_0: proc, ClE_0: pointer)
-    let prc = env.buildProc(tkProc, ccClosure, h.retType(env), bu):
+    var prc = env.buildProc(tkProc, ccClosure, h.retType(env), bu):
       for _, typ, flags in params(env, h):
         bu.addParam(flags, typ)
+    prc = env.newPtrTy(prc)
 
     env.buildStruct(h.size, h.align, bu):
       bu.addField(env, prc, "ClP_0", mangle=false)
@@ -1101,6 +1125,26 @@ proc add*(env: var TypeEnv, t: PType): TypeId =
   if result == env.symbols.nextId(): # not seen yet?
     result = handleImported(env, t)
     # translation of the type registered the mapping for us
+
+proc addSignature*(env: var TypeEnv, t: PType): TypeId =
+  ## Adds the proc type `t` to `env`, treating it as the type of a *procedure*,
+  ## not as the type of a *value*.
+  result = env.signatures.getOrDefault(t, env.symbols.nextId())
+  if result == env.symbols.nextId():
+    # create the type description preserving the original type symbols:
+    let
+      orig  = procTypeToMir(env, tkProc, t, canon=false)
+      canon = procTypeToMir(env, tkProc, t, canon=true)
+
+    var prev = env.canon.getOrDefault(canon, env.symbols.nextId())
+    if prev == env.symbols.nextId():
+      # the new type symbol is the *canonical* one
+      env.canon[canon] = prev
+
+    # now add the symbol and mapping:
+    result = env.symbols.add TypeSym(inst: t, canon: prev,
+                                     desc: [orig, canon, canon])
+    env.signatures[t] = result
 
 func get*(env: TypeEnv, id: TypeId): lent TypeSym =
   ## Returns the symbol for `id`.

--- a/compiler/mir/tailcall_elim.nim
+++ b/compiler/mir/tailcall_elim.nim
@@ -186,8 +186,9 @@ proc lowerProcvals*(tree: MirTree, env: var MirEnv, changes: var Changeset) =
   ## creation of the associated application procedure.
   for pos, it in tree.pairs:
     if it.kind == mnkProcVal:
-      let canon = env.types.canonical(it.typ)
-      if env.types.headerFor(canon, Canonical).callConv(env.types) ==
+      let desc = env.types.headerFor(it.typ, Canonical)
+      if desc.kind != tkClosure and
+         env.types.headerFor(desc.elem, Canonical).callConv(env.types) ==
           ccTailcall:
         # the type of the expression must stay the same; the application
         # procedure procval is bitcast to the correct type


### PR DESCRIPTION
## Summary

Add the concept of procedure signatures to the MIR type IR and
translate `tyProc` types used in valued contexts to pointer-to-
procedure types.

## Details

* add `mirtypes.addSignature`, for registering `tyProc` types to be
  representing procedure signatures
* translate non-`.closure` `tyProc` types to pointer-to-procedure types
  in `mirtypes.typeToMir`
* adjust `.tailcall` procedure detection in `tailcall_elim` to handle
  pointer-to-procedure types
* change `ccgtypes` to translate `tkProc` types to C proc types
  * the `N_<name>_PTR` C macros in `nimbase.h` are now obsolete, but
    have to be kept for bootstrapping reasons
* adjust the `.closure` lowering in `cgen` to always return a
  pointer-to-procedure type

Not all target languages distinguish between procedure values and
pointer-to-procedure values (only C does), but for those that do, code
generation becomes simpler when there's a distinction made at the MIR
type level.