### PR TITLE
sem: make `isCyclical` work with resolved concepts

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1506,7 +1506,10 @@ proc productReachable(marker: var IntSet, g: ModuleGraph, t: PType, search: PTyp
   of IntegralTypes, tyTypeDesc, tyEmpty, tyNil, tyOrdinal, tySet, tyRange,
      tyString, tyCstring, tyVoid:
     result = false
-  of tyDistinct, tyGenericInst, tyAlias, tyUserTypeClassInst, tyInferred:
+  of tyDistinct, tyGenericInst, tyAlias, tyInferred:
+    result = productReachable(marker, g, t.lastSon, search, isInd)
+  of tyUserTypeClasses:
+    assert t.isResolvedUserTypeClass
     result = productReachable(marker, g, t.lastSon, search, isInd)
   of tyError:
     # ``productReachable`` returning true usually means more work for the
@@ -1517,7 +1520,7 @@ proc productReachable(marker: var IntSet, g: ModuleGraph, t: PType, search: PTyp
     unreachable("handled by check")
   of tyNone, tyUntyped, tyTyped, tyGenericInvocation, tyGenericBody,
      tyGenericParam, tyForward, tySink, tyBuiltInTypeClass,
-     tyCompositeTypeClass, tyUserTypeClass, tyAnd, tyOr, tyNot, tyAnything,
+     tyCompositeTypeClass, tyAnd, tyOr, tyNot, tyAnything,
      tyStatic, tyFromExpr:
     unreachable("not a concrete type")
 

--- a/compiler/sem/semmagic.nim
+++ b/compiler/sem/semmagic.nim
@@ -293,11 +293,23 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
                                     PAstDiag(kind: adSemExpectedRangeType))
       result = c.config.wrapError(result)
   of "isCyclical":
-    let r =
-      if operand.skipTypes(abstractInst).kind in ConcreteTypes:
-        isCyclePossible(operand, c.graph)
+    proc findConcrete(typ: PType): PType =
+      let t = typ.skipTypes(abstractInst)
+      case t.kind
+      of ConcreteTypes:
+        typ
+      of tyUserTypeClasses:
+        if isResolvedUserTypeClass(t):
+          findConcrete(t.lastSon)
+        else:
+          nil
       else:
-        false
+        nil
+
+    let con = findConcrete(operand)
+    let r =
+      if con != nil: isCyclePossible(con, c.graph)
+      else:          false
 
     result = newIntNodeT(toInt128(ord(r)), traitCall, c.idgen, c.graph)
   else:

--- a/tests/typerel/tcyclic.nim
+++ b/tests/typerel/tcyclic.nim
@@ -126,3 +126,15 @@ type
 
 testNot WithUncheckedArray
 testNot (ref WithUncheckedArray)
+
+# instantiated concepts are treated as if they were their bound type
+type Concept = concept T
+
+proc wrapper(x: Concept) =
+  test typeof(x)
+
+proc wrapperNot(x: Concept) =
+  testNot typeof(x)
+
+wrapper Cyclic()
+wrapperNot NonCyclicObj()


### PR DESCRIPTION
## Summary

Make the `isCyclical` type-trait return whether the bound type for
resolved concept types is cyclical, instead of always `false`.

## Details

* change the "is concrete" test in `evalTypeTrait` to "skip" resolved
  concept types
* consider all resolved concept types in `types.productReachable` (used
  in implementing the `isCyclical` type trait), not just generic
  concept types
* extend the `tcyclic.nim` test with a test case for resolved concept 
  operands