### PR TITLE
extccomp: move build instruction handling to separate module

### DIFF
--- a/compiler/backend/build_insts.nim
+++ b/compiler/backend/build_insts.nim
@@ -48,7 +48,7 @@ proc getBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
   # works out of the box with `hashMainCompilationParams`.
   result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
 
-proc writeBuildInstructions*(conf: ConfigRef; bcache: var BuildCache) =
+proc writeBuildInstructions*(conf: ConfigRef; bcache: sink BuildCache) =
   ## Populates shared build data and writes it to `outFile`.
   bcache.cacheVersion = cacheVersion
   bcache.outputFile = conf.absOutFile.string

--- a/compiler/backend/build_insts.nim
+++ b/compiler/backend/build_insts.nim
@@ -1,0 +1,133 @@
+import
+  compiler/backend/[
+    extccomp
+  ],
+  compiler/front/[
+    options,
+    msgs
+  ],
+  compiler/utils/[
+    pathutils,
+  ],
+  compiler/ast/[
+    lineinfos,
+  ],
+  std/[
+    jsonutils,
+    sequtils,
+    strutils,
+    tables,
+    sugar,
+    json,
+    sha1,
+    os
+  ]
+
+from compiler/ast/report_enums import ReportKind
+from compiler/ast/reports_cmd import CmdReport
+from compiler/ast/reports_backend import BackendReport
+
+template writePrettyCmds(cmd: CmdReport) =
+  if cmd.msg.len > 0:
+    # TODO: don't use `localReport`. Log the message/diagnostic directly
+    conf.localReport(cmd)
+
+template hashNimExe(): string = $secureHashFile(os.getAppFilename())
+
+proc getBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
+  # `outFile` is better than `projectName`, as it allows having different json
+  # files for a given source file compiled with different options; it also
+  # works out of the box with `hashMainCompilationParams`.
+  result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
+
+const cacheVersion = "D20230310T000000" # update when `BuildCache` spec changes
+type
+  BuildCache = object
+    cacheVersion: string
+    outputFile: string
+    compile: seq[(string, string)]
+    link: seq[string]
+    linkcmd: string
+    extraCmds: seq[string]
+    configFiles: seq[string] # the hash shouldn't be needed
+    inputMode: ProjectInputMode
+    currentDir: string
+    cmdline: string
+    depfiles: seq[(string, string)]
+    nimexe: string
+
+proc writeBuildInstructions*(conf: ConfigRef) =
+  ## Writes the build instructions to `outFile`.
+  var linkFiles = collect(for it in conf.externalToLink:
+    var it = it
+    if conf.noAbsolutePaths: it = it.extractFilename
+    it.addFileExt(CC[conf.cCompiler].objExt))
+  for it in conf.toCompile: linkFiles.add it.obj.string
+  var bcache = BuildCache(
+    cacheVersion: cacheVersion,
+    outputFile: conf.absOutFile.string,
+    compile: collect(for i, it in conf.toCompile:
+      if CfileFlag.Cached notin it.flags: (it.cname.string, getCompileCFileCmd(conf, it))),
+    link: linkFiles,
+    linkcmd: getLinkCmd(conf, conf.absOutFile, linkFiles.quoteShellCommand),
+    extraCmds: getExtraCmds(conf, conf.absOutFile),
+    inputMode: conf.inputMode,
+    configFiles: conf.configFiles.mapIt(it.string),
+    currentDir: getCurrentDir())
+  if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
+    bcache.cmdline = conf.commandLine
+    bcache.depfiles = collect(for it in conf.m.fileInfos:
+      let path = it.fullPath.string
+      if isAbsolute(path): # TODO: else?
+        (path, $secureHashFile(path)))
+    bcache.nimexe = hashNimExe()
+  conf.jsonBuildFile = conf.getBuildInstructionsFile()
+  conf.jsonBuildFile.string.writeFile(bcache.toJson.pretty)
+
+proc buildInstructionsStatus*(conf: ConfigRef; jsonFile: AbsoluteFile): bool =
+  ## Returns true if the build instructions are out of date.
+  if not fileExists(jsonFile) or not fileExists(conf.absOutFile): return true
+  var bcache: BuildCache
+  try: bcache.fromJson(jsonFile.string.parseFile)
+  except IOError, OSError, ValueError:
+    echo getCurrentException().msg
+    stderr.write "Warning: JSON processing failed for: $#\n" % jsonFile.string
+    return true
+  if bcache.currentDir != getCurrentDir() or # fixes bug #16271
+     bcache.configFiles != conf.configFiles.mapIt(it.string) or
+     bcache.cacheVersion != cacheVersion or bcache.outputFile != conf.absOutFile.string or
+     bcache.cmdline != conf.commandLine or bcache.nimexe != hashNimExe() or
+     bcache.inputMode != conf.inputMode: return true
+  if bcache.inputMode != pimFile: return true
+    # xxx optimize by returning false if stdin input was the same
+  for (file, hash) in bcache.depfiles:
+    if $secureHashFile(file) != hash: return true
+
+proc runBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
+  ## Runs the build instructions.
+  var bcache: BuildCache
+  try: bcache.fromJson(jsonFile.string.parseFile)
+  except:
+    let e = getCurrentException()
+    conf.quitOrRaise "\ncaught exception:\n$#\nstacktrace:\n$#error evaluating JSON file: $#" %
+      [e.msg, e.getStackTrace(), jsonFile.string]
+  let output = bcache.outputFile
+  createDir output.parentDir
+  let outputCurrent = $conf.absOutFile
+  if output != outputCurrent or bcache.cacheVersion != cacheVersion:
+    conf.globalReport BackendReport(
+      kind: rbackJsonScriptMismatch,
+      jsonScriptParams: (outputCurrent, output, jsonFile.string))
+
+  var cmds: TStringSeq
+  var prettyCmds: seq[CmdReport]
+  let prettyCb = proc (idx: int) = writePrettyCmds(prettyCmds[idx])
+  for (name, cmd) in bcache.compile:
+    cmds.add cmd
+    prettyCmds.add displayProgressCC(conf, name, cmd)
+
+  execCmdsInParallel(conf, cmds, prettyCb)
+  execLinkCmd(conf, bcache.linkcmd)
+
+  for cmd in bcache.extraCmds:
+    execExternalProgram(conf, cmd, rcmdExecuting)

--- a/compiler/backend/build_insts.nim
+++ b/compiler/backend/build_insts.nim
@@ -12,9 +12,6 @@ import
     sha1,
     os
   ],
-  compiler/backend/[
-    extccomp
-  ],
   compiler/front/[
     options,
     msgs
@@ -31,13 +28,13 @@ from compiler/ast/reports_cmd import CmdReport
 from compiler/ast/reports_backend import BackendReport
 
 type
-  BuildCache = object
-    cacheVersion: string
-    outputFile: string
-    compile: seq[(string, string)]
-    link: seq[string]
-    linkcmd: string
-    extraCmds: seq[string]
+  BuildCache* = object
+    cacheVersion*: string
+    outputFile*: string
+    compile*: seq[(string, string)]
+    link*: seq[string]
+    linkcmd*: string
+    extraCmds*: seq[string]
     configFiles: seq[string] # the hash shouldn't be needed
     inputMode: ProjectInputMode
     currentDir: string
@@ -45,12 +42,7 @@ type
     depfiles: seq[(string, string)]
     nimexe: string
 
-const cacheVersion = "D20230310T000000" # update when `BuildCache` spec changes
-
-template writePrettyCmds(cmd: CmdReport) =
-  if cmd.msg.len > 0:
-    # TODO: don't use `localReport`. Log the message/diagnostic directly
-    conf.localReport(cmd)
+const cacheVersion* = "D20230310T000000" # update when `BuildCache` spec changes
 
 template hashNimExe(): string = $secureHashFile(os.getAppFilename())
 
@@ -60,31 +52,22 @@ proc getBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
   # works out of the box with `hashMainCompilationParams`.
   result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
 
-proc writeBuildInstructions*(conf: ConfigRef) =
-  ## Writes the build instructions to `outFile`.
-  var linkFiles = collect(for it in conf.externalToLink:
-    var it = it
-    if conf.noAbsolutePaths: it = it.extractFilename
-    it.addFileExt(CC[conf.cCompiler].objExt))
-  for it in conf.toCompile: linkFiles.add it.obj.string
-  var bcache = BuildCache(
-    cacheVersion: cacheVersion,
-    outputFile: conf.absOutFile.string,
-    compile: collect(for i, it in conf.toCompile:
-      if CfileFlag.Cached notin it.flags: (it.cname.string, getCompileCFileCmd(conf, it))),
-    link: linkFiles,
-    linkcmd: getLinkCmd(conf, conf.absOutFile, linkFiles.quoteShellCommand),
-    extraCmds: getExtraCmds(conf, conf.absOutFile),
-    inputMode: conf.inputMode,
-    configFiles: conf.configFiles.mapIt(it.string),
-    currentDir: getCurrentDir())
+proc writeBuildInstructions*(conf: ConfigRef; bcache: var BuildCache) =
+  ## Populates shared build data and writes it to `outFile`.
+  bcache.cacheVersion = cacheVersion
+  bcache.outputFile = conf.absOutFile.string
+  bcache.inputMode = conf.inputMode
+  bcache.configFiles = conf.configFiles.mapIt(it.string)
+  bcache.currentDir = getCurrentDir()
+
   if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
     bcache.cmdline = conf.commandLine
     bcache.depfiles = collect(for it in conf.m.fileInfos:
       let path = it.fullPath.string
-      if isAbsolute(path): # TODO: else?
+      if isAbsolute(path):
         (path, $secureHashFile(path)))
     bcache.nimexe = hashNimExe()
+
   conf.jsonBuildFile = conf.getBuildInstructionsFile()
   conf.jsonBuildFile.string.writeFile(bcache.toJson.pretty)
 
@@ -106,32 +89,3 @@ proc buildInstructionsStatus*(conf: ConfigRef; jsonFile: AbsoluteFile): bool =
     # xxx optimize by returning false if stdin input was the same
   for (file, hash) in bcache.depfiles:
     if $secureHashFile(file) != hash: return true
-
-proc runBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
-  ## Runs the build instructions.
-  var bcache: BuildCache
-  try: bcache.fromJson(jsonFile.string.parseFile)
-  except:
-    let e = getCurrentException()
-    conf.quitOrRaise "\ncaught exception:\n$#\nstacktrace:\n$#error evaluating JSON file: $#" %
-      [e.msg, e.getStackTrace(), jsonFile.string]
-  let output = bcache.outputFile
-  createDir output.parentDir
-  let outputCurrent = $conf.absOutFile
-  if output != outputCurrent or bcache.cacheVersion != cacheVersion:
-    conf.globalReport BackendReport(
-      kind: rbackJsonScriptMismatch,
-      jsonScriptParams: (outputCurrent, output, jsonFile.string))
-
-  var cmds: TStringSeq
-  var prettyCmds: seq[CmdReport]
-  let prettyCb = proc (idx: int) = writePrettyCmds(prettyCmds[idx])
-  for (name, cmd) in bcache.compile:
-    cmds.add cmd
-    prettyCmds.add displayProgressCC(conf, name, cmd)
-
-  execCmdsInParallel(conf, cmds, prettyCb)
-  execLinkCmd(conf, bcache.linkcmd)
-
-  for cmd in bcache.extraCmds:
-    execExternalProgram(conf, cmd, rcmdExecuting)

--- a/compiler/backend/build_insts.nim
+++ b/compiler/backend/build_insts.nim
@@ -2,6 +2,16 @@
 ## with the cache.
 
 import
+  std/[
+    jsonutils,
+    sequtils,
+    strutils,
+    tables,
+    sugar,
+    json,
+    sha1,
+    os
+  ],
   compiler/backend/[
     extccomp
   ],
@@ -14,36 +24,12 @@ import
   ],
   compiler/ast/[
     lineinfos,
-  ],
-  std/[
-    jsonutils,
-    sequtils,
-    strutils,
-    tables,
-    sugar,
-    json,
-    sha1,
-    os
   ]
 
 from compiler/ast/report_enums import ReportKind
 from compiler/ast/reports_cmd import CmdReport
 from compiler/ast/reports_backend import BackendReport
 
-template writePrettyCmds(cmd: CmdReport) =
-  if cmd.msg.len > 0:
-    # TODO: don't use `localReport`. Log the message/diagnostic directly
-    conf.localReport(cmd)
-
-template hashNimExe(): string = $secureHashFile(os.getAppFilename())
-
-proc getBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
-  # `outFile` is better than `projectName`, as it allows having different json
-  # files for a given source file compiled with different options; it also
-  # works out of the box with `hashMainCompilationParams`.
-  result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
-
-const cacheVersion = "D20230310T000000" # update when `BuildCache` spec changes
 type
   BuildCache = object
     cacheVersion: string
@@ -58,6 +44,21 @@ type
     cmdline: string
     depfiles: seq[(string, string)]
     nimexe: string
+
+const cacheVersion = "D20230310T000000" # update when `BuildCache` spec changes
+
+template writePrettyCmds(cmd: CmdReport) =
+  if cmd.msg.len > 0:
+    # TODO: don't use `localReport`. Log the message/diagnostic directly
+    conf.localReport(cmd)
+
+template hashNimExe(): string = $secureHashFile(os.getAppFilename())
+
+proc getBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
+  # `outFile` is better than `projectName`, as it allows having different json
+  # files for a given source file compiled with different options; it also
+  # works out of the box with `hashMainCompilationParams`.
+  result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
 
 proc writeBuildInstructions*(conf: ConfigRef) =
   ## Writes the build instructions to `outFile`.

--- a/compiler/backend/build_insts.nim
+++ b/compiler/backend/build_insts.nim
@@ -23,10 +23,6 @@ import
     lineinfos,
   ]
 
-from compiler/ast/report_enums import ReportKind
-from compiler/ast/reports_cmd import CmdReport
-from compiler/ast/reports_backend import BackendReport
-
 type
   BuildCache* = object
     cacheVersion*: string

--- a/compiler/backend/build_insts.nim
+++ b/compiler/backend/build_insts.nim
@@ -1,3 +1,6 @@
+## Implements a cache for build instructions, plus the routines for interacting
+## with the cache.
+
 import
   compiler/backend/[
     extccomp

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -895,30 +895,6 @@ proc callCCompiler*(conf: ConfigRef) =
     script.add("\n")
     generateScript(conf, script)
 
-proc genMappingFiles(conf: ConfigRef; list: CfileList): Rope =
-  for it in list:
-    ropes.addf(result, "--file:r\"$1\"$N", [rope(it.cname.string)])
-
-proc writeMapping*(conf: ConfigRef; symbolMapping: Rope) =
-  if optGenMapping notin conf.globalOptions: return
-  var code = rope("[C_Files]\n")
-  code.add(genMappingFiles(conf, conf.toCompile))
-  code.add("\n[C_Compiler]\nFlags=")
-  code.add(strutils.escape(getCompileOptions(conf)))
-
-  code.add("\n[Linker]\nFlags=")
-  code.add(strutils.escape(getLinkOptions(conf) & " " &
-                            getConfigVar(conf, conf.cCompiler, ".options.linker")))
-
-  code.add("\n[Environment]\nlibpath=")
-  code.add(strutils.escape(conf.libpath.string))
-
-  ropes.addf(code, "\n[Symbols]$n$1", [symbolMapping])
-  let filename = getNimcacheDir(conf) / RelativeFile"mapping.txt"
-  if not writeRope(code, filename):
-    conf.localReport BackendReport(
-      kind: rbackCannotWriteMappingFile, filename: filename.string)
-
 proc runBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
   ## Runs the build instructions.
   var bcache: BuildCache
@@ -967,3 +943,27 @@ proc writeBuildInstructions*(conf: ConfigRef) =
   )
 
   build_insts.writeBuildInstructions(conf, bcache)
+
+proc genMappingFiles(conf: ConfigRef; list: CfileList): Rope =
+  for it in list:
+    ropes.addf(result, "--file:r\"$1\"$N", [rope(it.cname.string)])
+
+proc writeMapping*(conf: ConfigRef; symbolMapping: Rope) =
+  if optGenMapping notin conf.globalOptions: return
+  var code = rope("[C_Files]\n")
+  code.add(genMappingFiles(conf, conf.toCompile))
+  code.add("\n[C_Compiler]\nFlags=")
+  code.add(strutils.escape(getCompileOptions(conf)))
+
+  code.add("\n[Linker]\nFlags=")
+  code.add(strutils.escape(getLinkOptions(conf) & " " &
+                            getConfigVar(conf, conf.cCompiler, ".options.linker")))
+
+  code.add("\n[Environment]\nlibpath=")
+  code.add(strutils.escape(conf.libpath.string))
+
+  ropes.addf(code, "\n[Symbols]$n$1", [symbolMapping])
+  let filename = getNimcacheDir(conf) / RelativeFile"mapping.txt"
+  if not writeRope(code, filename):
+    conf.localReport BackendReport(
+      kind: rbackCannotWriteMappingFile, filename: filename.string)

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -13,6 +13,18 @@
 ## compile nim files.
 
 import
+  std/[
+    jsonutils,
+    sequtils,
+    strutils,
+    strtabs,
+    osproc,
+    sugar,
+    times,
+    json,
+    sha1,
+    os,
+  ],
   compiler/utils/[
     ropes,
     platform,
@@ -26,15 +38,8 @@ import
     options,
     msgs
   ],
-  std/[
-    os,
-    strutils,
-    osproc,
-    sha1,
-    sequtils,
-    times,
-    strtabs,
-    json,
+  compiler/backend/[
+    build_insts
   ]
 
 # TODO: does it really make sense that this module should produce all these
@@ -913,3 +918,51 @@ proc writeMapping*(conf: ConfigRef; symbolMapping: Rope) =
   if not writeRope(code, filename):
     conf.localReport BackendReport(
       kind: rbackCannotWriteMappingFile, filename: filename.string)
+
+proc runBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
+  ## Runs the build instructions.
+  var bcache: BuildCache
+  try: bcache.fromJson(jsonFile.string.parseFile)
+  except:
+    let e = getCurrentException()
+    conf.quitOrRaise "\ncaught exception:\n$#\nstacktrace:\n$#error evaluating JSON file: $#" %
+      [e.msg, e.getStackTrace(), jsonFile.string]
+  let output = bcache.outputFile
+  createDir output.parentDir
+  let outputCurrent = $conf.absOutFile
+  if output != outputCurrent or bcache.cacheVersion != cacheVersion:
+    conf.globalReport BackendReport(
+      kind: rbackJsonScriptMismatch,
+      jsonScriptParams: (outputCurrent, output, jsonFile.string))
+
+  var cmds: TStringSeq
+  var prettyCmds: seq[CmdReport]
+  let prettyCb = proc (idx: int) = writePrettyCmds(prettyCmds[idx])
+  for (name, cmd) in bcache.compile:
+    cmds.add cmd
+    prettyCmds.add displayProgressCC(conf, name, cmd)
+
+  execCmdsInParallel(conf, cmds, prettyCb)
+  execLinkCmd(conf, bcache.linkcmd)
+
+  for cmd in bcache.extraCmds:
+    execExternalProgram(conf, cmd, rcmdExecuting)
+
+
+proc writeBuildInstructions*(conf: ConfigRef) =
+  ## Gathers C-compiler-specific information and orchestrates writing the build instructions.
+  var linkFiles = collect(for it in conf.externalToLink:
+    var it = it
+    if conf.noAbsolutePaths: it = it.extractFilename
+    it.addFileExt(CC[conf.cCompiler].objExt))
+  for it in conf.toCompile: linkFiles.add it.obj.string
+
+  var bcache = BuildCache(
+    compile: collect(for i, it in conf.toCompile:
+      if CfileFlag.Cached notin it.flags: (it.cname.string, getCompileCFileCmd(conf, it))),
+    link: linkFiles,
+    linkcmd: getLinkCmd(conf, conf.absOutFile, linkFiles.quoteShellCommand),
+    extraCmds: getExtraCmds(conf, conf.absOutFile)
+  )
+
+  build_insts.writeBuildInstructions(conf, bcache)

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -35,8 +35,6 @@ import
     times,
     strtabs,
     json,
-    jsonutils,
-    sugar
   ]
 
 # TODO: does it really make sense that this module should produce all these
@@ -424,7 +422,7 @@ proc execWithEcho(conf: ConfigRef; cmd: string, execKind: ReportKind): int =
   conf.localReport(CmdReport(kind: execKind, cmd: cmd))
   result = execCmd(cmd)
 
-proc execExternalProgram(conf: ConfigRef; cmd: string, kind: ReportKind) =
+proc execExternalProgram*(conf: ConfigRef; cmd: string, kind: ReportKind) =
   let code = execWithEcho(conf, cmd, kind)
   if code != 0:
     conf.localReport CmdReport(kind: rcmdFailedExecution, cmd: cmd, code: code)
@@ -454,7 +452,7 @@ proc getOptSize(conf: ConfigRef; c: TSystemCC): string =
   if result == "":
     result = CC[c].optSize    # use default settings from this file
 
-proc noAbsolutePaths(conf: ConfigRef): bool {.inline.} =
+proc noAbsolutePaths*(conf: ConfigRef): bool {.inline.} =
   # We used to check current OS != specified OS, but this makes no sense
   # really: Cross compilation from Linux to Linux for example is entirely
   # reasonable.
@@ -729,7 +727,7 @@ proc getLinkCmd(conf: ConfigRef; output: AbsoluteFile,
   if optCDebug in conf.globalOptions and conf.cCompiler == ccVcc:
     result.add " /Zi /FS /Od"
 
-template getLinkCmd(conf: ConfigRef; output: AbsoluteFile, objfiles: string,
+template getLinkCmd*(conf: ConfigRef; output: AbsoluteFile, objfiles: string,
                     removeStaticFile = false): string =
   getLinkCmd(conf, output, objfiles, optGenDynLib in conf.globalOptions, removeStaticFile)
 
@@ -745,18 +743,18 @@ template tryExceptOSErrorMessage(conf: ConfigRef; errorPrefix: string = "", body
 
     raise
 
-proc getExtraCmds(conf: ConfigRef; output: AbsoluteFile): seq[string] =
+proc getExtraCmds*(conf: ConfigRef; output: AbsoluteFile): seq[string] =
   when defined(macosx):
     if optCDebug in conf.globalOptions and optGenStaticLib notin conf.globalOptions:
       # if needed, add an option to skip or override location
       result.add "dsymutil " & $(output).quoteShell
 
-proc execLinkCmd(conf: ConfigRef; linkCmd: string) =
+proc execLinkCmd*(conf: ConfigRef; linkCmd: string) =
   conf.timeTracer.traceStr(tikBackend, "link")
   tryExceptOSErrorMessage(conf, "invocation of external linker program failed."):
     execExternalProgram(conf, linkCmd, rcmdLinking)
 
-proc execCmdsInParallel(conf: ConfigRef; cmds: seq[string]; prettyCb: proc (idx: int)) =
+proc execCmdsInParallel*(conf: ConfigRef; cmds: seq[string]; prettyCb: proc (idx: int)) =
   let runCb = proc (idx: int, p: Process) =
     let exitCode = p.peekExitCode
     if exitCode != 0:
@@ -812,7 +810,7 @@ proc linkViaResponseFile(conf: ConfigRef; cmd: string) =
   finally:
     removeFile(linkerArgs)
 
-proc displayProgressCC(conf: ConfigRef, path, compileCmd: string): CmdReport =
+proc displayProgressCC*(conf: ConfigRef, path, compileCmd: string): CmdReport =
   if conf.hasHint(rcmdCompiling):
     CmdReport(
       kind: rcmdCompiling,
@@ -891,102 +889,6 @@ proc callCCompiler*(conf: ConfigRef) =
     script.add(linkCmd)
     script.add("\n")
     generateScript(conf, script)
-
-template hashNimExe(): string = $secureHashFile(os.getAppFilename())
-
-proc jsonBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
-  # `outFile` is better than `projectName`, as it allows having different json
-  # files for a given source file compiled with different options; it also
-  # works out of the box with `hashMainCompilationParams`.
-  result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
-
-const cacheVersion = "D20230310T000000" # update when `BuildCache` spec changes
-type BuildCache = object
-  cacheVersion: string
-  outputFile: string
-  compile: seq[(string, string)]
-  link: seq[string]
-  linkcmd: string
-  extraCmds: seq[string]
-  configFiles: seq[string] # the hash shouldn't be needed
-  inputMode: ProjectInputMode
-  currentDir: string
-  cmdline: string
-  depfiles: seq[(string, string)]
-  nimexe: string
-
-proc writeJsonBuildInstructions*(conf: ConfigRef) =
-  var linkFiles = collect(for it in conf.externalToLink:
-    var it = it
-    if conf.noAbsolutePaths: it = it.extractFilename
-    it.addFileExt(CC[conf.cCompiler].objExt))
-  for it in conf.toCompile: linkFiles.add it.obj.string
-  var bcache = BuildCache(
-    cacheVersion: cacheVersion,
-    outputFile: conf.absOutFile.string,
-    compile: collect(for i, it in conf.toCompile:
-      if CfileFlag.Cached notin it.flags: (it.cname.string, getCompileCFileCmd(conf, it))),
-    link: linkFiles,
-    linkcmd: getLinkCmd(conf, conf.absOutFile, linkFiles.quoteShellCommand),
-    extraCmds: getExtraCmds(conf, conf.absOutFile),
-    inputMode: conf.inputMode,
-    configFiles: conf.configFiles.mapIt(it.string),
-    currentDir: getCurrentDir())
-  if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
-    bcache.cmdline = conf.commandLine
-    bcache.depfiles = collect(for it in conf.m.fileInfos:
-      let path = it.fullPath.string
-      if isAbsolute(path): # TODO: else?
-        (path, $secureHashFile(path)))
-    bcache.nimexe = hashNimExe()
-  conf.jsonBuildFile = conf.jsonBuildInstructionsFile
-  conf.jsonBuildFile.string.writeFile(bcache.toJson.pretty)
-
-proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile): bool =
-  if not fileExists(jsonFile) or not fileExists(conf.absOutFile): return true
-  var bcache: BuildCache
-  try: bcache.fromJson(jsonFile.string.parseFile)
-  except IOError, OSError, ValueError:
-    echo getCurrentException().msg
-    stderr.write "Warning: JSON processing failed for: $#\n" % jsonFile.string
-    return true
-  if bcache.currentDir != getCurrentDir() or # fixes bug #16271
-     bcache.configFiles != conf.configFiles.mapIt(it.string) or
-     bcache.cacheVersion != cacheVersion or bcache.outputFile != conf.absOutFile.string or
-     bcache.cmdline != conf.commandLine or bcache.nimexe != hashNimExe() or
-     bcache.inputMode != conf.inputMode: return true
-  if bcache.inputMode != pimFile: return true
-    # xxx optimize by returning false if stdin input was the same
-  for (file, hash) in bcache.depfiles:
-    if $secureHashFile(file) != hash: return true
-
-proc runJsonBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
-  var bcache: BuildCache
-  try: bcache.fromJson(jsonFile.string.parseFile)
-  except:
-    let e = getCurrentException()
-    conf.quitOrRaise "\ncaught exception:\n$#\nstacktrace:\n$#error evaluating JSON file: $#" %
-      [e.msg, e.getStackTrace(), jsonFile.string]
-  let output = bcache.outputFile
-  createDir output.parentDir
-  let outputCurrent = $conf.absOutFile
-  if output != outputCurrent or bcache.cacheVersion != cacheVersion:
-    conf.globalReport BackendReport(
-      kind: rbackJsonScriptMismatch,
-      jsonScriptParams: (outputCurrent, output, jsonFile.string))
-
-  var cmds: TStringSeq
-  var prettyCmds: seq[CmdReport]
-  let prettyCb = proc (idx: int) = writePrettyCmds(prettyCmds[idx])
-  for (name, cmd) in bcache.compile:
-    cmds.add cmd
-    prettyCmds.add displayProgressCC(conf, name, cmd)
-
-  execCmdsInParallel(conf, cmds, prettyCb)
-  execLinkCmd(conf, bcache.linkcmd)
-
-  for cmd in bcache.extraCmds:
-    execExternalProgram(conf, cmd, rcmdExecuting)
 
 proc genMappingFiles(conf: ConfigRef; list: CfileList): Rope =
   for it in list:

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -427,7 +427,7 @@ proc execWithEcho(conf: ConfigRef; cmd: string, execKind: ReportKind): int =
   conf.localReport(CmdReport(kind: execKind, cmd: cmd))
   result = execCmd(cmd)
 
-proc execExternalProgram*(conf: ConfigRef; cmd: string, kind: ReportKind) =
+proc execExternalProgram(conf: ConfigRef; cmd: string, kind: ReportKind) =
   let code = execWithEcho(conf, cmd, kind)
   if code != 0:
     conf.localReport CmdReport(kind: rcmdFailedExecution, cmd: cmd, code: code)
@@ -457,7 +457,7 @@ proc getOptSize(conf: ConfigRef; c: TSystemCC): string =
   if result == "":
     result = CC[c].optSize    # use default settings from this file
 
-proc noAbsolutePaths*(conf: ConfigRef): bool {.inline.} =
+proc noAbsolutePaths(conf: ConfigRef): bool {.inline.} =
   # We used to check current OS != specified OS, but this makes no sense
   # really: Cross compilation from Linux to Linux for example is entirely
   # reasonable.
@@ -732,7 +732,7 @@ proc getLinkCmd(conf: ConfigRef; output: AbsoluteFile,
   if optCDebug in conf.globalOptions and conf.cCompiler == ccVcc:
     result.add " /Zi /FS /Od"
 
-template getLinkCmd*(conf: ConfigRef; output: AbsoluteFile, objfiles: string,
+template getLinkCmd(conf: ConfigRef; output: AbsoluteFile, objfiles: string,
                     removeStaticFile = false): string =
   getLinkCmd(conf, output, objfiles, optGenDynLib in conf.globalOptions, removeStaticFile)
 
@@ -748,18 +748,18 @@ template tryExceptOSErrorMessage(conf: ConfigRef; errorPrefix: string = "", body
 
     raise
 
-proc getExtraCmds*(conf: ConfigRef; output: AbsoluteFile): seq[string] =
+proc getExtraCmds(conf: ConfigRef; output: AbsoluteFile): seq[string] =
   when defined(macosx):
     if optCDebug in conf.globalOptions and optGenStaticLib notin conf.globalOptions:
       # if needed, add an option to skip or override location
       result.add "dsymutil " & $(output).quoteShell
 
-proc execLinkCmd*(conf: ConfigRef; linkCmd: string) =
+proc execLinkCmd(conf: ConfigRef; linkCmd: string) =
   conf.timeTracer.traceStr(tikBackend, "link")
   tryExceptOSErrorMessage(conf, "invocation of external linker program failed."):
     execExternalProgram(conf, linkCmd, rcmdLinking)
 
-proc execCmdsInParallel*(conf: ConfigRef; cmds: seq[string]; prettyCb: proc (idx: int)) =
+proc execCmdsInParallel(conf: ConfigRef; cmds: seq[string]; prettyCb: proc (idx: int)) =
   let runCb = proc (idx: int, p: Process) =
     let exitCode = p.peekExitCode
     if exitCode != 0:
@@ -815,7 +815,7 @@ proc linkViaResponseFile(conf: ConfigRef; cmd: string) =
   finally:
     removeFile(linkerArgs)
 
-proc displayProgressCC*(conf: ConfigRef, path, compileCmd: string): CmdReport =
+proc displayProgressCC(conf: ConfigRef, path, compileCmd: string): CmdReport =
   if conf.hasHint(rcmdCompiling):
     CmdReport(
       kind: rcmdCompiling,
@@ -950,7 +950,8 @@ proc runBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
 
 
 proc writeBuildInstructions*(conf: ConfigRef) =
-  ## Gathers C-compiler-specific information and orchestrates writing the build instructions.
+  ## Gathers C-compiler-specific information and orchestrates writing the
+  ## build instructions.
   var linkFiles = collect(for it in conf.externalToLink:
     var it = it
     if conf.noAbsolutePaths: it = it.extractFilename

--- a/compiler/backend/extccomp.nim
+++ b/compiler/backend/extccomp.nim
@@ -895,6 +895,25 @@ proc callCCompiler*(conf: ConfigRef) =
     script.add("\n")
     generateScript(conf, script)
 
+proc writeBuildInstructions*(conf: ConfigRef) =
+  ## Gathers C-compiler-specific information and orchestrates writing the
+  ## build instructions.
+  var linkFiles = collect(for it in conf.externalToLink:
+    var it = it
+    if conf.noAbsolutePaths: it = it.extractFilename
+    it.addFileExt(CC[conf.cCompiler].objExt))
+  for it in conf.toCompile: linkFiles.add it.obj.string
+
+  var bcache = BuildCache(
+    compile: collect(for i, it in conf.toCompile:
+      if CfileFlag.Cached notin it.flags: (it.cname.string, getCompileCFileCmd(conf, it))),
+    link: linkFiles,
+    linkcmd: getLinkCmd(conf, conf.absOutFile, linkFiles.quoteShellCommand),
+    extraCmds: getExtraCmds(conf, conf.absOutFile)
+  )
+
+  build_insts.writeBuildInstructions(conf, bcache)
+
 proc runBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
   ## Runs the build instructions.
   var bcache: BuildCache
@@ -923,26 +942,6 @@ proc runBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile) =
 
   for cmd in bcache.extraCmds:
     execExternalProgram(conf, cmd, rcmdExecuting)
-
-
-proc writeBuildInstructions*(conf: ConfigRef) =
-  ## Gathers C-compiler-specific information and orchestrates writing the
-  ## build instructions.
-  var linkFiles = collect(for it in conf.externalToLink:
-    var it = it
-    if conf.noAbsolutePaths: it = it.extractFilename
-    it.addFileExt(CC[conf.cCompiler].objExt))
-  for it in conf.toCompile: linkFiles.add it.obj.string
-
-  var bcache = BuildCache(
-    compile: collect(for i, it in conf.toCompile:
-      if CfileFlag.Cached notin it.flags: (it.cname.string, getCompileCFileCmd(conf, it))),
-    link: linkFiles,
-    linkcmd: getLinkCmd(conf, conf.absOutFile, linkFiles.quoteShellCommand),
-    extraCmds: getExtraCmds(conf, conf.absOutFile)
-  )
-
-  build_insts.writeBuildInstructions(conf, bcache)
 
 proc genMappingFiles(conf: ConfigRef; list: CfileList): Rope =
   for it in list:

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -43,6 +43,7 @@ import
     modulegraphs # Project module graph
   ],
   compiler/backend/[
+    build_insts, # JSON build instructions
     extccomp,    # Calling C compiler
   ],
   compiler/utils/[
@@ -70,6 +71,7 @@ import compiler/backend/cbackend as cbackend2
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_internal import InternalReport
+from compiler/ast/reports_backend import BackendReport
 from compiler/ast/report_enums import ReportKind,
   repHintKinds,
   repWarningKinds,
@@ -192,8 +194,7 @@ proc commandCompileToC(graph: ModuleGraph) =
     registerPass(graph, collectPass)
 
     if {optRun, optForceFullMake} * conf.globalOptions == {optRun} or isDefined(conf, "nimBetterRun"):
-      if not changeDetectedViaJsonBuildInstructions(conf, conf.jsonBuildInstructionsFile):
-        # nothing changed
+      if not buildInstructionsStatus(conf, conf.getBuildInstructionsFile()):
         graph.config.notes = graph.config.mainPackageNotes
         return
 
@@ -211,14 +212,14 @@ proc commandCompileToC(graph: ModuleGraph) =
     cbackend2.generateCode(graph, graph.finalizeModules())
 
   extccomp.callCCompiler(conf)
-  extccomp.writeJsonBuildInstructions(conf)
+  build_insts.writeBuildInstructions(conf)
   if conf.depfile.string.len != 0:
     writeGccDepfile(conf)
   if optGenScript in graph.config.globalOptions:
     writeDepsFile(graph)
 
 proc commandJsonScript(graph: ModuleGraph) =
-  extccomp.runJsonBuildInstructions(graph.config, graph.config.jsonBuildInstructionsFile)
+  build_insts.runBuildInstructions(graph.config, graph.config.getBuildInstructionsFile())
 
 proc commandCompileToJS(graph: ModuleGraph) =
   let conf = graph.config

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -71,7 +71,6 @@ import compiler/backend/cbackend as cbackend2
 
 # xxx: reports are a code smell meaning data types are misplaced
 from compiler/ast/reports_internal import InternalReport
-from compiler/ast/reports_backend import BackendReport
 from compiler/ast/report_enums import ReportKind,
   repHintKinds,
   repWarningKinds,

--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -211,14 +211,14 @@ proc commandCompileToC(graph: ModuleGraph) =
     cbackend2.generateCode(graph, graph.finalizeModules())
 
   extccomp.callCCompiler(conf)
-  build_insts.writeBuildInstructions(conf)
+  extccomp.writeBuildInstructions(conf)
   if conf.depfile.string.len != 0:
     writeGccDepfile(conf)
   if optGenScript in graph.config.globalOptions:
     writeDepsFile(graph)
 
 proc commandJsonScript(graph: ModuleGraph) =
-  build_insts.runBuildInstructions(graph.config, graph.config.getBuildInstructionsFile())
+  extccomp.runBuildInstructions(graph.config, graph.config.getBuildInstructionsFile())
 
 proc commandCompileToJS(graph: ModuleGraph) =
   let conf = graph.config


### PR DESCRIPTION
## Summary
  * Separated build instructions out into  `build_insts.nim`  to
separate C build instructions from general build information

## Details
  * Remove 'json' prefix from build instruction procedures