### PR TITLE
don't unnecessarily register closures with the cycle collector

### DIFF
--- a/compiler/sem/lambdalifting.nim
+++ b/compiler/sem/lambdalifting.nim
@@ -168,6 +168,9 @@ proc createStateField(g: ModuleGraph; iter: PSym; idgen: IdGenerator): PSym =
 
 proc createEnvObj(g: ModuleGraph; idgen: IdGenerator; owner: PSym; info: TLineInfo): PType =
   result = createObj(g, idgen, owner, info, final=false)
+  # the object needs to inherit from `RootObj` (hence final=false), but it
+  # cannot be inherited from itself
+  result.flags.incl tfFinal
 
 proc getClosureIterResult*(g: ModuleGraph; iter: PSym; idgen: IdGenerator): PSym =
   if resultPos < iter.ast.len:


### PR DESCRIPTION
## Summary

Instead of all closures, only register those that contain potentially
cycle-introducing indirections as potential cycle roots, reducing
pressure on the cycle collector.

## Details

While they don't need to be, the generated closure environment object
types were all marked as inheritable. Since the "potential cycle root"
detection treats non-final object types and object types containing
`ref`s to non-final objects as potential cycle roots, this led to all
non-cyclic closure environments being candidates for being scanned by
the cycle collector.

Closure environment object types are now marked as final.