### PR TITLE
sem: add and use new error detection strategy

### DIFF
--- a/compiler/ast/ast.nim
+++ b/compiler/ast/ast.nim
@@ -392,13 +392,16 @@ proc isGCedMem*(t: PType): bool {.inline.} =
            t.kind == tyProc and t.callConv == ccClosure
 
 proc propagateToOwner*(owner, elem: PType; propagateHasAsgn = true) =
-  owner.flags.incl elem.flags * {tfHasMeta, tfTriggersCompileTime}
+  owner.flags.incl elem.flags * {tfHasMeta, tfHasError, tfTriggersCompileTime}
   if tfNotNil in elem.flags:
     if owner.kind in {tyGenericInst, tyGenericBody, tyGenericInvocation}:
       owner.flags.incl tfNotNil
 
   if elem.isMetaType:
     owner.flags.incl tfHasMeta
+
+  if elem.kind == tyError:
+    owner.flags.incl tfHasError
 
   let mask = elem.flags * {tfHasAsgn}
   if mask != {} and propagateHasAsgn:

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -683,6 +683,9 @@ type
     tfExplicitCallConv
     tfIsConstructor
     tfEffectSystemWorkaround
+    tfHasError
+      ## marks the type as there being some error type or AST reachable
+      ## through it. Not relevant to the type system
 
   TTypeFlags* = set[TTypeFlag]
 

--- a/compiler/modules/modulegraphs.nim
+++ b/compiler/modules/modulegraphs.nim
@@ -104,6 +104,9 @@ type
     libs*: seq[seq[TLib]] ## indexed by ``LibId``
     transformed*: seq[Table[int32, PNode]] ## the cached transformed routine
                                            ## bodies for all modules
+    withErrors*: Table[int, bool]
+      ## caches the result of scanning routines for whether error types or AST
+      ## are reachable from them
 
     startupPackedConfig*: PackedConfig
     packageSyms*: TStrTable
@@ -519,6 +522,7 @@ proc newModuleGraph*(cache: IdentCache; config: ConfigRef): ModuleGraph =
   result.ifaces = @[]
   result.importStack = @[]
   result.transformed = @[]
+  result.withErrors = initTable[int, bool]()
   result.inclToMod = initTable[FileIndex, FileIndex]()
   result.config = config
   result.cache = cache
@@ -542,6 +546,7 @@ proc resetAllModules*(g: ModuleGraph) =
   g.ifaces = @[]
   g.importStack = @[]
   g.transformed = @[]
+  g.withErrors = initTable[int, bool]()
   g.inclToMod = initTable[FileIndex, FileIndex]()
   g.usageSym = nil
   g.owners = @[]

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -822,6 +822,11 @@ proc semMacroExpr(c: PContext, n: PNode, sym: PSym,
   if args.kind == nkError:
     return args
 
+  # prevent error AST and types from being visible to macros:
+  if areErrorsReachable(c.graph, n):
+    # don't evaluate the macro and leave the call as is
+    return n
+
   let reportTraceExpand = c.config.macrosToExpand.hasKey(sym.name.s)
   var original: PNode
   if reportTraceExpand:

--- a/compiler/sem/sempass2.nim
+++ b/compiler/sem/sempass2.nim
@@ -1259,7 +1259,7 @@ proc track(tracked: PEffects, n: PNode) =
       oldState = tracked.init.len
       oldFacts = tracked.guards.s.len
       iterCall = n[n.len-2]
-    
+
     if optStaticBoundsCheck in tracked.currOptions and iterCall.kind in nkCallKinds:
       let op = iterCall[0]
       if op.kind == nkSym and fromSystem(op.sym):
@@ -1900,3 +1900,123 @@ proc trackStmt*(c: PContext; module: PSym; n: PNode, isTopLevel: bool) =
   initEffects(g, effects, module, t, c)
   t.isTopLevel = isTopLevel
   track(t, n)
+
+proc areErrorsReachable*(graph: ModuleGraph, n: PNode): bool =
+  ## Looks for error types and error AST reachable from `n` via macro-
+  ## accessible facilities. Completed routines transitively referenced by `n`
+  ## are only scanned once, with the scan result cached in `graph`.
+  ## Returns `true` if errors are reachable from `n`, `false` otherwise.
+  type State = enum
+    Unknown
+    Error
+    NoError
+
+  var delayed: seq[tuple[sym: PSym, st: State, deps: seq[PSym]]]
+  var seen: IntSet
+    ## routines added to `rest`
+  var localSeen: IntSet
+    ## symbols already seen in the scan of the current AST
+
+  proc scanAux(n: PNode, s: var State, cur: PSym, deps: var seq[PSym]) =
+    if n.isNil:
+      # XXX: nil nodes do exist in AST in some cases, necessitating the
+      #      guard, but ideally they shouldn't
+      return
+    elif n.typ != nil and
+         (n.typ.kind == tyError or tfHasError in n.typ.flags):
+      s = Error
+      return
+
+    case n.kind
+    of nkError:
+      s = Error
+    of nkSym:
+      if cur != nil and cur.id == n.sym.id:
+        discard "ignore"
+      elif n.sym.kind in routineKinds:
+        graph.withErrors.withValue n.sym.id, val:
+          if val[]:
+            s = Error
+        do:
+          if not containsOrIncl(seen, n.sym.id):
+            delayed.add (n.sym, Unknown, @[])
+          if not containsOrIncl(localSeen, n.sym.id):
+            deps.add n.sym
+      elif n.sym.kind in {skVar, skLet, skConst, skForVar} and
+           not containsOrIncl(localSeen, n.sym.id):
+        # don't cache the test result for non-routine symbols
+        scanAux(n.sym.ast, s, cur, deps)
+    of nkWithSons:
+      for it in n.items:
+        scanAux(it, s, cur, deps)
+        if s == Error:
+          # the "Error" state is terminal, so there's no need to
+          # continue scanning
+          return
+    of nkWithoutSons - {nkSym, nkError}:
+      discard "nothing changes"
+
+  var st = NoError
+  var rdeps: seq[PSym]
+  scanAux(n, st, nil, rdeps)
+
+  if st == Error:
+    # no need to scan the dependencies (if any); we already found an error
+    return true
+
+  # iteratively scan all routines that haven't been so far:
+  var i = 0
+  while i < delayed.len:
+    let sym {.cursor.} = delayed[i].sym
+    var st = if sfForward in sym.flags: Unknown else: NoError
+    var deps: seq[PSym]
+    localSeen.clear()
+    scanAux(sym.ast, st, sym, deps)
+
+    if st == Error or deps.len == 0:
+      # we've found the final state for the symbol already
+      delayed.del(i)
+      if st != Unknown:
+        graph.withErrors[sym.id] = st == Error
+    else:
+      delayed[i].st = st
+      delayed[i].deps = deps
+      inc i
+
+  # propagate the error state through the dependency graph. Since the graph
+  # may be cyclic, the propagation is repeated until a fixpoint is reached
+  var changed = true
+  while changed:
+    changed = false
+    var i = 0
+    while i < delayed.len:
+      var di = 0
+      var hasError = false
+      while di < delayed[i].deps.len:
+        graph.withErrors.withValue delayed[i].deps[di].id, val:
+          if val[]:
+            # found a dependency through which an error is reachable
+            hasError = true
+            break
+          delayed[i].deps.del(di)
+        do:
+          inc di
+
+      if hasError or (delayed[i].deps.len == 0 and delayed[i].st == NoError):
+        changed = true
+        graph.withErrors[delayed[i].sym.id] = hasError
+        delayed.del(i)
+      else:
+        inc i
+
+  # all remaining symbols are part of one or more cycles
+  for (it, st, _) in delayed.items:
+    if st != Unknown:
+      graph.withErrors[it.id] = false
+
+  result = false # presume no error
+  for it in rdeps.items:
+    graph.withErrors.withValue it.id, val:
+      if val[]:
+        result = true
+        break

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -3154,6 +3154,10 @@ proc semStaticStmt(c: PContext, n: PNode): PNode =
   case a.kind
   of nkError:
     result = c.config.wrapError(result)
+  elif areErrorsReachable(c.graph, a):
+    # don't evaluate and just turn into a discard
+    result.transitionSonsKind(nkDiscardStmt)
+    result[0] = c.graph.emptyNode
   else:
     result.transitionSonsKind(nkDiscardStmt)
     result[0] = evalStaticStmt(c.module, c.idgen, c.graph, a, c.p.owner)

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -409,7 +409,11 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
   if weakLeValue(result.n[0], result.n[1]) == impNo:
     localReport(c.config, n, reportSem rsemRangeIsEmpty)
 
+  # clear the error flag added earlier:
+  result.flags.excl tfHasError
+
   result[0] = rangeT[0]
+  propagateToOwner(result, rangeT[0], false)
 
 proc semRange(c: PContext, n: PNode, prev: PType): PType =
   result = nil


### PR DESCRIPTION
## Summary

Prepare for the incremental removal of `nkError` wrapping by adding a
separate mechanism for disabling macro evaluation, based on deep-
scanning the invocation AST for errors.

## Details

### Rationale

Errors, be it `nkError` nodes or `tyError` types, must not reach into
either macros or compile-time code generation. This is currently
enforced through `nkError` wrapping, with macro invocations (and other
compile-time evaluation) not being evaluated if either the callee or
any of the arguments is an `nkError` node.

Since the plan is to remove `nkError` wrapping, there needs to be
another way to reliably disable compile-time evaluation.

### Implementation

1. add the `tfHasError` flag for marking compound types as containing
   errors somewhere and propagate it through types via the
   `propagateToOwner` mechanism
2. scan AST used in or connected with compile-time evaluation for
   reachable error AST or types via the new `areErrorsReachable`
   procedure, and disable evaluation of the code in question when
   errors are found

The after-the-fact scanning for AST is chosen because it's transparent
to the rest of semantic analysis, making it a small impact change (in
terms of added code) that's trivial to revert, should a better approach
to disabling compile-time evaluation emerge.

Traversing the AST is not free, so the result of scanning the AST of
routines is cached in the module graph.