### PR TITLE
mir2cg: restore support for constants with imported types

### DIFF
--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -70,6 +70,9 @@ from compiler/ast/report_enums import ReportKind
 
 from std/importutils import privateAccess
 
+when defined(nimCompilerStacktraceHints):
+  import compiler/utils/debugutils
+
 type
   Capability* = enum
     ## A capability of the targeted code generator.
@@ -2242,6 +2245,9 @@ proc emitPostCall(c; env; tree; n; stmts; bu) =
 proc exprToCgir(c; env; tree; n; dest: Expr, stmts, bu) =
   ## Translates a MIR assignment RHS into an analogous CGIR assignment,
   ## lowering where appropriate.
+  when defined(nimCompilerStacktraceHints):
+    frameMsg(c.graph.config, c.prc.body.source[tree[n].info])
+
   template operand(n: NodePosition): Expr =
     c.valueToCgir(env, tree, n, bu)
   template value(n: NodePosition): NodeRef =
@@ -2698,6 +2704,8 @@ proc emitToCgir(c; env; tree; n; bu): NodeRef =
 proc stmtToCgir(c; env; tree; n; stmts; bu) =
   ## Translates simple MIR statements to the semantically equivalent CGIR
   ## statement(s).
+  when defined(nimCompilerStacktraceHints):
+    frameMsg(c.graph.config, c.prc.body.source[tree[n].info])
   c.useSourceLoc(tree[n].info, bu)
   case tree[n].kind
   of mnkDef, mnkDefCursor:

--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -757,7 +757,9 @@ proc constToCgir(c; env; tree; n; bu): NodeRef =
 
       proc traverse(c; env; curr, typ: TypeId, bu) =
         let start = path.len
-        let desc = env.types.headerFor(typ, Lowered)
+        # imported types are treated as their underlying struct/union type when
+        # inspecting their structure here
+        let desc = env.types.headerFor(env.types.skip(typ), Lowered)
         if desc.kind == tkStruct:
           let base = desc.base(env.types)
           if base != VoidType:
@@ -770,16 +772,23 @@ proc constToCgir(c; env; tree; n; bu): NodeRef =
                 *use(^c.getTypeInfoV2(env, env.types[outer], bu)))
 
         proc field(c; env; curr: TypeId, id: FieldId, strf: StructField, bu) =
+          proc access(c; env; curr: TypeId; id: FieldId, bu) =
+            if env.types.headerFor(curr, Lowered).kind == tkImported:
+              path.add bu.build(
+                ExtField(^env.types[id].typ, ^env.types.name(env.types[id])))
+            else:
+              c.rawFieldAccess(env, curr, id, path, bu)
+
           if strf.isEmbedded:
             traverse(c, env, curr, strf.typ, bu)
           elif id in preproc:
             # field has an explicit value
-            c.rawFieldAccess(env, curr, id, path, bu)
+            c.access(env, curr, id, bu)
             elems.add bu.build do:
               FieldInit(path, ^recurse(preproc[id]))
           elif containsTypeHeaders(env.types, strf.typ):
             # zero-filling is not enough
-            c.rawFieldAccess(env, curr, id, path, bu)
+            c.access(env, curr, id, bu)
             elems.add bu.build do:
               FieldInit(path, ^c.genConstDefault(env, strf.typ, bu))
 

--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -1289,7 +1289,6 @@ proc getTypeInfoV2(c; env; typ: PType, bu): Expr =
   ## Returns a pointer expression referring to the RTTI global for `typ`.
   ## The RTTI data is created first if it wasn't already.
   var global: StringId
-  let orig = typ
   let (hash, typ) = hashTypeForRttiV2(typ)
   c.rttiV2Map.withValue hash, val:
     global = val[]
@@ -1306,19 +1305,15 @@ proc getTypeInfoV2(c; env; typ: PType, bu): Expr =
       # the RTTI types are cached on first use
       c.rttiV2Type = env.types.add(c.graph.getCompilerProc("TNimTypeV2").typ)
 
-    try:
-      var bu = initBuilder()
-      let got = bu.build GlobalDef(
-        ^CgStorage.Const,
-        0, # no custom alignment
-        0, # no flags
-        ^c.rttiV2Type,
-        ^globalRef(global),
-        ^genTypeInfoV2(c, env, typ, bu))
-      c.module.globals[global] = c.module.ast.append(bu, got)
-    except:
-      echo "Failed for: ", typeToString(orig)
-      raise
+    var bu = initBuilder()
+    let got = bu.build GlobalDef(
+      ^CgStorage.Const,
+      0, # no custom alignment
+      0, # no flags
+      ^c.rttiV2Type,
+      ^globalRef(global),
+      ^genTypeInfoV2(c, env, typ, bu))
+    c.module.globals[global] = c.module.ast.append(bu, got)
 
   let pt = env.newPtrType(c.rttiV2Type)
   bu.buildExpr pt, Addr(pt, ^globalRef(global))

--- a/compiler/backend/validation.nim
+++ b/compiler/backend/validation.nim
@@ -1379,7 +1379,7 @@ proc typeConst(m; pos; err): Type =
         if not match(m, expect, got):
           err.emit m, at, typeMismatchMsg(m, expect, got)
   of cnkRecConstr:
-    result = expectType(m, pos, {cnkStructTy, cnkArrayTy}, err)
+    result = expectType(m, pos, {cnkStructTy, cnkArrayTy, cnkOpaqueTy}, err)
     for _ in 1..<len(n):
       context at:
         let field = advance(m.ast, pos)

--- a/tests/lang/s05_pragmas/s01_interop/t07_imported_struct_at_compile_time.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t07_imported_struct_at_compile_time.nim
@@ -1,0 +1,29 @@
+discard """
+  description: '''
+    Imported C struct types can be used in compile-time evaluation contexts.
+  '''
+  targets: "c"
+"""
+
+type Extern {.importc: "struct NoTypedef", header: "t01_c_interop.nim.h".} = object
+  field1: cint
+  field2: cint
+  # not all fields need to exposed
+
+## The external type is usable in a compile-time evaluation context.
+
+proc make(val: int): Extern {.compiletime.} =
+  result = Extern(field1: cint(val))
+
+## It's also usable for the type of constants, whose value may cross the
+## compile-/run-time boundary.
+
+const c1 = make(1)
+const c2 = (a: Extern(field1: 1, field2: 2), b: 3)
+
+doAssert c1.field1 == 1
+doAssert c1.field2 == 0
+
+doAssert c2.a.field1 == 1
+doAssert c2.a.field2 == 2
+doAssert c2.b == 3

--- a/tests/lang/s05_pragmas/s01_interop/t07_imported_struct_at_compile_time.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t07_imported_struct_at_compile_time.nim
@@ -3,6 +3,7 @@ discard """
     Imported C struct types can be used in compile-time evaluation contexts.
   '''
   targets: "c"
+  joinable: false
 """
 
 type Extern {.importc: "struct NoTypedef", header: "t01_c_interop.nim.h".} = object


### PR DESCRIPTION
## Summary

Make constants of or containing imported types work like the did prior
to the code generator rewrite, no longer crashing the compiler.

## Details

* allow `cnkRecConstr` to use opaque types in the CGIR
* change the record construction translation logic in `mir2cg` to skip
  over `tkImported` types, so that the struct's fields are properly
  traversed
* add a specification test for the current behaviour of constants of or
  containing imported types
* remove some leftover debugging logic from `mir2cg`
* add some stack-trace message decorations in `mir2cg`, to aid with
  future debugging