### PR TITLE
sem: fix a case of AST corruption with overloaded calls

### DIFF
--- a/compiler/ast/ast_query.nim
+++ b/compiler/ast/ast_query.nim
@@ -63,7 +63,7 @@ const
   
   PersistentNodeFlags*: TNodeFlags = {nfDotSetter, nfDotField, nfLL,
                                       nfFromTemplate, nfDefaultRefsParam,
-                                      nfWasGensym}
+                                      nfWasGensym, nfExplicitCall}
   
   namePos*          = 0 ## Name of the type/proc-like node
   patternPos*       = 1 ## empty except for term rewriting macros

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -652,6 +652,7 @@ proc getBody*(g: ModuleGraph; s: PSym): PNode {.inline.} =
     assert result != nil and result.kind == nkError,
       "assume we've populated the nkError here"
   else:
+    internalAssert(g.config, s.ast.kind != nkError, s.info)
     result = s.ast[bodyPos]
     if result == nil and g.config.symbolFiles in {readOnlySf, v2Sf, stressTest}:
       result = loadProcBody(g.config, g.cache, g.packed, s)

--- a/compiler/sem/pragmas.nim
+++ b/compiler/sem/pragmas.nim
@@ -1031,7 +1031,7 @@ proc semCustomPragma(c: PContext, n: PNode, invalid: InvalidPragmaHandler): PNod
     result = invalid(c, n)
     return
 
-  let r = c.semOverloadedCall(c, callNode, callNode, {skTemplate}, {efNoUndeclared})
+  let r = c.semOverloadedCall(c, callNode, {skTemplate}, {efNoUndeclared})
   if r.isError:
     return r
   elif r.isNil or sfCustomPragma notin r[0].sym.flags:

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -278,14 +278,17 @@ proc semGenericArgs(c: PContext, n: PNode): PNode =
   if hasError:
     result = c.config.wrapError(result)
 
-proc resolveOverloads(c: PContext, nOrig: PNode,
+proc resolveOverloads(c: PContext, n: PNode,
                       filter: TSymKinds, flags: TExprFlags,
                       errors: var seq[SemCallMismatch]): TCandidate =
-  addInNimDebugUtils(c.config, "resolveOverloads", nOrig, filter, errors, result)
+  ## Performs overload resolution for the untyped, static call expression `n`,
+  ## filtered by callee symbol kinds specified by `filter`.
+  ## As arguments are typed, they're written back to `n`, with `errors`
+  ## accumulating all tried-and-rejected overloads.
+  addInNimDebugUtils(c.config, "resolveOverloads", n, filter, errors, result)
   var
     alt: TCandidate
-    # `n` itself will be modified, so create a shallow copy first
-    n = copyNodeWithKids(nOrig)
+    nOrig = copyNodeWithKids(n)
     f = n[0]
   
   case f.kind
@@ -389,9 +392,7 @@ proc resolveOverloads(c: PContext, nOrig: PNode,
       if {nfDotField, nfDotSetter} * n.flags != {}:
         # clean up the inserted ops
         n.sons.delete(2)
-        nOrig.sons.delete(2)
         n[0] = f
-        nOrig[0] = f
       # make sure that all recorded diagnostics are emitted, by adding them to
       # the no-match candidate
       result.addAllDiagnostics(diags)
@@ -591,6 +592,9 @@ proc semOverloadedCall(c: PContext, n: PNode,
   addInNimDebugUtils(c.config, "semOverloadedCall", n, result)
   var errors: seq[SemCallMismatch]
 
+  let n = copyNodeWithKids(n)
+  # `n` will be updated with the typed arguments, so a shallow copy has to
+  # be created
   var r = resolveOverloads(c, n, filter, flags, errors)
   emitDiagnostics(c, r) # always emit all captured diags for the match
   if r.state == csMatch:

--- a/compiler/sem/semcall.nim
+++ b/compiler/sem/semcall.nim
@@ -278,12 +278,14 @@ proc semGenericArgs(c: PContext, n: PNode): PNode =
   if hasError:
     result = c.config.wrapError(result)
 
-proc resolveOverloads(c: PContext, n, nOrig: PNode,
+proc resolveOverloads(c: PContext, nOrig: PNode,
                       filter: TSymKinds, flags: TExprFlags,
                       errors: var seq[SemCallMismatch]): TCandidate =
-  addInNimDebugUtils(c.config, "resolveOverloads", n, filter, errors, result)
+  addInNimDebugUtils(c.config, "resolveOverloads", nOrig, filter, errors, result)
   var
     alt: TCandidate
+    # `n` itself will be modified, so create a shallow copy first
+    n = copyNodeWithKids(nOrig)
     f = n[0]
   
   case f.kind
@@ -584,12 +586,12 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   result.typ = finalCallee.typ[0]
   result = updateDefaultParams(c.config, result)
 
-proc semOverloadedCall(c: PContext, n, nOrig: PNode,
+proc semOverloadedCall(c: PContext, n: PNode,
                        filter: TSymKinds, flags: TExprFlags): PNode =
   addInNimDebugUtils(c.config, "semOverloadedCall", n, result)
   var errors: seq[SemCallMismatch]
 
-  var r = resolveOverloads(c, n, nOrig, filter, flags, errors)
+  var r = resolveOverloads(c, n, filter, flags, errors)
   emitDiagnostics(c, r) # always emit all captured diags for the match
   if r.state == csMatch:
     # this may be triggered, when the explain pragma is used
@@ -764,7 +766,7 @@ proc searchForBorrowProc(c: PContext, startScope: PScope, fn: PSym): PSym =
     call.add(newNodeIT(nkEmpty, fn.info, x))
   if hasDistinct:
     let filter = if fn.kind in {skProc, skFunc}: {skProc, skFunc} else: {fn.kind}
-    var resolved = semOverloadedCall(c, call, call, filter, {})
+    var resolved = semOverloadedCall(c, call, filter, {})
     if resolved != nil:
       result = resolved[0].sym
       if not compareTypes(result.typ[0], fn.typ[0], dcEqIgnoreDistinct):

--- a/compiler/sem/semdata.nim
+++ b/compiler/sem/semdata.nim
@@ -619,7 +619,7 @@ type
     semConstBoolExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # XXX bite the bullet
       ## read to break cyclic dependencies, init in sem during module open and
       ## read in pragmas
-    semOverloadedCall*: proc (c: PContext, n, nOrig: PNode,
+    semOverloadedCall*: proc (c: PContext, n: PNode,
                               filter: TSymKinds, flags: TExprFlags): PNode {.nimcall.}
       ## read to break cyclic dependencies, init in sem during module open and
       ## read in pragmas and semtypinst

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -1140,10 +1140,10 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode,
     # to 'skIterator' anymore; skIterator is preferred in sigmatch already
     # for typeof support.
     # for ``typeof(countup(1,3))``, see ``tests/ttoseq``.
-    result = semOverloadedCall(c, n, copyNodeWithKids(n),
+    result = semOverloadedCall(c, n,
       {skProc, skFunc, skMethod, skConverter, skMacro, skTemplate, skIterator}, flags)
   else:
-    result = semOverloadedCall(c, n, copyNodeWithKids(n),
+    result = semOverloadedCall(c, n,
       {skProc, skFunc, skMethod, skConverter, skMacro, skTemplate}, flags)
 
   if result != nil and result.kind != nkError:

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -548,7 +548,7 @@ proc tryMacroPragma(c: PContext, pragmas: ptr PNode, i: int,
   x.add(operand) # the definition AST the pragma appears on
 
   # recursion assures that this works for multiple macro annotations too:
-  let r = semOverloadedCall(c, x, copyNodeWithKids(x), {skMacro, skTemplate}, {efNoUndeclared})
+  let r = semOverloadedCall(c, x, {skMacro, skTemplate}, {efNoUndeclared})
   if r.isNil:
     # restore the old list of pragmas since we couldn't process this one
     pragmas[] = n

--- a/compiler/sem/semtypinst.nim
+++ b/compiler/sem/semtypinst.nim
@@ -287,7 +287,7 @@ proc reResolveCallsWithTypedescParams(c: PContext, n: PNode): PNode =
       if isTypeParam(n[i]): needsFixing = true
     if needsFixing:
       n[0] = newSymNode(n[0].sym.owner)
-      return c.semOverloadedCall(c, n, n, {skProc, skFunc}, {})
+      return c.semOverloadedCall(c, n, {skProc, skFunc}, {})
 
   for i in 0..<n.safeLen:
     n[i] = reResolveCallsWithTypedescParams(c, n[i])

--- a/tests/lang_callable/overload/toverload_resolution_ast_corruption_bug.nim
+++ b/tests/lang_callable/overload/toverload_resolution_ast_corruption_bug.nim
@@ -1,0 +1,18 @@
+discard """
+  description: '''
+    Regression test for argument expressions in call expressions passed to
+    untyped parameters being typed when there exists another overload accepting
+    a typed parameter in the same position.
+  '''
+"""
+
+proc test1(x: int, y: int) =
+  discard
+
+proc test2(x: int, y: int) =
+  discard
+
+template test2(x, y: untyped) =
+  doAssert astToStr(x) == "test1(1 + 3, 2)"
+
+test2(test1(1 + 3, 2), 1)


### PR DESCRIPTION
## Summary

Fix arguments to untyped template/macro parameters being fully or
partially typed when other overloads with the typed parameters in the
same position exist, and the argument is an overloaded call itself.

## Details

* remove the `nOrig` parameter from `semOverloadedCall`; all callsites
  now only pass in the "original" AST
* handle the necessary shallow-copying in `semOverloadedCall` and
  `resolveOverloads`, instead of leaving it to the callsites
* keep the `nfExplicitCall` flag when copying nodes
* add an assertion to `getBody`, for producing more useful error
  messages when an `nkError` node erroneously reaches there (due to
  a bug)