### PR TITLE
sempass2: fix crash with tuple-in-array edge case

### DIFF
--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1407,8 +1407,10 @@ proc track(tracked: PEffects, n: PNode) =
     for i in 0..<n.safeLen:
       track(tracked, n[i])
       objConvCheck(tracked.config, n[i])
-    if tracked.owner.kind != skMacro:
-      createTypeBoundOps(tracked, n.typ.lastSon, n.info)
+    if tracked.owner.kind != skMacro and n.typ != nil:
+      # the type might be nil when sempass2 is invoked in a
+      # ``compiles`` context
+      createTypeBoundOps(tracked, elemType(n.typ), n.info)
       createTypeBoundOps(tracked, n.typ, n.info)
   of nkBracketExpr:
     if optStaticBoundsCheck in tracked.currOptions and n.len == 2:

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1408,6 +1408,7 @@ proc track(tracked: PEffects, n: PNode) =
       track(tracked, n[i])
       objConvCheck(tracked.config, n[i])
     if tracked.owner.kind != skMacro:
+      createTypeBoundOps(tracked, n.typ.lastSon, n.info)
       createTypeBoundOps(tracked, n.typ, n.info)
   of nkBracketExpr:
     if optStaticBoundsCheck in tracked.currOptions and n.len == 2:

--- a/tests/lang_objects/destructor/tmissing_array_element_hooks_bug.nim
+++ b/tests/lang_objects/destructor/tmissing_array_element_hooks_bug.nim
@@ -1,0 +1,19 @@
+discard """
+  description: '''
+    Regression test for a compiler crash in the edge case where the tuple type
+    used as an error is not used anywhere and a temporary has to be
+    materialized.
+  '''
+  joinable: false
+"""
+
+type Object = object
+
+proc `=destroy`(x: var Object) =
+  discard
+
+proc test(): Object = discard
+
+# how the second element expression looks like is irrelevant as long as
+# it conditionally raises
+var arr = [(Object(),), (test(),)]

--- a/tests/lang_objects/destructor/tmissing_array_element_hooks_bug.nim
+++ b/tests/lang_objects/destructor/tmissing_array_element_hooks_bug.nim
@@ -1,8 +1,8 @@
 discard """
   description: '''
     Regression test for a compiler crash in the edge case where the tuple type
-    used as an error is not used anywhere and a temporary has to be
-    materialized.
+    used as an array element type is not used anywhere else and a temporary of
+    said tuple type has to be materialized.
   '''
   joinable: false
 """


### PR DESCRIPTION
## Summary

Fix the compiler crashing in an edge case where a tuple type used as
the element type of an array is not used anywhere.

## Details

Synthesizing the hooks for a type embedding a tuple type doesn't, by
itself, synthesize the hooks for the tuple type. For array construction
expressions, `sempass2` didn't separately pass the the array's element
type to `createTypeBoundOps`, leaving the tuple type without hooks
(unless synthesized elsewhere), causing the compiler to crash when
the hooks were needed (happens when the result of a sub-expression is
materialized).

Passing the array's element type to `createTypeBoundOps` fixes the
issue.

Fixes https://github.com/nim-works/nimskull/issues/1695 .

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor
(guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine
ideas
* refine the pull request message over time; don't have to nail it in
one go