### PR TITLE
mir2cg: emit better code for string concatenation

### DIFF
--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -1870,18 +1870,29 @@ proc magicToCgir(c; env; tree; n; dest: Expr, stmts, bu) =
     var
       temp  = c.newTemp(env, StringType, stmts, bu)
       len   = Expr(typ: VoidType)
+      clen  = 0 # constant length
 
     # compute the length expression:
     for (_, _, it) in tree.arguments(n):
-      let val =
-        if tree[it].typ == CharType:
-          bu.buildExpr env.types.sizeType:
-            ^c.genInt(env, 1, env.types.sizeType, bu)
-        else:
-          let L = c.newTemp(env, env.types.sizeType, stmts, bu)
-          c.emitLength(env, L, value(it), stmts, bu)
-          L
+      if tree[it].typ == CharType:
+        inc clen
+      elif tree[it].kind == mnkConst:
+        # can only be a constant string
+        inc clen, env[env[env.dataFor(tree[it].cnst)][0].strVal].len
+      else:
+        let L = c.newTemp(env, env.types.sizeType, stmts, bu)
+        c.emitLength(env, L, value(it), stmts, bu)
 
+        if len.typ == VoidType:
+          len = L
+        else:
+          len = bu.buildExpr env.types.sizeType:
+            Add(^env.types.sizeType, *use(len), *use(L))
+
+    # combine the 'len' expression with the constant part, if any:
+    if clen != 0:
+      let val = bu.buildExpr env.types.sizeType:
+        ^c.genInt(env, clen, env.types.sizeType, bu)
       if len.typ == VoidType:
         len = val
       else:


### PR DESCRIPTION
## Summary

Improve the code emitted for string concatenation with many static-
length operands. Only the C backend is affected.

## Details

Restore the optimization from the old C code generator where the
additions of all statically-known operand lengths are folded into a
single int constant. This significantly reduces the amount of code
produced for a string concatenation expression with many operands
whose length is statically known.

The optimization mainly improves compilation times (less CG trees
means less downstream work) and memory usage, but not run-time
efficiency, as the folding is trivial to perform for C compilers.