### PR TITLE
jsgen: implement proper 64-bit integer support

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -184,6 +184,10 @@ type
     addrTaken: PackedSet[LocalId]
       ## locals that have their address taken at some point
 
+  MagicOp = distinct string
+    ## Helper type for marking a string as being the name of a
+    ## `system`-provided operation.
+
 const
   sfModuleInit* = sfMainModule
     ## the procedure is the 'init' procedure of a module
@@ -198,8 +202,12 @@ template `$`(x: BlockId): string =
 template isFilled(x: string): bool =
   x.len != 0
 
+proc isInt64(typ: PType): bool =
+  skipTypes(typ, abstractRange).kind in {tyUInt64, tyInt64}
+
 # forward declarations:
 proc setupLocalLoc(p: PProc, id: LocalId, kind: TSymKind; name = "")
+proc genConv(p: PProc, dest: PType, n: CgNode, r: var TCompRes)
 
 func analyseIfAddressTaken(n: CgNode, addrTaken: var PackedSet[LocalId]) =
   ## Recursively traverses the tree `n` and includes the IDs of all locals
@@ -444,66 +452,6 @@ proc getTemp(p: PProc, defineInLocals: bool = true): Rope =
   if defineInLocals:
     p.defs.add(p.indentLine("var $1;$n" % [result]))
 
-type
-  TMagicOps = array[mAddI..mUnaryPlusF64, string]
-
-const # magic checked op
-  jsMagics: TMagicOps = [
-    mAddI: "addInt",
-    mSubI: "subInt",
-    mMulI: "mulInt",
-    mDivI: "divInt",
-    mModI: "modInt",
-    mSucc: "addInt",
-    mPred: "subInt",
-    mAddF64: "",
-    mSubF64: "",
-    mMulF64: "",
-    mDivF64: "",
-    mShrI: "",
-    mShlI: "",
-    mAshrI: "",
-    mBitandI: "",
-    mBitorI: "",
-    mBitxorI: "",
-    mMinI: "nimMin",
-    mMaxI: "nimMax",
-    mAddU: "",
-    mSubU: "",
-    mMulU: "",
-    mDivU: "",
-    mModU: "",
-    mEqI: "",
-    mLeI: "",
-    mLtI: "",
-    mEqF64: "",
-    mLeF64: "",
-    mLtF64: "",
-    mLeU: "",
-    mLtU: "",
-    mEqEnum: "",
-    mLeEnum: "",
-    mLtEnum: "",
-    mEqCh: "",
-    mLeCh: "",
-    mLtCh: "",
-    mEqB: "",
-    mLeB: "",
-    mLtB: "",
-    mEqRef: "",
-    mLePtr: "",
-    mLtPtr: "",
-    mXor: "",
-    mEqCString: "",
-    mEqProc: "",
-    mUnaryMinusI: "negInt",
-    mUnaryMinusI64: "negInt64",
-    mAbsI: "absInt",
-    mNot: "",
-    mUnaryPlusI: "",
-    mBitnotI: "",
-    mUnaryPlusF64: ""]
-
 template binaryExpr(p: PProc, n: CgNode, r: var TCompRes, magic, frmt: string) =
   # $1 and $2 in the `frmt` string bind to lhs and rhs of the expr,
   # $3 or $4 are legacy substitutions that also bind to the lhs and rhs
@@ -536,16 +484,18 @@ proc unsignedTrimmerJS(size: BiggestInt): Rope =
 template unsignedTrimmer(size: BiggestInt): Rope =
   size.unsignedTrimmerJS
 
-proc binaryUintExpr(p: PProc, n: CgNode, r: var TCompRes, op: string,
-                    reassign: static[bool] = false) =
+proc binaryUintExpr(p: PProc, n: CgNode, r: var TCompRes, op: string or MagicOp) =
   var x, y: TCompRes
   gen(p, n[1], x)
   gen(p, n[2], y)
   let trimmer = unsignedTrimmer(n[1].typ.skipTypes(abstractRange).size)
-  when reassign:
-    r.res = "$1 = (($1 $2 $3) $4)" % [x.rdLoc, rope op, y.rdLoc, trimmer]
+  when op is string:
+    r.res = op % [x.rdLoc, y.rdLoc]
+    r.res.add " "
+    r.res.add trimmer
   else:
-    r.res = "(($1 $2 $3) $4)" % [x.rdLoc, rope op, y.rdLoc, trimmer]
+    useMagic(p, op.string)
+    r.res = "($1($2, $3) $4)" % [string(op), x.rdLoc, y.rdLoc, trimmer]
   r.kind = resExpr
 
 template unaryExpr(p: PProc, n: CgNode, r: var TCompRes, magic, frmt: string) =
@@ -555,104 +505,195 @@ template unaryExpr(p: PProc, n: CgNode, r: var TCompRes, magic, frmt: string) =
   r.res = frmt % [r.rdLoc]
   r.kind = resExpr
 
-proc arithAux(p: PProc, n: CgNode, r: var TCompRes, op: TMagic) =
-  var
-    x, y: TCompRes
-    xLoc,yLoc: Rope
-
-  useMagic(p, jsMagics[op])
-  if numArgs(n) == 2:
-    gen(p, n[1], x)
-    gen(p, n[2], y)
-    xLoc = x.rdLoc
-    yLoc = y.rdLoc
+proc unaryExpr(p: PProc, a: CgNode, r: var TCompRes, frmt: string or MagicOp) =
+  let arg = gen(p, a)
+  when frmt is string:
+    r.res = frmt % [rdLoc(arg)]
   else:
-    gen(p, n[1], r)
-    xLoc = r.rdLoc
+    # the operator is a `system`-provided procedure
+    useMagic(p, frmt.string)
+    r.res = "$1($2)" % [frmt.string, rdLoc(arg)]
 
-  template applyFormat(frmt) =
-    r.res = frmt % [xLoc, yLoc]
+  r.kind = resExpr
+
+proc binaryExpr(p: PProc, a, b: CgNode, r: var TCompRes, frmt: string or MagicOp) =
+  let x = gen(p, a)
+  let y = gen(p, b)
+  when frmt is string:
+    r.res = frmt % [rdLoc(x), rdLoc(y)]
+  else:
+    # the operator is a `system`-provided procedure
+    useMagic(p, frmt.string)
+    r.res = "$1($2, $3)" % [frmt.string, rdLoc(x), rdLoc(y)]
+
+  r.kind = resExpr
+
+proc rdNumLoc(p: PProc, a: TCompRes, typ: PType): Rope =
+  ## Returns the JavaScript expression for reading a JavaScript number value
+  ## from location `a`. True 64-bit integers are converted to doubles
+  ## (potentially losing information).
+  result = rdLoc(a)
+  case skipTypes(typ, abstractInst).kind
+  of tyInt64:
+    useMagic(p, "int64ToDouble")
+    result = "int64ToDouble($1)" % [result]
+  of tyUInt64:
+    useMagic(p, "uint64ToDouble")
+    result = "uint64ToDouble($1)" % [result]
+  else:
+    discard "nothing to do"
+
+proc patchedBinaryExpr(p: PProc, a, b: CgNode, r: var TCompRes,
+                       frmt: string or MagicOp) =
+  ## Like `binaryArith`, but inserts a conversion for the second operand when
+  ## it doesn't have the same type as the first operand, to work around
+  ## upstream compiler bugs. Also handles unsigned integer trimming.
+  let x = gen(p, a)
+  var y: TCompRes
+  genConv(p, a.typ, b, y)
+  when frmt is string:
+    r.res = frmt % [rdLoc(x), rdLoc(y)]
+  else:
+    # the operator is a `system`-provided procedure
+    useMagic(p, frmt.string)
+    r.res = "$1($2, $3)" % [frmt.string, rdLoc(x), rdLoc(y)]
+
+  if isUnsigned(a.typ):
+    r.res = "($1 $2)" %
+      [r.res, unsignedTrimmer(skipTypes(a.typ, abstractRange).size)]
+
+  r.kind = resExpr
+
+proc arithAux(p: PProc, n: CgNode, r: var TCompRes, op: TMagic) =
+  template binary(frmt) =
+    binaryExpr(p, n[1], n[2], r, frmt)
+
+  template unary(frmt) =
+    unaryExpr(p, n[1], r, frmt)
+
+  template binary(frmtInt, frmtInt64) =
+    if isInt64(n[1].typ):
+      binaryExpr(p, n[1], n[2], r, frmtInt64)
+    elif isUnsigned(n.typ):
+      binaryUintExpr(p, n, r, frmtInt)
+    else:
+      binaryExpr(p, n[1], n[2], r, frmtInt)
+
+  template unary(frmtInt, frmtInt64) =
+    if isInt64(n[1].typ):
+      unaryExpr(p, n[1], r, frmtInt64)
+    else:
+      unaryExpr(p, n[1], r, frmtInt)
 
   case op:
-  of mAddI: applyFormat("addInt($1, $2)")
-  of mSubI: applyFormat("subInt($1, $2)")
-  of mMulI: applyFormat("mulInt($1, $2)")
-  of mDivI: applyFormat("divInt($1, $2)")
-  of mModI: applyFormat("modInt($1, $2)")
-  of mSucc: applyFormat("addInt($1, $2)")
-  of mPred: applyFormat("subInt($1, $2)")
-  of mAddF64: applyFormat("($1 + $2)")
-  of mSubF64: applyFormat("($1 - $2)")
-  of mMulF64: applyFormat("($1 * $2)")
-  of mDivF64: applyFormat("($1 / $2)")
-  of mShrI: applyFormat("")
+  of mAddI:
+    if isInt64(n[1].typ):
+      patchedBinaryExpr(p, n[1], n[2], r, MagicOp"checkedAddInt64")
+    else:
+      patchedBinaryExpr(p, n[1], n[2], r, MagicOp"addInt")
+  of mSubI:
+    if isInt64(n[1].typ):
+      patchedBinaryExpr(p, n[1], n[2], r, MagicOp"checkedSubInt64")
+    else:
+      patchedBinaryExpr(p, n[1], n[2], r, MagicOp"subInt")
+  of mMulI: binary(MagicOp"mulInt", MagicOp"checkedMulInt64")
+  of mDivI: binary(MagicOp"divInt", MagicOp"checkedDivInt64")
+  of mModI: binary(MagicOp"modInt", MagicOp"checkedModInt64")
+  of mAddF64: binary("($1 + $2)")
+  of mSubF64: binary("($1 - $2)")
+  of mMulF64: binary("($1 * $2)")
+  of mDivF64: binary("($1 / $2)")
   of mShlI:
-    if n[1].typ.size <= 4:
-      applyFormat("($1 << $2)")
+    let a = gen(p, n[1])
+    let b = gen(p, n[2])
+    # needs special handling for the shift operand
+    if isInt64(n[1].typ):
+      useMagic(p, "shlInt64")
+      r.res = "shlInt64($1, $2)" % [rdLoc(a), rdNumLoc(p, b, n[2].typ)]
+    elif isUnsigned(n[1].typ):
+      r.res = "(($1 << $2) $3)" % [rdLoc(a), rdNumLoc(p, b, n[2].typ),
+                                   unsignedTrimmer(getSize(p.config, n.typ))]
     else:
-      applyFormat("($1 * Math.pow(2, $2))")
+      r.res = "($1 << $2)" % [rdLoc(a), rdNumLoc(p, b, n[2].typ)]
   of mAshrI:
-    if n[2].typ.size <= 4:
-      applyFormat("($1 >> $2)")
+    let a = gen(p, n[1])
+    let b = gen(p, n[2])
+    # needs special handling for the shift operand
+    if isInt64(n[1].typ):
+      useMagic(p, "ashrInt64")
+      r.res = "ashrInt64($1, $2)" % [rdLoc(a), rdNumLoc(p, b, n[2].typ)]
     else:
-      applyFormat("Math.floor($1 / Math.pow(2, $2))")
-  of mBitandI: applyFormat("($1 & $2)")
-  of mBitorI: applyFormat("($1 | $2)")
-  of mBitxorI: applyFormat("($1 ^ $2)")
-  of mMinI: applyFormat("nimMin($1, $2)")
-  of mMaxI: applyFormat("nimMax($1, $2)")
-  of mAddU: applyFormat("")
-  of mSubU: applyFormat("")
-  of mMulU: applyFormat("")
-  of mDivU: applyFormat("")
-  of mModU: applyFormat("($1 % $2)")
-  of mEqI: applyFormat("($1 == $2)")
-  of mLeI: applyFormat("($1 <= $2)")
-  of mLtI: applyFormat("($1 < $2)")
-  of mEqF64: applyFormat("($1 == $2)")
-  of mLeF64: applyFormat("($1 <= $2)")
-  of mLtF64: applyFormat("($1 < $2)")
-  of mLeU: applyFormat("($1 <= $2)")
-  of mLtU: applyFormat("($1 < $2)")
-  of mEqEnum: applyFormat("($1 == $2)")
-  of mLeEnum: applyFormat("($1 <= $2)")
-  of mLtEnum: applyFormat("($1 < $2)")
-  of mEqCh: applyFormat("($1 == $2)")
-  of mLeCh: applyFormat("($1 <= $2)")
-  of mLtCh: applyFormat("($1 < $2)")
-  of mEqB: applyFormat("($1 == $2)")
-  of mLeB: applyFormat("($1 <= $2)")
-  of mLtB: applyFormat("($1 < $2)")
-  of mEqRef: applyFormat("($1 == $2)")
-  of mLePtr: applyFormat("($1 <= $2)")
-  of mLtPtr: applyFormat("($1 < $2)")
-  of mXor: applyFormat("($1 != $2)")
-  of mEqCString: applyFormat("($1 == $2)")
-  of mEqProc: applyFormat("($1 == $2)")
-  of mUnaryMinusI: applyFormat("negInt($1)")
-  of mUnaryMinusI64: applyFormat("negInt64($1)")
-  of mAbsI: applyFormat("absInt($1)")
-  of mNot: applyFormat("!($1)")
-  of mUnaryPlusI: applyFormat("+($1)")
-  of mBitnotI: applyFormat("~($1)")
-  of mUnaryPlusF64: applyFormat("+($1)")
+      r.res = "($1 >> $2)" % [rdLoc(a), rdNumLoc(p, b, n[2].typ)]
+  of mBitandI: binary("($1 & $2)", MagicOp"bitAndInt64")
+  of mBitorI: binary("($1 | $2)", MagicOp"bitOrInt64")
+  of mBitxorI: binary("($1 ^ $2)", MagicOp"bitXorInt64")
+  of mMinI: binary(MagicOp"nimMin", MagicOp"nimMin64")
+  of mMaxI: binary(MagicOp"nimMax", MagicOp"nimMax64")
+  of mModU: binary("($1 % $2)", MagicOp"modUInt64")
+  of mEqI: binary("($1 == $2)", MagicOp"eqInt64")
+  of mLeI: binary("($1 <= $2)", MagicOp"leInt64")
+  of mLtI: binary("($1 < $2)", MagicOp"ltInt64")
+  of mEqF64: binary("($1 == $2)")
+  of mLeF64: binary("($1 <= $2)")
+  of mLtF64: binary("($1 < $2)")
+  of mLeU: binary("($1 <= $2)", MagicOp"leUInt64")
+  of mLtU: binary("($1 < $2)", MagicOp"ltUInt64")
+  of mEqEnum: binary("($1 == $2)")
+  of mLeEnum: binary("($1 <= $2)")
+  of mLtEnum: binary("($1 < $2)")
+  of mEqCh: binary("($1 == $2)")
+  of mLeCh: binary("($1 <= $2)")
+  of mLtCh: binary("($1 < $2)")
+  of mEqB: binary("($1 == $2)")
+  of mLeB: binary("($1 <= $2)")
+  of mLtB: binary("($1 < $2)")
+  of mEqRef: binary("($1 == $2)")
+  of mLePtr: binary("($1 <= $2)")
+  of mLtPtr: binary("($1 < $2)")
+  of mXor: binary("($1 != $2)")
+  of mEqCString: binary("($1 == $2)")
+  of mEqProc: binary("($1 == $2)")
+  of mUnaryMinusI: unary(MagicOp"negInt")
+  of mUnaryMinusI64: unary(MagicOp"checkedNegInt64")
+  of mAbsI: unary(MagicOp"absInt", MagicOp"absInt64")
+  of mNot: unary("!($1)")
+  of mUnaryPlusI: unary("$1") # a no-op
+  of mBitnotI:
+    if isInt64(n[1].typ):
+      unary(MagicOp"bitNotInt64")
+    elif isUnsigned(n[1].typ):
+      let arg = gen(p, n[1])
+      r.res = "(~($1) $2)" %
+        [rdLoc(arg), unsignedTrimmer(getSize(p.config, n.typ))]
+    else:
+      unary("~($1)")
+  of mUnaryPlusF64: unary("+($1)")
   else:
     unreachable(op)
 
 proc arith(p: PProc, n: CgNode, r: var TCompRes, op: TMagic) =
   case op
-  of mAddU: binaryUintExpr(p, n, r, "+")
-  of mSubU: binaryUintExpr(p, n, r, "-")
-  of mMulU: binaryUintExpr(p, n, r, "*")
+  of mAddU:
+    if isInt64(n.typ): patchedBinaryExpr(p, n[1], n[2], r, MagicOp"addInt64")
+    else:              patchedBinaryExpr(p, n[1], n[2], r, "($1 + $2)")
+  of mSubU:
+    if isInt64(n.typ): patchedBinaryExpr(p, n[1], n[2], r, MagicOp"subInt64")
+    else:              patchedBinaryExpr(p, n[1], n[2], r, "($1 - $2)")
+  of mMulU:
+    if isInt64(n.typ): binaryExpr(p, n[1], n[2], r, MagicOp"mulInt64")
+    else:              binaryUintExpr(p, n, r, "Math.imul($1, $2)")
   of mDivU:
-    binaryUintExpr(p, n, r, "/")
-    if n[1].typ.skipTypes(abstractRange).size == 8:
-      r.res = "Math.trunc($1)" % [r.res]
+    if isInt64(n.typ): binaryExpr(p, n[1], n[2], r, MagicOp"divUInt64")
+    else:              binaryUintExpr(p, n, r, "($1 / $2)")
   of mShrI:
-    var x, y: TCompRes
-    gen(p, n[1], x)
-    gen(p, n[2], y)
-    r.res = "($1 >>> $2)" % [x.rdLoc, y.rdLoc]
+    let a = gen(p, n[1])
+    let b = gen(p, n[2])
+    # needs special handling for the shift operand
+    if isInt64(n.typ):
+      useMagic(p, "shrInt64")
+      r.res = "shrInt64($1, $2)" % [rdLoc(a), rdNumLoc(p, b, n[2].typ)]
+    else:
+      r.res = "($1 >>> $2)" % [rdLoc(a), rdNumLoc(p, b, n[2].typ)]
   of mEqRef:
     if mapType(n[1].typ) != etyBaseIndex:
       arithAux(p, n, r, op)
@@ -2002,10 +2043,10 @@ proc genObjConstr(p: PProc, n: CgNode, r: var TCompRes) =
   createObjInitList(p, t, fieldIDs, initList)
   r.res = ("{$1}") % [initList]
 
-proc genConv(p: PProc, n: CgNode, r: var TCompRes) =
-  var dest = skipTypes(n.typ, abstractVarRange)
-  var src = skipTypes(n.operand.typ, abstractVarRange)
-  gen(p, n.operand, r)
+proc genConv(p: PProc, dest: PType, n: CgNode, r: var TCompRes) =
+  let dest = skipTypes(dest, abstractVarRange)
+  let src = skipTypes(n.typ, abstractVarRange)
+  gen(p, n, r)
   if dest.kind == src.kind:
     # no-op conversion
     return
@@ -2500,19 +2541,42 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
     else:
       genCall(p, n, r)
   of cnkNeg:
-    let x = gen(p, n[0])
-    r.res = "(-$1)" % rdLoc(x)
+    if isInt64(n.typ):
+      unaryExpr(p, n[0], r, MagicOp"negInt64")
+    else:
+      let x = gen(p, n[0])
+      r.res = "(-$1)" % rdLoc(x)
     r.typ = mapType(n.typ)
     r.kind = resExpr
-  of cnkAdd: binaryExpr(p, n[0], n[1], r, "($1 + $2)")
-  of cnkSub: binaryExpr(p, n[0], n[1], r, "($1 - $2)")
-  of cnkMul: binaryExpr(p, n[0], n[1], r, "($1 * $2)")
-  of cnkDiv:
-    if mapType(n.typ) == etyFloat:
-      binaryExpr(p, n[0], n[1], r, "($1 / $2)")
+  of cnkAdd:
+    case mapType(n.typ)
+    of etyFloat:  binaryExpr(p, n[0], n[1], r, "($1 + $2)")
+    of etyObject: patchedBinaryExpr(p, n[0], n[1], r, MagicOp"addInt64")
+    of etyInt:    patchedBinaryExpr(p, n[0], n[1], r, "($1 + $2)")
+    else:         unreachable()
+  of cnkSub:
+    case mapType(n.typ)
+    of etyFloat:  binaryExpr(p, n[0], n[1], r, "($1 - $2)")
+    of etyObject: patchedBinaryExpr(p, n[0], n[1], r, MagicOp"subInt64")
+    of etyInt:    patchedBinaryExpr(p, n[0], n[1], r, "($1 - $2)")
+    else:         unreachable()
+  of cnkMul:
+    if isInt64(n.typ):
+      binaryExpr(p, n[0], n[1], r, MagicOp"mulInt64")
     else:
-      binaryExpr(p, n[0], n[1], r, "Math.trunc($1 / $2)")
-  of cnkModI: binaryExpr(p, n[0], n[1], r, "Math.trunc($1 % $2)")
+      # ``Math.imul`` doesn't have to be used here, as signed-integer overflow
+      # is undefined behaviour
+      binaryExpr(p, n[0], n[1], r, "($1 * $2)")
+  of cnkDiv:
+    case mapType(n.typ)
+    of etyFloat:  binaryExpr(p, n[0], n[1], r, "($1 / $2)")
+    of etyObject: binaryExpr(p, n[0], n[1], r, MagicOp"divInt64")
+    else:         binaryExpr(p, n[0], n[1], r, "Math.trunc($1 / $2)")
+  of cnkModI:
+    if isInt64(n.typ):
+      binaryExpr(p, n[0], n[1], r, MagicOp"modInt64")
+    else:
+      binaryExpr(p, n[0], n[1], r, "Math.trunc($1 % $2)")
   of cnkClosureConstr:
     useMagic(p, "makeClosure")
     var tmp1, tmp2: TCompRes
@@ -2524,7 +2588,7 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   of cnkArrayConstr: genArrayConstr(p, n, r)
   of cnkTupleConstr: genTupleConstr(p, n, r)
   of cnkObjConstr: genObjConstr(p, n, r)
-  of cnkHiddenConv, cnkConv: genConv(p, n, r)
+  of cnkHiddenConv, cnkConv: genConv(p, n.typ, n.operand, r)
   of cnkLvalueConv:
     # non-object lvalue conversion are irrelevant to the JS backend
     gen(p, n.operand, r)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2422,30 +2422,8 @@ proc genCast(p: PProc, n: CgNode, r: var TCompRes) =
   if dest.kind == src.kind:
     # no-op conversion
     return
-  let toInt = (dest.kind in tyInt..tyInt32)
-  let toUint = (dest.kind in tyUInt..tyUInt32)
-  let fromInt = (src.kind in tyInt..tyInt32)
-  let fromUint = (src.kind in tyUInt..tyUInt32)
 
-  if toUint and (fromInt or fromUint):
-    let trimmer = unsignedTrimmer(dest.size)
-    r.res = "($1 $2)" % [r.res, trimmer]
-  elif toInt and (fromInt or fromUint):
-    if fromInt:
-      return
-    elif fromUint:
-      if src.size == 4 and dest.size == 4:
-        # XXX prevent multi evaluations
-        r.res = "($1 | 0)" % [r.res]
-      else:
-        let trimmer = unsignedTrimmer(dest.size)
-        let minuend = case dest.size
-          of 1: "0xfe"
-          of 2: "0xfffe"
-          of 4: "0xfffffffe"
-          else: ""
-        r.res = "($1 - ($2 $3))" % [rope minuend, r.res, trimmer]
-  elif dest.kind == tyPointer:
+  if dest.kind == tyPointer:
     # cast into pointer
     if r.typ == etyBaseIndex:
       discard "already a fat pointer, do nothing"
@@ -2462,6 +2440,105 @@ proc genCast(p: PProc, n: CgNode, r: var TCompRes) =
       r.res = r.address
       r.address = "" # clear out the address
       r.typ = d
+  elif src.kind in IntegralTypes and dest.kind in IntegralTypes:
+    case dest.kind
+    of tyInt64, tyUInt64:
+      case src.kind
+      of tyInt..tyInt32:
+        useMagic(p, "sextInt64")
+        r.res = "sextInt64($1)" % [rdLoc(r)]
+      of tyUInt..tyUInt32, tyChar:
+        useMagic(p, "zextInt64")
+        r.res = "zextInt64($1)" % [rdLoc(r)]
+      of tyFloat, tyFloat64:
+        useMagic(p, "castDoubleToInt64")
+        r.res = "castDoubleToInt64($1)" % [rdLoc(r)]
+      of tyFloat32:
+        useMagic(p, "castFloatToInt64")
+        r.res = "castFloatToInt64($1)" % [rdLoc(r)]
+      else:
+        discard "silently ignore"
+    of tyInt..tyInt32:
+      let op =
+        case dest.size
+        of 1: "<< 24 >> 24"
+        of 2: "<< 16 >> 16"
+        of 4: "| 0"
+        else: unreachable()
+
+      case src.kind
+      of tyInt..tyInt32, tyUInt..tyUInt32, tyChar:
+        r.res = "($1 $2)" % [rdLoc(r), op]
+      of tyInt64, tyUInt64:
+        useMagic(p, "truncInt64")
+        r.res = "(truncInt64($1) $2)" % [rdLoc(r), op]
+      of tyFloat, tyFloat64:
+        useMagic(p, "castDoubleToInt")
+        r.res = "(castDoubleToInt($1) $2)" % [rdLoc(r), op]
+      of tyFloat32:
+        useMagic(p, "castFloatToInt")
+        r.res = "(castFloatToInt($1) $2)" % [rdLoc(r), op]
+      else:
+        discard "silently ignore"
+    of tyUInt..tyUInt32, tyChar:
+      let op = unsignedTrimmer(dest.size)
+      case src.kind
+      of tyInt..tyInt32, tyUInt..tyUInt32, tyChar:
+        r.res = "($1 $2)" % [rdLoc(r), op]
+      of tyFloat, tyFloat64:
+        useMagic(p, "castDoubleToInt")
+        r.res = "(castDoubleToInt($1) $2)" % [rdLoc(r), op]
+      of tyFloat32:
+        useMagic(p, "castFloatToInt")
+        r.res = "(castFloatToInt($1) $2)" % [rdLoc(r), op]
+      of tyUInt64, tyInt64:
+        useMagic(p, "truncInt64")
+        r.res = "(truncInt64($1) $2)" % [rdLoc(r), op]
+      else:
+        discard "silently ignore"
+    of tyFloat, tyFloat64:
+      case src.kind
+      of tyFloat32:
+        useMagic(p, "castFloatToInt")
+        useMagic(p, "castIntToDobule")
+        r.res = "castIntToDouble(castFloatToInt($n))" % [rdLoc(r)]
+      of tyInt..tyInt32:
+        useMagic(p, "castIntToDouble")
+        # cast to a same-sized uint first, then cast to double
+        r.res = "castIntToDouble($1 $2)" %
+          [rdLoc(r), unsignedTrimmer(src.size)]
+      of tyUInt..tyUInt32, tyChar:
+        useMagic(p, "castIntToDouble")
+        r.res = "castIntToDouble($1)" % [rdLoc(r)]
+      of tyInt64, tyUInt64:
+        useMagic(p, "castInt64ToDouble")
+        r.res = "castInt64ToDouble($1)" % [rdLoc(r)]
+      else:
+        discard "silently ignore"
+    of tyFloat32:
+      case src.kind
+      of tyFloat64, tyFloat:
+        useMagic(p, "castDoubleToInt")
+        useMagic(p, "castIntToFloat")
+        r.res = "castIntToFloat(castDoubleToInt($n))" % [rdLoc(r)]
+      of tyInt..tyInt32:
+        useMagic(p, "castIntToFloat")
+        # cast to a same-sized uint first, then cast to float
+        r.res = "castIntToFloat($1 $2)" %
+          [rdLoc(r), unsignedTrimmer(src.size)]
+      of tyUInt..tyUInt32, tyChar:
+        useMagic(p, "castIntToFloat")
+        r.res = "castIntToFloat($1)" % [rdLoc(r)]
+      of tyInt64, tyUInt64:
+        useMagic(p, "castInt64ToFloat")
+        r.res = "castInt64ToFloat($1)" % [rdLoc(r)]
+      else:
+        discard "silently ignore"
+    else:
+      discard "silently ignore"
+  else:
+    # other casts require serialization/deserialization from bytes
+    discard "not implemented; silently ignored"
 
 proc gen(p: PProc, n: CgNode, r: var TCompRes) =
   r.typ = etyNone

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -899,6 +899,51 @@ proc genCaseJS(p: PProc, desc: StructDesc, stmts: openArray[CgNode], n: CgNode) 
 
   lineF(p, "}$n", [])
 
+proc genCaseInt64(p: PProc, desc: StructDesc, stmts: openArray[CgNode], n: CgNode) =
+  ## Similar to `genCaseJs`, but handles selectors of 64-bit integer type, which
+  ## cannot be used in JavaScript switch statements.
+  let sel = gen(p, n[0])
+  let typ = n[0].typ
+  let leOp =
+    if isUnsigned(n[0].typ): "leUInt64"
+    else:                    "leInt64"
+
+  for i in 1..<n.len:
+    let it = n[i]
+    if isOfBranch(it):
+      var cond = ""
+      for j in 0..<it.len-1:
+        let e = it[j]
+        var expr = ""
+        if e.kind == cnkRange:
+          expr = "($2($3, $1) && $2($1, $4))" %
+            [rdLoc(sel), leOp, intLiteral(getInt(e[0]), typ),
+             intLiteral(getInt(e[1]), typ)]
+        else:
+          expr = "eqInt64($1, $2)" % [rdLoc(sel), intLiteral(getInt(e), typ)]
+
+        if cond.len == 0:
+          cond = expr
+        else:
+          cond.add " || "
+          cond.add expr
+
+      if i == 1: lineF(p, "if ($1) {$n", [cond])
+      else:      lineF(p, "} else if($1) {$n", [cond])
+    else:
+      if i == 1: lineF(p, "{$n", [])
+      else:      lineF(p, "} else {$n", [])
+
+    # as for normal switch-case statements, also perform inlining here
+    let target = it[^1].label
+    p.nested:
+      if target in desc.inline:
+        gen(p, desc, stmts, desc.inline[target])
+      else:
+        lineF(p, "break Label$1;$n", [$target])
+
+  lineF(p, "}$n", [])
+
 proc genAsmOrEmitStmt(p: PProc, n: CgNode) =
   genLineDir(p, n)
   p.body.add p.indentLine("")
@@ -2392,7 +2437,10 @@ proc gen(p: PProc, desc: StructDesc, stmts: openArray[CgNode], start: int) =
     of stkTerminator:
       let n = stmts[it.stmt]
       if n.kind == cnkCaseStmt:
-        genCaseJS(p, desc, stmts, n)
+        if isInt64(n[0].typ):
+          genCaseInt64(p, desc, stmts, n)
+        else:
+          genCaseJS(p, desc, stmts, n)
       else:
         genStmt(p, n)
       # the statements immediately following the terminator are dead code,

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1742,8 +1742,14 @@ proc genReprAux(p: PProc, n: CgNode, r: var TCompRes, magic: string; typ = "") =
 proc genRepr(p: PProc, n: CgNode, r: var TCompRes) =
   let t = skipTypes(n[1].typ, abstractVarRange)
   case t.kind:
-  of tyInt..tyInt64, tyUInt..tyUInt64:
+  of tyInt..tyInt32:
     genReprAux(p, n, r, "reprInt")
+  of tyUInt..tyUInt32:
+    genReprAux(p, n, r, "reprUInt")
+  of tyInt64:
+    genReprAux(p, n, r, "reprInt64")
+  of tyUInt64:
+    genReprAux(p, n, r, "reprUInt64")
   of tyChar:
     genReprAux(p, n, r, "reprChar")
   of tyBool:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2050,21 +2050,95 @@ proc genConv(p: PProc, dest: PType, n: CgNode, r: var TCompRes) =
   if dest.kind == src.kind:
     # no-op conversion
     return
-  let toInt = (dest.kind in tyInt..tyInt32)
-  let fromInt = (src.kind in tyInt..tyInt32)
-  let toUint = (dest.kind in tyUInt..tyUInt32)
-  let fromUint = (src.kind in tyUInt..tyUInt32)
-  if toUint and (fromInt or fromUint):
-    let trimmer = unsignedTrimmer(dest.size)
-    r.res = "($1 $2)" % [r.res, trimmer]
-  elif dest.kind == tyBool:
-    r.res = "(!!($1))" % [r.res]
-    r.kind = resExpr
-  elif toInt:
-    r.res = "(($1) | 0)" % [r.res]
+
+  case dest.kind
+  of tyBool:
+    case src.kind
+    of tyInt64, tyUInt64:
+      useMagic(p, "eqInt64")
+      r.res = "(!eqInt64($1, {lo: 0, hi: 0}))" % [rdLoc(r)]
+    else:
+      r.res = "(!!$1)" % [rdLoc(r)]
+  of tyInt64, tyUInt64:
+    case src.kind
+    of tyInt..tyInt32:
+      useMagic(p, "sextInt64")
+      r.res = "sextInt64($1)" % [rdLoc(r)]
+    of tyUInt..tyUInt32, tyChar:
+      useMagic(p, "zextInt64")
+      r.res = "zextInt64($1)" % [rdLoc(r)]
+    of tyFloat, tyFloat64:
+      useMagic(p, "doubleToInt64")
+      r.res = "doubleToInt64($1)" % [rdLoc(r)]
+    of tyFloat32:
+      useMagic(p, "doubleToInt64")
+      r.res = "doubleToInt64($1)" % [rdLoc(r)]
+    of tyBool:
+      r.res = "($1 ? {lo: 1, hi: 0} : {lo: 0, hi: 0})" % [rdLoc(r)]
+    else:
+      discard "silently ignore"
+  of tyInt..tyInt32:
+    case src.kind
+    of tyInt..tyInt32, tyUInt..tyUInt32, tyChar:
+      discard "a no-op"
+    of tyInt64, tyUInt64:
+      useMagic(p, "truncInt64")
+      r.res = "(truncInt64($1) | 0)"
+    of tyFloat, tyFloat64, tyFloat32:
+      # NaN becomes zero
+      r.res = "($1 < $2 ? $2 : ($1 > $3 ? $3 : ($1 == $1 ? ($1|0) : 0)))" %
+        [rdLoc(r), $firstOrd(p.config, dest), $lastOrd(p.config, dest)]
+    of tyBool:
+      r.res = "($1 ? 1 : 0)" % [rdLoc(r)]
+    else:
+      discard "silently ignore"
+  of tyUInt..tyUInt32, tyChar:
+    case src.kind
+    of tyInt..tyInt32, tyUInt..tyUInt32, tyChar:
+      r.res = "($1 $2)" % [rdLoc(r), unsignedTrimmer(dest.size)]
+    of tyFloat, tyFloat64, tyFloat32:
+      # NaN becomes zero
+      r.res = "($1 > $2 ? $2 : ($1 > 0 ? ($1>>>0) : 0))" %
+        [rdLoc(r), $lastOrd(p.config, dest)]
+    of tyUInt64, tyInt64:
+      useMagic(p, "truncInt64")
+      r.res = "(truncInt64($1) $2)" % [rdLoc(r), unsignedTrimmer(dest.size)]
+    of tyBool:
+      r.res = "($1 ? 1 : 0)" % [rdLoc(r)]
+    else:
+      discard "silently ignore"
+  of tyFloat, tyFloat64:
+    case src.kind
+    of tyFloat32, tyInt..tyInt32, tyUInt..tyUInt32, tyChar:
+      discard "nothing to do"
+    of tyInt64:
+      useMagic(p, "int64ToDouble")
+      r.res = "int64ToDouble($1)" % [rdLoc(r)]
+    of tyUInt64:
+      useMagic(p, "uint64ToDouble")
+      r.res = "uint64ToDouble($1)" % [rdLoc(r)]
+    of tyBool:
+      r.res = "($1 ? 1 : 0)" % [rdLoc(r)]
+    else:
+      discard "silently ignore"
+  of tyFloat32:
+    # FIXME: the conversion needs to use fround for demoting from double
+    #        to single precision
+    case src.kind
+    of tyFloat64, tyFloat, tyInt..tyInt32, tyUInt..tyUInt32, tyChar:
+      discard "nothing to do"
+    of tyInt64:
+      useMagic(p, "int64ToDouble")
+      r.res = "int64ToDouble($1)" % [rdLoc(r)]
+    of tyUInt64:
+      useMagic(p, "uint64ToDouble")
+      r.res = "uint64ToDouble($1)" % [rdLoc(r)]
+    of tyBool:
+      r.res = "($1 ? 1 : 0)" % [rdLoc(r)]
+    else:
+      discard "silently ignore"
   else:
-    # TODO: What types must we handle here?
-    discard
+    discard "silently ignore"
 
 proc downConv(p: PProc, n: CgNode, r: var TCompRes) =
   gen(p, n.operand, r)        # XXX

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -1103,9 +1103,12 @@ proc genArrayAddr(p: PProc, n: CgNode, r: var TCompRes) =
   if typ.kind == tyArray:
     first = firstOrd(p.config, typ[0])
   if first != 0:
-    r.res = "($1) - ($2)" % [b.res, rope(first)]
+    # TODO: handle 64-bit indices properly properly, by using the type-specific
+    #       arithmetic ops. The index processing should be inserted
+    #       by `mirgen`
+    r.res = "($1) - ($2)" % [rdNumLoc(p, b, m[1].typ), rope(first)]
   else:
-    r.res = b.res
+    r.res = rdNumLoc(p, b, m[1].typ)
   r.kind = resExpr
 
 proc genArrayAccess(p: PProc, n: CgNode, r: var TCompRes) =
@@ -1907,6 +1910,7 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
     discard "implementation is missing"
   of mChckIndex:
     let
+      typ = n[2].typ
       first = firstOrd(p.config, n[1].typ)
       arr = gen(p, n[1])
       idx = gen(p, n[2])
@@ -1914,13 +1918,14 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
     useMagic(p, "chckIndx")
     if first == 0:
       lineF(p, "(chckIndx($2, 0, ($1).length - 1));$n",
-            [rdLoc(arr), rdLoc(idx)])
+            [rdLoc(arr), rdNumLoc(p, idx, typ)])
     else:
       # can only be a statically-sized array
       lineF(p, "(chckIndx($1, $2, $3));$n",
-            [rdLoc(idx), rope(first), rope(lastOrd(p.config, n[1].typ))])
+            [rdNumLoc(p, idx, typ), rope(first), rope(lastOrd(p.config, n[1].typ))])
   of mChckBounds:
     let
+      typ = n[2].typ
       first = firstOrd(p.config, n[1].typ)
       arr = gen(p, n[1])
       lo = gen(p, n[2])
@@ -1929,11 +1934,11 @@ proc genMagic(p: PProc, n: CgNode, r: var TCompRes) =
     useMagic(p, "chckBounds")
     if first == 0:
       lineF(p, "chckBounds($2, $3, 0, ($1).length - 1);$n",
-            [rdLoc(arr), rdLoc(lo), rdLoc(hi)])
+            [rdLoc(arr), rdNumLoc(p, lo, typ), rdNumLoc(p, hi, typ)])
     else:
       # can only be a statically-sized array
       lineF(p, "(chckBounds($1, $2, $3, $4));$n",
-            [rdLoc(lo), rdLoc(hi), rope(first),
+            [rdNumLoc(p, lo, typ), rdNumLoc(p, hi, typ), rope(first),
              rope(lastOrd(p.config, n[1].typ))])
   of mChckField:
     genFieldCheck(p, n)

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -298,7 +298,8 @@ proc mapType(typ: PType; indirect = false): TJSTypeKind =
   of tyRange, tyDistinct, tyOrdinal, tyProxy, tyLent:
     # tyLent is no-op as JS has pass-by-reference semantics
     result = mapType(t[0], indirect)
-  of tyInt..tyInt64, tyUInt..tyUInt64, tyChar: result = etyInt
+  of tyInt..tyInt32, tyUInt..tyUInt32, tyChar: result = etyInt
+  of tyInt64, tyUInt64: result = etyObject
   of tyBool: result = etyBool
   of tyFloat..tyFloat64: result = etyFloat
   of tySet: result = etyObject # map a set to a table
@@ -790,9 +791,13 @@ proc genRaiseStmt(p: PProc, n: CgNode) =
   lineF(p, "throw lastJSError;$n", [])
 
 func intLiteral(v: Int128, typ: PType): string =
-  if typ.kind == tyBool:
+  case skipTypes(typ, abstractRange + tyUserTypeClasses).kind
+  of tyBool:
     if v == Zero: "false"
     else:         "true"
+  of tyInt64, tyUInt64:
+    let bits = castToUInt64(v)
+    "{lo: $1, hi: $2}" % [$cast[uint32](bits), $cast[uint32](bits shr 32)]
   else:           $v
 
 proc gen(p: PProc, desc: StructDesc, stmts: openArray[CgNode], start: int)
@@ -911,7 +916,8 @@ proc needsNoCopy(p: PProc; y: CgNode): bool =
   return y.kind in nodeKindsNeedNoCopy or
         ((mapType(y.typ) != etyBaseIndex) and
           (skipTypes(y.typ, abstractInst).kind in
-            {tyRef, tyPtr, tyLent, tyVar, tyCstring, tyProc, tyOpenArray} + IntegralTypes))
+            {tyRef, tyPtr, tyLent, tyVar, tyCstring, tyProc, tyOpenArray} + IntegralTypes -
+            {tyInt64, tyUInt64}))
 
 proc genAsgnAux(p: PProc, x, y: CgNode, noCopyNeeded: bool) =
   var a, b: TCompRes
@@ -1390,13 +1396,15 @@ proc arrayTypeForElemType(typ: PType): string =
 proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
   var t = skipTypes(typ, abstractInst)
   case t.kind
-  of tyInt..tyInt64, tyUInt..tyUInt64, tyEnum, tyChar:
+  of tyInt..tyInt32, tyUInt..tyUInt32, tyEnum, tyChar:
     if t.sym.extname == "bigint":
       result = putToSeq("0n", indirect)
     else:
       result = putToSeq("0", indirect)
   of tyFloat..tyFloat64:
     result = putToSeq("0.0", indirect)
+  of tyUInt64, tyInt64:
+    result = putToSeq("{lo: 0, hi: 0}", indirect)
   of tyRange, tyGenericInst, tyAlias, tySink, tyLent:
     result = createVar(p, lastSon(typ), indirect)
   of tySet:

--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -2155,7 +2155,7 @@ proc genRangeChck(p: PProc, n: CgNode, r: var TCompRes) =
     gen(p, n[2], a)
     gen(p, n[3], b)
     useMagic(p, "chckRange")
-    r.res = "chckRange($1, $2, $3)" % [r.res, a.res, b.res]
+    r.res = "chckRange($1, $2, $3)" % [rdNumLoc(p, r, n[1].typ), a.res, b.res]
     r.kind = resExpr
 
 proc frameCreate(p: PProc; procname, filename: Rope): Rope =

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -143,7 +143,7 @@ when defined(js):
       P1 = big"0xe7037ed1a0b428db"
       P58 = big"0xeb44accab455d16d" # big"0xeb44accab455d165" xor big"8"
       res = hiXorLoJs(hiXorLoJs(P0, x xor P1), P58)
-    cast[Hash](toNumber(wrapToInt(res, 32)))
+    cast[Hash](int64(toNumber(wrapToInt(res, 32))))
 
   template toBits(num: float): JsBigInt =
     let

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -897,7 +897,9 @@ proc toWinTime*(t: Time): int64 =
 proc getTime*(): Time {.tags: [TimeEffect], benign.} =
   ## Gets the current time as a `Time` with up to nanosecond resolution.
   when defined(js):
-    let millis = newDate().getTime()
+    # XXX: converting to float first and then int64 is a workaround for
+    #      `getTime` not returning a `float`
+    let millis = int64(float(newDate().getTime()))
     let seconds = convert(Milliseconds, Seconds, millis)
     let nanos = convert(Milliseconds, Nanoseconds,
       millis mod convert(Seconds, Milliseconds, 1).int)

--- a/lib/std/jsbigints.nim
+++ b/lib/std/jsbigints.nim
@@ -203,17 +203,18 @@ proc low*(_: typedesc[JsBigInt]): JsBigInt {.error:
 proc high*(_: typedesc[JsBigInt]): JsBigInt {.error:
   "Arbitrary precision integers do not have a known high.".} ## **Do NOT use.**
 
-proc big(val: float): JsBigInt {.importjs: "BigInt(#)".}
-
-proc big*(integer: uint64): JsBigInt =
+func big*(integer: uint64): JsBigInt =
   ## Constructor for `JsBigInt`.
-  # a 64-bit integer is only a float underneath, making this the only way to
-  # properly perform the conversion
-  big(float(integer))
+  big(uint(integer)) + (big(uint(integer shr 32)) shl big"32")
 
-proc big*(integer: int64): JsBigInt =
+func big*(integer: int64): JsBigInt =
   ## Constructor for `JsBigInt`.
-  big(float(integer))
+  if integer < 0:
+    # safely compute the absolute first, convert that, and then negate
+    # the result
+    -big(0 - cast[uint64](integer))
+  else:
+    big(uint64(integer))
 
 runnableExamples:
   block:

--- a/lib/std/private/digitsutils.nim
+++ b/lib/std/private/digitsutils.nim
@@ -36,9 +36,6 @@ proc utoa2Digits*(buf: var openArray[char]; pos: int; digits: uint32) {.inline.}
 proc trailingZeros2Digits*(digits: uint32): int32 {.inline.} =
   return trailingZeros100[digits]
 
-when defined(js):
-  proc numToString(a: float): cstring {.importjs: "((#) + \"\")".}
-
 func addChars[T](result: var string, x: T, start: int, n: int) {.inline.} =
   let old = result.len
   result.setLen old + n
@@ -79,11 +76,7 @@ func addIntImpl(result: var string, x: uint64) {.inline.} =
   addChars(result, tmp, next, tmp.len - next)
 
 func addInt*(result: var string, x: uint64) =
-  when nimvm: addIntImpl(result, x)
-  else:
-    when not defined(js): addIntImpl(result, x)
-    else:
-      addChars(result, numToString(float(x)))
+  addIntImpl(result, x)
 
 proc addInt*(result: var string; x: int64) =
   ## Converts integer to its string representation and appends it to `result`.
@@ -91,7 +84,7 @@ proc addInt*(result: var string; x: int64) =
     var s = "foo"
     s.addInt(45)
     assert s == "foo45"
-  template impl =
+  if true:
     var num: uint64
     if x < 0:
       if x == low(int64):
@@ -104,11 +97,6 @@ proc addInt*(result: var string; x: int64) =
     else:
       num = uint64(x)
     addInt(result, num)
-  when nimvm: impl()
-  else:
-    when defined(js):
-      addChars(result, numToString(float(x)))
-    else: impl()
 
 proc addInt*(result: var string; x: int) {.inline.} =
   addInt(result, int64(x))

--- a/lib/std/private/jsutils.nim
+++ b/lib/std/private/jsutils.nim
@@ -62,8 +62,8 @@ when defined(js):
     ## The same as `Number.MAX_SAFE_INTEGER` or `2^53 - 1`.
     ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
   runnableExamples:
-    let a {.importjs: "Number.MAX_SAFE_INTEGER".}: int64
-    assert a == maxSafeInteger
+    let a {.importjs: "Number.MAX_SAFE_INTEGER".}: float
+    assert int64(a) == maxSafeInteger
 
   proc isInteger*[T](x: T): bool {.importjs: "Number.isInteger(#)".} =
     runnableExamples:

--- a/lib/system/jsint64.nim
+++ b/lib/system/jsint64.nim
@@ -317,8 +317,7 @@ proc castFloatToInt64(val: float32): Int64 {.compilerproc, asmNoStackFrame.} =
     var buf = new ArrayBuffer(4);
     (new Float32Array(buf))[0] = `val`;
     var view = new Uint32Array(buf);
-    `result`.lo = view[0];
-    `result`.hi = 0;
+    return {lo: view[0], hi: 0};
   """
 
 proc castDoubleToInt64(val: float64): Int64 {.compilerproc, asmNoStackFrame.} =
@@ -326,8 +325,7 @@ proc castDoubleToInt64(val: float64): Int64 {.compilerproc, asmNoStackFrame.} =
     var buf = new ArrayBuffer(8);
     (new Float64Array(buf))[0] = `val`;
     var view = new Uint32Array(buf);
-    `result`.lo = view[0];
-    `result`.hi = view[1];
+    return {lo: view[0], hi: view[1]};
   """
 
 proc castInt64ToDouble(val: Int64): float64 {.compilerproc, asmNoStackFrame.} =
@@ -336,7 +334,7 @@ proc castInt64ToDouble(val: Int64): float64 {.compilerproc, asmNoStackFrame.} =
     var view = new Uint32Array(buf);
     view[0] = `val`.lo;
     view[1] = `val`.hi;
-    `result` = (new Float64Array(buf))[0];
+    return (new Float64Array(buf))[0];
   """
 
 proc castInt64ToFloat(val: Int64): float32 {.compilerproc, asmNoStackFrame.} =
@@ -344,7 +342,7 @@ proc castInt64ToFloat(val: Int64): float32 {.compilerproc, asmNoStackFrame.} =
     var buf = new ArrayBuffer(4);
     var view = new Uint32Array(buf);
     view[0] = `val`.lo;
-    `result` = (new Float32Array(buf))[0];
+    return (new Float32Array(buf))[0];
   """
 
 {.pop.}

--- a/lib/system/jsint64.nim
+++ b/lib/system/jsint64.nim
@@ -1,0 +1,350 @@
+## Implement the various operations (e.g., basic arithmetic, bit operations,
+## conversion, etc.) for 64-bit integers for the JavaScript target.
+
+type
+  Int64 = object
+    ## The internal representation of a sign-less 64-bit integer. How the bit
+    ## pattern is interpreted depends on the operation.
+    lo, hi: uint32
+
+{.push stackTrace: off, checks: off.}
+
+proc negInt64(a: Int64): Int64 {.compilerproc.}
+
+# MARK: conversion operations
+
+proc doubleToUInt64(val: float64): Int64 {.compilerproc, asmNoStackFrame.} =
+  # needs to use the JavaScript logical right shift operator, hence the asm
+  asm """
+    if (`val` > 0.0) {
+      if (`val` >= Math.pow(2, 64)) {
+        return {lo: 0xFFFFFFFF, hi: 0xFFFFFFFF};
+      } else {
+        return {lo: `val`>>>0, hi: (`val` / Math.pow(2, 32)) >>> 0};
+      }
+    } else {
+      return {lo: 0, hi: 0};
+    }
+  """
+
+proc doubleToInt64(val: float64): Int64 {.compilerproc, asmNoStackFrame.} =
+  # needs to use the JavaScript logical right shift operator, hence the asm
+  asm """
+    if (`val` > 0.0) {
+      if (`val` >= Math.pow(2, 63)) {
+        return {lo: 0xFFFFFFFF, hi: 0x7FFFFFFF};
+      } else {
+        return {lo: `val`>>>0, hi: (`val` / Math.pow(2, 32)) >>> 0};
+      }
+    } else if (`val` < 0.0) {
+      if (`val` < -Math.pow(2, 63)) {
+        return {lo: 0, hi: 0x8000_0000};
+      } else {
+        return `negInt64`({lo: (-`val`) >>> 0,
+                           hi: (-`val` / Math.pow(2, 32)) >>> 0});
+      }
+    } else {
+      return {lo: 0, hi: 0};
+    }
+  """
+
+proc uint64ToDouble(a: Int64): float64 {.compilerproc.} =
+  float64(a.lo) + float64(a.hi) * float64(1'i64 shl 32)
+
+proc int64ToDouble(a: Int64): float64 {.compilerproc.} =
+  if a.hi >= 0x8000_0000'u32:
+    -uint64ToDouble(negInt64(a))
+  else:
+    uint64ToDouble(a)
+
+proc zextInt64(val: uint32): Int64 {.compilerproc.} =
+  Int64(lo: cast[uint32](val), hi: 0)
+
+proc sextInt64(val: int32): Int64 {.compilerproc.} =
+  Int64(lo: cast[uint32](val), hi: cast[uint32](val shr 31))
+
+proc truncInt64(a: Int64): uint32 {.compilerproc.} =
+  a.lo
+
+# MARK: comparison operations
+
+proc ltInt64(a, b: Int64): bool {.compilerproc.} =
+  if cast[int32](a.hi) < cast[int32](b.hi):
+    true
+  else:
+    a.hi == b.hi and a.lo < b.lo
+
+proc eqInt64(a, b: Int64): bool {.compilerproc.} =
+  a.hi == b.hi and a.lo == b.lo
+
+proc leInt64(a, b: Int64): bool {.compilerproc.} =
+  if cast[int32](a.hi) < cast[int32](b.hi):
+    true
+  else:
+    a.hi == b.hi and a.lo <= b.lo
+
+proc leUInt64(a, b: Int64): bool {.compilerproc.} =
+  if a.hi < b.hi:
+    true
+  else:
+    a.hi == b.hi and a.lo <= b.lo
+
+proc ltUInt64(a, b: Int64): bool {.compilerproc.} =
+  if a.hi < b.hi:
+    true
+  else:
+    a.hi == b.hi and a.lo < b.lo
+
+# MARK: bit operations
+
+proc shlInt64(a: Int64, shift: int): Int64 {.compilerproc.} =
+  if shift == 0:
+    a
+  elif shift < 32:
+    Int64(lo: a.lo shl shift, hi: (a.hi shl shift) or (a.lo shr (32 - shift)))
+  else:
+    Int64(lo: 0'u32, hi: (a.lo shl (shift - 32)))
+
+proc shrInt64(a: Int64, shift: int): Int64 {.compilerproc.} =
+  if shift == 0:
+    a
+  elif shift < 32:
+    Int64(lo: (a.lo shr shift) or (a.hi shl (32 - shift)), hi: a.hi shr shift)
+  else:
+    Int64(lo: (a.hi shr (shift - 32)), hi: 0)
+
+proc ashrInt64(a: Int64, shift: int): Int64 {.compilerproc.} =
+  proc ashr(x: uint32, by: int): uint32 =
+    cast[uint32](cast[int32](x) shr by)
+
+  if shift == 0:
+    a
+  elif shift < 32:
+    Int64(lo: (a.lo shr shift) or (a.hi shl (32 - shift)),
+          hi: ashr(a.hi, shift))
+  else:
+    Int64(lo: ashr(a.hi, shift - 32), hi: ashr(a.hi, 31))
+
+proc bitAndInt64(a, b: Int64): Int64 {.compilerproc.} =
+  Int64(lo: a.lo and b.lo, hi: a.hi and b.hi)
+
+proc bitOrInt64(a, b: Int64): Int64 {.compilerproc.} =
+  Int64(lo: a.lo or b.lo, hi: a.hi or b.hi)
+
+proc bitXorInt64(a, b: Int64): Int64 {.compilerproc.} =
+  Int64(lo: a.lo xor b.lo, hi: a.hi xor b.hi)
+
+proc bitNotInt64(a: Int64): Int64 {.compilerproc.} =
+  Int64(lo: not a.lo, hi: not a.hi)
+
+# MARK: arithmetic operations
+
+proc negInt64(a: Int64): Int64 {.compilerproc.} =
+  # negation is the same as `0 - a`
+  result.lo = not(a.lo) + 1
+  # `a.lo == 0` is the only value for which the above addition can overflow
+  result.hi = not(a.hi) + uint32(ord(a.lo == 0))
+
+proc addInt64(a, b: Int64): Int64 {.compilerproc.} =
+  result.lo = a.lo + b.lo
+  result.hi = a.hi + b.hi + uint32(ord(result.lo < a.lo))
+
+proc subInt64(a, b: Int64): Int64 {.compilerproc.} =
+  # subtracting `b` is the same as adding the two's complement of `b`
+  result.lo = a.lo + not(b.lo) + 1
+  result.hi = a.hi + not(b.hi) + uint32(ord(result.lo <= not(b.lo)))
+
+proc mulInt32(a, b: uint32): Int64 =
+  ## Multiplies two 32-bit integers, returning a 64-bit result.
+  let aLo = a and 0xFFFF
+  let aHi = a shr 16
+  let bLo = b and 0xFFFF
+  let bHi = b shr 16
+  let part1 = aLo * bLo
+  let part2 = aHi * bLo
+  let part3 = aLo * bHi
+  let part4 = aHi * bHi
+
+  let tmp = part2 + part3
+  result.lo = part1 + (tmp shl 16)
+  result.hi = part4 + (tmp shr 16) + (if tmp < part2: 1'u32 shl 16 else: 0) +
+              uint32(ord(result.lo < part1))
+
+proc mulInt64(a, b: Int64): Int64 {.compilerproc.} =
+  # integer multiplication works the same regardless of sign
+  # a * b = (aLo + aHi*shift) * (bLo + bHi*shift)
+  #       = aLo*bLo + aHi*bLo*shift + aLo*bHi*shift + aHi*bHi*shift*shift
+  let part1 = mulInt32(a.lo, b.lo)
+  let part2 = mulInt32(a.hi, b.lo)
+  let part3 = mulInt32(a.lo, b.hi)
+  # a.hi * b.hi is always outside the valid range and can thus be ignored
+  result.lo = part1.lo
+  result.hi = part1.hi + part2.lo + part3.lo
+
+proc udiv(dividend, divisor: Int64): Int64 =
+  ## Treats both operands as unsigned and performs an integer division.
+  if ltUInt64(dividend, divisor):
+    return Int64()
+
+  # convert both operands to double (lossy) and use fp division. The
+  # result will be close (or equal) to the real result
+  let approximate = uint64ToDouble(dividend) / uint64ToDouble(divisor)
+  result = doubleToUInt64(approximate)
+
+  # shrink the approximate quotient until q * divisor <= dividend * divisor
+  var got = mulInt64(divisor, result)
+  while ltUInt64(got, result) or ltUInt64(dividend, got):
+    result = shrInt64(result, 1)
+    got = mulInt64(divisor, result)
+
+  # `(a + b) / c` is the same as `(a/c) + (a/b)` (including when the
+  # intermediate results are truncated)
+  if not eqInt64(dividend, got):
+    # note: with the V8 engine, this check and branch (even though not
+    # necessary for correctness) have shown to be beneficial for performance
+    let tmp = udiv(subInt64(dividend, got), divisor)
+    result = addInt64(result, tmp)
+
+proc idiv(dividend, divisor: Int64): Int64 =
+  ## Treats both operands as signed integers and performs a division.
+  let
+    ndividend = dividend.hi >= 0x8000_0000'u32
+    ndivisor  = divisor.hi >= 0x8000_0000'u32
+    a = if ndividend: negInt64(dividend) else: dividend
+    b = if ndivisor:  negInt64(divisor)  else: divisor
+  result = udiv(a, b)
+  if ndivisor xor ndividend:
+    # the quotient must be negative
+    result = negInt64(result)
+
+proc divInt64(a, b: Int64): Int64 {.compilerproc.} =
+  idiv(a, b)
+
+proc divUInt64(a, b: Int64): Int64 {.compilerproc.} =
+  udiv(a, b)
+
+proc modInt64(a, b: Int64): Int64 {.compilerproc.} =
+  subInt64(a, mulInt64(idiv(a, b), b))
+
+proc modUInt64(a, b: Int64): Int64 {.compilerproc.} =
+  subInt64(a, mulInt64(udiv(a, b), b))
+
+proc absInt64(a: Int64): Int64 {.compilerproc.} =
+  if a.hi >= 0x8000_0000'u32:
+    negInt64(a)
+  else:
+    a
+
+proc nimMin64(a, b: Int64): Int64 {.compilerproc.} =
+  if ltInt64(a, b): a else: b
+
+proc nimMax64(a, b: Int64): Int64 {.compilerproc.} =
+  if ltInt64(a, b): b else: a
+
+# MARK: checked operations
+
+proc checkedNegInt64(a: Int64): Int64 {.compilerproc.} =
+  # if a == low(int64), the result of the negation will overflow
+  if a.lo == 0 and a.hi == 0x8000_0000'u32:
+    raiseOverflow()
+  else:
+    result = negInt64(a)
+
+proc checkedAddInt64(a, b: Int64): Int64 {.compilerproc.} =
+  const HiBit = 0x8000_0000'u32
+  result = addInt64(a, b)
+  # if adding two negative numbers results in a positive one, or adding two
+  # positive numbers in a negative one, the operation overflowed
+  if (result.hi xor a.hi) >= HiBit and (result.hi xor b.hi) >= HiBit:
+    raiseOverflow()
+
+proc checkedSubInt64(a, b: Int64): Int64 {.compilerproc.} =
+  const HiBit = 0x8000_0000'u32
+  result = subInt64(a, b)
+  if (result.hi xor a.hi) >= HiBit and (result.hi xor not b.hi) >= HiBit:
+    raiseOverflow()
+
+proc checkedMulInt64(x, y: Int64): Int64 {.compilerproc.} =
+  var a = x
+  var b = y
+  # perform an unsigned multiplication, by using the absolute of both operands
+  if a.hi >= 0x8000_0000'u32:
+    a = negInt64(a)
+  if b.hi >= 0x8000_0000'u32:
+    b = negInt64(b)
+
+  if a.hi != 0 and b.hi != 0:
+    raiseOverflow()
+
+  let part1 = mulInt32(a.lo, b.lo)
+  let part2 = mulInt32(a.hi, b.lo)
+  let part3 = mulInt32(a.lo, b.hi)
+  var tmp = addInt64(addInt64(part2, part3), Int64(lo: part1.hi))
+  # tmp will be shifted left by 32, so the high part being != 0 means that
+  # an overflow will occur
+  if tmp.hi != 0:
+    raiseOverflow()
+
+  result = Int64(lo: part1.lo, hi: tmp.lo)
+  # restore the sign
+  if (x.hi xor y.hi) >= 0x8000_0000'u32:
+    # the result needs to be negative
+    result = negInt64(result)
+  elif result.hi >= 0x8000_0000'u32:
+    # both operands were positive, but the result is negative -> overflow
+    raiseOverflow()
+
+proc checkedDivInt64(a, b: Int64): Int64 {.compilerproc.} =
+  # check for division by zero and overflow
+  if (b.lo == 0 and b.hi == 0):
+    raiseDivByZero()
+  elif (b.lo == high(uint32) and b.hi == high(uint32) and
+        a.hi == 0x8000_0000'u32 and a.lo == 0):
+    raiseOverflow()
+  else:
+    divInt64(a, b)
+
+proc checkedModInt64(a, b: Int64): Int64 {.compilerproc.} =
+  if (b.lo == 0 and b.hi == 0):
+    raiseDivByZero()
+  else:
+    modInt64(a, b)
+
+# MARK: cast operations
+
+proc castFloatToInt64(val: float32): Int64 {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(4);
+    (new Float32Array(buf))[0] = `val`;
+    var view = new Uint32Array(buf);
+    `result`.lo = view[0];
+    `result`.hi = 0;
+  """
+
+proc castDoubleToInt64(val: float64): Int64 {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(8);
+    (new Float64Array(buf))[0] = `val`;
+    var view = new Uint32Array(buf);
+    `result`.lo = view[0];
+    `result`.hi = view[1];
+  """
+
+proc castInt64ToDouble(val: Int64): float64 {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(8);
+    var view = new Uint32Array(buf);
+    view[0] = `val`.lo;
+    view[1] = `val`.hi;
+    `result` = (new Float64Array(buf))[0];
+  """
+
+proc castInt64ToFloat(val: Int64): float32 {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(4);
+    var view = new Uint32Array(buf);
+    view[0] = `val`.lo;
+    `result` = (new Float32Array(buf))[0];
+  """
+
+{.pop.}

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -477,6 +477,9 @@ else:
     """.}
 
 # Arithmetic:
+
+include system/jsint64
+
 proc checkOverflowInt(a: int) {.asmNoStackFrame, compilerproc.} =
   asm """
     if (`a` > 2147483647 || `a` < -2147483648) `raiseOverflow`();
@@ -522,53 +525,11 @@ proc checkOverflowInt64(a: int64) {.asmNoStackFrame, compilerproc.} =
     if (`a` > 9223372036854775807 || `a` < -9223372036854775808) `raiseOverflow`();
   """
 
-proc addInt64(a, b: int): int {.asmNoStackFrame, compilerproc.} =
-  asm """
-    var result = `a` + `b`;
-    `checkOverflowInt64`(result);
-    return result;
-  """
-
-proc subInt64(a, b: int): int {.asmNoStackFrame, compilerproc.} =
-  asm """
-    var result = `a` - `b`;
-    `checkOverflowInt64`(result);
-    return result;
-  """
-
-proc mulInt64(a, b: int): int {.asmNoStackFrame, compilerproc.} =
-  asm """
-    var result = `a` * `b`;
-    `checkOverflowInt64`(result);
-    return result;
-  """
-
-proc divInt64(a, b: int): int {.asmNoStackFrame, compilerproc.} =
-  asm """
-    if (`b` == 0) `raiseDivByZero`();
-    if (`b` == -1 && `a` == 9223372036854775807) `raiseOverflow`();
-    return Math.trunc(`a` / `b`);
-  """
-
-proc modInt64(a, b: int): int {.asmNoStackFrame, compilerproc.} =
-  asm """
-    if (`b` == 0) `raiseDivByZero`();
-    if (`b` == -1 && `a` == 9223372036854775807) `raiseOverflow`();
-    return Math.trunc(`a` % `b`);
-  """
-
 proc negInt(a: int): int {.compilerproc.} =
   result = a*(-1)
   checkOverflowInt(result)
 
-proc negInt64(a: int64): int64 {.compilerproc.} =
-  result = a*(-1)
-  checkOverflowInt64(result)
-
 proc absInt(a: int): int {.compilerproc.} =
-  result = if a < 0: a*(-1) else: a
-
-proc absInt64(a: int64): int64 {.compilerproc.} =
   result = if a < 0: a*(-1) else: a
 
 when not defined(nimNoZeroExtendMagic):

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -699,6 +699,15 @@ proc nimCopy(dest, src: JSRef, ti: PNimType): JSRef =
         `result` = `src`.slice(0);
       }
     """
+  of tyInt64, tyUInt64:
+    asm """
+      if (`dest` === null || `dest` === undefined) {
+        `dest` = {};
+      }
+      `result` = `dest`;
+      `result`.lo = `src`.lo;
+      `result`.hi = `src`.hi;
+    """
   else:
     result = src
 
@@ -729,6 +738,10 @@ proc genericReset(x: JSRef, ti: PNimType): JSRef {.compilerproc.} =
       for (var i = 0; i < `x`.length; ++i) {
         `result`[i] = genericReset(`x`[i], `ti`.base);
       }
+    """
+  of tyInt64, tyUInt64:
+    asm """
+      `result` = {lo: 0, hi: 0};
     """
   else:
     discard

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -557,6 +557,41 @@ when not defined(nimNoZeroExtendMagic):
 proc nimMin(a, b: int): int {.compilerproc.} = return if a <= b: a else: b
 proc nimMax(a, b: int): int {.compilerproc.} = return if a >= b: a else: b
 
+# conversions and casts
+
+proc castIntToDouble(val: int): float64 {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(8);
+    var view = new Int32Array(buf);
+    view[0] = `val`;
+    view[1] = 0;
+    return (new Float64Array(buf))[0];
+  """
+
+proc castIntToFloat(val: int): float32 {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(4);
+    var view = new Int32Array(buf);
+    view[0] = `val`;
+    return (new Float32Array(buf))[0];
+  """
+
+proc castDoubleToInt(val: float64): int {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(8);
+    var view = new Float64Array(buf);
+    view[0] = `val`;
+    return (new Int32Array(buf))[0];
+  """
+
+proc castFloatToInt(val: float32): int {.compilerproc, asmNoStackFrame.} =
+  asm """
+    var buf = new ArrayBuffer(4);
+    var view = new Float32Array(buf);
+    view[0] = `val`;
+    return (new Int32Array(buf))[0];
+  """
+
 include "system/hti"
 
 proc isFatPointer(ti: PNimType): bool =

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -8,7 +8,10 @@
 #
 # The generic ``repr`` procedure for the javascript backend.
 
-proc reprInt(x: int64): string {.compilerproc.} = $x
+proc reprInt(x: int): string {.compilerproc.} = $x
+proc reprInt64(x: int64): string {.compilerproc.} = $x
+proc reprUInt(x: uint): string {.compilerproc.} = $x
+proc reprUInt64(x: uint64): string {.compilerproc.} = $x
 proc reprFloat(x: float): string {.compilerproc.} = $x
 
 proc reprPointer(p: pointer): string {.compilerproc.} =
@@ -190,8 +193,14 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
     return
   dec(cl.recDepth)
   case typ.kind
-  of tyInt..tyInt64, tyUInt..tyUInt64:
+  of tyInt..tyInt32:
     add(result, reprInt(cast[int](p)))
+  of tyInt64:
+    add(result, reprInt64(cast[int64](p)))
+  of tyUInt..tyUInt32:
+    add(result, reprUInt(cast[uint](p)))
+  of tyUInt64:
+    add(result, reprUInt64(cast[uint64](p)))
   of tyChar:
     add(result, reprChar(cast[char](p)))
   of tyBool:

--- a/tests/arithm/tarithm.nim
+++ b/tests/arithm/tarithm.nim
@@ -21,11 +21,6 @@ description: '''
   . It is expected that the order of operands on these operators should not
     affect the operation.
 '''
-knownIssue.js: '''
-  The JavaScript backend generates non BigInteger integer literals for these
-  calculations resulting in a rounding error for integers over 2^53-1 due
-  to JavaScript using floating point numbers internally.
-'''
 """
 
 import typetraits

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -29,13 +29,13 @@ block uints:
     a: uint8 = 254'u8
     b: uint16 = 65300'u16
     c: uint32 = 4294967290'u32
-    # d: uint64 = 18446744073709551610'u64  -> unknown node type
+    d: uint64 = 18446744073709551610'u64
     e: uint = 1234567
 
   doAssert(repr(a) == "254")
   doAssert(repr(b) == "65300")
   doAssert(repr(c) == "4294967290")
-  # doAssert(repr(d) == "18446744073709551610")
+  doAssert(repr(d) == "18446744073709551610")
   doAssert(repr(e) == "1234567")
 
 block floats:

--- a/tests/lang/s01_basics/s02_basic_literals/t01_integer.nim
+++ b/tests/lang/s01_basics/s02_basic_literals/t01_integer.nim
@@ -151,42 +151,18 @@ block:
   let rtInt64Min = vmInt64Min
   doAssert rtInt64Min == int64 -9_223_372_036_854_775_808, "int 64 min"
   const sMin = $vmInt64Min
-  when defined(js):
-    # JS codegen has a bug and Nimskull emits the raw literal into JS which
-    # then gets approximated as a double, here JS and the VM disagree
-    if $rtInt64Min == sMin:
-      doAssert false, "JS coddegen fixed for int64, congrats, renable this test"
-    else:
-      discard "Javascript code gen is still broken"
-  else:
-    doAssert $rtInt64Min == sMin, "string compare int64 min VM vs runtime"
+  doAssert $rtInt64Min == sMin, "string compare int64 min VM vs runtime"
 
 block:
   const vmInt64Max = 0x7FFF_FFFF_FFFF_FFFF'i64
   let rtInt64Max = vmInt64Max
   doAssert rtInt64Max == int64 9_223_372_036_854_775_807, "int 64 max"
   const sMax = $vmInt64Max
-  when defined(js):
-    # JS codegen has a bug and Nimskull emits the raw literal into JS which
-    # then gets approximated as a double, here JS and the VM disagree
-    if $rtInt64Max == sMax:
-      doAssert false, "JS coddegen fixed for int64, congrats, renable this test"
-    else:
-      discard "Javascript code gen is still broken"
-  else:
-    doAssert $rtInt64Max == sMax, "string compare int64 max VM vs runtime"
+  doAssert $rtInt64Max == sMax, "string compare int64 max VM vs runtime"
 
 block:
   const vmUint64Max = 0xFFFF_FFFF_FFFF_FFFF'u64
   let rtUint64Max = vmUint64Max
   doAssert rtUint64Max == 18_446_744_073_709_551_615'u64, "unsigned int 64 max"
   const sMax = $vmUint64Max
-  when defined(js):
-    # JS codegen has a bug and Nimskull emits the raw literal into JS which
-    # then gets approximated as a double, here JS and the VM disagree
-    if $rtUint64max == sMax:
-      doAssert false, "JS coddegen fixed for uint64, congrats, renable this test"
-    else:
-      discard "Javascript code gen is still broken"
-  else:
-    doAssert $rtUint64Max == sMax, "string compare uint64 max VM vs runtime"
+  doAssert $rtUint64Max == sMax, "string compare uint64 max VM vs runtime"

--- a/tests/lang_objects/destructor/tnewruntime_strutils.nim
+++ b/tests/lang_objects/destructor/tnewruntime_strutils.nim
@@ -51,8 +51,7 @@ proc nonStaticTests =
   doAssert "${1}12 ${-1}$2" % ["a", "b"] == "a12 bb"
 
   block: # formatSize tests
-    when not defined(js):
-      doAssert formatSize((1'i64 shl 31) + (300'i64 shl 20)) == "2.293GiB"   # <=== bug #8231
+    doAssert formatSize((1'i64 shl 31) + (300'i64 shl 20)) == "2.293GiB"   # <=== bug #8231
     doAssert formatSize((2.234*1024*1024).int) == "2.234MiB"
     doAssert formatSize(4096) == "4KiB"
     doAssert formatSize(4096, prefix=bpColloquial, includeSpace=true) == "4 kB"

--- a/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
+++ b/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
@@ -4,8 +4,13 @@ discard """
     Ensures that case statements work with uint operands and of-branch values
     not representable with the same-sized signed integer type
   '''
-  knownIssue.js: "Running the generated code crashes `node` version < 24"
+  disabled: windows
 """
+
+# XXX: the test is disabled on Windows due to what seems to be a bug
+#      specifically with the Windows distribution of `node` version < 24,
+#      making the JS-variant of the test fail at run-time with an internal
+#      error in `node`
 
 proc test[T: uint64|uint; S]() =
   const Border = T(high(S)) # the highest possible signed integer value

--- a/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
+++ b/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
@@ -4,6 +4,7 @@ discard """
     Ensures that case statements work with uint operands and of-branch values
     not representable with the same-sized signed integer type
   '''
+  knownIssue.js: "Running the generated code crashes `node` version < 24"
 """
 
 proc test[T: uint64|uint; S]() =

--- a/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
+++ b/tests/lang_stmts/casestmt/tcase_with_uint_values.nim
@@ -4,10 +4,6 @@ discard """
     Ensures that case statements work with uint operands and of-branch values
     not representable with the same-sized signed integer type
   '''
-  knownIssue.js: '''
-    Compiles correctly for JS, but doesn't work at run-time because
-    of the improper large integer support
-  '''
 """
 
 proc test[T: uint64|uint; S]() =

--- a/tests/lang_syntax/lexer/tunary_minus.nim
+++ b/tests/lang_syntax/lexer/tunary_minus.nim
@@ -60,8 +60,7 @@ template main =
     doAssert -2147483648'i32 == int32.low
     when int.sizeof > 4:
       doAssert -9223372036854775808 == int.low
-    when not defined(js):
-      doAssert -9223372036854775808 == int64.low
+    doAssert -9223372036854775808 == int64.low
 
   block: # check when a minus (-) is an unary op
     doAssert -one == minusOne:

--- a/tests/misc/tints.nim
+++ b/tests/misc/tints.nim
@@ -23,29 +23,24 @@ template test(opr, a, b, c: untyped): untyped =
 
 test(`+`, 12'i8, -13'i16, -1'i16)
 test(`shl`, 0b11, 0b100, 0b110000)
-when not defined(js):
-  test(`shl`, 0b11'i32, 0b100'i64, 0b110000'i64)
+test(`shl`, 0b11'i32, 0b100'i64, 0b110000'i64)
 test(`shl`, 0b11'i32, 0b100'i32, 0b110000'i32)
 
 test(`or`, 0xf0f0'i16, 0x0d0d'i16, 0xfdfd'i16)
 test(`and`, 0xf0f0'i16, 0xfdfd'i16, 0xf0f0'i16)
 
-when not defined(js):
-  test(`shr`, 0xffffffffffffffff'i64, 0x4'i64, 0xffffffffffffffff'i64)
+test(`shr`, 0xffffffffffffffff'i64, 0x4'i64, 0xffffffffffffffff'i64)
 test(`shr`, 0xffff'i16, 0x4'i16, 0xffff'i16)
 test(`shr`, 0xff'i8, 0x4'i8, 0xff'i8)
 
-when not defined(js):
-  test(`shr`, 0xffffffff'i64, 0x4'i64, 0x0fffffff'i64)
+test(`shr`, 0xffffffff'i64, 0x4'i64, 0x0fffffff'i64)
 test(`shr`, 0xffffffff'i32, 0x4'i32, 0xffffffff'i32)
 
-when not defined(js):
-  test(`shl`, 0xffffffffffffffff'i64, 0x4'i64, 0xfffffffffffffff0'i64)
+test(`shl`, 0xffffffffffffffff'i64, 0x4'i64, 0xfffffffffffffff0'i64)
 test(`shl`, 0xffff'i16, 0x4'i16, 0xfff0'i16)
 test(`shl`, 0xff'i8, 0x4'i8, 0xf0'i8)
 
-when not defined(js):
-  test(`shl`, 0xffffffff'i64, 0x4'i64, 0xffffffff0'i64)
+test(`shl`, 0xffffffff'i64, 0x4'i64, 0xffffffff0'i64)
 test(`shl`, 0xffffffff'i32, 0x4'i32, 0xfffffff0'i32)
 
 # bug #916

--- a/tests/misc/tnumeric_conversions.nim
+++ b/tests/misc/tnumeric_conversions.nim
@@ -3,7 +3,7 @@ discard """
   description: "Tests for conversion between the primitive numeric types"
 """
 
-when defined(amd64) or defined(i386) or defined(js) or defined(vm):
+when defined(amd64) or defined(i386) or defined(vm):
   # FIXME: This test right now depends on architecture-specific behavior on x86
   #
   # This bug is tracked at https://github.com/nim-works/nimskull/issues/1155

--- a/tests/misc/tnumeric_conversions.nim
+++ b/tests/misc/tnumeric_conversions.nim
@@ -1,7 +1,6 @@
 discard """
   targets: "c js vm"
   description: "Tests for conversion between the primitive numeric types"
-  knownIssue.js: "full-range integers aren't supported yet"
 """
 
 when defined(amd64) or defined(i386) or defined(js) or defined(vm):

--- a/tests/overflw/toverflow_abs.nim
+++ b/tests/overflw/toverflow_abs.nim
@@ -4,7 +4,6 @@ discard """
   matrix: "--overflowChecks:on"
   exitcode: 1
   outputsub: "over- or underflow"
-  knownIssue.js: "64-bit signed integers aren't fully supported"
 """
 
 {.push overflowChecks: off.}

--- a/tests/overflw/toverflow_negation_64.nim
+++ b/tests/overflw/toverflow_negation_64.nim
@@ -3,9 +3,6 @@ discard """
   description: "Ensure that overflow checks work for 64-bit integer negations"
   exitcode: 1
   outputsub: "over- or underflow"
-  knownIssue.js: '''
-    The lowest 64-bit signed integer value isn't properly represented in JS
-  '''
 """
 
 var x = low(int64)

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -66,10 +66,9 @@ block: # `$`(SomeInteger)
   testType int
   testType bool
 
-  when not defined(js): # requires BigInt support
-    testType uint64
-    testType int64
-    testType BiggestInt
+  testType uint64
+  testType int64
+  testType BiggestInt
 
 block: # #14350, #16674, #16686 for JS
   var cstr: cstring
@@ -171,9 +170,8 @@ proc main()=
       res.addInt int64(i)
     doAssert res == "-9-8-7-6-5-4-3-2-10"
 
-    when not defined(js):
-      test2 high(int64), "9223372036854775807"
-      test2 low(int64), "-9223372036854775808"
+    test2 high(int64), "9223372036854775807"
+    test2 low(int64), "-9223372036854775808"
 
     test2 high(int32), "2147483647"
     test2 low(int32), "-2147483648"

--- a/tests/vm/tcastint.nim
+++ b/tests/vm/tcastint.nim
@@ -1,3 +1,13 @@
+discard """
+  targets: c js vm
+  knownIssue.vm: '''
+    The test transitively relies on `os` (imported by `testutils`, which is
+    currently not supported for the VM target
+  '''
+"""
+
+# TODO: move this test elsewhere, it's not specific to the VM
+
 import macros
 from stdtest/testutils import disableVM
 type


### PR DESCRIPTION
## Summary

For the JavaScript backend, make `int64`, `uint64` and other integer
types work like they do when using the other backends.

## Details

The changes to run-time behaviour are:
* `int64` and `uint64` are full 64-bit precision integers
* casting from unsigned to signed integers performs a proper bitcast
* casting float to int and vice versa performs a bitcast instead of
  being a no-op
* converting `bool` to numeric types yields either 1 or 0 instead of
  being a no-op
* converting from float to unsigned int performs a truncation +
  clamp-to-range instead of being a no-op
* converting from float to signed int clamps to range instead of
  truncating and bitcasting
* `uint32` multiplication returns the correct result for large operand
  values now
* left-shifting `uint16` and `uint8` doesn't yield invalid values
  anymore
* inverting the bits of `uint16` and `uint8` via `not` doesn't yield
  invalid values anymore

The main intention was to implement support for 64-bit integers for the
JavaScript backend, with some of the other fixes being required by
the 64-bit integer implementation.

Internally, `jsgen` is changed such that it uses different paths for
`int64` and `uint64` compared to the other integer types, both for
constants and when used as operands. The implementation for the various
64-bit integer operations is provided as procedure in the new `jsint64`
system module -- they're pure implementation as much as possible in
order for them to still work without change when switching to `asm.js`.

When used as an index, 64-bit integer are internally converted to a
`float64` (a JS `Number`) first, which keeps the behaviour the same as
it was previously.

Similarly, for range checks, 64-bit integers are first converted to
`float64`, meaning that range checks with values outside the
32-bit integer range still don't work. The reason for this is to not
having to duplicate the logic in `rtchecks` into `jsgen` for now
(`rtchecks` should be enabled for the JavaScript target eventually).

Finally:
* the 64-bit integer conversion to `JsBigInt` in the standard library
  are adjusted such that they keep the full precision
* internal adjustments are made to the `hashes` and `times` modules
  where the previous `cast` and `int` behaviour was relied on
* various tests related to casting, conversions, and bit operations are
  enabled for the JavaScript backend