### PR TITLE
compiler: release VM instance prior to code generation

### DIFF
--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -183,7 +183,7 @@ template prepareForCodegen(g: ModuleGraph) =
   # the compiler, so make sure that they do
   g.config.errorMax = 1
   # the VM instance is not needed anymore. Free it to save memory
-  g.vm = nil
+  reset g.vm
 
 proc commandCompileToC(graph: ModuleGraph) =
   let conf = graph.config

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -182,6 +182,8 @@ template prepareForCodegen(g: ModuleGraph) =
   # the backend / code generation phase generally expects errors to terminate
   # the compiler, so make sure that they do
   g.config.errorMax = 1
+  # the VM instance is not needed anymore. Free it to save memory
+  g.vm = nil
 
 proc commandCompileToC(graph: ModuleGraph) =
   let conf = graph.config

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -930,6 +930,15 @@ func refresh*(c: var TCtx, module: PSym; idgen: IdGenerator) =
   c.module = module
   c.idgen = idgen
 
+proc `=copy`(x: var VmAllocator, y: VmAllocator) {.error.}
+
+proc `=destroy`(x: var VmAllocator) =
+  for it in x.cells.items:
+    if it.p != nil:
+      dealloc(it.p)
+  `=destroy`(x.cells)
+  `=destroy`(x.byteType)
+
 const pseudoAtomKinds* = {akObject, akArray}
 const realAtomKinds* = {low(AtomKind)..high(AtomKind)} - pseudoAtomKinds
 


### PR DESCRIPTION
## Summary

Release the compiler's VM instance before code generation in order to
reduce peak memory usage.

## Details

* the `ModuleGraph` instance is the only location holding a reference
  to the `vmdef.TCtx` instance, setting it to `nil` leads to the VM
  instance being cleaned up and its memory released
* implement a destructor for  `VmAllocator` , to free the
manually-managed
  heap locations pointed to by the stored `VmCell`s
* prevent implicit copies of `VmAllocator` (and thus `vmdef.TCtx`)