### PR TITLE
vm: fix `macros.add` crashing with `openArray` argument

### DIFF
--- a/compiler/vm/vmtypes.nim
+++ b/compiler/vm/vmtypes.nim
@@ -17,7 +17,7 @@ type VmTypeRel* = enum
 
 func elemType*(typ: PVmType): PVmType =
   case typ.kind
-  of akSeq:
+  of akSeq, akOpenArray:
     typ.seqElemType
   of akArray:
     typ.elementType

--- a/compiler/vm/vmtypes.nim
+++ b/compiler/vm/vmtypes.nim
@@ -17,7 +17,7 @@ type VmTypeRel* = enum
 
 func elemType*(typ: PVmType): PVmType =
   case typ.kind
-  of akSeq, akOpenArray:
+  of akSeq, akString, akOpenArray:
     typ.seqElemType
   of akArray:
     typ.elementType

--- a/tests/lang_callable/macros/tnode_add_true_openarray.nim
+++ b/tests/lang_callable/macros/tnode_add_true_openarray.nim
@@ -1,0 +1,20 @@
+discard """
+  description: '''
+    Regression test for passing a real `openArray` value to
+    `add(NimNode, varargs[NimNode])` not working.
+  '''
+  targets: native
+  action: compile
+"""
+
+import std/macros
+
+proc test() =
+  let arr = [newIntLitNode(1), newIntLitNode(2), newIntLitNode(3)]
+  var n = nnkStmtList.newNimNode()
+  n.add(arr.toOpenArray(1, 2))
+  doAssert n.len == 2
+  doAssert n[0].intVal == 2
+  doAssert n[1].intVal == 3
+
+static: test()


### PR DESCRIPTION
## Summary

Fix the compiler crashing when passing `openArray` value to
`macros.add`.

## Details

* handle `akOpenArray` in `vmtypes.elemType` (used by the
  `mNAddMultiple` implementation)
* handle `akString` in `vmtypes.elemType` (fixes nothing, but it
  should still be handled)