### PR TITLE
ast_types: fix possible memory leak with `TAstDiag`

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1278,9 +1278,7 @@ type
     adSemDeprecatedCompilerOptArg   # warning promoted to error
 
   PAstDiag* = ref TAstDiag
-  TAstDiag* {.acyclic.} = object
-    ## A diagnostic must never store a tree that references the diagnostic
-    ## itself.
+  TAstDiag* = object
     # xxx: consider splitting storage type vs message
     # xxx: consider breaking up diag into smaller types
     # xxx: try to shrink the int/int128 etc types for counts/ordinals


### PR DESCRIPTION
## Summary

Fix a compiler memory leak involving diagnostics. Only long running
processes, such as `nimsuggest`, were affected to a significant degree.

## Details

While diagnostics mustn't hold a tree directly holding a reference to
the diagnostic itself (which is the assumption the decision to use
`TAstDiag` as `.acyclic` was based on), it's possible (and valid) for a
diagnostic to contain a tree that holds a reference to a symbol, which
in turn holds a reference to the tree containing the diagnostic
(a reference cycle).

Due to the `.acyclic` marker on `TAstDiag`, all reference cycles in
which a `TAstDiag` is a contributor were never freed. The `.acyclic`
marker is removed, fixing the problem.