### PR TITLE
packedsets: simplify implementation using Table

### DIFF
--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -1,165 +1,49 @@
 #
 #
-#            Nim's Runtime Library
-#        (c) Copyright 2012 Andreas Rumpf
+#                 NimSkull's runtime library
+#              (c) Copyright 2012 Andreas Rumpf
+#     (c) Copyright 2024 Leorize <leorize+oss@disroot.org>
 #
-#    See the file "copying.txt", included in this
-#    distribution, for details about the copyright.
-#
+# See the file "copying.txt", included in this distribution, for
+# details about copyright.
+
+import std/tables
 
 ## The `packedsets` module implements an efficient `Ordinal` set implemented as a
-## `sparse bit set`:idx:.
+## simple sparse bitmap:idx:.
 ##
-## Supports any Ordinal type.
-##
-## .. note:: Currently the assignment operator `=` for `PackedSet[A]`
-##   performs some rather meaningless shallow copy. Since Nim currently does
-##   not allow the assignment operator to be overloaded, use the `assign proc
-##   <#assign,PackedSet[A],PackedSet[A]>`_ to get a deep copy.
+## This bitmap is optimized for relatively low number of values (less than 1
+## million entries) and trade memory usage for time.
 ##
 ## See also
 ## ========
 ## * `sets module <sets.html>`_ for more general hash sets
 
-import std/private/since
-import std/hashes
-
 type
-  BitScalar = uint
-
-const
-  InitIntSetSize = 8              # must be a power of two!
-  TrunkShift = 9
-  BitsPerTrunk = 1 shl TrunkShift # needs to be a power of 2 and
-                                  # divisible by 64
-  TrunkMask = BitsPerTrunk - 1
-  IntsPerTrunk = BitsPerTrunk div (sizeof(BitScalar) * 8)
-  IntShift = 5 + ord(sizeof(BitScalar) == 8) # 5 or 6, depending on int width
-  IntMask = 1 shl IntShift - 1
-
-type
-  Trunk {.acyclic.} = ref object
-    next: Trunk                                 # all nodes are connected with this pointer
-    key: int                                    # start address at bit 0
-    bits: array[0..IntsPerTrunk - 1, BitScalar] # a bit vector
-
-  TrunkSeq = seq[Trunk]
+  Word = set[uint8]
+    ## A bitmap "word".
 
   PackedSet*[A: Ordinal] = object
-    ## An efficient set of `Ordinal` types implemented as a sparse bit set.
-    elems: int           # only valid for small numbers
-    counter, max: int
-    head: Trunk
-    data: TrunkSeq
-    a: array[0..33, int] # profiling shows that 34 elements are enough
+    ## An efficient set of `Ordinal` implemented as a sparse bitmap.
+    # Bootstrap is tripped by the sizeof
+    when defined(nimKochBootstrap):
+      bitmap: Table[uint64, Word]
+    else:
+      when sizeof(A) > sizeof(uint32):
+        bitmap: Table[uint64, Word]
+      else:
+        bitmap: Table[uint32, Word]
 
-proc mustRehash[T](t: T): bool {.inline.} =
-  let length = t.max + 1
-  assert length > t.counter
-  result = (length * 2 < t.counter * 3) or (length - t.counter < 4)
-
-proc nextTry(h, maxHash: Hash, perturb: var Hash): Hash {.inline.} =
-  const PERTURB_SHIFT = 5
-  var perturb2 = cast[uint](perturb) shr PERTURB_SHIFT
-  perturb = cast[Hash](perturb2)
-  result = ((5 * h) + 1 + perturb) and maxHash
-
-proc packedSetGet[A](t: PackedSet[A], key: int): Trunk =
-  var h = key and t.max
-  var perturb = key
-  while t.data[h] != nil:
-    if t.data[h].key == key:
-      return t.data[h]
-    h = nextTry(h, t.max, perturb)
-  result = nil
-
-proc intSetRawInsert[A](t: PackedSet[A], data: var TrunkSeq, desc: Trunk) =
-  var h = desc.key and t.max
-  var perturb = desc.key
-  while data[h] != nil:
-    assert data[h] != desc
-    h = nextTry(h, t.max, perturb)
-  assert data[h] == nil
-  data[h] = desc
-
-proc intSetEnlarge[A](t: var PackedSet[A]) =
-  var n: TrunkSeq
-  var oldMax = t.max
-  t.max = ((t.max + 1) * 2) - 1
-  newSeq(n, t.max + 1)
-  for i in countup(0, oldMax):
-    if t.data[i] != nil: intSetRawInsert(t, n, t.data[i])
-  swap(t.data, n)
-
-proc intSetPut[A](t: var PackedSet[A], key: int): Trunk =
-  var h = key and t.max
-  var perturb = key
-  while t.data[h] != nil:
-    if t.data[h].key == key:
-      return t.data[h]
-    h = nextTry(h, t.max, perturb)
-  if mustRehash(t): intSetEnlarge(t)
-  inc(t.counter)
-  h = key and t.max
-  perturb = key
-  while t.data[h] != nil: h = nextTry(h, t.max, perturb)
-  assert t.data[h] == nil
-  new(result)
-  result.next = t.head
-  result.key = key
-  t.head = result
-  t.data[h] = result
-
-proc bitincl[A](s: var PackedSet[A], key: int) {.inline.} =
-  var t = intSetPut(s, key shr TrunkShift)
-  var u = key and TrunkMask
-  t.bits[u shr IntShift] = t.bits[u shr IntShift] or
-      (BitScalar(1) shl (u and IntMask))
-
-proc exclImpl[A](s: var PackedSet[A], key: int) =
-  if s.elems <= s.a.len:
-    for i in 0..<s.elems:
-      if s.a[i] == key:
-        s.a[i] = s.a[s.elems - 1]
-        dec(s.elems)
-        return
+template internalType(A: typedesc[Ordinal]): untyped =
+  ## Return the internal type used for representation of `A`.
+  when defined(nimKochBootstrap):
+    uint64
+  elif sizeof(A) > sizeof(uint32):
+    uint64
   else:
-    var t = packedSetGet(s, key shr TrunkShift)
-    if t != nil:
-      var u = key and TrunkMask
-      t.bits[u shr IntShift] = t.bits[u shr IntShift] and
-          not(BitScalar(1) shl (u and IntMask))
+    uint32
 
-template dollarImpl(): untyped =
-  result = "{"
-  for key in items(s):
-    if result.len > 1: result.add(", ")
-    result.add $key
-  result.add("}")
-
-iterator items*[A](s: PackedSet[A]): A {.inline.} =
-  ## Iterates over any included element of `s`.
-  if s.elems <= s.a.len:
-    for i in 0..<s.elems:
-      yield A(s.a[i])
-  else:
-    var r = s.head
-    while r != nil:
-      var i = 0
-      while i <= high(r.bits):
-        var w: uint = r.bits[i]
-        # taking a copy of r.bits[i] here is correct, because
-        # modifying operations are not allowed during traversation
-        var j = 0
-        while w != 0: # test all remaining bits for zero
-          if (w and 1) != 0: # the bit is set!
-            yield A((r.key shl TrunkShift) or (i shl IntShift +% j))
-          inc(j)
-          w = w shr 1
-        inc(i)
-      r = r.next
-
-proc initPackedSet*[A]: PackedSet[A] =
+proc initPackedSet*[A]: PackedSet[A] {.inline.} =
   ## Returns an empty `PackedSet[A]`.
   ## `A` must be `Ordinal`.
   ##
@@ -173,15 +57,43 @@ proc initPackedSet*[A]: PackedSet[A] =
     var ids = initPackedSet[Id]()
     ids.incl(3.Id)
 
-  result = PackedSet[A](
-    elems: 0,
-    counter: 0,
-    max: 0,
-    head: nil,
-    data: @[])
-  #  a: array[0..33, int] # profiling shows that 34 elements are enough
+  PackedSet[A]()
 
-proc contains*[A](s: PackedSet[A], key: A): bool =
+proc initPackedSet[A](cap: Natural): PackedSet[A] {.inline.} =
+  ## Creates a PackedSet with `cap` buckets preallocated.
+  result.bitmap = initTable[internalType(A), Word](cap)
+
+proc len*[A](s: PackedSet[A]): int {.inline.} =
+  ## Returns the number of elements in `s`.
+  runnableExamples:
+    let a = [1, 3, 5].toPackedSet
+    assert len(a) == 3
+
+  for word in s.bitmap.values:
+    result.inc len(word)
+
+proc clear*[A](result: var PackedSet[A]) {.inline.} =
+  ## Clears the `PackedSet[A]` back to an empty state.
+  runnableExamples:
+    var a = [5, 7].toPackedSet
+    clear(a)
+    assert len(a) == 0
+
+  clear result.bitmap
+
+proc toInternal[A](x: A): uint16 or uint32 or uint64 {.inline.} =
+  ## Convert `x` into the internal representation.
+  cast[internalType(A)](x)
+
+proc split[T: uint32 or uint64](key: T): tuple[high: T, low: uint8] {.inline.} =
+  ## Split `key` into low and high portions
+  (key shr 8, uint8(key))
+
+proc join[T: uint32 or uint64](high: T, low: uint8): T {.inline.} =
+  ## Join high and low portions into the original value
+  (high shl 8) or T(low)
+
+proc contains*[A](s: PackedSet[A], key: A): bool {.inline.} =
   ## Returns true if `key` is in `s`.
   ##
   ## This allows the usage of the `in` operator.
@@ -199,82 +111,10 @@ proc contains*[A](s: PackedSet[A], key: A): bool =
     assert C in letters
     assert B notin letters
 
-  if s.elems <= s.a.len:
-    for i in 0..<s.elems:
-      if s.a[i] == ord(key): return true
-  else:
-    var t = packedSetGet(s, ord(key) shr TrunkShift)
-    if t != nil:
-      var u = ord(key) and TrunkMask
-      result = (t.bits[u shr IntShift] and
-                (BitScalar(1) shl (u and IntMask))) != 0
-    else:
-      result = false
+  let (high, low) = split(key.toInternal)
+  s.bitmap.getOrDefault(high, {}).contains(low)
 
-proc incl*[A](s: var PackedSet[A], key: A) =
-  ## Includes an element `key` in `s`.
-  ##
-  ## This doesn't do anything if `key` is already in `s`.
-  ##
-  ## **See also:**
-  ## * `excl proc <#excl,PackedSet[A],A>`_ for excluding an element
-  ## * `incl proc <#incl,PackedSet[A],PackedSet[A]>`_ for including a set
-  ## * `containsOrIncl proc <#containsOrIncl,PackedSet[A],A>`_
-  runnableExamples:
-    var a = initPackedSet[int]()
-    a.incl(3)
-    a.incl(3)
-    assert len(a) == 1
-
-  if s.elems <= s.a.len:
-    for i in 0..<s.elems:
-      if s.a[i] == ord(key): return
-    if s.elems < s.a.len:
-      s.a[s.elems] = ord(key)
-      inc(s.elems)
-      return
-    newSeq(s.data, InitIntSetSize)
-    s.max = InitIntSetSize - 1
-    for i in 0..<s.elems:
-      bitincl(s, s.a[i])
-    s.elems = s.a.len + 1
-    # fall through:
-  bitincl(s, ord(key))
-
-proc incl*[A](s: var PackedSet[A], other: PackedSet[A]) =
-  ## Includes all elements from `other` into `s`.
-  ##
-  ## This is the in-place version of `s + other <#+,PackedSet[A],PackedSet[A]>`_.
-  ##
-  ## **See also:**
-  ## * `excl proc <#excl,PackedSet[A],PackedSet[A]>`_ for excluding a set
-  ## * `incl proc <#incl,PackedSet[A],A>`_ for including an element
-  ## * `containsOrIncl proc <#containsOrIncl,PackedSet[A],A>`_
-  runnableExamples:
-    var a = [1].toPackedSet
-    a.incl([5].toPackedSet)
-    assert len(a) == 2
-    assert 5 in a
-
-  for item in other.items: incl(s, item)
-
-proc toPackedSet*[A](x: openArray[A]): PackedSet[A] {.since: (1, 3).} =
-  ## Creates a new `PackedSet[A]` that contains the elements of `x`.
-  ##
-  ## Duplicates are removed.
-  ##
-  ## **See also:**
-  ## * `initPackedSet proc <#initPackedSet>`_
-  runnableExamples:
-    let a = [5, 6, 7, 8, 8].toPackedSet
-    assert len(a) == 4
-    assert $a == "{5, 6, 7, 8}"
-
-  result = initPackedSet[A]()
-  for item in x:
-    result.incl(item)
-
-proc containsOrIncl*[A](s: var PackedSet[A], key: A): bool =
+proc containsOrIncl*[A](s: var PackedSet[A], key: A): bool {.inline.} =
   ## Includes `key` in the set `s` and tells if `key` was already in `s`.
   ##
   ## The difference with regards to the `incl proc <#incl,PackedSet[A],A>`_ is
@@ -291,75 +131,67 @@ proc containsOrIncl*[A](s: var PackedSet[A], key: A): bool =
     assert a.containsOrIncl(3) == true
     assert a.containsOrIncl(4) == false
 
-  if s.elems <= s.a.len:
-    for i in 0..<s.elems:
-      if s.a[i] == ord(key):
-        return true
-    incl(s, key)
+  let (high, low) = split(key.toInternal)
+  if high notin s.bitmap:
+    s.bitmap[high] = {low}
     result = false
   else:
-    var t = packedSetGet(s, ord(key) shr TrunkShift)
-    if t != nil:
-      var u = ord(key) and TrunkMask
-      result = (t.bits[u shr IntShift] and BitScalar(1) shl (u and IntMask)) != 0
-      if not result:
-        t.bits[u shr IntShift] = t.bits[u shr IntShift] or
-            (BitScalar(1) shl (u and IntMask))
-    else:
-      incl(s, key)
-      result = false
+    result = s.bitmap[high].contains(low)
+    s.bitmap[high].incl(low)
 
-proc excl*[A](s: var PackedSet[A], key: A) =
-  ## Excludes `key` from the set `s`.
+proc incl*[A](s: var PackedSet[A], key: A) {.inline.} =
+  ## Includes an element `key` in `s`.
   ##
-  ## This doesn't do anything if `key` is not found in `s`.
+  ## This doesn't do anything if `key` is already in `s`.
   ##
   ## **See also:**
-  ## * `incl proc <#incl,PackedSet[A],A>`_ for including an element
-  ## * `excl proc <#excl,PackedSet[A],PackedSet[A]>`_ for excluding a set
-  ## * `missingOrExcl proc <#missingOrExcl,PackedSet[A],A>`_
-  runnableExamples:
-    var a = [3].toPackedSet
-    a.excl(3)
-    a.excl(3)
-    a.excl(99)
-    assert len(a) == 0
-
-  exclImpl[A](s, ord(key))
-
-proc excl*[A](s: var PackedSet[A], other: PackedSet[A]) =
-  ## Excludes all elements from `other` from `s`.
-  ##
-  ## This is the in-place version of `s - other <#-,PackedSet[A],PackedSet[A]>`_.
-  ##
-  ## **See also:**
-  ## * `incl proc <#incl,PackedSet[A],PackedSet[A]>`_ for including a set
   ## * `excl proc <#excl,PackedSet[A],A>`_ for excluding an element
-  ## * `missingOrExcl proc <#missingOrExcl,PackedSet[A],A>`_
+  ## * `incl proc <#incl,PackedSet[A],PackedSet[A]>`_ for including a set
+  ## * `containsOrIncl proc <#containsOrIncl,PackedSet[A],A>`_
   runnableExamples:
-    var a = [1, 5].toPackedSet
-    a.excl([5].toPackedSet)
+    var a = initPackedSet[int]()
+    a.incl(3)
+    a.incl(3)
     assert len(a) == 1
-    assert 5 notin a
 
-  for item in other.items:
-    excl(s, item)
+  let (high, low) = split(key.toInternal)
+  s.bitmap.mgetOrPut(high, {low}).incl(low)
 
-proc len*[A](s: PackedSet[A]): int {.inline.} =
-  ## Returns the number of elements in `s`.
+proc incl*[A](s: var PackedSet[A], other: PackedSet[A]) {.inline.} =
+  ## Includes all elements from `other` into `s`.
+  ##
+  ## This is the in-place version of `s + other <#+,PackedSet[A],PackedSet[A]>`_.
+  ##
+  ## **See also:**
+  ## * `excl proc <#excl,PackedSet[A],PackedSet[A]>`_ for excluding a set
+  ## * `incl proc <#incl,PackedSet[A],A>`_ for including an element
+  ## * `containsOrIncl proc <#containsOrIncl,PackedSet[A],A>`_
   runnableExamples:
-    let a = [1, 3, 5].toPackedSet
-    assert len(a) == 3
+    var a = [1].toPackedSet
+    a.incl([5].toPackedSet)
+    assert len(a) == 2
+    assert 5 in a
 
-  if s.elems < s.a.len:
-    result = s.elems
-  else:
-    result = 0
-    for _ in s.items:
-      # pending bug #11167; when fixed, check each explicit `items` to see if it can be removed
-      inc(result)
+  for high, word in other.bitmap.pairs:
+    let merged = s.bitmap.getOrDefault(high, {}) + word
+    s.bitmap[high] = merged
 
-proc missingOrExcl*[A](s: var PackedSet[A], key: A): bool =
+proc toPackedSet*[A](x: openArray[A]): PackedSet[A] =
+  ## Creates a new `PackedSet[A]` that contains the elements of `x`.
+  ##
+  ## Duplicates are removed.
+  ##
+  ## **See also:**
+  ## * `initPackedSet proc <#initPackedSet>`_
+  runnableExamples:
+    let a = [5, 6, 7, 8, 8].toPackedSet
+    assert len(a) == 4
+    assert $a == "{5, 6, 7, 8}"
+
+  for value in x.items:
+    result.incl(value)
+
+proc missingOrExcl*[A](s: var PackedSet[A], key: A): bool {.inline.} =
   ## Excludes `key` from the set `s` and tells if `key` was already missing from `s`.
   ##
   ## The difference with regards to the `excl proc <#excl,PackedSet[A],A>`_ is
@@ -376,79 +208,57 @@ proc missingOrExcl*[A](s: var PackedSet[A], key: A): bool =
     assert a.missingOrExcl(5) == false
     assert a.missingOrExcl(5) == true
 
-  var count = s.len
-  exclImpl(s, ord(key))
-  result = count == s.len
+  let (high, low) = split(key.toInternal)
+  if high notin s.bitmap:
+    result = true
+  else:
+    result = not s.bitmap[high].contains(low)
+    s.bitmap[high].excl(low)
+    if s.bitmap[high].len == 0:
+      s.bitmap.del(high)
 
-proc clear*[A](result: var PackedSet[A]) =
-  ## Clears the `PackedSet[A]` back to an empty state.
+proc excl*[A](s: var PackedSet[A], key: A) {.inline.} =
+  ## Excludes `key` from the set `s`.
+  ##
+  ## This doesn't do anything if `key` is not found in `s`.
+  ##
+  ## **See also:**
+  ## * `incl proc <#incl,PackedSet[A],A>`_ for including an element
+  ## * `excl proc <#excl,PackedSet[A],PackedSet[A]>`_ for excluding a set
+  ## * `missingOrExcl proc <#missingOrExcl,PackedSet[A],A>`_
   runnableExamples:
-    var a = [5, 7].toPackedSet
-    clear(a)
+    var a = [3].toPackedSet
+    a.excl(3)
+    a.excl(3)
+    a.excl(99)
     assert len(a) == 0
 
-  # setLen(result.data, InitIntSetSize)
-  # for i in 0..InitIntSetSize - 1: result.data[i] = nil
-  # result.max = InitIntSetSize - 1
-  result.data = @[]
-  result.max = 0
-  result.counter = 0
-  result.head = nil
-  result.elems = 0
+  discard s.missingOrExcl(key)
 
-proc isNil*[A](x: PackedSet[A]): bool {.inline.} =
-  ## Returns true if `x` is empty, false otherwise.
+proc excl*[A](s: var PackedSet[A], other: PackedSet[A]) =
+  ## Excludes all elements from `other` from `s`.
+  ##
+  ## This is the in-place version of `s - other <#-,PackedSet[A],PackedSet[A]>`_.
+  ##
+  ## **See also:**
+  ## * `incl proc <#incl,PackedSet[A],PackedSet[A]>`_ for including a set
+  ## * `excl proc <#excl,PackedSet[A],A>`_ for excluding an element
+  ## * `missingOrExcl proc <#missingOrExcl,PackedSet[A],A>`_
   runnableExamples:
-    var a = initPackedSet[int]()
-    assert a.isNil
-    a.incl(2)
-    assert not a.isNil
-    a.excl(2)
-    assert a.isNil
+    var a = [1, 5].toPackedSet
+    a.excl([5].toPackedSet)
+    assert len(a) == 1
+    assert 5 notin a
 
-  x.head.isNil and x.elems == 0
+  for high, word in other.bitmap.pairs:
+    if high in s.bitmap:
+      let excluded = s.bitmap[high] - word
+      if excluded.len == 0:
+        s.bitmap.del high
+      else:
+        s.bitmap[high] = excluded
 
-proc assign*[A](dest: var PackedSet[A], src: PackedSet[A]) =
-  ## Copies `src` to `dest`.
-  ## `dest` does not need to be initialized by the `initPackedSet proc <#initPackedSet>`_.
-  runnableExamples:
-    var
-      a = initPackedSet[int]()
-      b = initPackedSet[int]()
-    b.incl(5)
-    b.incl(7)
-    a.assign(b)
-    assert len(a) == 2
-
-  if src.elems <= src.a.len:
-    dest.data = @[]
-    dest.max = 0
-    dest.counter = src.counter
-    dest.head = nil
-    dest.elems = src.elems
-    dest.a = src.a
-  else:
-    dest.counter = src.counter
-    dest.max = src.max
-    dest.elems = src.elems
-    newSeq(dest.data, src.data.len)
-
-    var it = src.head
-    while it != nil:
-      var h = it.key and dest.max
-      var perturb = it.key
-      while dest.data[h] != nil: h = nextTry(h, dest.max, perturb)
-      assert dest.data[h] == nil
-      var n: Trunk
-      new(n)
-      n.next = dest.head
-      n.key = it.key
-      n.bits = it.bits
-      dest.head = n
-      dest.data[h] = n
-      it = it.next
-
-proc union*[A](s1, s2: PackedSet[A]): PackedSet[A] =
+proc union*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
   ## Returns the union of the sets `s1` and `s2`.
   ##
   ## The same as `s1 + s2 <#+,PackedSet[A],PackedSet[A]>`_.
@@ -460,10 +270,10 @@ proc union*[A](s1, s2: PackedSet[A]): PackedSet[A] =
     assert c.len == 5
     assert c == [1, 2, 3, 4, 5].toPackedSet
 
-  result.assign(s1)
-  incl(result, s2)
+  result = s1
+  result.incl s2
 
-proc intersection*[A](s1, s2: PackedSet[A]): PackedSet[A] =
+proc intersection*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
   ## Returns the intersection of the sets `s1` and `s2`.
   ##
   ## The same as `s1 * s2 <#*,PackedSet[A],PackedSet[A]>`_.
@@ -475,12 +285,17 @@ proc intersection*[A](s1, s2: PackedSet[A]): PackedSet[A] =
     assert c.len == 1
     assert c == [3].toPackedSet
 
-  result = initPackedSet[A]()
-  for item in s1.items:
-    if contains(s2, item):
-      incl(result, item)
+  if s1.bitmap.len < s2.bitmap.len:
+    result = intersection(s2, s1)
+  else:
+    result = initPackedSet[A](s1.bitmap.len)
+    for high, word in s1.bitmap.pairs:
+      if high in s2.bitmap:
+        let intersection = s2.bitmap[high] * word
+        if intersection.len > 0:
+          result.bitmap[high] = intersection
 
-proc difference*[A](s1, s2: PackedSet[A]): PackedSet[A] =
+proc difference*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
   ## Returns the difference of the sets `s1` and `s2`.
   ##
   ## The same as `s1 - s2 <#-,PackedSet[A],PackedSet[A]>`_.
@@ -492,12 +307,14 @@ proc difference*[A](s1, s2: PackedSet[A]): PackedSet[A] =
     assert c.len == 2
     assert c == [1, 2].toPackedSet
 
-  result = initPackedSet[A]()
-  for item in s1.items:
-    if not contains(s2, item):
-      incl(result, item)
+  result = initPackedSet[A](s1.bitmap.len)
+  for high, word in s1.bitmap.pairs:
+    if high in s2.bitmap:
+      let difference = word - s2.bitmap[high]
+      if difference.len > 0:
+        result.bitmap[high] = difference
 
-proc symmetricDifference*[A](s1, s2: PackedSet[A]): PackedSet[A] =
+proc symmetricDifference*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
   ## Returns the symmetric difference of the sets `s1` and `s2`.
   runnableExamples:
     let
@@ -507,24 +324,16 @@ proc symmetricDifference*[A](s1, s2: PackedSet[A]): PackedSet[A] =
     assert c.len == 4
     assert c == [1, 2, 4, 5].toPackedSet
 
-  result.assign(s1)
-  for item in s2.items:
-    if containsOrIncl(result, item):
-      excl(result, item)
+  result = s1
+  for high, word in s2.bitmap.pairs:
+    let rword = result.bitmap.getOrDefault(high)
+    let difference = (rword + word) - (rword * word)
+    if difference.len > 0:
+      result.bitmap[high] = difference
+    else:
+      result.bitmap.del(high)
 
-proc `+`*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
-  ## Alias for `union(s1, s2) <#union,PackedSet[A],PackedSet[A]>`_.
-  result = union(s1, s2)
-
-proc `*`*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
-  ## Alias for `intersection(s1, s2) <#intersection,PackedSet[A],PackedSet[A]>`_.
-  result = intersection(s1, s2)
-
-proc `-`*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
-  ## Alias for `difference(s1, s2) <#difference,PackedSet[A],PackedSet[A]>`_.
-  result = difference(s1, s2)
-
-proc disjoint*[A](s1, s2: PackedSet[A]): bool =
+proc disjoint*[A](s1, s2: PackedSet[A]): bool {.inline.} =
   ## Returns true if the sets `s1` and `s2` have no items in common.
   runnableExamples:
     let
@@ -534,10 +343,15 @@ proc disjoint*[A](s1, s2: PackedSet[A]): bool =
     assert disjoint(a, b) == false
     assert disjoint(a, c) == true
 
-  for item in s1.items:
-    if contains(s2, item):
-      return false
-  return true
+  if s1.bitmap.len < s2.bitmap.len:
+    result = disjoint(s2, s1)
+  else:
+    result = true
+    for high, word in s1.bitmap.pairs:
+      if high in s2.bitmap:
+        let intersection = s2.bitmap[high] * word
+        if intersection.len > 0:
+          return false
 
 proc card*[A](s: PackedSet[A]): int {.inline.} =
   ## Alias for `len() <#len,PackedSet[A]>`_.
@@ -546,7 +360,7 @@ proc card*[A](s: PackedSet[A]): int {.inline.} =
   ## of a set.
   result = s.len()
 
-proc `<=`*[A](s1, s2: PackedSet[A]): bool =
+proc `<=`*[A](s1, s2: PackedSet[A]): bool {.inline.} =
   ## Returns true if `s1` is a subset of `s2`.
   ##
   ## A subset `s1` has all of its elements in `s2`, but `s2` doesn't necessarily
@@ -560,12 +374,15 @@ proc `<=`*[A](s1, s2: PackedSet[A]): bool =
     assert b <= b
     assert not (c <= b)
 
-  for item in s1.items:
-    if not s2.contains(item):
-      return false
-  return true
+  if s1.bitmap.len > s2.bitmap.len:
+    return false
 
-proc `<`*[A](s1, s2: PackedSet[A]): bool =
+  result = true
+  for high, word in s1.bitmap.pairs:
+    if high notin s2.bitmap or word > s2.bitmap[high]:
+      return false
+
+proc `<`*[A](s1, s2: PackedSet[A]): bool {.inline.} =
   ## Returns true if `s1` is a proper subset of `s2`.
   ##
   ## A strict or proper subset `s1` has all of its elements in `s2`, but `s2` has
@@ -579,20 +396,44 @@ proc `<`*[A](s1, s2: PackedSet[A]): bool =
     assert not (b < b)
     assert not (c < b)
 
-  return s1 <= s2 and not (s2 <= s1)
+  s1.len < s2.len and s1 <= s2
 
-proc `==`*[A](s1, s2: PackedSet[A]): bool =
-  ## Returns true if both `s1` and `s2` have the same elements and set size.
-  runnableExamples:
-    assert [1, 2].toPackedSet == [2, 1].toPackedSet
-    assert [1, 2].toPackedSet == [2, 1, 2].toPackedSet
-
-  return s1 <= s2 and s2 <= s1
+iterator items*[A](s: PackedSet[A]): A {.inline.} =
+  ## Iterates over included elements of `s`.
+  for high, word in s.bitmap.pairs:
+    for low in word.items:
+      yield cast[A](join(high, low))
 
 proc `$`*[A](s: PackedSet[A]): string =
-  ## Converts `s` to a string.
-  runnableExamples:
-    let a = [1, 2, 3].toPackedSet
-    assert $a == "{1, 2, 3}"
+  ## Returns the string representation of `s`.
+  result.add '{'
+  for value in s.items:
+    let value = cast[A](value)
+    if result.len > 1:
+      result.add ", "
+    result.add $value
+  result.add '}'
 
-  dollarImpl()
+proc `+`*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
+  ## Alias for `union(s1, s2) <#union,PackedSet[A],PackedSet[A]>`_.
+  union(s1, s2)
+
+proc `*`*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
+  ## Alias for `intersection(s1, s2) <#intersection,PackedSet[A],PackedSet[A]>`_.
+  intersection(s1, s2)
+
+proc `-`*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
+  ## Alias for `difference(s1, s2) <#difference,PackedSet[A],PackedSet[A]>`_.
+  difference(s1, s2)
+
+proc `-+-`*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
+  ## Alias for `symmetricDifference(s1, s2) <#symmetricDifference,PackedSet[A],PackedSet[A]>`_.
+  symmetricDifference(s1, s2)
+
+proc isNil*[A](x: PackedSet[A]): bool {.inline, deprecated: "PackedSet can no longer be nil; use `x.len == 0` instead".} =
+  ## Returns true if `x` is empty, false otherwise.
+  x.len == 0
+
+proc assign*[A](dest: var PackedSet[A], src: sink PackedSet[A]) {.inline, deprecated: "PackedSet is now always deep copied; use `dest = src` instead".} =
+  ## Copies `src` to `dest`.
+  dest = src

--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -379,7 +379,7 @@ proc `<=`*[A](s1, s2: PackedSet[A]): bool {.inline.} =
 
   result = true
   for high, word in s1.bitmap.pairs:
-    if high notin s2.bitmap or word > s2.bitmap[high]:
+    if high notin s2.bitmap or not (word <= s2.bitmap[high]):
       return false
 
 proc `<`*[A](s1, s2: PackedSet[A]): bool {.inline.} =
@@ -397,6 +397,20 @@ proc `<`*[A](s1, s2: PackedSet[A]): bool {.inline.} =
     assert not (c < b)
 
   s1.len < s2.len and s1 <= s2
+
+proc `==`*[A](s1, s2: PackedSet[A]): bool =
+  ## Returns true if both `s1` and `s2` have the same elements and set size.
+  runnableExamples:
+    assert [1, 2].toPackedSet == [2, 1].toPackedSet
+    assert [1, 2].toPackedSet == [2, 1, 2].toPackedSet
+
+  if s1.bitmap.len != s2.bitmap.len:
+    return false
+
+  result = true
+  for high, word in s1.bitmap.pairs:
+    if high notin s2.bitmap or word != s2.bitmap[high]:
+      return false
 
 iterator items*[A](s: PackedSet[A]): A {.inline.} =
   ## Iterates over included elements of `s`.

--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -313,6 +313,8 @@ proc difference*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
       let difference = word - s2.bitmap[high]
       if difference.len > 0:
         result.bitmap[high] = difference
+    else:
+      result.bitmap[high] = word
 
 proc symmetricDifference*[A](s1, s2: PackedSet[A]): PackedSet[A] {.inline.} =
   ## Returns the symmetric difference of the sets `s1` and `s2`.

--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -136,8 +136,11 @@ proc containsOrIncl*[A](s: var PackedSet[A], key: A): bool {.inline.} =
     s.bitmap[high] = {low}
     result = false
   else:
-    result = s.bitmap[high].contains(low)
-    s.bitmap[high].incl(low)
+    try:
+      result = s.bitmap[high].contains(low)
+      s.bitmap[high].incl(low)
+    except KeyError:
+      unreachable()
 
 proc incl*[A](s: var PackedSet[A], key: A) {.inline.} =
   ## Includes an element `key` in `s`.
@@ -212,10 +215,13 @@ proc missingOrExcl*[A](s: var PackedSet[A], key: A): bool {.inline.} =
   if high notin s.bitmap:
     result = true
   else:
-    result = not s.bitmap[high].contains(low)
-    s.bitmap[high].excl(low)
-    if s.bitmap[high].len == 0:
-      s.bitmap.del(high)
+    try:
+      result = not s.bitmap[high].contains(low)
+      s.bitmap[high].excl(low)
+      if s.bitmap[high].len == 0:
+        s.bitmap.del(high)
+    except KeyError:
+      unreachable()
 
 proc excl*[A](s: var PackedSet[A], key: A) {.inline.} =
   ## Excludes `key` from the set `s`.

--- a/tests/stdlib/types/tpackedsets.nim
+++ b/tests/stdlib/types/tpackedsets.nim
@@ -4,6 +4,134 @@ import std/sets
 import std/sequtils
 import std/algorithm
 
+import std/typetraits
+
+import experimental/property_testing
+
+proc genOrdSet[T: SomeOrdinal](
+  g: sink Gen[T],
+  minLen = 0.Natural,
+  maxLen = 100.Natural,
+  exclude = HashSet[T](),
+  maxRetries = 100
+): Gen[HashSet[T]] =
+  assert minLen <= maxLen
+
+  result = proc (s: Source): HashSet[T] =
+    let (len, oldLen, _) = s.beginArray(minLen.uint32, maxLen.uint32)
+
+    var output = initHashSet[T](len.int)
+    let
+      pred = proc (x: T): bool =
+        x notin output and x notin exclude
+      filtered = filter(g, pred, maxRetries)
+    for _ in 0 ..< len:
+      output.incl filtered(s)
+
+    s.skipNodes(oldLen.int - len.int)
+
+    output
+
+proc toPackedSet[T: SomeOrdinal](hs: HashSet[T]): PackedSet[T] =
+  for i in hs.items:
+    result.incl i
+
+proc genPackedOrdSet[T: SomeOrdinal](
+  g: sink Gen[T],
+  minLen = 0.Natural,
+  maxLen = 100.Natural,
+  exclude = HashSet[T](),
+  maxRetries = 100
+): Gen[PackedSet[T]] =
+  map(
+    genOrdSet(g, minLen, maxLen, exclude, maxRetries),
+    toPackedSet
+  )
+
+proc `==`[T](ps: PackedSet[T], hs: HashSet[T]): bool =
+  if ps.len != hs.len:
+    return false
+
+  for i in hs.items:
+    if i notin ps:
+      return false
+
+  return true
+
+template property(name, gens, check: untyped): untyped =
+  block name:
+    let result = runProperty:
+      forAll gens: check
+
+    doAssert result.status == psPass, $result
+
+property canStoreInts, (hs: genOrdSet(genInt())):
+  let ps = toPackedSet(hs)
+  if ps == hs:
+    psPass
+  else:
+    psFail
+
+property canStoreUints, (hs: genOrdSet(genUint64())):
+  let ps = toPackedSet(hs)
+  if ps == hs:
+    psPass
+  else:
+    psFail
+
+block:
+  type Enum = enum A, B, C, D, E, F
+  property canStoreEnum, (hs: genOrdSet(genEnum[Enum](), maxLen = enumLen(Enum))):
+    let ps = toPackedSet(hs)
+    if ps == hs:
+      psPass
+    else:
+      psFail
+
+property toPackedSetDedups, (s: genSeq(genInt())):
+  let
+    hs = toHashSet(s)
+    ps = toPackedSet(s)
+
+  if ps == hs:
+    psPass
+  else:
+    psFail
+
+property iterateAllMembers, (hs: genOrdSet(genInt())):
+  let
+    ps = toPackedSet(hs)
+    hsElems = toSeq(hs.items).sorted()
+    psElems = toSeq(ps.items).sorted()
+
+  if ps == hs:
+    psPass
+  else:
+    psFail
+
+property containsOrIncl, (i: genInt(), ps: genPackedOrdSet(genInt(), exclude = [i].toHashSet)):
+  # Add once, should not be in the set
+  if ps.containsOrIncl(i):
+    return psFail
+
+  # Should now be in the set
+  if not ps.containsOrIncl(i):
+    return psFail
+
+  return psPass
+
+property missingOrExcl, (i: genInt()):
+  var ps = PackedSet[int]()
+  # Add once, should not be in the set
+  if ps.containsOrIncl(i):
+    return psFail
+
+  # Should now be in the set
+  if not ps.containsOrIncl(i):
+    return psFail
+
+  return psPass
+
 block basicIntSetTests:
   var y = initPackedSet[int]()
   y.incl(1)

--- a/tests/stdlib/types/tpackedsets.nim
+++ b/tests/stdlib/types/tpackedsets.nim
@@ -15,7 +15,7 @@ block basicIntSetTests:
   y.excl(1044)
 
   doAssert y == [1, 2, 7, 1056].toPackedSet
-  doAssert toSeq(y.items) == [1, 2, 7, 1056]
+  doAssert toSeq(y.items).sorted() == [1, 2, 7, 1056]
 
   doAssert y.containsOrIncl(888) == false
   doAssert 888 in y
@@ -254,6 +254,12 @@ block legacyMainModuleTests:
 
   var intGenericInit = initPackedSet[int]()
   genericTests(int, intGenericInit)
+
+  var int32GenericInit = initPackedSet[int32]()
+  genericTests(int32, int32GenericInit)
+
+  var int64GenericInit = initPackedSet[int64]()
+  genericTests(int64, int64GenericInit)
 
   var intDistinct = initPackedSet[Id]()
   genericTests(Id, intDistinct)


### PR DESCRIPTION
## Summary
Instead of using a custom ordered table implementation, convert `packedsets` to take advantage of `Table` and built-in `set[T]`. This cut down on the amount of code in the stdlib without compromising performance.

## Details
This came out of the prior work on [Roaring Bitmap][1], where I needed a few sample implementations to measure performance with. I found the original `PackedSet` resembles a simple ordered table with clustered lower bits, and experimented with building a simplified version based on existing stdlib components.

In this new structure, keys are grouped by their top `N - 8` bits and indexed via a `Table`, with the bottom 8 bits packed into a `set[uint8]`. Due to the change in internal structure, `items()` no longer yield keys in insert order.

Performance metrics for `nim c --hints:off --warnings:off -fc compiler/nim.nim` (on the same compiler checkout):

| Implementation | Compiler runtime | Ratio        | Improvement  |
| -------------- | ---------------- | ------------ | ------------ |
| Original       | 10.469s ± 0.075s | 1.0 ± 0.007  | 0 ± 0.007    |
| Simplified     | 10.114s ± 0.107s | 0.97 ± 0.011 | 0.03 ± 0.011 |

| Implementation | Compiler peak memory | Ratio        | Improvement |
| -------------- | -------------------- | ------------ | ----------- |
| Original       | 1.137GiB             | 1.0          | 0           |
| Simplified     | 1.123GiB             | 0.988        | 0.012       |

For the compiler, the new implementation performance is very similar to the original.

[1]: https://github.com/nim-works/nimskull/pull/1412

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
* ~~While tests passes, the original suite isn't very comprehensive.~~ Other compiler failures showed that the tests are not good enough. Draft until tests and microbenchs are written.
* I have not yet measured the performance of individual set operations in detail. The compiler mostly uses `incl` and `contains` while not employing many mathematical operations.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
