### PR TITLE
sem: fix illegal proc type conversions being allowed

### DIFF
--- a/compiler/ast/types.nim
+++ b/compiler/ast/types.nim
@@ -764,6 +764,31 @@ proc skipGenericAlias*(t: PType): PType =
 proc sameFlags*(a, b: PType): bool {.inline.} =
   result = eqTypeFlags*a.flags == eqTypeFlags*b.flags
 
+proc sameProcEffects(a, b: PNode, c: var TSameTypeClosure): bool =
+  ## Whether the two effect lists are equal.
+  if a.isNil:
+    result = b.isNil
+  elif b.isNil:
+    result = false
+  else: # both a and b are not nil
+    # for every unique type in `a`, the same needs to exist in `b` and
+    # vice versa. Duplicate types are fine
+    for it in a.items:
+      block search:
+        for other in b.items:
+          if sameTypeAux(it.typ, other.typ, c):
+            break search
+        return false
+
+    for it in b.items:
+      block search:
+        for other in a.items:
+          if sameTypeAux(it.typ, other.typ, c):
+            break search
+        return false
+
+    result = true
+
 proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
   template cycleCheck() =
     # believe it or not, the direct check for ``containsOrIncl(c, a, b)``
@@ -878,6 +903,11 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
     if result and a.kind == tyProc:
       result = ((IgnoreCC in c.flags) or a.callConv == b.callConv) and
                ((ExactConstraints notin c.flags) or sameConstraints(a.n, b.n))
+      if result and IgnoreTupleFields notin c.flags:
+        result = sameProcEffects(a.n[0][exceptionEffects],
+                                 b.n[0][exceptionEffects], c)
+        if result:
+          result = sameProcEffects(a.n[0][tagEffects], b.n[0][tagEffects], c)
   of tyRange:
     cycleCheck()
     result = sameTypeOrNilAux(a[0], b[0], c) and

--- a/tests/effects/tproc_type_conversion.nim
+++ b/tests/effects/tproc_type_conversion.nim
@@ -1,0 +1,84 @@
+discard """
+  description: '''
+    Regression test for explicit conversions allowing conversion between
+    unrelated proc types (that only differ in their effects)
+  '''
+  targets: native
+"""
+
+type Unknown = proc() # has all possible effects
+
+block exception_effects:
+  proc test1() = discard # no exception effects
+  proc test2() {.raises: [CatchableError].} = discard
+  proc test3() {.raises: [ValueError].} = discard
+  proc test4() {.raises: [IOError].} = discard
+  proc test5() {.raises: [ValueError, IOError].} = discard
+  var test6: Unknown
+
+  # "no effects" only matches "no effects"
+  doAssert not compiles((typeof(test1))(test2))
+  doAssert not compiles((typeof(test1))(test3))
+  doAssert not compiles((typeof(test1))(test4))
+  doAssert not compiles((typeof(test1))(test5))
+  doAssert not compiles((typeof(test1))(test6))
+
+  # "no effects" is a subtype of all other effects
+  doAssert compiles((typeof(test2))(test1))
+  doAssert compiles((typeof(test3))(test1))
+  doAssert compiles((typeof(test4))(test1))
+  doAssert compiles((typeof(test5))(test1))
+  doAssert compiles((typeof(test6))(test1))
+
+  # sub typing
+  doAssert compiles((typeof(test2))(test3))
+  doAssert compiles((typeof(test2))(test4))
+  doAssert compiles((typeof(test2))(test5))
+  doAssert not compiles((typeof(test3))(test2))
+  doAssert not compiles((typeof(test4))(test2))
+  doAssert not compiles((typeof(test5))(test2))
+
+  # "all effects" only fits into "all effects"
+  doAssert compiles(Unknown(test6))
+  doAssert not compiles((typeof(test1))(test6))
+  doAssert not compiles((typeof(test2))(test6))
+
+block tag_effects:
+  type
+    TagA = object of RootEffect
+    TagB = object of RootEffect
+
+  # same structure as the exception effect tests above, just with tags
+  proc test1() {.tags: [].} = discard
+  proc test2() {.tags: [RootEffect].} = discard
+  proc test3() {.tags: [TagA].} = discard
+  proc test4() {.tags: [TagB].} = discard
+  proc test5() {.tags: [TagA, TagB].} = discard
+  var test6: Unknown
+
+  # "no effects" only matches "no effects"
+  doAssert not compiles((typeof(test1))(test2))
+  doAssert not compiles((typeof(test1))(test3))
+  doAssert not compiles((typeof(test1))(test4))
+  doAssert not compiles((typeof(test1))(test5))
+  doAssert not compiles((typeof(test1))(test6))
+
+  # "no effects" is a subtype of all other effects
+  doAssert compiles((typeof(test2))(test1))
+  doAssert compiles((typeof(test3))(test1))
+  doAssert compiles((typeof(test4))(test1))
+  doAssert compiles((typeof(test5))(test1))
+  doAssert compiles((typeof(test6))(test1))
+
+  # sub typing
+  doAssert compiles((typeof(test2))(test3))
+  doAssert compiles((typeof(test2))(test4))
+  doAssert compiles((typeof(test2))(test5))
+  doAssert not compiles((typeof(test3))(test2))
+  doAssert not compiles((typeof(test4))(test2))
+  doAssert not compiles((typeof(test5))(test2))
+
+  # "all effects" only fits into "all effects"
+  doAssert compiles(Unknown(test6))
+  doAssert not compiles((typeof(test1))(test6))
+  doAssert not compiles((typeof(test2))(test6))


### PR DESCRIPTION
## Summary

Fix conversion between unrelated `proc` type being allowed when their
only difference was in their tag or exception effects.

## Details

Judging whether a conversion is allowed (`checkConvertible`) uses
`sameType` first, which so far ignored effects on proc types. This led
to proc types that are equal in everything except their effects to be
admitted for conversion, even when the effects were incompatible.

To fix the problem, `sameType` is changed to also consider effect list
for proc types, but only when the `IgnoreTupleFields` flag is not
provided (which is already used to disable `.noSideEffect` being
considered).