### PR TITLE
mir2cg: handle casts between imported types

### DIFF
--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -2562,19 +2562,36 @@ proc exprToCgir(c; env; tree; n; dest: Expr, stmts, bu) =
          env.types.headerFor(env.types.skip(src), Lowered).kind in BlitTypes:
       # either the target or source type is something that requires a
       # blit copy for casting
-      let size = min(env.types.headerFor(typ, Lowered).size(env.types),
-                     env.types.headerFor(src, Lowered).size(env.types))
       if arg.mode == emValue:
         # not something that the address can be taken of; commit to a temporary
         let tmp = c.newTemp(env, arg.typ, stmts, bu)
         stmts.add c.genAsgn(env, tmp, arg, bu)
         arg = tmp
 
+      let size = min(env.types.headerFor(typ, Lowered).size(env.types),
+                     env.types.headerFor(src, Lowered).size(env.types))
+      let sizeExpr =
+        if size < 0:
+          # the size of either target or source type is unknown
+          # (e.g. imported types)
+          #
+          # offload the min size comparison to the target backend
+          let tmp = c.newTemp(env, env.types.sizeType, stmts, bu)
+          stmts.addStmt bu, If(
+            Lt(BoolType, ^env.types.sizeType,
+              Sizeof(^env.types.sizeType, src),
+              Sizeof(^env.types.sizeType, typ)),
+            *asgn(tmp, Sizeof(^env.types.sizeType, src)),
+            *asgn(tmp, Sizeof(^env.types.sizeType, typ)))
+          bu.use(tmp)
+        else:
+          c.genInt(env, size, env.types.sizeType, bu)
+
       stmts.addStmt bu, Call(
         ^bu.useCompilerProc(c, env, "nimCopyMem"),
         PtrCast(PointerType, ^c.genAddr(env, dest, bu)),
         PtrCast(PointerType, ^c.genAddr(env, arg, bu)),
-        ^c.genInt(env, size, env.types.sizeType, bu))
+        sizeExpr)
     elif env.types.headerFor(typ, Lowered).kind == tkImported or
          env.types.headerFor(src, Lowered).kind == tkImported:
       # use an opaque type conversion for any non-blit types where the cast

--- a/tests/lang/s05_pragmas/s01_interop/t08_imported_struct_cast.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t08_imported_struct_cast.nim
@@ -1,0 +1,30 @@
+discard """
+  description: '''
+    Imported C struct types can be casted to other types.
+  '''
+  targets: "c"
+  joinable: false
+"""
+
+type
+  ExternBig {.importc: "struct Struct1", header: "t08_imported_struct_cast.nim.h".} = object
+    field1: cint
+    field2: cint
+    # not all fields need to exposed
+
+  ExternSmall {.importc: "struct Struct2", header: "t08_imported_struct_cast.nim.h"} = object
+    field1: cint
+
+  Intern = object
+    field1: cint
+
+let v1 = ExternBig(field1: 1, field2: 2)
+let v2 = cast[ExternSmall](v1)
+let v3 = cast[Intern](v1)
+
+doAssert v1.field1 == 1
+doAssert v1.field2 == 2
+
+doAssert v2.field1 == 1
+
+doAssert v3.field1 == 1

--- a/tests/lang/s05_pragmas/s01_interop/t08_imported_struct_cast.nim
+++ b/tests/lang/s05_pragmas/s01_interop/t08_imported_struct_cast.nim
@@ -1,6 +1,6 @@
 discard """
   description: '''
-    Imported C struct types can be casted to other types.
+    Imported C struct types can be cast to other types.
   '''
   targets: "c"
   joinable: false
@@ -10,7 +10,7 @@ type
   ExternBig {.importc: "struct Struct1", header: "t08_imported_struct_cast.nim.h".} = object
     field1: cint
     field2: cint
-    # not all fields need to exposed
+    # not all fields need to be exposed
 
   ExternSmall {.importc: "struct Struct2", header: "t08_imported_struct_cast.nim.h"} = object
     field1: cint

--- a/tests/lang/s05_pragmas/s01_interop/t08_imported_struct_cast.nim.h
+++ b/tests/lang/s05_pragmas/s01_interop/t08_imported_struct_cast.nim.h
@@ -1,0 +1,14 @@
+#ifndef __C_HEADER_H_
+#define __C_HEADER_H_
+
+struct Struct1 {
+  int field1;
+  int field2;
+  int __field3;
+};
+
+struct Struct2 {
+  int field1;
+};
+
+#endif // __C_HEADER_H_


### PR DESCRIPTION
## Summary
Fix stack corruption due to oversized  `copyMem`  when casting from/to
imported types.

## Details
Type sizes encoded in AST and MIR both use special negative values to
denote either an error or unknown size. This detail is then picked up by
CGIR and rendered verbatim into C code, causing  `nimCopyMem`  to be
called with an excessively large value, corrupting the stack.

This change renders the required computation directly into CGIR when the
size could not be computed by the compiler for casts, solving the
problem.

Fixes https://github.com/nim-works/nimskull/issues/1661