### PR TITLE
mirtypes: properly translate recursive imported types

### DIFF
--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -1015,7 +1015,9 @@ proc typeSymToMir(env: var TypeEnv, t: PType): TypeId =
     # register the type symbol *first*. This prevents infinite recursion for
     # cyclic types
     result = env.symbols.add TypeSym(inst: t, canon: env.symbols.nextId())
-    env.map[t] = result
+    # don't override mappings pointing to the imported type
+    if sfImportc notin t.sym.flags:
+      env.map[t] = result
 
     let
       orig  = typeToMir(env, t, canon=false)
@@ -1064,12 +1066,16 @@ proc typeSymToMir(env: var TypeEnv, t: PType): TypeId =
     # now add the symbol and mapping:
     result = env.symbols.add TypeSym(inst: t, canon: prev,
                                      desc: [orig, canon, lowered])
-    env.map[t] = result
+    if t.sym.isNil or sfImportc notin t.sym.flags:
+      env.map[t] = result
 
 proc handleImported(env: var TypeEnv, t: PType): TypeId =
   if t.sym != nil and sfImportc in t.sym.flags:
-    # an imported type. It's wrapped in a ``tkImported``, referencing the
-    # underlying type
+    # add and register a preliminary symbol first, so that recursive types
+    # work correctly
+    result = env.symbols.add TypeSym(inst: t, canon: env.symbols.nextId())
+    env.map[t] = result
+
     let base =
       if t.kind in Skip:
         env.add t.lastSon.skipIrrelevant()
@@ -1085,12 +1091,8 @@ proc handleImported(env: var TypeEnv, t: PType): TypeId =
       orig  = env.add makeDesc(tkImported, size, t.align, base)
       canon = env.add makeDesc(tkImported, size, t.align,
                                env.canonical(base))
-    result = env.symbols.add TypeSym(inst: t, canon: env.symbols.nextId(),
-                                     desc: [orig, canon, canon])
 
-    # doesn't matter if a symbol mapping already exists (happens when
-    # `base` == `t`); override it
-    env.map[t] = result
+    env.symbols[result].desc = [orig, canon, canon]
   else:
     result = typeSymToMir(env, t)
 


### PR DESCRIPTION
## Summary

Fix an internal issue with MIR type translation of recursive
imported types.

## Details

In the MIR type IR, imported types use a dedicated type kind
(`tkImported`), which has the "to be treated as" type as the element/
base.

Due to unconditionally updating the `PType`->MIR mapping when
translating `importc`ed object types, usages of the imported types
within their own body (via a pointer/ref indirection) used the
`tkStruct` symbol, not the `tkImported` symbol.

```nim
type Foreign {.importc: "...".} = object
  field: ptr Foreign
  # ^^ the field had type `(tkPtr (tkStruct ...))`,
  # not `(tkPtr (tkImported ...))`
```

This led to internal type mismatches between the actual and computed
type of MIR access expression, but since the type of access expressions
is never recomputed at the moment, the bug had no user-facing effect. 

To fix the bug, `handleImported` now adds a symbol and registers a
mapping right away, with creation of a MIR type symbol for the
"internal" type of `importc`ed types leaving the mapping as is.