### PR TITLE
sem: fix wrong procedure type relation w.r.t. effects

### DIFF
--- a/compiler/ast/enumtostr.nim
+++ b/compiler/ast/enumtostr.nim
@@ -2,7 +2,8 @@ import
   compiler/ast/[
     ast,
     idents,
-    lineinfos
+    lineinfos,
+    types
   ],
   compiler/modules/[
     modulegraphs,
@@ -27,6 +28,8 @@ proc genEnumToStrProc*(t: PType; info: TLineInfo; g: ModuleGraph; idgen: IdGener
   result.typ[0] = res.typ
   propagateToOwner(result.typ, res.typ, false)
   result.typ.addParam dest
+  result.typ.initNoEffects()
+  result.typ.flags.incl {tfGcSafe, tfNoSideEffect}
 
   var caseStmt = newNodeI(nkCaseStmt, info)
   caseStmt.add(newSymNode dest)

--- a/compiler/ast/trees.nim
+++ b/compiler/ast/trees.nim
@@ -165,8 +165,8 @@ proc effectSpec*(n: PNode, effectType: TSpecialWord): PNode =
   for it in n:
     if it.kind == nkExprColonExpr and whichPragma(it) == effectType:
       result = it[1]
-      if result.kind notin {nkCurly, nkBracket}:
-        result = newNodeI(nkCurly, result.info)
+      if result.kind != nkBracket:
+        result = newNodeI(nkBracket, result.info)
         result.add(it[1])
       return
 

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1030,7 +1030,8 @@ proc safeInheritanceDiff*(a, b: PType): int =
 proc compatibleEffectsAux(se, re: PNode, unknown, differ: EffectsCompat
                          ): EffectsCompat =
   ## Computes whether effect lists `se` and `re` are compatible; they are when
-  ## `se` is a superset of `re`.
+  ## `se` is a superset of `re`. If compatible returns `efCompat`, otherwise `differ`
+  ## or `unknown` if incompatible or cannot be determined, respectively.
   if se.isNil:
     # assume that it means "any effect"
     # FIXME: ^^ this is not always true! 'nil' can also mean

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1027,15 +1027,30 @@ proc safeInheritanceDiff*(a, b: PType): int =
   else:
     result = inheritanceDiff(a.skipTypes(skipPtrs), b.skipTypes(skipPtrs))
 
-proc compatibleEffectsAux(se, re: PNode): bool =
-  if re.isNil: return false
-  for r in items(re):
-    block search:
-      for s in items(se):
-        if safeInheritanceDiff(s.typ, r.typ) <= 0:
-          break search
-      return false
-  result = true
+proc compatibleEffectsAux(se, re: PNode, unknown, differ: EffectsCompat
+                         ): EffectsCompat =
+  ## Computes whether effect lists `se` and `re` are compatible; they are when
+  ## `se` is a superset of `re`.
+  if se.isNil:
+    # assume that it means "any effect"
+    # FIXME: ^^ this is not always true! 'nil' can also mean
+    #        "not computed yet", in which case types will be considered
+    #        compatible that in reality are not
+    result = efCompat
+  elif re.isNil:
+    # actual effects are either "any effect" or "not computed yet"
+    # FIXME: when `se` is computed but `re` is not, both are still compatible
+    #        when `se` contains the top type
+    result = unknown
+  else:
+    # every type in `re` must be equal to or a subtype of a type in `se`
+    for r in items(re):
+      block search:
+        for s in items(se):
+          if safeInheritanceDiff(s.typ, r.typ) <= 0:
+            break search
+        return differ
+    result = efCompat
 
 
 proc compatibleEffects*(formal, actual: PType): EffectsCompat =
@@ -1044,32 +1059,26 @@ proc compatibleEffects*(formal, actual: PType): EffectsCompat =
   #if tfEffectSystemWorkaround in actual.flags:
   #  return efCompat
 
-  if formal.n[0].kind != nkEffectList or
-     actual.n[0].kind != nkEffectList:
+  let
+    spec = formal.n[0]
+    real = actual.n[0]
+
+  if spec.kind != nkEffectList or
+     real.kind != nkEffectList:
     return efTagsUnknown
 
-  var spec = formal.n[0]
-  if spec.len != 0:
-    var real = actual.n[0]
+  result = compatibleEffectsAux(
+    spec[exceptionEffects], real[exceptionEffects],
+    efRaisesUnknown, efRaisesDiffer)
+  if result != efCompat:
+    return
 
-    let se = spec[exceptionEffects]
-    # if 'se.kind == nkArgList' it is no formal type really, but a
-    # computed effect and as such no spec:
-    # 'r.msgHandler = if isNil(msgHandler): defaultMsgHandler else: msgHandler'
-    if not isNil(se) and se.kind != nkArgList:
-      # spec requires some exception or tag, but we don't know anything:
-      if real.len == 0: return efRaisesUnknown
-      let res = compatibleEffectsAux(se, real[exceptionEffects])
-      if not res: return efRaisesDiffer
+  result = compatibleEffectsAux(
+    spec[tagEffects], real[tagEffects],
+    efTagsUnknown, efTagsDiffer)
+  if result != efCompat:
+    return
 
-    let st = spec[tagEffects]
-    if not isNil(st) and st.kind != nkArgList:
-      # spec requires some exception or tag, but we don't know anything:
-      if real.len == 0: return efTagsUnknown
-      let res = compatibleEffectsAux(st, real[tagEffects])
-      if not res:
-        #if tfEffectSystemWorkaround notin actual.flags:
-        return efTagsDiffer
   if formal.lockLevel.ord < 0 or
       actual.lockLevel.ord <= formal.lockLevel.ord:
 

--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -1082,6 +1082,16 @@ proc compatibleEffects*(formal, actual: PType): EffectsCompat =
   else:
     result = efLockLevelsDiffer
 
+proc initNoEffects*(t: PType) =
+  ## Sets the tag or exception effect specification to an empty list (meaning
+  ## "no effects")
+  let eff = t.n[0]
+  assert eff.kind == nkEffectList and eff.len == 0
+  eff.sons.newSeq(effectListLen)
+  eff[exceptionEffects] = newNode(nkBracket)
+  eff[tagEffects] = newNode(nkBracket)
+  eff[pragmasEffects] = newNode(nkEmpty)
+
 proc isCompileTimeOnly*(t: PType): bool {.inline.} =
   result = t.kind in {tyTypeDesc, tyStatic}
 

--- a/compiler/mir/mirtypes.nim
+++ b/compiler/mir/mirtypes.nim
@@ -834,7 +834,7 @@ proc procTypeToMir(env: var TypeEnv, kind: TypeKind, t: PType,
       #        portable tailcalls are *not* enabled
       # XXX: this also makes the actual types of MIR expressions not match
       #      their declared types prior to tailcall lowering
-      typeref(t.n[0][3].typ)
+      typeref(t.n[0][effectListLen].typ)
     elif isEmptyType(t[0]):
       VoidType
     else:

--- a/compiler/sem/liftdestructors.nim
+++ b/compiler/sem/liftdestructors.nim
@@ -830,6 +830,8 @@ proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp
   result.typ.addParam dest
   if kind != attachedDestructor:
     result.typ.addParam src
+  result.typ.initNoEffects() # hooks cannot raise nor have tags
+  result.typ.flags.incl {tfNoSideEffect, tfGcSafe}
 
   if kind == attachedAsgn and g.config.selectedGC == gcOrc and
       cyclicType(typ.skipTypes(abstractInst), g):

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1554,8 +1554,8 @@ proc setEffectsForProcType*(g: ModuleGraph; t: PType, n: PNode; s: PSym = nil) =
 proc rawInitEffects(g: ModuleGraph; effects: PNode) =
   if effects.len < effectListLen:
     newSeq(effects.sons, effectListLen)
-  effects[exceptionEffects] = newNodeI(nkArgList, effects.info)
-  effects[tagEffects] = newNodeI(nkArgList, effects.info)
+  effects[exceptionEffects] = newNodeI(nkBracket, effects.info)
+  effects[tagEffects] = newNodeI(nkBracket, effects.info)
   effects[pragmasEffects] = g.emptyNode
 
 proc initEffects(g: ModuleGraph; effects: PNode; s: PSym; t: var TEffects; c: PContext) =
@@ -1796,7 +1796,7 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
     # exceptions, if any, were already reported; don't report errors again in
     # that case
     if raisesSpec.isNil or raisesSpec.len > 0:
-      let newSpec = newNodeI(nkArgList, s.info)
+      let newSpec = newNodeI(nkBracket, s.info)
       checkRaisesSpec(g, rsemHookCannotRaise, newSpec,
                       t.exc, hints=off, nil)
       # override the raises specification to prevent cascading errors:

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1871,7 +1871,7 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
     genApply(c, s)
 
     # create the type-bound ops for the continuation type:
-    let cont = s.typ.n[0][3].typ.skipTypes(skipForHooks)
+    let cont = s.typ.n[0][effectListLen].typ.skipTypes(skipForHooks)
     createTypeBoundOps(c.graph, c, cont, s.info, c.idgen)
 
 proc trackStmt*(c: PContext; module: PSym; n: PNode, isTopLevel: bool) =

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1514,26 +1514,39 @@ proc checkMethodEffects*(g: ModuleGraph; disp, branch: PSym) =
           [$branch.typ.lockLevel, $disp.typ.lockLevel])
 
 proc setEffectsForProcType*(g: ModuleGraph; t: PType, n: PNode; s: PSym = nil) =
+  ## Initializes the effect lists for the proc type `t`. `n` is the pragma
+  ## list to take the explicit effect specification (if any) from, while `s`
+  ## is the symbol of the routine the type is attached to.
+  internalAssert(g.config, t.kind == tyProc)
   var effects = t.n[0]
-  if t.kind != tyProc or effects.kind != nkEffectList: return
-  if n.kind != nkEmpty:
-    internalAssert(g.config, isNoEffectList(effects), "Starting effects list must be empty")
+  internalAssert(g.config, effects.kind == nkEffectList)
+  internalAssert(g.config, effects.len == 0, "Starting effects list must be empty")
+  newSeq(effects.sons, effectListLen)
 
-    if effects.len < effectListLen:
-      newSeq(effects.sons, effectListLen)
-    let raisesSpec = effectSpec(n, wRaises)
+  let raisesSpec = if n.kind == nkPragma: effectSpec(n, wRaises) else: nil
+  let exc =
     if not isNil(raisesSpec):
-      effects[exceptionEffects] = raisesSpec
+      raisesSpec
     elif s != nil and (s.magic != mNone or {sfImportc, sfExportc} * s.flags == {sfImportc}):
-      effects[exceptionEffects] = newNodeI(nkArgList, effects.info)
+      # cannot have exception effects by itself
+      newNodeI(nkBracket, effects.info)
+    else:
+      nil # means both "not computed yet" and "any exceptions"
 
-    let tagsSpec = effectSpec(n, wTags)
+  let tagsSpec = if n.kind == nkPragma: effectSpec(n, wTags) else: nil
+  let tags =
     if not isNil(tagsSpec):
-      effects[tagEffects] = tagsSpec
+      tagsSpec
     elif s != nil and (s.magic != mNone or {sfImportc, sfExportc} * s.flags == {sfImportc}):
-      effects[tagEffects] = newNodeI(nkArgList, effects.info)
+      # cannot have tag effects by itself
+      newNodeI(nkBracket, effects.info)
+    else:
+      nil # means both "not computed yet" and "any tags"
 
-    effects[pragmasEffects] = n
+  effects[exceptionEffects] = exc
+  effects[tagEffects] = tags
+  effects[pragmasEffects] = n
+
   if s != nil and s.magic != mNone:
     if s.magic != mEcho:
       t.flags.incl tfNoSideEffect

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2622,7 +2622,7 @@ proc semProcAux(c: PContext, n: PNode, validPragmas: TSpecialWords,
     popOwner(c)
     return wrapErrorAndUpdate(c.config, result, s)
 
-  if result[pragmasPos].kind != nkEmpty and sfBorrow notin s.flags:
+  if sfBorrow notin s.flags:
     setEffectsForProcType(c.graph, s.typ, result[pragmasPos], s)
   s.typ.flags.incl tfEffectSystemWorkaround
 
@@ -2904,8 +2904,7 @@ proc semMacroDef(c: PContext, n: PNode): PNode =
     popOwner(c)
     return wrapErrorAndUpdate(c.config, result, s)
 
-  if result[pragmasPos].kind != nkEmpty:
-    setEffectsForProcType(c.graph, s.typ, result[pragmasPos], s)
+  setEffectsForProcType(c.graph, s.typ, result[pragmasPos], s)
   s.typ.flags.incl tfEffectSystemWorkaround
 
   # analyse the body:

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -1893,12 +1893,12 @@ proc semProcTypeWithScope(c: PContext, n: PNode,
     # we're still interested in implicit tags and raises pragmas
     n[1] = implicitPragmas(c, s, n[1], {wTags, wRaises})
 
+  when useEffectSystem:
+    setEffectsForProcType(c.graph, result, n[1])
+
   # instantiate the type of the continuation for .tailcall procedures
   if result.callConv == ccTailcall:
     prepareTailcallProc(c, n.info, result)
-
-  when true:
-    when useEffectSystem: setEffectsForProcType(c.graph, result, n[1])
   closeScope(c)
 
 proc symFromType(c: PContext; t: PType, info: TLineInfo): PSym =

--- a/compiler/sem/tailcall_analysis.nim
+++ b/compiler/sem/tailcall_analysis.nim
@@ -194,7 +194,7 @@ proc genApply*(c: PContext, s: PSym) =
   apply.flags.incl sfGeneratedOp
 
   let
-    contType    = s.typ.n[0][3].typ # use the hidden type
+    contType    = s.typ.n[0][effectListLen].typ # use the hidden type
     tupType     = newParamTuple(c.config, c.idgen, apply, s.typ)
     tupPtrType  = makePtrType(apply, tupType, c.idgen)
     pointerType = c.graph.getSysType(s.info, tyPointer)

--- a/tests/effects/tproc_type_relations.nim
+++ b/tests/effects/tproc_type_relations.nim
@@ -1,0 +1,37 @@
+discard """
+  description: '''
+    Tests to make sure type relationship correctly takes effects into
+    consideration.
+  '''
+  target: native
+"""
+
+# procedures with inferred exception effects
+proc test1() = raise newException(CatchableError, "")
+proc test2() = raise newException(ValueError, "")
+proc test3() = raise newException(IOError, "")
+
+# procedures with declared exception effects
+proc test1e() {.raises: [CatchableError].} = discard
+proc test2e() {.raises: [ValueError].} = discard
+proc test3e() {.raises: [IOError].} = discard
+
+# sub-typing
+doAssert typeof(test2) is typeof(test1)
+doAssert typeof(test3) is typeof(test1)
+# ... but not the other way around
+doAssert typeof(test1) isnot typeof(test2)
+doAssert typeof(test3) isnot typeof(test2)
+# sibling exception types are not compatible
+doAssert typeof(test2) isnot typeof(test3)
+doAssert typeof(test3) isnot typeof(test2)
+
+# declared vs. inferred exception effects are the same, type wise
+doAssert typeof(test1e) is typeof(test1)
+doAssert typeof(test1)  is typeof(test1e)
+doAssert typeof(test2e) is typeof(test2)
+doAssert typeof(test2)  is typeof(test2e)
+
+doAssert typeof(test2) is    proc() {.raises: [CatchableError], nimcall.}
+doAssert typeof(test3) is    proc() {.raises: [CatchableError], nimcall.}
+doAssert typeof(test2) isnot proc() {.raises: [IOError], nimcall.}


### PR DESCRIPTION
## Summary

Fix `proc` types derived from routines with inferred effects being
treated as if they had no effects, in the context of `proc` type
relations.

## Details

* always initialize the effect slot list for valid proc types, even
  when there's no pragma 
  * this removes the "missing effect list" state, simplifying further
    processing, but also increasing overall memory usage a little
  * generated enum-to-string procedure have their effect lists set to
    empty (they never raise) and are marked as side-effect free
  * the same goes for generated hooks
* always store effect lists as `nkBracket` trees in the respective
  effect slots in `PType`s
  * removes the wrong distinguishing between inferred and declared
    effects from types
  * also makes the encoding more uniform
* rewrite effect compatibility test (`types.compatibleEffects`) to be
  clearer and better documented, taking the previously described
  changes into account
* add a basic test for the effects of effects on proc type relations