### PR TITLE
sigmatch: fix missing conversion for number constants

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -334,7 +334,7 @@ proc toIntLiteral(env: var MirEnv, n: PNode): Value =
   assert n.kind in nkIntLiterals
   let typ = env.types.add(n.typ)
   # use the type for deciding what whether it's a signed or unsigned value
-  case n.typ.skipTypes(abstractRange + {tyEnum}).kind
+  case n.typ.skipTypes(abstractRange + {tyEnum} + tyUserTypeClasses).kind
   of tyInt..tyInt64, tyBool:
     intLiteral(env, n.intVal, typ)
   of tyUInt..tyUInt64, tyChar, tyPtr, tyPointer, tyProc:

--- a/compiler/sem/sigmatch.nim
+++ b/compiler/sem/sigmatch.nim
@@ -2435,6 +2435,10 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     elif skipTypes(arg.typ, abstractVar-{tyTypeDesc}).kind == tyTuple or
          m.inheritancePenalty > oldInheritancePenalty:
       result = implicitConv(nkHiddenSubConv, f, arg, m, c)
+    elif f.kind != tyVar and (arg.typ.isIntLit or arg.typ.isFloatLit):
+      # assume that the resolved formal type and the argument type aren't
+      # equal and pessimisticely insert a conversion
+      result = implicitConv(nkHiddenStdConv, f, arg, m, c)
     elif arg.typ.isEmptyContainer:
       result = arg.copyTree
       result.typ = getInstantiatedType(c, arg, m, f)


### PR DESCRIPTION
## Summary

Fix integer and float constants having an incorrect type when passed to
generic parameters. This is presently an internal-only problem, with no
observable consequences.

## Details

The type relation between an integer/float type and a literal is
`isFromIntLit`, but when the substitution of a type variable is
necessary for reaching the integer/float type, the relation regresses
to `isGeneric`, which led to no hidden conversion being injected by
`paramTypesMatchAux`.

Apart from an inconsequential type error at the MIR level, these
wrongly
typed number constants caused no issue, but they would once final
translation differs between the different integer/floats.

`paramTypesMatchAux` is changed to insert a hidden conversion when the
argument is a literal number and the type relation is  `isGeneric` .
Since
this makes it possible for `concept`-typed integers (conversions of
constant integer values are folded) to reach `mirgen`, `intLiteral` has
to skip `tyUserTypeClasses`.