### PR TITLE
std: enumutils no longer warns iterating over holey enums

### DIFF
--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -12,7 +12,7 @@ from std/typetraits import OrdinalEnum, HoleyEnum
 
 macro enumFullRange(a: typed): untyped =
   let typ = getTypeImpl(getType(a)[1]) # the ``nnkEnumTy`` AST
-  nnkPrefix.newTree(ident"@", newNimNode(nnkBracket).add(typ[1..^1]))
+  newNimNode(nnkBracket).add(typ[1..^1])
 
 # xxx `genEnumCaseStmt` needs tests and runnableExamples
 

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -12,7 +12,7 @@ from std/typetraits import OrdinalEnum, HoleyEnum
 
 macro enumFullRange(a: typed): untyped =
   let typ = getTypeImpl(getType(a)[1]) # the ``nnkEnumTy`` AST
-  newNimNode(nnkCurly).add(typ[1..^1])
+  nnkPrefix.newTree(ident"@", newNimNode(nnkBracket).add(typ[1..^1]))
 
 # xxx `genEnumCaseStmt` needs tests and runnableExamples
 


### PR DESCRIPTION
## Summary

`enumutils`  no longer results in a warning of conversion when iterating
over a holey enum.

## Details

The internal macro  `enumFullRange`  used by  `enumutils.items` 
expanded to a constant  `set` , and iteration of that set via  `items` 
performs a conversion from int to the holey enum type internally,
causing the warning. Returning an array instead of a set solves this.