### PR TITLE
mir2cg: use a better implementation for `of`

### DIFF
--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -1372,9 +1372,9 @@ proc emitDefault(c; env; dest: Expr, stmts; bu) =
 
 proc genOf(c; env; tree; e: Expr, typ: TypeId; bu): NodeRef =
   bu.build Call(
-    ^bu.useCompilerProc(c, env, "isObj"),
+    ^bu.useCompilerProc(c, env, "isObjV2"),
     ^c.fieldAccess(env, e, -1, bu),
-    Value(CstringType, ^genTypeInfo2Name(env[typ])))
+    *use(^c.getTypeInfoV2(env, env[typ], bu)))
 
 proc emitLength(c; env; dest, val: Expr, stmts, bu) =
   ## Emits a statement for storing the length of sequence-like `val` in `dest`.

--- a/compiler/backend/rtti.nim
+++ b/compiler/backend/rtti.nim
@@ -22,6 +22,7 @@ const
   MemberV2Trace = 4
   MemberV2TypeInfo = 5
   MemberV2Flags = 6
+  MemberV2Base = 7
 
   # ``TNimType`` fields
   MemberV1Size = 0
@@ -160,6 +161,11 @@ proc genTypeInfoV2(c; env; typ: PType, bu): NodeRef =
     # the v2 RTTI needs to link back to the v1 RTTI
     let info = getTypeInfoV1(c, env, t, bu)
     fields.addField bu, MemberV2TypeInfo, ^bu.use(info)
+
+  if t.kind == tyObject and t[0] != nil:
+    # link the base type's RTTI
+    let base = skipToObject(t[0])
+    fields.addField bu, MemberV2Base, ^bu.use(getTypeInfoV2(c, env, base, bu))
 
   bu.build RecConstr(^c.rttiV2Type, fields)
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1733,6 +1733,9 @@ when not defined(js) and not isNimVmTarget:
       traceImpl: pointer
       typeInfoV1: pointer # for backwards compat, usually nil
       flags: int
+      base: ptr TNimTypeV2
+        ## only used for object types. The parent type, or nil, when there's
+        ## no parent
     PNimTypeV2 = ptr TNimTypeV2
 
 when notJSnotNims and defined(nimSeqsV2):

--- a/lib/system/arc.nim
+++ b/lib/system/arc.nim
@@ -241,10 +241,20 @@ template tearDownForeignThreadGc* =
   discard
 
 proc isObj(obj: PNimTypeV2, subclass: cstring): bool {.compilerRtl, inl.} =
+  # TODO: obsolete. Remove when the csources are updated
   proc strstr(s, sub: cstring): cstring {.header: "<string.h>", importc.}
 
   result = strstr(obj.name, subclass) != nil
 
 proc chckObj(obj: PNimTypeV2, subclass: cstring) {.compilerRtl.} =
+  # TODO: obsolete. Remove when the csources are updated
   # checks if obj is of type subclass:
   if not isObj(obj, subclass): sysFatal(ObjectConversionDefect, "invalid object conversion")
+
+proc isObjV2(obj: PNimTypeV2, other: PNimTypeV2): bool {.compilerRtl, inl.} =
+  ## Computes whether the RTTI `obj` is that of an object type derived from
+  ## or equal to the object type for `other`.
+  var p = obj
+  while p != nil and p != other:
+    p = p.base
+  result = p == other

--- a/tests/lang_objects/objects/tgeneric_base_runtime_of.nim
+++ b/tests/lang_objects/objects/tgeneric_base_runtime_of.nim
@@ -1,0 +1,26 @@
+discard """
+  description: '''
+    Tests to make sure the run-time 'of' works correctly when the base type
+    is generic.
+  '''
+  targets: "c js vm"
+"""
+
+type
+  Base[T] = object of RootObj
+    x: T
+  DerivedA = object of Base[int]
+  DerivedB = object of Base[float]
+
+var a: ref RootObj = new(DerivedA)
+var b: ref RootObj = new(DerivedB)
+
+doAssert a of DerivedA
+doAssert a of Base[int]
+doAssert not(a of DerivedB)
+doAssert not(a of Base[float])
+
+doAssert b of DerivedB
+doAssert b of Base[float]
+doAssert not(b of DerivedA)
+doAssert not(b of Base[int])

--- a/tests/lang_objects/objects/tphantom_object_runtime_relation.nim
+++ b/tests/lang_objects/objects/tphantom_object_runtime_relation.nim
@@ -26,15 +26,5 @@ var
 # dynamic checks (the location's static type is not known at compile-time):
 doAssert r1 of PhantomBase[int]
 doAssert r2 of PhantomBase[float]
-
-template check(cond: bool) =
-  when defined(c):
-    # XXX: the tests don't fail at the moment, as the generated names
-    #      don't include the instantiated-with parameters
-    doAssert(not cond, "run-time relation works as it should")
-  else:
-    # works properly with the other backends
-    doAssert cond
-
-check not(r1 of PhantomBase[float])
-check not(r2 of PhantomBase[int])
+doAssert not(r1 of PhantomBase[float])
+doAssert not(r2 of PhantomBase[int])


### PR DESCRIPTION
## Summary

Use a pointer-chasing approach for implementing `of` for CGIR-based
backends, fixing a bug with generic base type and improving the
performance of `of` and `method` dispatching.

## Details

* add the `base` field to the version 2 RTTI, for storing a reference
  to the parent type's RTTI
* add the `isObjV2` compilerproc, which uses the new `base` field for
  implementing the `of` type relation test
  * `isObj` cannot be reused, as it's still needed by the csources
    compiler
* change `mir2cg` to emit the necessary RTTI initialization and to
  use `isObjV2`

In theory, the new approach also allows for RTTI to work across dynamic
library borders (by using known names for the RTTI global and then
importing them), but this isn't implemented nor tested yet.

Judging by some limited testing, the pointer-chasing approach to
implementing the `of` relation test is quite a bit faster than the
previous string comparison.

Fixes https://github.com/nim-works/nimskull/issues/1677 .