### PR TITLE
mir2cg: handle unary int and float plus

### DIFF
--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -1624,6 +1624,8 @@ proc magicToCgir(c; env; tree; n; dest: Expr, stmts, bu) =
           Bitcast(UInt8Type, ^arg(0)),
           Bitcast(UInt8Type, ^arg(1))),
         ^c.genInt(env, 0, UInt8Type, bu)))
+  of mUnaryPlusI, mUnaryPlusF64:
+    wrapAsgn ^arg(0)
   of mAddU, mSubU, mMulU, mDivU, mModU:
     const Map = [mAddU: cnkAdd, mSubU: cnkSub,
                  mMulU: cnkMul, mDivU: cnkDiv, mModU: cnkMod]

--- a/tests/ccgbugs/tunary_plus.nim
+++ b/tests/ccgbugs/tunary_plus.nim
@@ -1,0 +1,38 @@
+discard """
+  description: "Compiler regression tests for unary plus"
+"""
+
+block static_plus:
+  discard +1
+
+block int_plus:
+  var i = 1
+  discard +i
+
+block int8_plus:
+  var i8: int8 = 1
+  discard +i8
+
+block int16_plus:
+  var i16: int16 = 1
+  discard +i16
+
+block int32_plus:
+  var i32: int32 = 1
+  discard +i32
+
+block int64_plus:
+  var i64: int64 = 1
+  discard +i64
+
+block float_plus:
+  var f = 1.0
+  discard +f
+
+block float32_plus:
+  var f32: float32 = 1.0
+  discard +f32
+
+block float64_plus:
+  var f64: float64 = 1.0
+  discard +f64

--- a/tests/magics/tunary_plus.nim
+++ b/tests/magics/tunary_plus.nim
@@ -1,5 +1,6 @@
 discard """
-  description: "Compiler regression tests for unary plus"
+  description: "Unary plus operator tests"
+  targets: "c js vm"
 """
 
 block static_plus:
@@ -24,6 +25,9 @@ block int32_plus:
 block int64_plus:
   var i64: int64 = 1
   discard +i64
+
+block static_float_plus:
+  discard +1.0
 
 block float_plus:
   var f = 1.0


### PR DESCRIPTION
## Summary

Unary int and float plus operations no longer result in a compiler
crash, and are handled correctly as a no-op.

## Details

`mir2cg`  now correctly handles no-oping unary int and float plus
operations, where previously it didn't and fell through to the catch-all
assertion resulting in a compiler crash. Also added a test to avoid
future regressions.

fixes: https://github.com/nim-works/nimskull/issues/1681