### PR TITLE
macros: fix `getType` crashing with generic type argument

### DIFF
--- a/compiler/mir/mirgen.nim
+++ b/compiler/mir/mirgen.nim
@@ -646,36 +646,10 @@ proc genCheckedVariantAccess(c: var TCtx, variant: Value, name: PIdent,
   result = call[2].sym
 
 proc genTypeExpr(c: var TCtx, n: PNode): Value =
-  ## Generates the code for an expression that yields a type. These are only
-  ## valid in metaprogramming contexts. If it's a static type expression, we
-  ## evaluate it directly and store the result as a type literal in the MIR
+  ## Generates the code for an expression that yields a type.
   assert n.typ.kind == tyTypeDesc
   c.builder.useSource(c.sp, n)
-  case n.kind
-  of nkStmtListExpr:
-    # FIXME: a ``nkStmtListExpr`` shouldn't reach here, but it does. See
-    #        ``tests/lang_callable/generics/t18859.nim`` for a case where it
-    #        does
-    genTypeExpr(c, n.lastSon)
-  of nkSym:
-    case n.sym.kind
-    of skType:
-      typeLit c.typeToMir(n.sym.typ)
-    of skVar, skLet, skForVar, skTemp, skParam:
-      # a first-class type value stored in a location
-      genLocation(c, n)
-    else:
-      unreachable()
-  of nkBracketExpr:
-    # the type description of a generic type, e.g. ``seq[int]``
-    typeLit c.typeToMir(n.typ)
-  of nkTupleTy, nkStaticTy, nkRefTy, nkPtrTy, nkVarTy, nkDistinctTy, nkProcTy,
-     nkIteratorTy, nkSharedTy, nkTupleConstr:
-    typeLit c.typeToMir(n.typ)
-  of nkTypeOfExpr, nkType:
-    typeLit c.typeToMir(n.typ)
-  else:
-    unreachable("not a type expression")
+  typeLit c.typeToMir(n.typ)
 
 proc genArgExpression(c: var TCtx, n: PNode, sink: bool) =
   ## Generates and emits the code for an expression appearing in a call or

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1948,7 +1948,15 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
   of mNIntVal: genUnaryABC(c, n, dest, opcNIntVal)
   of mNFloatVal: genUnaryABC(c, n, dest, opcNFloatVal)
   of mNGetType:
-    let tmp = c.genx(n[1])
+    var tmp: TRegister
+    if n[1].typ.kind == tyTypeDesc:
+      var dst = TDest(-1)
+      c.genLit(n[1],
+        c.toNodeCnst(newNodeIT(nkType, n[1].info, n[1].typ.base)), dst)
+      tmp = dst
+    else:
+      tmp = c.genx(n[1])
+
     if dest.isUnset: dest = c.getTemp(n.typ)
     let rc = case c.env.procedures[n[0].prc].name.s:
       of "getType":     0

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -772,7 +772,7 @@ proc newLit*(f: float64): NimNode =
 
 proc newLit*(arg: enum): NimNode =
   result = newCall(
-    arg.typeof.getTypeInst[1],
+    arg.typeof.getTypeInst,
     newLit(int(arg))
   )
 
@@ -782,13 +782,13 @@ proc newLit*[T](s: set[T]): NimNode
 proc newLit*[T: tuple](arg: T): NimNode
 
 proc newLit*(arg: object): NimNode =
-  result = nnkObjConstr.newTree(arg.typeof.getTypeInst[1])
+  result = nnkObjConstr.newTree(arg.typeof.getTypeInst)
   for a, b in arg.fieldPairs:
     result.add nnkExprColonExpr.newTree( newIdentNode(a), newLit(b) )
 
 proc newLit*(arg: ref object): NimNode =
   ## produces a new ref type literal node.
-  result = nnkObjConstr.newTree(arg.typeof.getTypeInst[1])
+  result = nnkObjConstr.newTree(arg.typeof.getTypeInst)
   for a, b in fieldPairs(arg[]):
     result.add nnkExprColonExpr.newTree(newIdentNode(a), newLit(b))
 
@@ -807,7 +807,7 @@ proc newLit*[T](arg: seq[T]): NimNode =
   )
   if arg.len == 0:
     # add type cast for empty seq
-    var typ = getTypeInst(typeof(arg))[1]
+    var typ = getTypeInst(typeof(arg))
     result = newCall(typ,result)
 
 proc newLit*[T](s: set[T]): NimNode =
@@ -816,7 +816,7 @@ proc newLit*[T](s: set[T]): NimNode =
     result.add newLit(x)
   if result.len == 0:
     # add type cast for empty set
-    var typ = getTypeInst(typeof(s))[1]
+    var typ = getTypeInst(typeof(s))
     result = newCall(typ,result)
 
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}

--- a/lib/std/genasts.nim
+++ b/lib/std/genasts.nim
@@ -48,7 +48,9 @@ macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untype
       newEmptyNode()
 
   template newLitMaybe(a): untyped =
-    when (a is type) or (typeof(a) is (proc | iterator | func | NimNode)):
+    when a is type:
+      getTypeInst(a)
+    elif (typeof(a) is (proc | iterator | func | NimNode)):
       a # `proc` actually also covers template, macro
     else: newLit(a)
 

--- a/tests/lang_callable/macros/tgettype.nim
+++ b/tests/lang_callable/macros/tgettype.nim
@@ -89,3 +89,11 @@ block:
     not compiles(1.map2(fn3))
     1.map2(fn4) == """(1, "fn4")"""
     1.map2(fn5) == """(1, "fn5")"""
+
+block get_type_with_typeclass:
+  # passing a type class (in the form of an uninstantiated generic) to
+  # `getType` must work
+  type Generic[T] = distinct T
+  static:
+    let n = getType(Generic)
+    doAssert n.kind == nnkSym

--- a/tests/lang_callable/macros/tgettypeinst.nim
+++ b/tests/lang_callable/macros/tgettypeinst.nim
@@ -214,3 +214,13 @@ block t9600:
 
   var z: Apple
   mixer(z)
+
+block get_type_inst_with_typeclass:
+  # passing a type class (in the form of an uninstantiated generic) to
+  # `getTypeInst` must work
+  type Generic[T] = distinct T
+  static:
+    let n = getTypeInst(Generic)
+    # note: the exact shape of the returned AST doesn't have to be what
+    # the assertion says here; `getTypeInst` just has to not crash
+    doAssert n.kind == nnkSym

--- a/tests/stdlib/metaprogramming/tmacros.nim
+++ b/tests/stdlib/metaprogramming/tmacros.nim
@@ -108,7 +108,7 @@ block: # SameType
 
   macro testTensorInt(x: typed): untyped =
     let
-      tensorIntType = getTypeInst(Tensor[int])[1]
+      tensorIntType = getTypeInst(Tensor[int])
       xTyp = x.getTypeInst
 
     newLit(xTyp.sameType(tensorIntType))


### PR DESCRIPTION
## Summary

Fix the `macros.getType` and `macros.getTypeInst` procedures taking
type parameters crashing the compiler upon execution when the type
argument is a generic type. In addition, both procedures *always*
return type AST *not* wrapped in a `typeDesc[...]` now, instead of this
being dependent on the argument's AST shape.

## Details

1. always turn type expressions into `tyTypeDesc` type literals in
   `mirgen`, instead of using the inner type for some AST shapes.
   Passing the inner type of a `typedesc` to `typeToMir` is wrong, as
   the type is not guaranteed to be a concrete value type
2. as a consequence, the type arguments passed to `getType` and
   `getTypeInst` always reach `vmgen` typed as a `tyTypeDesc`. Since
   both procedures should return the unwrapped type AST, the code
   generation logic for `mNGetType` is changed to skip to the base
   type of `tyTypeDesc`s
3. update the callsites of `getType` and `getTypeInst` in the `macros`
   module and test files, as the procedures always return an unwrapped
   type AST now
4. handling of type arguments for `genasts.genAst` relied on the old
   behaviour of type expression handling in `mirgen`. It's changed to
   fetch the type AST with `getTypeInst` instead of embedding the
   type expression directly into the constructed AST