### PR TITLE
mir2cg: implement missing bool comparison magics

### DIFF
--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -1576,11 +1576,11 @@ proc magicToCgir(c; env; tree; n; dest: Expr, stmts, bu) =
     wrapAsgn Le(BoolType, ^argt(0), ^arg(0), ^arg(1))
   of mEqI, mEqF64, mEqEnum, mEqRef, mEqCh, mEqB:
     wrapAsgn Eq(BoolType, ^argt(0), ^arg(0), ^arg(1))
-  of mLtCh:
+  of mLtB, mLtCh:
     wrapAsgn Lt(BoolType, UInt8Type,
       Bitcast(UInt8Type, ^arg(0)),
       Bitcast(UInt8Type, ^arg(1)))
-  of mLeCh:
+  of mLeB, mLeCh:
     wrapAsgn Le(BoolType, UInt8Type,
       Bitcast(UInt8Type, ^arg(0)),
       Bitcast(UInt8Type, ^arg(1)))

--- a/tests/magics/tmagics.nim
+++ b/tests/magics/tmagics.nim
@@ -69,3 +69,19 @@ block wrong_finished_result:
     doAssert f
 
   test()
+
+block bool_comparison:
+  # tests for the boolean less-than and less-than-or-equal operators
+  let t = true
+  let f = false
+
+  doAssert t > f # 'true' is greater than 'false'
+  doAssert f < t
+  doAssert not (t > t) # 'true' is not greater or less than itself
+  doAssert not (t < t)
+  doAssert not (f > f) # 'false' is not greater or less than itself
+  doAssert not (f < f)
+  doAssert t >= t
+  doAssert t <= t
+  doAssert f >= f
+  doAssert f <= f


### PR DESCRIPTION
## Summary

Fix using either `<`, `>`, `<=`, or `>=` with boolean operands crashing
the compiler.

## Details

Implement the `mLtB` and `mLeB` magics in `mir2cg`. Since `bool` is not
a numeric type at the CGIR level, the operands are bitcast to `uint8`
first before being compared, much like it works for `char` comparisons.