### PR TITLE
disallow 64-bit integer values crossing JS FFI border

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -909,6 +909,7 @@ type
     taNoUntyped
     taIsTemplateOrMacro
     taProcContextIsNotMacro
+    taFFI ## the context is a usage at the FFI border, in either direction
 
   TTypeAllowedFlags* = set[TTypeAllowedFlag]
 

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -528,10 +528,16 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym
 
-proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
+proc paramsTypeCheck(c: PContext, typ: PType, sflags: TSymFlags) {.inline.} =
   let
     kind = skProc
-    t = typeAllowed(typ, kind, c)
+    flags =
+      if c.config.backend == backendJs and
+         {sfImportc, sfInfixCall} * sflags == {sfImportc, sfInfixCall}:
+        {taFFI}
+      else:
+        {}
+    t = typeAllowed(typ, kind, c, flags)
     info = typ.n.info
   if t != nil:
     # var err: string

--- a/compiler/sem/seminst.nim
+++ b/compiler/sem/seminst.nim
@@ -436,7 +436,7 @@ proc generateInstance(c: PContext, fn: PSym, pt: TIdTable,
     sideEffectsCheck(c, result)
     if result.magic notin {mSlice, mTypeOf}:
       # 'toOpenArray' is special and it is allowed to return 'openArray':
-      paramsTypeCheck(c, result.typ)
+      paramsTypeCheck(c, result.typ, result.flags)
   else:
     result = oldPrc
   popProcCon(c)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2689,6 +2689,9 @@ proc semProcAux(c: PContext, n: PNode, validPragmas: TSpecialWords,
       result[namePos] = checkSpecialOperators(c, result[namePos])
       hasError = hasError or result[namePos].kind == nkError
 
+  if result[genericParamsPos].kind == nkEmpty and s.magic == mNone:
+    paramsTypeCheck(c, s.typ, s.flags)
+
   if n[bodyPos].kind != nkEmpty and sfError notin s.flags:
     # for DLL generation we allow sfImportc to have a body, for use in VM
     if sfBorrow in s.flags:
@@ -2715,9 +2718,6 @@ proc semProcAux(c: PContext, n: PNode, validPragmas: TSpecialWords,
     else:
       pushProcCon(c, s)
       if result[genericParamsPos].kind == nkEmpty:
-        if s.magic == mNone:
-          paramsTypeCheck(c, s.typ)
-
         maybeAddResult(c, s, result)
         # semantic checking also needed with importc in case used in VM
         s.ast[bodyPos] = hloBody(c, semProcBody(c, n[bodyPos]))

--- a/compiler/sem/typeallowed.nim
+++ b/compiler/sem/typeallowed.nim
@@ -119,15 +119,24 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     result = t
   of tyNil:
     if kind != skConst and kind != skParam: result = t
-  of tyString, tyBool, tyChar, tyEnum, tyInt..tyUInt64, tyCstring, tyPointer:
+  of tyString, tyBool, tyChar, tyEnum, tyInt..tyInt32, tyUInt..tyUInt32,
+     tyFloat..tyFloat64, tyCstring, tyPointer:
     result = nil
+  of tyInt64, tyUInt64:
+    if taFFI in flags:
+      result = t
+    else:
+      result = nil
   of tyOrdinal:
     if kind != skParam: result = t
   of tyGenericInst, tyDistinct, tyAlias, tyInferred:
     result = typeAllowedAux(marker, lastSon(t), kind, c, flags)
   of tyRange:
     if skipTypes(t[0], abstractInst-{tyTypeDesc}).kind notin
-      {tyChar, tyEnum, tyInt..tyFloat64, tyInt..tyUInt64, tyRange}: result = t
+       {tyChar, tyEnum, tyInt..tyFloat64, tyInt..tyUInt64, tyRange}:
+      result = t
+    else:
+      result = typeAllowedAux(marker, lastSon(t), kind, c, flags)
   of tyOpenArray:
     # you cannot nest openArrays/sinks/etc.
     if (kind != skParam or taIsOpenArray in flags) and views notin c.features:

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -781,7 +781,7 @@ type
 
   UIEvent* = ref UIEventObj ## see `docs<https://developer.mozilla.org/en-US/docs/Web/API/UIEvent>`_
   UIEventObj {.importc.} = object of Event
-    detail*: int64
+    detail*: int32
     view*: Window
 
   KeyboardEvent* = ref KeyboardEventObj ## see `docs<https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent>`_
@@ -1654,7 +1654,7 @@ proc item*(list: TouchList, i: int): Touch
 proc clearData*(dt: DataTransfer, format: cstring)
 proc getData*(dt: DataTransfer, format: cstring): cstring
 proc setData*(dt: DataTransfer, format: cstring, data: cstring)
-proc setDragImage*(dt: DataTransfer, img: Element, xOffset: int64, yOffset: int64)
+proc setDragImage*(dt: DataTransfer, img: Element, xOffset: int32, yOffset: int32)
 
 # DataTransferItem "methods"
 proc getAsFile*(dti: DataTransferItem): File

--- a/lib/js/jscore.nim
+++ b/lib/js/jscore.nim
@@ -74,7 +74,7 @@ proc parse*(d: DateLib, s: cstring): int {.importjs.}
 proc newDate*(): DateTime {.
   importjs: "new Date()".}
 
-proc newDate*(date: int|int64|string): DateTime {.
+proc newDate*(date: int|float|string): DateTime {.
   importjs: "new Date(#)".}
 
 proc newDate*(year, month, day, hours, minutes,

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -152,6 +152,14 @@ proc to*(x: JsObject, T: typedesc): T {.importjs: "(#)".}
 proc toJs*[T](val: T): JsObject {.importjs: "(#)".}
   ## Converts a value of any type to type JsObject.
 
+proc toJs*(val: int64): JsObject =
+  ## Converts a 64-bit signed integer to a JavaScript Number.
+  toJs(float(val))
+
+proc toJs*(val: uint64): JsObject =
+  ## Converts a 64-bit unsigned integer to a JavaScript Number.
+  toJs(float(val))
+
 template toJs*(s: string): JsObject = cstring(s).toJs
 
 macro jsFromAst*(n: untyped): untyped =

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1199,14 +1199,14 @@ proc toAdjTime(dt: DateTime): Time =
 
 when defined(js):
   proc localZonedTimeFromTime(time: Time): ZonedTime {.benign.} =
-    let jsDate = newDate(time.seconds * 1000)
+    let jsDate = newDate(float(time.seconds * 1000))
     let offset = jsDate.getTimezoneOffset() * secondsInMin
     result.time = time
     result.utcOffset = offset
     result.isDst = false
 
   proc localZonedTimeFromAdjTime(adjTime: Time): ZonedTime {.benign.} =
-    let utcDate = newDate(adjTime.seconds * 1000)
+    let utcDate = newDate(float(adjTime.seconds * 1000))
     let localDate = newDate(utcDate.getUTCFullYear(), utcDate.getUTCMonth(),
         utcDate.getUTCDate(), utcDate.getUTCHours(), utcDate.getUTCMinutes(),
         utcDate.getUTCSeconds(), 0)

--- a/lib/std/jsbigints.nim
+++ b/lib/std/jsbigints.nim
@@ -6,7 +6,7 @@ when not defined(js):
 type JsBigIntImpl {.importjs: "bigint".} = int # https://github.com/nim-lang/Nim/pull/16606
 type JsBigInt* = distinct JsBigIntImpl         ## Arbitrary precision integer for JavaScript target.
 
-func big*(integer: SomeInteger): JsBigInt {.importjs: "BigInt(#)".} =
+func big*(integer: int|uint): JsBigInt {.importjs: "BigInt(#)".} =
   ## Constructor for `JsBigInt`.
   runnableExamples:
     doAssert big(1234567890) == big"1234567890"
@@ -61,10 +61,10 @@ func wrapToUint*(this: JsBigInt; bits: Natural): JsBigInt {.importjs:
   runnableExamples:
     doAssert (big("3") + big("2") ** big("66")).wrapToUint(66) == big("3")
 
-func toNumber*(this: JsBigInt): BiggestInt {.importjs: "Number(#)".} =
+func toNumber*(this: JsBigInt): float {.importjs: "Number(#)".} =
   ## Does not do any bounds check and may or may not return an inexact representation.
   runnableExamples:
-    doAssert toNumber(big"2147483647") == 2147483647.BiggestInt
+    doAssert toNumber(big"2147483647") == 2147483647.0
 
 func `+`*(x, y: JsBigInt): JsBigInt {.importjs: "(# $1 #)".} =
   runnableExamples:
@@ -203,6 +203,18 @@ proc low*(_: typedesc[JsBigInt]): JsBigInt {.error:
 proc high*(_: typedesc[JsBigInt]): JsBigInt {.error:
   "Arbitrary precision integers do not have a known high.".} ## **Do NOT use.**
 
+proc big*(integer: uint64): JsBigInt =
+  ## Constructor for `JsBigInt`.
+  big(cast[uint](integer)) + (big(cast[uint](integer shr 32)) shl big(32))
+
+proc big*(integer: int64): JsBigInt =
+  ## Constructor for `JsBigInt`.
+  if integer < 0:
+    # safely compute the absolute value of the int64, turn that into a
+    # bigint, and negate
+    -big(0'u64 - cast[uint64](integer))
+  else:
+    big(uint64(integer))
 
 runnableExamples:
   block:

--- a/lib/std/jsbigints.nim
+++ b/lib/std/jsbigints.nim
@@ -203,18 +203,17 @@ proc low*(_: typedesc[JsBigInt]): JsBigInt {.error:
 proc high*(_: typedesc[JsBigInt]): JsBigInt {.error:
   "Arbitrary precision integers do not have a known high.".} ## **Do NOT use.**
 
+proc big(val: float): JsBigInt {.importjs: "BigInt(#)".}
+
 proc big*(integer: uint64): JsBigInt =
   ## Constructor for `JsBigInt`.
-  big(cast[uint](integer)) + (big(cast[uint](integer shr 32)) shl big(32))
+  # a 64-bit integer is only a float underneath, making this the only way to
+  # properly perform the conversion
+  big(float(integer))
 
 proc big*(integer: int64): JsBigInt =
   ## Constructor for `JsBigInt`.
-  if integer < 0:
-    # safely compute the absolute value of the int64, turn that into a
-    # bigint, and negate
-    -big(0'u64 - cast[uint64](integer))
-  else:
-    big(uint64(integer))
+  big(float(integer))
 
 runnableExamples:
   block:

--- a/lib/std/private/digitsutils.nim
+++ b/lib/std/private/digitsutils.nim
@@ -37,7 +37,7 @@ proc trailingZeros2Digits*(digits: uint32): int32 {.inline.} =
   return trailingZeros100[digits]
 
 when defined(js):
-  proc numToString(a: SomeInteger): cstring {.importjs: "((#) + \"\")".}
+  proc numToString(a: float): cstring {.importjs: "((#) + \"\")".}
 
 func addChars[T](result: var string, x: T, start: int, n: int) {.inline.} =
   let old = result.len
@@ -83,7 +83,7 @@ func addInt*(result: var string, x: uint64) =
   else:
     when not defined(js): addIntImpl(result, x)
     else:
-      addChars(result, numToString(x))
+      addChars(result, numToString(float(x)))
 
 proc addInt*(result: var string; x: int64) =
   ## Converts integer to its string representation and appends it to `result`.
@@ -107,7 +107,7 @@ proc addInt*(result: var string; x: int64) =
   when nimvm: impl()
   else:
     when defined(js):
-      addChars(result, numToString(x))
+      addChars(result, numToString(float(x)))
     else: impl()
 
 proc addInt*(result: var string; x: int) {.inline.} =

--- a/tests/js/timported_proc_type_usage_error.nim
+++ b/tests/js/timported_proc_type_usage_error.nim
@@ -1,0 +1,29 @@
+discard """
+  description: '''
+    Ensure that types disallowed for incoming or outgoing values at the FFI
+    border are detected and rejected.
+  '''
+  matrix: "--errorMax:0"
+  action: reject
+"""
+
+proc test(x: int64) {.importjs.} #[tt.Error
+         ^ invalid type: 'int64' in this context: 'proc (x: int64)' for proc]#
+
+proc test(x: range[0'i64 .. 1'i64]) {.importjs.} #[tt.Error
+         ^ invalid type: 'int64' in this context: 'proc (x: range 0..1(int64))' for proc]#
+
+proc test(x: seq[int64]) {.importjs.} #[tt.Error
+         ^ invalid type: 'int64' in this context: 'proc (x: seq[int64])' for proc]#
+
+proc test(x: (bool, int64)) {.importjs.} #[tt.Error
+         ^ invalid type: 'int64' in this context: 'proc (x: (bool, int64))' for proc]#
+
+proc testRet(): int64 {.importjs.} #[tt.Error
+            ^ invalid type: 'int64' in this context: 'proc (): int64' for proc]#
+
+
+proc generic[T](x: T) {.importjs.} #[tt.Error
+               ^ invalid type: 'int64' in this context: 'proc (x: int64)' for proc]#
+
+generic(1'i64)


### PR DESCRIPTION
## Summary

Statically disallow `int64` and `uint64` values being passed across the
FFI border when using the JavaScript target, which is the first step
towards cleaning up / specifying the JavaScript FFI.

## Details

### Rationale

Only values of types that correspond to native JavaScript, without
requiring a conversion, should be allowed to cross the FFI border, both
for safety (in the case of return types) and so that the language
doesn't have to provide a specification of how these values look like
in JavaScript.

At the moment, both  `int64`  and  `uint64`  are treated as a JS 
`Number`  in
the end, meaning that they do correspond to a native type right now,
but this is subject to change.

There are other types besides `int64` that don't have a known native
representation (such as `set`) or require a conversion (such as `int32`
in result type positions), but disallowing those is delayed to a
later day.

### Compiler Changes

* report `tyUInt64` and `tyInt64` types via `typeAllowed` when the new
  `taFFI` flag is provided
* always check the parameter and result type for procedure, even when
  forward declared or imported

### Standard Library API Changes

* change `jscore.newDate` to accept a `float` instead of a `int64`
* change `dom.setDragImage` to accept `int32` coordinates instead of
  `int64`
  * this also matches their official specification
* change `UIEvent.detail` to be of type `int32`
  * this is also what official WebAPI specification says the type is

### Internal Standard Library Changes

* add dedicated `JsBigInt` constructors for `int64` and `uint64`
* add dedicated `jsffi.toJs` overloads for `int64` and `uint64`
* use `float` instead of `int64` for parameter of
  `digitsutils.numToString`

The observable behaviour of the changed procedure stays the same.