### PR TITLE
remove the `canonical` filename rendering option

### DIFF
--- a/compiler/front/in_options.nim
+++ b/compiler/front/in_options.nim
@@ -143,7 +143,6 @@ type
     ## Filename formatting option
     foAbs           ## absolute path, e.g.: /pathto/bar/foo.nim
     foRelProject    ## relative to project path, e.g.: ../foo.nim
-    foCanonical     ## canonical module name
     foLegacyRelProj ## legacy, shortest of (foAbs, foRelProject)
     foName          ## lastPathPart, e.g.: foo.nim
     foStacktrace    ## if optExcessiveStackTrace: foAbs else: foName

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -153,9 +153,6 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
   case opt
   of foAbs: result = toFullPath(conf, fileIdx)
   of foRelProject: result = toProjPath(conf, fileIdx)
-  of foCanonical:
-    let absPath = toFullPath(conf, fileIdx)
-    result = canonicalImportAux(conf, absPath.AbsoluteFile)
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
   of foLegacyRelProj:
     let
@@ -187,17 +184,7 @@ proc formatPath*(conf: ConfigRef, path: string): string =
   else:
     # Path not registered in the filename table - most likely an
     # instantiation info report location
-    when compileOption"excessiveStackTrace":
-      # instLoc(), when `--excessiveStackTrace` is used, generates full
-      # paths that /might/ need to be filtered if `--filenames:canonical`.
-      const compilerRoot = currentSourcePath().parentDir().parentDir()
-      if conf.filenameOption == foCanonical and
-         path.startsWith(compilerRoot):
-        result = path[(compilerRoot.len + 1) .. ^1]
-      else:
-        result = path
-    else:
-      result = path
+    result = path
 
 proc toMsgFilename*(conf: ConfigRef; fileIdx: FileIndex): string =
   toFilenameOption(conf, fileIdx, conf.filenameOption)

--- a/compiler/front/options.nim
+++ b/compiler/front/options.nim
@@ -1452,27 +1452,6 @@ proc findProjectNimFile*(conf: ConfigRef; pkg: string): string =
     if dir == "": break
   return ""
 
-proc canonicalImportAux*(conf: ConfigRef, file: AbsoluteFile): string =
-  ## canonical module import filename, e.g.: system.nim, std/tables.nim,
-  ## system/assertions.nim, etc. Canonical module import filenames follow the
-  ## same rules as canonical imports (see `canonicalImport`), except the module
-  ## name is followed by a `.nim` file extension, and the directory separators
-  ## are OS specific.
-  let
-    desc = getPkgDesc(conf, file.string)
-    (_, moduleName, ext) = file.splitFile
-  if desc.pkgKnown and
-     desc.pkgFile != AbsoluteFile(conf.getNimbleFile(conf.projectFull.string)):
-    # we ignore the pkg root name for intra-package module imports, allows for
-    # easier pkg renames (without changing all files using canonical imports).
-    result = desc.pkgRootName
-    if desc.pkgSubpath != "":
-      result = result / desc.pkgSubpath
-  else:
-    result = desc.pkgSubpath
-  result = if result == "": moduleName else: result / moduleName
-  result = result.changeFileExt(ext) # since we lost it above
-
 proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
   ## Shows the canonical module import, e.g.: system, std/tables,
   ## fusion/pointers, system/assertions, std/private/asciitables
@@ -1483,8 +1462,20 @@ proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
   ## - if a module is at the base of a package, then `pkgroot/module`
   ## - if a module is within the project's package, `pkgroot` is skipped like
   ##   so `pkgsubpath/module` or `module` (if the module is at the package root).
-  let ret = canonicalImportAux(conf, file)
-  result = ret.nativeToUnixPath.changeFileExt("")
+  let
+    desc = getPkgDesc(conf, file.string)
+    (_, moduleName, _) = file.splitFile
+  if desc.pkgKnown and
+     desc.pkgFile != AbsoluteFile(conf.getNimbleFile(conf.projectFull.string)):
+    # we ignore the pkg root name for intra-package module imports, allows for
+    # easier pkg renames (without changing all files using canonical imports).
+    result = desc.pkgRootName
+    if desc.pkgSubpath != "":
+      result = result / desc.pkgSubpath
+  else:
+    result = desc.pkgSubpath
+  result = if result == "": moduleName else: result / moduleName
+  result = result.nativeToUnixPath
 
 proc canonDynlibName*(s: string): string =
   ## Get 'canonical' dynamic library name - without optional `lib` prefix

--- a/compiler/front/optionsprocessor.nim
+++ b/compiler/front/optionsprocessor.nim
@@ -1496,7 +1496,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass,
     setSwitchAndSrc cmdSwitchFilenames
     case arg.normalize
     of "abs": conf.filenameOption = foAbs
-    of "canonical": conf.filenameOption = foCanonical
     of "legacyrelproj": conf.filenameOption = foLegacyRelProj
     else:
       invalidArgValue(arg, switch)
@@ -1518,9 +1517,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass,
   of "listfullpaths":
     setSwitchAndSrc cmdSwitchListfullpaths
     # xxx: this should probably get subsubed with filenames
-    conf.filenameOption =
-      if switchOn(switch.normalize, arg): foAbs
-      else:                               foCanonical
+    conf.filenameOption = foAbs
   of "spellsuggest":
     setSwitchAndSrc cmdSwitchSpellsuggest
     if arg.len == 0: conf.spellSuggestMax = spellSuggestSecretSauce

--- a/compiler/front/optionsprocessor.nim
+++ b/compiler/front/optionsprocessor.nim
@@ -610,7 +610,7 @@ func allowedCompileOptionsArgs*(switch: CmdSwitchKind): seq[string] =
   of cmdSwitchVerbosity   : @["0", "1", "2", "3"]
   of cmdSwitchIncremental : @["on", "off", "writeonly", "readonly", "v2", "stress"]
   of cmdSwitchCc          : listCCnames()
-  of cmdSwitchFilenames   : @["abs", "canonical", "legacyRelProj"]
+  of cmdSwitchFilenames   : @["abs", "legacyRelProj"]
   of cmdSwitchProcessing  : @["dots", "filenames", "off"]
   of cmdSwitchExperimental: experimentalFeatures.toSeq.mapIt($it)
   of cmdSwitchExceptions  : @["native", "goto"]

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -34,7 +34,7 @@ Advanced options:
                             to after all options have been processed
   --stdout:on|off           output to stdout
   --colors:on|off           turn compiler messages coloring on|off
-  --filenames:abs|canonical|legacyRelProj
+  --filenames:abs|legacyRelProj
                             customize how filenames are rendered in compiler messages,
                             defaults to `abs` (absolute)
   --processing:dots|filenames|off

--- a/nimsuggest/nim.cfg
+++ b/nimsuggest/nim.cfg
@@ -1,1 +1,0 @@
-# xxx not sure why this flag isn't needed: processing:filenames

--- a/nimsuggest/nim.cfg
+++ b/nimsuggest/nim.cfg
@@ -1,2 +1,1 @@
 # xxx not sure why this flag isn't needed: processing:filenames
-filenames:canonical

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -690,7 +690,7 @@ proc checkForInlineErrors(run: TestRun, given: CompilerOutput): TestResult =
       if j notin covered:
         var e: string
         let exp = run.expected.inlineErrors[j]
-        e = run.test.name
+        e = extractFilename run.test.name
         e.add '('
         e.addInt exp.line
         if exp.col > 0:
@@ -727,7 +727,7 @@ proc sexpCheck(test: TTest, expected: TSpec, nimout: string): TOutCompare =
 
   for exp in expected.inlineErrors:
     var parsed = parseSexp(exp.msg)
-    var loc = convertSexp([sexp(test.name), sexp(exp.line)])
+    var loc = convertSexp([sexp(extractFilename test.name), sexp(exp.line)])
     if exp.col > 0:
       loc.add sexp(exp.col)
 

--- a/tests/compilerfeatures/tstructured_echo.nim
+++ b/tests/compilerfeatures/tstructured_echo.nim
@@ -1,7 +1,7 @@
 discard """
 description: "Structured echo message comparison"
 nimoutformat: "sexp"
-cmd: "nim c --filenames=canonical --msgFormat=sexp --hint:successx:off $file"
+cmd: "nim c --msgFormat=sexp --hint:successx:off $file"
 action: compile
 nimout: '''
 (IntEchoMessage :severity Trace :msg "test message" :location nil :reportInst _ :reportFrom _)

--- a/tests/compilerfeatures/tstructured_parse_fail.nim
+++ b/tests/compilerfeatures/tstructured_parse_fail.nim
@@ -1,11 +1,11 @@
 discard """
 description: "Structured parser error report"
 nimoutformat: "sexp"
-cmd: "nim c --filenames=canonical --msgFormat=sexp $file"
+cmd: "nim c --msgFormat=sexp $file"
 action: reject
 disabled: windows
 nimout: '''
-(ParInvalidIndentation :location ("tests/compilerfeatures/tstructured_parse_fail.nim" 13 0) :reportFrom ("parser.nim" _ _) :reportInst ("parser.nim" _ _) :severity Error)
+(ParInvalidIndentation :location ("tstructured_parse_fail.nim" 13 0) :reportFrom ("parser.nim" _ _) :reportInst ("parser.nim" _ _) :severity Error)
 '''
 """
 

--- a/tests/errmsgs/t17460.nim
+++ b/tests/errmsgs/t17460.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: "nim check --msgFormat=sexp --filenames=canonical $options $file"
+  cmd: "nim check --msgFormat=sexp $options $file"
   nimoutFormat: sexp
   action: reject
 """

--- a/tests/errmsgs/tyield_view_tuple.nim
+++ b/tests/errmsgs/tyield_view_tuple.nim
@@ -1,6 +1,6 @@
 discard """
   nimoutFormat: sexp
-  cmd: "nim check --msgFormat=sexp --filenames=canonical --hints:off $options $file"
+  cmd: "nim check --msgFormat=sexp --hints:off $options $file"
   action: reject
 """
 

--- a/tests/lang_callable/closure/tillegal_comptime_capture.nim
+++ b/tests/lang_callable/closure/tillegal_comptime_capture.nim
@@ -2,7 +2,7 @@ discard """
   description: '''
     Tests for detection of illegal captures across the compile-/run-time border
   '''
-  cmd: "nim check --msgFormat:sexp --filenames=canonical $options $file"
+  cmd: "nim check --msgFormat:sexp $options $file"
   nimoutformat: sexp
   action: reject
 """

--- a/tests/lang_callable/macros/tsymbol_must_match.nim
+++ b/tests/lang_callable/macros/tsymbol_must_match.nim
@@ -1,7 +1,7 @@
 discard """
   description: "Symbols not matching the definition must be rejected"
   action: reject
-  cmd: "nim check --msgFormat:sexp --filenames:canonical $options $file"
+  cmd: "nim check --msgFormat:sexp $options $file"
   nimoutFormat: sexp
 """
 

--- a/tests/lang_defs/enum/tenumconvdetectlitoutofrange.nim
+++ b/tests/lang_defs/enum/tenumconvdetectlitoutofrange.nim
@@ -1,6 +1,6 @@
 discard """
 description: "Test out of range int literal conversion for enums"
-cmd: "nim check --filenames:canonical --backend:$target $options $file"
+cmd: "nim check --backend:$target $options $file"
 action: reject
 """
 

--- a/tests/lang_objects/destructor/tdisallow_branch_switch.nim
+++ b/tests/lang_objects/destructor/tdisallow_branch_switch.nim
@@ -3,7 +3,7 @@ discard """
     Attempting to switch the branch of a variant object with an overridden
     destructor produces an error
   '''
-  cmd: "nim check --msgFormat=sexp --filenames=canonical $options $file"
+  cmd: "nim check --msgFormat=sexp $options $file"
   nimoutFormat: sexp
   action: reject
 """

--- a/tests/lang_objects/destructor/tlate_use.nim
+++ b/tests/lang_objects/destructor/tlate_use.nim
@@ -4,7 +4,7 @@ discard """
     control-flow reaches the call, not when it reaches the argument expression
   '''
   action: reject
-  matrix: "--filenames=canonical --msgFormat=sexp"
+  matrix: "--msgFormat=sexp"
   targets: "c js vm"
   nimoutFormat: sexp
 """

--- a/tests/lang_types/sink/tsink_is_not_a_typeclass.nim
+++ b/tests/lang_types/sink/tsink_is_not_a_typeclass.nim
@@ -2,7 +2,7 @@ discard """
   description: '''
     Ensure that `sink` cannot be used as a type-class or constraint
   '''
-  cmd: "nim check --filenames=canonical --hints:off $options $file"
+  cmd: "nim check --hints:off $options $file"
   action: reject
 """
 

--- a/tests/pragmas/tpragma_compiletime_var_error.nim
+++ b/tests/pragmas/tpragma_compiletime_var_error.nim
@@ -4,7 +4,7 @@ discard """
     declarations in compile-time-only contexts
   '''
   nimoutformat: "sexp"
-  cmd: "nim check --filenames=canonical --msgFormat=sexp $options $file"
+  cmd: "nim check --msgFormat=sexp $options $file"
 """
 
 block non_compiletime_only_procedure:

--- a/tests/types/tillegal_base_type.nim
+++ b/tests/types/tillegal_base_type.nim
@@ -2,7 +2,7 @@ discard """
   labels: "generic inheritance"
   description: "Ensure that errors are reported for illegal inheritance"
   action: reject
-  cmd: "nim check --hints:off --filenames:canonical $file"
+  cmd: "nim check --hints:off $file"
   nimoutfull: true
 """
 

--- a/tests/vm/taccess_checks.nim
+++ b/tests/vm/taccess_checks.nim
@@ -2,7 +2,7 @@ discard """
   description: '''Tests to make sure access violations are properly detected
                   and reported'''
   nimoutFormat: sexp
-  cmd: "nim check --msgFormat=sexp --filenames=canonical --hints:off $options $file"
+  cmd: "nim check --msgFormat=sexp --hints:off $options $file"
   action: reject
 """
 


### PR DESCRIPTION
## Summary
Removed the  `--filenames:canonical`  option and related logic from the
compiler.

## Details
* Removed `foCanonical` and canonical filename output in the compiler.
* Patched testament so it no longer uses canonical filenames.
* Amended the CLI and relevant tests to no longer use the canonical
option.
* This change addresses the fact that  `--filenames:canonical`  often
produced paths that weren't real paths on the filesystem, which made it
difficult to track down errors to their actual modules.