### PR TITLE
check `uint` division and modulo for division-by-zero

### DIFF
--- a/compiler/backend/jsgen.nim
+++ b/compiler/backend/jsgen.nim
@@ -484,11 +484,11 @@ proc unsignedTrimmerJS(size: BiggestInt): Rope =
 template unsignedTrimmer(size: BiggestInt): Rope =
   size.unsignedTrimmerJS
 
-proc binaryUintExpr(p: PProc, n: CgNode, r: var TCompRes, op: string or MagicOp) =
+proc binaryUintExpr(p: PProc, a, b: CgNode, r: var TCompRes, op: string or MagicOp) =
   var x, y: TCompRes
-  gen(p, n[1], x)
-  gen(p, n[2], y)
-  let trimmer = unsignedTrimmer(n[1].typ.skipTypes(abstractRange).size)
+  gen(p, a, x)
+  gen(p, b, y)
+  let trimmer = unsignedTrimmer(a.typ.skipTypes(abstractRange).size)
   when op is string:
     r.res = op % [x.rdLoc, y.rdLoc]
     r.res.add " "
@@ -575,7 +575,7 @@ proc arithAux(p: PProc, n: CgNode, r: var TCompRes, op: TMagic) =
     if isInt64(n[1].typ):
       binaryExpr(p, n[1], n[2], r, frmtInt64)
     elif isUnsigned(n.typ):
-      binaryUintExpr(p, n, r, frmtInt)
+      binaryUintExpr(p, n[1], n[2], r, frmtInt)
     else:
       binaryExpr(p, n[1], n[2], r, frmtInt)
 
@@ -629,7 +629,6 @@ proc arithAux(p: PProc, n: CgNode, r: var TCompRes, op: TMagic) =
   of mBitxorI: binary("($1 ^ $2)", MagicOp"bitXorInt64")
   of mMinI: binary(MagicOp"nimMin", MagicOp"nimMin64")
   of mMaxI: binary(MagicOp"nimMax", MagicOp"nimMax64")
-  of mModU: binary("($1 % $2)", MagicOp"modUInt64")
   of mEqI: binary("($1 == $2)", MagicOp"eqInt64")
   of mLeI: binary("($1 <= $2)", MagicOp"leInt64")
   of mLtI: binary("($1 < $2)", MagicOp"ltInt64")
@@ -681,10 +680,13 @@ proc arith(p: PProc, n: CgNode, r: var TCompRes, op: TMagic) =
     else:              patchedBinaryExpr(p, n[1], n[2], r, "($1 - $2)")
   of mMulU:
     if isInt64(n.typ): binaryExpr(p, n[1], n[2], r, MagicOp"mulInt64")
-    else:              binaryUintExpr(p, n, r, "Math.imul($1, $2)")
+    else:              binaryUintExpr(p, n[1], n[2], r, "Math.imul($1, $2)")
   of mDivU:
-    if isInt64(n.typ): binaryExpr(p, n[1], n[2], r, MagicOp"divUInt64")
-    else:              binaryUintExpr(p, n, r, "($1 / $2)")
+    if isInt64(n.typ): binaryExpr(p, n[1], n[2], r, MagicOp"checkedDivUInt64")
+    else:              binaryExpr(p, n[1], n[2], r, MagicOp"divUInt")
+  of mModU:
+    if isInt64(n.typ): binaryExpr(p, n[1], n[2], r, MagicOp"checkedModUInt64")
+    else:              binaryExpr(p, n[1], n[2], r, MagicOp"modUInt")
   of mShrI:
     let a = gen(p, n[1])
     let b = gen(p, n[2])
@@ -2779,14 +2781,29 @@ proc gen(p: PProc, n: CgNode, r: var TCompRes) =
       binaryExpr(p, n[0], n[1], r, "($1 * $2)")
   of cnkDiv:
     case mapType(n.typ)
-    of etyFloat:  binaryExpr(p, n[0], n[1], r, "($1 / $2)")
-    of etyObject: binaryExpr(p, n[0], n[1], r, MagicOp"divInt64")
-    else:         binaryExpr(p, n[0], n[1], r, "Math.trunc($1 / $2)")
+    of etyFloat:
+      binaryExpr(p, n[0], n[1], r, "($1 / $2)")
+    of etyObject:
+      if isUnsigned(n.typ):
+        binaryExpr(p, n[0], n[1], r, MagicOp"divUInt64")
+      else:
+        binaryExpr(p, n[0], n[1], r, MagicOp"divInt64")
+    else:
+      if isUnsigned(n.typ):
+        binaryUintExpr(p, n[0], n[1], r, "Math.trunc($1 / $2)")
+      else:
+        binaryExpr(p, n[0], n[1], r, "Math.trunc($1 / $2)")
   of cnkModI:
     if isInt64(n.typ):
-      binaryExpr(p, n[0], n[1], r, MagicOp"modInt64")
+      if isUnsigned(n.typ):
+        binaryExpr(p, n[0], n[1], r, MagicOp"modUInt64")
+      else:
+        binaryExpr(p, n[0], n[1], r, MagicOp"modInt64")
     else:
-      binaryExpr(p, n[0], n[1], r, "Math.trunc($1 % $2)")
+      if isUnsigned(n.typ):
+        binaryUintExpr(p, n[0], n[1], r, "Math.trunc($1 % $2)")
+      else:
+        binaryExpr(p, n[0], n[1], r, "Math.trunc($1 % $2)")
   of cnkClosureConstr:
     useMagic(p, "makeClosure")
     var tmp1, tmp2: TCompRes

--- a/compiler/backend/mir2cg.nim
+++ b/compiler/backend/mir2cg.nim
@@ -1626,9 +1626,8 @@ proc magicToCgir(c; env; tree; n; dest: Expr, stmts, bu) =
         ^c.genInt(env, 0, UInt8Type, bu)))
   of mUnaryPlusI, mUnaryPlusF64:
     wrapAsgn ^arg(0)
-  of mAddU, mSubU, mMulU, mDivU, mModU:
-    const Map = [mAddU: cnkAdd, mSubU: cnkSub,
-                 mMulU: cnkMul, mDivU: cnkDiv, mModU: cnkMod]
+  of mAddU, mSubU, mMulU:
+    const Map = [mAddU: cnkAdd, mSubU: cnkSub, mMulU: cnkMul]
     wrapAsgn (Map[tree[n, 1].magic])(
       ^tree[n].typ, ^arg(0), ^arg(1))
   of mBitandI:

--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -1061,6 +1061,19 @@ proc genMagic(c: var TCtx, n: PNode; m: TMagic) =
         genArgExpression(c, n[1], sink=false)
         genArgExpression(c, n[2], sink=false)
 
+  of mDivU, mModU:
+    # division-by-zero checks (enabled by overflow checks) are also enabled for
+    # unsigned division
+    if optOverflowCheck in c.userOptions:
+      c.buildDefectMagicCall m, rtyp:
+        arg n[1]
+        arg n[2]
+    else:
+      const Map = [mDivU: mnkDiv, mModU: mnkModI]
+      c.buildTree Map[m], rtyp:
+        genArgExpression(c, n[1], sink=false)
+        genArgExpression(c, n[2], sink=false)
+
   of mUnaryMinusI, mUnaryMinusI64:
     # negation can cause overflows too
     if optOverflowCheck in c.userOptions:

--- a/compiler/mir/mirtrees.nim
+++ b/compiler/mir/mirtrees.nim
@@ -167,10 +167,10 @@ type
     mnkSub ## signed integer and float subtraction (for ints, overflow is UB)
     mnkMul ## signed integer and float multiplication (for ints, overflow is
            ##  UB)
-    mnkDiv ## signed integer and float division (for ints, division by zero is
-           ## UB)
-    mnkModI ## compute the remainder of an integer division (division by zero
-            ## is UB)
+    mnkDiv ## signed/unsigned integer and float division (for ints, division by
+           ## zero is UB)
+    mnkModI ## compute the remainder of an signed/unsigned integer division
+            ## (division by zero is UB)
     # future direction: the arithmetic operations should also apply to
     # unsigned integers
 

--- a/compiler/mir/rtchecks.nim
+++ b/compiler/mir/rtchecks.nim
@@ -516,6 +516,34 @@ proc emitCheckedBinaryIntOp(tree; call; graph; env; bu): Value =
       bu.emitCall(tree, call, env.addCompilerProc(graph, "raiseOverflow")):
         discard
 
+proc emitCheckedDivOp(tree; call; graph; env; bu): Value =
+  ## Emits the lowered version of a checked unsigned division operation,
+  ## looking like this (for division):
+  ##   def _1 = eqI(arg b, arg 0)
+  ##   if _2:
+  ##     raiseDivByZero()
+  ##   result = divU(arg a, arg b)
+  let
+    magic = tree[tree.callee(call)].magic
+    a = NodePosition tree.argument(call, 0)
+    b = NodePosition tree.argument(call, 1)
+
+  let cond = bu.wrapTemp BoolType:
+    bu.buildMagicCall mEqI, BoolType:
+      bu.subTree mnkArg:
+        bu.emitFrom(tree, b)
+      bu.emitByVal literal(mnkIntLit, env.getOrIncl(0), tree[b].typ)
+
+  bu.buildIf cond:
+    bu.emitCall(tree, call, env.addCompilerProc(graph, "raiseDivByZero")):
+      discard
+
+  const Map = [mDivU: mnkDiv, mModU: mnkModI]
+  bu.wrapTemp tree[call].typ:
+    bu.subTree Map[magic], tree[call].typ:
+      bu.emitFrom(tree, a)
+      bu.emitFrom(tree, b)
+
 proc emitUnaryOverflowCheck(tree; call; graph; env; bu) =
   ## Emits the overflow check for an integer negation operation:
   ##   if x == low(x):
@@ -638,6 +666,13 @@ proc lowerChecks*(body; graph; env; changes: var Changeset) =
         var tmp: Value
         changes.insert(tree, tree.parent(call), call, bu):
           tmp = emitCheckedBinaryIntOp(tree, call, graph, env, bu)
+        changes.replaceMulti(tree, call, bu):
+          bu.use tmp
+      of mDivU, mModU:
+        let call = tree.parent(i)
+        var tmp: Value
+        changes.insert(tree, tree.parent(call), call, bu):
+          tmp = emitCheckedDivOp(tree, call, graph, env, bu)
         changes.replaceMulti(tree, call, bu):
           bu.use tmp
       of mUnaryMinusI, mUnaryMinusI64:

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1730,8 +1730,25 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mAddU: genBinaryABCnarrowU(c, n, dest, opcAddu)
   of mSubU: genBinaryABCnarrowU(c, n, dest, opcSubu)
   of mMulU: genBinaryABCnarrowU(c, n, dest, opcMulu)
-  of mDivU: genBinaryABCnarrowU(c, n, dest, opcDivu)
-  of mModU: genBinaryABCnarrowU(c, n, dest, opcModu)
+  of mDivU, mModU:
+    # the VM has no opcode for checked uint division/modulo, so this has to
+    # be emulated
+    let tmp = c.getTemp(slotTempInt)
+    let a = c.genx(n[1])
+    let b = c.genx(n[2])
+    c.gABx(n, opcLdImmInt, tmp, 0)
+    c.gABC(n, opcEqInt, tmp, b, tmp)
+    c.freeTemp(tmp)
+    prepare(c, dest, n.typ)
+    let lab = c.xjmp(n, opcFJmp, tmp)
+    # when the divisor is zero, run a checked integer division, which will
+    # then report an error
+    c.gABC(n, opcDivInt, dest, a, b)
+    c.patch(lab)
+    c.gABC(n, (if m == mDivU: opcDivu else: opcModu), dest, a, b)
+    # the result is always in range, so there's no need to narrow
+    c.freeTemp(a)
+    c.freeTemp(b)
   of mEqI, mEqB, mEqEnum, mEqCh:
     genBinaryABC(c, n, dest, opcEqInt)
   of mLeI, mLeEnum, mLeCh, mLeB:
@@ -2912,8 +2929,18 @@ proc gen(c: var TCtx; n: CgNode; dest: var TDest) =
   of cnkAdd: binaryArith(c, n, n[0], n[1], dest, opcAddu, opcAddFloat)
   of cnkSub: binaryArith(c, n, n[0], n[1], dest, opcSubu, opcSubFloat)
   of cnkMul: binaryArith(c, n, n[0], n[1], dest, opcMulu, opcMulFloat)
-  of cnkDiv: binaryArith(c, n, n[0], n[1], dest, opcDivInt, opcDivFloat)
-  of cnkModI: binaryArith(c, n, n[0], n[1], dest, opcModInt, opcModInt)
+  of cnkDiv:
+    if isUnsigned(n.typ):
+      # no need to narrow; the result cannot be out of range
+      binaryArith(c, n, n[0], n[1], dest, opcDivu, opcDivFloat)
+    else:
+      binaryArith(c, n, n[0], n[1], dest, opcDivInt, opcDivFloat)
+  of cnkModI:
+    if isUnsigned(n.typ):
+      # no need to narrow; the result cannot be out of range
+      binaryArith(c, n, n[0], n[1], dest, opcModu, opcDivFloat)
+    else:
+      binaryArith(c, n, n[0], n[1], dest, opcModInt, opcModInt)
   of cnkIntLit, cnkUIntLit:
     prepare(c, dest, n.typ)
     c.loadInt(n, dest, getInt(n))

--- a/lib/system/jsint64.nim
+++ b/lib/system/jsint64.nim
@@ -310,6 +310,18 @@ proc checkedModInt64(a, b: Int64): Int64 {.compilerproc.} =
   else:
     modInt64(a, b)
 
+proc checkedDivUInt64(a, b: Int64): Int64 {.compilerproc.} =
+  if (b.lo == 0 and b.hi == 0):
+    raiseDivByZero()
+  else:
+    divUInt64(a, b)
+
+proc checkedModUInt64(a, b: Int64): Int64 {.compilerproc.} =
+  if (b.lo == 0 and b.hi == 0):
+    raiseDivByZero()
+  else:
+    modUInt64(a, b)
+
 # MARK: cast operations
 
 proc castFloatToInt64(val: float32): Int64 {.compilerproc, asmNoStackFrame.} =

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -520,6 +520,18 @@ proc modInt(a, b: int): int {.asmNoStackFrame, compilerproc.} =
     return Math.trunc(`a` % `b`);
   """
 
+proc divUInt(a, b: uint): uint {.asmNoStackFrame, compilerproc.} =
+  asm """
+    if (`b` == 0) `raiseDivByZero`();
+    return Math.trunc(`a` / `b`) >>> 0;
+  """
+
+proc modUInt(a, b: uint): uint {.asmNoStackFrame, compilerproc.} =
+  asm """
+    if (`b` == 0) `raiseDivByZero`();
+    return Math.trunc(`a` % `b`) >>> 0;
+  """
+
 proc checkOverflowInt64(a: int64) {.asmNoStackFrame, compilerproc.} =
   asm """
     if (`a` > 9223372036854775807 || `a` < -9223372036854775808) `raiseOverflow`();

--- a/tests/arithm/tdiv.nim
+++ b/tests/arithm/tdiv.nim
@@ -1,8 +1,9 @@
 discard """
-  labels: "js arithmetic int"
+  labels: "arithmetic int"
   description: '''
-    . Fix div uint64 without truncation for JS.
+    Tests to make sure division works as intended.
   '''
+  knownIssue.vm: "Defects cannot be caught, not even for testing purpose"
 """
 
 
@@ -19,3 +20,30 @@ block divUint64:
 
   divTest()
 
+block unsigned_integer_division_by_zero:
+  proc op[T](a, b: T): T {.noinline.} = a div b
+
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u8, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u16, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u32, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u64, 0)
+
+block unsigned_integer_modulo_by_zero:
+  proc op[T](a, b: T): T {.noinline.} = a mod b
+
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u8, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u16, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u32, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u, 0)
+  doAssertRaises DivByZeroDefect:
+    discard op(1'u64, 0)


### PR DESCRIPTION
## Summary

When overflow checks are enabled, all unsigned integer division is now
checked for division-by-zero, with a `DivByZeroDefect` raised if the
divisor is zero. Previously, this caused undefined behaviour.

## Details

* also use `mnkDiv` and `mnkModI` for uint division and modulo, so that
  `mDivU` and `mModU` can be used to represent checked operations
* lower `mDivU` and `mModU` into a check + `mnkDiv` and `mnkModI`
  (respectively) in `rtchecks`
* remove the `mDivU` and `mModU` handling from `mir2cg`. The magics are
  lowered by `rtchecks` now
* implement checked uint division and modulo in `jsgen`
  * the checks are performed as part of new compilerprocs introduced
    for checked uint division and modulo
* implement checked uint division and module in `vmgen`
  * since the VM has no dedicated checked uint div/mod instructions
    (nor should it have them), the check + error is implemented in
    bytecode

Same as it is for signed integer, when overflow checks are disabled,
division by zero continues to be undefined behaviour for unsigned
integers.

Fixes https://github.com/nim-works/nimskull/issues/1709.