### PR TITLE
fix terminal expression used as construction operand

### DIFF
--- a/compiler/sem/unreachable_elim.nim
+++ b/compiler/sem/unreachable_elim.nim
@@ -160,9 +160,10 @@ proc process(c: var PassContext, n: PNode): PNode =
       n[i][1] = recurse(n[i][1])
       if doesntReturn(n[i][1]):
         # turn the operands so far into a valid statement list:
-        result = newNodeIT(nkStmtList, n.info, c.voidType, i - 1)
+        result = newNodeIT(nkStmtList, n.info, c.voidType, i)
         for j in 1..<i:
           result[j - 1] = newTreeI(nkDiscardStmt, n[j][1].info, n[j][1])
+        result[i - 1] = n[i][1]
         return
 
     result = n

--- a/tests/lang_exprs/tnon_returning_expressions.nim
+++ b/tests/lang_exprs/tnon_returning_expressions.nim
@@ -153,10 +153,16 @@ type Obj = object
 # construction expressions:
 testExprWithEffect 0:
   [(;return; var val = 0; 1), val, effect()]
+testExprWithEffect 2:
+  [effect(), (discard effect(); return; 1)]
 testExprWithEffect 0:
   ((;return; var val = 0; 1), val, effect())
+testExprWithEffect 2:
+  (effect(), (discard effect(); return; 1))
 testExprWithEffect 0:
   Obj(a: (;return; var val = 0; 1), b: val, c: effect())
+testExprWithEffect 2:
+  Obj(a: effect(), b: (discard effect(); return; 1))
 
 # cast:
 testExprWithEffect 0:


### PR DESCRIPTION
## Summary

Fix using a terminal expressions as an object construction operand
resulting in incorrect run-time behaviour.

## Details

Elimination of unreachable expression didn't handle object constructors
properly, not adding the terminal expression to the resulting statement
list. For example:

```nim
  Obj(a: x, b: (stmt; return; 1))
  # was turned into just
  discard x
  # `stmt; return` was erroneously omitted 
```

Since the surrounding statement was marked as not returning, the lack
of terminator statement caused incorrect MIR to be produced by
`mirgen`.

The terminal expression is now added to the produced statement list,
and a test is added to make sure eliminating construction expressions
works.