### PR TITLE
sem: fix invalid case object discriminant crash

### DIFF
--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -888,26 +888,23 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   incl(a[0].sym.flags, sfDiscriminant)
   var covered = toInt128(0)
   var chckCovered = false
-  var doOrdinalChecks = true
   var typ = skipTypes(a[0].typ, abstractVar-{tyTypeDesc})
   const shouldChckCovered = {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32, tyBool}
   case typ.kind
   of shouldChckCovered:
     chckCovered = true
   of tyFloat..tyFloat64, tyError:
-    doOrdinalChecks = false
+    discard
   of tyRange:
     if skipTypes(typ[0], abstractInst).kind in shouldChckCovered:
       chckCovered = true
   of tyForward:
     errorUndeclaredIdentifier(c, n[0].info, typ.sym.name.s)
-    doOrdinalChecks = false
   elif not isOrdinalType(typ):
     localReport(c.config, n[0].info, reportTyp(
       rsemExpectedOrdinalOrFloat, typ))
-    doOrdinalChecks = false
 
-  if doOrdinalChecks:
+  if chckCovered:
     if firstOrd(c.config, typ) != 0:
       localReport(c.config, n.info, SemReport(
         kind: rsemExpectedLow0Discriminant,

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -888,38 +888,42 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   incl(a[0].sym.flags, sfDiscriminant)
   var covered = toInt128(0)
   var chckCovered = false
+  var doOrdinalChecks = true
   var typ = skipTypes(a[0].typ, abstractVar-{tyTypeDesc})
   const shouldChckCovered = {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32, tyBool}
   case typ.kind
   of shouldChckCovered:
     chckCovered = true
   of tyFloat..tyFloat64, tyError:
-    discard
+    doOrdinalChecks = false
   of tyRange:
     if skipTypes(typ[0], abstractInst).kind in shouldChckCovered:
       chckCovered = true
   of tyForward:
     errorUndeclaredIdentifier(c, n[0].info, typ.sym.name.s)
+    doOrdinalChecks = false
   elif not isOrdinalType(typ):
     localReport(c.config, n[0].info, reportTyp(
       rsemExpectedOrdinalOrFloat, typ))
+    doOrdinalChecks = false
 
-  if firstOrd(c.config, typ) != 0:
-    localReport(c.config, n.info, SemReport(
-      kind: rsemExpectedLow0Discriminant,
-      # TODO: fix storage and actually report data, previously captured:
-      #       - expected: toInt128(0),
-      #       - got: firstOrd(c.config, typ)),
-      typ: typ,
-      sym: a[0].sym))
-  elif lengthOrd(c.config, typ) > 0x00007FFF:
-    localReport(c.config, n.info, SemReport(
-      kind: rsemExpectedHighCappedDiscriminant,
-      # TODO: fix storage and actually report data, previously captured:
-      #       - expected: toInt128(32768),
-      #       - got: firstOrd(c.config, typ)),
-      typ: typ,
-      sym: a[0].sym))
+  if doOrdinalChecks:
+    if firstOrd(c.config, typ) != 0:
+      localReport(c.config, n.info, SemReport(
+        kind: rsemExpectedLow0Discriminant,
+        # TODO: fix storage and actually report data, previously captured:
+        #       - expected: toInt128(0),
+        #       - got: firstOrd(c.config, typ)),
+        typ: typ,
+        sym: a[0].sym))
+    elif lengthOrd(c.config, typ) > 0x00007FFF:
+      localReport(c.config, n.info, SemReport(
+        kind: rsemExpectedHighCappedDiscriminant,
+        # TODO: fix storage and actually report data, previously captured:
+        #       - expected: toInt128(32768),
+        #       - got: firstOrd(c.config, typ)),
+        typ: typ,
+        sym: a[0].sym))
 
   for i in 1..<n.len:
     let b = n[i]

--- a/tests/errmsgs/tout_of_order_case.nim
+++ b/tests/errmsgs/tout_of_order_case.nim
@@ -1,0 +1,17 @@
+discard """
+  errormsg: "undeclared identifier: 'Enum'"
+  line: 14
+"""
+
+# TODO: This is not an ideal error message, it should be improved and the
+#       test updated accordingly. Alternatively, and likely better we should
+#       defer the current type semantic analysis, and perform it after the
+#       `Enum` type has been declared, and if we can't defer any more we should
+#       report an error.
+
+type
+  Object = object
+    case x: Enum
+    of a, b:
+      discard
+  Enum = enum a, b

--- a/tests/errmsgs/tout_of_order_case.nim
+++ b/tests/errmsgs/tout_of_order_case.nim
@@ -1,6 +1,6 @@
 discard """
-  errormsg: "undeclared identifier: 'Enum'"
-  line: 14
+  action: reject
+  matrix: "--errorMax:2"
 """
 
 # TODO: This is not an ideal error message, it should be improved and the
@@ -11,7 +11,9 @@ discard """
 
 type
   Object = object
-    case x: Enum
-    of a, b:
+    case x: Enum #[tt.Error
+         ^ undeclared identifier: 'Enum' ]#
+    of a, b: #[tt.Error
+       ^ undeclared identifier: 'a' ]#
       discard
   Enum = enum a, b


### PR DESCRIPTION
## Summary

The compiler no longer crashes when an invalid discrimanant type is
provided in a variant type declaration.

## Details

The compiler crashed if error reporting beyond the first error was
enabled, and the discrimanant field was invalid. This is because ordinal
field validation functions, which contain assertions on input type, were
being called on an invalid discrimanant field.

Now the checks are only run if the field is a valid type.

Fixes: https://github.com/nim-works/nimskull/issues/1680