### PR TITLE
dust: use a better reduction strategy

### DIFF
--- a/tools/dust/dust.nim
+++ b/tools/dust/dust.nim
@@ -5,9 +5,7 @@
 
 import
   std/[
-    algorithm,
-    os,
-    sets
+    os
   ],
   compiler/ast/[
     ast,
@@ -21,7 +19,6 @@ import
   compiler/sem/[
     passes,
     sem,
-    sighashes,
   ],
   compiler/utils/[astrepr,],
   std/options as std_options, # due to legacy reports stupidity
@@ -117,50 +114,31 @@ proc dust*(args: openArray[string]): ErrorCode =
 
   # make note of the expected number of errors
   let expected = config.errorCounter
-  var seen: HashSet[SigHash]
 
   while true:
-    var remains: seq[(SigHash, PNode)]
-    # gather all possible, not-yet-tried mutations:
-    for mutant in mutations(best):
-      let hash = hashTree(mutant)
-      if hash notin seen:
-        remains.add (hash, mutant)
-  
-    if remains.len == 0:
-      # there are none; we're done
-      break
-    # sort by their score. The one with the lowest score has to come first
-    sort(remains, proc(a, b: auto): int =
-      calculateScore(config, a[1]) - calculateScore(config, b[1]))
-
     echo best
     echo "----- current score: ", calculateScore(config, best)
 
     var found = PNode nil
-    # try all candidates, starting with the smallest one
-    for (hash, node) in remains.items:
-      seen.incl(hash)
-
+    var iter = initMutator(best)
+    # go over all mutations, committing the ones that reproduce the error
+    while (let node = iter.get(); node != nil):
       semcheck:
-        try:
-          writeFile(config.projectFull.string, $node)
-        except IndexError:
-          echo "cheating to get around rendering bug"
-          continue
+        writeFile(config.projectFull.string, $node)
 
       # extra errors are a problem
       if config.errorCounter > expected:
         echo "(unexpected errors)"
+        iter.next()
       # if we didn't unhook the errors,
       # it means we didn't find the error we were looking for
       elif config.structuredReportHook != dustReportHook:
         echo "(uninteresting errors)"
-      # i guess this node is a viable reproduction
+        iter.next()
       else:
         # found a viable tree
+        iter.keep()
         found = node
-        break
     
     if found.isNil:
       # none of the candidates reproduces the property; we're done

--- a/tools/dust/mutate.nim
+++ b/tools/dust/mutate.nim
@@ -3,17 +3,42 @@
 
 import
   compiler/ast/[
-    lineinfos,
-    renderer,
-    ast,
+    ast
   ]
 
+type
+  Elem = tuple[n: PNode, i: int, next: pointer]
+  # note: `next` is actually a `Continuation`, but structural types cannot be
+  # cyclic and thus the type has to be erased
+  Stack = seq[Elem]
+  Jield = object
+    ## The internal result of an mutation iterator invocation. If terminal
+    ## (i.e., not holding a value), the iterator is done, otherwise `Jield`
+    ## holds the yielded value (i.e., mutation) plus the continuation
+    ## representing the next iterator step.
+    case isValue: bool
+    of true:
+      n: PNode
+      resume: proc(stack: var Stack, n: PNode): Jield
+    of false:
+      discard
+
+  Continuation = proc(stack: var Stack): Jield {.tailcall.}
+
+  MutationIter* = object
+    ## The mutation iterator state.
+    stack: Stack
+      ## the manually-managed call stack of the mutator
+    n: PNode
+      ## the current mutation, or nil, if there are no more possible mutations
+    resume: proc(stack: var Stack, n: PNode): Jield
+      ## the continuation to call for fetching the next mutation
 
 const
   DynamicSize = {nkBracket, nkCurly, nkRecList, nkTupleTy, nkPragma,
       nkGenericParams}
     ## syntax where an arbitrary number of children is allowed (including none)
-  WithBody = callableDefs +
+  WithBody {.used.} = callableDefs +
       {nkElifExpr, nkElifBranch, nkElse, nkElseExpr, nkWhileStmt, nkForStmt,
        nkBlockExpr, nkBlockStmt, nkPragmaBlock, nkOfBranch}
     ## syntax with a fixed number of children, where the last child represents
@@ -21,161 +46,330 @@ const
   WithBodyReplaceable = callableDefs +
       {nkWhileStmt, nkForStmt, nkBlockExpr, nkBlockStmt, nkPragmaBlock}
     ## syntax that may be replace with its body (i.e., the last child)
-  FixedFirstChild = {nkCall, nkCurlyExpr, nkBracketExpr, nkObjConstr} -
-      {nkPostFix}
+  FixedFirstChild = {nkCall, nkCurlyExpr, nkBracketExpr, nkObjConstr,
+      nkFormalParams} - {nkPostFix}
     ## syntax where the child has to always be present
   ListLike = {nkTupleConstr, nkTableConstr, nkVarSection, nkLetSection,
-      nkConstSection, nkTypeSection, nkStmtList, nkStmtListExpr,
-      nkFormalParams, nkBindStmt, nkMixinStmt, nkEnumTy, nkUsingStmt,
+      nkConstSection, nkTypeSection, nkBindStmt, nkMixinStmt, nkEnumTy, nkUsingStmt,
       nkImportStmt}
     ## syntax that must always have at least one element
   IfLike = {nkIfExpr, nkIfStmt, nkWhenStmt, nkRecWhen}
     ## syntax that has branches (e.g., `nkElse`, `nkElifBranch`, etc.) as children
 
+using
+  next: Continuation
 
-proc numSteps*(n: PNode): int =
-  ## Computes the number of distinct single modifications (i.e., removing a
-  ## child node, replacing a child node, etc.) that can be performed
-  ## for AST `n` (including its sub-trees).
-  proc count(n: PNode): int =
-    for it in n.items:
-      result += numSteps(it)
+# since NimSkull lacks coroutines (or something to implement them with, such
+# as algebraic effects), the iterator has to be implemented as a set of
+# hand-written procedures using continuation-passing style (with manually
+# create continuations). Yielding from the iterator then amounts to returning
+# a properly set-up `Jield` value from one of the constituent procedures
 
-  case n.kind
-  of nkWithoutSons:
-    # no steps are possible
-    result = 0
-  of nkIdentDefs:
-    # the identdefs must always have at least one element
-    result = count(n) + (if n.len > 3: n.len - 2 else: 0) +
-      ord(n[^1].kind != nkEmpty)
-  of nkConstDef:
-    # similar to an identdefs, but the value expression cannot be removed
-    result = count(n) + (if n.len > 3: n.len - 2 else: 0)
-  of DynamicSize:
-    result = count(n) + n.len
-  of WithBody:
-    result = count(n) + ord(n[^1].kind != nkEmpty) +
-      ord(n.kind in WithBodyReplaceable)
-  of nkCaseStmt, nkRecCase:
-    # the selector must be kept, but replacing with branch bodies is possible
-    result = count(n) + (n.len - 1) + (n.len - 1)
-  of FixedFirstChild:
-    # the first node must always stay
-    result = count(n) + n.len - 1
-  of ListLike:
-    # no removals are possible when the list has a single element
-    result = count(n) + (if n.len > 1: n.len else: 0)
-  of IfLike:
-    # the statement/expression can also be reduced by replacing it with
-    # one of the bodies
-    result = count(n) + (if n.len > 1: n.len else: 0) + n.len
-  of nkCommand:
-    result = count(n) + (if n.len > 2: (n.len - 1) else: 0)
-  of nkPostfix:
-    # the postfix can be replaced with its body
-    result = count(n) + 1
-  of nkPragmaExpr:
-    result = count(n) + 1
+proc step(stack: var Stack, n: sink PNode, next): Jield {.tailcall.}
+
+proc drop(n: sink PNode) =
+  discard n
+
+proc apply(stack: var Stack, next): Jield {.tailcall.} =
+  if next.isNil:
+    # no continuation; we're done
+    assert stack.len == 0
+    Jield(isValue: false)
   else:
-    # everything else has to keep all their children
-    result = count(n)
+    next(stack)
 
+proc update(stack: var Stack, n: PNode) =
+  ## Synchronizes the stack with the new root `n`.
+  var current {.cursor.} = n
+  for i in 0..<stack.len:
+    stack[i].n = current
+    # the index for the last entry may be invalid; don't use it for lookup
+    if i < stack.high:
+      current = current[stack[i].i]
 
-proc reduce*(n: PNode, index: var int): PNode =
-  ## Computes the tree corresponding to a step.
-  if index < 0:
-    return n
+proc extract(stack: Stack, idx: BackwardsIndex, n: sink PNode): PNode =
+  ## Creates a tree derived from the root tree but with the node at the
+  ## position the `idx`-th frame points to being replaced with `n`.
+  result = n
+  for i in countdown(stack.len - int(idx), 0):
+    let tree = copyNodeWithKids(stack[i].n)
+    tree[stack[i].i] = result
+    result = tree
 
-  template doStep(): bool =
-    let res = index == 0
-    dec index
-    res
+proc replaceAndEnter(stack: Stack, n: sink PNode, next): Jield {.tailcall.} =
+  ## 1. yields a mutation where the node at the parent frame's tree position
+  ##    is replaced with `n`
+  ## 2. (when committing) returns from the current frame and steps into `n`
+  ## 2. (when not committing) steps into the current node, invoking `next`
+  ##    upon returning
+  proc resume(stack: var Stack, n: PNode): Jield =
+    if n != nil:
+      let (_, _, ret) = stack.pop()
+      update(stack, n)
+      step(stack, stack[^1].n[stack[^1].i], cast[Continuation](ret))
+    else:
+      step(stack, stack[^1].n[stack[^1].i], next)
 
-  proc reduceAll(n: PNode, index: var int): PNode =
-    # TODO: only copy on write
-    result = shallowCopy(n)
-    for i, it in n.pairs:
-      result[i] = reduce(it, index)
+  Jield(isValue: true, n: extract(stack, ^2, n), resume: resume)
 
-  proc reduceWithRemove(n: PNode, start: int, index: var int): PNode =
-    result = newNode(n.kind)
-    for i in 0..<start:
-      result.add reduce(n[i], index)
-    for i in start..<n.len:
-      if not doStep():
-        result.add reduce(n[i], index)
+proc replaceParent(stack: Stack, n: sink PNode, next): Jield {.tailcall.} =
+  ## 1. yields a mutation where the node at the parent frame's tree position is
+  ##    replaced with `n`.
+  ## 2. (when committing) returns to parent frame
+  ## 2. (when not committing) invokes `next`
+  proc resume(stack: var Stack, n: PNode): Jield =
+    if n != nil:
+      let (_, _, next) = stack.pop()
+      update(stack, n)
+      apply(stack, cast[Continuation](next))
+    else:
+      next(stack)
+
+  Jield(isValue: true, n: extract(stack, ^2, n), resume: resume)
+
+proc replaceOrEnter(stack: Stack, n: sink PNode, next): Jield {.tailcall.} =
+  ## 1. yields a mutation where the node at the *current* tree position is
+  ##   replaced with `n`
+  ## 2. (when not committing) enters the sub-tree at the current position
+  ## 3. invokes `next`
+  proc resume(stack: var Stack, n: PNode): Jield =
+    if n != nil:
+      update(stack, n)
+      next(stack)
+    else:
+      step(stack, stack[^1].n[stack[^1].i], next)
+
+  Jield(isValue: true, n: extract(stack, ^1, n), resume: resume)
+
+proc removeOrEnter(stack: Stack, onKeep, onFail: Continuation): Jield {.tailcall.} =
+  ## 1. yields a mutation where the node at the current tree position
+  ##    is removed
+  ## 2. (when committing) invokes `onKeep`
+  ## 2. (when not committing) steps into the node at the current position,
+  ##    invoking `onFail` upon returning
+  let modified = copyNodeWithKids(stack[^1].n)
+  modified.delSon(stack[^1].i)
+
+  proc resume(stack: var Stack, n: PNode): Jield =
+    if n.isNil:
+      step(stack, stack[^1].n[stack[^1].i], onFail)
+    else:
+      update(stack, n)
+      onKeep(stack)
+
+  Jield(isValue: true, n: extract(stack, ^2, modified), resume: resume)
+
+proc removeOrEnter(stack: Stack, next): Jield {.tailcall.} =
+  removeOrEnter(stack, next, next)
+
+proc ret(stack: var Stack): Jield {.tailcall.} =
+  ## Applies a "return" action to the call stack.
+  let (n, _, next) = stack.pop()
+  drop n
+  apply(stack, cast[Continuation](next))
+
+proc mutateDyn(stack: var Stack): Jield {.tailcall.} =
+  # for each node/subtree, first try removing it from the list-like tree. If
+  # that doesn't work, reduce the node/tree
+  let fr {.cursor.} = stack[^1]
+  if fr.i >= 0:
+    removeOrEnter(stack,
+      proc(stack: var Stack): Jield {.tailcall.} =
+        dec stack[^1].i
+        mutateDyn(stack))
+  else:
+    ret(stack)
+
+proc mutateListElems(stack: var Stack): Jield {.tailcall.} =
+  # step into every element, but don't modify the shape of the list-like
+  # tree itself
+  let fr {.cursor.} = stack[^1]
+  if fr.i >= 0:
+    step(stack, fr.n[fr.i],
+      proc(stack: var Stack): Jield {.tailcall.} =
+        dec stack[^1].i
+        mutateListElems(stack))
+  else:
+    ret(stack)
+
+proc mutateList(stack: var Stack): Jield {.tailcall.} =
+  # works similar to `mutateDyn`, but makes sure that there's always at least
+  # one subnode in the list
+  let fr {.cursor.} = stack[^1]
+  if fr.i >= 0:
+    if fr.n.len == 1:
+      step(stack, fr.n[0], ret)
+    else:
+      removeOrEnter(stack,
+        proc(stack: var Stack): Jield {.tailcall.} =
+          dec stack[^1].i
+          mutateList(stack))
+  else:
+    ret(stack)
+
+proc mutateStmtList(stack: var Stack): Jield {.tailcall.} =
+  # a specialization of `mutateList`. Removes the wrapping nkStmtList if it
+  # has only one subnode
+  let fr {.cursor.} = stack[^1]
+  if fr.i == 0 and fr.n.len == 1:
+    step(stack, fr.n[0],
+      proc(stack: var Stack): Jield {.tailcall.} =
+        replaceParent(stack, stack[^1].n[0], ret))
+  elif fr.i >= 0:
+    removeOrEnter(stack,
+      proc(stack: var Stack): Jield {.tailcall.} =
+        dec stack[^1].i
+        mutateStmtList(stack))
+  else:
+    ret(stack)
+
+proc mutateIdentDefs(stack: var Stack): Jield {.tailcall.} =
+  proc next(stack: var Stack): Jield {.tailcall.} =
+    dec stack[^1].i
+    mutateIdentDefs(stack)
+
+  let fr {.cursor.} = stack[^1]
+  if fr.i >= fr.n.len - 2: # type and value slot
+    if fr.n[^1].kind != nkEmpty and fr.n[^2].kind != nkEmpty:
+      # when there's something in both the type and value slot, removing
+      # either the value or type expression could work
+      replaceOrEnter(stack, newNode(nkEmpty), next)
+    else:
+      step(stack, fr.n[fr.i], next)
+  elif fr.i >= 0: # identifier slots
+    if fr.n.len > 3:
+      removeOrEnter(stack, next)
+    else:
+      step(stack, fr.n[fr.i], next)
+  else:
+    ret(stack)
+
+proc mutateWithBody(stack: var Stack): Jield {.tailcall.} =
+  proc next(stack: var Stack): Jield {.tailcall.} =
+    dec stack[^1].i
+    mutateWithBody(stack)
+
+  # first, reduce the body (in the last slot). Afterwards, try replacing the
+  # node with the reduced body. If the latter fails, only reduce the
+  # remaining subnodes
+  let fr {.cursor.} = stack[^1]
+  if fr.i == fr.n.len - 1:
+    step(stack, fr.n[fr.i],
+      proc(stack: var Stack): Jield {.tailcall.} =
+        replaceParent(stack, stack[^1].n[^1], next))
+  elif fr.i >= 0:
+    step(stack, fr.n[fr.i], next)
+  else:
+    ret(stack)
+
+proc mutateIfLike(stack: var Stack): Jield {.tailcall.} =
+  let fr {.cursor.} = stack[^1]
+  if fr.i >= 0:
+    replaceAndEnter(stack, fr.n[fr.i][^1],
+      proc(stack: var Stack): Jield {.tailcall.} =
+        dec stack[^1].i
+        mutateIfLike(stack))
+  else:
+    ret(stack)
+
+proc mutateFixedFirst(stack: var Stack): Jield {.tailcall.} =
+  # like `mutateDyn`, but with the first subnode always being kept
+  let fr {.cursor.} = stack[^1]
+  if fr.i >= 1:
+    removeOrEnter(stack,
+      proc(stack: var Stack): Jield {.tailcall.} =
+        dec stack[^1].i
+        mutateFixedFirst(stack))
+  else: # i == 0
+    step(stack, fr.n[0], ret)
+
+proc mutateCaseStmt(stack: var Stack): Jield {.tailcall.} =
+  let fr {.cursor.} = stack[^1]
+  if fr.i >= 1:
+    replaceAndEnter(stack, fr.n[fr.i][^1],
+      proc(stack: var Stack): Jield {.tailcall.} =
+        dec stack[^1].i
+        mutateCaseStmt(stack))
+  else: # i == 0
+    step(stack, fr.n[0], ret)
+
+proc mutatePostfix(stack: var Stack): Jield {.tailcall.} =
+  replaceAndEnter(stack, stack[^1].n[1], ret)
+
+proc step(stack: var Stack, n: sink PNode, next): Jield {.tailcall.} =
+  ## Process `n`, invoking `next` once done.
+  proc push(stack: var Stack, n: sink PNode, next) {.inline.} =
+    stack.add (n, n.len - 1, cast[pointer](next))
 
   case n.kind
   of nkWithoutSons:
-    result = n
+    # nothing to do; just return
+    drop(n)
+    apply(stack, next)
   of nkIdentDefs, nkConstDef:
-    result = reduceAll(n, index)
-    if n.len > 3 and index >= 0:
-      if index < n.len - 2:
-        # remove the given identifier
-        result.delSon(index)
-      index -= (n.len - 2)
-    if n.kind == nkIdentDefs and n[^1].kind != nkEmpty and doStep():
-      # remove the value expression
-      result[^1] = newNode(nkEmpty)
+    push(stack, n, next)
+    mutateIdentDefs(stack)
   of nkCaseStmt, nkRecCase:
-    if index < n.len - 1:
-      result = n[1 + index][^1]
-      index -= (n.len - 1)
-    else:
-      index -= (n.len - 1)
-      result = reduceWithRemove(n, 1, index) # the selector is always present
+    push(stack, n, next)
+    mutateCaseStmt(stack)
   of FixedFirstChild:
-    result = reduceWithRemove(n, 1, index)
-  of WithBody:
-    result = reduceAll(n, index)
-    if n[^1].kind != nkEmpty:
-      if doStep():
-        # remove the body
-        result[^1] = nkDiscardStmt.newTree(nkEmpty.newNode())
-    if n.kind in WithBodyReplaceable and doStep():
-      # replace with the body
-      result = result[^1]
+    push(stack, n, next)
+    mutateFixedFirst(stack)
+  of WithBodyReplaceable:
+    push(stack, n, next)
+    mutateWithBody(stack)
   of DynamicSize:
-    result = reduceWithRemove(n, 0, index)
+    push(stack, n, next)
+    mutateDyn(stack)
   of ListLike:
-    if n.len > 1:
-      result = reduceWithRemove(n, 0, index)
-    else:
-      result = reduceAll(n, index)
+    push(stack, n, next)
+    mutateList(stack)
+  of nkStmtList, nkStmtListExpr:
+    push(stack, n, next)
+    mutateStmtList(stack)
   of IfLike:
-    if index < n.len:
-      # replace with the body of the given branch
-      result = n[index][^1]
-      index -= n.len
-    else:
-      index -= n.len
-      if n.len > 1:
-        result = reduceWithRemove(n, 0, index)
-      else:
-        result = reduceAll(n, index)
-  of nkCommand:
-    if n.len > 2:
-      result = reduceWithRemove(n, 1, index)
-    else:
-      result = reduceAll(n, index)
+    push(stack, n, next)
+    mutateIfLike(stack)
+  # of nkCommand:
+  #   mutateCommand(stack)
   of nkPostfix:
-    if doStep():
-      result = n[1]
-    else:
-      result = reduceAll(n, index)
-  of nkPragmaExpr:
-    if doStep():
-      result = n[0] # replace with the inner expression
-    else:
-      result = reduceAll(n, index)
+    push(stack, n, next)
+    mutatePostfix(stack)
+  # of nkPragmaExpr:
+  #   mutatePragmaExpr(stack)
   else:
-    result = reduceAll(n, index)
+    push(stack, n, next)
+    mutateListElems(stack)
 
+proc initMutator*(root: PNode): MutationIter =
+  ## Sets up a mutation iterator over `root`, moving it to the first
+  ## candidate, if one exists.
+  result = MutationIter()
+  let got = step(result.stack, root, nil)
+  if got.isValue:
+    result.n = got.n
+    result.resume = got.resume
 
-iterator mutations*(n: PNode): PNode =
-  for i in 0 ..< numSteps(n):
-    var index = i
-    yield reduce(n, index)
-    assert index < 0 # sanity check
+proc get*(mut: MutationIter): PNode =
+  ## Returns the current mutation.
+  mut.n
+
+proc next*(mut: var MutationIter) =
+  ## Computes the next mutant and loads it into `mut`.
+  let got = mut.resume(mut.stack, nil)
+  if got.isValue:
+    mut.n = got.n
+    mut.resume = got.resume
+  else:
+    mut.n = nil
+
+proc keep*(mut: var MutationIter) =
+  ## Makes the current mutant the new root and computes the next mutant based
+  ## on it. This is functionally equivalent to spawning a new iterator with
+  ## for the current mutant and moving its tree position to that of `mut`.
+  let got = mut.resume(mut.stack, mut.n)
+  if got.isValue:
+    mut.n = got.n
+    mut.resume = got.resume
+  else:
+    mut.n = nil


### PR DESCRIPTION
Replace the reduction strategy preferring the largest removal at each step with one preferring progress (i.e., a successful mutation to be found quickly, even if only a small reduction).

Whereas the old strategy was to start with the mutation representing the largest removal at each step, successively trying the next smaller mutation until a reproducer is found, discarding context (i.e., where the previous mutation took place) between successive steps, the new strategy is to go over the tree with a cursor (from end to start) and remove/simplify nodes/subtrees at every step until a fixpoint is reached.

Especially for larger programs, the new strategy results in finding a minimal reproducer with significantly less semchecks.

The new strategy is derived from an attempt at simulating how one would reduce programs by hand, which is based on the observation that removing from the end of an AST is, in most cases, more likely to be yield a reproduction than removing from the start. This is because NimSkull programs, much like programs written in most other programming languages, are structured in a top-to-bottom left-to-right manner.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## To-Do

- [ ] implement dedicated iteration for `nkCommand` and `nkPragmaExpr` again
- [ ] (maybe) improve the documentation in some places
- [ ] write a proper commit message

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
