### PR TITLE
sem: replace diagnostic-based error recovery for symbols

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1365,8 +1365,6 @@ type
         adSemSelectorMustBeOfCertainTypes,
         adSemInvalidPragmaBlock,
         adSemConceptPredicateFailed,
-        adSemDotOperatorsNotEnabled,
-        adSemCallOperatorsNotEnabled,
         adSemUnexpectedPattern,
         adSemCannotBeRaised,
         adSemCannotRaiseNonException,
@@ -1402,6 +1400,9 @@ type
         adSemExternalLocalNotAllowed,
         adSemGeneratedSymUsed:
       discard
+    of adSemDotOperatorsNotEnabled,
+       adSemCallOperatorsNotEnabled:
+      operator*: PSym
     of adSemExpectedIdentifierInExpr:
       notIdent*: PNode
     of adSemUseOrDiscardExpr:

--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -1171,7 +1171,6 @@ type
     adSemWrongNumberOfGenericParams
     # sem
     adSemExpressionHasNoType
-    adSemDefNameSym   ## when creating a sym node from `nkIdentKinds`
     # semtypes
     adSemTypeExpected
     adSemStringRangeNotAllowed
@@ -1570,26 +1569,8 @@ type
     of adSemCompilerOptionArgInvalid:
       forCompilerOpt*: PNode
       badCompilerOptArg*: PNode
-    of adSemDefNameSym:
-      defNameSym*: PSym
-      defNameSymData*: AdSemDefNameSym
     of adSemInvalidControlFlow:
       label*: PSym
-
-  AdSemDefNameSymKind* = enum
-    adSemDefNameSymExpectedKindMismatch
-    adSemDefNameSymIdentGenFailed
-    adSemDefNameSymExistingError
-    adSemDefNameSymIllformedAst
-  AdSemDefNameSym* = object
-    case kind*: AdSemDefNameSymKind:
-      of adSemDefNameSymExpectedKindMismatch:
-        expectedKind*: TSymKind # xxx: maybe always capture this?
-      of adSemDefNameSymIdentGenFailed:
-        identGenErr*: PNode
-      of adSemDefNameSymExistingError,
-          adSemDefNameSymIllformedAst:
-        discard
 
   TNode*{.final.} = object # on a 32bit machine, this takes 32 bytes
                            # on a 64bit machine, this takes 40 bytes

--- a/compiler/ast/errorhandling.nim
+++ b/compiler/ast/errorhandling.nim
@@ -206,3 +206,14 @@ iterator anyErrorsWalk*(config: ConfigRef; n: PNode
   if n != nil:
     for e in walkErrors(config, n):
       yield e
+
+proc emit*(config: ConfigRef, info: TLineInfo, diag: PAstDiag,
+           inst: InstantiationInfo) =
+  ## Emits the diagnostic `diag`, initializing its location info with `info`
+  ## if not set already.
+  if not diag.location.isValid:
+    diag.location = info
+  config.emit(config.astDiagToLegacyReport(config, diag), inst)
+
+template emit*(config: ConfigRef, info: TLineInfo, diag: PAstDiag) =
+  config.emit(info, diag, instLoc())

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3334,15 +3334,20 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind,
         ast: diag.wrongNode)
-  of adSemDotOperatorsNotEnabled,
-     adSemCallOperatorsNotEnabled,
-     adSemGeneratedSymUsed:
+  of adSemGeneratedSymUsed:
     semRep = SemReport(
         location: some diag.location,
         reportInst: diag.instLoc.toReportLineInfo,
         kind: kind,
         ast: diag.wrongNode,
         sym: diag.wrongNode.sym)
+  of adSemDotOperatorsNotEnabled,
+     adSemCallOperatorsNotEnabled:
+    semRep = SemReport(
+        location: some diag.location,
+        reportInst: diag.instLoc.toReportLineInfo,
+        kind: kind,
+        sym: diag.operator)
   of adSemInvalidTupleSubscript:
     semRep = SemReport(
         location: some diag.location,

--- a/compiler/front/cli_reporter.nim
+++ b/compiler/front/cli_reporter.nim
@@ -3851,26 +3851,6 @@ func astDiagToLegacyReport(conf: ConfigRef, diag: PAstDiag): Report {.inline.} =
       kind: kind,
       ast: diag.wrongNode,
       str: diag.invalidDef)
-  of adSemDefNameSym:
-    case diag.defNameSymData.kind
-    of adSemDefNameSymExpectedKindMismatch:
-      semRep = SemReport(
-        location: some diag.location,
-        reportInst: diag.instLoc.toReportLineInfo,
-        kind: rsemSymbolKindMismatch,
-        sym: diag.wrongNode.sym,
-        expectedSymbolKind: {diag.defNameSymData.expectedKind},
-        ast: diag.wrongNode)
-    of adSemDefNameSymIllformedAst:
-      semRep = SemReport(
-        location: some diag.location,
-        reportInst: diag.instLoc.toReportLineInfo,
-        kind: rsemExpectedIdentifier,
-        ast: diag.wrongNode)
-    of adSemDefNameSymIdentGenFailed:
-      return astDiagToLegacyReport(conf, diag.defNameSymData.identGenErr.diag)
-    of adSemDefNameSymExistingError:
-      return astDiagToLegacyReport(conf, diag.wrongNode.diag)
   of adSemCompilerOptionInvalid,
       adSemDeprecatedCompilerOpt:
     semRep = SemReport(

--- a/compiler/front/msgs.nim
+++ b/compiler/front/msgs.nim
@@ -401,9 +401,6 @@ func astDiagToLegacyReportKind*(
   vmGenDiag: Option[AstDiagVmGenKind] = none(AstDiagVmGenKind),
   vmEvent: Option[AstDiagVmKind] = none(AstDiagVmKind)
   ): ReportKind {.inline.} =
-  ## with the introduction of `adSemDefNameSym` style diagnostics, this
-  ## function is no longer all that sensible. `AstDiagKind` will move towards
-  ## very broad categories and they'll no longer map to "reports".
   case diag
   of adWrappedError: rsemWrappedError
   of adWrappedSymError: rsemWrappedError
@@ -581,7 +578,6 @@ func astDiagToLegacyReportKind*(
   of adSemFoldOverflow: rsemSemfoldOverflow
   of adSemFoldDivByZero: rsemSemfoldDivByZero
   of adSemFoldCannotComputeOffset: rsemCantComputeOffsetof
-  of adSemDefNameSym: rsemExpectedIdentifier
   of adSemCompilerOptionInvalid: rsemCompilerOptionInvalid
   of adSemDeprecatedCompilerOpt: rsemDeprecatedCompilerOpt
   of adSemCompilerOptionArgInvalid: rsemCompilerOptionArgInvalid

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -401,26 +401,6 @@ proc newSymS(kind: TSymKind, n: PNode, c: PContext): PSym =
   when defined(nimsuggest):
     suggestDecl(c, n, result)
 
-func defNameErrorNodeAllowsSymUpdate*(n: PNode): bool {.inline.} =
-  ## true if `n` is an `nkError` of kind `adSemSymNameSym` and the error is
-  ## minor enough to allow the recovery sym to be updated. Used to see if
-  ## progress is allowed inspite of errors.
-  n.kind == nkError and n.diag.kind == adSemDefNameSym and
-    n.diag.defNameSymData.kind == adSemDefNameSymExpectedKindMismatch
-
-func getDefNameSymOrRecover*(n: PNode): PSym {.inline.} =
-  ## extracts the symbol from `n`, which must be an `nkSym` or `nkError` with
-  ## diagnostic kind of `adSemDefNameSym`. If `n` is an error, a
-  ## recovery symbol is extracted, allowing progress to be made.
-  case n.kind
-  of nkSym: n.sym
-  of nkError:
-    case n.diag.kind
-    of adSemDefNameSym: n.diag.defNameSym
-    else: unreachable("all error cases must be covered, got: " & $n.diag.kind)
-  else:
-    unreachable("no other cases supported, got: " & $n.kind)
-
 proc produceSymbol*(kind: TSymKind, n: PNode, c: PContext): PSym =
   ## Creates (or reuses) a symbol with the given kind `kind` from the
   ## identifier-like node `n` appearing in an identifier-binding position.

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -436,7 +436,8 @@ proc produceSymbol*(kind: TSymKind, n: PNode, c: PContext): PSym =
     if err != nil:
       result.flags.incl sfGenSym # don't add to the symbol table
   of nkAllNodeKinds - nkIdentKinds + nkSymChoices:
-    c.config.semReportIllformedAst(n, "expected identifier-like node")
+    c.config.localReport(n.info,
+      SemReport(kind: rsemExpectedIdentifier, ast: n))
     result = newSym(kind, c.cache.getNotFoundIdent(),
                     nextSymId c.idgen, currOwner, info)
     result.flags.incl sfGenSym # don't add to the symbol table

--- a/compiler/sem/sem.nim
+++ b/compiler/sem/sem.nim
@@ -421,40 +421,14 @@ func getDefNameSymOrRecover*(n: PNode): PSym {.inline.} =
   else:
     unreachable("no other cases supported, got: " & $n.kind)
 
-proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
-  ## like newSymS, but considers gensym'ed symbols, analyses `n` producing a
-  ## canonical symbol node (`nkSym`), or if unsuccessful an `nkError` with an
-  ## `adSemDefNameSym` diagnostic.
-  ## 
-  ## Symbol canonicalization is is as follows:
-  ## 1. `nkSym` -> match `kind` (or `skTemp`) and updates the sym owner to the
-  ##               current context (gensym specific)
-  ## 2. `nkIdentKinds` -> instantiate a symbol considering quoted identifiers
-  ## 3. `nkError` -> simply returns the same error
-  ## 4. other kinds -> new error
-  # TODO: come up with a better name for this proc
+proc produceSymbol*(kind: TSymKind, n: PNode, c: PContext): PSym =
+  ## Creates (or reuses) a symbol with the given kind `kind` from the
+  ## identifier-like node `n` appearing in an identifier-binding position.
+  ## Always returns a valid symbol, even when there's an error (in which
+  ## case a diagnostic is emitted).
   let
     info = n.info
     currOwner = getCurrOwner(c)
-
-  template makeError(config: ConfigRef, n: PNode, sym: PSym,
-                     dataKindSuffix: untyped): PNode =
-    let
-      dataKind = `adSemDefNameSym dataKindSuffix`
-      (wrongNode, defData) =
-        case dataKind
-        of adSemDefNameSymExpectedKindMismatch:
-          (n, AdSemDefNameSym(kind: dataKind, expectedKind: kind))
-        of adSemDefNameSymIdentGenFailed:
-          (n.diag.wrongNode,
-          AdSemDefNameSym(kind: dataKind, identGenErr: n))
-        of adSemDefNameSymExistingError,
-            adSemDefNameSymIllformedAst:
-          (n, AdSemDefNameSym(kind: dataKind))
-
-    config.newError(wrongNode, PAstDiag(kind: adSemDefNameSym,
-                                        defNameSym: sym,
-                                        defNameSymData: defData))
 
   case n.kind
   of nkSym:
@@ -467,60 +441,27 @@ proc newSymGNode*(kind: TSymKind, n: PNode, c: PContext): PNode =
         if n.sym.kind == skGenerated:
           n.sym.kind = kind
         n.sym.owner = currOwner # xxx: modifying the sym owner is suss
-        n
+        n.sym
       else:
         # a symbol with the wrong kind is transplanted into a definition
         # position. Create a new symbol instead of a copy in order to prevent
         # follow-up errors due to the symbol's flags, type, etc.
-        let recoverySym = newSym(kind, n.sym.name, nextSymId c.idgen,
-                                 currOwner, info)
-        c.config.makeError(n, recoverySym, ExpectedKindMismatch)
+        c.config.localReport(n.info,
+          SemReport(kind: rsemSymbolKindMismatch, sym: n.sym,
+                    expectedSymbolKind: {kind}))
+        newSym(kind, n.sym.name, nextSymId c.idgen, currOwner, info)
   of nkIdent, nkAccQuoted:
-    # xxx: sym choices qualify here, but shouldn't those be errors in
-    #      definition positions?
-    let
-      (ident, err) = considerQuotedIdent(c, n)
-      sym = newSym(kind, ident, nextSymId c.idgen, currOwner, info)
-    result =
-      if err.isNil:
-        newSymNode(sym)
-      else:
-        c.config.makeError(err, sym, IdentGenFailed)
-  of nkError:
-    result = 
-      case n.diag.kind
-      of adSemDefNameSym:
-        # TODO: this branch needs to cover all `adSemDefinitionName...` diag
-        #       kinds, so `newSymGNode`, `semIdentVis`, `semIdentWithPragma` etc
-        #       get along and we don't overwrap
-        n
-      else:
-        # TODO: once known kinds are covered (above) and can differentiate
-        #       from errors copied around by macros/tempaltes, then we can safely
-        #       wrap this in `adSemDefinitionNameExistingError`; for now we have
-        #       this defensive check.
-        var innerNode = n.diag.wrongNode
-        while innerNode.kind == nkError and
-              innerNode.diag.kind != adSemDefNameSym:
-          innerNode = n.diag.wrongNode
-        doAssert innerNode.kind != nkError: # false means we're rewrapping
-          "this can only happen due to a bug/potential infinite loop"
-
-        let recoverySym = newSym(kind, c.cache.getNotFoundIdent(),
-                                nextSymId c.idgen, currOwner, info)
-        c.config.makeError(n, recoverySym, ExistingError)
-  of nkAllNodeKinds - nkIdentKinds - {nkError} + nkSymChoices:
-    let recoverySym = newSym(kind, c.cache.getNotFoundIdent(),
-                             nextSymId c.idgen, currOwner, info)
-    result = c.config.makeError(n, recoverySym, IllformedAst)
+    let (ident, err) = considerQuotedIdent(c, n)
+    result = newSym(kind, ident, nextSymId c.idgen, currOwner, info)
+    if err != nil:
+      result.flags.incl sfGenSym # don't add to the symbol table
+  of nkAllNodeKinds - nkIdentKinds + nkSymChoices:
+    c.config.semReportIllformedAst(n, "expected identifier-like node")
+    result = newSym(kind, c.cache.getNotFoundIdent(),
+                    nextSymId c.idgen, currOwner, info)
+    result.flags.incl sfGenSym # don't add to the symbol table
   when defined(nimsuggest):
-    case result.kind
-    of nkError:
-      suggestDecl(c, n, result.diag.defNameSym)
-    of nkSym:
-      suggestDecl(c, n, result.sym)
-    else:
-      unreachable("only produces `nkSym` or `nkError`")
+    suggestDecl(c, n, result)
 
 proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
                  allowed: TSymFlags): PSym

--- a/compiler/sem/semexprs.nim
+++ b/compiler/sem/semexprs.nim
@@ -3234,12 +3234,10 @@ proc semBlock(c: PContext, n: PNode; flags: TExprFlags): PNode =
       givenLabl = n[0]
       lablRes =
         case givenLabl.kind
-        of nkEmpty, nkError:
+        of nkEmpty:
           givenLabl
-        of nkIdent, nkSym, nkAccQuoted:
-          let
-            lablNode = newSymGNode(skLabel, givenLabl, c)
-            labl = getDefNameSymOrRecover(lablNode)
+        else:
+          let labl = produceSymbol(skLabel, givenLabl, c)
 
           if sfGenSym notin labl.flags:
             addDecl(c, labl)
@@ -3250,13 +3248,10 @@ proc semBlock(c: PContext, n: PNode; flags: TExprFlags): PNode =
           # macro, meaning that we always have to set the context value here:
           labl.context = c.executionCons.high
 
-          suggestSym(c.graph, lablNode.info, labl, c.graph.usageSym)
+          suggestSym(c.graph, givenLabl.info, labl, c.graph.usageSym)
           styleCheckDef(c.config, labl)
 
-          lablNode
-        else:
-          c.config.newError(givenLabl,
-                            PAstDiag(kind: adSemExpectedIdentifier))
+          newSymNode(labl)
       bodyRes = semExpr(c, n[1], flags)
 
     result = copyNode(n)

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2451,9 +2451,11 @@ proc checkSpecialOperators(c: PContext, s: PSym) =
   ## Checks whether `name` is that of a special operator, and if yes, whether
   ## the respective special operator is enabled. If not, an error is emitted.
   if s.name.s in [".", ".()", ".="] and dotOperators notin c.features:
-    c.config.emit(s.info, PAstDiag(kind: adSemDotOperatorsNotEnabled))
+    c.config.emit(s.info,
+      PAstDiag(kind: adSemDotOperatorsNotEnabled, operator: s))
   if s.name.s == "()" and callOperator notin c.features:
-    c.config.emit(s.info, PAstDiag(kind: adSemCallOperatorsNotEnabled))
+    c.config.emit(s.info,
+      PAstDiag(kind: adSemCallOperatorsNotEnabled, operator: s))
 
 func isAnon(cache: IdentCache, s: PSym): bool {.inline.} =
   s.name.id == cache.idAnon.id

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -255,8 +255,7 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
         # support ``except Exception as ex: body``
         let
           isImported = semExceptBranchType(a[0][1])
-          symbolNode = newSymGNode(skLet, a[0][2], c)
-          symbol = getDefNameSymOrRecover(symbolNode)
+          symbol = produceSymbol(skLet, a[0][2], c)
         symbol.typ =
           if isImported or
              a[0][1].typ.skipTypes({tyGenericInst, tyAlias}).kind == tyRef:
@@ -264,13 +263,11 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
           else:
             makeRefType(c.config, a[0][1].typ, c.idgen)
 
-        if symbolNode.kind != nkError:
-          # propagate the symbol's type to the node
-          symbolNode.typ = symbol.typ
-
+        # TODO: handle recovery symbols correctly (by not adding them to the
+        #       symbol table)
         addDecl(c, symbol)
         # Overwrite symbol in AST with the symbol in the symbol table.
-        a[0][2] = symbolNode
+        a[0][2] = newSymNode(symbol)
       elif a.len == 1:
         # count number of ``except: body`` blocks
         inc catchAllExcepts
@@ -1406,26 +1403,15 @@ proc semConstLetOrVar(c: PContext, n: PNode, symkind: TSymKind): PNode =
 include semfields
 
 proc symForVar(c: PContext, n: PNode): PSym =
-  # TODO: replace with a node return variant that can in band errors
-  let
-    hasPragma = n.kind == nkPragmaExpr
-    resultNode = newSymGNode(skForVar, (if hasPragma: n[0] else: n), c)
-    semmedNode = if hasPragma: copyNodeWithKids(n) else: resultNode
+  let hasPragma = n.kind == nkPragmaExpr
 
-  result = getDefNameSymOrRecover(resultNode)
+  # TODO: add forvar pragma handling to semIdentWithPragma and then use the
+  #       latter here instead
+  result = produceSymbol(skForVar, (if hasPragma: n[0] else: n), c)
   styleCheckDef(c.config, result)
 
   if hasPragma:
-    let pragma = pragmaDecl(c, result, n[1], forVarPragmas)
-    if pragma.kind == nkError:
-      semmedNode[0] = resultNode
-      semmedNode[1] = pragma
-
-  if resultNode.kind == nkError or hasPragma and semmedNode[1].kind == nkError:
-    result = newSym(skError, result.name, nextSymId(c.idgen), result.owner,
-                    n.info)
-    result.typ = c.errorType
-    result.ast = c.config.wrapError(semmedNode)
+    discard pragmaDecl(c, result, n[1], forVarPragmas)
 
 proc semSingleForVar(c: PContext, formal: PType, view: ViewTypeKind, n: PNode): PNode =
   ## Semantically analyses a single definition of a variable in the context of
@@ -2385,7 +2371,7 @@ proc semRoutineName(c: PContext, n: PNode, kind: TSymKind; allowAnon = true): PN
     else:
       return c.config.newError(n, PAstDiag(kind: adSemExpectedIdentifier))
   of nkSym:
-    return newSymGNode(kind, n, c)
+    return newSymNode(produceSymbol(kind, n, c))
   of nkPostfix, nkIdent, nkAccQuoted:
     # do *not* use ``semIdentDef``. It marks the procedure as global even if
     # not at top-level scope. In addition, using it would also allow pragma

--- a/compiler/sem/semstmts.nim
+++ b/compiler/sem/semstmts.nim
@@ -2447,20 +2447,13 @@ proc semRoutineParams(c: PContext, routine: PNode, formal, generic: PNode, kind:
     # remember the original generic-parameter list in the misc slot
     routine[miscPos] = newTree(nkBracket, c.graph.emptyNode, generic)
 
-proc checkSpecialOperators(c: PContext, name: PNode): PNode =
+proc checkSpecialOperators(c: PContext, s: PSym) =
   ## Checks whether `name` is that of a special operator, and if yes, whether
-  ## the respective special operator is enabled. If not, an error is produced.
-  ## If there was no error, `name` is returned.
-  assert name.kind == nkSym or defNameErrorNodeAllowsSymUpdate(name)
-  let s = name.getDefNameSymOrRecover()
-  if s.name.s[0] notin {'.', '('}:
-    name
-  elif s.name.s in [".", ".()", ".="] and dotOperators notin c.features:
-    c.config.newError(name, PAstDiag(kind: adSemDotOperatorsNotEnabled))
-  elif s.name.s == "()" and callOperator notin c.features:
-    c.config.newError(name, PAstDiag(kind: adSemCallOperatorsNotEnabled))
-  else:
-    name
+  ## the respective special operator is enabled. If not, an error is emitted.
+  if s.name.s in [".", ".()", ".="] and dotOperators notin c.features:
+    c.config.emit(s.info, PAstDiag(kind: adSemDotOperatorsNotEnabled))
+  if s.name.s == "()" and callOperator notin c.features:
+    c.config.emit(s.info, PAstDiag(kind: adSemCallOperatorsNotEnabled))
 
 func isAnon(cache: IdentCache, s: PSym): bool {.inline.} =
   s.name.id == cache.idAnon.id
@@ -2468,9 +2461,9 @@ func isAnon(cache: IdentCache, s: PSym): bool {.inline.} =
 proc semProcAux(c: PContext, n: PNode, validPragmas: TSpecialWords,
                 flags: TExprFlags = {}): PNode =
   var
-    hasError = n[namePos].kind == nkError # XXX: hasError is not yet fully
-                                          #      integrated into ``semProcAux``
-    s = n[namePos].getDefNameSymOrRecover()
+    hasError = false # XXX: hasError is not yet fully
+                     #      integrated into ``semProcAux``
+    s = n[namePos].sym
   let isAnon = c.cache.isAnon(s)
 
   result = shallowCopy(n)
@@ -2602,19 +2595,7 @@ proc semProcAux(c: PContext, n: PNode, validPragmas: TSpecialWords,
     result[genericParamsPos] = proto.ast[genericParamsPos]
     result[paramsPos] = proto.ast[paramsPos]
     result[pragmasPos] = proto.ast[pragmasPos]
-
-    case result[namePos].kind
-    of nkSym:
-      result[namePos].sym = proto
-    of nkError:
-      if result[namePos].defNameErrorNodeAllowsSymUpdate:
-        # this is the only error we can recover from and do so only for more
-        # thorough semantic analysis for `check`, `suggest`, etc
-        result[namePos].diag.defNameSym = proto
-      else:
-        c.config.internalAssert(false, "semProcAux - unexpected error")
-    else:
-      c.config.internalAssert(false, "semProcAux")
+    result[namePos].sym = proto
 
     if importantComments(c.config) and proto.ast.comment.len > 0:
       result.comment = proto.ast.comment
@@ -2626,8 +2607,7 @@ proc semProcAux(c: PContext, n: PNode, validPragmas: TSpecialWords,
     if sfOverriden in s.flags or s.name.s[0] == '=':
       semOverride(c, s, result.info)
     else:
-      result[namePos] = checkSpecialOperators(c, result[namePos])
-      hasError = hasError or result[namePos].kind == nkError
+      checkSpecialOperators(c, result[namePos].sym)
 
   if result[genericParamsPos].kind == nkEmpty and s.magic == mNone:
     paramsTypeCheck(c, s.typ, s.flags)
@@ -2728,7 +2708,7 @@ proc semProc(c: PContext, n: PNode): PNode =
 
 proc semFunc(c: PContext, n: PNode): PNode =
   let validPragmas =
-    if c.cache.isAnon(n[namePos].getDefNameSymOrRecover()):
+    if c.cache.isAnon(n[namePos].sym):
       lambdaPragmas
     else:
       procPragmas
@@ -2742,7 +2722,7 @@ proc semMethod(c: PContext, n: PNode): PNode =
   if result.kind == nkError:
     return
 
-  let s = result[namePos].getDefNameSymOrRecover()
+  let s = result[namePos].sym
   # we need to fix the 'auto' return type for the dispatcher here (see tautonotgeneric
   # test case):
   let disp = getDispatcher(s)
@@ -2763,7 +2743,7 @@ proc semConverterDef(c: PContext, n: PNode): PNode =
   if result.kind == nkError:
     return
 
-  var s = result[namePos].getDefNameSymOrRecover()
+  var s = result[namePos].sym
   var t = s.typ
   if t[0] == nil:
     localReport(c.config, n.info, reportSym(
@@ -2786,8 +2766,8 @@ proc semMacroDef(c: PContext, n: PNode): PNode =
     result[i] = n[i]
 
   var
-    s = n[namePos].getDefNameSymOrRecover()
-    hasError = n[namePos].kind == nkError
+    s = n[namePos].sym
+    hasError = false
 
   s.ast = result
   s.options = c.config.options # captue the current options
@@ -2835,8 +2815,7 @@ proc semMacroDef(c: PContext, n: PNode): PNode =
   if result[pragmasPos].kind == nkError: # did application fail?
     hasError = true
   else:
-    result[namePos] = checkSpecialOperators(c, result[namePos])
-    hasError = hasError or result[namePos].kind == nkError
+    checkSpecialOperators(c, result[namePos].sym)
 
   if hasError:
     # don't analyse the body if the header has errors:
@@ -2968,10 +2947,9 @@ proc semRoutineDef(c: PContext, n: PNode): PNode =
     c.config.timeTracer.traceSym(tikSem, result[namePos].sym)
 
   if result[namePos].kind == nkError:
-    if result[namePos].diag.kind == adSemDefNameSym:
-      discard "don't leave early, we can still make progress"
-    else:
-      return c.config.wrapError(result) # early out
+    # TODO: always produce a valid symbol in `semRoutineName` and remove
+    #       this case
+    return c.config.wrapError(result) # early out
 
   result =
     case kind

--- a/compiler/sem/semtempl.nim
+++ b/compiler/sem/semtempl.nim
@@ -1067,9 +1067,9 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   result.sons.newSeq(n.len) # make space for the kids
 
   result[namePos] = n[namePos]
-  var hasError = result[namePos].kind == nkError
+  var hasError = false
 
-  let s = result[namePos].getDefNameSymOrRecover()
+  let s = result[namePos].sym
 
   assert s.kind == skTemplate
 

--- a/compiler/sem/semtypes.nim
+++ b/compiler/sem/semtypes.nim
@@ -640,9 +640,7 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
       localReport(c.config, a[^1], reportSem rsemInitHereNotAllowed)
 
     for j in 0 ..< a.len - 2:
-      let
-        fieldNode = newSymGNode(skField, a[j], c)
-        field = getDefNameSymOrRecover(fieldNode)
+      let field = produceSymbol(skField, a[j], c)
       field.typ = typ
       field.position = counter
       inc(counter)
@@ -662,17 +660,11 @@ proc semTuple(c: PContext, n: PNode, prev: PType): PType =
 
 proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
                  allowed: TSymFlags): PSym =
-  # TODO: replace with a node return variant that can in band errors
   # identifier with visibility
   if n.kind == nkPostfix:
     if n.len == 2:
-      # for gensym'ed identifiers the identifier may already have been
-      # transformed to a symbol and we need to use that here:
-      let
-        identNode = newSymGNode(kind, n[1], c)
-        (star, _) = considerQuotedIdent(c, n[0])
-
-      result = getDefNameSymOrRecover(identNode)
+      let (star, _) = considerQuotedIdent(c, n[0])
+      result = produceSymbol(kind, n[1], c)
 
       # xxx: we can move the export allowed check much earlier
       if sfExported in allowed and star.id == ord(wStar):
@@ -683,11 +675,11 @@ proc semIdentVis(c: PContext, kind: TSymKind, n: PNode,
         else:
           localReport(c.config, n[0], reportSem rsemInvalidVisibility)
     else:
+      # FIXME: still produce a valid symbol
       c.config.semReportIllformedAst(
         n, "Expected two nodes for postfix expression, but found " & $n.len)
   else:
-    let sym = newSymGNode(kind, n, c)
-    result = getDefNameSymOrRecover(sym)
+    result = produceSymbol(kind, n, c)
 
 proc semIdentWithPragma(c: PContext, kind: TSymKind, n: PNode,
                         allowed: TSymFlags): PSym =
@@ -1535,8 +1527,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
     for j in 0..<a.len-2:
       let
         givenArg = if a[j].kind == nkPragmaExpr: a[j][0] else: a[j]
-        argNode = newSymGNode(skParam, givenArg, c)
-        arg = getDefNameSymOrRecover(argNode)
+        arg = produceSymbol(skParam, givenArg, c)
 
       if a[j].kind == nkPragmaExpr:
         a[j][1] = pragmaDecl(c, arg, a[j][1], paramPragmas)
@@ -2510,8 +2501,7 @@ proc semGenericParamList(c: PContext, n: PNode, father: PType = nil): PNode =
               skGenericParam
             else:
               skType
-          sNode = newSymGNode(sKind, paramName, c)
-          s = getDefNameSymOrRecover(sNode).linkTo(finalType)
+          s = produceSymbol(sKind, paramName, c).linkTo(finalType)
 
         if covarianceFlag != tfUnresolved: s.typ.flags.incl(covarianceFlag)
         if def.kind != nkEmpty: s.ast = def


### PR DESCRIPTION
## Summary

Replace the diagnostic-based error recovery for symbol production with
creating a recovery symbol right away, which is a lot simpler.

## Details

1. turn `newSymGNode` from a procedure returning a node into one
   returning a symbol, and rename the procedure to `produceSymbol`.
   Errors are emitted right away, with the recovery symbol returned
   directly
2. update all callsites of the former `newSymGNode`; they don't need to
   handle error recovery anymore 
3. remove the now-obsolete routines for working with potentially
   erroneous symbol nodes (`defNameErrorNodeAllowsSymUpdate` and
   `getDefNameSymOrRecover`)
4. remove the diagnostics meant for carrying recovery symbols
5. add an `emit` procedure to the `errorhandling` module, for emitting
   diagnostics directly and without going through `newError`. This
   means that it's now possible for diagnostics that have no
   `wrongNode` attached to reach diagnostic handling
6. add a dedicated variant for `adSemDotOperatorsNotEnabled` and
   `adSemCallOperatorsNotEnabled`, so that they don't rely on the
   diagnostic having an attached `wrongNode`

For the AST produced by type-checking, this means that there's always a
valid `nkSym` node in symbol definition positions, even if the
untyped AST at that position is bogus (e.g., not an identifier, some
illegal symbol, etc.).